### PR TITLE
fix: keep project modal open until transaction completes

### DIFF
--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -669,7 +669,6 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         throw new Error("Failed to connect to wallet", { cause: error });
       }
       const walletSigner = await walletClientToSigner(walletClient);
-      closeModal();
       changeStepperStep("preparing");
       await project.attest(walletSigner, changeStepperStep).then(async (res) => {
         let retries = 1000;
@@ -738,6 +737,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
 
             toast.success(MESSAGES.PROJECT.CREATE.SUCCESS);
             changeStepperStep("indexed");
+            closeModal();
             router.push(PAGES.PROJECT.SCREENS.NEW_GRANT(slug || project.uid));
             router.refresh();
             break;
@@ -766,8 +766,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         }
       );
       setIsStepper(false);
-      // Don't reset form on error - keep user's data
-      openModal();
+      // Don't reset form on error - keep user's data (modal stays open)
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- Fixes issue where the create project modal would disappear when clicking "Create Project", leaving users unable to edit their form data if they cancelled in the wallet
- Modal now stays open during the entire transaction flow and only closes after successful indexing
- Matches the behavior of other flows like creating milestones

## Changes
- Removed premature `closeModal()` call before transaction starts
- Added `closeModal()` after transaction is successfully indexed
- Removed unnecessary `openModal()` from catch block since modal already stays open

## Test plan
- [x] Go to create project flow and fill in all details
- [x] Click "Create Project" button
- [x] Verify modal stays visible while wallet pops up
- [x] Cancel the transaction in the wallet
- [x] Verify modal is still open with all form data preserved
- [x] Complete a transaction and verify modal closes after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project dialog lifecycle to ensure it closes at the correct time after successful project creation and all initial processing steps have completed
  * Improved error handling—the dialog now remains open when errors occur, preserving context and allowing users to review error details and make necessary corrections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212507187572115