### PR TITLE
fix: profile editing w/o isGlobal setting

### DIFF
--- a/components/Dialogs/StepperDialog.tsx
+++ b/components/Dialogs/StepperDialog.tsx
@@ -78,7 +78,7 @@ export const StepperDialog = () => {
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={closeModal}>
+      <Dialog as="div" className="relative z-[150]" onClose={closeModal}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -122,7 +122,12 @@ export function NavbarUserMenu() {
                                         {address ? <span className={menuStyles.itemText}>{formatAddress(address)}</span> : <span className={menuStyles.itemText}>No wallet connected</span>}
                                     </div>
                                 </MenubarItem>
-                                <MenubarItem className="w-full" onClick={() => openProfileModal()}>
+                                <MenubarItem
+                                    className="w-full"
+                                    onClick={() => openProfileModal({
+                                        isGlobal: true
+                                    })}
+                                >
                                     <div className="flex items-center w-full flex-row gap-2 justify-between">
                                         <div className="flex items-center flex-row gap-2">
                                             <CircleUser className={menuStyles.itemIcon} />


### PR DESCRIPTION
## Summary

Fixes an issue where the profile editing modal was not functioning correctly when opened from the navbar user menu due to a missing `isGlobal` parameter.

## Changes

- **navbar-user-menu.tsx**: Added `isGlobal: true` parameter when opening the profile modal from the navbar menu, ensuring the modal operates in global context mode
- **StepperDialog.tsx**: Increased z-index from `z-50` to `z-[150]` to ensure the stepper dialog appears above the navbar menu and other UI elements

## Problem

The profile editing modal was not working as expected when triggered from the navbar because the `openProfileModal()` function was being called without the required `isGlobal` parameter.

## Solution

Pass `isGlobal: true` to the `openProfileModal()` function call in the navbar user menu, ensuring the profile modal operates in the correct context.

## Test Plan

- [x] Click on user menu in navbar
- [x] Click on "Edit Profile" option
- [x] Verify profile modal opens correctly with all fields populated
- [x] Verify profile changes can be saved successfully
- [x] Verify modal z-index is correct and appears above navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)