### PR TITLE
fix: auto-switch to supported network when GAP detects unsupported chain

### DIFF
--- a/hooks/useGap.ts
+++ b/hooks/useGap.ts
@@ -1,19 +1,20 @@
 "use client";
 
-import { GAP } from "@show-karma/karma-gap-sdk/core/class/GAP";
 import type { TNetwork } from "@show-karma/karma-gap-sdk";
-import { Networks } from "@show-karma/karma-gap-sdk/core/consts";
+import { GAP } from "@show-karma/karma-gap-sdk/core/class/GAP";
 import { GapIndexerClient } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/GapIndexerClient";
+import { IpfsStorage } from "@show-karma/karma-gap-sdk/core/class/remote-storage/IpfsStorage";
+import { Networks } from "@show-karma/karma-gap-sdk/core/consts";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useAccount } from "wagmi";
-
+import { useAccount, useSwitchChain } from "wagmi";
+import { ensureCorrectChain } from "@/utilities/ensureCorrectChain";
+import { envVars } from "@/utilities/enviromentVars";
 import {
   appNetwork,
+  gapSupportedNetworks,
   getChainIdByName,
   getChainNameById,
 } from "@/utilities/network";
-import { envVars } from "@/utilities/enviromentVars";
-import { IpfsStorage } from "@show-karma/karma-gap-sdk/core/class/remote-storage/IpfsStorage";
 
 const ipfsClient = new IpfsStorage({
   token: envVars.IPFS_TOKEN,
@@ -36,7 +37,7 @@ const getSupportedNetworkForChain = (chainID: number): TNetwork | null => {
 
 const findDefaultSupportedChainId = (): number | undefined => {
   const fallbackChain = appNetwork.find((chain) =>
-    isSupportedNetwork(getChainNameById(chain.id))
+    isSupportedNetwork(getChainNameById(chain.id)),
   );
   return fallbackChain?.id;
 };
@@ -72,18 +73,43 @@ export const getGapClient = (chainID: number): GAP => {
 
 export const useGap = () => {
   const [gap, setGapClient] = useState<GAP>();
+  const [isSwitching, setIsSwitching] = useState(false);
   const { chain } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
   const defaultSupportedChainId = useMemo(findDefaultSupportedChainId, []);
 
   const updateGapClient = useCallback(
-    (chainId: number) => {
+    async (chainId: number) => {
+      if (isSwitching) return;
+
       const network = getSupportedNetworkForChain(chainId);
+
       if (!network) {
-        console.warn(`GAP::Unsupported chain ${chainId}. GAP client disabled.`);
-        setGapClient(undefined);
+        // Unsupported chain - switch to first supported network
+        const firstSupportedChain = gapSupportedNetworks[0];
+        console.warn(
+          `GAP::Unsupported chain ${chainId}. Switching to ${firstSupportedChain.name}...`,
+        );
+
+        setIsSwitching(true);
+
+        const result = await ensureCorrectChain({
+          targetChainId: firstSupportedChain.id,
+          currentChainId: chainId,
+          switchChainAsync,
+        });
+
+        if (result.success && result.gapClient) {
+          setGapClient(result.gapClient);
+        } else {
+          setGapClient(undefined);
+        }
+
+        setIsSwitching(false);
         return;
       }
 
+      // Supported chain - normal flow
       const normalizedChainId = getChainIdByName(network);
 
       try {
@@ -94,7 +120,7 @@ export const useGap = () => {
         setGapClient(undefined);
       }
     },
-    []
+    [isSwitching, switchChainAsync],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## 📋 Overview

This PR fixes a critical issue where users connecting with wallets on unsupported GAP networks (e.g., mainnet, base, polygon) would experience app crashes across 30+ components. The solution automatically switches to the first supported GAP network when an unsupported chain is detected, preventing the gap client from being undefined during normal operations.

## 🔄 Changes Made

### Bug Fixes
- **Auto-switch to supported network**: When GAP detects an unsupported chain, automatically switch to the first network in `gapSupportedNetworks`
- **Prevent undefined gap client**: Ensures gap client is always defined during normal operations, preventing crashes in 30+ components
- **Infinite loop protection**: Added `isSwitching` guard to prevent recursive switching behavior

### Improvements
- **Better error handling**: Graceful fallback to undefined gap client only if switch fails
- **Async chain switching**: Refactored `updateGapClient` to be async for proper network switching flow

### Technical Changes
- Modified `useGap` hook to detect unsupported chains
- Added `useSwitchChain` hook from wagmi for network switching
- Integrated `ensureCorrectChain` utility for user-friendly switching experience
- Added `isSwitching` state to prevent concurrent switch attempts
- Updated dependency array to include `isSwitching` and `switchChainAsync`

## 📊 Impact Analysis

### Affected Components
- **useGap hook** (`hooks/useGap.ts`): Core hook used by 30+ components throughout the app
- **GAP client initialization**: Now includes automatic network switching logic
- **All components using GAP SDK**: No longer crash when user is on unsupported network

### Breaking Changes
- [x] No breaking changes
- Component API remains the same
- Behavior is now safer and more user-friendly

### Performance Impact
- [x] No performance impact
- Switch only occurs once when unsupported network detected
- Guard prevents infinite loops

## 🧪 Testing Steps

1. **Setup**
   ```bash
   cd gap-app-v2
   pnpm dev
   ```

2. **Verification - Unsupported Network**
   - Connect wallet to app
   - Switch wallet to mainnet (unsupported GAP network)
   - App should automatically prompt to switch to Optimism (first supported network)
   - Accept the switch
   - Verify no crashes occur
   - Verify GAP features work normally

3. **Verification - Supported Network**
   - Connect wallet to Optimism or Arbitrum
   - Verify no automatic switching occurs
   - Verify GAP features work normally

4. **Edge Cases**
   - User declines network switch → gap client should be undefined, app should not crash
   - User on unsupported network without wallet → should handle gracefully
   - Rapid network switching → `isSwitching` guard should prevent issues

## 🔧 Technical Details

### Before
```typescript
if (!network) {
  console.warn(`GAP::Unsupported chain ${chainId}. GAP client disabled.`);
  setGapClient(undefined); // This caused crashes
  return;
}
```

### After
```typescript
if (!network) {
  // Auto-switch to supported network
  const firstSupportedChain = gapSupportedNetworks[0];
  setIsSwitching(true);
  
  const result = await ensureCorrectChain({
    targetChainId: firstSupportedChain.id,
    currentChainId: chainId,
    switchChainAsync,
  });
  
  if (result.success && result.gapClient) {
    setGapClient(result.gapClient);
  } else {
    setGapClient(undefined); // Only undefined if switch failed
  }
  
  setIsSwitching(false);
  return;
}
```

## 🔗 Related Issues

- [Asana Task](https://app.asana.com/0/0/1211672247245886)

## 📝 Notes for Reviewers

- The `ensureCorrectChain` utility handles toast notifications and user feedback
- The `isSwitching` guard is critical to prevent infinite loops during async operations
- If user declines the switch, gap client will be undefined (expected behavior)
- This change makes the app significantly more resilient to network switching

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
