### PR TITLE
feat: add count display option to SearchDropdown component

### DIFF
--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -274,6 +274,7 @@ export const ReportMilestonePage = ({
                   prefixUnselected="All"
                   type={"Grant Programs"}
                   selected={selectedProgramLabels}
+                  showCount={true}
                 />
               </div>
             </div>

--- a/components/Pages/ProgramRegistry/SearchDropdown.tsx
+++ b/components/Pages/ProgramRegistry/SearchDropdown.tsx
@@ -39,6 +39,7 @@ interface SearchDropdownProps {
   rightIcon?: React.ReactNode;
   customAddButton?: React.ReactNode;
   placeholderText?: string;
+  showCount?: boolean;
 }
 export const SearchDropdown: FC<SearchDropdownProps> = ({
   onSelectFunction,
@@ -59,6 +60,7 @@ export const SearchDropdown: FC<SearchDropdownProps> = ({
   rightIcon = <ChevronDown className="h-5 w-5 text-black dark:text-white" />,
   customAddButton,
   placeholderText = `Search ${type}...`,
+  showCount = false,
 }) => {
   const [open, setOpen] = useState(false);
   const [adding, setAdding] = useState(false);
@@ -141,15 +143,17 @@ export const SearchDropdown: FC<SearchDropdownProps> = ({
             {leftIcon ? leftIcon : null}
             <p className={cn("block w-full truncate", paragraphClassname)}>
               {selected.length
-                ? selected
-                    .map(
-                      (item) =>
-                        orderedList.find(
-                          (orderedItem) => orderedItem.value === item
-                        )?.value
-                    )
-                    .sort()
-                    .join(", ")
+                ? showCount
+                  ? `${selected.length} ${type} selected`
+                  : selected
+                      .map(
+                        (item) =>
+                          orderedList.find(
+                            (orderedItem) => orderedItem.value === item
+                          )?.value
+                      )
+                      .sort()
+                      .join(", ")
                 : `${prefixUnselected} ${type}`}
             </p>
             <span>{rightIcon ? rightIcon : null}</span>


### PR DESCRIPTION
Add optional showCount prop to SearchDropdown that displays "{length} {type} selected" instead of listing all selected items. This improves UX when multiple items are selected by preventing long concatenated lists. Applied to Grant Programs selector in ReportMilestonePage for cleaner display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)