### PR TITLE
fix(tests): add missing PAGES.REGISTRY mock to homepage tests

### DIFF
--- a/__tests__/homepage/integration/navigation-flow.test.tsx
+++ b/__tests__/homepage/integration/navigation-flow.test.tsx
@@ -21,6 +21,11 @@ jest.mock("@/utilities/pages", () => ({
     COMMUNITY: {
       ALL_GRANTS: (slug: string) => `/community/${slug}/grants`,
     },
+    REGISTRY: {
+      ROOT: "/funding-map",
+      ADD_PROGRAM: "/funding-map/add-program",
+      MANAGE_PROGRAMS: "/funding-map/manage-programs",
+    },
   },
 }));
 

--- a/__tests__/homepage/unit/live-funding-opportunities.test.tsx
+++ b/__tests__/homepage/unit/live-funding-opportunities.test.tsx
@@ -26,6 +26,11 @@ jest.mock("@/src/services/funding/getLiveFundingOpportunities", () => ({
 jest.mock("@/utilities/pages", () => ({
   PAGES: {
     FUNDING_APP: "/funding-map",
+    REGISTRY: {
+      ROOT: "/funding-map",
+      ADD_PROGRAM: "/funding-map/add-program",
+      MANAGE_PROGRAMS: "/funding-map/manage-programs",
+    },
   },
 }));
 


### PR DESCRIPTION
## Summary

- Add missing `PAGES.REGISTRY` mock to homepage test files to fix 36 failing tests

## Problem

The homepage tests were failing with `TypeError: Cannot read properties of undefined (reading 'ROOT')` because the `PAGES` mock in test files was missing the `REGISTRY` property. The actual code uses `PAGES.REGISTRY.ROOT` in:
- `src/features/homepage/components/live-funding-opportunities.tsx`
- `src/features/homepage/components/live-funding-opportunities-skeleton.tsx`

## Solution

Added the `REGISTRY` property with `ROOT`, `ADD_PROGRAM`, and `MANAGE_PROGRAMS` to the `PAGES` mock in:
- `__tests__/homepage/integration/navigation-flow.test.tsx`
- `__tests__/homepage/unit/live-funding-opportunities.test.tsx`

## Test plan

- [x] Run `pnpm test` - all 4581 tests pass (previously 36 failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test mocks to support expanded routing references and improve test coverage for navigation flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->