### PR TITLE
Extract internal ai score from total_score field

### DIFF
--- a/__tests__/integration/components/FundingPlatform/helper/getAIScore.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIScore.test.ts
@@ -144,7 +144,7 @@ describe("getAIScore", () => {
       const score = getAIScore(application);
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        "aiEvaluation evaluation missing or invalid final_score field:",
+        expect.stringContaining("aiEvaluation evaluation missing valid score field"),
         {}
       );
     });
@@ -158,7 +158,7 @@ describe("getAIScore", () => {
       const score = getAIScore(application);
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        "aiEvaluation evaluation missing or invalid final_score field:",
+        expect.stringContaining("aiEvaluation evaluation missing valid score field"),
         { score: 4.5 }
       );
     });

--- a/__tests__/integration/components/FundingPlatform/helper/getInternalAIScore.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getInternalAIScore.test.ts
@@ -35,9 +35,9 @@ describe("getInternalAIScore", () => {
   });
 
   describe("Valid score extraction", () => {
-    it("should extract valid final_score from internal AI evaluation", () => {
+    it("should extract valid total_score from internal AI evaluation", () => {
       const application = createMockApplication({
-        evaluation: JSON.stringify({ final_score: 4.5 }),
+        evaluation: JSON.stringify({ total_score: 4.5 }),
         promptId: "internal-prompt",
       });
 
@@ -45,9 +45,19 @@ describe("getInternalAIScore", () => {
       expect(score).toBe(4.5);
     });
 
+    it("should also extract final_score from internal AI evaluation", () => {
+      const application = createMockApplication({
+        evaluation: JSON.stringify({ final_score: 8.5 }),
+        promptId: "internal-prompt",
+      });
+
+      const score = getInternalAIScore(application);
+      expect(score).toBe(8.5);
+    });
+
     it("should handle integer scores", () => {
       const application = createMockApplication({
-        evaluation: JSON.stringify({ final_score: 3 }),
+        evaluation: JSON.stringify({ total_score: 3 }),
         promptId: "internal-prompt",
       });
 
@@ -57,7 +67,7 @@ describe("getInternalAIScore", () => {
 
     it("should handle zero score", () => {
       const application = createMockApplication({
-        evaluation: JSON.stringify({ final_score: 0 }),
+        evaluation: JSON.stringify({ total_score: 0 }),
         promptId: "internal-prompt",
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AI evaluation score extraction to recognize both `final_score` and `total_score` fields, with priority given to `final_score` when both are present.

* **Refactor**
  * Streamlined internal score validation logic with improved error messaging and removed redundant validation utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->