### PR TITLE
fix: improve grant card description length and fix CSS line-clamp

### DIFF
--- a/__tests__/components/Cards/GrantCard.test.tsx
+++ b/__tests__/components/Cards/GrantCard.test.tsx
@@ -415,7 +415,7 @@ describe("GrantCard", () => {
       expect(screen.getByText(/2.*Milestones/i)).toBeInTheDocument();
     });
 
-    it("should truncate description to 100 characters", () => {
+    it("should truncate description to 200 characters", () => {
       const grantWithLongDescription = {
         ...mockGrant,
         project: {
@@ -423,7 +423,7 @@ describe("GrantCard", () => {
           details: {
             data: {
               ...mockGrant.project?.details?.data,
-              description: "A".repeat(200),
+              description: "A".repeat(400),
             },
           },
         },
@@ -432,7 +432,7 @@ describe("GrantCard", () => {
       render(<GrantCard grant={grantWithLongDescription} index={0} />);
 
       const markdownPreview = screen.getByTestId("markdown-preview");
-      expect(markdownPreview.textContent?.length).toBe(100);
+      expect(markdownPreview.textContent?.length).toBe(200);
     });
 
     it("should calculate updates correctly (completed milestones + updates)", () => {

--- a/components/GrantCard.tsx
+++ b/components/GrantCard.tsx
@@ -140,7 +140,7 @@ const GrantCardContent = ({
           <div className="flex flex-col gap-1 flex-1 h-[64px]">
             <div className="text-sm text-gray-900 dark:text-gray-400 text-ellipsis line-clamp-3">
               <MarkdownPreview
-                source={grant.project?.details?.data?.description?.slice(0, 100)}
+                source={grant.project?.details?.data?.description?.slice(0, 200)}
                 allowElement={(element) => {
                   // Prevent rendering links to avoid nested <a> tags
                   return element.tagName !== "a";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,7 @@ body * {
 .line-clamp-1 {
   display: -webkit-box;
   -webkit-line-clamp: 1;
+  line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
@@ -115,6 +116,7 @@ body * {
 .line-clamp-2 {
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
@@ -142,6 +144,7 @@ body * {
 .line-clamp-3 {
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   max-height: 73px;
@@ -168,6 +171,7 @@ body * {
 .line-clamp-4 {
   display: -webkit-box;
   -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -102,7 +102,7 @@ body * {
     display: inline;
   }
   *::after {
-    content: " A";
+    content: " \A";
     white-space: pre;
   }
   strong::after,
@@ -124,7 +124,7 @@ body * {
     display: inline;
   }
   *::after {
-    content: " A";
+    content: " \A";
     white-space: pre;
   }
   strong::after,
@@ -157,7 +157,7 @@ body * {
     display: list-item;
   }
   *::after {
-    content: " A";
+    content: " \A";
     white-space: pre;
   }
   strong::after,
@@ -179,7 +179,7 @@ body * {
     display: inline;
   }
   *::after {
-    content: " A";
+    content: " \A";
     white-space: pre;
   }
   strong::after,


### PR DESCRIPTION
## Problem

1. **Grant card description preview is too short** - Only showing 100 characters makes it difficult for users to get a meaningful preview of grant descriptions
2. **CSS line-clamp compatibility issues** - Missing standard `line-clamp` property alongside `-webkit-line-clamp`
3. **Incorrect line break character** - `::after` pseudo-elements were using `' A'` instead of `' \A'` for line breaks

## Solution

### GrantCard.tsx
- Increased description preview from 100 to 200 characters for better readability

### styles/globals.css
- Added standard `line-clamp` property alongside `-webkit-line-clamp` for better CSS specification compliance
- Fixed `::after` pseudo-element content from `' A'` to `' \A'` (the correct CSS line break character)

## Testing
- Verified grant cards display longer description previews
- Confirmed line-clamp styles work correctly across browsers

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Style/UI improvement

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212327023756164