### PR TITLE
fix: resolve grant creation redirect issue preventing grants list update

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
@@ -276,14 +276,13 @@ export const MilestonesScreen: React.FC = () => {
                 }
               }
 
+              await refreshProject();
               router.push(
                 PAGES.PROJECT.GRANT(
                   selectedProject.details?.data.slug || selectedProject.uid,
                   grant.uid
                 )
               );
-              router.refresh();
-              await refreshProject();
             }
 
             retries -= 1;


### PR DESCRIPTION
## Overview

Fixed a critical issue where the grants list wasn't updating after creating a new grant, requiring users to manually refresh the page to see the new grant.

## Problem

When creating a new grant in MilestonesScreen.tsx, the `router.refresh()` was being called immediately after `router.push()`, causing the refresh to happen on the current URL (`/funding/new`) instead of the intended grant page. This prevented the grants list from updating properly and caused a poor user experience, especially when a project had no existing grants.

**Problematic flow:**
```mermaid
sequenceDiagram
    participant U as User
    participant C as Component
    participant R as Router
    participant S as Store
    
    U->>C: Click "Create Grant"
    C->>S: Save grant data
    C->>R: router.push(/grant/new-grant-id)
    C->>R: router.refresh() [IMMEDIATE]
    Note over R: Refreshes current page (/funding/new)
    Note over R: Navigation never completes
    U->>U: Must manually refresh to see grant
```

## Solution

1. **Removed the problematic `router.refresh()` call** that was interfering with navigation
2. **Moved `await refreshProject()` before navigation** to ensure the project store is updated with fresh grant data
3. **Simplified the flow** to allow natural navigation completion

**Fixed flow:**
```mermaid
sequenceDiagram
    participant U as User
    participant C as Component
    participant R as Router
    participant S as Store
    
    U->>C: Click "Create Grant"
    C->>S: Save grant data
    C->>S: refreshProject() [WAIT]
    S-->>C: Updated project with new grant
    C->>R: router.push(/grant/new-grant-id)
    R-->>U: Navigate to grant page
    Note over U: Grants list is already updated
```

## Why This Approach

- **Preserves data integrity**: `refreshProject()` ensures the store has the latest data before navigation
- **Eliminates race conditions**: Removing `router.refresh()` prevents competing navigation actions
- **Improves UX**: Users see their new grant immediately without manual refresh
- **Minimal change**: Surgical fix that doesn't disrupt existing functionality

## Technical Details

**File:** `components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx`

**Change:** Lines 279-285
```diff
- router.push(
-   PAGES.PROJECT.GRANT(
-     selectedProject.details?.data.slug || selectedProject.uid,
-     grant.uid
-   )
- );
- router.refresh();
- await refreshProject();
+ await refreshProject();
+ router.push(
+   PAGES.PROJECT.GRANT(
+     selectedProject.details?.data.slug || selectedProject.uid,
+     grant.uid
+   )
+ );
```

## Testing Steps

1. **Setup**: Navigate to a project with no existing grants
2. **Action**: Create a new grant using the funding form
3. **Verify**: After clicking "Create Grant":
   - ✅ User is redirected to the new grant page
   - ✅ Grants list shows the new grant immediately
   - ✅ No manual refresh required
   - ✅ Navigation flow is smooth

4. **Edge case**: Test with existing grants to ensure no regression

## Related Issues

This fix addresses user experience issues where grant creation appeared to fail due to the redirect problem, leading to user confusion and support requests.

🤖 Generated with [Claude Code](https://claude.ai/code)