### PR TITLE
fix: display milestone completion section when only completionDeliverables is set

### DIFF
--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -429,11 +429,18 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
           }
         />
       </div>
-      {isCompleting || isEditing || completionReason || completionProof ? (
-        <div className="flex flex-col w-full pl-8 md:pl-[120px]">
-          {renderMilestoneCompletion()}
-        </div>
-      ) : null}
+      {
+        isCompleting ||
+        isEditing ||
+        completionReason ||
+        completionProof ||
+        completionDeliverables ?
+        (
+          <div className="flex flex-col w-full pl-8 md:pl-[120px]">
+            {renderMilestoneCompletion()}
+          </div>
+        ) : null
+      }
     </div>
   );
 };


### PR DESCRIPTION
Previously, the ActivityCard MilestoneCard only showed the completion section when completionReason or completionProof were present. This caused updates with only completionDeliverables to not be displayed. Now includes completionDeliverables in the visibility check to ensure all milestone completion data is shown.