### PR TITLE
Make reject optional in StatusChangeModal

### DIFF
--- a/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -445,7 +445,7 @@ export default function ApplicationDetailPage() {
         onConfirm={handleStatusChangeConfirm}
         status={pendingStatus}
         isSubmitting={isUpdatingStatus}
-        isReasonRequired={pendingStatus === "revision_requested" || pendingStatus === "rejected"}
+        isReasonRequired={pendingStatus === "revision_requested"}
         application={application}
         programConfig={isFundingProgramConfig(program) ? program : undefined}
       />


### PR DESCRIPTION
Remove 'rejected' status from isReasonRequired condition in the admin application detail page, aligning it with ApplicationContent.tsx behavior. Now only 'revision_requested' status requires a reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated application status change validation to require a reason only when requesting revision, removing the requirement for rejection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->