### PR TITLE
feat: Add internal AI evaluation column and CSV export formatting

### DIFF
--- a/__tests__/integration/components/FundingPlatform/ApplicationList/ApplicationList.aiScore.test.tsx
+++ b/__tests__/integration/components/FundingPlatform/ApplicationList/ApplicationList.aiScore.test.tsx
@@ -72,6 +72,7 @@ describe("ApplicationList - AI Score Column", () => {
           sortBy="status"
           sortOrder="asc"
           onSortChange={jest.fn()}
+          showAIScoreColumn={true}
         />
       );
 
@@ -91,6 +92,7 @@ describe("ApplicationList - AI Score Column", () => {
           sortBy="status"
           sortOrder="asc"
           onSortChange={mockOnSortChange}
+          showAIScoreColumn={true}
         />
       );
 
@@ -113,6 +115,7 @@ describe("ApplicationList - AI Score Column", () => {
           sortBy="aiEvaluationScore"
           sortOrder="desc"
           onSortChange={jest.fn()}
+          showAIScoreColumn={true}
         />
       );
 
@@ -139,6 +142,7 @@ describe("ApplicationList - AI Score Column", () => {
           applications={applications}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -166,6 +170,7 @@ describe("ApplicationList - AI Score Column", () => {
           applications={applications}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -199,6 +204,7 @@ describe("ApplicationList - AI Score Column", () => {
           applications={applications}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -222,6 +228,7 @@ describe("ApplicationList - AI Score Column", () => {
           applications={applications}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -247,6 +254,7 @@ describe("ApplicationList - AI Score Column", () => {
           applications={applications}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -282,6 +290,7 @@ describe("ApplicationList - AI Score Column", () => {
           onApplicationSelect={jest.fn()}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 
@@ -309,6 +318,7 @@ describe("ApplicationList - AI Score Column", () => {
           onApplicationHover={mockOnApplicationHover}
           sortBy="status"
           sortOrder="asc"
+          showAIScoreColumn={true}
         />
       );
 

--- a/__tests__/integration/components/FundingPlatform/helper/formatEvaluationResponse.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/formatEvaluationResponse.test.ts
@@ -1,0 +1,332 @@
+import { formatEvaluationResponse } from "@/components/FundingPlatform/helper/formatEvaluationResponse";
+
+// Mock console.warn to avoid noise in tests
+const mockConsoleWarn = jest.spyOn(console, "warn").mockImplementation();
+
+describe("formatEvaluationResponse", () => {
+  beforeEach(() => {
+    mockConsoleWarn.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleWarn.mockRestore();
+  });
+
+  describe("Null and undefined handling", () => {
+    it("should return empty string for null input", () => {
+      expect(formatEvaluationResponse(null)).toBe("");
+    });
+
+    it("should return empty string for undefined input", () => {
+      expect(formatEvaluationResponse(undefined)).toBe("");
+    });
+
+    it("should return empty string for empty string input", () => {
+      expect(formatEvaluationResponse("")).toBe("");
+    });
+  });
+
+  describe("Invalid JSON handling", () => {
+    it("should return empty string for invalid JSON", () => {
+      const result = formatEvaluationResponse("invalid json {");
+      expect(result).toBe("");
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        "Failed to parse evaluation JSON:",
+        expect.any(Error)
+      );
+    });
+
+    it("should handle malformed JSON gracefully", () => {
+      const result = formatEvaluationResponse('{"incomplete":');
+      expect(result).toBe("");
+      expect(mockConsoleWarn).toHaveBeenCalled();
+    });
+  });
+
+  describe("Simple field formatting", () => {
+    it("should format evaluation with simple fields", () => {
+      const evaluation = {
+        evaluation_status: "approved",
+        decision: "accept",
+        final_score: 85,
+        reviewer_confidence: "high",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_status");
+      expect(result).toContain("approved");
+      expect(result).toContain("decision");
+      expect(result).toContain("accept");
+      expect(result).toContain("final_score");
+      expect(result).toContain("85");
+      expect(result).toContain("reviewer_confidence");
+      expect(result).toContain("high");
+    });
+
+    it("should handle null values in simple fields", () => {
+      const evaluation = {
+        evaluation_status: null,
+        decision: "pending",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_status");
+      expect(result).toContain("null");
+      expect(result).toContain("decision");
+      expect(result).toContain("pending");
+    });
+
+    it("should handle boolean values", () => {
+      const evaluation = {
+        is_approved: true,
+        is_rejected: false,
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("is_approved");
+      expect(result).toContain("true");
+      expect(result).toContain("is_rejected");
+      expect(result).toContain("false");
+    });
+
+    it("should escape newlines in string values", () => {
+      const evaluation = {
+        additional_notes: "Line 1\nLine 2\nLine 3",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("Line 1\\nLine 2\\nLine 3");
+      expect(result).not.toContain("\n");
+    });
+
+    it("should format numeric values correctly", () => {
+      const evaluation = {
+        final_score: 42.5,
+        reviewer_confidence: 95,
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("final_score");
+      expect(result).toContain("42.5");
+      expect(result).toContain("reviewer_confidence");
+      expect(result).toContain("95");
+    });
+  });
+
+  describe("Evaluation summary formatting", () => {
+    it("should format evaluation_summary with arrays", () => {
+      const evaluation = {
+        evaluation_summary: {
+          strengths: ["Strong team", "Clear vision"],
+          concerns: ["Limited budget"],
+          risk_factors: ["Market volatility"],
+        },
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_summary");
+      expect(result).toContain("strengths");
+      expect(result).toContain("Strong team");
+      expect(result).toContain("Clear vision");
+      expect(result).toContain("concerns");
+      expect(result).toContain("Limited budget");
+      expect(result).toContain("risk_factors");
+      expect(result).toContain("Market volatility");
+    });
+
+    it("should handle empty arrays in evaluation_summary", () => {
+      const evaluation = {
+        evaluation_summary: {
+          strengths: [],
+          concerns: ["Some concern"],
+        },
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_summary");
+      expect(result).not.toContain("strengths:");
+      expect(result).toContain("concerns");
+      expect(result).toContain("Some concern");
+    });
+
+    it("should handle missing array fields in evaluation_summary", () => {
+      const evaluation = {
+        evaluation_summary: {
+          strengths: ["Only strength"],
+        },
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_summary");
+      expect(result).toContain("strengths");
+      expect(result).toContain("Only strength");
+    });
+  });
+
+  describe("Improvement recommendations formatting", () => {
+    it("should format improvement_recommendations with all fields", () => {
+      const evaluation = {
+        improvement_recommendations: [
+          {
+            priority: "high",
+            recommendation: "Improve documentation",
+            impact: "High impact on clarity",
+          },
+          {
+            priority: 1,
+            recommendation: "Add more examples",
+            impact: "Medium impact",
+          },
+        ],
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("improvement_recommendations");
+      expect(result).toContain("priority");
+      expect(result).toContain("high");
+      expect(result).toContain("recommendation");
+      expect(result).toContain("Improve documentation");
+      expect(result).toContain("impact");
+      expect(result).toContain("High impact on clarity");
+      expect(result).toContain("1");
+      expect(result).toContain("Add more examples");
+    });
+
+    it("should handle recommendations with missing fields", () => {
+      const evaluation = {
+        improvement_recommendations: [
+          {
+            recommendation: "Only recommendation",
+          },
+          {
+            priority: "low",
+          },
+        ],
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("improvement_recommendations");
+      expect(result).toContain("Only recommendation");
+      expect(result).toContain("low");
+    });
+
+    it("should handle empty recommendations array", () => {
+      const evaluation = {
+        improvement_recommendations: [],
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).not.toContain("improvement_recommendations");
+    });
+  });
+
+  describe("Complex evaluation formatting", () => {
+    it("should format complete evaluation with all fields", () => {
+      const evaluation = {
+        evaluation_status: "approved",
+        disqualification_reason: null,
+        decision: "accept",
+        final_score: 87.5,
+        evaluation_summary: {
+          strengths: ["Innovative approach", "Strong team"],
+          concerns: ["Budget constraints"],
+          risk_factors: ["Market competition"],
+        },
+        improvement_recommendations: [
+          {
+            priority: "high",
+            recommendation: "Expand team",
+            impact: "High",
+          },
+        ],
+        reviewer_confidence: "very_high",
+        additional_notes: "Excellent application",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_status");
+      expect(result).toContain("approved");
+      expect(result).toContain("decision");
+      expect(result).toContain("accept");
+      expect(result).toContain("final_score");
+      expect(result).toContain("87.5");
+      expect(result).toContain("evaluation_summary");
+      expect(result).toContain("strengths");
+      expect(result).toContain("Innovative approach");
+      expect(result).toContain("improvement_recommendations");
+      expect(result).toContain("reviewer_confidence");
+      expect(result).toContain("very_high");
+      expect(result).toContain("additional_notes");
+      expect(result).toContain("Excellent application");
+    });
+
+    it("should handle additional unknown fields", () => {
+      const evaluation = {
+        evaluation_status: "pending",
+        custom_field: "custom value",
+        another_field: 123,
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_status");
+      expect(result).toContain("pending");
+      expect(result).toContain("custom_field");
+      expect(result).toContain("custom value");
+      expect(result).toContain("another_field");
+      expect(result).toContain("123");
+    });
+
+    it("should skip null/undefined unknown fields", () => {
+      const evaluation = {
+        evaluation_status: "pending",
+        null_field: null,
+        undefined_field: undefined,
+        valid_field: "value",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("evaluation_status");
+      expect(result).toContain("valid_field");
+      expect(result).toContain("value");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty object", () => {
+      const result = formatEvaluationResponse(JSON.stringify({}));
+      expect(result).toBe("");
+    });
+
+    it("should handle object with only undefined fields", () => {
+      const evaluation = {
+        evaluation_status: undefined,
+        decision: undefined,
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toBe("");
+    });
+
+    it("should handle very long string values", () => {
+      const longString = "a".repeat(1000);
+      const evaluation = {
+        additional_notes: longString,
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("additional_notes");
+      expect(result).toContain(longString);
+    });
+
+    it("should handle special characters in strings", () => {
+      const evaluation = {
+        decision: "accept & approve",
+        additional_notes: "Value: $100, Score: 85%",
+      };
+
+      const result = formatEvaluationResponse(JSON.stringify(evaluation));
+      expect(result).toContain("accept & approve");
+      expect(result).toContain("Value: $100, Score: 85%");
+    });
+  });
+});

--- a/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
@@ -1,0 +1,185 @@
+import { getAIColumnVisibility } from "@/components/FundingPlatform/helper/getAIColumnVisibility";
+
+describe("getAIColumnVisibility", () => {
+  describe("When formSchema has aiConfig", () => {
+    it("should show AI score column when langfusePromptId is present in aiConfig", () => {
+      const formSchema = {
+        aiConfig: {
+          langfusePromptId: "prompt-123",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should show internal AI score column when internalLangfusePromptId is present", () => {
+      const formSchema = {
+        aiConfig: {
+          internalLangfusePromptId: "internal-prompt-456",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should show both columns when both prompt IDs are present", () => {
+      const formSchema = {
+        aiConfig: {
+          langfusePromptId: "prompt-123",
+          internalLangfusePromptId: "internal-prompt-456",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should not show columns when aiConfig is empty", () => {
+      const formSchema = {
+        aiConfig: {},
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("When using fallback langfusePromptId", () => {
+    it("should show AI score column when fallback langfusePromptId is provided", () => {
+      const formSchema = undefined;
+      const langfusePromptId = "fallback-prompt-789";
+
+      const result = getAIColumnVisibility(formSchema, langfusePromptId);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should prefer aiConfig langfusePromptId over fallback", () => {
+      const formSchema = {
+        aiConfig: {
+          langfusePromptId: "config-prompt",
+        },
+      };
+      const langfusePromptId = "fallback-prompt";
+
+      const result = getAIColumnVisibility(formSchema, langfusePromptId);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should use fallback when aiConfig langfusePromptId is missing", () => {
+      const formSchema = {
+        aiConfig: {},
+      };
+      const langfusePromptId = "fallback-prompt";
+
+      const result = getAIColumnVisibility(formSchema, langfusePromptId);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle undefined formSchema", () => {
+      const result = getAIColumnVisibility(undefined);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle null formSchema", () => {
+      const result = getAIColumnVisibility(null as any);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle formSchema without aiConfig", () => {
+      const formSchema = {
+        fields: [],
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle empty string prompt IDs as falsy", () => {
+      const formSchema = {
+        aiConfig: {
+          langfusePromptId: "",
+          internalLangfusePromptId: "",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle empty string fallback prompt ID as falsy", () => {
+      const formSchema = undefined;
+      const langfusePromptId = "";
+
+      const result = getAIColumnVisibility(formSchema, langfusePromptId);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("Real-world scenarios", () => {
+    it("should handle typical program config structure", () => {
+      const formSchema = {
+        fields: [
+          { name: "projectTitle", type: "text" },
+          { name: "description", type: "textarea" },
+        ],
+        aiConfig: {
+          langfusePromptId: "prompt-abc-123",
+          internalLangfusePromptId: "internal-prompt-xyz-789",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should handle program with only external AI evaluation", () => {
+      const formSchema = {
+        aiConfig: {
+          langfusePromptId: "external-prompt",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle program with only internal AI evaluation", () => {
+      const formSchema = {
+        aiConfig: {
+          internalLangfusePromptId: "internal-only-prompt",
+        },
+      };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should handle legacy program with fallback prompt ID", () => {
+      const formSchema = undefined;
+      const langfusePromptId = "legacy-prompt-id";
+
+      const result = getAIColumnVisibility(formSchema, langfusePromptId);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+});

--- a/__tests__/integration/components/FundingPlatform/helper/getAIScoreBase.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIScoreBase.test.ts
@@ -1,11 +1,19 @@
-import { formatAIScore, getAIScore } from "@/components/FundingPlatform/helper/getAIScore";
+import {
+  formatAIScoreBase,
+  getAIResponseBase,
+  getAIScoreBase,
+  isValidEvaluation,
+} from "@/components/FundingPlatform/helper/getAIScoreBase";
 import type { IFundingApplication } from "@/types/funding-platform";
 
 // Mock console.warn to avoid noise in tests
 const mockConsoleWarn = jest.spyOn(console, "warn").mockImplementation();
 
 // Helper to create a basic application object
-const createMockApplication = (aiEvaluation?: any): IFundingApplication => ({
+const createMockApplication = (
+  aiEvaluation?: any,
+  internalAIEvaluation?: any
+): IFundingApplication => ({
   id: "test-id",
   programId: "test-program",
   chainID: 11155111,
@@ -16,11 +24,45 @@ const createMockApplication = (aiEvaluation?: any): IFundingApplication => ({
   referenceNumber: "APP-TEST-123",
   submissionIP: "127.0.0.1",
   aiEvaluation,
+  internalAIEvaluation,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 });
 
-describe("getAIScore", () => {
+describe("isValidEvaluation", () => {
+  it("should return true for valid evaluation object", () => {
+    expect(isValidEvaluation({ final_score: 85 })).toBe(true);
+    expect(isValidEvaluation({ final_score: 0 })).toBe(true);
+    expect(isValidEvaluation({ final_score: 100 })).toBe(true);
+  });
+
+  it("should return false for null", () => {
+    expect(isValidEvaluation(null)).toBe(false);
+  });
+
+  it("should return false for non-object types", () => {
+    expect(isValidEvaluation("string")).toBe(false);
+    expect(isValidEvaluation(123)).toBe(false);
+    expect(isValidEvaluation([])).toBe(false);
+  });
+
+  it("should return false when final_score is missing", () => {
+    expect(isValidEvaluation({})).toBe(false);
+    expect(isValidEvaluation({ score: 85 })).toBe(false);
+  });
+
+  it("should return false when final_score is not a number", () => {
+    expect(isValidEvaluation({ final_score: "85" })).toBe(false);
+    expect(isValidEvaluation({ final_score: null })).toBe(false);
+    expect(isValidEvaluation({ final_score: undefined })).toBe(false);
+  });
+
+  it("should return false when final_score is NaN", () => {
+    expect(isValidEvaluation({ final_score: NaN })).toBe(false);
+  });
+});
+
+describe("getAIScoreBase", () => {
   beforeEach(() => {
     mockConsoleWarn.mockClear();
   });
@@ -30,14 +72,24 @@ describe("getAIScore", () => {
   });
 
   describe("Valid score extraction", () => {
-    it("should extract valid final_score from AI evaluation", () => {
+    it("should extract valid final_score from aiEvaluation", () => {
       const application = createMockApplication({
         evaluation: JSON.stringify({ final_score: 4.5 }),
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBe(4.5);
+    });
+
+    it("should extract valid final_score from internalAIEvaluation", () => {
+      const application = createMockApplication(undefined, {
+        evaluation: JSON.stringify({ final_score: 7.2 }),
+        promptId: "internal-prompt",
+      });
+
+      const score = getAIScoreBase(application, "internalAIEvaluation");
+      expect(score).toBe(7.2);
     });
 
     it("should handle integer scores", () => {
@@ -46,7 +98,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBe(3);
     });
 
@@ -56,7 +108,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBe(0);
     });
 
@@ -69,22 +121,22 @@ describe("getAIScore", () => {
           promptId: "test-prompt",
         });
 
-        const score = getAIScore(application);
+        const score = getAIScoreBase(application, "aiEvaluation");
         expect(score).toBe(scoreValue);
       });
     });
   });
 
   describe("Missing or invalid data handling", () => {
-    it("should return null when aiEvaluation is undefined", () => {
+    it("should return null when evaluation is undefined", () => {
       const application = createMockApplication(undefined);
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
-    it("should return null when aiEvaluation is null", () => {
+    it("should return null when evaluation is null", () => {
       const application = createMockApplication(null);
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
@@ -92,7 +144,7 @@ describe("getAIScore", () => {
       const application = createMockApplication({
         promptId: "test-prompt",
       });
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
@@ -101,7 +153,7 @@ describe("getAIScore", () => {
         evaluation: "",
         promptId: "test-prompt",
       });
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
@@ -110,9 +162,8 @@ describe("getAIScore", () => {
         evaluation: { final_score: 4.5 }, // Object instead of string
         promptId: "test-prompt",
       });
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
-      // New implementation silently returns null without warning for non-string evaluation
     });
   });
 
@@ -123,7 +174,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "Failed to parse aiEvaluation for application:",
@@ -141,7 +192,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "aiEvaluation evaluation missing or invalid final_score field:",
@@ -155,7 +206,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "aiEvaluation evaluation missing or invalid final_score field:",
@@ -171,7 +222,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
@@ -181,7 +232,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
 
@@ -191,7 +242,7 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
+      const score = getAIScoreBase(application, "aiEvaluation");
       expect(score).toBeNull();
     });
   });
@@ -203,8 +254,8 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
-      expect(score).toBeNull(); // New implementation returns null for out-of-range scores
+      const score = getAIScoreBase(application, "aiEvaluation");
+      expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "aiEvaluation score outside expected range (0-100):",
         -1
@@ -217,62 +268,104 @@ describe("getAIScore", () => {
         promptId: "test-prompt",
       });
 
-      const score = getAIScore(application);
-      expect(score).toBeNull(); // New implementation returns null for out-of-range scores
+      const score = getAIScoreBase(application, "aiEvaluation");
+      expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "aiEvaluation score outside expected range (0-100):",
         150
       );
     });
   });
+
+  describe("Source-specific behavior", () => {
+    it("should extract from correct source based on parameter", () => {
+      const application = createMockApplication(
+        {
+          evaluation: JSON.stringify({ final_score: 50 }),
+          promptId: "ai-prompt",
+        },
+        {
+          evaluation: JSON.stringify({ final_score: 75 }),
+          promptId: "internal-prompt",
+        }
+      );
+
+      const aiScore = getAIScoreBase(application, "aiEvaluation");
+      const internalScore = getAIScoreBase(application, "internalAIEvaluation");
+
+      expect(aiScore).toBe(50);
+      expect(internalScore).toBe(75);
+    });
+  });
 });
 
-describe("formatAIScore", () => {
-  it("should format whole numbers without decimals", () => {
+describe("getAIResponseBase", () => {
+  it("should return evaluation string for aiEvaluation", () => {
+    const evaluationString = JSON.stringify({ final_score: 85 });
     const application = createMockApplication({
-      evaluation: JSON.stringify({ final_score: 3 }),
+      evaluation: evaluationString,
       promptId: "test-prompt",
     });
 
-    const formatted = formatAIScore(application);
-    expect(formatted).toBe("3");
+    const response = getAIResponseBase(application, "aiEvaluation");
+    expect(response).toBe(evaluationString);
+  });
+
+  it("should return evaluation string for internalAIEvaluation", () => {
+    const evaluationString = JSON.stringify({ final_score: 90 });
+    const application = createMockApplication(undefined, {
+      evaluation: evaluationString,
+      promptId: "internal-prompt",
+    });
+
+    const response = getAIResponseBase(application, "internalAIEvaluation");
+    expect(response).toBe(evaluationString);
+  });
+
+  it("should return null when evaluation is missing", () => {
+    const application = createMockApplication(undefined);
+    const response = getAIResponseBase(application, "aiEvaluation");
+    expect(response).toBeNull();
+  });
+
+  it("should return null when evaluation is not a string", () => {
+    const application = createMockApplication({
+      evaluation: { final_score: 85 },
+      promptId: "test-prompt",
+    });
+
+    const response = getAIResponseBase(application, "aiEvaluation");
+    expect(response).toBeNull();
+  });
+
+  it("should return null when evaluation is empty string", () => {
+    const application = createMockApplication({
+      evaluation: "",
+      promptId: "test-prompt",
+    });
+
+    const response = getAIResponseBase(application, "aiEvaluation");
+    expect(response).toBe("");
+  });
+});
+
+describe("formatAIScoreBase", () => {
+  it("should format whole numbers without decimals", () => {
+    expect(formatAIScoreBase(3)).toBe("3");
+    expect(formatAIScoreBase(100)).toBe("100");
   });
 
   it("should format decimal numbers with 1 decimal place", () => {
-    const application = createMockApplication({
-      evaluation: JSON.stringify({ final_score: 3.7 }),
-      promptId: "test-prompt",
-    });
-
-    const formatted = formatAIScore(application);
-    expect(formatted).toBe("3.7");
+    expect(formatAIScoreBase(3.7)).toBe("3.7");
+    expect(formatAIScoreBase(85.5)).toBe("85.5");
   });
 
   it('should show "0" for zero score', () => {
-    const application = createMockApplication({
-      evaluation: JSON.stringify({ final_score: 0 }),
-      promptId: "test-prompt",
-    });
-
-    const formatted = formatAIScore(application);
-    expect(formatted).toBe("0");
+    expect(formatAIScoreBase(0)).toBe("0");
   });
 
-  it("should return empty string for missing score", () => {
-    const application = createMockApplication(undefined);
-
-    const formatted = formatAIScore(application);
-    expect(formatted).toBe("");
-  });
-
-  it("should return empty string for invalid score", () => {
-    const application = createMockApplication({
-      evaluation: "invalid json",
-      promptId: "test-prompt",
-    });
-
-    const formatted = formatAIScore(application);
-    expect(formatted).toBe("");
+  it("should return empty string for null score", () => {
+    expect(formatAIScoreBase(null)).toBe("");
   });
 
   it("should handle edge case formatting", () => {
@@ -285,13 +378,7 @@ describe("formatAIScore", () => {
     ];
 
     testCases.forEach(({ score, expected }) => {
-      const application = createMockApplication({
-        evaluation: JSON.stringify({ final_score: score }),
-        promptId: "test-prompt",
-      });
-
-      const formatted = formatAIScore(application);
-      expect(formatted).toBe(expected);
+      expect(formatAIScoreBase(score)).toBe(expected);
     });
   });
 });

--- a/__tests__/integration/components/FundingPlatform/helper/getInternalAIScore.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getInternalAIScore.test.ts
@@ -1,0 +1,243 @@
+import {
+  formatInternalAIScore,
+  getFormattedInternalAIResponse,
+  getInternalAIResponse,
+  getInternalAIScore,
+} from "@/components/FundingPlatform/helper/getInternalAIScore";
+import type { IFundingApplication } from "@/types/funding-platform";
+
+// Mock console.warn to avoid noise in tests
+const mockConsoleWarn = jest.spyOn(console, "warn").mockImplementation();
+
+// Helper to create a basic application object
+const createMockApplication = (internalAIEvaluation?: any): IFundingApplication => ({
+  id: "test-id",
+  programId: "test-program",
+  chainID: 11155111,
+  applicantEmail: "test@example.com",
+  applicationData: {},
+  status: "pending",
+  statusHistory: [],
+  referenceNumber: "APP-TEST-123",
+  submissionIP: "127.0.0.1",
+  internalAIEvaluation,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+describe("getInternalAIScore", () => {
+  beforeEach(() => {
+    mockConsoleWarn.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleWarn.mockRestore();
+  });
+
+  describe("Valid score extraction", () => {
+    it("should extract valid final_score from internal AI evaluation", () => {
+      const application = createMockApplication({
+        evaluation: JSON.stringify({ final_score: 4.5 }),
+        promptId: "internal-prompt",
+      });
+
+      const score = getInternalAIScore(application);
+      expect(score).toBe(4.5);
+    });
+
+    it("should handle integer scores", () => {
+      const application = createMockApplication({
+        evaluation: JSON.stringify({ final_score: 3 }),
+        promptId: "internal-prompt",
+      });
+
+      const score = getInternalAIScore(application);
+      expect(score).toBe(3);
+    });
+
+    it("should handle zero score", () => {
+      const application = createMockApplication({
+        evaluation: JSON.stringify({ final_score: 0 }),
+        promptId: "internal-prompt",
+      });
+
+      const score = getInternalAIScore(application);
+      expect(score).toBe(0);
+    });
+  });
+
+  describe("Missing or invalid data handling", () => {
+    it("should return null when internalAIEvaluation is undefined", () => {
+      const application = createMockApplication(undefined);
+      const score = getInternalAIScore(application);
+      expect(score).toBeNull();
+    });
+
+    it("should return null when evaluation field is missing", () => {
+      const application = createMockApplication({
+        promptId: "internal-prompt",
+      });
+      const score = getInternalAIScore(application);
+      expect(score).toBeNull();
+    });
+
+    it("should return null when evaluation is invalid JSON", () => {
+      const application = createMockApplication({
+        evaluation: "invalid json {",
+        promptId: "internal-prompt",
+      });
+
+      const score = getInternalAIScore(application);
+      expect(score).toBeNull();
+    });
+  });
+});
+
+describe("formatInternalAIScore", () => {
+  it("should format whole numbers without decimals", () => {
+    const application = createMockApplication({
+      evaluation: JSON.stringify({ final_score: 3 }),
+      promptId: "internal-prompt",
+    });
+
+    const formatted = formatInternalAIScore(application);
+    expect(formatted).toBe("3");
+  });
+
+  it("should format decimal numbers with 1 decimal place", () => {
+    const application = createMockApplication({
+      evaluation: JSON.stringify({ final_score: 3.7 }),
+      promptId: "internal-prompt",
+    });
+
+    const formatted = formatInternalAIScore(application);
+    expect(formatted).toBe("3.7");
+  });
+
+  it('should show "0" for zero score', () => {
+    const application = createMockApplication({
+      evaluation: JSON.stringify({ final_score: 0 }),
+      promptId: "internal-prompt",
+    });
+
+    const formatted = formatInternalAIScore(application);
+    expect(formatted).toBe("0");
+  });
+
+  it("should return empty string for missing score", () => {
+    const application = createMockApplication(undefined);
+
+    const formatted = formatInternalAIScore(application);
+    expect(formatted).toBe("");
+  });
+
+  it("should return empty string for invalid score", () => {
+    const application = createMockApplication({
+      evaluation: "invalid json",
+      promptId: "internal-prompt",
+    });
+
+    const formatted = formatInternalAIScore(application);
+    expect(formatted).toBe("");
+  });
+});
+
+describe("getInternalAIResponse", () => {
+  it("should return evaluation string when available", () => {
+    const evaluationString = JSON.stringify({ final_score: 85 });
+    const application = createMockApplication({
+      evaluation: evaluationString,
+      promptId: "internal-prompt",
+    });
+
+    const response = getInternalAIResponse(application);
+    expect(response).toBe(evaluationString);
+  });
+
+  it("should return null when evaluation is missing", () => {
+    const application = createMockApplication(undefined);
+    const response = getInternalAIResponse(application);
+    expect(response).toBeNull();
+  });
+
+  it("should return null when evaluation is not a string", () => {
+    const application = createMockApplication({
+      evaluation: { final_score: 85 },
+      promptId: "internal-prompt",
+    });
+
+    const response = getInternalAIResponse(application);
+    expect(response).toBeNull();
+  });
+});
+
+describe("getFormattedInternalAIResponse", () => {
+  beforeEach(() => {
+    mockConsoleWarn.mockClear();
+  });
+
+  it("should format valid evaluation JSON", () => {
+    const evaluation = {
+      evaluation_status: "approved",
+      final_score: 85,
+      decision: "accept",
+    };
+
+    const application = createMockApplication({
+      evaluation: JSON.stringify(evaluation),
+      promptId: "internal-prompt",
+    });
+
+    const formatted = getFormattedInternalAIResponse(application);
+    expect(formatted).toContain("evaluation_status");
+    expect(formatted).toContain("approved");
+    expect(formatted).toContain("final_score");
+    expect(formatted).toContain("85");
+  });
+
+  it("should return empty string when evaluation is missing", () => {
+    const application = createMockApplication(undefined);
+    const formatted = getFormattedInternalAIResponse(application);
+    expect(formatted).toBe("");
+  });
+
+  it("should return empty string for invalid JSON", () => {
+    const application = createMockApplication({
+      evaluation: "invalid json {",
+      promptId: "internal-prompt",
+    });
+
+    const formatted = getFormattedInternalAIResponse(application);
+    expect(formatted).toBe("");
+    // Note: formatEvaluationResponse logs a warning, but it's in a different module
+    // so the mock may not capture it. The important part is that it returns empty string.
+  });
+
+  it("should format complex evaluation with all fields", () => {
+    const evaluation = {
+      evaluation_status: "approved",
+      final_score: 87.5,
+      evaluation_summary: {
+        strengths: ["Strong team"],
+        concerns: ["Budget"],
+      },
+      improvement_recommendations: [
+        {
+          priority: "high",
+          recommendation: "Expand team",
+        },
+      ],
+    };
+
+    const application = createMockApplication({
+      evaluation: JSON.stringify(evaluation),
+      promptId: "internal-prompt",
+    });
+
+    const formatted = getFormattedInternalAIResponse(application);
+    expect(formatted).toContain("evaluation_status");
+    expect(formatted).toContain("evaluation_summary");
+    expect(formatted).toContain("strengths");
+    expect(formatted).toContain("improvement_recommendations");
+  });
+});

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -8,6 +8,7 @@ import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import StatusChangeModal from "../ApplicationView/StatusChangeModal";
 import { formatAIScore } from "../helper/getAIScore";
+import { formatInternalAIScore } from "../helper/getInternalAIScore";
 import { getProjectTitle } from "../helper/getProjecTitle";
 import { TableStatusActionButtons } from "./TableStatusActionButtons";
 
@@ -20,6 +21,8 @@ interface IApplicationListComponentProps extends IApplicationListProps {
   sortBy?: IApplicationFilters["sortBy"];
   sortOrder?: IApplicationFilters["sortOrder"];
   onSortChange?: (sortBy: string) => void;
+  showAIScoreColumn?: boolean;
+  showInternalAIScoreColumn?: boolean;
 }
 
 const statusColors = {
@@ -48,6 +51,8 @@ const ApplicationList: FC<IApplicationListComponentProps> = ({
   sortBy,
   sortOrder,
   onSortChange,
+  showAIScoreColumn = false,
+  showInternalAIScoreColumn = false,
 }) => {
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
   const [statusModalOpen, setStatusModalOpen] = useState(false);
@@ -147,13 +152,24 @@ const ApplicationList: FC<IApplicationListComponentProps> = ({
                   currentSortDirection={sortOrder}
                   onSort={onSortChange}
                 />
-                <SortableTableHeader
-                  label="AI Score"
-                  sortKey="aiEvaluationScore"
-                  currentSortKey={sortBy}
-                  currentSortDirection={sortOrder}
-                  onSort={onSortChange}
-                />
+                {showAIScoreColumn && (
+                  <SortableTableHeader
+                    label="AI Score"
+                    sortKey="aiEvaluationScore"
+                    currentSortKey={sortBy}
+                    currentSortDirection={sortOrder}
+                    onSort={onSortChange}
+                  />
+                )}
+                {showInternalAIScoreColumn && (
+                  <SortableTableHeader
+                    label="Internal AI Score"
+                    sortKey="internalAIEvaluationScore"
+                    currentSortKey={sortBy}
+                    currentSortDirection={sortOrder}
+                    onSort={onSortChange}
+                  />
+                )}
                 <SortableTableHeader
                   label="Created Date"
                   sortKey="createdAt"
@@ -205,9 +221,16 @@ const ApplicationList: FC<IApplicationListComponentProps> = ({
                   <td className="px-4 py-4 whitespace-nowrap">
                     {getStatusBadge(application.status)}
                   </td>
-                  <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 text-center">
-                    <span className="font-medium">{formatAIScore(application)}</span>
-                  </td>
+                  {showAIScoreColumn && (
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 text-center">
+                      <span className="font-medium">{formatAIScore(application)}</span>
+                    </td>
+                  )}
+                  {showInternalAIScoreColumn && (
+                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 text-center">
+                      <span className="font-medium">{formatInternalAIScore(application)}</span>
+                    </td>
+                  )}
                   <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                     {formatDate(application.createdAt)}
                   </td>

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -8,10 +8,16 @@ import pluralize from "pluralize";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { Button } from "@/components/Utilities/Button";
-import { useApplicationExport, useFundingApplications } from "@/hooks/useFundingPlatform";
+import {
+  useApplicationExport,
+  useFundingApplications,
+  useProgramConfig,
+} from "@/hooks/useFundingPlatform";
+import { useProgram } from "@/hooks/usePrograms";
 import type { IApplicationFilters } from "@/services/fundingPlatformService";
 import type { IFundingApplication } from "@/types/funding-platform";
 import formatCurrency from "@/utilities/formatCurrency";
+import { getAIColumnVisibility } from "../helper/getAIColumnVisibility";
 import ApplicationList from "./ApplicationList";
 
 interface IApplicationListWithAPIProps {
@@ -96,6 +102,16 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const { exportApplications, isExporting } = useApplicationExport(programId, chainId, isAdmin);
+
+  // Fetch program config and program data to determine AI column visibility
+  const { config } = useProgramConfig(programId, chainId);
+  const { data: program } = useProgram(programId);
+
+  // Determine column visibility based on configured prompts
+  const { showAIScoreColumn, showInternalAIScoreColumn } = useMemo(
+    () => getAIColumnVisibility(config?.formSchema, program?.langfusePromptId),
+    [config?.formSchema, program?.langfusePromptId]
+  );
 
   // Sync filters and sorting with URL
   useEffect(() => {
@@ -414,6 +430,8 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
           sortBy={sortBy}
           sortOrder={sortOrder}
           onSortChange={handleSortChange}
+          showAIScoreColumn={showAIScoreColumn}
+          showInternalAIScoreColumn={showInternalAIScoreColumn}
         />
       </InfiniteScroll>
     </div>

--- a/components/FundingPlatform/helper/formatEvaluationResponse.ts
+++ b/components/FundingPlatform/helper/formatEvaluationResponse.ts
@@ -1,0 +1,129 @@
+/**
+ * Evaluation object structure
+ */
+interface EvaluationObject {
+  evaluation_status?: string;
+  disqualification_reason?: string;
+  decision?: string;
+  final_score?: number;
+  evaluation_summary?: {
+    strengths?: string[];
+    concerns?: string[];
+    risk_factors?: string[];
+  };
+  improvement_recommendations?: Array<{
+    priority?: string | number;
+    recommendation?: string;
+    impact?: string;
+  }>;
+  reviewer_confidence?: string | number;
+  additional_notes?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Formats AI evaluation response JSON into a human-readable YAML-like string
+ * This format is used for CSV export and display purposes
+ * @param evaluationJsonString - The evaluation JSON string from the database
+ * @returns Formatted string in YAML-like format, or empty string if invalid
+ */
+export function formatEvaluationResponse(evaluationJsonString: string | null | undefined): string {
+  if (!evaluationJsonString) {
+    return "";
+  }
+
+  try {
+    const evaluation = JSON.parse(evaluationJsonString) as EvaluationObject;
+    return formatEvaluationObject(evaluation);
+  } catch (error) {
+    console.warn("Failed to parse evaluation JSON:", error);
+    return "";
+  }
+}
+
+/**
+ * Formats an evaluation object into YAML-like string format
+ * @param evaluation - The parsed evaluation object
+ * @returns Formatted YAML-like string
+ */
+function formatEvaluationObject(evaluation: EvaluationObject): string {
+  const lines: string[] = [];
+  const KEY_PADDING = 30;
+
+  const padKey = (key: string) => key.padEnd(KEY_PADDING);
+
+  const formatSimpleField = (key: string, value: unknown): void => {
+    if (value === null || value === undefined) {
+      lines.push(`${padKey(key)}: null`);
+      return;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      const stringValue = typeof value === "string" ? value.replace(/\n/g, "\\n") : String(value);
+      lines.push(`${padKey(key)}: ${stringValue}`);
+    }
+  };
+
+  const formatArrayField = (fieldName: string, items: string[]): void => {
+    if (Array.isArray(items) && items.length > 0) {
+      lines.push(`  ${fieldName}: `);
+      for (const item of items) {
+        lines.push(`    - ${item}`);
+      }
+    }
+  };
+
+  // Format simple fields
+  const simpleFields: Array<keyof EvaluationObject & string> = [
+    "evaluation_status",
+    "disqualification_reason",
+    "decision",
+    "final_score",
+    "reviewer_confidence",
+    "additional_notes",
+  ];
+
+  simpleFields.forEach((field) => {
+    if (evaluation[field] !== undefined) {
+      formatSimpleField(field, evaluation[field]);
+    }
+  });
+
+  // Format evaluation_summary
+  if (evaluation.evaluation_summary) {
+    lines.push(`${padKey("evaluation_summary")}: `);
+    const summary = evaluation.evaluation_summary;
+    formatArrayField("strengths", summary.strengths || []);
+    formatArrayField("concerns", summary.concerns || []);
+    formatArrayField("risk_factors", summary.risk_factors || []);
+  }
+
+  // Format improvement_recommendations
+  const recommendations = evaluation.improvement_recommendations;
+  if (Array.isArray(recommendations) && recommendations.length > 0) {
+    lines.push(`${padKey("improvement_recommendations")}: `);
+    recommendations.forEach((rec) => {
+      lines.push(`  - `);
+      if (rec.priority !== undefined) lines.push(`    priority:       ${String(rec.priority)}`);
+      if (rec.recommendation) lines.push(`    recommendation: ${rec.recommendation}`);
+      if (rec.impact) lines.push(`    impact:         ${rec.impact}`);
+    });
+  }
+
+  // Handle any other fields that weren't explicitly handled
+  const handledKeys = new Set([
+    ...simpleFields,
+    "evaluation_summary",
+    "improvement_recommendations",
+  ]);
+
+  Object.entries(evaluation).forEach(([key, value]) => {
+    if (!handledKeys.has(key) && value !== null && value !== undefined) {
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        formatSimpleField(key, value);
+      }
+    }
+  });
+
+  return lines.join("\n");
+}

--- a/components/FundingPlatform/helper/getAIColumnVisibility.ts
+++ b/components/FundingPlatform/helper/getAIColumnVisibility.ts
@@ -1,0 +1,31 @@
+/**
+ * Type for form schema with AI configuration
+ */
+type FormSchemaWithAiConfig = {
+  aiConfig?: {
+    langfusePromptId?: string;
+    internalLangfusePromptId?: string;
+  };
+};
+
+/**
+ * Determines AI column visibility based on configured prompts
+ * @param formSchema - The form schema from program config (may have aiConfig)
+ * @param langfusePromptId - Fallback langfusePromptId from program registry
+ * @returns Object with column visibility flags
+ */
+export function getAIColumnVisibility(
+  formSchema: unknown,
+  langfusePromptId?: string
+): {
+  showAIScoreColumn: boolean;
+  showInternalAIScoreColumn: boolean;
+} {
+  const formSchemaWithAiConfig = formSchema as FormSchemaWithAiConfig | undefined;
+  const aiConfig = formSchemaWithAiConfig?.aiConfig;
+
+  return {
+    showAIScoreColumn: !!(aiConfig?.langfusePromptId || langfusePromptId),
+    showInternalAIScoreColumn: !!aiConfig?.internalLangfusePromptId,
+  };
+}

--- a/components/FundingPlatform/helper/getAIScore.ts
+++ b/components/FundingPlatform/helper/getAIScore.ts
@@ -1,4 +1,6 @@
 import type { IFundingApplication } from "@/types/funding-platform";
+import { formatEvaluationResponse } from "./formatEvaluationResponse";
+import { formatAIScoreBase, getAIResponseBase, getAIScoreBase } from "./getAIScoreBase";
 
 /**
  * Extracts AI evaluation score from funding application
@@ -6,57 +8,8 @@ import type { IFundingApplication } from "@/types/funding-platform";
  * @returns number | null - The AI score (0-100) or null if not available
  * @throws Never throws - handles all errors gracefully
  */
-/**
- * Type guard for AI evaluation object
- */
-const isValidEvaluation = (evaluation: unknown): evaluation is { final_score: number } => {
-  return (
-    evaluation !== null &&
-    typeof evaluation === "object" &&
-    "final_score" in evaluation &&
-    typeof (evaluation as any).final_score === "number" &&
-    !Number.isNaN((evaluation as any).final_score)
-  );
-};
-
 export const getAIScore = (application: IFundingApplication): number | null => {
-  try {
-    // Type guard: Check if application exists and has required structure
-    if (!application?.aiEvaluation?.evaluation) {
-      return null;
-    }
-
-    // Type guard: Check if evaluation is a string
-    if (typeof application.aiEvaluation.evaluation !== "string") {
-      console.warn("AI evaluation is not a string:", typeof application.aiEvaluation.evaluation);
-      return null;
-    }
-
-    // Parse the evaluation JSON string with error handling
-    const evaluation = JSON.parse(application.aiEvaluation.evaluation);
-
-    // Type guard: Validate the parsed evaluation structure
-    if (!isValidEvaluation(evaluation)) {
-      console.warn("AI evaluation missing or invalid final_score field:", evaluation);
-      return null;
-    }
-
-    // Additional validation: Ensure score is within expected range (0-100)
-    const score = evaluation.final_score;
-    if (score < 0 || score > 100) {
-      console.warn("AI score outside expected range (0-100):", score);
-    }
-
-    return score;
-  } catch (error) {
-    // Enhanced error logging for debugging
-    console.warn("Failed to parse AI evaluation for application:", {
-      referenceNumber: application.referenceNumber,
-      error: error instanceof Error ? error.message : String(error),
-      evaluationData: `${application.aiEvaluation?.evaluation?.substring(0, 100)}...`,
-    });
-    return null;
-  }
+  return getAIScoreBase(application, "aiEvaluation");
 };
 
 /**
@@ -66,17 +19,25 @@ export const getAIScore = (application: IFundingApplication): number | null => {
  */
 export const formatAIScore = (application: IFundingApplication): string => {
   const score = getAIScore(application);
+  return formatAIScoreBase(score);
+};
 
-  // Return empty string for null/undefined (completely blank cell)
-  if (score === null || score === undefined) {
-    return "";
-  }
+/**
+ * Gets the AI evaluation response text from funding application
+ * @param application - The funding application to extract response from
+ * @returns string | null - The AI evaluation response or null if not available
+ * @throws Never throws - handles all errors gracefully
+ */
+export const getAIResponse = (application: IFundingApplication): string | null => {
+  return getAIResponseBase(application, "aiEvaluation");
+};
 
-  // Show "0" for actual zero scores
-  if (score === 0) {
-    return "0";
-  }
-
-  // Format to 1 decimal place if it's a whole number, 2 decimal places otherwise
-  return score % 1 === 0 ? score.toString() : score.toFixed(1);
+/**
+ * Gets the formatted AI evaluation response for CSV export
+ * Formats the JSON evaluation into a human-readable YAML-like format
+ * @param application - The funding application to extract response from
+ * @returns string - Formatted evaluation response or empty string if not available
+ */
+export const getFormattedAIResponse = (application: IFundingApplication): string => {
+  return formatEvaluationResponse(getAIResponse(application));
 };

--- a/components/FundingPlatform/helper/getAIScoreBase.ts
+++ b/components/FundingPlatform/helper/getAIScoreBase.ts
@@ -1,0 +1,108 @@
+import type { IFundingApplication } from "@/types/funding-platform";
+
+/**
+ * Type guard for AI evaluation object
+ */
+export const isValidEvaluation = (evaluation: unknown): evaluation is { final_score: number } => {
+  return (
+    evaluation !== null &&
+    typeof evaluation === "object" &&
+    "final_score" in evaluation &&
+    typeof (evaluation as Record<string, unknown>).final_score === "number" &&
+    !Number.isNaN((evaluation as Record<string, unknown>).final_score)
+  );
+};
+
+/**
+ * Evaluation source type for different AI evaluation types
+ */
+export type EvaluationSource = "aiEvaluation" | "internalAIEvaluation";
+
+/**
+ * Gets evaluation data from application based on source
+ * @param application - The funding application
+ * @param source - The evaluation source to extract from
+ * @returns The evaluation string or undefined
+ */
+function getEvaluationData(
+  application: IFundingApplication,
+  source: EvaluationSource
+): string | undefined {
+  return source === "aiEvaluation"
+    ? application?.aiEvaluation?.evaluation
+    : application?.internalAIEvaluation?.evaluation;
+}
+
+/**
+ * Extracts AI evaluation score from a funding application
+ * @param application - The funding application to extract score from
+ * @param source - The evaluation source to extract from ("aiEvaluation" or "internalAIEvaluation")
+ * @returns number | null - The AI score (0-100) or null if not available
+ * @throws Never throws - handles all errors gracefully
+ */
+export const getAIScoreBase = (
+  application: IFundingApplication,
+  source: EvaluationSource
+): number | null => {
+  const evaluationData = getEvaluationData(application, source);
+
+  if (!evaluationData || typeof evaluationData !== "string") {
+    return null;
+  }
+
+  try {
+    const evaluation = JSON.parse(evaluationData);
+
+    if (!isValidEvaluation(evaluation)) {
+      console.warn(`${source} evaluation missing or invalid final_score field:`, evaluation);
+      return null;
+    }
+
+    const score = evaluation.final_score;
+    if (score < 0 || score > 100) {
+      console.warn(`${source} score outside expected range (0-100):`, score);
+      return null;
+    }
+
+    return score;
+  } catch (error) {
+    console.warn(`Failed to parse ${source} for application:`, {
+      referenceNumber: application.referenceNumber,
+      error: error instanceof Error ? error.message : String(error),
+      evaluationData: evaluationData.substring(0, 100),
+    });
+    return null;
+  }
+};
+
+/**
+ * Gets the AI evaluation response text from funding application
+ * @param application - The funding application to extract response from
+ * @param source - The evaluation source to extract from ("aiEvaluation" or "internalAIEvaluation")
+ * @returns string | null - The AI evaluation response or null if not available
+ */
+export const getAIResponseBase = (
+  application: IFundingApplication,
+  source: EvaluationSource
+): string | null => {
+  const evaluationData = getEvaluationData(application, source);
+  return typeof evaluationData === "string" ? evaluationData : null;
+};
+
+/**
+ * Formats AI score for display in the table
+ * @param score - The score to format (number | null)
+ * @returns string - Formatted score string, "0" for zero, or empty string for missing scores
+ */
+export const formatAIScoreBase = (score: number | null): string => {
+  if (score === null) {
+    return "";
+  }
+
+  if (score === 0) {
+    return "0";
+  }
+
+  // Format to whole number if integer, otherwise 1 decimal place
+  return score % 1 === 0 ? score.toString() : score.toFixed(1);
+};

--- a/components/FundingPlatform/helper/getInternalAIScore.ts
+++ b/components/FundingPlatform/helper/getInternalAIScore.ts
@@ -1,0 +1,43 @@
+import type { IFundingApplication } from "@/types/funding-platform";
+import { formatEvaluationResponse } from "./formatEvaluationResponse";
+import { formatAIScoreBase, getAIResponseBase, getAIScoreBase } from "./getAIScoreBase";
+
+/**
+ * Extracts internal AI evaluation score from funding application
+ * @param application - The funding application to extract score from
+ * @returns number | null - The internal AI score (0-100) or null if not available
+ * @throws Never throws - handles all errors gracefully
+ */
+export const getInternalAIScore = (application: IFundingApplication): number | null => {
+  return getAIScoreBase(application, "internalAIEvaluation");
+};
+
+/**
+ * Formats internal AI score for display in the table
+ * @param application - The funding application to format score for
+ * @returns string - Formatted score string, "0" for zero, or empty string for missing scores
+ */
+export const formatInternalAIScore = (application: IFundingApplication): string => {
+  const score = getInternalAIScore(application);
+  return formatAIScoreBase(score);
+};
+
+/**
+ * Gets the internal AI evaluation response text from funding application
+ * @param application - The funding application to extract response from
+ * @returns string | null - The internal AI evaluation response or null if not available
+ * @throws Never throws - handles all errors gracefully
+ */
+export const getInternalAIResponse = (application: IFundingApplication): string | null => {
+  return getAIResponseBase(application, "internalAIEvaluation");
+};
+
+/**
+ * Gets the formatted internal AI evaluation response for CSV export
+ * Formats the JSON evaluation into a human-readable YAML-like format
+ * @param application - The funding application to extract response from
+ * @returns string - Formatted evaluation response or empty string if not available
+ */
+export const getFormattedInternalAIResponse = (application: IFundingApplication): string => {
+  return formatEvaluationResponse(getInternalAIResponse(application));
+};


### PR DESCRIPTION
## Summary
Adds support for internal AI evaluation scores in the funding platform application list, with dynamic column visibility based on program configuration. Also includes CSV export formatting for AI evaluation responses.

## Changes

### ✨ New Features
- **Internal AI Score Column**: Added support for displaying internal AI evaluation scores alongside regular AI scores
- **Dynamic Column Visibility**: AI score columns are now conditionally displayed based on `aiConfig` in program form schema
  - `showAIScoreColumn`: Shown when `langfusePromptId` is configured (supports fallback from program registry)
  - `showInternalAIScoreColumn`: Shown when `internalLangfusePromptId` is configured
- **CSV Export Formatting**: Added YAML-like formatting for AI evaluation responses in CSV exports

### 🔧 Refactoring
- **Extracted Base Functions**: Refactored AI score extraction logic into reusable `getAIScoreBase` functions
  - Created `getAIScoreBase.ts` with shared logic for both regular and internal AI scores
  - Updated `getAIScore.ts` to use base functions
  - Created `getInternalAIScore.ts` for internal evaluation handling

### 🐛 Improvements
- **Stricter Validation**: Score validation now returns `null` for out-of-range scores (previously only warned)
- **Better Error Handling**: Improved error messages with source context (`aiEvaluation` vs `internalAIEvaluation`)

### 📝 New Helper Functions
- `getAIColumnVisibility()` - Determines column visibility from form schema config
- `getInternalAIScore()` - Extracts internal AI score from applications
- `formatInternalAIScore()` - Formats internal AI score for display
- `getInternalAIResponse()` - Gets raw internal AI evaluation response
- `getFormattedInternalAIResponse()` - Gets formatted response for CSV export
- `formatEvaluationResponse()` - Formats evaluation JSON into human-readable YAML-like format

## Testing
- ✅ Added comprehensive tests for `getAIColumnVisibility`
- ✅ Added tests for `getInternalAIScore` and related functions
- ✅ Added tests for `formatEvaluationResponse`
- ✅ Updated existing tests to match new implementation
- ✅ Updated `ApplicationList` tests to include new column visibility props

## Migration Notes
- Programs without `aiConfig` in form schema will continue to work with fallback `langfusePromptId` from program registry
- Internal AI score column only appears when `internalLangfusePromptId` is configured in `formSchema.aiConfig`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212362216702070
  
  
![Xnip2025-12-10_14-07-49](https://github.com/user-attachments/assets/fe9275bc-a709-4039-a7e6-d5a8e1b32069)
![Xnip2025-12-10_14-14-50](https://github.com/user-attachments/assets/b19beae1-ff8e-4ab6-9acc-58b150be0f85)
