### PR TITLE
fix: allow program selection when editing grants

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/CommunitySelectionScreen.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/CommunitySelectionScreen.tsx
@@ -105,12 +105,16 @@ export const CommunitySelectionScreen: React.FC = () => {
   const isProjectAlreadyInProgram = useMemo(() => {
     if (!formData.programId || !selectedProject?.grants) return false;
 
+    if (isEditing) {
+      return false;
+    }
+
     const selectedProgramId = formData.programId.split("_")[0];
     return selectedProject.grants.some(grant => {
       const existingProgramId = grant.details?.data?.programId?.split("_")[0];
       return existingProgramId === selectedProgramId;
     });
-  }, [formData.programId, selectedProject?.grants]);
+  }, [formData.programId, selectedProject?.grants, isEditing]);
 
   const canProceed = useMemo(() => {
     return !!formData.community &&


### PR DESCRIPTION
## Summary

- Fixes grant editing workflow where users were blocked from selecting programs due to incorrect validation
- When editing a grant, the system was incorrectly preventing program selection if the project already had a grant in that program
- Added conditional check to skip program validation during editing mode

## Issue Description

The `isProjectAlreadyInProgram` validation was incorrectly blocking users from editing grants when they tried to select a program. This validation should only apply when creating new grants, not when editing existing ones.

## Changes Made

- Added `isEditing` condition to bypass program validation check when in editing mode
- Updated dependency array in `useMemo` to include `isEditing` state
- Maintains existing validation behavior for new grant creation

## Test Plan

### Manual Testing Steps

1. **Test Grant Editing Flow:**
   - Navigate to an existing grant
   - Click "Edit Grant" 
   - Go to Community Selection step
   - Verify you can select any program without validation errors
   - Complete the editing process successfully

2. **Test New Grant Creation Flow:**
   - Create a new grant for a project that already has grants
   - Go to Community Selection step  
   - Try to select a program where the project already has a grant
   - Verify validation still prevents duplicate program selection
   - Confirm error message displays correctly

3. **Edge Cases:**
   - Test with projects that have no existing grants
   - Test with projects that have grants in multiple programs
   - Verify the validation works correctly in both editing and creation modes

🤖 Generated with [Claude Code](https://claude.ai/code)