### PR TITLE
Fix/community admin janky add funding

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/index.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/index.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/Utilities/Button";
 import { PAGES } from "@/utilities/pages";
 import { TypeSelectionScreen } from "./screens/TypeSelectionScreen";
 import { DefaultLoading } from "@/components/Utilities/DefaultLoading";
+import { useCommunitiesStore } from "@/store/communities";
 export { SearchGrantProgram } from "./SearchGrantProgram";
 
 const DetailsScreen = dynamic(
@@ -70,8 +71,9 @@ export const NewGrant: FC<NewGrantProps> = ({ grantToEdit }) => {
   const selectedProject = useProjectStore((state) => state.project);
   const { isProjectAdmin } = useProjectStore();
   const { isOwner } = useOwnerStore();
-  const { isCommunityAdmin } = useCommunityAdminStore();
-  const isAuthorized = isProjectAdmin || isOwner || isCommunityAdmin;
+  const { communities } = useCommunitiesStore();
+  const isCommunityAdminOfSome = communities.length !== 0;
+  const isAuthorized = isProjectAdmin || isOwner || isCommunityAdminOfSome;
 
   const isProgramApplication = formData.description.includes(
     "I am applying to participate in the"

--- a/components/Pages/Project/Grants/Layout.tsx
+++ b/components/Pages/Project/Grants/Layout.tsx
@@ -111,7 +111,7 @@ export const GrantsLayout = ({
   useEffect(() => {
     if (!project || !screen) return;
 
-    if (!isAuthorized && authorizedViews.includes(screen)) {
+    if (!(isAuthorized || isCommunityAdminOfSome) && authorizedViews.includes(screen)) {
       router.replace(
         PAGES.PROJECT.GRANTS(project.details?.data.slug || project.uid || "")
       );
@@ -122,7 +122,7 @@ export const GrantsLayout = ({
     if (currentTab !== screen) {
       setCurrentTab(screen);
     }
-  }, [screen, isAuthorized, project, currentTab, router]);
+  }, [screen, isAuthorized, isCommunityAdminOfSome, project, currentTab, router]);
 
   useEffect(() => {
     if (project) {


### PR DESCRIPTION
Community admins were being redirected from "new" to "overview" because the useEffect authorization check only used isAuthorized, but the UI buttons correctly check (isAuthorized || isCommunityAdminOfSome).
For adding a new grant, also checks if is community admin of atleast one community