### PR TITLE
fix: appNetwork issue

### DIFF
--- a/components/ProjectDialog.tsx
+++ b/components/ProjectDialog.tsx
@@ -10,6 +10,7 @@ import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import {
   MESSAGES,
   appNetwork,
+  checkNetworkIsValid,
   cn,
   createNewProject,
   updateProject,
@@ -25,7 +26,7 @@ import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { Project, nullRef } from "@show-karma/karma-gap-sdk";
 import toast from "react-hot-toast";
 import { useRouter } from "next/router";
-import { getGapClient } from "@/hooks";
+import { getGapClient, useGap } from "@/hooks";
 import { Button } from "./Utilities/Button";
 import {
   GithubIcon,
@@ -428,6 +429,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const { openConnectModal } = useConnectModal();
   const router = useRouter();
+  const { gap } = useGap();
 
   const createProject = async (data: SchemaType) => {
     try {
@@ -437,7 +439,6 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         return;
       }
       if (!address) return;
-      const gap = getGapClient(appNetwork[0].id);
       if (!gap) return;
       const project = new Project({
         data: {
@@ -447,7 +448,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         recipient: (data.recipient || address) as Hex,
         uid: nullRef,
       });
-      if (chain && chain.id !== project.chainID) {
+      if (!checkNetworkIsValid(chain?.id)) {
         await switchNetworkAsync?.(project.chainID);
       }
 
@@ -482,7 +483,8 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         },
         project,
         signer,
-        router
+        router,
+        gap
       );
 
       reset();
@@ -508,7 +510,6 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         return;
       }
       if (!address || !projectToUpdate) return;
-      const gap = getGapClient(appNetwork[0].id);
       if (!gap) return;
       if (chain && chain.id !== projectToUpdate.chainID) {
         await switchNetworkAsync?.(projectToUpdate.chainID);
@@ -526,7 +527,8 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
           linkedin: data.linkedin,
           twitter: data.twitter,
         },
-        signer
+        signer,
+        gap
       ).then(async () => {
         toast.success(MESSAGES.PROJECT.UPDATE.SUCCESS);
         closeModal();

--- a/pages/project/[projectId]/project.tsx
+++ b/pages/project/[projectId]/project.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/router";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { ProjectFeed } from "@/components/ProjectFeed";
 import dynamic from "next/dynamic";
+import { useGap } from "@/hooks";
 
 const ProjectDialog = dynamic(() =>
   import("@/components/ProjectDialog").then((mod) => mod.ProjectDialog)
@@ -34,6 +35,7 @@ function ProjectPage() {
   const { switchNetworkAsync } = useSwitchNetwork();
   const router = useRouter();
   const signer = useSigner();
+  const { gap } = useGap();
 
   const deleteFn = async () => {
     if (!address || !project) return;
@@ -42,7 +44,7 @@ function ProjectPage() {
       if (chain && chain.id !== project.chainID) {
         await switchNetworkAsync?.(project.chainID);
       }
-      await deleteProject(project, signer)
+      await deleteProject(project, signer, gap)
         .then(async () => {
           toast.success(MESSAGES.PROJECT.DELETE.SUCCESS);
           router.push(PAGES.MY_PROJECTS);

--- a/utilities/sdk/projects/createNewProject.ts
+++ b/utilities/sdk/projects/createNewProject.ts
@@ -24,10 +24,10 @@ export const createNewProject = async (
   newProjectInfo: NewProjectData,
   project: Project,
   signer: any,
-  router: any
+  router: any,
+  gap: any
 ) => {
   try {
-    const gap = getGapClient(appNetwork[0].id);
     if (!gap) return;
 
     const slug = await gap.generateSlug(newProjectInfo.title);

--- a/utilities/sdk/projects/deleteProject.ts
+++ b/utilities/sdk/projects/deleteProject.ts
@@ -1,12 +1,11 @@
-import { getGapClient } from "@/hooks";
-import { zeroUID } from "@/utilities/commons";
-import { appNetwork } from "@/utilities/network";
 import { Project } from "@show-karma/karma-gap-sdk";
-import { Hex } from "viem";
 
-export const deleteProject = async (project: Project, signer: any) => {
+export const deleteProject = async (
+  project: Project,
+  signer: any,
+  gap: any
+) => {
   try {
-    const gap = getGapClient(appNetwork[0].id);
     if (!gap) return;
     await project.revoke(signer as any);
   } catch (error: any) {

--- a/utilities/sdk/projects/editProject.ts
+++ b/utilities/sdk/projects/editProject.ts
@@ -20,11 +20,10 @@ export const updateProject = async (
     website?: string;
     linkedin?: string;
   },
-  signer: any
+  signer: any,
+  gap: any
 ) => {
   try {
-    const gap = getGapClient(appNetwork[0].id);
-    if (!gap) return;
     const slug =
       project.details?.slug || (await gap.generateSlug(newProjectInfo.title));
     const linkKeys = Object.keys(data);


### PR DESCRIPTION
## Summary

Rebrand from "Karma GAP" / "Grantee Accountability Protocol" to just "Karma" across the entire ecosystem. Also fixes SEO canonical paths and funding page metadata.

### URL changes
- `gap.karmahq.xyz` → `www.karmahq.xyz` (user-facing domain)
- `SITE_URL` fixed: `https://karmahq.xyz` → `https://www.karmahq.xyz`
- **Preserved**: `docs.gap.karmahq.xyz`, `gapapi.karmahq.xyz`, `gapstagapi.karmahq.xyz`, `api.gap.karmahq.xyz`

### Submodule PRs
- [gap-indexer#997](https://github.com/show-karma/gap-indexer/pull/997) — 19 files: email templates, User-Agent headers, tests
- [gap-app-v2#1096](https://github.com/show-karma/gap-app-v2/pull/1096) — 16 files: SEO/canonicals, funding page metadata, runtime URLs
- [karma-gap-sdk#133](https://github.com/show-karma/karma-gap-sdk/pull/133) — 3 files: readme, example scripts

### Changes by area

**gap-indexer** (19 files)
- "Karma GAP" → "Karma" in email sender names, subjects, footers
- "New to GAP?" → "New to Karma?" in grant notification
- `KarmaGAP/1.0` → `Karma/1.0` in User-Agent headers (ethglobal, devfolio, superteam adapters)
- `gap.karmahq.xyz` → `www.karmahq.xyz` in 12 test files

**gap-app-v2** (16 files, 4 new)
- `SITE_URL`: `https://karmahq.xyz` → `https://www.karmahq.xyz`
- Canonical paths: `/grants/` → `/funding/`, `/milestones` → `/milestones-and-updates` (matching actual routes)
- 4 funding pages converted from `"use client"` to server components with `generateMetadata` for self-referencing canonicals
- `gap.karmahq.xyz` → `www.karmahq.xyz` in KarmaProjectLink, seeds pages, llms-full.txt

**karma-gap-sdk** (3 files)
- `gap.karmahq.xyz` → `www.karmahq.xyz` in readme, create-community-example, create-program

**Root repo** (2 files in this PR after merge)
- `Initials/INITIAL_PAYOUT_CSV.md`, `PRPs/csv-payouts-upload.md` — example URLs updated

### Not changed (by design)
- API subdomains (`docs.gap.karmahq.xyz`, `gapapi.karmahq.xyz`, `gapstagapi.karmahq.xyz`)
- Email addresses, variable/function names, file paths, repo names
- CSV field matching patterns in gap-profile-extractor (backward compatibility)
- gap-whitelabel-app (archived, removed from super-gap in main)

## Test plan

- [x] `cd gap-indexer && yarn test` — 405 suites, 5,910 tests pass
- [x] `cd gap-app-v2 && pnpm test` — 375 suites, 7,589 tests pass
- [x] `grep -r "gap\.karmahq\.xyz"` returns only acceptable matches (CSV backward-compat, API subdomains)
- [ ] Verify funding pages render correctly with new server component structure
- [ ] Verify DNS redirect `gap.karmahq.xyz` → `www.karmahq.xyz` is configured in infra