### PR TITLE
Fix project_id redirects (swap uuid for slug) missing trailing paths

### DIFF
--- a/components/Pages/Project/ProjectWrapper.tsx
+++ b/components/Pages/Project/ProjectWrapper.tsx
@@ -313,7 +313,10 @@ export const ProjectWrapper = ({ projectId, project }: ProjectWrapperProps) => {
         ?.projectById(project.pointers[0].data?.ogProjectUID)
         .then((_project) => {
           if (_project) {
-            const newPath = pathname.replace(`/project/${project.uid}`, `/project/${_project?.details?.data?.slug}`);
+            const isUsingUid = pathname.includes(`/project/${project.uid}`);
+            const newPath = isUsingUid
+              ? pathname.replace(`/project/${project.uid}`, `/project/${_project?.details?.data?.slug}`)
+              : pathname.replace(`/project/${project.details?.data?.slug}`, `/project/${_project?.details?.data?.slug}`);
             router.push(newPath);
           }
         });


### PR DESCRIPTION
Task ref: https://app.asana.com/0/1201924619794704/1209213260904246

> The attempt to access https://gap.karmahq.xyz/project/0xe3c6951bcc5d08b04a9150e51af31c7b16caf6e92c306a22c82a5bd6930a3760/grants immediately redirects to https://gap.karmahq.xyz/project/agroforestdao-1 (note that the /grants isn't carried over the redirect)

