### PR TITLE
fix: invalidate React Query cache after project edit to refresh custom links

### DIFF
--- a/utilities/sdk/projects/editProject.ts
+++ b/utilities/sdk/projects/editProject.ts
@@ -9,6 +9,7 @@ import {
   Project,
   TExternalLink,
 } from "@show-karma/karma-gap-sdk";
+import { queryClient } from "@/components/Utilities/PrivyProviderWrapper";
 
 export const updateProject = async (
   project: Project,
@@ -118,6 +119,17 @@ export const updateProject = async (
           if (fetchedProject.details?.uid !== projectBefore.details?.uid) {
             retries = 0;
             changeStepperStep("indexed");
+
+            // Invalidate React Query cache to force refresh of project data
+            await Promise.all([
+              queryClient.invalidateQueries({
+                queryKey: ["project", project.uid],
+              }),
+              queryClient.invalidateQueries({
+                queryKey: ["project", project.details?.slug],
+              }),
+            ]);
+
             closeModal();
             return;
           }


### PR DESCRIPTION
## Overview

Fixes a visual bug where custom links with their custom icons would not display after editing a project, requiring page refreshes to see the updated data.

## Problem

After editing a project and adding/modifying custom links:
1. The project update transaction completes successfully
2. The indexer processes the new data
3. However, the UI still shows stale data (missing custom links/icons)
4. Only after manual page refresh would the custom links appear

This was caused by Next.js client-side caching via React Query not being invalidated after the project edit operation completed.

## Root Cause

In `utilities/sdk/projects/editProject.ts`, the `updateProject` function:
- Waits for the indexer to process the updated project data (lines 113-128)
- Detects when the new project details are indexed
- Closes the modal and returns
- **BUT** never invalidates the React Query cache

The `ProjectWrapper` component uses the `useProject()` hook which caches project data with React Query. Without cache invalidation, the old cached data persists even though fresh data exists in the backend.

## Solution

Added React Query cache invalidation immediately after successful indexing:

```typescript
// Invalidate React Query cache to force refresh of project data
await Promise.all([
  queryClient.invalidateQueries({
    queryKey: ["project", project.uid],
  }),
  queryClient.invalidateQueries({
    queryKey: ["project", project.details?.slug],
  }),
]);
```

This invalidates both the UID-based and slug-based query keys, forcing React Query to refetch fresh data from the API.

## Why This Approach

1. **Follows existing patterns**: The same pattern is already used in `hooks/useUpdateActions.ts` for similar cache invalidation scenarios
2. **Minimal changes**: Only adds cache invalidation without changing existing logic
3. **Immediate feedback**: Users see their changes instantly without manual refresh
4. **Comprehensive**: Invalidates both UID and slug query keys to cover all access patterns

## Files Changed

- `utilities/sdk/projects/editProject.ts`
  - Added import for `queryClient` from `PrivyProviderWrapper`
  - Added cache invalidation after successful project indexing

## Testing Steps

1. Create or navigate to an existing project
2. Click "Edit Project" button
3. Navigate to "Add your socials" step
4. Add a new custom link (e.g., "Documentation" → "https://docs.example.com")
5. Complete the form and submit
6. Wait for transaction to complete
7. **Expected**: Custom links should appear immediately in the project header with the globe icon
8. **Previously**: Would require page refresh to see the new custom links

## Technical Details

### Cache Keys Invalidated
- `["project", project.uid]` - Direct UID lookup
- `["project", project.details?.slug]` - Slug-based lookup

Both are invalidated because projects can be accessed via either identifier.

### Flow Diagram

```mermaid
sequenceDiagram
    participant User
    participant Modal as Edit Modal
    participant SDK as GAP SDK
    participant Indexer
    participant Cache as React Query
    participant UI as ProjectWrapper

    User->>Modal: Edit project & add custom links
    Modal->>SDK: updateProject()
    SDK->>Indexer: Attest new project details
    Indexer-->>SDK: Transaction hash
    SDK->>Indexer: Poll for updated data
    Indexer-->>SDK: New details indexed
    SDK->>Cache: invalidateQueries(["project", uid])
    SDK->>Cache: invalidateQueries(["project", slug])
    Cache-->>UI: Trigger refetch
    UI->>Indexer: Fetch fresh project data
    Indexer-->>UI: Updated project with custom links
    UI->>User: Display custom links immediately
```

## Related Issues

Fixes the issue reported where custom links would not load even after multiple refreshes, potentially caused by stale cache persisting across navigation.

## Checklist

- [x] Follows existing cache invalidation patterns
- [x] Minimal code changes
- [x] No breaking changes
- [x] Improves user experience
- [x] Consistent with React Query best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)