### PR TITLE
feat: add farcaster.xyz domain support and centralize Farcaster link handling

### DIFF
--- a/components/Dialogs/Member/index.tsx
+++ b/components/Dialogs/Member/index.tsx
@@ -11,6 +11,7 @@ import { Twitter2Icon } from "@/components/Icons/Twitter2";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { GithubIcon, LinkedInIcon } from "@/components/Icons";
 import { FarcasterIcon } from "@/components/Icons/Farcaster";
+import { formatFarcasterLink } from "@/utilities/farcaster";
 
 interface MemberDialogProps {
   profile: ContributorProfile;
@@ -136,15 +137,7 @@ export const MemberDialog: FC<MemberDialogProps> = ({
                         ) : null}
                         {profile?.data.farcaster ? (
                           <ExternalLink
-                            href={
-                              profile?.data.farcaster.includes("http")
-                                ? profile?.data.farcaster
-                                : profile?.data.farcaster.includes(
-                                    "warpcast.com"
-                                  )
-                                ? `https://${profile?.data.farcaster}`
-                                : `https://warpcast.com/${profile?.data.farcaster}`
-                            }
+                            href={formatFarcasterLink(profile?.data.farcaster)}
                             className="w-max"
                           >
                             <FarcasterIcon

--- a/components/Pages/Project/Team/MemberCard.tsx
+++ b/components/Pages/Project/Team/MemberCard.tsx
@@ -4,6 +4,7 @@ import { DemoteMemberDialog } from "@/components/Dialogs/Member/DemoteMember";
 import { PromoteMemberDialog } from "@/components/Dialogs/Member/PromoteMember";
 import { GithubIcon, LinkedInIcon, Twitter2Icon } from "@/components/Icons";
 import { FarcasterIcon } from "@/components/Icons/Farcaster";
+import { formatFarcasterLink } from "@/utilities/farcaster";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -185,13 +186,7 @@ export const MemberCard = ({ member }: { member: string }) => {
             ) : null}
             {profile?.data.farcaster ? (
               <ExternalLink
-                href={
-                  profile?.data.farcaster.includes("http")
-                    ? profile?.data.farcaster
-                    : profile?.data.farcaster.includes("warpcast.com")
-                    ? `https://${profile?.data.farcaster}`
-                    : `https://warpcast.com/${profile?.data.farcaster}`
-                }
+                href={formatFarcasterLink(profile?.data.farcaster)}
                 className="w-max"
               >
                 <FarcasterIcon className={iconsClassnames.general} />

--- a/hooks/useProjectSocials.ts
+++ b/hooks/useProjectSocials.ts
@@ -8,6 +8,7 @@ import {
 } from "@/components/Icons";
 import { FarcasterIcon } from "@/components/Icons/Farcaster";
 import type { IProjectDetails } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/api/types";
+import { formatFarcasterLink } from "@/utilities/farcaster";
 
 interface SocialLink {
   name: string;
@@ -31,7 +32,11 @@ export const useProjectSocials = (
       { name: "Discord", prefix: "discord.gg/", icon: DiscordIcon },
       { name: "Website", prefix: "https://", icon: WebsiteIcon },
       { name: "LinkedIn", prefix: "linkedin.com/", icon: LinkedInIcon },
-      { name: "Farcaster", prefix: "warpcast.com/", icon: FarcasterIcon },
+      {
+        name: "Farcaster",
+        prefix: ["warpcast.com/", "farcaster.xyz/"],
+        icon: FarcasterIcon
+      },
     ];
 
     const hasHttpOrWWW = (link?: string) => {
@@ -92,6 +97,14 @@ export const useProjectSocials = (
                 icon,
               };
             }
+          }
+
+          if (name === "Farcaster") {
+            return {
+              name,
+              url: formatFarcasterLink(socialLink),
+              icon,
+            };
           }
 
           return {

--- a/utilities/farcaster.ts
+++ b/utilities/farcaster.ts
@@ -1,0 +1,24 @@
+/**
+ * Formats a Farcaster link to ensure it has the proper protocol and domain
+ * @param farcasterInput - The Farcaster link or username
+ * @returns Formatted Farcaster URL
+ */
+export function formatFarcasterLink(farcasterInput: string): string {
+  if (!farcasterInput) return "";
+
+  // If it already includes http/https, return as is
+  if (farcasterInput.includes("http")) {
+    return farcasterInput;
+  }
+
+  // If it includes warpcast.com or farcaster.xyz, just prepend https://
+  if (
+    farcasterInput.includes("warpcast.com") ||
+    farcasterInput.includes("farcaster.xyz")
+  ) {
+    return `https://${farcasterInput}`;
+  }
+
+  // Default to warpcast.com for usernames
+  return `https://warpcast.com/${farcasterInput}`;
+}


### PR DESCRIPTION
## Summary
- Centralized Farcaster link handling logic into a reusable utility function
- Added support for both `warpcast.com` and `farcaster.xyz` domains  
- Replaced duplicate inline logic across components with the new utility
- Updated `useProjectSocials` hook to handle both Farcaster domains

## Problem
The codebase had duplicate Farcaster link formatting logic scattered across multiple components (`components/Dialogs/Member/index.tsx:140`, `components/Pages/Project/Team/MemberCard.tsx:191`, and `hooks/useProjectSocials.ts:34`). This logic only supported `warpcast.com` domain and needed to be extended to also support `farcaster.xyz`.

## Solution
1. **Created `utilities/farcaster.ts`** with `formatFarcasterLink()` function that:
   - Handles both `warpcast.com` and `farcaster.xyz` domains
   - Preserves existing HTTP/HTTPS URLs unchanged
   - Prepends `https://` to domain-prefixed URLs
   - Defaults to `https://warpcast.com/` for plain usernames
   - Returns empty string for invalid input

2. **Refactored components** to use the centralized utility:
   - `components/Dialogs/Member/index.tsx`
   - `components/Pages/Project/Team/MemberCard.tsx`
   - `hooks/useProjectSocials.ts`

3. **Maintained backward compatibility** - existing `warpcast.com` links continue to work exactly as before

## Test plan
- [ ] Verify plain usernames (e.g., "username") link to `https://warpcast.com/username`
- [ ] Verify `warpcast.com/username` links to `https://warpcast.com/username`
- [ ] Verify `farcaster.xyz/username` links to `https://farcaster.xyz/username`
- [ ] Verify full URLs with `https://` are preserved unchanged
- [ ] Test in Member dialogs and Team member cards
- [ ] Verify project social links work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)