### PR TITLE
fix(contracts): show API error message instead of status code

### DIFF
--- a/services/contracts.service.ts
+++ b/services/contracts.service.ts
@@ -11,6 +11,16 @@ apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
     console.error("Contract API Error:", error.response?.data || error.message);
+
+    // Extract the API error message if available, otherwise use a user-friendly message
+    const apiErrorMessage = error.response?.data?.message;
+    if (apiErrorMessage) {
+      // Create a new error with the API message
+      const enhancedError = new Error(apiErrorMessage);
+      (enhancedError as Error & { originalError?: unknown }).originalError = error;
+      throw enhancedError;
+    }
+
     throw error;
   }
 );


### PR DESCRIPTION
## Summary
Update the contracts service error interceptor to show meaningful error messages from the API instead of generic axios status messages.

## Problem
When contract verification failed, users saw unhelpful messages like:
> "Request failed with status code 503"

## Solution
Extract the actual error message from API responses (`error.response.data.message`) and display that instead:
> "Contract 0x... not found on celo explorer. If you recently deployed this contract, it may take some time to be indexed. Please try again later."

## Changes
- Updated `services/contracts.service.ts` response interceptor to extract API error messages

## Test plan
- [ ] Manual test with contract verification flow
- [ ] Verify error messages are user-friendly

🤖 Generated with [Claude Code](https://claude.com/claude-code)