### PR TITLE
fix: toast content overflow issue

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         >
           <PrivyProviderWrapper>
             <PermissionsProvider />
-            <Toaster />
+            <Toaster
+              position="top-right"
+              toastOptions={{
+                className: "toast-content",
+                style: {
+                  maxWidth: "500px",
+                  wordWrap: "break-word",
+                  overflowWrap: "anywhere",
+                  wordBreak: "break-word",
+                },
+                duration: 4000,
+              }}
+              containerStyle={{
+                maxWidth: "500px",
+              }}
+            />
             <StepperDialog />
             <Suspense fallback={null}>
               <ContributorProfileDialog />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -357,6 +357,9 @@ body * {
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+
+    /* Toast max-width for overflow prevention */
+    --toast-max-width: 500px;
   }
 
   .dark {
@@ -432,5 +435,40 @@ body * {
 @layer utilities {
   .section-title {
     @apply font-semibold text-3xl leading-tight tracking-tight md:text-4xl;
+  }
+}
+
+/* Toast content overflow fix */
+body .react-hot-toast {
+  max-width: var(--toast-max-width);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+body .react-hot-toast > div {
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.toast-content {
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+  max-width: 100%;
+}
+
+/* Ensure text content inside toast breaks long strings */
+body .react-hot-toast * {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+@media (max-width: 640px) {
+  body .react-hot-toast {
+    max-width: calc(100vw - 32px);
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -417,9 +417,7 @@ body * {
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
   }
-}
 
-@layer base {
   * {
     @apply border-border;
   }
@@ -471,7 +469,8 @@ body .react-hot-toast * {
   body .react-hot-toast {
     max-width: calc(100vw - 32px);
   }
-  
+}
+
 /* Prevent scrollbar from overlapping textarea in MarkdownEditor */
 .markdown-editor-wrapper .w-md-editor-text {
   padding-right: 1rem !important;


### PR DESCRIPTION
## Fix toast content overflow issue

Fixes toast content overflow by configuring proper text wrapping and max-width constraints. Handles long unbreakable strings (addresses, hex values) using `overflow-wrap: anywhere`.

**Changes:**
- Configured `Toaster` component with `maxWidth` and text wrapping styles
- Added CSS rules for proper text wrapping and overflow handling
- Set responsive max-width (500px desktop, `calc(100vw - 32px)` mobile)

**Files modified:**
- `app/layout.tsx` - Added Toaster configuration
- `styles/globals.css` - Added toast-specific CSS rules

![Xnip2025-12-05_11-32-52](https://github.com/user-attachments/assets/65ae184a-9154-4cb5-bead-538a98569acc)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212317233704855