### PR TITLE
Add create project button

### DIFF
--- a/components/FundingPlatform/ApplicationView/ApplicationVersionSelector.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationVersionSelector.tsx
@@ -67,7 +67,7 @@ const ApplicationVersionSelector: FC<ApplicationVersionSelectorProps> = ({
       <div className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
         Select Version
       </div>
-      <Listbox value={selectedVersionId} onChange={handleVersionChange}>
+      <Listbox value={selectedVersionId ?? undefined} onChange={handleVersionChange}>
         <div className="relative">
           <Listbox.Button className="relative w-full cursor-pointer rounded-lg bg-white dark:bg-zinc-800 border border-gray-300 dark:border-gray-600 py-2.5 pl-3 pr-10 text-left shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:text-sm">
             <span className="flex items-center">

--- a/components/Pages/MyProjects/index.tsx
+++ b/components/Pages/MyProjects/index.tsx
@@ -101,7 +101,25 @@ export default function MyProjects() {
       <div className="mt-5 w-full gap-5">
         {isConnected && isAuth ? (
           <div className="flex flex-col gap-4">
-            {isLoading ? (
+            <div className="flex flex-row items-center justify-between mb-6">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">My Projects</h1>
+              <ProjectDialog
+                buttonElement={{
+                  icon: (
+                    <img
+                      className="h-5 w-5 text-white"
+                      alt="Create"
+                      src="/icons/arrow-right-2.svg"
+                    />
+                  ),
+                  iconSide: "right",
+                  text: "Create Project",
+                  styleClass:
+                    "flex rounded-md hover:opacity-75 border-none transition-all ease-in-out duration-300 items-center h-max w-max flex-row gap-2 bg-brand-darkblue dark:bg-gray-700 px-5 py-2.5 text-base font-semibold text-white hover:bg-brand-darkblue",
+                }}
+              />
+            </div>
+          {isLoading ? (
               <div className="flex flex-col gap-4 justify-start">
                 <div className="grid grid-cols-4 gap-7 pb-4 max-xl:grid-cols-3 max-lg:grid-cols-2 max-sm:grid-cols-1">
                   {loadingArray.map((item) => (


### PR DESCRIPTION
## Summary
Adds a "Create Project" button to the /my-projects page, positioned at the top right before the project list
Reuses the existing ProjectDialog component from the homepage with consistent styling
Adds a "My Projects" title header for better page structure

### Test plan
- [ ] Navigate to /my-projects when logged in
- [ ] Verify the "Create Project" button appears at the top right of the page
- [ ] Click the button and confirm the project creation dialog opens
- [ ] Verify the button is visible during loading state, when projects exist, and in empty state
- [ ] Test on mobile and desktop viewports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application version selection dropdown to correctly handle edge cases involving null or undefined version states.

* **New Features**
  * Added a new header section to the My Projects page, featuring the "My Projects" title and a dedicated Create Project button to simplify project creation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->