### PR TITLE
fix: return status code from fetchData for proper error handling

### DIFF
--- a/components/Pages/Project/SetPayoutAddressButton.tsx
+++ b/components/Pages/Project/SetPayoutAddressButton.tsx
@@ -227,7 +227,7 @@ export const SetPayoutAddressButton: FC<SetPayoutAddressButtonProps> = ({
     }
 
     try {
-      const [data, error] = await fetchData(
+      const [data, error, , status] = await fetchData(
         INDEXER.PROJECT.PAYOUT_ADDRESS.UPDATE(project.uid),
         "PATCH",
         {
@@ -273,7 +273,7 @@ export const SetPayoutAddressButton: FC<SetPayoutAddressButtonProps> = ({
 
       if (error) {
         // Use the error message from the API, with fallbacks for different status codes
-        const errorMessage = error.message || getDefaultErrorMessage(error.status);
+        const errorMessage = error || getDefaultErrorMessage(status);
         setError(errorMessage);
         throw new Error(errorMessage);
       }
@@ -307,7 +307,7 @@ export const SetPayoutAddressButton: FC<SetPayoutAddressButtonProps> = ({
     setError(null);
 
     try {
-      const [data, error] = await fetchData(
+      const [data, error, , status] = await fetchData(
         INDEXER.PROJECT.PAYOUT_ADDRESS.UPDATE(project.uid),
         "PATCH",
         {
@@ -352,7 +352,7 @@ export const SetPayoutAddressButton: FC<SetPayoutAddressButtonProps> = ({
 
       if (error) {
         // Use the error message from the API, with fallbacks for different status codes
-        const errorMessage = error.message || getDefaultErrorMessage(error.status);
+        const errorMessage = error || getDefaultErrorMessage(status);
         setError(errorMessage);
         throw new Error(errorMessage);
       }

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -52,14 +52,16 @@ export default async function fetchData(
     const res = await axios.request(requestConfig);
     const resData = res.data;
     const pageInfo = res.data.pageInfo || null;
-    return [resData, null, pageInfo];
+    return [resData, null, pageInfo, res.status];
   } catch (err: any) {
     let error = "";
+    let status = 500;
     if (!err.response) {
       error = err;
     } else {
       error = err.response.data.message || err.message;
+      status = err.response.status;
     }
-    return [null, error];
+    return [null, error, null, status];
   }
 }


### PR DESCRIPTION
## Summary
- Add HTTP status code as 4th return parameter from `fetchData` utility
- Update `SetPayoutAddressButton` to use status code for appropriate error messages
- Users now see meaningful error messages based on status (400, 401, 403, 422, 500) instead of generic errors

## Changes
- `utilities/fetchData.ts`: Returns `[data, error, pageInfo, status]` instead of `[data, error, pageInfo]`
- `components/Pages/Project/SetPayoutAddressButton.tsx`: Destructures status and uses `getDefaultErrorMessage(status)` as fallback

## Test plan
- [ ] Trigger various API errors (401, 403, 500) on payout address update
- [ ] Verify appropriate error messages are displayed to user
- [ ] Verify successful operations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)