### PR TITLE
fix: resolve infinite render loop in ProjectNavigator component

### DIFF
--- a/components/Pages/Project/ProjectNavigator.tsx
+++ b/components/Pages/Project/ProjectNavigator.tsx
@@ -2,7 +2,7 @@
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/Utilities/Button";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useProgressModalStore } from "@/store/modals/progress";
@@ -21,28 +21,31 @@ export const ProjectNavigator = ({
   const pathname = usePathname();
   const projectId = useParams().projectId as string;
   const project = useProjectStore((state) => state.project);
-  const publicTabs = [
-    {
-      name: "Project",
-      href: PAGES.PROJECT.OVERVIEW(project?.details?.data?.slug || projectId),
-    },
-    {
-      name: "Updates",
-      href: PAGES.PROJECT.UPDATES(project?.details?.data?.slug || projectId),
-    },
-    {
-      name: "Funding",
-      href: PAGES.PROJECT.GRANTS(project?.details?.data?.slug || projectId),
-    },
-    {
-      name: "Impact",
-      href: PAGES.PROJECT.IMPACT.ROOT(project?.details?.data?.slug || projectId),
-    },
-    {
-      name: "Team",
-      href: PAGES.PROJECT.TEAM(project?.details?.data?.slug || projectId),
-    },
-  ];
+  const publicTabs = useMemo(
+    () => [
+      {
+        name: "Project",
+        href: PAGES.PROJECT.OVERVIEW(project?.details?.data?.slug || projectId),
+      },
+      {
+        name: "Updates",
+        href: PAGES.PROJECT.UPDATES(project?.details?.data?.slug || projectId),
+      },
+      {
+        name: "Funding",
+        href: PAGES.PROJECT.GRANTS(project?.details?.data?.slug || projectId),
+      },
+      {
+        name: "Impact",
+        href: PAGES.PROJECT.IMPACT.ROOT(project?.details?.data?.slug || projectId),
+      },
+      {
+        name: "Team",
+        href: PAGES.PROJECT.TEAM(project?.details?.data?.slug || projectId),
+      },
+    ],
+    [project?.details?.data?.slug, projectId]
+  );
   const [tabs, setTabs] = useState<typeof publicTabs>(publicTabs);
 
   const isOwner = useOwnerStore((state) => state.isOwner);


### PR DESCRIPTION
## Overview

Fixes a critical infinite render loop in the ProjectNavigator component that was causing the application to crash with "Maximum update depth exceeded" error.

## Problem

After the Biome migration (commit `25067c8d`), the ProjectNavigator component entered an infinite render loop when users navigated to project pages. 

**Root Cause:**
- The `publicTabs` array was defined inside the component body, causing it to be recreated on every render with a new object reference
- Biome's `useExhaustiveDependencies` linter rule (enabled during migration) correctly identified that `publicTabs` was used inside `useEffect` but not in the dependency array
- When `publicTabs` was added to the dependency array, it triggered an infinite loop:
  1. Component renders → creates new `publicTabs` array
  2. `useEffect` sees dependency changed → calls `setTabs(publicTabs)`
  3. State update triggers re-render → goto step 1

**Error Message:**
```
Maximum update depth exceeded. This can happen when a component calls setState 
inside useEffect, but useEffect either doesn't have a dependency array, or one 
of the dependencies changes on every render.

at ProjectNavigator.tsx:63
```

## Solution

Wrapped the `publicTabs` array with React's `useMemo` hook to ensure it only recreates when its actual dependencies change (`project?.details?.data?.slug` or `projectId`).

**Changes:**
1. Added `useMemo` import from React
2. Memoized `publicTabs` array with proper dependencies: `[project?.details?.data?.slug, projectId]`

This approach:
- ✅ Prevents infinite render loops by maintaining stable array reference
- ✅ Satisfies Biome's `useExhaustiveDependencies` linter rule
- ✅ Maintains all existing functionality
- ✅ Only recreates tabs when project slug or ID actually changes

## Why This Approach

**Considered Alternatives:**

1. **Remove publicTabs from dependency array** ❌
   - Violates React best practices
   - Could cause stale closure bugs
   - Silences linter without fixing root cause

2. **Move publicTabs outside component** ❌
   - Wouldn't work - tabs need access to `project` and `projectId` props
   - Would require complex props drilling

3. **Derive tabs directly without state** ⚠️
   - Could work but requires larger refactor
   - More invasive change for hotfix

4. **Use useMemo (chosen)** ✅
   - Minimal code change
   - Fixes root cause (unstable reference)
   - Follows React best practices
   - Satisfies linter rules

## Technical Details

### Before (Infinite Loop):
```typescript
const publicTabs = [/* ... */]; // New reference every render
useEffect(() => {
  setTabs(publicTabs);
}, [isAuthorized, project, projectId, publicTabs]); // publicTabs triggers re-render
```

### After (Stable Reference):
```typescript
const publicTabs = useMemo(() => [/* ... */], 
  [project?.details?.data?.slug, projectId]); // Only recreates when deps change
useEffect(() => {
  setTabs(publicTabs);
}, [isAuthorized, project, projectId, publicTabs]); // publicTabs stable now
```

### Flow Diagram

```mermaid
graph TD
    A[Component Renders] --> B{publicTabs changed?}
    B -->|Before: Always YES| C[useEffect Runs]
    B -->|After: Only if slug/id changed| D[Skip useEffect]
    C --> E[setTabs called]
    E --> F[Re-render triggered]
    F --> A
    D --> G[No re-render]
    
    style C fill:#ff6b6b
    style E fill:#ff6b6b
    style F fill:#ff6b6b
    style D fill:#51cf66
    style G fill:#51cf66
```

## Testing Steps

### Manual Testing

1. **Start development server:**
   ```bash
   yarn dev
   ```

2. **Navigate to any project page:**
   - Go to `http://localhost:3000/project/[any-project-id]`
   - Examples: `/project/test-project` or `/project/optimism-grants`

3. **Verify no errors:**
   - ✅ Page should load without console errors
   - ✅ No "Maximum update depth exceeded" error
   - ✅ Navigation tabs display correctly

4. **Test both user types:**
   - **As public user:** Should see 5 tabs (Project, Updates, Funding, Impact, Team)
   - **As project admin/owner:** Should see 6 tabs (+ Contact Info)

5. **Test tab navigation:**
   - Click each tab to verify routing works
   - Tabs should highlight correctly based on active route

### Automated Testing

```bash
# Type checking
yarn tsc --noEmit

# Linting (should pass with no warnings)
yarn lint
```

## Breaking Changes

None. This is a backward-compatible bug fix with no API changes.

## Related Issues

This bug was introduced in commit `25067c8d` during the Biome linter migration when the `useExhaustiveDependencies` rule was enabled.

## Checklist

- [x] Bug fix tested manually
- [x] No TypeScript errors
- [x] Biome linter passes
- [x] No breaking changes
- [x] Solution follows React best practices
- [x] Minimal code change (surgical fix)

## Additional Context

**Impact:** This was a critical bug that made all project pages unusable, causing immediate application crashes for all users attempting to view project details.

**Timeline:**
- **Introduced:** Nov 27, 2025 (commit `25067c8d` - Biome migration)
- **Fixed:** Nov 28, 2025 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>