### PR TITLE
🔒 Security: Fix simple-swizzle npm supply chain compromise

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
   },
   "overrides": {
     "pbkdf2": "^3.1.3",
-    "error-ex": "^1.3.2"
+    "error-ex": "^1.3.2",
+    "simple-swizzle": "^0.2.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "simple-swizzle": "^0.2.4"
+    }
   },
   "dependencies": {
     "@headlessui/react": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@noble/curves': ^1.4.2
   '@types/react': 19.1.8
   '@types/react-dom': 19.1.6
+  simple-swizzle: ^0.2.4
 
 importers:
 
@@ -7660,8 +7661,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-swizzle@0.2.3:
-    resolution: {integrity: sha512-NLgA1P4m+AAQuaetDKl899hwnPQd8cF0XjfIX/zdMga/kgeanRFn0MP2/HbMxPYNeJckKiB/1M4DLpb1XSWcvA==}
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   simple-ts-job-runner@1.0.12:
     resolution: {integrity: sha512-0oz/inZvlSgQkFNLyRH+2zn6AeQnaEyYvIADQdBGLJbI/Y6Ar6QO7p37goGjTMztksfVjkgQWbxFRbZchsU4CQ==}
@@ -14578,7 +14579,7 @@ snapshots:
   color-string@1.9.1:
     dependencies:
       color-name: 1.1.4
-      simple-swizzle: 0.2.3
+      simple-swizzle: 0.2.4
     optional: true
 
   color@4.2.3:
@@ -19226,7 +19227,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-swizzle@0.2.3:
+  simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.2
     optional: true


### PR DESCRIPTION
## Summary
- Fixes critical npm supply chain compromise in simple-swizzle package
- Forces safe version 0.2.4 to replace compromised 0.2.3
- Adds package overrides for both npm and pnpm compatibility

## Security Issue
The `simple-swizzle@0.2.3` package was compromised in an npm supply chain attack and has been removed from the registry. This was being pulled as a transitive dependency via:
```
color-string → simple-swizzle@0.2.3
```

Installation attempts for the compromised version now return `404 Not Found`.

## Changes
- **Package overrides**: Added both `overrides` and `pnpm.overrides` to force version 0.2.4
- **Lock file regeneration**: Removed and regenerated `pnpm-lock.yaml` to enforce safe version
- **Verification**: Confirmed all instances now use `simple-swizzle@0.2.4`

## Impact
- ✅ Prevents installation of compromised package
- ✅ Maintains functionality with verified safe version
- ✅ Ensures consistent security across all environments
- ✅ Compatible with both npm and pnpm package managers

## Test plan
- [x] Verify installation succeeds without 404 errors
- [x] Confirm lock file shows simple-swizzle@0.2.4
- [x] Ensure TypeScript compilation passes
- [x] Validate package overrides work for transitive dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)