### PR TITLE
feat: Enable comments visibility on public pages

### DIFF
--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -44,7 +44,13 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-const TAB_KEYS = ["build", "settings", "post-approval", "ai-config", "reviewers"] as const;
+const TAB_KEYS = [
+  "build",
+  "settings",
+  "post-approval",
+  "ai-config",
+  "reviewers",
+] as const;
 type TabKey = (typeof TAB_KEYS)[number];
 const DEFAULT_TAB: TabKey = "build";
 
@@ -58,14 +64,19 @@ const getValidTab = (value: string | null): TabKey =>
 const TAB_CONFIG = [
   { key: "build" as TabKey, icon: WrenchScrewdriverIcon, label: "Build" },
   { key: "settings" as TabKey, icon: Cog6ToothIcon, label: "Settings" },
-  { key: "post-approval" as TabKey, icon: CheckCircleIcon, label: "Post Approval" },
+  {
+    key: "post-approval" as TabKey,
+    icon: CheckCircleIcon,
+    label: "Post Approval",
+  },
   { key: "ai-config" as TabKey, icon: CpuChipIcon, label: "AI Config" },
   { key: "reviewers" as TabKey, icon: UserGroupIcon, label: "Reviewers" },
 ] as const;
 
 // Helper to get tab button class names
 const getTabButtonClassName = (isActive: boolean): string => {
-  const base = "flex items-center px-3 py-1 text-sm font-medium rounded-lg transition-colors";
+  const base =
+    "flex items-center px-3 py-1 text-sm font-medium rounded-lg transition-colors";
   return isActive
     ? `${base} bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm`
     : `${base} text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white`;
@@ -120,7 +131,8 @@ export function QuestionBuilder({
       fields: [],
       settings: {
         submitButtonText: "Submit Post Approval Information",
-        confirmationMessage: "Thank you for providing the additional information!",
+        confirmationMessage:
+          "Thank you for providing the additional information!",
         privateApplications: true, // Post-approval forms are always private
       },
     }
@@ -136,7 +148,9 @@ export function QuestionBuilder({
   // Helper to determine if we're working with post approval form
   const isPostApprovalMode = activeTab === "post-approval";
   const currentSchema = isPostApprovalMode ? postApprovalSchema : schema;
-  const setCurrentSchema = isPostApprovalMode ? setPostApprovalSchema : setSchema;
+  const setCurrentSchema = isPostApprovalMode
+    ? setPostApprovalSchema
+    : setSchema;
 
   // Sync URL tab parameter with local state and clean up invalid tabs
   useEffect(() => {
@@ -155,11 +169,9 @@ export function QuestionBuilder({
         router.replace(url);
       }
     } catch (error) {
-      errorManager(
-        "Failed to synchronize tab state with URL",
-        error,
-        { pathname }
-      );
+      errorManager("Failed to synchronize tab state with URL", error, {
+        pathname,
+      });
       // Fallback to default tab on error
       setActiveTab(DEFAULT_TAB);
     }
@@ -178,12 +190,13 @@ export function QuestionBuilder({
       const url = params.toString() ? `${pathname}?${params}` : pathname;
       router.replace(url);
     } catch (error) {
-      errorManager(
-        `Failed to update URL for tab: ${tab}`,
-        error,
-        { tab, pathname }
+      errorManager(`Failed to update URL for tab: ${tab}`, error, {
+        tab,
+        pathname,
+      });
+      toast.error(
+        "Navigation updated locally. The URL may not reflect your current view."
       );
-      toast.error("Navigation updated locally. The URL may not reflect your current view.");
     }
   };
 
@@ -195,7 +208,9 @@ export function QuestionBuilder({
 
     // Only update URL if it needs to change
     const currentTabParam = searchParams.get("tab");
-    const needsUrlUpdate = (tab !== DEFAULT_TAB || currentTabParam !== null) && currentTabParam !== tab;
+    const needsUrlUpdate =
+      (tab !== DEFAULT_TAB || currentTabParam !== null) &&
+      currentTabParam !== tab;
 
     if (needsUrlUpdate) {
       updateTabInUrl(tab);
@@ -218,7 +233,10 @@ export function QuestionBuilder({
       setPostApprovalSchema({
         ...initialPostApprovalSchema,
         fields: Array.isArray(initialPostApprovalSchema.fields)
-          ? initialPostApprovalSchema.fields.map(field => ({ ...field, private: true })) // Ensure all fields are private
+          ? initialPostApprovalSchema.fields.map((field) => ({
+              ...field,
+              private: true,
+            })) // Ensure all fields are private
           : [],
         settings: {
           ...initialPostApprovalSchema.settings,
@@ -332,11 +350,10 @@ export function QuestionBuilder({
         }));
       }
     } catch (error) {
-      errorManager(
-        "Failed to reorder form fields",
-        error,
-        { activeId: event.active.id, overId: event.over?.id }
-      );
+      errorManager("Failed to reorder form fields", error, {
+        activeId: event.active.id,
+        overId: event.over?.id,
+      });
       toast.error("Failed to reorder fields. Please try again.");
     }
   };
@@ -390,15 +407,13 @@ export function QuestionBuilder({
         toast.success("Form saved successfully!");
       }
     } catch (error) {
-      errorManager(
-        "Failed to save form schema",
-        error,
-        {
-          isPostApprovalMode,
-          formId: isPostApprovalMode ? postApprovalSchema.id : schema.id,
-          fieldsCount: isPostApprovalMode ? postApprovalSchema.fields.length : schema.fields.length
-        }
-      );
+      errorManager("Failed to save form schema", error, {
+        isPostApprovalMode,
+        formId: isPostApprovalMode ? postApprovalSchema.id : schema.id,
+        fieldsCount: isPostApprovalMode
+          ? postApprovalSchema.fields.length
+          : schema.fields.length,
+      });
       toast.error("Failed to save form. Please try again.");
     }
   };
@@ -449,7 +464,10 @@ export function QuestionBuilder({
     try {
       setCurrentSchema((prev) => ({
         ...prev,
-        emailNotifications: prev.emailNotifications?.filter((_email: string, i: number) => i !== index) || [],
+        emailNotifications:
+          prev.emailNotifications?.filter(
+            (_email: string, i: number) => i !== index
+          ) || [],
       }));
       toast.success("Email removed successfully!");
     } catch (error) {
@@ -465,46 +483,41 @@ export function QuestionBuilder({
     }
   };
 
-
   return (
-    <div
-      className={`flex flex-col h-full${className}`}
-    >
+    <div className={`flex flex-col h-full${className}`}>
       {/* Header */}
       <div className="border-b border-gray-200 dark:border-gray-700 sm:px-3 md:px-4 px-6 py-2">
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between flex-wrap gap-4">
           <div className="flex flex-col gap-2 mb-4 sm:mb-0">
-            {
-              readOnly ? (
-                <>
-                  <div className="text-xl font-bold text-gray-900 dark:text-white px-3 py-2">
-                    {schema.title}
-                  </div>
-                  <div className="text-sm text-gray-600 dark:text-gray-400 px-3 py-1">
-                    <MarkdownPreview source={schema.description || ""} />
-                  </div>
-                </>
-              ) : (
-                <>
-                  <input
-                    type="text"
-                    value={currentSchema.title}
-                    onChange={(e) => handleTitleChange(e.target.value)}
-                    className="text-xl font-bold bg-transparent border-none outline-none bg-zinc-100 dark:bg-zinc-800 rounded-md text-gray-900 dark:text-white placeholder-gray-400"
-                    placeholder="Form Title"
-                  />
-                  <MarkdownEditor
-                    value={currentSchema.description || ""}
-                    onChange={(value: string) => handleDescriptionChange(value)}
-                    className="mt-1 text-sm bg-transparent border-none outline-none bg-zinc-100 dark:bg-zinc-800 rounded-md text-gray-600 dark:text-gray-400 placeholder-gray-500"
-                    placeholderText="Form Description"
-                    height={100}
-                    minHeight={100}
-                  />
-                </>
-              )
-            }
-          </div >
+            {readOnly ? (
+              <>
+                <div className="text-xl font-bold text-gray-900 dark:text-white px-3 py-2">
+                  {schema.title}
+                </div>
+                <div className="text-sm text-gray-600 dark:text-gray-400 px-3 py-1">
+                  <MarkdownPreview source={schema.description || ""} />
+                </div>
+              </>
+            ) : (
+              <>
+                <input
+                  type="text"
+                  value={currentSchema.title}
+                  onChange={(e) => handleTitleChange(e.target.value)}
+                  className="text-xl font-bold bg-transparent border-none outline-none bg-zinc-100 dark:bg-zinc-800 rounded-md text-gray-900 dark:text-white placeholder-gray-400"
+                  placeholder="Form Title"
+                />
+                <MarkdownEditor
+                  value={currentSchema.description || ""}
+                  onChange={(value: string) => handleDescriptionChange(value)}
+                  className="mt-1 text-sm bg-transparent border-none outline-none bg-zinc-100 dark:bg-zinc-800 rounded-md text-gray-600 dark:text-gray-400 placeholder-gray-500"
+                  placeholderText="Form Description"
+                  height={100}
+                  minHeight={100}
+                />
+              </>
+            )}
+          </div>
 
           <div className="flex items-center gap-3 flex-row flex-wrap">
             <div className="flex flex-row flex-wrap bg-gray-100 dark:bg-gray-700 p-1 rounded-lg">
@@ -520,13 +533,14 @@ export function QuestionBuilder({
               ))}
             </div>
 
-            {
-              !readOnly && (<Button
+            {!readOnly && (
+              <Button
                 onClick={handleSave}
-                className={`py-2 ${needsEmailValidation()
-                  ? "bg-yellow-600 hover:bg-yellow-700"
-                  : "bg-blue-600 hover:bg-blue-700"
-                  }`}
+                className={`py-2 ${
+                  needsEmailValidation()
+                    ? "bg-yellow-600 hover:bg-yellow-700"
+                    : "bg-blue-600 hover:bg-blue-700"
+                }`}
                 title={
                   needsEmailValidation()
                     ? "Add an email field before saving"
@@ -537,25 +551,28 @@ export function QuestionBuilder({
                   <ExclamationTriangleIcon className="w-4 h-4 mr-2" />
                 )}
                 {isPostApprovalMode ? "Save Post Approval Form" : "Save Form"}
-              </Button>)}
+              </Button>
+            )}
           </div>
         </div>
       </div>
 
       {/* Content */}
-      < div className="flex-1 overflow-hidden  sm:px-3 md:px-4 px-6 py-2" >
+      <div className="flex-1 overflow-hidden  sm:px-3 md:px-4 px-6 py-2">
         {activeTab === "build" || activeTab === "post-approval" ? (
           <div className="h-full grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Field Types Panel */}
             {!readOnly && (
-
               <div className="lg:col-span-1">
-                <FieldTypeSelector onFieldAdd={handleFieldAdd} isPostApprovalMode={isPostApprovalMode} />
+                <FieldTypeSelector
+                  onFieldAdd={handleFieldAdd}
+                  isPostApprovalMode={isPostApprovalMode}
+                />
               </div>
             )}
 
             {/* Form Builder */}
-            <div className={readOnly ? '' : 'lg:col-span-2 overflow-y-auto'}>
+            <div className={readOnly ? "" : "lg:col-span-2 overflow-y-auto"}>
               <div className="space-y-4">
                 {/* Email Field Warning - only for main application form */}
                 {needsEmailValidation() && (
@@ -583,7 +600,8 @@ export function QuestionBuilder({
                         Post Approval Form
                       </h4>
                       <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
-                        This form will be shown to applicants after their application is approved.
+                        This form will be shown to applicants after their
+                        application is approved.
                         {`Use it to collect additional information needed for the next steps. All fields are automatically set as private, and email fields are not required since we already have the applicant's information.`}
                       </p>
                     </div>
@@ -647,56 +665,61 @@ export function QuestionBuilder({
                           Post Approval Email Notifications
                         </h3>
                         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                          Add email addresses that should receive notifications when post-approval forms are submitted.
+                          Add email addresses that should receive notifications
+                          when post-approval forms are submitted.
                         </p>
                       </div>
                     </div>
 
                     {/* Email List */}
-                    {currentSchema.emailNotifications && currentSchema.emailNotifications.length > 0 && (
-                      <div className="space-y-2 mb-4">
-                        {currentSchema.emailNotifications.map((email, index) => (
-                          <div
-                            key={index}
-                            className="flex items-center justify-between bg-gray-50 dark:bg-gray-700 px-4 py-3 rounded-lg group hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
-                          >
-                            <div className="flex items-center gap-3">
-                              <div className="flex-shrink-0 w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
-                                <svg
-                                  className="w-4 h-4 text-blue-600 dark:text-blue-400"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                                  />
-                                </svg>
-                              </div>
-                              <span className="text-sm font-medium text-gray-900 dark:text-white">
-                                {email}
-                              </span>
-                            </div>
-                            {!readOnly && (
-                              <button
-                                type="button"
-                                onClick={() => handleRemoveEmail(index)}
-                                className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors opacity-0 group-hover:opacity-100"
-                                aria-label={`Remove ${email}`}
+                    {currentSchema.emailNotifications &&
+                      currentSchema.emailNotifications.length > 0 && (
+                        <div className="space-y-2 mb-4">
+                          {currentSchema.emailNotifications.map(
+                            (email, index) => (
+                              <div
+                                key={index}
+                                className="flex items-center justify-between bg-gray-50 dark:bg-gray-700 px-4 py-3 rounded-lg group hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
                               >
-                                <XMarkIcon className="w-5 h-5" />
-                              </button>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
+                                <div className="flex items-center gap-3">
+                                  <div className="flex-shrink-0 w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-full flex items-center justify-center">
+                                    <svg
+                                      className="w-4 h-4 text-blue-600 dark:text-blue-400"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                                      />
+                                    </svg>
+                                  </div>
+                                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                                    {email}
+                                  </span>
+                                </div>
+                                {!readOnly && (
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveEmail(index)}
+                                    className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors opacity-0 group-hover:opacity-100"
+                                    aria-label={`Remove ${email}`}
+                                  >
+                                    <XMarkIcon className="w-5 h-5" />
+                                  </button>
+                                )}
+                              </div>
+                            )
+                          )}
+                        </div>
+                      )}
 
                     {/* Empty state */}
-                    {(!currentSchema.emailNotifications || currentSchema.emailNotifications.length === 0) && (
+                    {(!currentSchema.emailNotifications ||
+                      currentSchema.emailNotifications.length === 0) && (
                       <div className="text-center py-8 mb-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
                         <svg
                           className="mx-auto h-12 w-12 text-gray-400"
@@ -799,7 +822,7 @@ export function QuestionBuilder({
           </div>
         ) : null}
       </div>
-    </div >
+    </div>
   );
 }
 
@@ -852,10 +875,11 @@ function SortableFieldItem({
         fieldRefs.current[field.id] = el;
       }}
       style={style}
-      className={`border rounded-lg transition-all ${selectedFieldId === field.id
-        ? "border-blue-500 bg-white dark:bg-gray-800 shadow-lg"
-        : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600"
-        } ${isDragging ? "z-50" : ""}`}
+      className={`border rounded-lg transition-all ${
+        selectedFieldId === field.id
+          ? "border-blue-500 bg-white dark:bg-gray-800 shadow-lg"
+          : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600"
+      } ${isDragging ? "z-50" : ""}`}
     >
       <div className="p-4">
         <div className="flex items-center justify-between">

--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -1,15 +1,18 @@
-'use client';
+"use client";
 
-import React, { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { FormSchema } from '@/types/question-builder';
-import { ExternalLink } from '../Utilities/ExternalLink';
-import { LinkIcon } from '@heroicons/react/24/outline';
-import { envVars } from '@/utilities/enviromentVars';
-import { fundingPlatformDomains } from '@/utilities/fundingPlatformDomains';
-import { useParams } from 'next/navigation';
-import { settingsConfigSchema, type SettingsConfigFormData } from '@/schemas/settingsConfigSchema';
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormSchema } from "@/types/question-builder";
+import { ExternalLink } from "../Utilities/ExternalLink";
+import { LinkIcon } from "@heroicons/react/24/outline";
+import { envVars } from "@/utilities/enviromentVars";
+import { fundingPlatformDomains } from "@/utilities/fundingPlatformDomains";
+import { useParams } from "next/navigation";
+import {
+  settingsConfigSchema,
+  type SettingsConfigFormData,
+} from "@/schemas/settingsConfigSchema";
 
 interface SettingsConfigurationProps {
   schema: FormSchema;
@@ -21,19 +24,26 @@ interface SettingsConfigurationProps {
 
 const getApplyUrlByCommunityId = (communityId: string, programId: string) => {
   if (communityId in fundingPlatformDomains) {
-    const domain = fundingPlatformDomains[communityId as keyof typeof fundingPlatformDomains];
-    return envVars.isDev ? `${domain.dev}/browse-applications?programId=${programId}` : `${domain.prod}/browse-applications?programId=${programId}`;
+    const domain =
+      fundingPlatformDomains[
+        communityId as keyof typeof fundingPlatformDomains
+      ];
+    return envVars.isDev
+      ? `${domain.dev}/browse-applications?programId=${programId}`
+      : `${domain.prod}/browse-applications?programId=${programId}`;
   } else {
-    return envVars.isDev ? `${fundingPlatformDomains.shared.dev}/${communityId}/browse-applications?programId=${programId}` : `${fundingPlatformDomains.shared.prod}/${communityId}/browse-applications?programId=${programId}`;
+    return envVars.isDev
+      ? `${fundingPlatformDomains.shared.dev}/${communityId}/browse-applications?programId=${programId}`
+      : `${fundingPlatformDomains.shared.prod}/${communityId}/browse-applications?programId=${programId}`;
   }
-}
+};
 
 export function SettingsConfiguration({
   schema,
   onUpdate,
-  className = '',
+  className = "",
   programId,
-  readOnly = false
+  readOnly = false,
 }: SettingsConfigurationProps) {
   const { communityId } = useParams() as { communityId: string };
   const {
@@ -44,8 +54,10 @@ export function SettingsConfiguration({
     resolver: zodResolver(settingsConfigSchema),
     defaultValues: {
       privateApplications: schema.settings?.privateApplications ?? true,
-      applicationDeadline: schema.settings?.applicationDeadline ?? '',
+      applicationDeadline: schema.settings?.applicationDeadline ?? "",
       donationRound: schema.settings?.donationRound ?? false,
+      showCommentsOnPublicPage:
+        schema.settings?.showCommentsOnPublicPage ?? false,
     },
   });
 
@@ -58,14 +70,17 @@ export function SettingsConfiguration({
         ...schema,
         settings: {
           ...schema.settings,
-          submitButtonText: schema.settings?.submitButtonText || 'Submit Application',
-          confirmationMessage: schema.settings?.confirmationMessage || 'Thank you for your submission!',
+          submitButtonText:
+            schema.settings?.submitButtonText || "Submit Application",
+          confirmationMessage:
+            schema.settings?.confirmationMessage ||
+            "Thank you for your submission!",
           privateApplications: data.privateApplications ?? true,
           applicationDeadline: data.applicationDeadline,
           donationRound: data.donationRound ?? false,
+          showCommentsOnPublicPage: data.showCommentsOnPublicPage ?? false,
         },
       };
-
 
       onUpdate(updatedSchema);
     });
@@ -73,27 +88,30 @@ export function SettingsConfiguration({
     return () => subscription.unsubscribe();
   }, [watch, onUpdate, schema]);
 
-  const privateApplicationsValue = watch('privateApplications');
-  const privateFieldsCount = schema.fields?.filter(field => field.private).length || 0;
+  const privateApplicationsValue = watch("privateApplications");
+  const privateFieldsCount =
+    schema.fields?.filter((field) => field.private).length || 0;
 
   return (
     <div className={`space-y-6 ${className}`}>
-
       <div className="bg-white dark:bg-zinc-800 rounded-lg border border-gray-200 dark:border-zinc-700 p-6">
-
         {/* Browse All Applications URL Setting */}
-        {watch('privateApplications') ? null : (
+        {watch("privateApplications") ? null : (
           <div className="flex flex-col space-y-2">
             <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
               All Applications URL
             </label>
-            <div className='flex flex-row items-center space-x-2'>
-              <ExternalLink className='underline text-blue-500'
-                href={getApplyUrlByCommunityId(communityId, programId as string)}
+            <div className="flex flex-row items-center space-x-2">
+              <ExternalLink
+                className="underline text-blue-500"
+                href={getApplyUrlByCommunityId(
+                  communityId,
+                  programId as string
+                )}
               >
                 Browse All Applications
               </ExternalLink>
-              <LinkIcon className='w-4 h-4 text-blue-500' />
+              <LinkIcon className="w-4 h-4 text-blue-500" />
             </div>
           </div>
         )}
@@ -103,18 +121,22 @@ export function SettingsConfiguration({
         <div className="space-y-6 py-4">
           {/* Application Deadline */}
           <div className="space-y-2">
-            <label htmlFor="applicationDeadline" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="applicationDeadline"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Application Deadline
             </label>
             <input
-              {...register('applicationDeadline')}
+              {...register("applicationDeadline")}
               type="datetime-local"
               id="applicationDeadline"
               disabled={readOnly}
-              className={`w-full px-3 py-2 border border-gray-300 dark:border-zinc-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-zinc-700 dark:text-white ${readOnly ? 'opacity-50 cursor-not-allowed' : ''}`}
+              className={`w-full px-3 py-2 border border-gray-300 dark:border-zinc-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-zinc-700 dark:text-white ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
             />
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              Set a deadline for when applications will no longer be accepted. Leave empty for no deadline.
+              Set a deadline for when applications will no longer be accepted.
+              Leave empty for no deadline.
             </p>
           </div>
 
@@ -122,18 +144,22 @@ export function SettingsConfiguration({
           <div className="space-y-3">
             <div className="flex items-start space-x-3">
               <input
-                {...register('donationRound')}
+                {...register("donationRound")}
                 type="checkbox"
                 id="donationRound"
                 disabled={readOnly}
-                className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
               />
               <div className="flex-1">
-                <label htmlFor="donationRound" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label
+                  htmlFor="donationRound"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
                   Donation Round
                 </label>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Enable this if this program is a donation round where users can contribute funds.
+                  Enable this if this program is a donation round where users
+                  can contribute funds.
                 </p>
               </div>
             </div>
@@ -143,21 +169,50 @@ export function SettingsConfiguration({
         <hr className="my-4" />
 
         <div className="space-y-6">
+          {/* Show Comments on Public Page */}
+          <div className="space-y-3">
+            <div className="flex items-start space-x-3">
+              <input
+                {...register("showCommentsOnPublicPage")}
+                type="checkbox"
+                id="showCommentsOnPublicPage"
+                disabled={readOnly}
+                className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+              />
+              <div className="flex-1">
+                <label
+                  htmlFor="showCommentsOnPublicPage"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Show comments on public page
+                </label>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Enable this to display comments on public application pages.
+                  By default, comments are hidden from public view.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <hr className="my-4" />
+
           {/* Private Applications Setting */}
           <div className="space-y-3">
             <div className="flex items-start space-x-3">
               <input
-                {...register('privateApplications')}
+                {...register("privateApplications")}
                 type="checkbox"
                 disabled={readOnly}
-                className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
               />
               <div className="flex-1">
                 <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   Private Applications
                 </label>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  When enabled, all application data will be hidden from public view. Only program administrators and applicants can see applications.
+                  When enabled, all application data will be hidden from public
+                  view. Only program administrators and applicants can see
+                  applications.
                 </p>
               </div>
             </div>
@@ -166,12 +221,22 @@ export function SettingsConfiguration({
             {!privateApplicationsValue && privateFieldsCount > 0 && (
               <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
                 <div className="flex items-start space-x-2">
-                  <svg className="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                  <svg
+                    className="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                      clipRule="evenodd"
+                    />
                   </svg>
                   <div className="text-xs text-amber-800 dark:text-amber-300">
-                    <strong>Note:</strong> You have {privateFieldsCount} private field{privateFieldsCount !== 1 ? 's' : ''} in your form.
-                    These will be filtered from public responses even with public applications enabled.
+                    <strong>Note:</strong> You have {privateFieldsCount} private
+                    field{privateFieldsCount !== 1 ? "s" : ""} in your form.
+                    These will be filtered from public responses even with
+                    public applications enabled.
                   </div>
                 </div>
               </div>
@@ -181,19 +246,26 @@ export function SettingsConfiguration({
             {privateApplicationsValue && (
               <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
                 <div className="flex items-start space-x-2">
-                  <svg className="w-4 h-4 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                  <svg
+                    className="w-4 h-4 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                      clipRule="evenodd"
+                    />
                   </svg>
                   <div className="text-xs text-blue-800 dark:text-blue-300">
-                    <strong>Private mode:</strong> Public API requests will return a privacy message instead of application data.
-                    Only authenticated administrators can access application details.
+                    <strong>Private mode:</strong> Public API requests will
+                    return a privacy message instead of application data. Only
+                    authenticated administrators can access application details.
                   </div>
                 </div>
               </div>
             )}
           </div>
-
-
 
           {/* Privacy Summary */}
           <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
@@ -202,21 +274,31 @@ export function SettingsConfiguration({
             </h4>
             <dl className="text-xs space-y-2">
               <div className="flex justify-between">
-                <dt className="text-gray-600 dark:text-gray-400">Application Visibility:</dt>
+                <dt className="text-gray-600 dark:text-gray-400">
+                  Application Visibility:
+                </dt>
                 <dd className="text-gray-900 dark:text-white font-medium">
-                  {privateApplicationsValue ? 'Private' : 'Public'}
+                  {privateApplicationsValue ? "Private" : "Public"}
                 </dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-600 dark:text-gray-400">Private Fields:</dt>
+                <dt className="text-gray-600 dark:text-gray-400">
+                  Private Fields:
+                </dt>
                 <dd className="text-gray-900 dark:text-white font-medium">
-                  {privateFieldsCount} field{privateFieldsCount !== 1 ? 's' : ''}
+                  {privateFieldsCount} field
+                  {privateFieldsCount !== 1 ? "s" : ""}
                 </dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-gray-600 dark:text-gray-400">Public Fields:</dt>
+                <dt className="text-gray-600 dark:text-gray-400">
+                  Public Fields:
+                </dt>
                 <dd className="text-gray-900 dark:text-white font-medium">
-                  {(schema.fields?.length || 0) - privateFieldsCount} field{((schema.fields?.length || 0) - privateFieldsCount) !== 1 ? 's' : ''}
+                  {(schema.fields?.length || 0) - privateFieldsCount} field
+                  {(schema.fields?.length || 0) - privateFieldsCount !== 1
+                    ? "s"
+                    : ""}
                 </dd>
               </div>
             </dl>
@@ -224,13 +306,18 @@ export function SettingsConfiguration({
 
           {/* Help Text */}
           <div className="text-xs text-gray-500 dark:text-gray-400">
-            <p className="mb-2"><strong>Private Applications:</strong> Hide all application data from public view</p>
-            <p><strong>Private Fields:</strong> Individual fields marked as private are filtered from public responses (configure per field in the form builder)</p>
+            <p className="mb-2">
+              <strong>Private Applications:</strong> Hide all application data
+              from public view
+            </p>
+            <p>
+              <strong>Private Fields:</strong> Individual fields marked as
+              private are filtered from public responses (configure per field in
+              the form builder)
+            </p>
           </div>
         </div>
-
       </div>
-
     </div>
   );
 }

--- a/schemas/settingsConfigSchema.ts
+++ b/schemas/settingsConfigSchema.ts
@@ -1,9 +1,10 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 export const settingsConfigSchema = z.object({
   privateApplications: z.boolean(),
   applicationDeadline: z.string().optional(),
   donationRound: z.boolean(),
+  showCommentsOnPublicPage: z.boolean(),
 });
 
 export type SettingsConfigFormData = z.infer<typeof settingsConfigSchema>;

--- a/types/question-builder.ts
+++ b/types/question-builder.ts
@@ -1,6 +1,16 @@
 export interface FormField {
   id: string;
-  type: 'text' | 'textarea' | 'select' | 'radio' | 'checkbox' | 'number' | 'email' | 'url' | 'date' | 'milestone';
+  type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "radio"
+    | "checkbox"
+    | "number"
+    | "email"
+    | "url"
+    | "date"
+    | "milestone";
   label: string;
   placeholder?: string;
   required?: boolean;
@@ -33,6 +43,7 @@ export interface FormSchema {
     privateApplications?: boolean; // Whether this program has private applications
     applicationDeadline?: string; // Application deadline date
     donationRound?: boolean; // Whether this is a donation round
+    showCommentsOnPublicPage?: boolean; // Whether to show comments on public application pages
   };
   // AI configuration for the entire form
   aiConfig?: {


### PR DESCRIPTION
## Summary
Adds `showCommentsOnPublicPage` setting to control comment visibility on public application pages. This feature allows program administrators to control comment visibility on public application pages. When enabled, comments will be visible to public users viewing applications (whitelable app). When disabled (default), comments remain visible only to admins and reviewers.

## Changes
- Added setting to schema and types
- Added checkbox in Settings Configuration UI
- Defaults to `false` (comments hidden from public by default)