### PR TITLE
fix: Set not being converted to Boolean but probably object

### DIFF
--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -150,7 +150,7 @@ export const ReportMilestonePage = ({
     return allowedSet.size > 0 ? allowedSet : null;
   }, [isAdmin, isContractOwner, reviewerPrograms, communityId]);
 
-  const isAuthorized = isConnected && isAuth && (isAdmin || isContractOwner || (allowedProgramIds && allowedProgramIds.size > 0));
+  const isAuthorized = Boolean(isConnected && isAuth && (isAdmin || isContractOwner || (allowedProgramIds && allowedProgramIds.size > 0)));
 
   const [currentPage, setCurrentPage] = useState(1);
   const [sortBy, setSortBy] = useState("totalMilestones");

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -150,7 +150,19 @@ export const ReportMilestonePage = ({
     return allowedSet.size > 0 ? allowedSet : null;
   }, [isAdmin, isContractOwner, reviewerPrograms, communityId]);
 
-  const isAuthorized = Boolean(isConnected && isAuth && (isAdmin || isContractOwner || (allowedProgramIds && allowedProgramIds.size > 0)));
+  const isAuthorized = useMemo(() => {
+    if (!isConnected || !isAuth) {
+      return false;
+    }
+
+    // Admins and contract owners have full access
+    if (isAdmin || isContractOwner) {
+      return true;
+    }
+
+    // Milestone reviewers have access if they have programs assigned
+    return allowedProgramIds !== null && allowedProgramIds.size > 0;
+  }, [isConnected, isAuth, isAdmin, isContractOwner, allowedProgramIds]);
 
   const [currentPage, setCurrentPage] = useState(1);
   const [sortBy, setSortBy] = useState("totalMilestones");


### PR DESCRIPTION
Summary

  - Fixed React Query error "Expected enabled to be a boolean or a callback that returns a boolean" in the Milestone Report page
  - Refactored isAuthorized logic to be more maintainable and properly memoized

  Problem

  The isAuthorized variable was using a complex inline expression that could evaluate to non-boolean values (specifically a Set object), causing React Query's enabled option to throw an error. The logic was also difficult to read and maintain.

  Solution

  - Wrapped isAuthorized in useMemo to prevent unnecessary recalculations
  - Restructured the authorization logic with explicit conditional checks:
    - Early return false if not connected or authenticated
    - Return true for admins and contract owners
    - Return proper boolean for milestone reviewers based on program assignments
  - Ensured the value is always a boolean, never a truthy object

  Test Plan

  - Verify milestone report page loads without errors for community admins
  - Verify milestone report page loads for milestone reviewers with assigned programs
  - Verify unauthorized users see the "not authorized" message
  - Verify the query is properly enabled/disabled based on authorization status

  🤖 Generated with https://claude.com/claude-code