### PR TITLE
feat: switch chain if user wants to update profile and has switched

### DIFF
--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -11,6 +11,7 @@ import { useAccount } from "wagmi";
 
 import { errorManager } from "@/components/Utilities/errorManager";
 import { getGapClient, useGap } from "@/hooks/useGap";
+import { getChainIdByName } from "@/utilities/network";
 import { useAuthStore } from "@/store/auth";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 import { useStepper } from "@/store/modals/txStepper";
@@ -128,7 +129,18 @@ export const ContributorProfileDialog: FC<
     if (!isGlobal && !project) return;
     try {
       setIsLoading(true);
-      const targetChainId = isGlobal ? chain?.id : project?.chainID;
+      let targetChainId = 0;
+
+      if (isGlobal) {
+        if (chain?.id) {
+          targetChainId = chain.id;
+        } else if (gap?.network) {
+          targetChainId = getChainIdByName(gap.network);
+        }
+      } else if (project?.chainID) {
+        targetChainId = project.chainID;
+      }
+
       if (!targetChainId) {
         toast.error("Chain not found");
         setIsLoading(false);


### PR DESCRIPTION
- "Chain not found" being thrown when user changes wallet to a unsupported network, so it now gets the original network logged in with and changes to that network (or the first supported one)