### PR TITLE
feat: fetch funding application by project UID in milestone review (#…

### DIFF
--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -9,7 +9,7 @@ import type { MappedGrantMilestone } from "@/services/milestones";
 import { updateMilestoneVerification } from "@/services/milestones";
 import { useProjectGrantMilestones } from "@/hooks/useProjectGrantMilestones";
 import { useMilestoneCompletionVerification } from "@/hooks/useMilestoneCompletionVerification";
-import { useApplicationByReference } from "@/hooks/useFundingPlatform";
+import { useFundingApplicationByProjectUID } from "@/hooks/useFundingApplicationByProjectUID";
 import toast from "react-hot-toast";
 import { CommentsAndActivity } from "./CommentsAndActivity";
 import { MilestoneCard } from "./MilestoneCard";
@@ -39,13 +39,17 @@ export function MilestonesReviewPage({
   const isContractOwner = useOwnerStore((state) => state.isOwner);
   const isOwnerLoading = useOwnerStore((state) => state.isOwnerLoading);
 
-  // Get reference number from first milestone with fundingApplicationCompletion
-  const referenceNumber = data?.grantMilestones.find(
-    (m) => m.fundingApplicationCompletion?.referenceNumber
-  )?.fundingApplicationCompletion?.referenceNumber;
+  // Get the actual project UID from the data (projectId might be a slug)
+  const projectUID = data?.project?.uid;
 
-  // Fetch funding application data to get statusHistory (must be before any returns)
-  const { application: fundingApplication } = useApplicationByReference(referenceNumber || "");
+  // Fetch funding application data by project UID (must be before any returns)
+  const { application: fundingApplication } = useFundingApplicationByProjectUID(projectUID || "");
+
+  // Memoize reference number from the funding application
+  const referenceNumber = useMemo(
+    () => fundingApplication?.referenceNumber,
+    [fundingApplication?.referenceNumber]
+  );
 
   // Get grant name from first milestone's programId (must be before any returns)
   const grantName = useMemo(() => {

--- a/hooks/useFundingApplicationByProjectUID.ts
+++ b/hooks/useFundingApplicationByProjectUID.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchApplicationByProjectUID } from "@/services/funding-applications";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
+
+/**
+ * Hook for fetching a funding application by project UID
+ */
+export const useFundingApplicationByProjectUID = (projectUID: string) => {
+  const applicationQuery = useQuery({
+    queryKey: QUERY_KEYS.APPLICATIONS.BY_PROJECT_UID(projectUID),
+    queryFn: () => fetchApplicationByProjectUID(projectUID),
+    enabled: !!projectUID,
+  });
+
+  return {
+    application: applicationQuery.data,
+    isLoading: applicationQuery.isLoading,
+    error: applicationQuery.error,
+    refetch: applicationQuery.refetch,
+  };
+};

--- a/services/funding-applications.ts
+++ b/services/funding-applications.ts
@@ -1,0 +1,23 @@
+import { INDEXER } from "@/utilities/indexer";
+import { envVars } from "@/utilities/enviromentVars";
+import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
+import type { IFundingApplication } from "@/types/funding-platform";
+
+const API_URL = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
+const apiClient = createAuthenticatedApiClient(API_URL, 30000);
+
+export async function fetchApplicationByProjectUID(
+  projectUID: string
+): Promise<IFundingApplication | null> {
+  try {
+    const response = await apiClient.get<IFundingApplication>(
+      INDEXER.V2.APPLICATIONS.BY_PROJECT_UID(projectUID)
+    );
+    return response.data;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -41,6 +41,8 @@ export const INDEXER = {
         `/v2/projects/${projectIdOrSlug}/updates`,
     },
     APPLICATIONS: {
+      BY_PROJECT_UID: (projectUID: string) =>
+        `/v2/funding-applications/project/${projectUID}`,
       COMMENTS: (referenceNumber: string) =>
         `/v2/applications/${referenceNumber}/comments`,
     },

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -8,6 +8,8 @@ export const QUERY_KEYS = {
       ["project-grant-milestones", projectId, programId] as const,
   },
   APPLICATIONS: {
+    BY_PROJECT_UID: (projectUID: string) =>
+      ["application-by-project-uid", projectUID] as const,
     COMMENTS: (referenceNumber: string) =>
       ["application-comments", referenceNumber] as const,
   },


### PR DESCRIPTION
…686)

- Add useFundingApplicationByProjectUID hook to fetch applications by project UID
- Create funding-applications service with fetchApplicationByProjectUID function
- Update INDEXER constant with BY_PROJECT_UID endpoint
- Add query key for application-by-project-uid queries
- Update MilestonesReview to use project UID from data instead of extracting referenceNumber from milestones
- Memoize referenceNumber to prevent unnecessary re-renders

This change ensures the component uses the actual project UID (from useProjectGrantMilestones data) rather than relying on milestone data to get the reference number, which is more reliable when projectId prop might be a slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)