### PR TITLE
feat: add delete application UI with approved status restriction

### DIFF
--- a/__tests__/components/FundingPlatform/ApplicationView/DeleteApplicationModal.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/DeleteApplicationModal.test.tsx
@@ -1,0 +1,406 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DeleteApplicationModal from '@/components/FundingPlatform/ApplicationView/DeleteApplicationModal';
+
+// Mock Headless UI Dialog components
+jest.mock('@headlessui/react', () => {
+  const MockDialog = ({ children, ...props }: any) => <div data-testid="dialog" {...props}>{children}</div>;
+  MockDialog.Panel = ({ children, ...props }: any) => <div data-testid="dialog-panel" {...props}>{children}</div>;
+  MockDialog.Title = ({ children, as, ...props }: any) => {
+    const Component = as || 'h3';
+    return <Component {...props}>{children}</Component>;
+  };
+
+  const MockTransitionRoot = ({ show, children, as, ...props }: any) => {
+    if (!show) return null;
+    const Component = as || 'div';
+    return <Component {...props}>{children}</Component>;
+  };
+
+  const MockTransitionChild = ({ children, as, ...props }: any) => {
+    const Component = as || 'div';
+    return <Component {...props}>{children}</Component>;
+  };
+
+  return {
+    Dialog: MockDialog,
+    Transition: {
+      Root: MockTransitionRoot,
+      Child: MockTransitionChild
+    },
+    Fragment: ({ children }: any) => <>{children}</>
+  };
+});
+
+// Mock Heroicons
+jest.mock('@heroicons/react/24/outline', () => ({
+  XMarkIcon: (props: any) => <svg role="img" aria-label="Close" aria-hidden={props['aria-hidden']} {...props} data-testid="xmark-icon" />,
+  ExclamationTriangleIcon: (props: any) => <svg role="img" aria-hidden={props['aria-hidden']} {...props} data-testid="warning-icon" />
+}));
+
+// Mock Button component
+jest.mock('@/components/Utilities/Button', () => ({
+  Button: ({ onClick, disabled, children, className, variant }: any) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={className}
+      data-variant={variant}
+    >
+      {children}
+    </button>
+  )
+}));
+
+describe('DeleteApplicationModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    onConfirm: jest.fn(),
+    referenceNumber: 'APP-TEST-12345',
+    isDeleting: false
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render modal when isOpen is true', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Delete Application')).toBeInTheDocument();
+    });
+
+    it('should not render modal when isOpen is false', () => {
+      render(<DeleteApplicationModal {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should display warning message', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      expect(
+        screen.getByText(/are you sure you want to delete this application/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/this action cannot be undone/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/will be permanently deleted/i)
+      ).toBeInTheDocument();
+    });
+
+    it('should display the application reference number', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      expect(screen.getByText('Application Reference:')).toBeInTheDocument();
+      expect(screen.getByText('APP-TEST-12345')).toBeInTheDocument();
+    });
+
+    it('should display delete and cancel buttons', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should call onConfirm when delete button is clicked', () => {
+      const onConfirm = jest.fn();
+      render(<DeleteApplicationModal {...defaultProps} onConfirm={onConfirm} />);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      fireEvent.click(deleteButton);
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when cancel button is clicked', () => {
+      const onClose = jest.fn();
+      render(<DeleteApplicationModal {...defaultProps} onClose={onClose} />);
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when close icon is clicked', () => {
+      const onClose = jest.fn();
+      render(<DeleteApplicationModal {...defaultProps} onClose={onClose} />);
+
+      // Find the close button by its testid (parent button of the icon)
+      const closeIcon = screen.getByTestId('xmark-icon');
+      const closeButton = closeIcon.closest('button');
+
+      if (closeButton) {
+        fireEvent.click(closeButton);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      } else {
+        // Fallback: try clicking the icon directly
+        fireEvent.click(closeIcon.parentElement!);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('Deleting State', () => {
+    it('should disable buttons when isDeleting is true', () => {
+      render(<DeleteApplicationModal {...defaultProps} isDeleting={true} />);
+
+      const deleteButton = screen.getByRole('button', { name: /deleting.../i });
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+      expect(deleteButton).toBeDisabled();
+      expect(cancelButton).toBeDisabled();
+    });
+
+    it('should show "Deleting..." text when isDeleting is true', () => {
+      render(<DeleteApplicationModal {...defaultProps} isDeleting={true} />);
+
+      expect(screen.getByText('Deleting...')).toBeInTheDocument();
+      expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+
+    it('should prevent onClose from being called when isDeleting is true', () => {
+      const onClose = jest.fn();
+      render(<DeleteApplicationModal {...defaultProps} onClose={onClose} isDeleting={true} />);
+
+      const closeIcon = screen.getByTestId('xmark-icon');
+      const closeButton = closeIcon.closest('button');
+
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      }
+
+      // onClose should not be called when deleting
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('should not call onConfirm multiple times when delete button is clicked rapidly', () => {
+      const onConfirm = jest.fn();
+      const { rerender } = render(
+        <DeleteApplicationModal {...defaultProps} onConfirm={onConfirm} isDeleting={false} />
+      );
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+
+      // First click
+      fireEvent.click(deleteButton);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+
+      // Simulate the parent component setting isDeleting to true
+      rerender(
+        <DeleteApplicationModal {...defaultProps} onConfirm={onConfirm} isDeleting={true} />
+      );
+
+      // Try to click again while deleting
+      const deletingButton = screen.getByRole('button', { name: /deleting.../i });
+      fireEvent.click(deletingButton);
+
+      // Should still only be called once
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper ARIA labels', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      // Check that the close icon has proper aria-label
+      const closeIcon = screen.getByTestId('xmark-icon');
+      expect(closeIcon).toBeInTheDocument();
+    });
+
+    it('should have appropriate button colors for delete action', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+
+      // Check that delete button has red styling (danger color)
+      expect(deleteButton.className).toContain('bg-red-600');
+    });
+
+    it('should have secondary variant for cancel button', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+      // Check that cancel button has secondary variant
+      expect(cancelButton.getAttribute('data-variant')).toBe('secondary');
+    });
+
+    it('should display warning icon', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      // The ExclamationTriangleIcon should be present
+      const warningIcon = screen.getByTestId('warning-icon');
+      expect(warningIcon).toBeInTheDocument();
+    });
+  });
+
+  describe('Reference Number Display', () => {
+    it('should handle different reference number formats', () => {
+      const referenceNumbers = [
+        'APP-123',
+        'REF-TEST-456789',
+        'GRANT-2024-001',
+        '12345'
+      ];
+
+      referenceNumbers.forEach((refNum) => {
+        const { unmount } = render(
+          <DeleteApplicationModal {...defaultProps} referenceNumber={refNum} />
+        );
+
+        expect(screen.getByText(refNum)).toBeInTheDocument();
+
+        unmount();
+      });
+    });
+
+    it('should display reference number in monospace font', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      const refNumber = screen.getByText('APP-TEST-12345');
+
+      // Check that reference number has monospace font class
+      expect(refNumber.className).toContain('font-mono');
+    });
+  });
+
+  describe('Modal Behavior', () => {
+    it('should prevent modal from closing during deletion', () => {
+      const onClose = jest.fn();
+      render(
+        <DeleteApplicationModal
+          {...defaultProps}
+          onClose={onClose}
+          isDeleting={true}
+        />
+      );
+
+      // Try to close by clicking the close button
+      const closeIcon = screen.getByTestId('xmark-icon');
+      const closeButton = closeIcon.closest('button');
+
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      }
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('should allow modal to close when not deleting', () => {
+      const onClose = jest.fn();
+      render(
+        <DeleteApplicationModal
+          {...defaultProps}
+          onClose={onClose}
+          isDeleting={false}
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      fireEvent.click(cancelButton);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty reference number gracefully', () => {
+      render(<DeleteApplicationModal {...defaultProps} referenceNumber="" />);
+
+      expect(screen.getByText('Application Reference:')).toBeInTheDocument();
+      // Empty reference number should still be in the document (empty text node)
+    });
+
+    it('should handle very long reference numbers', () => {
+      const longRefNumber = 'APP-' + 'X'.repeat(100);
+      render(<DeleteApplicationModal {...defaultProps} referenceNumber={longRefNumber} />);
+
+      expect(screen.getByText(longRefNumber)).toBeInTheDocument();
+    });
+
+    it('should not crash when callbacks are undefined', () => {
+      const { container } = render(
+        <DeleteApplicationModal
+          isOpen={true}
+          onClose={undefined as any}
+          onConfirm={undefined as any}
+          referenceNumber="TEST-123"
+        />
+      );
+
+      expect(container).toBeInTheDocument();
+    });
+  });
+
+  describe('Dark Mode Support', () => {
+    it('should have dark mode classes', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      // Check for dark mode classes in various elements
+      const dialog = screen.getByTestId('dialog');
+      const htmlContent = dialog.innerHTML;
+
+      // Should contain dark mode styling classes
+      expect(htmlContent).toContain('dark:bg-zinc-800');
+      expect(htmlContent).toContain('dark:text-white');
+      expect(htmlContent).toContain('dark:bg-zinc-900');
+    });
+  });
+
+  describe('Button States', () => {
+    it('should enable buttons in normal state', () => {
+      render(<DeleteApplicationModal {...defaultProps} isDeleting={false} />);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+      expect(deleteButton).not.toBeDisabled();
+      expect(cancelButton).not.toBeDisabled();
+    });
+
+    it('should maintain button state consistency', () => {
+      const { rerender } = render(
+        <DeleteApplicationModal {...defaultProps} isDeleting={false} />
+      );
+
+      let deleteButton = screen.getByRole('button', { name: /delete/i });
+      expect(deleteButton).not.toBeDisabled();
+
+      // Change to deleting state
+      rerender(<DeleteApplicationModal {...defaultProps} isDeleting={true} />);
+
+      deleteButton = screen.getByRole('button', { name: /deleting.../i });
+      expect(deleteButton).toBeDisabled();
+
+      // Change back to normal state
+      rerender(<DeleteApplicationModal {...defaultProps} isDeleting={false} />);
+
+      deleteButton = screen.getByRole('button', { name: /delete/i });
+      expect(deleteButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Warning Message Content', () => {
+    it('should emphasize the permanent nature of deletion', () => {
+      render(<DeleteApplicationModal {...defaultProps} />);
+
+      // Check for key warning phrases
+      const warningText = screen.getByText(/are you sure you want to delete this application/i);
+      expect(warningText).toBeInTheDocument();
+
+      const permanentText = screen.getByText(/permanently deleted/i);
+      expect(permanentText).toBeInTheDocument();
+
+      const cannotUndoText = screen.getByText(/cannot be undone/i);
+      expect(cannotUndoText).toBeInTheDocument();
+    });
+  });
+});

--- a/components/FundingPlatform/ApplicationView/DeleteApplicationModal.tsx
+++ b/components/FundingPlatform/ApplicationView/DeleteApplicationModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { FC, Fragment } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { XMarkIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Button } from "@/components/Utilities/Button";
+
+interface DeleteApplicationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  referenceNumber: string;
+  isDeleting?: boolean;
+}
+
+const DeleteApplicationModal: FC<DeleteApplicationModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  referenceNumber,
+  isDeleting = false,
+}) => {
+  const handleClose = () => {
+    if (!isDeleting) {
+      onClose();
+    }
+  };
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 dark:bg-gray-900 bg-opacity-75 dark:bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white dark:bg-zinc-800 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
+                  <button
+                    type="button"
+                    className="rounded-md bg-white dark:bg-zinc-800 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    onClick={handleClose}
+                    disabled={isDeleting}
+                  >
+                    <span className="sr-only">Close</span>
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                  </button>
+                </div>
+                <div className="sm:flex sm:items-start">
+                  <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20 sm:mx-0 sm:h-10 sm:w-10">
+                    <ExclamationTriangleIcon
+                      className="h-6 w-6 text-red-600 dark:text-red-400"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-lg font-semibold leading-6 text-gray-900 dark:text-white"
+                    >
+                      Delete Application
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Are you sure you want to delete this application? This
+                        action cannot be undone and the application will be
+                        permanently deleted.
+                      </p>
+                      <div className="mt-3 rounded-md bg-gray-50 dark:bg-zinc-900 px-3 py-2">
+                        <p className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                          Application Reference:
+                        </p>
+                        <p className="text-sm font-mono text-gray-900 dark:text-white">
+                          {referenceNumber}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse gap-2">
+                  <Button
+                    onClick={onConfirm}
+                    disabled={isDeleting}
+                    className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:w-auto"
+                  >
+                    {isDeleting ? "Deleting..." : "Delete"}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={handleClose}
+                    disabled={isDeleting}
+                    className="mt-3 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm sm:mt-0 sm:w-auto"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};
+
+export default DeleteApplicationModal;

--- a/services/funding-applications.ts
+++ b/services/funding-applications.ts
@@ -21,3 +21,21 @@ export async function fetchApplicationByProjectUID(
     throw error;
   }
 }
+
+export async function deleteApplication(
+  referenceNumber: string
+): Promise<void> {
+  try {
+    await apiClient.delete(INDEXER.V2.APPLICATIONS.DELETE(referenceNumber));
+  } catch (error: any) {
+    // Log error with context before re-throwing for hook to handle
+    console.error('Service layer: Failed to delete application', {
+      referenceNumber,
+      status: error?.response?.status,
+      statusText: error?.response?.statusText,
+      errorMessage: error?.response?.data?.message || error?.message,
+      timestamp: new Date().toISOString()
+    });
+    throw error;
+  }
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -45,6 +45,8 @@ export const INDEXER = {
         `/v2/funding-applications/project/${projectUID}`,
       COMMENTS: (referenceNumber: string) =>
         `/v2/applications/${referenceNumber}/comments`,
+      DELETE: (referenceNumber: string) =>
+        `/v2/funding-applications/${referenceNumber}`,
     },
   },
   PROGRAMS: {


### PR DESCRIPTION
## Summary

Implements frontend UI for community administrators to delete funding applications, with validation to hide the delete button for approved applications.

## Changes

- ✅ Add delete button to application detail page (community admin only)
- ✅ Create `DeleteApplicationModal` component with warning and confirmation
- ✅ Implement `useDeleteApplication` hook with React Query mutations
- ✅ Add status-specific error messages (401/403/404/500/network) using errorManager
- ✅ Hide delete button for approved applications
- ✅ Modal stays open on error to allow retry
- ✅ Proper query cache invalidation after deletion
- ✅ Add `deleteApplication` service function
- ✅ Add DELETE endpoint constant to indexer utilities

## UI/UX

- Delete button only visible to community admins
- Delete button hidden for approved applications
- Confirmation modal with warning message
- Shows application reference number in modal
- Modal prevents closing during deletion
- Clear error messages for different failure scenarios
- Automatic navigation after successful deletion

## Validation

- ✅ Linter passing
- ✅ TypeScript compilation successful
- ✅ No new lint warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211737064587940