### PR TITLE
Feat: Click on datapoint to view proofs and navigate to autosynced proofs

### DIFF
--- a/components/Pages/Admin/IndicatorsHub.tsx
+++ b/components/Pages/Admin/IndicatorsHub.tsx
@@ -93,12 +93,12 @@ export const autosyncedIndicators: IndicatorWithPrograms[] = [
     description: "Number of repository stars (*oso)",
     unitOfMeasure: "int"
   },
-  {
-    name: "COMMIT_CODE",
-    id: "",
-    description: "Number of code commits (*oso)",
-    unitOfMeasure: "int"
-  },
+  // {
+  //   name: "COMMIT_CODE",
+  //   id: "",
+  //   description: "Number of code commits (*oso)",
+  //   unitOfMeasure: "int"
+  // },
   {
     name: 'GitHub Commits',
     id: "",

--- a/components/Pages/Communities/Impact/ImpactCharts.tsx
+++ b/components/Pages/Communities/Impact/ImpactCharts.tsx
@@ -11,8 +11,9 @@ export const prepareChartData = (
   values: number[],
   timestamps: string[],
   name: string,
-  runningValues?: number[]
-): { date: string; [key: string]: number | string }[] => {
+  runningValues?: number[],
+  proofs?: string[]
+): { date: string;[key: string]: number | string }[] => {
   const chartData = timestamps
     .map((timestamp, index) => {
       if (runningValues?.length) {
@@ -20,11 +21,13 @@ export const prepareChartData = (
           date: formatDate(new Date(timestamp), "UTC"),
           [name]: Number(values[index]) || 0,
           Cumulative: Number(runningValues[index]) || 0,
+          proof: proofs?.[index] || "",
         };
       }
       return {
         date: formatDate(new Date(timestamp), "UTC"),
         [name]: Number(values[index]) || 0,
+        proof: proofs?.[index] || "",
       };
     })
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -20,6 +20,13 @@ import { GrantsOutputsLoading } from "../Loading/Grants/Outputs";
 import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { sendImpactAnswers, getImpactAnswers } from "@/utilities/impact";
 
+// Helper function to handle comma-separated URLs
+const parseProofUrls = (proof: string): string[] => {
+  if (!proof) return [];
+  // Split by comma and trim whitespace
+  return proof.split(',').map(url => url.trim()).filter(url => url && urlRegex.test(url));
+};
+
 type OutputForm = {
   id: string;
   categoryId: string;
@@ -568,24 +575,28 @@ export const OutputsAndOutcomes = () => {
                                             }
                                             className="w-full px-3 py-1.5 bg-white dark:bg-zinc-900 border border-gray-300 dark:border-zinc-700 rounded-md shadow-sm focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 dark:text-zinc-100"
                                           />
-                                        ) : form?.datapoints?.[index]?.proof &&
-                                          urlRegex.test(
-                                            form?.datapoints?.[index]?.proof
-                                          ) ? (
-                                          <a
-                                            href={
-                                              form?.datapoints?.[index]?.proof
-                                            }
-                                            target="_blank"
-                                            className="text-blue-500 underline dark:text-blue-400"
-                                          >
-                                            {form?.datapoints?.[index]?.proof ||
-                                              "No proof provided"}
-                                          </a>
+                                        ) : form?.datapoints?.[index]?.proof ? (
+                                          <div className="flex flex-col gap-1">
+                                            {parseProofUrls(form?.datapoints?.[index]?.proof).length > 0 ? (
+                                              parseProofUrls(form?.datapoints?.[index]?.proof).map((url, urlIndex) => (
+                                                <a
+                                                  key={urlIndex}
+                                                  href={url}
+                                                  target="_blank"
+                                                  className="text-blue-500 underline dark:text-blue-400 truncate max-w-xs"
+                                                >
+                                                  {url}
+                                                </a>
+                                              ))
+                                            ) : (
+                                              <span className="text-gray-900 dark:text-zinc-100">
+                                                {form?.datapoints?.[index]?.proof || "No proof provided"}
+                                              </span>
+                                            )}
+                                          </div>
                                         ) : (
                                           <span className="text-gray-900 dark:text-zinc-100">
-                                            {form?.datapoints?.[index]?.proof ||
-                                              "No proof provided"}
+                                            No proof provided
                                           </span>
                                         )}
                                       </td>
@@ -785,15 +796,24 @@ export const OutputsAndOutcomes = () => {
                     <label className="text-sm font-medium text-gray-500 dark:text-zinc-400">
                       Proof
                     </label>
-                    <div className="mt-1">
-                      <a
-                        href={selectedPoint.data.proof}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-blue-500 transition-colors"
-                      >
-                        View Proof
-                      </a>
+                    <div className="mt-1 flex flex-col gap-2">
+                      {parseProofUrls(selectedPoint.data.proof).length > 0 ? (
+                        parseProofUrls(selectedPoint.data.proof).map((url, index) => (
+                          <a
+                            key={index}
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-blue-500 transition-colors"
+                          >
+                            View Proof {parseProofUrls(selectedPoint.data.proof).length > 1 ? `#${index + 1}` : ''}
+                          </a>
+                        ))
+                      ) : (
+                        <span className="text-gray-500 dark:text-zinc-400">
+                          {selectedPoint.data.proof}
+                        </span>
+                      )}
                     </div>
                   </div>
                 )}

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -54,6 +54,10 @@ export const OutputsAndOutcomes = () => {
   );
   const [forms, setForms] = useState<OutputForm[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [selectedPoint, setSelectedPoint] = useState<{
+    itemId: string;
+    data: any;
+  } | null>(null);
 
   const handleSubmit = async (id: string) => {
     const form = forms.find((f) => f.id === id);
@@ -622,25 +626,59 @@ export const OutputsAndOutcomes = () => {
                         <Title className="text-sm font-medium text-gray-700 dark:text-zinc-300 mb-4">
                           Historical Values
                         </Title>
-                        <AreaChart
-                          className="h-48 mt-4"
-                          data={prepareChartData(
-                            item.datapoints.map((datapoint) =>
-                              Number(datapoint.value)
-                            ),
-                            item.datapoints.map(
-                              (datapoint) =>
-                                datapoint.endDate || new Date().toISOString()
-                            ),
-                            item.name
-                          )}
-                          index="date"
-                          categories={[item.name]}
-                          colors={["blue"]}
-                          valueFormatter={(value) => `${value}`}
-                          showLegend={false}
-                          noDataText="Awaiting grantees to submit values"
-                        />
+                        <div className="relative">
+                          <AreaChart
+                            className="h-48 mt-4"
+                            data={prepareChartData(
+                              item.datapoints.map((datapoint) =>
+                                Number(datapoint.value)
+                              ),
+                              item.datapoints.map(
+                                (datapoint) =>
+                                  datapoint.endDate || new Date().toISOString()
+                              ),
+                              item.name,
+                              undefined,
+                              item.datapoints.map((datapoint) => datapoint.proof)
+                            )}
+                            index="date"
+                            categories={[item.name]}
+                            colors={["blue"]}
+                            valueFormatter={(value) => `${value}`}
+                            showLegend={false}
+                            noDataText="Awaiting grantees to submit values"
+                            onValueChange={(v) => {
+                              if (!v) {
+                                console.log('No value received from chart click');
+                                return;
+                              }
+                              console.log('Chart click data:', v);
+
+                              const selectedItem = filteredOutputs.find(i => i.id === item.id);
+                              if (!selectedItem) {
+                                console.log('Could not find matching item');
+                                return;
+                              }
+
+                              // Find the exact datapoint that matches this date and value
+                              const exactDatapoint = item.datapoints.find(dp => {
+                                const dpDate = formatDate(new Date(dp.endDate || new Date().toISOString()), "UTC");
+                                return dpDate === v.date && Number(dp.value) === Number(v[selectedItem.name]);
+                              });
+
+                              console.log('Found matching datapoint:', exactDatapoint);
+
+                              setSelectedPoint({
+                                itemId: item.id,
+                                data: {
+                                  value: v[selectedItem.name],
+                                  date: v.date,
+                                  proof: exactDatapoint?.proof || v.proof
+                                }
+                              });
+                            }}
+                          />
+                        </div>
                       </Card>
                     )}
                   </div>
@@ -696,6 +734,72 @@ export const OutputsAndOutcomes = () => {
           <p className="text-gray-600 dark:text-zinc-300">
             {MESSAGES.GRANT.OUTPUTS.EMPTY}
           </p>
+        </div>
+      )}
+
+      {/* Modal */}
+      {selectedPoint && (
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          {/* Modal backdrop */}
+          <div
+            className="fixed inset-0 bg-black/50 dark:bg-black/70"
+            onClick={() => setSelectedPoint(null)}
+          />
+
+          {/* Modal content */}
+          <div className="relative bg-white dark:bg-zinc-800 p-6 rounded-lg shadow-xl max-w-md w-full mx-4 z-50">
+            <div className="flex flex-col gap-4">
+              <div className="flex justify-between items-start">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-zinc-100">
+                  Data Point Details
+                </h3>
+                <button
+                  onClick={() => setSelectedPoint(null)}
+                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                  <span className="text-2xl">×</span>
+                </button>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <label className="text-sm font-medium text-gray-500 dark:text-zinc-400">
+                    Value
+                  </label>
+                  <p className="text-base text-gray-900 dark:text-zinc-100">
+                    {selectedPoint.data.value}
+                  </p>
+                </div>
+
+                <div>
+                  <label className="text-sm font-medium text-gray-500 dark:text-zinc-400">
+                    Date
+                  </label>
+                  <p className="text-base text-gray-900 dark:text-zinc-100">
+                    {selectedPoint.data.date}
+                  </p>
+                </div>
+
+                {selectedPoint.data.proof && (
+                  <div>
+                    <label className="text-sm font-medium text-gray-500 dark:text-zinc-400">
+                      Proof
+                    </label>
+                    <div className="mt-1">
+                      <a
+                        href={selectedPoint.data.proof}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-blue-500 transition-colors"
+                      >
+                        View Proof
+                      </a>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
1. Click on datapoint on a project's impact charts: https://gap-app-v2-git-feat-show-proof-on-charts-karma-devs.vercel.app/project/karma-gap/impact
![image](https://github.com/user-attachments/assets/796d5539-9ac2-42fd-b821-d1093434f7e8)

2. Modal opens with View proof button
![image](https://github.com/user-attachments/assets/ae43185a-0586-431b-afeb-3d15e5bdaf7b)

3. Clicking on View Proof takes you to the proof page
![image](https://github.com/user-attachments/assets/8fc2f7dd-e714-4a49-9cff-0ccf6dfc7b43)
