### PR TITLE
fix: update unified search to use V2 API response format

### DIFF
--- a/services/unified-search.service.ts
+++ b/services/unified-search.service.ts
@@ -37,37 +37,34 @@ export interface UnifiedSearchResponse {
 }
 
 interface UnifiedSearchApiResponse {
-  statusCode: number;
-  result: {
-    data: {
-      projects: Array<{
-        uid: string;
-        chainID: number;
-        title: string | null;
-        slug: string | null;
-        description: string | null;
-        logoUrl: string | null;
-        createdAt: string;
-      }>;
-      communities: Array<{
-        uid: string;
-        chainID: number;
-        name: string | null;
-        slug: string | null;
-        description: string | null;
-        imageUrl: string | null;
-        createdAt: string;
-      }>;
-    };
-    error: null;
+  data: {
+    projects: Array<{
+      uid: string;
+      chainID: number;
+      title: string | null;
+      slug: string | null;
+      description: string | null;
+      logoUrl: string | null;
+      createdAt: string;
+    }>;
+    communities: Array<{
+      uid: string;
+      chainID: number;
+      name: string | null;
+      slug: string | null;
+      description: string | null;
+      imageUrl: string | null;
+      createdAt: string;
+    }>;
   };
 }
 
 /**
  * Transform API response to match existing UnifiedSearchResponse format
+ * Updated to use V2 API response format: { data: { projects, communities } }
  */
 const transformSearchResponse = (apiResponse: UnifiedSearchApiResponse): UnifiedSearchResponse => {
-  const { projects, communities } = apiResponse.result.data;
+  const { projects, communities } = apiResponse.data;
 
   return {
     projects: projects.map((p) => ({


### PR DESCRIPTION
## Problem Statement

The backend unified search endpoint () was recently updated to follow V2 architecture standards in [gap-indexer PR #751](https://github.com/show-karma/gap-indexer/pull/751).

The backend now returns:
```typescript
{
  data: {
    projects: [...],
    communities: [...]
  }
}
```

However, the frontend was still expecting the old V1 format:
```typescript
{
  statusCode: 200,
  result: {
    data: {
      projects: [...],
      communities: [...]
    },
    error: null
  }
}
```

This mismatch caused the unified search feature to fail.

## Implementation

### Changes Made

**Updated** `services/unified-search.service.ts`:
- Updated `UnifiedSearchApiResponse` interface to match V2 response format
- Removed `statusCode` and `result` wrapper from type definition
- Updated `transformSearchResponse` to access `apiResponse.data` directly (instead of `apiResponse.result.data`)

### Why This Works
- The `responseInterceptor` in the backend wraps all successful responses in `{ data: ... }` format
- The frontend now correctly expects and handles this format
- Test fixtures don't need updating as they mock the transformed response, not the API response

## Testing

### Existing Tests
- ✅ All existing unit tests pass (test fixtures mock the service, not the API response)
- ✅ No changes needed to test fixtures
- ✅ Biome linter passes

### Manual Testing Needed
Please verify:
- [ ] Navbar search works correctly
- [ ] Search dropdown displays results
- [ ] Both projects and communities appear in results
- [ ] Empty search states work
- [ ] Search with < 3 characters returns empty results

## Impact

- **Fixes**: Unified search functionality
- **Dependencies**: Requires backend PR #751 to be deployed
- **Breaking Changes**: None (maintains API contract with updated backend)
- **Architecture Compliance**: ✅ Now follows V2 API response format

## Related PRs

- Backend Fix: [gap-indexer #751](https://github.com/show-karma/gap-indexer/pull/751)

## Deployment Notes

⚠️ **Important**: This PR should be deployed **after** the backend PR #751 is deployed to avoid breaking the search functionality during the deployment window.