### PR TITLE
fix: filter some networks for project creation

### DIFF
--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -59,7 +59,7 @@ import type { Contact } from "@/types/project";
 import fetchData from "@/utilities/fetchData";
 import { gapIndexerApi } from "@/utilities/gapIndexerApi";
 import { INDEXER } from "@/utilities/indexer";
-import { appNetwork } from "@/utilities/network";
+import { gapSupportedNetworks } from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
 import { sanitizeObject } from "@/utilities/sanitize";
 import { getProjectById } from "@/utilities/sdk";
@@ -1604,7 +1604,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                 }}
                 onNetworkChange={handleNetworkChange}
                 isChangingNetwork={isChangingNetwork}
-                networks={appNetwork}
+                networks={gapSupportedNetworks}
                 previousValue={watch("chainID")}
               />
               <p className="text-red-500">{errors.chainID?.message}</p>

--- a/utilities/network.ts
+++ b/utilities/network.ts
@@ -50,6 +50,22 @@ const configuredNetworks = includeTestNetworks
 
 export const appNetwork = configuredNetworks as [Chain, ...Chain[]];
 
+
+/**
+ * Networks supported by GAP SDK for project creation.
+ * Filters out chains that are available for other features (e.g., donations)
+ * but cannot be used for creating projects/attestations.
+ */
+const gapUnsupportedChainIds: number[] = [
+  mainnet.id,
+  base.id,
+  polygon.id
+];
+
+export const gapSupportedNetworks = appNetwork.filter(
+  (chain) => !gapUnsupportedChainIds.includes(chain.id)
+) as [Chain, ...Chain[]];
+
 export function getExplorerUrl(chainId: number, transactionHash: string) {
   const chain = [
     mainnet,


### PR DESCRIPTION
## 📋 Overview

Filters out specific networks from project creation that are supported in the app for other features (e.g., donations) but cannot be used for creating projects/attestations via the GAP SDK.

This prevents users from attempting to create projects on unsupported chains, which would result in transaction failures.

## 🔄 Changes Made

### Bug Fixes
- **Network Filtering**: Added `gapSupportedNetworks` list that excludes Mainnet, Base, and Polygon from project creation
- **Project Dialog**: Updated `ProjectDialog` component to use `gapSupportedNetworks` instead of `appNetwork` for chain selection

### Code Quality
- **Documentation**: Added JSDoc comment explaining the purpose of the network filtering
- **Type Safety**: Maintained type-safe chain array structure with `[Chain, ...Chain[]]`

## 📊 Impact Analysis

### Affected Components
- **ProjectDialog** (`components/Dialogs/ProjectDialog/index.tsx`): Now uses filtered network list for project creation
- **Network Utilities** (`utilities/network.ts`): New exported constant `gapSupportedNetworks`
  
## 📐 Architecture

### Before
```
ProjectDialog
    ↓
uses appNetwork (all configured networks)
    ↓
Includes unsupported networks for project creation
```

### After
```
appNetwork (all networks) ──→ Used for donations, other features
         ↓
    filter out unsupported
         ↓
gapSupportedNetworks ──→ Used for project creation
         ↓
    ProjectDialog
```

## 📝 Notes for Reviewers

### Key Points
- The filtered networks list (`gapUnsupportedChainIds`) currently includes:
  - Mainnet (Ethereum) - ID: 1
  - Base - ID: 8453
  - Polygon - ID: 137

- `appNetwork` is intentionally kept unchanged to ensure other features (donations, etc.) continue to support all networks

### Questions for Review
1. Are there any other networks that should be excluded from project creation?
2. Should we add integration tests to verify the network filtering logic?
3. Consider adding a constant export for `gapUnsupportedChainIds` if needed elsewhere

## 🚀 Post-Merge Actions
- [ ] Monitor for any user reports about network availability
- [ ] Verify project creation analytics for supported networks
- [ ] Consider documenting supported networks in user-facing documentation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>