### PR TITLE
fix: sanitize unsupported chain when updating profile

### DIFF
--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -11,7 +11,7 @@ import { useAccount } from "wagmi";
 
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useGap } from "@/hooks/useGap";
-import { getChainIdByName } from "@/utilities/network";
+import { getChainIdByName, gapSupportedNetworks } from "@/utilities/network";
 
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 import { useStepper } from "@/store/modals/txStepper";
@@ -134,10 +134,16 @@ export const ContributorProfileDialog: FC<
       let targetChainId = 0;
 
       if (isGlobal) {
-        if (chain?.id) {
+        // Check if current chain is supported for GAP attestations
+        const isChainSupported = chain?.id && gapSupportedNetworks.some(c => c.id === chain.id);
+
+        if (isChainSupported) {
           targetChainId = chain.id;
         } else if (gap?.network) {
           targetChainId = getChainIdByName(gap.network);
+        } else {
+          // Default to first supported GAP network if current chain is unsupported
+          targetChainId = gapSupportedNetworks[0].id;
         }
       } else if (project?.chainID) {
         targetChainId = project.chainID;


### PR DESCRIPTION
## Summary

Fixes profile update failures when users are connected to unsupported blockchain networks. The contributor profile dialog now properly validates the current chain and falls back to a supported GAP network when necessary.

## Changes

- Added chain validation check using `gapSupportedNetworks` to verify if the current connected chain supports GAP attestations
- Implemented fallback logic that defaults to the first supported GAP network when the current chain is unsupported
- Prevents attestation failures by ensuring profile updates always use a valid GAP-supported chain

## Technical Details

**Before**: When a user was connected to an unsupported chain (e.g., a testnet not supported by GAP), the profile update would attempt to attest on that chain and fail.

**After**: The system now checks if the current chain is in the `gapSupportedNetworks` list and falls back gracefully:
1. If chain is supported → use current chain ID
2. If not supported but GAP network exists → use GAP network's chain ID
3. Otherwise → use first supported GAP network's chain ID

**File Changed**: `components/Dialogs/ContributorProfileDialog.tsx:137-146`

## Testing Checklist

- [ ] Profile updates work when connected to supported chains
- [ ] Profile updates gracefully fallback when connected to unsupported chains
- [ ] No errors thrown during profile update flow
- [ ] Chain switching behavior is correct for global profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)