### PR TITLE
fix: redirect community slugs with forbidden characters

### DIFF
--- a/utilities/sanitize.ts
+++ b/utilities/sanitize.ts
@@ -1,3 +1,5 @@
+import { cache } from "react";
+
 export function sanitizeInput<T>(input: T): T {
   if (typeof input === "string") {
     return input.trim() as T;
@@ -25,4 +27,23 @@ export function sanitizeObject(obj: any): any {
   }
 
   return sanitizedObj;
+}
+
+/**
+ * Sanitizes a community slug by removing characters that could cause routing issues
+ * Removes trailing commas, periods, and other special characters that aren't part of valid slugs
+ * @param slug The community slug to sanitize
+ * @returns The sanitized slug
+ */
+export function sanitizeCommunitySlug(slug: string): string {
+  return slug.replace(/[,.\s]+$/g, "").trim();
+}
+
+/**
+ * Checks if a community slug contains forbidden characters and needs sanitization
+ * @param slug The community slug to check
+ * @returns True if the slug contains forbidden trailing characters
+ */
+export function hasForbiddenChars(slug: string): boolean {
+  return /[,.\s]+$/.test(slug);
 }


### PR DESCRIPTION
## Summary

Fixes an issue where community URLs with trailing forbidden characters (commas, periods, spaces) would result in 404 errors instead of properly loading the community page.

## Changes

- Added `sanitizeCommunitySlug()` function to remove trailing forbidden characters from slugs
- Added `hasForbiddenChars()` function to detect slugs that need sanitization
- Implemented middleware redirect logic for `/community/*` paths with forbidden characters
- Redirects preserve sub-paths (e.g., `/community/celo,/grants` → `/community/celo/grants`)

## Example

**Before:**
- User visits `/community/celo,` → 404 Community Not Found

**After:**
- User visits `/community/celo,` → Automatically redirects to `/community/celo` → Community loads successfully

## Technical Details

The redirect is handled in middleware rather than in the layout component because:
1. Middleware runs before page rendering (better performance)
2. Redirects work consistently at the request level
3. Prevents wasted rendering cycles for invalid URLs

## Test Plan

- [x] Visit `/community/celo,` - should redirect to `/community/celo`
- [x] Visit `/community/optimism.` - should redirect to `/community/optimism`
- [x] Visit `/community/arbitrum,/grants` - should redirect to `/community/arbitrum/grants`
- [x] Visit valid community URLs - should load normally without redirect
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)