### PR TITLE
refactor: remove applicationDeadline in favor of metadata.endsAt

### DIFF
--- a/app/community/[communityId]/admin/funding-platform/page.tsx
+++ b/app/community/[communityId]/admin/funding-platform/page.tsx
@@ -622,11 +622,7 @@ export default function FundingPlatformAdminPage() {
                   <CalendarIcon className="w-4 h-4 text-orange-700 dark:text-orange-300" />
                   <span className="text-orange-700 dark:text-orange-300">
                     Deadline:{" "}
-                    {program.applicationConfig?.formSchema?.settings?.applicationDeadline
-                      ? formatDate(
-                          program.applicationConfig.formSchema.settings.applicationDeadline
-                        )
-                      : "N/A"}
+                    {program.metadata?.endsAt ? formatDate(program.metadata.endsAt) : "N/A"}
                   </span>
                 </div>
 

--- a/app/community/[communityId]/reviewer/funding-platform/page.tsx
+++ b/app/community/[communityId]/reviewer/funding-platform/page.tsx
@@ -465,11 +465,7 @@ export default function ReviewerFundingPlatformPage() {
                     <CalendarIcon className="w-5 h-5 text-orange-700 dark:text-orange-300" />
                     <span className="flex items-center gap-2 text-orange-700 dark:text-orange-300">
                       Deadline:{" "}
-                      {program.applicationConfig?.formSchema?.settings?.applicationDeadline
-                        ? formatDate(
-                            program.applicationConfig.formSchema.settings.applicationDeadline
-                          )
-                        : "N/A"}
+                      {program.metadata?.endsAt ? formatDate(program.metadata.endsAt) : "N/A"}
                     </span>
                   </div>
 

--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -72,7 +72,6 @@ export function SettingsConfiguration({
     resolver: zodResolver(settingsConfigSchema),
     defaultValues: {
       privateApplications: schema.settings?.privateApplications ?? true,
-      applicationDeadline: convertUTCToLocal(schema.settings?.applicationDeadline),
       donationRound: schema.settings?.donationRound ?? false,
       successPageContent: schema.settings?.successPageContent ?? "",
       showCommentsOnPublicPage: schema.settings?.showCommentsOnPublicPage ?? false,
@@ -96,7 +95,6 @@ export function SettingsConfiguration({
           confirmationMessage:
             schema.settings?.confirmationMessage || "Thank you for your submission!",
           privateApplications: data.privateApplications ?? true,
-          applicationDeadline: convertLocalToUTC(data.applicationDeadline),
           donationRound: data.donationRound ?? false,
           successPageContent: data.successPageContent,
           showCommentsOnPublicPage: data.showCommentsOnPublicPage ?? false,
@@ -140,27 +138,6 @@ export function SettingsConfiguration({
         <hr className="my-4" />
 
         <div className="space-y-6 py-4">
-          {/* Application Deadline */}
-          <div className="space-y-2">
-            <label
-              htmlFor="applicationDeadline"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Application Deadline
-            </label>
-            <input
-              {...register("applicationDeadline")}
-              type="datetime-local"
-              id="applicationDeadline"
-              disabled={readOnly}
-              className={`w-full px-3 py-2 border border-gray-300 dark:border-zinc-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 dark:bg-zinc-700 dark:text-white ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
-            />
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Set a deadline for when applications will no longer be accepted. Leave empty for no
-              deadline.
-            </p>
-          </div>
-
           {/* Donation Round */}
           <div className="space-y-3">
             <div className="flex items-start space-x-3">

--- a/schemas/__tests__/settingsConfigSchema.test.ts
+++ b/schemas/__tests__/settingsConfigSchema.test.ts
@@ -5,7 +5,6 @@ describe("settingsConfigSchema", () => {
     it("should validate with successPageContent", () => {
       const validData = {
         privateApplications: true,
-        applicationDeadline: "2024-12-31T23:59",
         donationRound: false,
         showCommentsOnPublicPage: true,
         successPageContent: "**Review**: Applications reviewed weekly.",
@@ -21,7 +20,6 @@ describe("settingsConfigSchema", () => {
     it("should validate without successPageContent (optional)", () => {
       const validData = {
         privateApplications: true,
-        applicationDeadline: "2024-12-31T23:59",
         donationRound: false,
         showCommentsOnPublicPage: true,
       };
@@ -138,52 +136,12 @@ describe("settingsConfigSchema", () => {
       const result = settingsConfigSchema.safeParse(invalidData);
       expect(result.success).toBe(false);
     });
-
-    it("should accept optional applicationDeadline", () => {
-      const validData = {
-        privateApplications: true,
-        applicationDeadline: "2024-12-31T23:59:59",
-        donationRound: false,
-        showCommentsOnPublicPage: true,
-      };
-
-      const result = settingsConfigSchema.safeParse(validData);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.applicationDeadline).toBe("2024-12-31T23:59:59");
-      }
-    });
-
-    it("should accept empty string for applicationDeadline", () => {
-      const validData = {
-        privateApplications: true,
-        applicationDeadline: "",
-        donationRound: false,
-        showCommentsOnPublicPage: true,
-      };
-
-      const result = settingsConfigSchema.safeParse(validData);
-      expect(result.success).toBe(true);
-    });
-
-    it("should reject if applicationDeadline is not a string", () => {
-      const invalidData = {
-        privateApplications: true,
-        applicationDeadline: 123456789,
-        donationRound: false,
-        showCommentsOnPublicPage: true,
-      };
-
-      const result = settingsConfigSchema.safeParse(invalidData);
-      expect(result.success).toBe(false);
-    });
   });
 
   describe("complete schema validation", () => {
     it("should validate with all fields present", () => {
       const validData = {
         privateApplications: true,
-        applicationDeadline: "2024-12-31T23:59",
         donationRound: false,
         showCommentsOnPublicPage: true,
         successPageContent: "**Important**: Check your email regularly.",
@@ -207,7 +165,6 @@ describe("settingsConfigSchema", () => {
 
       const validData = {
         privateApplications: false,
-        applicationDeadline: "2025-01-31T23:59",
         donationRound: true,
         showCommentsOnPublicPage: false,
         successPageContent: markdownContent,
@@ -327,7 +284,6 @@ describe("settingsConfigSchema", () => {
         privateApplications: true,
         donationRound: false,
         showCommentsOnPublicPage: true,
-        applicationDeadline: undefined,
         successPageContent: undefined,
       };
 
@@ -342,7 +298,6 @@ describe("settingsConfigSchema", () => {
         privateApplications: true,
         donationRound: false,
         showCommentsOnPublicPage: true,
-        applicationDeadline: "2024-12-31T23:59",
         successPageContent: "**Test content**",
       };
 
@@ -350,7 +305,6 @@ describe("settingsConfigSchema", () => {
       expect(validData.privateApplications).toBeDefined();
       expect(validData.donationRound).toBeDefined();
       expect(validData.showCommentsOnPublicPage).toBeDefined();
-      expect(validData.applicationDeadline).toBeDefined();
       expect(validData.successPageContent).toBeDefined();
     });
 
@@ -362,7 +316,6 @@ describe("settingsConfigSchema", () => {
       };
 
       // Optional fields should be allowed to be undefined
-      expect(validData.applicationDeadline).toBeUndefined();
       expect(validData.successPageContent).toBeUndefined();
     });
   });

--- a/schemas/settingsConfigSchema.ts
+++ b/schemas/settingsConfigSchema.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export const settingsConfigSchema = z.object({
   privateApplications: z.boolean(),
-  applicationDeadline: z.string().optional(),
   donationRound: z.boolean(),
   successPageContent: z.string().optional(),
   showCommentsOnPublicPage: z.boolean(),

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -75,7 +75,6 @@ export interface IFormSchema {
   settings?: {
     submitButtonText?: string;
     confirmationMessage?: string;
-    applicationDeadline?: string;
     donationRound?: boolean;
     approvalEmailTemplate?: string; // Markdown/HTML template for approval emails with variable placeholders
     approvalEmailSubject?: string; // Custom subject for approval emails with variable placeholders (e.g., {{programName}})

--- a/types/question-builder.ts
+++ b/types/question-builder.ts
@@ -41,7 +41,6 @@ export interface FormSchema {
     submitButtonText: string;
     confirmationMessage: string;
     privateApplications?: boolean; // Whether this program has private applications
-    applicationDeadline?: string; // Application deadline date
     donationRound?: boolean; // Whether this is a donation round
     successPageContent?: string; // Markdown content for "What happens next?" section on success page
     showCommentsOnPublicPage?: boolean; // Whether to show comments on public application pages

--- a/utilities/funding-programs.ts
+++ b/utilities/funding-programs.ts
@@ -67,9 +67,8 @@ export function isProgramOpen(startsAt: string | undefined, endsAt: string | und
 export function isProgramEnabled(program: FundingProgram): boolean {
   const isEnabled = program.applicationConfig?.isEnabled ?? false;
   const hasFormConfig = !!program.applicationConfig?.formSchema;
-  const applicationDeadline = program.applicationConfig?.formSchema?.settings?.applicationDeadline;
-  const isApplicationDeadlinePassed = applicationDeadline
-    ? new Date(applicationDeadline) < new Date()
+  const isApplicationDeadlinePassed = program.metadata?.endsAt
+    ? new Date(program.metadata.endsAt) < new Date()
     : false;
 
   const isOpen =
@@ -88,9 +87,8 @@ export function isProgramEnabled(program: FundingProgram): boolean {
 export function getProgramStatusInfo(program: FundingProgram): ProgramStatusInfo {
   const isEnabled = program.applicationConfig?.isEnabled ?? false;
   const hasFormConfig = !!program.applicationConfig?.formSchema;
-  const applicationDeadline = program.applicationConfig?.formSchema?.settings?.applicationDeadline;
-  const isApplicationDeadlinePassed = applicationDeadline
-    ? new Date(applicationDeadline) < new Date()
+  const isApplicationDeadlinePassed = program.metadata?.endsAt
+    ? new Date(program.metadata.endsAt) < new Date()
     : false;
 
   const isOpen =


### PR DESCRIPTION
## Summary

Remove all references to `applicationDeadline` from the codebase. The program end date (`metadata.endsAt`) is now the single source of truth for determining application deadlines.

## Changes

- Remove `applicationDeadline` from settings configuration in `SettingsConfiguration.tsx`
- Update admin and reviewer funding platform pages
- Remove `applicationDeadline` from types (`funding-platform.ts`, `question-builder.ts`)
- Remove from schema (`settingsConfigSchema.ts`)
- Update `funding-programs.ts` utilities
- Update related tests in `settingsConfigSchema.test.ts`

## Why This Change

Having two separate fields (`applicationDeadline` in form settings and `endsAt` in metadata) for essentially the same concept was causing confusion and potential inconsistencies. This refactor simplifies the codebase by using a single source of truth.

## Test Plan

- [x] Schema tests pass
- [ ] Manual verification of admin funding platform page
- [ ] Manual verification of reviewer funding platform page

## Related PRs

- gap-whitelabel-app: Remove applicationDeadline references
- gap-indexer: Remove applicationDeadline from domain model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deadline information sourcing for funding programs to use program metadata instead of form settings, ensuring accurate deadline displays across the platform.

* **Refactor**
  * Removed Application Deadline field from funding program settings configuration forms.
  * Simplified deadline validation logic to use centralized program metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->