### PR TITLE
fix: error on deleting contact and creating one after the other

### DIFF
--- a/components/ContactInfoSubscription.tsx
+++ b/components/ContactInfoSubscription.tsx
@@ -152,7 +152,7 @@ export const ContactInfoSubscription: FC<ContactInfoSubscriptionProps> = ({
   const clear = () => {
     reset(
       {
-        id: generateRandomString(10),
+        id: "0",
         name: "",
         email: "",
         telegram: "",
@@ -239,7 +239,7 @@ export const ContactInfoSubscription: FC<ContactInfoSubscriptionProps> = ({
 
   const [isDeleteLoading, setIsDeleteLoading] = useState(false);
 
-  const deleteContact = async () => {
+  const deleteContact = async (id: string) => {
     setIsDeleteLoading(true);
     try {
       await fetchData(
@@ -247,7 +247,7 @@ export const ContactInfoSubscription: FC<ContactInfoSubscriptionProps> = ({
           project?.details?.data?.slug || (project?.uid as string)
         ),
         "DELETE",
-        { contacts: [watch("id")] },
+        { contacts: [id] },
         {},
         {},
         true


### PR DESCRIPTION
After creating or updating a contact, the `clear()` call would set id for a random number, and when user would try to create yet another contact right away, they would get an error because it would try to update a existing id instead of adding new contact, changing default `clear()` id to "0", avoids that.

For deletion, the value of "id" would not be set previously, so `watch("id")` pointer would be wrong and call would error.

## Test plan
- Go to a `/contact-info` (by clicking the Contact info navigation) route of a project that you're are an admin of and test the following:
- [x] Create a contact, and create another contact in sequence
- [x] Select a contact for editing and successfully edit it
- [x] Delete a contact