### PR TITLE
feat: add custom not-found page for non-existent communities

### DIFF
--- a/app/community/[communityId]/layout.tsx
+++ b/app/community/[communityId]/layout.tsx
@@ -7,6 +7,7 @@ import { getCommunityDetailsV2 } from "@/utilities/queries/getCommunityDataV2";
 import { Metadata } from "next";
 import { CommunityImpactStatCards } from "@/components/Pages/Communities/Impact/StatCards";
 import CommunityHeader from "@/components/Community/Header";
+import { CommunityNotFound } from "@/components/Pages/Communities/CommunityNotFound";
 
 type Params = Promise<{
   communityId: string;
@@ -68,7 +69,7 @@ export default async function Layout(props: {
   const community = await getCommunityDetailsV2(communityId);
 
   if (!community) {
-    return undefined;
+    return <CommunityNotFound communityId={communityId} />;
   }
 
   return (

--- a/app/community/[communityId]/page.tsx
+++ b/app/community/[communityId]/page.tsx
@@ -31,6 +31,11 @@ export default async function Page(props: Props) {
     getCommunityProjectsV2(communityId, { page: 1, limit: 12 }),
   ]);
 
+  // Layout handles notFound, but TypeScript needs this check
+  if (!communityDetails) {
+    return null;
+  }
+
   const defaultSortBy = "milestones" as SortByOptions;
   const defaultSelectedCategories: string[] = [];
   const defaultSelectedMaturityStage = "all" as MaturityStageOptions;

--- a/components/Pages/Communities/CommunityNotFound.tsx
+++ b/components/Pages/Communities/CommunityNotFound.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+
+interface CommunityNotFoundProps {
+  communityId: string;
+}
+
+export const CommunityNotFound: React.FC<CommunityNotFoundProps> = ({
+  communityId,
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4 py-12">
+      <div className="flex flex-col items-center gap-6 max-w-2xl text-center">
+        <h1 className="text-4xl sm:text-5xl font-bold text-black dark:text-white">
+          Create {communityId} community
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400">
+          This community does not exist yet. Be the first to create it and start
+          building a transparent, accountable ecosystem for grants and impact
+          measurement.
+        </p>
+        <Link
+          href="https://tally.so/r/wd0jeq"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <button
+            type="button"
+            className="bg-primary-500 text-white font-bold rounded-sm px-6 py-3 text-lg hover:bg-primary-600 transition-colors"
+          >
+            Create Community
+          </button>
+        </Link>
+        <Link
+          href="/communities"
+          className="text-primary-500 hover:text-primary-600 font-medium transition-colors"
+        >
+          ← Browse existing communities
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/hooks/useAggregatedIndicators.ts
+++ b/hooks/useAggregatedIndicators.ts
@@ -39,16 +39,20 @@ export function useAggregatedIndicators(
 
   const queryFn = async (): Promise<AggregatedIndicator[]> => {
     if (!indicatorIds.length) return [];
-    
+
     // First get the community details to obtain the UID
     const communityDetails = await getCommunityDetailsV2(communityId as string);
-    
+
+    if (!communityDetails) {
+      return [];
+    }
+
     // Calculate date range based on selected timeframe
     const startDateObj = new Date();
     startDateObj.setMonth(startDateObj.getMonth() - timeframeMonths);
     const startDate = startDateObj.toISOString();
     const endDate = new Date().toISOString();
-    
+
     // Call the new aggregated indicators endpoint
     const [data, error] = await fetchData(
       INDEXER.COMMUNITY.V2.INDICATORS.AGGREGATED(
@@ -60,7 +64,7 @@ export function useAggregatedIndicators(
         endDate
       )
     );
-    
+
     if (error) {
       throw error;
     }

--- a/utilities/queries/getCommunityDataV2.ts
+++ b/utilities/queries/getCommunityDataV2.ts
@@ -1,5 +1,4 @@
 import { cache } from "react";
-import { notFound } from "next/navigation";
 import { CommunityDetailsV2, CommunityStatsV2, CommunityProjectsV2Response } from "@/types/community";
 import { SortByOptions, StatusOptions } from "@/types/filters";
 import fetchData from "@/utilities/fetchData";
@@ -7,20 +6,20 @@ import { zeroUID } from "@/utilities/commons";
 import { INDEXER } from "@/utilities/indexer";
 
 export const getCommunityDetailsV2 = cache(
-  async (slug: string): Promise<CommunityDetailsV2> => {
+  async (slug: string): Promise<CommunityDetailsV2 | null> => {
     try {
       const [data] = await fetchData(
         INDEXER.COMMUNITY.V2.GET(slug)
       );
 
       if (!data || data?.uid === zeroUID || !data?.details?.name) {
-        notFound();
+        return null;
       }
-      
+
       return data as CommunityDetailsV2;
     } catch (error) {
       console.log("Not found community", slug, error);
-      notFound();
+      return null;
     }
   }
 );

--- a/utilities/registry/getProgramsImpact.ts
+++ b/utilities/registry/getProgramsImpact.ts
@@ -14,7 +14,18 @@ export async function getProgramsImpact(
   try {
     // First get the community details to obtain the UID
     const communityDetails = await getCommunityDetailsV2(communityId);
-    
+
+    if (!communityDetails) {
+      return {
+        data: [],
+        stats: {
+          totalCategories: 0,
+          totalProjects: 0,
+          totalFundingAllocated: "0",
+        },
+      };
+    }
+
     // Use the new V2 impact-segments endpoint with community UID
     const [data, error] = await fetchData(
       INDEXER.COMMUNITY.V2.IMPACT_SEGMENTS(communityDetails.uid)


### PR DESCRIPTION
## Summary

Replaces the generic 404 error page with a custom "Create Community" page when users try to access a non-existent community via `/community/[communityId]`.

## Problem

Previously, when a user attempted to reach a community page that doesn't exist (e.g., `/community/my-new-dao`), they would see a generic 404 page, which provided a poor user experience and didn't guide them toward creating the community.

## Solution

When users now visit `/community/[communityId]` for a non-existent community, they see a friendly custom page that:

- Displays "Create **{communityId}** community" as the heading (showing the actual community name they tried to access)
- Shows a welcoming message explaining the community doesn't exist yet
- Provides a prominent "Create Community" button linking to the Tally form
- Includes a secondary link to browse existing communities

### Screenshot

The new page shows:
```
Create my-new-dao community

This community does not exist yet. Be the first to create it and start
building a transparent, accountable ecosystem for grants and impact
measurement.

[Create Community Button]

← Browse existing communities
```

## Technical Changes

- **`utilities/queries/getCommunityDataV2.ts`**: Modified `getCommunityDetailsV2()` to return `null` instead of throwing `notFound()` when a community doesn't exist
- **`app/community/[communityId]/layout.tsx`**: Updated to render `CommunityNotFound` component when `getCommunityDetailsV2()` returns `null`
- **`components/Pages/Communities/CommunityNotFound.tsx`**: New component that displays the custom not-found page with create community CTA
- **Null safety**: Added null checks in `page.tsx`, `useAggregatedIndicators.ts`, and `getProgramsImpact.ts` to handle cases where community details might be null

## Testing

To test:
1. Navigate to `/community/some-non-existent-community`
2. Verify the custom "Create {communityId} community" page appears
3. Verify the "Create Community" button links to https://tally.so/r/wd0jeq
4. Verify the "Browse existing communities" link navigates to `/communities`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206158986373344