### PR TITLE
Feat: Add email notification configuration for post-approval forms

### DIFF
--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -21,6 +21,8 @@ import {
   CheckCircleIcon,
   UserGroupIcon,
   Bars3Icon,
+  PlusIcon,
+  XMarkIcon,
 } from "@heroicons/react/24/solid";
 import { MarkdownPreview } from "../Utilities/MarkdownPreview";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
@@ -129,6 +131,7 @@ export function QuestionBuilder({
   );
   const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
   const fieldRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+  const [newEmail, setNewEmail] = useState<string>("");
 
   // Helper to determine if we're working with post approval form
   const isPostApprovalMode = activeTab === "post-approval";
@@ -408,6 +411,60 @@ export function QuestionBuilder({
     }
   };
 
+  const handleAddEmail = () => {
+    try {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const trimmedEmail = newEmail.trim();
+
+      if (!trimmedEmail) {
+        toast.error("Please enter an email address.");
+        return;
+      }
+
+      if (!emailRegex.test(trimmedEmail)) {
+        toast.error("Please enter a valid email address.");
+        return;
+      }
+
+      const currentEmails = currentSchema.emailNotifications || [];
+      
+      if (currentEmails.includes(trimmedEmail)) {
+        toast.error("This email is already in the list.");
+        return;
+      }
+
+      setCurrentSchema((prev) => ({
+        ...prev,
+        emailNotifications: [...currentEmails, trimmedEmail],
+      }));
+      setNewEmail("");
+      toast.success("Email added successfully!");
+    } catch (error) {
+      errorManager("Failed to add email", error, { email: newEmail });
+      toast.error("Failed to add email. Please try again.");
+    }
+  };
+
+  const handleRemoveEmail = (index: number) => {
+    try {
+      setCurrentSchema((prev) => ({
+        ...prev,
+        emailNotifications: prev.emailNotifications?.filter((_email: string, i: number) => i !== index) || [],
+      }));
+      toast.success("Email removed successfully!");
+    } catch (error) {
+      errorManager("Failed to remove email", error, { index });
+      toast.error("Failed to remove email. Please try again.");
+    }
+  };
+
+  const handleEmailKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddEmail();
+    }
+  };
+
 
   return (
     <div
@@ -577,13 +634,128 @@ export function QuestionBuilder({
                           ))}
                         </div>
                       </SortableContext>
-                    </DndContext>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        ) : activeTab === "settings" ? (
+                     </DndContext>
+                   </>
+                 )}
+
+                 {/* Post Approval Email Notification Section - Only show in post-approval mode */}
+                 {isPostApprovalMode && (
+                   <div className="mt-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+                     <div className="flex items-start justify-between mb-4">
+                       <div>
+                         <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+                           Post Approval Email Notifications
+                         </h3>
+                         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                           Add email addresses that should receive notifications when post-approval forms are submitted.
+                         </p>
+                       </div>
+                     </div>
+
+                     {/* Email List */}
+                     {currentSchema.emailNotifications && currentSchema.emailNotifications.length > 0 && (
+                       <div className="space-y-2 mb-4">
+                         {currentSchema.emailNotifications.map((email, index) => (
+                           <div
+                             key={index}
+                             className="flex items-center justify-between bg-gray-50 dark:bg-gray-700 px-4 py-3 rounded-lg group hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                           >
+                             <div className="flex items-center gap-3">
+                               <div className="flex-shrink-0 w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
+                                 <svg
+                                   className="w-4 h-4 text-blue-600 dark:text-blue-400"
+                                   fill="none"
+                                   stroke="currentColor"
+                                   viewBox="0 0 24 24"
+                                 >
+                                   <path
+                                     strokeLinecap="round"
+                                     strokeLinejoin="round"
+                                     strokeWidth={2}
+                                     d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                                   />
+                                 </svg>
+                               </div>
+                               <span className="text-sm font-medium text-gray-900 dark:text-white">
+                                 {email}
+                               </span>
+                             </div>
+                             {!readOnly && (
+                               <button
+                                 type="button"
+                                 onClick={() => handleRemoveEmail(index)}
+                                 className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors opacity-0 group-hover:opacity-100"
+                                 aria-label={`Remove ${email}`}
+                               >
+                                 <XMarkIcon className="w-5 h-5" />
+                               </button>
+                             )}
+                           </div>
+                         ))}
+                       </div>
+                     )}
+
+                     {/* Empty state */}
+                     {(!currentSchema.emailNotifications || currentSchema.emailNotifications.length === 0) && (
+                       <div className="text-center py-8 mb-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
+                         <svg
+                           className="mx-auto h-12 w-12 text-gray-400"
+                           fill="none"
+                           stroke="currentColor"
+                           viewBox="0 0 24 24"
+                         >
+                           <path
+                             strokeLinecap="round"
+                             strokeLinejoin="round"
+                             strokeWidth={2}
+                             d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                           />
+                         </svg>
+                         <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                           No email addresses added yet
+                         </p>
+                       </div>
+                     )}
+
+                     {/* Add Email Input */}
+                     {!readOnly && (
+                       <div className="space-y-2">
+                         <label
+                           htmlFor="email-input"
+                           className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                         >
+                           Add Email Address
+                         </label>
+                         <div className="flex gap-2">
+                           <input
+                             id="email-input"
+                             type="email"
+                             value={newEmail}
+                             onChange={(e) => setNewEmail(e.target.value)}
+                             onKeyDown={handleEmailKeyDown}
+                             className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 dark:placeholder-gray-500"
+                             placeholder="Enter email address (e.g., admin@example.com)"
+                           />
+                           <Button
+                             type="button"
+                             onClick={handleAddEmail}
+                             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors flex items-center gap-2"
+                           >
+                             <PlusIcon className="w-5 h-5" />
+                             Add
+                           </Button>
+                         </div>
+                         <p className="text-xs text-gray-500 dark:text-gray-400">
+                           Press Enter or click Add to include the email address
+                         </p>
+                       </div>
+                     )}
+                   </div>
+                 )}
+               </div>
+             </div>
+           </div>
+         ) : activeTab === "settings" ? (
           <div className="h-full p-4 sm:p-6 lg:p-8 overflow-y-auto">
             <div className="max-w-4xl mx-auto">
               <SettingsConfiguration

--- a/types/question-builder.ts
+++ b/types/question-builder.ts
@@ -42,6 +42,8 @@ export interface FormSchema {
     enableRealTimeEvaluation?: boolean;
     langfusePromptId?: string;
   };
+  // Email addresses that should receive post-approval notifications (only for post-approval forms)
+  emailNotifications?: string[];
 }
 
 export interface FormSubmission {


### PR DESCRIPTION
## 🎯 Overview
Adds the ability for community admins to configure email addresses that should receive notifications when applicants submit post-approval forms.

## 📋 Changes

### Frontend (`gap-app-v2`)
- **New UI Section**: Added "Post Approval Email Notifications" section in the post-approval tab
- **Email Management**: 
  - Input field with "Add" button to add email addresses
  - List display with hover-to-remove functionality
  - Email format validation using regex
  - Duplicate prevention with user feedback
  - Empty state when no emails added
- **Type Updates**: Added `emailNotifications?: string[]` to `FormSchema` interface
- **UX Enhancements**:
  - Toast notifications for all actions (add/remove/errors)
  - Email icon indicators for better visual clarity
  - Enter key support for quick adding
  - Proper error handling with errorManager
  - Read-only mode support

### Backend (`gap-indexer`)
- **Type Updates**: Added `emailNotifications?: string[]` to `FormSchema` interface in domain models
- **Data Structure**: Moved `emailNotifications` to top level of FormSchema (outside settings) for better separation of concerns

## 🎨 UI/UX Features
- ✅ Completely optional (admins can leave it blank)
- ✅ Email format validation
- ✅ Duplicate prevention
- ✅ Individual email removal with hover interaction
- ✅ Empty state with helpful messaging
- ✅ Dark mode support
- ✅ Keyboard shortcuts (Enter to add)
- ✅ Toast notifications for user feedback

## 📊 Data Storage
Email addresses are stored at the top level of the post-approval form schema:
```json
{
  "postApprovalFormSchema": {
    "id": "...",
    "fields": [...],
    "settings": {...},
    "emailNotifications": ["admin@example.com", "manager@example.com"]
  }
}
```

## 🧪 Testing Notes
- Test adding valid email addresses
- Test adding invalid email formats (should show error)
- Test adding duplicate emails (should show error)
- Test removing emails
- Test saving form with and without emails
- Test read-only mode (should hide add/remove buttons)
- Test dark mode appearance

## 📸 Screenshots
<img width="1270" height="327" alt="image" src="https://github.com/user-attachments/assets/72616a09-0f89-4cca-b1f3-b2a65d0ccb44" />
<img width="1250" height="327" alt="image" src="https://github.com/user-attachments/assets/f8c268e2-55d9-47e0-80bc-5e38d138689a" />


## 🔗 Related
- Backend changes: N/A (API already accepts the field via passthrough)
- Follows architectural pattern similar to `aiConfig`