### PR TITLE
fix(question-builder): display backend validation errors in toast

### DIFF
--- a/hooks/useQuestionBuilder.ts
+++ b/hooks/useQuestionBuilder.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import toast from "react-hot-toast";
 import { fundingPlatformService } from "@/services/fundingPlatformService";
 import type { IFundingProgramConfig } from "@/types/funding-platform";
@@ -110,7 +111,7 @@ function createFormSchemaHook(
         });
         toast.success(successMessage);
       },
-      onError: (error: any) => {
+      onError: (error: AxiosError<{ message?: string }>) => {
         console.error(`Failed to save ${schemaType} schema:`, error);
         // Extract specific error message from API response (e.g., validation errors)
         const apiErrorMessage = error.response?.data?.message;

--- a/hooks/useQuestionBuilder.ts
+++ b/hooks/useQuestionBuilder.ts
@@ -110,9 +110,11 @@ function createFormSchemaHook(
         });
         toast.success(successMessage);
       },
-      onError: (error) => {
+      onError: (error: any) => {
         console.error(`Failed to save ${schemaType} schema:`, error);
-        toast.error(errorMessage);
+        // Extract specific error message from API response (e.g., validation errors)
+        const apiErrorMessage = error.response?.data?.message;
+        toast.error(apiErrorMessage || errorMessage);
       },
     });
 


### PR DESCRIPTION
## Summary
Updates the `useQuestionBuilder` hook to display specific backend validation error messages instead of generic errors.

## Context
This PR works together with [gap-indexer#748](https://github.com/show-karma/gap-indexer/pull/748) which adds backend validation for email fields in form schemas.

## Changes
- Updated `onError` handler in `useQuestionBuilder.ts` to extract `error.response?.data?.message`
- Falls back to generic error message if no specific API error message is available

## Behavior
When the backend returns a validation error like:
> "Form schema must contain at least one email field for application tracking"

This message will now be displayed in the toast notification instead of:
> "Failed to save form schema"

## Test plan
- [ ] Try saving a form without email field (with backend PR deployed) → should show specific error message
- [ ] Try saving with network error → should show generic error message
- [ ] Try saving valid form → should show success message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging so users now see server-provided validation/API error details in toast notifications instead of generic messages, making failures clearer and more actionable.
  * Existing success behavior remains unchanged; only error-display behavior was refined to surface more informative messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->