### PR TITLE
fix: hide milestone delete btn from community adms & error check on del

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDelete.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDelete.tsx
@@ -18,6 +18,7 @@ import { useAccount } from "wagmi";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { retryUntilConditionMet } from "@/utilities/retries";
 import { useWallet } from "@/hooks/useWallet";
+import { useCommunityAdminStore } from "@/store/communityAdmin";
 interface MilestoneDeleteProps {
   milestone: IMilestoneResponse;
 }
@@ -92,7 +93,13 @@ export const MilestoneDelete: FC<MilestoneDeleteProps> = ({ milestone }) => {
           "POST",
           {}
         )
-          .then(async () => {
+          .then(async (res) => {
+            if (res[1]) {
+              toast.dismiss(toastLoading);
+              toast.error(res[1]);
+              return;
+            }
+
             await checkIfAttestationExists()
               .then(() => {
                 toast.success(MESSAGES.MILESTONES.DELETE.SUCCESS, {

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
@@ -111,6 +111,7 @@ export const MilestoneDetails: FC<MilestoneDetailsProps> = ({
     (state) => state.isCommunityAdmin
   );
   const isAuthorized = isProjectAdmin || isContractOwner || isCommunityAdmin;
+  const isOnChainAuthorized = isProjectAdmin || isContractOwner;
   return (
     <div className="flex flex-col gap-2">
       <div className="flex w-full flex-1 flex-col rounded-lg border border-zinc-200 bg-white dark:bg-zinc-800 transition-all duration-200 ease-in-out">
@@ -137,7 +138,10 @@ export const MilestoneDetails: FC<MilestoneDetailsProps> = ({
             </div>
             <div className="flex flex-row items-center justify-start gap-2">
               <MilestoneDateStatus milestone={milestone} />
-              {isAuthorized ? <MilestoneDelete milestone={milestone} /> : null}
+              {isOnChainAuthorized 
+                ? <MilestoneDelete milestone={milestone} /> 
+                : null
+              }
             </div>
           </div>
           <div


### PR DESCRIPTION
- removes milestone delete btn (temporarily) for community admins. **why?** they are not set-up to delete via back-end, and on-chain they are not allowed to, we need to check how to better handle it
- fixed infinite loading if error on `REVOKE_ATTESTATION` call