### PR TITLE
feat: Save application deadline as UTC in funding platform (#842)

### DIFF
--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form";
 import { type SettingsConfigFormData, settingsConfigSchema } from "@/schemas/settingsConfigSchema";
 import type { FormSchema } from "@/types/question-builder";
 import { envVars } from "@/utilities/enviromentVars";
+import { formatDate } from "@/utilities/formatDate";
 import { fundingPlatformDomains } from "@/utilities/fundingPlatformDomains";
 import { ExternalLink } from "../Utilities/ExternalLink";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
@@ -33,6 +34,26 @@ const getApplyUrlByCommunityId = (communityId: string, programId: string) => {
   }
 };
 
+// Convert local datetime-local value to UTC ISO string
+const convertLocalToUTC = (localDatetime: string | undefined): string | undefined => {
+  if (!localDatetime) return undefined;
+
+  const localDate = new Date(localDatetime);
+  if (isNaN(localDate.getTime())) return undefined;
+
+  return formatDate(localDate, "ISO");
+};
+
+// Convert UTC ISO string to local datetime-local format (YYYY-MM-DDTHH:mm)
+const convertUTCToLocal = (utcDatetime: string | undefined): string => {
+  if (!utcDatetime) return "";
+
+  const date = new Date(utcDatetime);
+  if (isNaN(date.getTime())) return "";
+
+  return formatDate(date, "local", "datetime-local");
+};
+
 export function SettingsConfiguration({
   schema,
   onUpdate,
@@ -41,6 +62,7 @@ export function SettingsConfiguration({
   readOnly = false,
 }: SettingsConfigurationProps) {
   const { communityId } = useParams() as { communityId: string };
+
   const {
     register,
     watch,
@@ -50,7 +72,7 @@ export function SettingsConfiguration({
     resolver: zodResolver(settingsConfigSchema),
     defaultValues: {
       privateApplications: schema.settings?.privateApplications ?? true,
-      applicationDeadline: schema.settings?.applicationDeadline ?? "",
+      applicationDeadline: convertUTCToLocal(schema.settings?.applicationDeadline),
       donationRound: schema.settings?.donationRound ?? false,
       successPageContent: schema.settings?.successPageContent ?? "",
       showCommentsOnPublicPage: schema.settings?.showCommentsOnPublicPage ?? false,
@@ -70,7 +92,7 @@ export function SettingsConfiguration({
           confirmationMessage:
             schema.settings?.confirmationMessage || "Thank you for your submission!",
           privateApplications: data.privateApplications ?? true,
-          applicationDeadline: data.applicationDeadline,
+          applicationDeadline: convertLocalToUTC(data.applicationDeadline),
           donationRound: data.donationRound ?? false,
           successPageContent: data.successPageContent,
           showCommentsOnPublicPage: data.showCommentsOnPublicPage ?? false,

--- a/utilities/formatDate.ts
+++ b/utilities/formatDate.ts
@@ -1,5 +1,5 @@
 type TimeZoneFormat = "UTC" | "ISO" | "local";
-type DateFormatOption = "MMM D, YYYY" | "h:mm a" | "DDD, MMM DD";
+type DateFormatOption = "MMM D, YYYY" | "h:mm a" | "DDD, MMM DD" | "datetime-local";
 
 export const formatDate = (
   date: number | Date | string,
@@ -65,6 +65,10 @@ export const formatDate = (
     }
 
     return `${monthNames[month]} ${day}, ${year}. ${timeString}`;
+  }
+
+  if (formatOption === "datetime-local") {
+    return `${year}-${pad(month + 1)}-${pad(day)}T${pad(hours)}:${pad(minutes)}`;
   }
 
   return d.toISOString();


### PR DESCRIPTION
* feat: save application deadline as UTC in funding platform

- Add datetime-local format support to formatDate utility
- Convert local datetime to UTC ISO format when saving application deadline
- Convert UTC datetime back to local format when displaying in form
- Update help text to clarify deadline is saved in UTC

This ensures consistent deadline handling across different timezones by storing all application deadlines as UTC in the backend while displaying them in the user's local timezone in the UI.

* fix(SettingsConfiguration): update help text for application deadline clarification

- Simplify the help text to remove redundancy regarding the deadline being saved in UTC, while maintaining clarity on leaving it empty for no deadline.

This change enhances the user experience by providing clearer instructions without unnecessary repetition.