### PR TITLE
feat: Add staff access to merge projects

### DIFF
--- a/components/Dialogs/MergeProjectDialog.tsx
+++ b/components/Dialogs/MergeProjectDialog.tsx
@@ -33,6 +33,7 @@ import EthereumAddressToENSName from "../EthereumAddressToENSName";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 import { useWallet } from "@/hooks/useWallet";
 import { ensureCorrectChain } from "@/utilities/ensureCorrectChain";
+import { useStaff } from "@/hooks/useStaff";
 
 type MergeProjectProps = {
   buttonElement?: {
@@ -196,6 +197,7 @@ export const MergeProjectDialog: FC<MergeProjectProps> = ({
   const setIsProjectAdmin = useProjectStore((state) => state.setIsProjectAdmin);
   const { switchChainAsync } = useWallet();
   const { changeStepperStep, setIsStepper } = useStepper();
+  const { isStaff } = useStaff();
 
   const createProjectPointer = async ({ ogProjectUID }: PointerType) => {
     let gapClient = gap;
@@ -304,7 +306,7 @@ export const MergeProjectDialog: FC<MergeProjectProps> = ({
     <>
       {buttonElement ? (
         <Button
-          disabled={!isProjectAdmin}
+          disabled={!isProjectAdmin && !isStaff}
           onClick={openModal}
           className={buttonElement.styleClass}
         >

--- a/components/Pages/Project/ProjectOptionsMenu.tsx
+++ b/components/Pages/Project/ProjectOptionsMenu.tsx
@@ -472,21 +472,38 @@ export const ProjectOptionsMenu = () => {
                   </>
                 )}
                 {isStaff && (
-                  <Menu.Item>
-                    {({ active }) => (
-                      <button
-                        type="button"
-                        onClick={openAdminTransferOwnershipModal}
-                        className={buttonClassName}
-                      >
-                        <ArrowsRightLeftIcon
-                          className={"mr-2 h-5 w-5"}
-                          aria-hidden="true"
-                        />
-                        Transfer ownership
-                      </button>
-                    )}
-                  </Menu.Item>
+                  <>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          type="button"
+                          onClick={openMergeModal}
+                          className={buttonClassName}
+                        >
+                          <ArrowDownOnSquareIcon
+                            className={"mr-2 h-5 w-5"}
+                            aria-hidden="true"
+                          />
+                          Merge
+                        </button>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          type="button"
+                          onClick={openAdminTransferOwnershipModal}
+                          className={buttonClassName}
+                        >
+                          <ArrowsRightLeftIcon
+                            className={"mr-2 h-5 w-5"}
+                            aria-hidden="true"
+                          />
+                          Transfer ownership
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </>
                 )}
               </div>
             </Menu.Items>


### PR DESCRIPTION
## Summary
Adds staff access to merge projects functionality.

## Changes
- Added staff permission check in MergeProjectDialog
- Added "Merge" button to staff section in ProjectOptionsMenu

## Backend Note
Staff merge currently uses direct on-chain attestation (user's wallet signs)