### PR TITLE
fix(tests): update test to match new optional rejection reason help text

### DIFF
--- a/__tests__/components/FundingPlatform/ApplicationView/StatusChangeModal.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/StatusChangeModal.test.tsx
@@ -561,7 +561,7 @@ describe("StatusChangeModal", () => {
       renderWithQueryClient(<StatusChangeModal {...defaultProps} status="rejected" />);
 
       expect(
-        screen.getByText(/this content will be sent to the applicant via email/i)
+        screen.getByText(/if provided, this message will be sent to the applicant via email/i)
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
The StatusChangeModal component was updated to show "If provided, this message will be sent to the applicant via email" for rejected status since the rejection reason is now optional. This test was not updated to match the new text.