### PR TITLE
Feat: Hide Total Grants Card When Program is Selected

### DIFF
--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
-import { useParams, usePathname } from "next/navigation";
+import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useImpactMeasurement } from "@/hooks/useImpactMeasurement";
@@ -69,7 +69,9 @@ export const ImpactStatCards = () => {
 
 export const CommunityStatCards = () => {
   const params = useParams();
+  const searchParams = useSearchParams();
   const communityId = params.communityId as string;
+  const programId = searchParams.get("programId");
   const {
     totalProjects: filteredProjectsCount,
     totalGrants: filteredGrantsCount,
@@ -150,7 +152,13 @@ export const CommunityStatCards = () => {
       ) : null,
     },
   ];
-  return stats.map((item) => (
+
+  // Filter out "Total Grants" card when programId is present
+  const filteredStats = programId
+    ? stats.filter((stat) => stat.title !== "Total Grants")
+    : stats;
+
+  return filteredStats.map((item) => (
     <div
       key={item.title}
       className="flex flex-1 rounded-lg border border-gray-300 dark:border-zinc-600"

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
@@ -154,9 +155,10 @@ export const CommunityStatCards = () => {
   ];
 
   // Filter out "Total Grants" card when programId is present
-  const filteredStats = programId
-    ? stats.filter((stat) => stat.title !== "Total Grants")
-    : stats;
+  const filteredStats = useMemo(
+    () => (programId ? stats.filter((stat) => stat.title !== "Total Grants") : stats),
+    [programId, stats]
+  );
 
   return filteredStats.map((item) => (
     <div


### PR DESCRIPTION
## Overview
This PR implements conditional rendering of the "Total Grants" stat card on the Gardens community page. When a program is selected via the `programId` query parameter, the Total Grants card is hidden, showing only the Total Projects and Project Updates cards.

## Changes Made
- Modified `CommunityStatCards` component to read `programId` from URL query parameters
- Added conditional filtering logic to hide "Total Grants" card when a program is selected
- Updated imports to include `useSearchParams` hook from Next.js

## Files Modified
- `gap-app-v2/components/Pages/Communities/Impact/StatCards.tsx`
  - Added `useSearchParams` import
  - Added `programId` extraction from search params
  - Added filtering logic to conditionally exclude "Total Grants" card

## Behavior
- **When `programId` is present** (e.g., `?programId=933_42161`): 
  - Shows: Total Projects, Project Updates (2 cards)
  - Hides: Total Grants
  
- **When no `programId` is present**:
  - Shows: Total Projects, Total Grants, Project Updates (3 cards)

## Testing Notes
- Test with URL: `http://localhost:3000/community/gardens-community?programId=933_42161`
  - Expected: Only Total Projects and Project Updates cards visible
- Test with URL: `http://localhost:3000/community/gardens-community`
  - Expected: All three cards (Total Projects, Total Grants, Project Updates) visible
- Verify that selecting/deselecting programs in the dropdown updates the card visibility correctly

## Breaking Changes
None - this is a UI-only change that doesn't affect API contracts or data structures.
