### PR TITLE
fix: align Live Funding Opportunities rules with whitelabel app

### DIFF
--- a/utilities/funding-programs.ts
+++ b/utilities/funding-programs.ts
@@ -2,6 +2,136 @@ import { errorManager } from "@/components/Utilities/errorManager";
 import type { FundingProgram } from "@/services/fundingPlatformService";
 
 /**
+ * Program Status Types and Interfaces
+ * Aligned with gap-whitelabel-app rules for consistency
+ */
+export type ProgramStatusType = "open" | "closed" | "coming-soon" | "deadline-passed";
+
+export type ProgramStatusColor = "success" | "danger" | "warning" | "default" | "primary";
+
+export interface ProgramStatusInfo {
+  status: ProgramStatusType;
+  label: string;
+  color: ProgramStatusColor;
+  dotColor: string;
+  endsSoon: boolean;
+}
+
+const statusConfig: Record<ProgramStatusType, Omit<ProgramStatusInfo, "status" | "endsSoon">> = {
+  open: {
+    label: "Open for Applications",
+    color: "success",
+    dotColor: "bg-green-600",
+  },
+  closed: {
+    label: "Applications Closed",
+    color: "default",
+    dotColor: "bg-gray-600",
+  },
+  "coming-soon": {
+    label: "Coming Soon",
+    color: "primary",
+    dotColor: "bg-blue-600",
+  },
+  "deadline-passed": {
+    label: "Deadline Passed",
+    color: "warning",
+    dotColor: "bg-amber-600",
+  },
+};
+
+/**
+ * Check if a program is within its open date range
+ * @param startsAt - Program start date
+ * @param endsAt - Program end date
+ * @returns true if current date is within the date range
+ */
+export function isProgramOpen(startsAt: string | undefined, endsAt: string | undefined): boolean {
+  if (!startsAt || !endsAt) return true;
+
+  const now = new Date();
+  const start = new Date(startsAt);
+  const end = new Date(endsAt);
+
+  return now >= start && now <= end;
+}
+
+/**
+ * Check if a program is enabled and accepting applications
+ * This is the source of truth for determining if users can apply to a program.
+ * Rules aligned with gap-whitelabel-app for consistency across apps.
+ *
+ * @param program - The funding program to check
+ * @returns true if the program is accepting applications
+ */
+export function isProgramEnabled(program: FundingProgram): boolean {
+  const isEnabled = program.applicationConfig?.isEnabled ?? false;
+  const hasFormConfig = !!program.applicationConfig?.formSchema;
+  const applicationDeadline = program.applicationConfig?.formSchema?.settings?.applicationDeadline;
+  const isApplicationDeadlinePassed = applicationDeadline
+    ? new Date(applicationDeadline) < new Date()
+    : false;
+
+  const isOpen =
+    program.metadata?.startsAt && program.metadata?.endsAt
+      ? isProgramOpen(program.metadata?.startsAt, program.metadata?.endsAt)
+      : true;
+
+  return hasFormConfig && isEnabled && isOpen && !isApplicationDeadlinePassed;
+}
+
+/**
+ * Get the display status information for a funding program.
+ * Returns status type, label, color, dot color, and endsSoon flag for UI display.
+ * Rules aligned with gap-whitelabel-app for consistency across apps.
+ */
+export function getProgramStatusInfo(program: FundingProgram): ProgramStatusInfo {
+  const isEnabled = program.applicationConfig?.isEnabled ?? false;
+  const hasFormConfig = !!program.applicationConfig?.formSchema;
+  const applicationDeadline = program.applicationConfig?.formSchema?.settings?.applicationDeadline;
+  const isApplicationDeadlinePassed = applicationDeadline
+    ? new Date(applicationDeadline) < new Date()
+    : false;
+
+  const isOpen =
+    program.metadata?.startsAt && program.metadata?.endsAt
+      ? isProgramOpen(program.metadata?.startsAt, program.metadata?.endsAt)
+      : true;
+
+  let status: ProgramStatusType;
+  let endsSoon = false;
+
+  if (!hasFormConfig || !isEnabled) {
+    status = "closed";
+  } else if (isApplicationDeadlinePassed) {
+    status = "deadline-passed";
+  } else if (!isOpen) {
+    if (program.metadata?.startsAt && new Date(program.metadata.startsAt) > new Date()) {
+      status = "coming-soon";
+    } else {
+      status = "closed";
+    }
+  } else {
+    status = "open";
+    const endsAt = program.metadata?.endsAt;
+    if (endsAt) {
+      const daysUntilEnd = Math.ceil(
+        (new Date(endsAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+      );
+      if (daysUntilEnd <= 7 && daysUntilEnd > 0) {
+        endsSoon = true;
+      }
+    }
+  }
+
+  return {
+    status,
+    endsSoon,
+    ...statusConfig[status],
+  };
+}
+
+/**
  * Constants for funding program detection across the application
  */
 
@@ -76,6 +206,12 @@ export const getFundingProgramDisplayName = (communityName: string): string => {
 /**
  * Transform and filter enabled funding programs
  * Shared utility for both client and server-side usage
+ *
+ * Uses isProgramEnabled for filtering, which checks:
+ * - isEnabled flag is true
+ * - formSchema is configured
+ * - Current date is within startsAt/endsAt range
+ * - Application deadline has not passed
  */
 export function transformLiveFundingOpportunities(programs: any[]): FundingProgram[] {
   try {
@@ -93,9 +229,10 @@ export function transformLiveFundingOpportunities(programs: any[]): FundingProgr
       return program as FundingProgram;
     });
 
-    // Filter to only include programs with valid metadata/title
+    // Filter to only include programs that are open for applications
+    // Uses isProgramEnabled which applies the same rules as gap-whitelabel-app
     const validPrograms = transformedPrograms.filter(
-      (program) => (program.metadata?.title || program.name) && program.applicationConfig?.isEnabled
+      (program) => (program.metadata?.title || program.name) && isProgramEnabled(program)
     );
 
     // Sort by startsAt date (most recent first)
@@ -109,7 +246,6 @@ export function transformLiveFundingOpportunities(programs: any[]): FundingProgr
       try {
         return new Date(bStartsAt).getTime() - new Date(aStartsAt).getTime();
       } catch (dateError) {
-        // Invalid date format - log but don't fail completely
         errorManager(`Invalid date format in funding program: ${dateError}`, dateError, {
           programA: a.metadata?.title || a.name,
           programB: b.metadata?.title || b.name,
@@ -124,7 +260,6 @@ export function transformLiveFundingOpportunities(programs: any[]): FundingProgr
       context: "transformLiveFundingOpportunities",
       programsCount: programs?.length,
     });
-    // Re-throw to propagate error instead of returning empty array silently
     throw error;
   }
 }


### PR DESCRIPTION
## Problem

The **Live Funding Opportunities** section in gap-app-v2 was showing programs that should not be considered "open" according to the rules defined in gap-whitelabel-app.

### Rules mismatch

| Check | Before (gap-app-v2) | After (aligned) |
|-------|---------------------|-----------------|
| `isEnabled` | ✅ | ✅ |
| `hasFormConfig` | ❌ | ✅ |
| Date range (`startsAt`/`endsAt`) | ❌ | ✅ |
| `applicationDeadline` passed | ❌ | ✅ |

## Solution

Copied the program status logic from `gap-whitelabel-app/src/lib/utils/isProgramOpen.ts` to `gap-app-v2/utilities/funding-programs.ts`:

### New utilities added:
- `isProgramOpen()` - Checks if current date is within `startsAt`/`endsAt` range
- `isProgramEnabled()` - Source of truth for filtering (checks all 4 conditions above)
- `getProgramStatusInfo()` - Returns rich status info for UI display

### Updated:
- `transformLiveFundingOpportunities()` - Now uses `isProgramEnabled()` for filtering
- `funding-opportunity-card.tsx` - Now uses shared `getProgramStatusInfo()` for status display

## Testing

- Programs without `formSchema` configured are now filtered out
- Programs outside their date range are now filtered out  
- Programs with passed application deadlines are now filtered out
- Status badges now show appropriate labels: "Open for Applications", "Coming Soon", "Deadline Passed", "Applications Closed"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and accuracy of funding opportunity status displays across the platform.

* **Enhancements**
  * Enhanced status indicators that clearly distinguish between open, closed, coming-soon, and deadline-passed funding programs.
  * Better identification of programs actively accepting applications.
  * Clearer indication of approaching application deadlines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->