### PR TITLE
fix: display karma profile link as clickable project link in post-approval forms

### DIFF
--- a/components/FundingPlatform/ApplicationView/PostApprovalData.tsx
+++ b/components/FundingPlatform/ApplicationView/PostApprovalData.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { type FC, useMemo } from "react";
+import { KarmaProjectLink } from "@/components/FundingPlatform/shared/KarmaProjectLink";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
+import { createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
+import { PROJECT_UID_REGEX } from "@/utilities/validation";
 
 interface PostApprovalDataProps {
   postApprovalData: Record<string, any>;
@@ -22,6 +25,12 @@ const PostApprovalData: FC<PostApprovalDataProps> = ({ postApprovalData, program
     }
     return labels;
   }, [program]);
+
+  // Create field type mapping from post-approval schema
+  const fieldTypeMap = useMemo(
+    () => createFieldTypeMap(program?.postApprovalFormSchema),
+    [program?.postApprovalFormSchema]
+  );
 
   const renderPostApprovalData = () => {
     if (!postApprovalData || Object.keys(postApprovalData).length === 0) {
@@ -85,6 +94,10 @@ const PostApprovalData: FC<PostApprovalDataProps> = ({ postApprovalData, program
                 <pre className="bg-zinc-50 dark:bg-zinc-800 p-2 rounded text-xs overflow-x-auto">
                   {JSON.stringify(value, null, 2)}
                 </pre>
+              ) : fieldTypeMap[key] === "karma_profile_link" &&
+                typeof value === "string" &&
+                PROJECT_UID_REGEX.test(value) ? (
+                <KarmaProjectLink uid={value} />
               ) : (
                 <div className="prose prose-sm dark:prose-invert max-w-none">
                   <MarkdownPreview source={String(value)} />


### PR DESCRIPTION
## Summary
- Display `karma_profile_link` fields as clickable project links instead of raw UIDs in Post Approval forms
- Aligns Post Approval data views with the existing Application data view behavior

## Problem
When viewing post-approval form data, `karma_profile_link` fields were being displayed as raw UIDs (e.g., `0x123abc...`), which are meaningless to users. The Application form already handles this correctly by rendering these UIDs as clickable links showing the project name.

## Solution
Updated both Post Approval data view components to use the same `KarmaProjectLink` component pattern:

### Changes in `PostApprovalDataView.tsx`
- Added imports for `KarmaProjectLink`, `createFieldTypeMap`, and `PROJECT_UID_REGEX`
- Created `fieldTypeMap` from post-approval form schema using `useMemo`
- Added karma profile link detection and rendering logic in `renderFieldValue`

### Changes in `PostApprovalData.tsx`
- Added the same imports
- Created `fieldTypeMap` from program's post-approval form schema
- Added karma profile link handling in the inline conditional rendering

## Testing Steps
1. Navigate to a funded application that has post-approval data with a `karma_profile_link` field
2. Verify the karma profile UID is now displayed as a clickable link showing the project name
3. Click the link and verify it opens the correct GAP project page in a new tab

## Related
Follows the same pattern as `ApplicationDataView.tsx` (lines 100-108) for consistency across the application.