### PR TITLE
feat(funding-platform): add markdown support for program descriptions

### DIFF
--- a/app/community/[communityId]/admin/funding-platform/page.tsx
+++ b/app/community/[communityId]/admin/funding-platform/page.tsx
@@ -25,6 +25,7 @@ import { CreateProgramModal } from "@/components/FundingPlatform/CreateProgramMo
 import { FundingPlatformStatsCard } from "@/components/FundingPlatform/Dashboard/card";
 import { Button } from "@/components/Utilities/Button";
 import { LoadingOverlay } from "@/components/Utilities/LoadingOverlay";
+import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
@@ -171,9 +172,10 @@ export default function FundingPlatformAdminPage() {
       const searchLower = searchTerm.toLowerCase();
       const matchesSearch =
         searchTerm === "" ||
-        program.name?.toLowerCase().includes(searchLower) ||
         program.metadata?.title?.toLowerCase().includes(searchLower) ||
+        program.name?.toLowerCase().includes(searchLower) ||
         program.metadata?.description?.toLowerCase().includes(searchLower) ||
+        program.metadata?.shortDescription?.toLowerCase().includes(searchLower) ||
         program.programId?.toLowerCase().includes(searchLower);
 
       // Enabled/Disabled filter
@@ -588,11 +590,15 @@ export default function FundingPlatformAdminPage() {
                 {/* Program Title and Description */}
                 <div className="mb-3">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 text-ellipsis line-clamp-2">
-                    {program.name || program.metadata?.title}
+                    {program.metadata?.title || program.name}
                   </h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 overflow-hidden text-ellipsis line-clamp-2">
-                    {program.metadata?.description}
-                  </p>
+                  <MarkdownPreview
+                    source={
+                      program.metadata?.shortDescription ||
+                      (program.metadata?.description as string)
+                    }
+                    className="text-sm mb-3 overflow-hidden text-ellipsis line-clamp-2"
+                  />
                 </div>
 
                 {/* Compact Stats Row */}

--- a/app/community/[communityId]/reviewer/funding-platform/page.tsx
+++ b/app/community/[communityId]/reviewer/funding-platform/page.tsx
@@ -22,6 +22,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import pluralize from "pluralize";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/Utilities/Button";
+import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import { useReviewerPrograms } from "@/hooks/usePermissions";
@@ -450,12 +451,16 @@ export default function ReviewerFundingPlatformPage() {
                 {/* Program Header */}
                 <div className="">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 text-ellipsis line-clamp-2">
-                    {program.name || program.metadata?.title}
+                    {program.metadata?.title || program.name}
                   </h3>
+                  <MarkdownPreview
+                    source={
+                      program.metadata?.shortDescription ||
+                      (program.metadata?.description as string)
+                    }
+                    className="text-sm mb-3 overflow-hidden text-ellipsis line-clamp-2"
+                  />
 
-                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 overflow-hidden text-ellipsis line-clamp-2 h-[46px]">
-                    {program.metadata?.description}
-                  </p>
                   <div className="flex flex-row gap-2 items-center text-xs text-gray-500 dark:text-gray-400 bg-orange-100 dark:bg-orange-900/20 p-2 rounded-md">
                     <CalendarIcon className="w-5 h-5 text-orange-700 dark:text-orange-300" />
                     <span className="flex items-center gap-2 text-orange-700 dark:text-orange-300">

--- a/components/FundingPlatform/CreateProgramModal.tsx
+++ b/components/FundingPlatform/CreateProgramModal.tsx
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -17,7 +18,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { useAuth } from "@/hooks/useAuth";
 import { type CreateProgramFormSchema, createProgramSchema } from "@/schemas/programFormSchema";
@@ -194,46 +194,56 @@ export function CreateProgramModal({
             </div>
 
             {/* Program Description */}
-            <div className="flex w-full flex-col gap-1">
-              <Label htmlFor="program-description">
-                Program Description <span className="text-destructive">*</span>
-              </Label>
-              <Textarea
-                id="program-description"
-                className="min-h-[120px] max-h-[240px] resize-y"
-                placeholder="Please provide a description of this program"
-                {...register("description")}
-                disabled={isSubmitting}
-              />
-              {errors.description && (
-                <p className="text-sm text-destructive">{errors.description.message}</p>
+            <Controller
+              name="description"
+              control={control}
+              render={({ field: { onChange, onBlur, value }, fieldState }) => (
+                <MarkdownEditor
+                  label="Program Description"
+                  placeholder="Please provide a description of this program"
+                  value={value || ""}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  error={fieldState.error?.message}
+                  isRequired
+                  isDisabled={isSubmitting}
+                  id="program-description"
+                  height={200}
+                  minHeight={150}
+                />
               )}
-            </div>
+            />
 
             {/* Short Description */}
-            <div className="flex w-full flex-col gap-1">
-              <Label htmlFor="short-description">
-                Program Short Description <span className="text-destructive">*</span>
-                <span className="text-xs text-muted-foreground ml-2 font-normal">
-                  (100 characters max)
-                </span>
-              </Label>
-              <Input
-                id="short-description"
-                placeholder="Brief description (max 100 characters)"
-                maxLength={100}
-                {...register("shortDescription")}
-                disabled={isSubmitting}
-              />
-              <div className="flex justify-between items-center">
-                {errors.shortDescription && (
-                  <p className="text-sm text-destructive">{errors.shortDescription.message}</p>
-                )}
-                <p className="text-xs text-muted-foreground">
-                  {watch("shortDescription")?.length || 0}/100
-                </p>
-              </div>
-            </div>
+            <Controller
+              name="shortDescription"
+              control={control}
+              render={({ field: { onChange, onBlur, value }, fieldState }) => (
+                <div className="flex w-full flex-col gap-1">
+                  <MarkdownEditor
+                    label="Program Short Description"
+                    description="100 characters max"
+                    placeholder="Brief description (max 100 characters)"
+                    value={value || ""}
+                    onChange={(val) => {
+                      if (val.length <= 100) {
+                        onChange(val);
+                      }
+                    }}
+                    onBlur={onBlur}
+                    error={fieldState.error?.message}
+                    isRequired
+                    isDisabled={isSubmitting}
+                    id="short-description"
+                    height={120}
+                    minHeight={100}
+                  />
+                  <p className="text-xs text-muted-foreground text-right">
+                    {value?.length || 0}/100
+                  </p>
+                </div>
+              )}
+            />
 
             {/* Dates */}
             <div className="grid grid-cols-2 gap-4">

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -7,11 +7,11 @@ import { useAccount } from "wagmi";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/hooks/useAuth";
 import { type CreateProgramFormSchema, createProgramSchema } from "@/schemas/programFormSchema";
 import { ProgramRegistryService } from "@/services/programRegistry.service";
@@ -344,58 +344,63 @@ export function ProgramDetailsTab({
           </div>
 
           {/* Program Description */}
-          <div className="flex w-full flex-col gap-1">
-            <Label htmlFor="program-description">
-              Program Description <span className="text-destructive">*</span>
-            </Label>
-            <Textarea
-              id="program-description"
-              className="min-h-[120px] max-h-[240px] resize-y"
-              placeholder="Please provide a description of this program"
-              {...register("description")}
-              disabled={isDisabled}
-              aria-invalid={errors.description ? "true" : "false"}
-              aria-describedby={errors.description ? "program-description-error" : undefined}
-            />
-            {errors.description && (
-              <p id="program-description-error" className="text-sm text-destructive" role="alert">
-                {errors.description.message}
-              </p>
+          <Controller
+            name="description"
+            control={control}
+            render={({ field: { onChange, onBlur, value }, fieldState }) => (
+              <div className="flex w-full flex-col gap-1">
+                <MarkdownEditor
+                  label="Program Description"
+                  placeholder="Please provide a description of this program"
+                  value={value || ""}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  error={fieldState.error?.message}
+                  isRequired
+                  isDisabled={isDisabled}
+                  id="program-description"
+                  height={200}
+                  minHeight={150}
+                />
+                <AriaLiveError error={fieldState.error} />
+              </div>
             )}
-            <AriaLiveError error={errors.description} />
-          </div>
+          />
 
           {/* Short Description */}
-          <div className="flex w-full flex-col gap-1">
-            <Label htmlFor="short-description">
-              Program Short Description <span className="text-destructive">*</span>
-              <span className="text-xs text-muted-foreground ml-2 font-normal">
-                (100 characters max)
-              </span>
-            </Label>
-            <Input
-              id="short-description"
-              placeholder="Brief description (max 100 characters)"
-              maxLength={SHORT_DESCRIPTION_MAX_LENGTH}
-              {...register("shortDescription")}
-              disabled={isDisabled}
-              aria-invalid={errors.shortDescription ? "true" : "false"}
-              aria-describedby={
-                errors.shortDescription ? "short-description-error" : "short-description-count"
-              }
-            />
-            <div className="flex justify-between items-center">
-              {errors.shortDescription && (
-                <p id="short-description-error" className="text-sm text-destructive" role="alert">
-                  {errors.shortDescription.message}
+          <Controller
+            name="shortDescription"
+            control={control}
+            render={({ field: { onChange, onBlur, value }, fieldState }) => (
+              <div className="flex w-full flex-col gap-1">
+                <MarkdownEditor
+                  label="Program Short Description"
+                  description="100 characters max"
+                  placeholder="Brief description (max 100 characters)"
+                  value={value || ""}
+                  onChange={(val) => {
+                    if (val.length <= SHORT_DESCRIPTION_MAX_LENGTH) {
+                      onChange(val);
+                    }
+                  }}
+                  onBlur={onBlur}
+                  error={fieldState.error?.message}
+                  isRequired
+                  isDisabled={isDisabled}
+                  id="short-description"
+                  height={120}
+                  minHeight={100}
+                />
+                <p
+                  id="short-description-count"
+                  className="text-xs text-muted-foreground text-right"
+                >
+                  {shortDescription?.length || 0}/{SHORT_DESCRIPTION_MAX_LENGTH}
                 </p>
-              )}
-              <p id="short-description-count" className="text-xs text-muted-foreground">
-                {shortDescription?.length || 0}/{SHORT_DESCRIPTION_MAX_LENGTH}
-              </p>
-            </div>
-            <AriaLiveError error={errors.shortDescription} />
-          </div>
+                <AriaLiveError error={fieldState.error} />
+              </div>
+            )}
+          />
 
           {/* Dates */}
           <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

This PR adds markdown support for program descriptions in the Funding Platform.

## Changes

### CreateProgramModal
- Replaced `Textarea` with `MarkdownEditor` for program description
- Replaced `Textarea` with `MarkdownEditor` for short description (with 100 char limit)

### ProgramDetailsTab
- Replaced `Textarea` with `MarkdownEditor` for all description fields

### Admin Funding Platform Page
- Added `MarkdownPreview` component to render formatted descriptions
- Updated search to include `shortDescription` field
- Prioritized `metadata.title` over `name` for display consistency

### Reviewer Funding Platform Page  
- Added `MarkdownPreview` component to render formatted descriptions

## Testing
- [ ] Verify markdown editor works correctly in CreateProgramModal
- [ ] Verify markdown preview renders correctly in admin and reviewer pages
- [ ] Verify search includes short description field