### PR TITLE
fix(tests): add missing PAGES.REGISTRY mock to homepage tests (#872)

### DIFF
--- a/__tests__/homepage/integration/navigation-flow.test.tsx
+++ b/__tests__/homepage/integration/navigation-flow.test.tsx
@@ -21,6 +21,11 @@ jest.mock("@/utilities/pages", () => ({
     COMMUNITY: {
       ALL_GRANTS: (slug: string) => `/community/${slug}/grants`,
     },
+    REGISTRY: {
+      ROOT: "/funding-map",
+      ADD_PROGRAM: "/funding-map/add-program",
+      MANAGE_PROGRAMS: "/funding-map/manage-programs",
+    },
   },
 }));
 

--- a/__tests__/homepage/unit/live-funding-opportunities.test.tsx
+++ b/__tests__/homepage/unit/live-funding-opportunities.test.tsx
@@ -26,6 +26,11 @@ jest.mock("@/src/services/funding/getLiveFundingOpportunities", () => ({
 jest.mock("@/utilities/pages", () => ({
   PAGES: {
     FUNDING_APP: "/funding-map",
+    REGISTRY: {
+      ROOT: "/funding-map",
+      ADD_PROGRAM: "/funding-map/add-program",
+      MANAGE_PROGRAMS: "/funding-map/manage-programs",
+    },
   },
 }));
 


### PR DESCRIPTION
Add the REGISTRY property to PAGES mock in homepage test files that were failing due to accessing PAGES.REGISTRY.ROOT which was undefined.

Files fixed:
- __tests__/homepage/integration/navigation-flow.test.tsx
- __tests__/homepage/unit/live-funding-opportunities.test.tsx

This resolves 36 test failures in the homepage test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)