### PR TITLE
fix: ensure valid URLs for deliverable proofs in Updates component

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/Updates.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/Updates.tsx
@@ -346,8 +346,12 @@ export const Updates: FC<UpdatesProps> = ({ milestone }) => {
                   )}
                   {deliverable.proof && (
                     <ExternalLink
-                      href={deliverable.proof}
-                      className="text-brand-blue hover:underline text-sm break-all"
+                    href={
+                      deliverable.proof.includes("http")
+                        ? deliverable.proof
+                        : `https://${deliverable.proof}`
+                    } 
+                    className="text-brand-blue hover:underline text-sm break-all"
                     >
                       {deliverable.proof}
                     </ExternalLink>
@@ -377,7 +381,11 @@ export const Updates: FC<UpdatesProps> = ({ milestone }) => {
                       </p>
                       {metric.datapoints[0].proof && (
                         <ExternalLink
-                          href={metric.datapoints[0].proof}
+                          href={
+                            metric.datapoints[0].proof.includes("http")
+                              ? metric.datapoints[0].proof
+                              : `https://${metric.datapoints[0].proof}`
+                          }
                           className="text-brand-blue hover:underline text-sm break-all"
                         >
                           {metric.datapoints[0].proof}


### PR DESCRIPTION
## Problem
Milestone deliverables and metric proof links without a protocol (e.g., "Moviemeter.io/home") were not treated as external links, causing navigation issues.

## Solution
Added URL protocol handling for deliverables and metric proof links. If a URL doesn't include "http", we prepend "https://" to ensure it opens as an external link. This matches the existing behavior for `proofOfWork` links.

## Changes
- Fixed external link handling for milestone deliverables proof
- Fixed external link handling for metric datapoints proof

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211317919533523