### PR TITLE
fix: resolve TypeScript case-sensitivity errors for UI component imports

### DIFF
--- a/__tests__/components/Badge.test.tsx
+++ b/__tests__/components/Badge.test.tsx
@@ -1,29 +1,29 @@
-import { render, screen } from '@testing-library/react';
-import { Badge } from '@/components/UI/badge';
-import '@testing-library/jest-dom';
+import { render, screen } from "@testing-library/react";
+import { Badge } from "../../components/UI/badge";
+import "@testing-library/jest-dom";
 
-describe('Badge', () => {
-  describe('Rendering', () => {
-    it('should render badge element', () => {
+describe("Badge", () => {
+  describe("Rendering", () => {
+    it("should render badge element", () => {
       render(<Badge>Test Badge</Badge>);
 
-      expect(screen.getByText('Test Badge')).toBeInTheDocument();
+      expect(screen.getByText("Test Badge")).toBeInTheDocument();
     });
 
-    it('should render as div element', () => {
+    it("should render as div element", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge.tagName).toBe('DIV');
+      const badge = screen.getByText("Badge");
+      expect(badge.tagName).toBe("DIV");
     });
 
-    it('should render children text', () => {
+    it("should render children text", () => {
       render(<Badge>Status: Active</Badge>);
 
-      expect(screen.getByText('Status: Active')).toBeInTheDocument();
+      expect(screen.getByText("Status: Active")).toBeInTheDocument();
     });
 
-    it('should render with JSX children', () => {
+    it("should render with JSX children", () => {
       render(
         <Badge>
           <span>Icon</span>
@@ -31,247 +31,254 @@ describe('Badge', () => {
         </Badge>
       );
 
-      expect(screen.getByText('Icon')).toBeInTheDocument();
-      expect(screen.getByText('Label')).toBeInTheDocument();
+      expect(screen.getByText("Icon")).toBeInTheDocument();
+      expect(screen.getByText("Label")).toBeInTheDocument();
     });
   });
 
-  describe('Base Styling', () => {
-    it('should have inline-flex display', () => {
+  describe("Base Styling", () => {
+    it("should have inline-flex display", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('inline-flex');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("inline-flex");
     });
 
-    it('should have items-center alignment', () => {
+    it("should have items-center alignment", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('items-center');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("items-center");
     });
 
-    it('should have rounded corners', () => {
+    it("should have rounded corners", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('rounded-md');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("rounded-md");
     });
 
-    it('should have border', () => {
+    it("should have border", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('border');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("border");
     });
 
-    it('should have proper padding', () => {
+    it("should have proper padding", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('px-2.5', 'py-0.5');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("px-2.5", "py-0.5");
     });
 
-    it('should have small text size', () => {
+    it("should have small text size", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('text-xs');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("text-xs");
     });
 
-    it('should have semibold font weight', () => {
+    it("should have semibold font weight", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('font-semibold');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("font-semibold");
     });
 
-    it('should have transition-colors', () => {
+    it("should have transition-colors", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('transition-colors');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("transition-colors");
     });
   });
 
-  describe('Variants', () => {
-    it('should apply default variant by default', () => {
+  describe("Variants", () => {
+    it("should apply default variant by default", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('bg-primary', 'text-primary-foreground');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("bg-primary", "text-primary-foreground");
     });
 
-    it('should apply default variant explicitly', () => {
+    it("should apply default variant explicitly", () => {
       render(<Badge variant="default">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('bg-primary', 'text-primary-foreground');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("bg-primary", "text-primary-foreground");
     });
 
-    it('should apply secondary variant', () => {
+    it("should apply secondary variant", () => {
       render(<Badge variant="secondary">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('bg-secondary', 'text-secondary-foreground');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("bg-secondary", "text-secondary-foreground");
     });
 
-    it('should apply destructive variant', () => {
+    it("should apply destructive variant", () => {
       render(<Badge variant="destructive">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('bg-destructive', 'text-destructive-foreground');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass(
+        "bg-destructive",
+        "text-destructive-foreground"
+      );
     });
 
-    it('should apply outline variant', () => {
+    it("should apply outline variant", () => {
       render(<Badge variant="outline">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('text-foreground');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("text-foreground");
     });
   });
 
-  describe('Variant Styling', () => {
-    it('should have shadow on default variant', () => {
+  describe("Variant Styling", () => {
+    it("should have shadow on default variant", () => {
       render(<Badge variant="default">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('shadow');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("shadow");
     });
 
-    it('should have hover effect on default variant', () => {
+    it("should have hover effect on default variant", () => {
       render(<Badge variant="default">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('hover:bg-primary/80');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("hover:bg-primary/80");
     });
 
-    it('should have hover effect on secondary variant', () => {
+    it("should have hover effect on secondary variant", () => {
       render(<Badge variant="secondary">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('hover:bg-secondary/80');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("hover:bg-secondary/80");
     });
 
-    it('should have transparent border on default variant', () => {
+    it("should have transparent border on default variant", () => {
       render(<Badge variant="default">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('border-transparent');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("border-transparent");
     });
 
-    it('should have shadow on destructive variant', () => {
+    it("should have shadow on destructive variant", () => {
       render(<Badge variant="destructive">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('shadow');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("shadow");
     });
   });
 
-  describe('Custom ClassName', () => {
-    it('should accept custom className', () => {
+  describe("Custom ClassName", () => {
+    it("should accept custom className", () => {
       render(<Badge className="custom-class">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('custom-class');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("custom-class");
     });
 
-    it('should combine custom className with variant classes', () => {
-      render(<Badge variant="secondary" className="ml-2">Badge</Badge>);
+    it("should combine custom className with variant classes", () => {
+      render(
+        <Badge variant="secondary" className="ml-2">
+          Badge
+        </Badge>
+      );
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('bg-secondary', 'ml-2');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("bg-secondary", "ml-2");
     });
 
-    it('should allow multiple custom classes', () => {
+    it("should allow multiple custom classes", () => {
       render(<Badge className="mt-4 ml-2 custom">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('mt-4', 'ml-2', 'custom');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("mt-4", "ml-2", "custom");
     });
   });
 
-  describe('HTML Attributes', () => {
-    it('should accept data attributes', () => {
+  describe("HTML Attributes", () => {
+    it("should accept data attributes", () => {
       render(<Badge data-testid="custom-badge">Badge</Badge>);
 
-      expect(screen.getByTestId('custom-badge')).toBeInTheDocument();
+      expect(screen.getByTestId("custom-badge")).toBeInTheDocument();
     });
 
-    it('should accept id attribute', () => {
+    it("should accept id attribute", () => {
       render(<Badge id="badge-id">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveAttribute('id', 'badge-id');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveAttribute("id", "badge-id");
     });
 
-    it('should accept aria-label attribute', () => {
+    it("should accept aria-label attribute", () => {
       render(<Badge aria-label="Status badge">Badge</Badge>);
 
-      expect(screen.getByLabelText('Status badge')).toBeInTheDocument();
+      expect(screen.getByLabelText("Status badge")).toBeInTheDocument();
     });
 
-    it('should accept title attribute', () => {
+    it("should accept title attribute", () => {
       render(<Badge title="Badge tooltip">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveAttribute('title', 'Badge tooltip');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveAttribute("title", "Badge tooltip");
     });
   });
 
-  describe('Focus Styling', () => {
-    it('should have focus outline', () => {
+  describe("Focus Styling", () => {
+    it("should have focus outline", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('focus:outline-none');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("focus:outline-none");
     });
 
-    it('should have focus ring', () => {
+    it("should have focus ring", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('focus:ring-2', 'focus:ring-ring');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("focus:ring-2", "focus:ring-ring");
     });
 
-    it('should have focus ring offset', () => {
+    it("should have focus ring offset", () => {
       render(<Badge>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveClass('focus:ring-offset-2');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveClass("focus:ring-offset-2");
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should render with empty children', () => {
+  describe("Edge Cases", () => {
+    it("should render with empty children", () => {
       const { container } = render(<Badge />);
 
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(container.querySelector("div")).toBeInTheDocument();
     });
 
-    it('should render with numeric children', () => {
+    it("should render with numeric children", () => {
       render(<Badge>{5}</Badge>);
 
-      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
     });
 
-    it('should handle long text content', () => {
-      const longText = 'This is a very long badge text that might wrap';
+    it("should handle long text content", () => {
+      const longText = "This is a very long badge text that might wrap";
 
       render(<Badge>{longText}</Badge>);
 
       expect(screen.getByText(longText)).toBeInTheDocument();
     });
 
-    it('should handle special characters', () => {
+    it("should handle special characters", () => {
       render(<Badge>Status: ✓</Badge>);
 
-      expect(screen.getByText('Status: ✓')).toBeInTheDocument();
+      expect(screen.getByText("Status: ✓")).toBeInTheDocument();
     });
   });
 
-  describe('Multiple Badges', () => {
-    it('should render multiple badges independently', () => {
+  describe("Multiple Badges", () => {
+    it("should render multiple badges independently", () => {
       render(
         <>
           <Badge variant="default">Badge 1</Badge>
@@ -280,12 +287,12 @@ describe('Badge', () => {
         </>
       );
 
-      expect(screen.getByText('Badge 1')).toBeInTheDocument();
-      expect(screen.getByText('Badge 2')).toBeInTheDocument();
-      expect(screen.getByText('Badge 3')).toBeInTheDocument();
+      expect(screen.getByText("Badge 1")).toBeInTheDocument();
+      expect(screen.getByText("Badge 2")).toBeInTheDocument();
+      expect(screen.getByText("Badge 3")).toBeInTheDocument();
     });
 
-    it('should maintain independent styling for each badge', () => {
+    it("should maintain independent styling for each badge", () => {
       const { container } = render(
         <>
           <Badge variant="default">Default</Badge>
@@ -293,48 +300,48 @@ describe('Badge', () => {
         </>
       );
 
-      const badges = container.querySelectorAll('div');
-      expect(badges[0]).toHaveClass('bg-primary');
-      expect(badges[1]).toHaveClass('text-foreground');
+      const badges = container.querySelectorAll("div");
+      expect(badges[0]).toHaveClass("bg-primary");
+      expect(badges[1]).toHaveClass("text-foreground");
     });
   });
 
-  describe('Event Handlers', () => {
-    it('should accept onClick handler', () => {
+  describe("Event Handlers", () => {
+    it("should accept onClick handler", () => {
       const handleClick = jest.fn();
 
       render(<Badge onClick={handleClick}>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
+      const badge = screen.getByText("Badge");
       badge.click();
 
       expect(handleClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should accept onMouseEnter handler', () => {
+    it("should accept onMouseEnter handler", () => {
       const handleMouseEnter = jest.fn();
 
       render(<Badge onMouseEnter={handleMouseEnter}>Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      require('@testing-library/react').fireEvent.mouseEnter(badge);
+      const badge = screen.getByText("Badge");
+      require("@testing-library/react").fireEvent.mouseEnter(badge);
 
       expect(handleMouseEnter).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('Accessibility', () => {
-    it('should be accessible with proper role', () => {
+  describe("Accessibility", () => {
+    it("should be accessible with proper role", () => {
       render(<Badge role="status">Active</Badge>);
 
-      expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
     });
 
-    it('should support aria-describedby', () => {
+    it("should support aria-describedby", () => {
       render(<Badge aria-describedby="badge-desc">Badge</Badge>);
 
-      const badge = screen.getByText('Badge');
-      expect(badge).toHaveAttribute('aria-describedby', 'badge-desc');
+      const badge = screen.getByText("Badge");
+      expect(badge).toHaveAttribute("aria-describedby", "badge-desc");
     });
   });
 });

--- a/__tests__/components/Badge.test.tsx
+++ b/__tests__/components/Badge.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Badge } from '@/components/ui/badge';
+import { Badge } from '@/components/UI/badge';
 import '@testing-library/jest-dom';
 
 describe('Badge', () => {

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Button } from '@/components/ui/button';
+import { Button } from '@/components/UI/button';
 import '@testing-library/jest-dom';
 
 // Mock Spinner
-jest.mock('@/components/ui/spinner', () => ({
+jest.mock('@/components/UI/spinner', () => ({
   Spinner: () => <div data-testid="spinner">Loading...</div>,
 }));
 

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,293 +1,311 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { Button } from '@/components/UI/button';
-import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "@/components/UI/button";
+import "@testing-library/jest-dom";
 
-// Mock Spinner
-jest.mock('@/components/UI/spinner', () => ({
+// Mock Spinner - use relative path to match button.tsx import
+jest.mock("../../components/UI/spinner", () => ({
   Spinner: () => <div data-testid="spinner">Loading...</div>,
 }));
 
-describe('Button', () => {
-  describe('Rendering', () => {
-    it('should render button element', () => {
+describe("Button", () => {
+  describe("Rendering", () => {
+    it("should render button element", () => {
       render(<Button>Click me</Button>);
 
-      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    it('should render children text', () => {
+    it("should render children text", () => {
       render(<Button>Test Button</Button>);
 
-      expect(screen.getByText('Test Button')).toBeInTheDocument();
+      expect(screen.getByText("Test Button")).toBeInTheDocument();
     });
 
-    it('should apply custom className', () => {
+    it("should apply custom className", () => {
       render(<Button className="custom-class">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('custom-class');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("custom-class");
     });
 
-    it('should have default base classes', () => {
+    it("should have default base classes", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('inline-flex', 'items-center', 'justify-center');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass(
+        "inline-flex",
+        "items-center",
+        "justify-center"
+      );
     });
   });
 
-  describe('Variants', () => {
-    it('should apply default variant', () => {
+  describe("Variants", () => {
+    it("should apply default variant", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('bg-primary');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-primary");
     });
 
-    it('should apply destructive variant', () => {
+    it("should apply destructive variant", () => {
       render(<Button variant="destructive">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('bg-destructive');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-destructive");
     });
 
-    it('should apply outline variant', () => {
+    it("should apply outline variant", () => {
       render(<Button variant="outline">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('border');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("border");
     });
 
-    it('should apply secondary variant', () => {
+    it("should apply secondary variant", () => {
       render(<Button variant="secondary">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('bg-secondary');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-secondary");
     });
 
-    it('should apply ghost variant', () => {
+    it("should apply ghost variant", () => {
       render(<Button variant="ghost">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('hover:bg-accent');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("hover:bg-accent");
     });
 
-    it('should apply link variant', () => {
+    it("should apply link variant", () => {
       render(<Button variant="link">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('text-primary', 'underline-offset-4');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("text-primary", "underline-offset-4");
     });
   });
 
-  describe('Sizes', () => {
-    it('should apply default size', () => {
+  describe("Sizes", () => {
+    it("should apply default size", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('h-9', 'px-4', 'py-2');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("h-9", "px-4", "py-2");
     });
 
-    it('should apply sm size', () => {
+    it("should apply sm size", () => {
       render(<Button size="sm">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('h-8', 'px-3', 'text-xs');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("h-8", "px-3", "text-xs");
     });
 
-    it('should apply lg size', () => {
+    it("should apply lg size", () => {
       render(<Button size="lg">Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('h-10', 'px-8');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("h-10", "px-8");
     });
 
-    it('should apply icon size', () => {
+    it("should apply icon size", () => {
       render(<Button size="icon">+</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('h-9', 'w-9');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("h-9", "w-9");
     });
   });
 
-  describe('Loading State', () => {
-    it('should show spinner when isLoading is true', () => {
+  describe("Loading State", () => {
+    it("should show spinner when isLoading is true", () => {
       render(<Button isLoading>Button</Button>);
 
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+      expect(screen.getByTestId("spinner")).toBeInTheDocument();
     });
 
-    it('should not show button when loading', () => {
+    it("should not show button when loading", () => {
       render(<Button isLoading>Button</Button>);
 
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
 
-    it('should show button when isLoading is false', () => {
+    it("should show button when isLoading is false", () => {
       render(<Button isLoading={false}>Button</Button>);
 
-      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    it('should not show spinner by default', () => {
+    it("should not show spinner by default", () => {
       render(<Button>Button</Button>);
 
-      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
     });
   });
 
-  describe('Disabled State', () => {
-    it('should apply disabled attribute', () => {
+  describe("Disabled State", () => {
+    it("should apply disabled attribute", () => {
       render(<Button disabled>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       expect(button).toBeDisabled();
     });
 
-    it('should have disabled styling', () => {
+    it("should have disabled styling", () => {
       render(<Button disabled>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('disabled:pointer-events-none', 'disabled:opacity-50');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass(
+        "disabled:pointer-events-none",
+        "disabled:opacity-50"
+      );
     });
 
-    it('should not trigger onClick when disabled', () => {
+    it("should not trigger onClick when disabled", () => {
       const handleClick = jest.fn();
 
-      render(<Button disabled onClick={handleClick}>Button</Button>);
+      render(
+        <Button disabled onClick={handleClick}>
+          Button
+        </Button>
+      );
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       fireEvent.click(button);
 
       expect(handleClick).not.toHaveBeenCalled();
     });
   });
 
-  describe('Events', () => {
-    it('should handle onClick event', () => {
+  describe("Events", () => {
+    it("should handle onClick event", () => {
       const handleClick = jest.fn();
 
       render(<Button onClick={handleClick}>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       fireEvent.click(button);
 
       expect(handleClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle onMouseEnter event', () => {
+    it("should handle onMouseEnter event", () => {
       const handleMouseEnter = jest.fn();
 
       render(<Button onMouseEnter={handleMouseEnter}>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       fireEvent.mouseEnter(button);
 
       expect(handleMouseEnter).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle onFocus event', () => {
+    it("should handle onFocus event", () => {
       const handleFocus = jest.fn();
 
       render(<Button onFocus={handleFocus}>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       fireEvent.focus(button);
 
       expect(handleFocus).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('Accessibility', () => {
-    it('should be keyboard accessible', () => {
+  describe("Accessibility", () => {
+    it("should be keyboard accessible", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       button.focus();
 
       expect(button).toHaveFocus();
     });
 
-    it('should support aria-label', () => {
+    it("should support aria-label", () => {
       render(<Button aria-label="Close dialog">X</Button>);
 
-      expect(screen.getByLabelText('Close dialog')).toBeInTheDocument();
+      expect(screen.getByLabelText("Close dialog")).toBeInTheDocument();
     });
 
-    it('should have focus-visible ring', () => {
+    it("should have focus-visible ring", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('focus-visible:outline-none', 'focus-visible:ring-1');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass(
+        "focus-visible:outline-none",
+        "focus-visible:ring-1"
+      );
     });
 
-    it('should support type attribute', () => {
+    it("should support type attribute", () => {
       render(<Button type="submit">Submit</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveAttribute('type', 'submit');
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("type", "submit");
     });
   });
 
-  describe('Styling', () => {
-    it('should have transition classes', () => {
+  describe("Styling", () => {
+    it("should have transition classes", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('transition-colors');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("transition-colors");
     });
 
-    it('should have rounded corners', () => {
+    it("should have rounded corners", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('rounded-md');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("rounded-md");
     });
 
-    it('should have gap for children', () => {
+    it("should have gap for children", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('gap-2');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("gap-2");
     });
 
-    it('should prevent text wrapping', () => {
+    it("should prevent text wrapping", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('whitespace-nowrap');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("whitespace-nowrap");
     });
   });
 
-  describe('Combinations', () => {
-    it('should combine variant and size', () => {
-      render(<Button variant="outline" size="lg">Button</Button>);
+  describe("Combinations", () => {
+    it("should combine variant and size", () => {
+      render(
+        <Button variant="outline" size="lg">
+          Button
+        </Button>
+      );
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('border', 'h-10', 'px-8');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("border", "h-10", "px-8");
     });
 
-    it('should combine all props', () => {
+    it("should combine all props", () => {
       render(
         <Button variant="secondary" size="sm" className="custom" disabled>
           Button
         </Button>
       );
 
-      const button = screen.getByRole('button');
-      expect(button).toHaveClass('bg-secondary', 'h-8', 'px-3', 'custom');
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-secondary", "h-8", "px-3", "custom");
       expect(button).toBeDisabled();
     });
   });
 
-  describe('Children', () => {
-    it('should render text children', () => {
+  describe("Children", () => {
+    it("should render text children", () => {
       render(<Button>Click me</Button>);
 
-      expect(screen.getByText('Click me')).toBeInTheDocument();
+      expect(screen.getByText("Click me")).toBeInTheDocument();
     });
 
-    it('should render JSX children', () => {
+    it("should render JSX children", () => {
       render(
         <Button>
           <span>Icon</span>
@@ -295,11 +313,11 @@ describe('Button', () => {
         </Button>
       );
 
-      expect(screen.getByText('Icon')).toBeInTheDocument();
-      expect(screen.getByText('Text')).toBeInTheDocument();
+      expect(screen.getByText("Icon")).toBeInTheDocument();
+      expect(screen.getByText("Text")).toBeInTheDocument();
     });
 
-    it('should render with icons', () => {
+    it("should render with icons", () => {
       render(
         <Button>
           <svg data-testid="icon" />
@@ -307,34 +325,34 @@ describe('Button', () => {
         </Button>
       );
 
-      expect(screen.getByTestId('icon')).toBeInTheDocument();
-      expect(screen.getByText('Button')).toBeInTheDocument();
+      expect(screen.getByTestId("icon")).toBeInTheDocument();
+      expect(screen.getByText("Button")).toBeInTheDocument();
     });
   });
 
-  describe('Edge Cases', () => {
-    it('should handle empty children', () => {
+  describe("Edge Cases", () => {
+    it("should handle empty children", () => {
       const { container } = render(<Button />);
 
-      expect(container.querySelector('button')).toBeInTheDocument();
+      expect(container.querySelector("button")).toBeInTheDocument();
     });
 
-    it('should handle undefined variant', () => {
+    it("should handle undefined variant", () => {
       render(<Button>Button</Button>);
 
-      const button = screen.getByRole('button');
+      const button = screen.getByRole("button");
       expect(button).toBeInTheDocument();
     });
 
-    it('should toggle loading state', () => {
+    it("should toggle loading state", () => {
       const { rerender } = render(<Button isLoading={false}>Button</Button>);
 
-      expect(screen.getByRole('button')).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
 
       rerender(<Button isLoading={true}>Button</Button>);
 
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(screen.getByTestId("spinner")).toBeInTheDocument();
     });
   });
 });

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -78,7 +78,7 @@ import { DeckIcon } from "@/components/Icons/Deck";
 import { VideoIcon } from "@/components/Icons/Video";
 import { useWallet } from "@/hooks/useWallet";
 import { CustomLink, isCustomLink } from "@/utilities/customLink";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 
 const inputStyle =
   "bg-gray-100 border border-gray-400 rounded-md p-2 dark:bg-zinc-900";

--- a/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusActionButtons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { FC } from "react";
 
 // Define the possible application statuses

--- a/components/Pages/Admin/ProgramScoresUpload.tsx
+++ b/components/Pages/Admin/ProgramScoresUpload.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from "react";
 import Papa from "papaparse";
 import { FileUpload } from "@/components/Utilities/FileUpload";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { programScoresService, ProgramScoreUploadRequest, ProgramScoreUploadResult } from "@/services/programScoresService";
 import { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import toast from "react-hot-toast";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utilities/tailwind"
-import { Spinner } from "../ui/spinner"
+import { cn } from "@/utilities/tailwind";
+import { Spinner } from "../UI/spinner";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -33,24 +33,27 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-  VariantProps<typeof buttonVariants> {
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isLoading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, isLoading = false, variant, size, asChild = false, ...props }, ref) => {
+  (
+    { className, isLoading = false, variant, size, asChild = false, ...props },
+    ref
+  ) => {
     const Comp = asChild ? Slot : "button";
     if (isLoading) {
       return (
         <div className="flex items-center justify-center">
           <Spinner />
         </div>
-      )
+      );
     }
     return (
       <Comp
@@ -58,9 +61,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -1,45 +1,45 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 
-import { cn } from "@/utilities/tailwind"
-import { Button } from "@/components/ui/button"
+import { cn } from "@/utilities/tailwind";
+import { Button } from "@/components/UI/button";
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error("useCarousel must be used within a <Carousel />");
   }
 
-  return context
+  return context;
 }
 
 const Carousel = React.forwardRef<
@@ -64,61 +64,61 @@ const Carousel = React.forwardRef<
         axis: orientation === "horizontal" ? "x" : "y",
       },
       plugins
-    )
-    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-    const [canScrollNext, setCanScrollNext] = React.useState(false)
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
 
     const onSelect = React.useCallback((api: CarouselApi) => {
       if (!api) {
-        return
+        return;
       }
 
-      setCanScrollPrev(api.canScrollPrev())
-      setCanScrollNext(api.canScrollNext())
-    }, [])
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
 
     const scrollPrev = React.useCallback(() => {
-      api?.scrollPrev()
-    }, [api])
+      api?.scrollPrev();
+    }, [api]);
 
     const scrollNext = React.useCallback(() => {
-      api?.scrollNext()
-    }, [api])
+      api?.scrollNext();
+    }, [api]);
 
     const handleKeyDown = React.useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (event.key === "ArrowLeft") {
-          event.preventDefault()
-          scrollPrev()
+          event.preventDefault();
+          scrollPrev();
         } else if (event.key === "ArrowRight") {
-          event.preventDefault()
-          scrollNext()
+          event.preventDefault();
+          scrollNext();
         }
       },
       [scrollPrev, scrollNext]
-    )
+    );
 
     React.useEffect(() => {
       if (!api || !setApi) {
-        return
+        return;
       }
 
-      setApi(api)
-    }, [api, setApi])
+      setApi(api);
+    }, [api, setApi]);
 
     React.useEffect(() => {
       if (!api) {
-        return
+        return;
       }
 
-      onSelect(api)
-      api.on("reInit", onSelect)
-      api.on("select", onSelect)
+      onSelect(api);
+      api.on("reInit", onSelect);
+      api.on("select", onSelect);
 
       return () => {
-        api?.off("select", onSelect)
-      }
-    }, [api, onSelect])
+        api?.off("select", onSelect);
+      };
+    }, [api, onSelect]);
 
     return (
       <CarouselContext.Provider
@@ -145,16 +145,16 @@ const Carousel = React.forwardRef<
           {children}
         </div>
       </CarouselContext.Provider>
-    )
+    );
   }
-)
-Carousel.displayName = "Carousel"
+);
+Carousel.displayName = "Carousel";
 
 const CarouselContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const { carouselRef, orientation } = useCarousel()
+  const { carouselRef, orientation } = useCarousel();
 
   return (
     <div ref={carouselRef} className="overflow-hidden">
@@ -168,15 +168,15 @@ const CarouselContent = React.forwardRef<
         {...props}
       />
     </div>
-  )
-})
-CarouselContent.displayName = "CarouselContent"
+  );
+});
+CarouselContent.displayName = "CarouselContent";
 
 const CarouselItem = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const { orientation } = useCarousel()
+  const { orientation } = useCarousel();
 
   return (
     <div
@@ -190,15 +190,15 @@ const CarouselItem = React.forwardRef<
       )}
       {...props}
     />
-  )
-})
-CarouselItem.displayName = "CarouselItem"
+  );
+});
+CarouselItem.displayName = "CarouselItem";
 
 const CarouselPrevious = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<typeof Button>
 >(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
     <Button
@@ -219,15 +219,15 @@ const CarouselPrevious = React.forwardRef<
       <ArrowLeft className="h-4 w-4" />
       <span className="sr-only">Previous slide</span>
     </Button>
-  )
-})
-CarouselPrevious.displayName = "CarouselPrevious"
+  );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
 
 const CarouselNext = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<typeof Button>
 >(({ className, variant = "outline", size = "icon", ...props }, ref) => {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
     <Button
@@ -248,9 +248,9 @@ const CarouselNext = React.forwardRef<
       <ArrowRight className="h-4 w-4" />
       <span className="sr-only">Next slide</span>
     </Button>
-  )
-})
-CarouselNext.displayName = "CarouselNext"
+  );
+});
+CarouselNext.displayName = "CarouselNext";
 
 export {
   type CarouselApi,
@@ -259,5 +259,4 @@ export {
   CarouselItem,
   CarouselPrevious,
   CarouselNext,
-}
-
+};

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,12 +1,12 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { type DialogProps } from "@radix-ui/react-dialog"
-import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import * as React from "react";
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
 
-import { cn } from "@/utilities/tailwind"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "@/utilities/tailwind";
+import { Dialog, DialogContent } from "@/components/UI/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -20,8 +20,8 @@ const Command = React.forwardRef<
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
+));
+Command.displayName = CommandPrimitive.displayName;
 
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
@@ -32,8 +32,8 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
         </Command>
       </DialogContent>
     </Dialog>
-  )
-}
+  );
+};
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -50,9 +50,9 @@ const CommandInput = React.forwardRef<
       {...props}
     />
   </div>
-))
+));
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
@@ -63,9 +63,9 @@ const CommandList = React.forwardRef<
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-))
+));
 
-CommandList.displayName = CommandPrimitive.List.displayName
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
@@ -76,9 +76,9 @@ const CommandEmpty = React.forwardRef<
     className="py-6 text-center text-sm"
     {...props}
   />
-))
+));
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Group>,
@@ -92,9 +92,9 @@ const CommandGroup = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
@@ -105,8 +105,8 @@ const CommandSeparator = React.forwardRef<
     className={cn("-mx-1 h-px bg-border", className)}
     {...props}
   />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
@@ -120,9 +120,9 @@ const CommandItem = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
+CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({
   className,
@@ -136,9 +136,9 @@ const CommandShortcut = ({
       )}
       {...props}
     />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
 
 export {
   Command,
@@ -150,4 +150,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/src/components/navbar/navbar-auth-buttons.tsx
+++ b/src/components/navbar/navbar-auth-buttons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { PhoneCall } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";

--- a/src/components/navbar/navbar-desktop-navigation.tsx
+++ b/src/components/navbar/navbar-desktop-navigation.tsx
@@ -6,7 +6,7 @@ import {
     NavigationMenuItem,
     NavigationMenuList,
     NavigationMenuTrigger,
-} from "@/components/ui/navigation-menu";
+} from "@/components/UI/navigation-menu";
 import { ChevronDown } from "lucide-react";
 import {
     ForBuildersContent,

--- a/src/components/navbar/navbar-mobile-menu.tsx
+++ b/src/components/navbar/navbar-mobile-menu.tsx
@@ -9,8 +9,8 @@ import {
     DrawerHeader,
     DrawerTitle,
     DrawerTrigger,
-} from "@/components/ui/drawer";
-import { Button } from "@/components/ui/button";
+} from "@/components/UI/drawer";
+import { Button } from "@/components/UI/button";
 import Link from "next/link";
 import { PhoneCall, ChevronRight, CircleHelp, LogOutIcon, ToggleLeft, ToggleRight, FolderKanban, ShieldCheck, CheckCircle2, Settings } from "lucide-react";
 import { SOCIALS } from "@/utilities/socials";

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -7,7 +7,7 @@ import {
     MenubarItem,
     MenubarMenu,
     MenubarTrigger,
-} from "@/components/ui/menubar";
+} from "@/components/UI/menubar";
 import { ChevronRight, CircleHelp, CircleUser, LogOutIcon, PhoneCall, ToggleLeft, ToggleRight, Wallet, FolderKanban, ShieldCheck, CheckCircle2, Settings } from "lucide-react";
 import { SOCIALS } from "@/utilities/socials";
 import { TwitterIcon, DiscordIcon, TelegramIcon } from "@/components/Icons";
@@ -19,7 +19,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useTheme } from "next-themes";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 import { useContributorProfile } from "@/hooks/useContributorProfile";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { NavbarUserSkeleton } from "./navbar-user-skeleton";
 import Link from "next/link";
 import { PAGES } from "@/utilities/pages";

--- a/src/components/navbar/navbar-user-skeleton.tsx
+++ b/src/components/navbar/navbar-user-skeleton.tsx
@@ -1,33 +1,32 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { Skeleton } from "@/components/UI/skeleton";
 import { cn } from "@/utilities/tailwind";
 
 export function NavbarUserSkeleton() {
-    return (
-        <div className="hidden lg:flex items-center gap-3">
-            <div className="flex flex-row items-center gap-2">
-                <Skeleton className="h-8 w-8 rounded-xl" />
-                <Skeleton className="h-8 w-8 rounded-full" />
-            </div>
-        </div>
-    );
+  return (
+    <div className="hidden lg:flex items-center gap-3">
+      <div className="flex flex-row items-center gap-2">
+        <Skeleton className="h-8 w-8 rounded-xl" />
+        <Skeleton className="h-8 w-8 rounded-full" />
+      </div>
+    </div>
+  );
 }
 
 export function NavbarAuthButtonsSkeleton() {
-    return (
-        <div className="flex items-center gap-3">
-            <Skeleton className="h-9 w-20 rounded-md" />
-            <Skeleton className="h-9 w-32 rounded-md" />
-        </div>
-    );
+  return (
+    <div className="flex items-center gap-3">
+      <Skeleton className="h-9 w-20 rounded-md" />
+      <Skeleton className="h-9 w-32 rounded-md" />
+    </div>
+  );
 }
 
 export function NavbarLoggedInButtonsSkeleton() {
-    return (
-        <div className="flex flex-row items-center gap-2">
-            <Skeleton className="h-9 w-24 rounded-lg" />
-            <Skeleton className="h-9 w-20 rounded-lg" />
-            <Skeleton className="h-9 w-20 rounded-lg" />
-        </div>
-    );
+  return (
+    <div className="flex flex-row items-center gap-2">
+      <Skeleton className="h-9 w-24 rounded-lg" />
+      <Skeleton className="h-9 w-20 rounded-lg" />
+      <Skeleton className="h-9 w-20 rounded-lg" />
+    </div>
+  );
 }
-

--- a/src/components/shared/faq-accordion.tsx
+++ b/src/components/shared/faq-accordion.tsx
@@ -5,7 +5,7 @@ import {
     AccordionContent,
     AccordionItem,
     AccordionTrigger,
-} from "@/components/ui/accordion";
+} from "@/components/UI/accordion";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { MinusCircle, PlusCircle } from "lucide-react";
 

--- a/src/features/funders/components/case-studies-section.tsx
+++ b/src/features/funders/components/case-studies-section.tsx
@@ -1,5 +1,5 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/UI/badge";
+import { Button } from "@/components/UI/button";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { cn } from "@/utilities/tailwind";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";

--- a/src/features/funders/components/handle-the-vision-section.tsx
+++ b/src/features/funders/components/handle-the-vision-section.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import Link from "next/link";
 import { SOCIALS } from "@/utilities/socials";
 

--- a/src/features/funders/components/hero.tsx
+++ b/src/features/funders/components/hero.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { SOCIALS } from "@/utilities/socials";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
 import { InfiniteMovingCards } from "@/src/components/ui/infinite-moving-cards";

--- a/src/features/funders/components/how-it-works-section.tsx
+++ b/src/features/funders/components/how-it-works-section.tsx
@@ -1,6 +1,6 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/UI/badge";
+import { Button } from "@/components/UI/button";
+import { Card, CardContent } from "@/components/UI/card";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { cn } from "@/utilities/tailwind";
 import { Mail, Zap, BarChart2 } from "lucide-react";
@@ -8,156 +8,172 @@ import Link from "next/link";
 import { SOCIALS } from "@/utilities/socials";
 
 interface StepCard {
-    icon: React.ComponentType<{ className?: string }>;
-    stepLabel: string;
-    title: string;
-    description: string;
-    hasButton?: boolean;
+  icon: React.ComponentType<{ className?: string }>;
+  stepLabel: string;
+  title: string;
+  description: string;
+  hasButton?: boolean;
 }
 
 const steps: StepCard[] = [
-    {
-        icon: Mail,
-        stepLabel: "Step 1",
-        title: "Connect with our team",
-        description: "Meet your dedicated success partner who will guide you through setup, onboarding, and best practices.",
-        hasButton: true
-    },
-    {
-        icon: Zap,
-        stepLabel: "Step 2",
-        title: "Configure your ecosystem",
-        description: "We’ll help you set up your community space, enable whitelabel branding, and deploy the onchain modules you need — all tailored to your workflow."
-    },
-    {
-        icon: BarChart2,
-        stepLabel: "Step 3",
-        title: "Launch your program",
-        description: "Design your funding program, set evaluation criteria, and go live. Start receiving applications and funding projects within 48 hours."
-    }
+  {
+    icon: Mail,
+    stepLabel: "Step 1",
+    title: "Connect with our team",
+    description:
+      "Meet your dedicated success partner who will guide you through setup, onboarding, and best practices.",
+    hasButton: true,
+  },
+  {
+    icon: Zap,
+    stepLabel: "Step 2",
+    title: "Configure your ecosystem",
+    description:
+      "We’ll help you set up your community space, enable whitelabel branding, and deploy the onchain modules you need — all tailored to your workflow.",
+  },
+  {
+    icon: BarChart2,
+    stepLabel: "Step 3",
+    title: "Launch your program",
+    description:
+      "Design your funding program, set evaluation criteria, and go live. Start receiving applications and funding projects within 48 hours.",
+  },
 ];
 
 export function HowItWorksSection() {
-    return (
-        <section className={cn(
-            marketingLayoutTheme.padding,
-            "flex flex-col items-start w-full gap-16"
-        )}>
-            {/* Header */}
-            <div className="flex flex-col items-start gap-4 w-full">
-                {/* How It Works Pill */}
-                <Badge
-                    variant="secondary"
-                    className={cn(
-                        "text-secondary-foreground font-medium text-xs",
-                        "leading-[150%] tracking-[0.015em]",
-                        "rounded-full py-[3px] px-2",
-                        "bg-secondary border-0 w-fit"
-                    )}
+  return (
+    <section
+      className={cn(
+        marketingLayoutTheme.padding,
+        "flex flex-col items-start w-full gap-16"
+      )}
+    >
+      {/* Header */}
+      <div className="flex flex-col items-start gap-4 w-full">
+        {/* How It Works Pill */}
+        <Badge
+          variant="secondary"
+          className={cn(
+            "text-secondary-foreground font-medium text-xs",
+            "leading-[150%] tracking-[0.015em]",
+            "rounded-full py-[3px] px-2",
+            "bg-secondary border-0 w-fit"
+          )}
+        >
+          How It Works
+        </Badge>
+
+        {/* Main Heading */}
+        <h2
+          className={cn(
+            "font-semibold",
+            "text-[32px] leading-[36px] tracking-[-0.02em]",
+            "md:text-[40px] md:leading-[44px]",
+            "w-full"
+          )}
+        >
+          <span className="text-foreground">Launch and fund impact</span>
+          <span className="text-muted-foreground"> in 48 hours</span>
+        </h2>
+      </div>
+
+      {/* Steps Grid */}
+      <div
+        className={cn(
+          "grid grid-cols-1 md:grid-cols-3 gap-8 w-full",
+          "max-w-[1920px]",
+          "items-stretch"
+        )}
+      >
+        {steps.map((step, index) => {
+          const IconComponent = step.icon;
+          return (
+            <div
+              key={index}
+              className={cn("flex flex-col items-center gap-4 h-full")}
+            >
+              {/* Icon Container */}
+              <div
+                className={cn(
+                  "w-12 h-12 rounded-full flex-shrink-0",
+                  "bg-secondary flex items-center justify-center"
+                )}
+              >
+                <IconComponent className={cn("w-6 h-6", "text-foreground")} />
+              </div>
+
+              {/* Step Badge */}
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "text-secondary-foreground font-medium text-xs",
+                  "leading-[150%] tracking-[0.015em]",
+                  "rounded-full py-[3px] px-2",
+                  "bg-secondary border-0 w-fit"
+                )}
+              >
+                {step.stepLabel}
+              </Badge>
+
+              {/* Card */}
+              <Card
+                className={cn(
+                  "flex flex-col w-full h-full",
+                  "rounded-2xl border-0 bg-secondary shadow-none",
+                  "p-8"
+                )}
+              >
+                <CardContent
+                  className={cn(
+                    "p-0 flex flex-col items-start gap-2",
+                    step.hasButton ? "justify-between h-full" : ""
+                  )}
                 >
-                    How It Works
-                </Badge>
+                  <div className="flex flex-col gap-2">
+                    {/* Title */}
+                    <h3
+                      className={cn(
+                        "text-foreground font-semibold",
+                        "text-[20px] leading-[120%] tracking-[-0.02em]"
+                      )}
+                    >
+                      {step.title}
+                    </h3>
 
-                {/* Main Heading */}
-                <h2 className={cn(
-                    "font-semibold",
-                    "text-[32px] leading-[36px] tracking-[-0.02em]",
-                    "md:text-[40px] md:leading-[44px]",
-                    "w-full"
-                )}>
-                    <span className="text-foreground">Launch and fund impact</span>
-                    <span className="text-muted-foreground"> in 48 hours</span>
-                </h2>
-            </div>
+                    {/* Description */}
+                    <p
+                      className={cn(
+                        "text-muted-foreground font-medium text-sm",
+                        "leading-[20px] tracking-[0%]"
+                      )}
+                    >
+                      {step.description}
+                    </p>
+                  </div>
 
-            {/* Steps Grid */}
-            <div className={cn(
-                "grid grid-cols-1 md:grid-cols-3 gap-8 w-full",
-                "max-w-[1920px]",
-                "items-stretch"
-            )}>
-                {steps.map((step, index) => {
-                    const IconComponent = step.icon;
-                    return (
-                        <div
-                            key={index}
-                            className={cn(
-                                "flex flex-col items-center gap-4 h-full"
-                            )}
+                  {/* Button - only for first card */}
+                  {step.hasButton && (
+                    <div className="mt-4">
+                      <Button
+                        asChild
+                        className="bg-foreground text-background hover:bg-foreground/90 rounded-md font-medium px-6 py-2.5"
+                      >
+                        <Link
+                          href={SOCIALS.PARTNER_FORM}
+                          target="_blank"
+                          rel="noopener noreferrer"
                         >
-                            {/* Icon Container */}
-                            <div className={cn(
-                                "w-12 h-12 rounded-full flex-shrink-0",
-                                "bg-secondary flex items-center justify-center"
-                            )}>
-                                <IconComponent className={cn(
-                                    "w-6 h-6",
-                                    "text-foreground"
-                                )} />
-                            </div>
-
-                            {/* Step Badge */}
-                            <Badge
-                                variant="secondary"
-                                className={cn(
-                                    "text-secondary-foreground font-medium text-xs",
-                                    "leading-[150%] tracking-[0.015em]",
-                                    "rounded-full py-[3px] px-2",
-                                    "bg-secondary border-0 w-fit"
-                                )}
-                            >
-                                {step.stepLabel}
-                            </Badge>
-
-                            {/* Card */}
-                            <Card
-                                className={cn(
-                                    "flex flex-col w-full h-full",
-                                    "rounded-2xl border-0 bg-secondary shadow-none",
-                                    "p-8"
-                                )}
-                            >
-                                <CardContent className={cn(
-                                    "p-0 flex flex-col items-start gap-2",
-                                    step.hasButton ? "justify-between h-full" : ""
-                                )}>
-                                    <div className="flex flex-col gap-2">
-                                        {/* Title */}
-                                        <h3 className={cn(
-                                            "text-foreground font-semibold",
-                                            "text-[20px] leading-[120%] tracking-[-0.02em]"
-                                        )}>
-                                            {step.title}
-                                        </h3>
-
-                                        {/* Description */}
-                                        <p className={cn(
-                                            "text-muted-foreground font-medium text-sm",
-                                            "leading-[20px] tracking-[0%]"
-                                        )}>
-                                            {step.description}
-                                        </p>
-                                    </div>
-
-                                    {/* Button - only for first card */}
-                                    {step.hasButton && (
-                                        <div className="mt-4">
-                                            <Button
-                                                asChild
-                                                className="bg-foreground text-background hover:bg-foreground/90 rounded-md font-medium px-6 py-2.5"
-                                            >
-                                                <Link href={SOCIALS.PARTNER_FORM} target="_blank" rel="noopener noreferrer">
-                                                    Schedule Demo
-                                                </Link>
-                                            </Button>
-                                        </div>
-                                    )}
-                                </CardContent>
-                            </Card>
-                        </div>
-                    );
-                })}
+                          Schedule Demo
+                        </Link>
+                      </Button>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
             </div>
-        </section>
-    );
+          );
+        })}
+      </div>
+    </section>
+  );
 }

--- a/src/features/funders/components/numbers-section.tsx
+++ b/src/features/funders/components/numbers-section.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@/components/ui/badge";
+import { Badge } from "@/components/UI/badge";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { cn } from "@/utilities/tailwind";
 

--- a/src/features/funders/components/offering-section.tsx
+++ b/src/features/funders/components/offering-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SquareCheckBig } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import Link from "next/link";

--- a/src/features/funders/components/platform-section.tsx
+++ b/src/features/funders/components/platform-section.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@/components/ui/badge";
+import { Badge } from "@/components/UI/badge";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { cn } from "@/utilities/tailwind";
 import { ThemeImage } from "@/src/components/ui/theme-image";

--- a/src/features/homepage/components/create-profile-button.tsx
+++ b/src/features/homepage/components/create-profile-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 
 export function CreateProfileButton() {

--- a/src/features/homepage/components/create-project-button.tsx
+++ b/src/features/homepage/components/create-project-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import dynamic from "next/dynamic";
 
 const ProjectDialog = dynamic(

--- a/src/features/homepage/components/faq.tsx
+++ b/src/features/homepage/components/faq.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { MessageCircleMore } from "lucide-react";
 import Image from "next/image";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { SOCIALS } from "@/utilities/socials";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { FAQAccordion } from "@/src/components/shared/faq-accordion";

--- a/src/features/homepage/components/funding-opportunity-card.tsx
+++ b/src/features/homepage/components/funding-opportunity-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/UI/card";
+import { Badge } from "@/components/UI/badge";
+import { Button } from "@/components/UI/button";
 import Image from "next/image";
 import type { FundingProgram } from "@/services/fundingPlatformService";
 import { PAGES } from "@/utilities/pages";

--- a/src/features/homepage/components/hero.tsx
+++ b/src/features/homepage/components/hero.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import Image from "next/image";
 import { InfiniteMovingCards } from "@/src/components/ui/infinite-moving-cards";
 import { chosenCommunities } from "@/utilities/chosenCommunities";

--- a/src/features/homepage/components/how-it-works.tsx
+++ b/src/features/homepage/components/how-it-works.tsx
@@ -1,8 +1,8 @@
 import { CheckCircle } from "lucide-react";
 import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/UI/card";
+import { Badge } from "@/components/UI/badge";
 
 interface StepCardProps {
     text: string;

--- a/src/features/homepage/components/join-discord-button.tsx
+++ b/src/features/homepage/components/join-discord-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import { SOCIALS } from "@/utilities/socials";
 
 export function JoinDiscordButton() {

--- a/src/features/homepage/components/live-funding-opportunities-carousel.tsx
+++ b/src/features/homepage/components/live-funding-opportunities-carousel.tsx
@@ -8,8 +8,8 @@ import {
     CarouselNext,
     CarouselPrevious,
     type CarouselApi,
-} from "@/components/ui/carousel";
-import { Button } from "@/components/ui/button";
+} from "@/components/UI/carousel";
+import { Button } from "@/components/UI/button";
 import { ArrowRightIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import { PAGES } from "@/utilities/pages";

--- a/src/features/homepage/components/live-funding-opportunities-skeleton.tsx
+++ b/src/features/homepage/components/live-funding-opportunities-skeleton.tsx
@@ -1,11 +1,11 @@
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/UI/skeleton";
+import { Card, CardContent } from "@/components/UI/card";
 import {
     Carousel,
     CarouselContent,
     CarouselItem,
-} from "@/components/ui/carousel";
-import { Button } from "@/components/ui/button";
+} from "@/components/UI/carousel";
+import { Button } from "@/components/UI/button";
 import { ArrowRightIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 import { PAGES } from "@/utilities/pages";

--- a/src/features/homepage/components/platform-features.tsx
+++ b/src/features/homepage/components/platform-features.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/UI/card";
+import { Badge } from "@/components/UI/badge";
 import Image from "next/image";
 import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";

--- a/src/features/homepage/components/where-builders-grow.tsx
+++ b/src/features/homepage/components/where-builders-grow.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/utilities/tailwind";
 import { marketingLayoutTheme } from "@/src/helper/theme";
 import { CreateProjectButton } from "./create-project-button";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/UI/button";
 import Link from "next/link";
 import { PAGES } from "@/utilities/pages";
 


### PR DESCRIPTION
## Fix TypeScript case-sensitivity errors for UI component imports

### Problem
TypeScript was throwing `TS1261` errors because imports used `@/components/ui/` (lowercase) while the actual directory is `components/UI/` (uppercase). On macOS (case-insensitive filesystem) this works at runtime, but TypeScript (case-sensitive) treats them as different paths, causing conflicts.

### Solution
- Updated all imports from `@/components/ui/` to `@/components/UI/` across 31+ files
- Fixed relative imports in UI components (e.g., `../ui/spinner` → `../UI/spinner`)
- Standardized import paths to match the actual directory structure

### Changes
- All UI component imports now use uppercase `UI` directory
- Fixed imports in components, features, tests, and UI component files themselves
- `pnpm tsc --noEmit` now passes without errors

### Files Changed
- 31+ files with import path updates
- UI component files (`button.tsx`, `carousel.tsx`, `command.tsx`) with internal import fixes