### PR TITLE
fix(funding-map): add community selector for multi-community programs

### DIFF
--- a/src/features/funding-map/components/funding-program-details-dialog.tsx
+++ b/src/features/funding-map/components/funding-program-details-dialog.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { BadgeCheck, Bug, Building2, ChevronRight, ExternalLink, Globe } from "lucide-react";
+import {
+  BadgeCheck,
+  Bug,
+  Building2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Globe,
+} from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -20,13 +28,23 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { envVars } from "@/utilities/enviromentVars";
 import formatCurrency from "@/utilities/formatCurrency";
-import { FUNDING_PLATFORM_PAGES, PAGES } from "@/utilities/pages";
+import { FUNDING_PLATFORM_PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { NETWORK_IMAGES } from "../constants/filter-options";
-import type { FundingProgramMetadata, FundingProgramResponse } from "../types/funding-program";
+import type {
+  FundingProgramCommunity,
+  FundingProgramMetadata,
+  FundingProgramResponse,
+} from "../types/funding-program";
 import { FUNDING_PLATFORM_DOMAINS } from "../utils/funding-platform-domains";
 import { isValidImageUrl } from "../utils/image-utils";
 
@@ -57,21 +75,22 @@ function normalizeUrl(url: string | undefined): string | null {
   return url.includes("http") ? url : `https://${url}`;
 }
 
-function getApplyUrl(program: FundingProgramResponse): string | null {
+function getApplyUrl(
+  program: FundingProgramResponse,
+  community?: FundingProgramCommunity
+): string | null {
   // If program is on Karma and has a community, use the Karma funding platform apply URL
-  if (program.isOnKarma && program.programId) {
-    const communitySlug = program.communities?.[0]?.slug;
-    if (communitySlug) {
-      const exclusiveDomain =
-        FUNDING_PLATFORM_DOMAINS[communitySlug as keyof typeof FUNDING_PLATFORM_DOMAINS];
-      // Use exclusive domain if available, otherwise fall through to shared domain
-      const domain = exclusiveDomain
-        ? envVars.isDev
-          ? exclusiveDomain.dev
-          : exclusiveDomain.prod
-        : undefined;
-      return FUNDING_PLATFORM_PAGES(communitySlug, domain).PROGRAM_PAGE(program.programId);
-    }
+  if (program.isOnKarma && program.programId && community?.slug) {
+    const communitySlug = community.slug;
+    const exclusiveDomain =
+      FUNDING_PLATFORM_DOMAINS[communitySlug as keyof typeof FUNDING_PLATFORM_DOMAINS];
+    // Use exclusive domain if available, otherwise fall through to shared domain
+    const domain = exclusiveDomain
+      ? envVars.isDev
+        ? exclusiveDomain.dev
+        : exclusiveDomain.prod
+      : undefined;
+    return FUNDING_PLATFORM_PAGES(communitySlug, domain).PROGRAM_PAGE(program.programId);
   }
   // Fallback to grantsSite from social links
   return normalizeUrl(program.metadata?.socialLinks?.grantsSite);
@@ -86,6 +105,99 @@ function isProgramActive(program: FundingProgramResponse): boolean {
   }
 
   return status === "active";
+}
+
+interface CommunityApplyButtonProps {
+  program: FundingProgramResponse;
+  isActive: boolean;
+}
+
+function CommunityApplyButton({ program, isActive }: CommunityApplyButtonProps) {
+  const validCommunities = program.communities?.filter((c) => c.slug) ?? [];
+
+  // Case 1: No valid communities with slugs - fall back to grantsSite
+  if (validCommunities.length === 0) {
+    const fallbackUrl = normalizeUrl(program.metadata?.socialLinks?.grantsSite);
+    if (!fallbackUrl) return null;
+
+    return (
+      <Button
+        asChild
+        size="sm"
+        disabled={!isActive}
+        className={cn("gap-1.5 ml-auto", !isActive && "pointer-events-none opacity-50")}
+      >
+        <Link href={isActive ? fallbackUrl : ""} target="_blank" rel="noopener noreferrer">
+          Apply
+          <ChevronRight className="h-4 w-4" />
+        </Link>
+      </Button>
+    );
+  }
+
+  // Case 2: Single community - direct button
+  if (validCommunities.length === 1) {
+    const applyUrl = getApplyUrl(program, validCommunities[0]);
+    if (!applyUrl) return null;
+
+    return (
+      <Button
+        asChild
+        size="sm"
+        disabled={!isActive}
+        className={cn("gap-1.5 ml-auto", !isActive && "pointer-events-none opacity-50")}
+      >
+        <Link href={isActive ? applyUrl : ""} target="_blank" rel="noopener noreferrer">
+          Apply on Karma
+          <ChevronRight className="h-4 w-4" />
+        </Link>
+      </Button>
+    );
+  }
+
+  // Case 3: Multiple communities - dropdown
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="sm"
+          disabled={!isActive}
+          className={cn("gap-1.5 ml-auto", !isActive && "pointer-events-none opacity-50")}
+        >
+          Apply on Karma
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {validCommunities.map((community) => {
+          const applyUrl = getApplyUrl(program, community);
+          if (!applyUrl) return null;
+
+          return (
+            <DropdownMenuItem key={community.uid} asChild>
+              <a
+                href={isActive ? applyUrl : undefined}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                {isValidImageUrl(community.imageUrl) && (
+                  <Image
+                    src={community.imageUrl}
+                    alt={community.name ?? ""}
+                    width={20}
+                    height={20}
+                    className="rounded-full"
+                  />
+                )}
+                <span>{community.name || community.slug}</span>
+              </a>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 function DialogSkeleton() {
@@ -240,7 +352,8 @@ function DialogContentInner({ program }: { program: FundingProgramResponse }) {
   const validCommunities = communities?.filter((c) => c.name && c.name.trim().length > 0) ?? [];
   const fallbackName = organizations?.join(", ") ?? "";
 
-  const applyUrl = getApplyUrl(program);
+  // Only used for non-Karma programs as fallback
+  const fallbackApplyUrl = normalizeUrl(metadata?.socialLinks?.grantsSite);
   const isActive = isProgramActive(program);
 
   const budget = formatBudgetValue(metadata?.programBudget);
@@ -408,18 +521,26 @@ function DialogContentInner({ program }: { program: FundingProgramResponse }) {
             </a>
           )}
 
-          {applyUrl && (
-            <Button
-              asChild
-              size="sm"
-              disabled={!isActive}
-              className={cn("gap-1.5 ml-auto", !isActive && "pointer-events-none opacity-50")}
-            >
-              <Link href={isActive ? applyUrl : ""} target="_blank" rel="noopener noreferrer">
-                {isOnKarma ? "Apply on Karma" : "Apply"}
-                <ChevronRight className="h-4 w-4" />
-              </Link>
-            </Button>
+          {isOnKarma ? (
+            <CommunityApplyButton program={program} isActive={isActive} />
+          ) : (
+            fallbackApplyUrl && (
+              <Button
+                asChild
+                size="sm"
+                disabled={!isActive}
+                className={cn("gap-1.5 ml-auto", !isActive && "pointer-events-none opacity-50")}
+              >
+                <Link
+                  href={isActive ? fallbackApplyUrl : ""}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Apply
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            )
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

When a funding program belongs to multiple communities, the "Apply on Karma" button now shows a dropdown allowing users to select which community to apply through.

## Problem

At `/funding-map?programId=990_42161`, clicking "Apply on Karma" redirected to the wrong community URL:
- **Before**: Always redirected to `https://app.karmahq.xyz/ethereum-foundation/programs/990`
- **Issue**: Program 990 belongs to both `ethereum-foundation` and `localism-fund` communities
- **Expected**: User should be able to choose which community to apply through

### Root Cause

The code at line 63 always used `program.communities?.[0]?.slug`, taking the first community regardless of which one was correct.

## Solution

Added a `CommunityApplyButton` component that handles three scenarios:

| Scenario | Behavior |
|----------|----------|
| No communities with slugs | Falls back to `grantsSite` URL with "Apply" button |
| Single community | Direct "Apply on Karma" button (unchanged UX) |
| Multiple communities | Dropdown with community logos and names |

### UI Preview

For multi-community programs:
```
+---------------------------+
| Apply on Karma      | ▼ |  <- Dropdown trigger
+---------------------------+
         |
         v
+---------------------------+
| [Logo] localism-fund      |
| [Logo] ethereum-foundation|
+---------------------------+
```

## Changes

- Created `CommunityApplyButton` component with dropdown support
- Modified `getApplyUrl()` to accept optional community parameter
- Added `DropdownMenu` imports from shadcn/ui
- Removed unused `PAGES` import

## Testing Steps

1. Navigate to `/funding-map?programId=990_42161`
2. Click "Apply on Karma" button
3. Verify dropdown appears with both communities:
   - `localism-fund`
   - `ethereum-foundation`
4. Click each option and verify correct redirect URL
5. Test with single-community programs (should show direct button)
6. Test with programs not on Karma (should show "Apply" with grantsSite URL)

## Checklist

- [x] TypeScript compiles without errors
- [x] Biome lint passes (pre-existing complexity warning only)
- [x] No breaking changes for single-community programs
- [x] Fallback behavior preserved for non-Karma programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown menu for selecting communities when applying to funding programs with multiple community options.

* **Refactor**
  * Improved apply flow logic to dynamically handle different community scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->