### PR TITLE
refactor: Update program filtering to use programId instead of grant names

### DIFF
--- a/components/Pages/Admin/EditCategoriesPage.tsx
+++ b/components/Pages/Admin/EditCategoriesPage.tsx
@@ -70,7 +70,7 @@ export default function EditCategoriesPage() {
     totalItems,
     paginatedGrants,
     uniquePrograms,
-    selectedProgram,
+    selectedProgramId,
     sort,
     handlePageChange,
     handleProgramChange,
@@ -189,10 +189,11 @@ export default function EditCategoriesPage() {
           <div className="flex items-center gap-4">
             <ProgramFilter
               programs={uniquePrograms}
-              selectedProgram={selectedProgram}
+              selectedProgramId={selectedProgramId}
               onChange={handleProgramChange}
             />
             <CategoryCreationDialog
+
               refreshCategories={async () => {
                 refreshCategories();
               }}

--- a/components/Pages/Admin/ProgramFilter.tsx
+++ b/components/Pages/Admin/ProgramFilter.tsx
@@ -8,35 +8,42 @@ import {
 import { Fragment } from "react";
 
 interface ProgramFilterProps {
-  programs: string[];
-  selectedProgram: string | null;
-  onChange: (program: string | null) => void;
+  programs: {
+    programId: string;
+    grant: string;
+  }[];
+  selectedProgramId: string | null;
+  onChange: (programId: string | null) => void;
 }
+
 
 export const ProgramFilter = ({
   programs,
-  selectedProgram,
+  selectedProgramId,
   onChange,
 }: ProgramFilterProps) => {
+
   return (
     <div className="relative w-64">
       <Listbox
-        value={selectedProgram}
+        value={selectedProgramId}
         onChange={(value) => {
-          if (value === selectedProgram) {
+          if (value === selectedProgramId) {
             onChange(null);
             return;
           }
           onChange(value);
         }}
+
       >
         <div className="relative">
           <Listbox.Button className="dark:bg-zinc-800 dark:text-white relative w-full cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-gray-900 ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-600 sm:text-sm sm:leading-6">
             <span className="block truncate">
-              {selectedProgram || "Filter by Grant Program"}
+              {selectedProgramId ? programs.find(program => program.programId === selectedProgramId)?.grant || "Filter by Grant Program" : "Filter by Grant Program"}
             </span>
             <span className="absolute inset-y-0 right-0 flex items-center pr-2">
-              {selectedProgram ? (
+
+              {selectedProgramId ? (
                 <XMarkIcon
                   className="h-5 w-5 text-gray-400 hover:text-gray-700 cursor-pointer"
                   aria-hidden="true"
@@ -62,8 +69,8 @@ export const ProgramFilter = ({
             <Listbox.Options className="dark:bg-zinc-800 dark:text-white absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
               {programs.map((program) => (
                 <Listbox.Option
-                  key={program}
-                  value={program}
+                  key={program.programId}
+                  value={program.programId}
                   className={({ active }) =>
                     cn(
                       active
@@ -81,7 +88,7 @@ export const ProgramFilter = ({
                           "block truncate"
                         )}
                       >
-                        {program}
+                        {program.grant}
                       </span>
                       {selected && (
                         <span

--- a/hooks/useGrants.ts
+++ b/hooks/useGrants.ts
@@ -13,6 +13,7 @@ export type SimplifiedGrant = {
   uid: string;
   projectUid: string;
   projectSlug: string;
+  programId: string;
 };
 
 export const useGrants = (communityId: string) => {
@@ -31,6 +32,7 @@ export const useGrants = (communityId: string) => {
             projectUid: grant.project?.uid || "",
             projectSlug: grant.project?.details?.data?.slug || "",
             createdOn: grant.createdOn || "",
+            programId: grant.details?.data?.programId || "",
           }));
         }
         return [];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fe1cc4f5-7b39-44f0-81cb-3f3df2f09317)

The program filter on the edit categories page is no longer mapped with just the grant name - but with the actual programIds