### PR TITLE
Feat: Add Grant Completion Status to Milestones Report Highlighting

### DIFF
--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -45,6 +45,7 @@ interface Report {
   totalMilestones: number;
   pendingMilestones: number;
   completedMilestones: number;
+  isGrantCompleted?: boolean;
   proofOfWorkLinks: string[];
   evaluations: Evaluation[] | null | undefined;
   projectSlug: string;
@@ -58,7 +59,7 @@ interface Evaluation {
 
 type MilestoneCompletion = Pick<
   Report,
-  "totalMilestones" | "pendingMilestones" | "completedMilestones"
+  "totalMilestones" | "pendingMilestones" | "completedMilestones" | "isGrantCompleted"
 >;
 
 interface ReportAPIResponse {
@@ -292,11 +293,14 @@ export const ReportMilestonePage = ({
   };
 
   const isFullyCompleted = useCallback((report: MilestoneCompletion) => {
-    return (
+    const allMilestonesComplete =
       report.totalMilestones > 0 &&
       report.pendingMilestones === 0 &&
-      report.completedMilestones === report.totalMilestones
-    );
+      report.completedMilestones === report.totalMilestones;
+    
+    const grantCompleted = report.isGrantCompleted === true;
+    
+    return allMilestonesComplete || grantCompleted;
   }, []);
 
   interface StatCardProps {


### PR DESCRIPTION
## Overview
This PR enhances the milestones report page to highlight grants in green when they are marked as completed, in addition to the existing milestone completion check. Grants will now be highlighted if either all milestones are completed OR the grant is explicitly marked as completed.

## Changes Made

### Frontend Components
- **`components/Pages/Admin/ReportMilestonePage.tsx`**
  - Added `isGrantCompleted?: boolean` field to `Report` interface
  - Updated `MilestoneCompletion` type to include `isGrantCompleted`
  - Enhanced `isFullyCompleted` logic to use OR condition (milestones complete OR grant completed)

## Technical Implementation

### Interface Updates
1. **Report Interface**: Added optional `isGrantCompleted` field
   ```typescript
   interface Report {
     // ... existing fields
     isGrantCompleted?: boolean;
   }
   ```

2. **Type Definition**: Updated `MilestoneCompletion` type
   ```typescript
   type MilestoneCompletion = Pick<
     Report,
     "totalMilestones" | "pendingMilestones" | "completedMilestones" | "isGrantCompleted"
   >;
   ```

### Logic Enhancement
3. **Completion Check**: Updated `isFullyCompleted` callback to use OR logic
   - **Before**: Green only if all milestones completed
   - **After**: Green if all milestones completed OR grant is marked as completed
   ```typescript
   const isFullyCompleted = useCallback((report: MilestoneCompletion) => {
     const allMilestonesComplete =
       report.totalMilestones > 0 &&
       report.pendingMilestones === 0 &&
       report.completedMilestones === report.totalMilestones;
     
     const grantCompleted = report.isGrantCompleted === true;
     
     return allMilestonesComplete || grantCompleted;
   }, []);
   ```

## User Experience

### Visual Changes
- Grants with all milestones completed continue to show in green (existing behavior)
- Grants marked as completed now also show in green (new behavior)
- Grants that are both milestone-complete and grant-complete show in green
- Grants with neither condition do not show in green

### Benefits
- ✅ **Clearer Status Indication**: Grants explicitly marked as completed are visually distinct
- ✅ **Flexible Completion**: Grants can be marked complete even if milestone tracking is incomplete
- ✅ **Backward Compatible**: Existing milestone-based highlighting continues to work

## Files Modified

### Frontend (`gap-app-v2`)
- `components/Pages/Admin/ReportMilestonePage.tsx`
  - Updated `Report` interface (line ~48)
  - Updated `MilestoneCompletion` type (line ~62)
  - Updated `isFullyCompleted` logic (lines ~295-304)

## API Integration

### Backend Dependency
This PR requires the backend PR that adds `isGrantCompleted` to the milestones report API response.

### Expected API Response
```json
{
  "data": [
    {
      "grantUid": "0x...",
      "grantTitle": "Example Grant",
      "totalMilestones": 5,
      "completedMilestones": 5,
      "pendingMilestones": 0,
      "isGrantCompleted": true,
      // ... other fields
    }
  ]
}
```

## Testing Notes

### Manual Testing Checklist
- [ ] Grants with all milestones completed show in green (existing behavior)
- [ ] Grants marked as completed (`isGrantCompleted: true`) show in green (new behavior)
- [ ] Grants with both conditions show in green
- [ ] Grants with neither condition do not show in green
- [ ] Grants with `isGrantCompleted: false` but all milestones complete show in green
- [ ] Grants with `isGrantCompleted: true` but incomplete milestones show in green
- [ ] Grants with `isGrantCompleted: undefined` fall back to milestone-only check

### Edge Cases Tested
- [ ] Grants with `isGrantCompleted: undefined` (backward compatibility)
- [ ] Grants with `isGrantCompleted: false` and incomplete milestones
- [ ] Grants with `isGrantCompleted: true` and no milestones (`totalMilestones: 0`)
- [ ] Grants with `isGrantCompleted: true` and pending milestones

## Breaking Changes
None - This is a backward-compatible enhancement. The field is optional and defaults gracefully.

## Migration Notes
No migration required. The feature works automatically once the backend PR is deployed and provides the `isGrantCompleted` field.

## Related Issues
- Enhances milestones report visual feedback
- Works in conjunction with backend PR that provides grant completion status
- Improves UX by highlighting grants marked as completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211642618098664