### PR TITLE
feat: Add funding opportunities page and UI improvements

### DIFF
--- a/__tests__/components/CommunityGrants/FundingOpportunities.test.tsx
+++ b/__tests__/components/CommunityGrants/FundingOpportunities.test.tsx
@@ -1,0 +1,483 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { FundingOpportunities } from "@/components/CommunityGrants/FundingOpportunities";
+import { useFundingOpportunities } from "@/hooks/useFundingOpportunities";
+import type { FundingProgram } from "@/src/features/funding-map/types/funding-program";
+
+// Mock the hook
+jest.mock("@/hooks/useFundingOpportunities");
+
+// Mock InfiniteScroll
+jest.mock("react-infinite-scroll-component", () => {
+  return ({ children, loader, hasMore, next, dataLength }: any) => (
+    <div data-testid="infinite-scroll" data-has-more={hasMore} data-length={dataLength}>
+      {children}
+      {hasMore && (
+        <button type="button" data-testid="load-more" onClick={next}>
+          Load More
+        </button>
+      )}
+    </div>
+  );
+});
+
+// Mock sub-components
+jest.mock("@/components/CommunityGrants/FundingOpportunities/FundingOpportunitiesGrid", () => ({
+  FundingOpportunitiesGrid: ({ programs }: { programs: FundingProgram[] }) => (
+    <div data-testid="funding-opportunities-grid">
+      {programs.map((program) => (
+        <div key={program._id} data-testid="program-card">
+          {program.name}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/CommunityGrants/FundingOpportunities/AlreadyAppliedBanner", () => ({
+  AlreadyAppliedBanner: ({ communitySlug }: { communitySlug: string }) => (
+    <div data-testid="already-applied-banner">Already applied? - {communitySlug}</div>
+  ),
+}));
+
+// Mock Spinner
+jest.mock("@/components/Utilities/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner">Loading...</div>,
+}));
+
+// Mock lucide-react
+jest.mock("lucide-react", () => ({
+  Coins: (props: any) => <svg {...props} data-testid="coins-icon" />,
+}));
+
+const mockUseFundingOpportunities = useFundingOpportunities as jest.MockedFunction<
+  typeof useFundingOpportunities
+>;
+
+describe("FundingOpportunities", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const createMockProgram = (overrides: Partial<FundingProgram> = {}): FundingProgram =>
+    ({
+      _id: "program-123",
+      programId: "program-123",
+      name: "Test Program",
+      description: "Test program description",
+      status: "Active",
+      chainId: 1,
+      chainName: "Ethereum",
+      organizationName: "Test Org",
+      communityName: "Test Community",
+      ...overrides,
+    }) as FundingProgram;
+
+  const defaultHookReturn = {
+    data: undefined,
+    isLoading: false,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    error: null,
+    isError: false,
+    refetch: jest.fn(),
+    status: "success" as const,
+    fetchStatus: "idle" as const,
+    isSuccess: true,
+    isPending: false,
+    isRefetching: false,
+    isFetching: false,
+    dataUpdatedAt: Date.now(),
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isStale: false,
+    isPlaceholderData: false,
+    isFetchedAfterMount: true,
+    isFetched: true,
+    isLoadingError: false,
+    isRefetchError: false,
+    hasPreviousPage: false,
+    isFetchingPreviousPage: false,
+    fetchPreviousPage: jest.fn(),
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("Loading State", () => {
+    it("should show spinner when loading without initial data", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: true,
+        data: undefined,
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getByTestId("spinner")).toBeInTheDocument();
+    });
+
+    it("should not show spinner when loading with initial data", () => {
+      const initialData = {
+        programs: [createMockProgram()],
+        count: 1,
+        totalPages: 1,
+      };
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: true,
+        data: undefined,
+      } as any);
+
+      render(
+        <FundingOpportunities
+          communityUid="test-uid"
+          communitySlug="test-community"
+          initialData={initialData}
+        />,
+        { wrapper }
+      );
+
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+      expect(screen.getByTestId("program-card")).toBeInTheDocument();
+    });
+  });
+
+  describe("Empty State", () => {
+    it("should show empty state when no programs exist", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: {
+          pages: [
+            {
+              programs: [],
+              count: 0,
+              totalPages: 0,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getByText("No funding opportunities available")).toBeInTheDocument();
+      expect(
+        screen.getByText(/There are no active funding programs in this community/)
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("coins-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Programs Display", () => {
+    it("should display programs in grid", () => {
+      const mockPrograms = [
+        createMockProgram({ _id: "program-1", name: "Program 1" }),
+        createMockProgram({ _id: "program-2", name: "Program 2" }),
+      ];
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: {
+          pages: [
+            {
+              programs: mockPrograms,
+              count: 2,
+              totalPages: 1,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getByTestId("funding-opportunities-grid")).toBeInTheDocument();
+      expect(screen.getAllByTestId("program-card")).toHaveLength(2);
+      expect(screen.getByText("Program 1")).toBeInTheDocument();
+      expect(screen.getByText("Program 2")).toBeInTheDocument();
+    });
+
+    it("should display AlreadyAppliedBanner with correct communitySlug", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: {
+          pages: [
+            {
+              programs: [createMockProgram()],
+              count: 1,
+              totalPages: 1,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="optimism" />, {
+        wrapper,
+      });
+
+      expect(screen.getByTestId("already-applied-banner")).toBeInTheDocument();
+      expect(screen.getByText(/Already applied\? - optimism/)).toBeInTheDocument();
+    });
+  });
+
+  describe("Infinite Scroll", () => {
+    it("should render InfiniteScroll component", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        hasNextPage: true,
+        data: {
+          pages: [
+            {
+              programs: [createMockProgram()],
+              count: 100,
+              totalPages: 2,
+              currentPage: 1,
+              hasNext: true,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getByTestId("infinite-scroll")).toBeInTheDocument();
+      expect(screen.getByTestId("infinite-scroll")).toHaveAttribute("data-has-more", "true");
+    });
+
+    it("should show load more when hasNextPage is true", () => {
+      const mockFetchNextPage = jest.fn();
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        hasNextPage: true,
+        fetchNextPage: mockFetchNextPage,
+        data: {
+          pages: [
+            {
+              programs: [createMockProgram()],
+              count: 100,
+              totalPages: 2,
+              currentPage: 1,
+              hasNext: true,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getByTestId("load-more")).toBeInTheDocument();
+    });
+
+    it("should not show load more when hasNextPage is false", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        hasNextPage: false,
+        data: {
+          pages: [
+            {
+              programs: [createMockProgram()],
+              count: 1,
+              totalPages: 1,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.queryByTestId("load-more")).not.toBeInTheDocument();
+    });
+
+    it("should flatten programs from multiple pages", () => {
+      const page1Programs = [createMockProgram({ _id: "program-1", name: "Program 1" })];
+      const page2Programs = [createMockProgram({ _id: "program-2", name: "Program 2" })];
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        hasNextPage: false,
+        data: {
+          pages: [
+            {
+              programs: page1Programs,
+              count: 2,
+              totalPages: 2,
+              currentPage: 1,
+              hasNext: true,
+              hasPrevious: false,
+            },
+            {
+              programs: page2Programs,
+              count: 2,
+              totalPages: 2,
+              currentPage: 2,
+              hasNext: false,
+              hasPrevious: true,
+            },
+          ],
+          pageParams: [1, 2],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="test-uid" communitySlug="test-community" />, {
+        wrapper,
+      });
+
+      expect(screen.getAllByTestId("program-card")).toHaveLength(2);
+      expect(screen.getByText("Program 1")).toBeInTheDocument();
+      expect(screen.getByText("Program 2")).toBeInTheDocument();
+    });
+  });
+
+  describe("Initial Data Fallback", () => {
+    it("should use initial data when hook data is not available", () => {
+      const initialData = {
+        programs: [createMockProgram({ _id: "initial-1", name: "Initial Program" })],
+        count: 1,
+        totalPages: 1,
+      };
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: undefined,
+      } as any);
+
+      render(
+        <FundingOpportunities
+          communityUid="test-uid"
+          communitySlug="test-community"
+          initialData={initialData}
+        />,
+        { wrapper }
+      );
+
+      expect(screen.getByText("Initial Program")).toBeInTheDocument();
+    });
+
+    it("should prefer hook data over initial data when available", () => {
+      const initialData = {
+        programs: [createMockProgram({ _id: "initial-1", name: "Initial Program" })],
+        count: 1,
+        totalPages: 1,
+      };
+
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: {
+          pages: [
+            {
+              programs: [createMockProgram({ _id: "hook-1", name: "Hook Program" })],
+              count: 1,
+              totalPages: 1,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(
+        <FundingOpportunities
+          communityUid="test-uid"
+          communitySlug="test-community"
+          initialData={initialData}
+        />,
+        { wrapper }
+      );
+
+      expect(screen.getByText("Hook Program")).toBeInTheDocument();
+      expect(screen.queryByText("Initial Program")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Hook Invocation", () => {
+    it("should call useFundingOpportunities with correct communityUid", () => {
+      mockUseFundingOpportunities.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: false,
+        data: {
+          pages: [
+            {
+              programs: [],
+              count: 0,
+              totalPages: 0,
+              currentPage: 1,
+              hasNext: false,
+              hasPrevious: false,
+            },
+          ],
+          pageParams: [1],
+        },
+      } as any);
+
+      render(<FundingOpportunities communityUid="my-community-uid" communitySlug="my-slug" />, {
+        wrapper,
+      });
+
+      expect(mockUseFundingOpportunities).toHaveBeenCalledWith({
+        communityUid: "my-community-uid",
+      });
+    });
+  });
+});

--- a/__tests__/components/Pages/Communities/CommunityPageNavigator.test.tsx
+++ b/__tests__/components/Pages/Communities/CommunityPageNavigator.test.tsx
@@ -1,0 +1,350 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { CommunityPageNavigator } from "@/components/Pages/Communities/CommunityPageNavigator";
+import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
+
+// Mock hooks
+jest.mock("@/hooks/communities/useCommunityDetails");
+
+// Mock next/navigation
+const mockUseParams = jest.fn();
+const mockUsePathname = jest.fn();
+const mockUseSearchParams = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useParams: () => mockUseParams(),
+  usePathname: () => mockUsePathname(),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+// Mock PAGES utility
+jest.mock("@/utilities/pages", () => ({
+  PAGES: {
+    COMMUNITY: {
+      FUNDING_OPPORTUNITIES: (id: string) => `/community/${id}/funding-opportunities`,
+      ALL_GRANTS: (id: string) => `/community/${id}`,
+      UPDATES: (id: string) => `/community/${id}/updates`,
+      IMPACT: (id: string) => `/community/${id}/impact`,
+    },
+  },
+}));
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  ChartLine: (props: any) => <svg data-testid="chart-line-icon" {...props} />,
+  Coins: (props: any) => <svg data-testid="coins-icon" {...props} />,
+  LandPlot: (props: any) => <svg data-testid="land-plot-icon" {...props} />,
+  SquareUser: (props: any) => <svg data-testid="square-user-icon" {...props} />,
+}));
+
+const mockUseCommunityDetails = useCommunityDetails as jest.MockedFunction<
+  typeof useCommunityDetails
+>;
+
+describe("CommunityPageNavigator", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+
+    // Default mocks
+    mockUseParams.mockReturnValue({ communityId: "test-community" });
+    mockUsePathname.mockReturnValue("/community/test-community");
+    mockUseSearchParams.mockReturnValue({
+      get: jest.fn(() => null),
+    });
+    mockUseCommunityDetails.mockReturnValue({
+      data: {
+        details: {
+          name: "Test Community",
+        },
+      },
+      isLoading: false,
+    } as any);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("Rendering", () => {
+    it("should render all navigation items", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      expect(screen.getByText("Funding opportunities")).toBeInTheDocument();
+      expect(screen.getByText(/View.*community projects/)).toBeInTheDocument();
+      expect(screen.getByText("Milestone updates")).toBeInTheDocument();
+      expect(screen.getByText("Impact")).toBeInTheDocument();
+    });
+
+    it("should render all icons", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      expect(screen.getByTestId("coins-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("square-user-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("land-plot-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("chart-line-icon")).toBeInTheDocument();
+    });
+
+    it("should render links with correct hrefs", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const fundingLink = screen.getByText("Funding opportunities").closest("a");
+      const grantsLink = screen.getByText(/View.*community projects/).closest("a");
+      const updatesLink = screen.getByText("Milestone updates").closest("a");
+      const impactLink = screen.getByText("Impact").closest("a");
+
+      expect(fundingLink).toHaveAttribute(
+        "href",
+        "/community/test-community/funding-opportunities"
+      );
+      expect(grantsLink).toHaveAttribute("href", "/community/test-community");
+      expect(updatesLink).toHaveAttribute("href", "/community/test-community/updates");
+      expect(impactLink).toHaveAttribute("href", "/community/test-community/impact");
+    });
+  });
+
+  describe("Active State", () => {
+    it("should apply active styles to funding opportunities link", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/funding-opportunities");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Funding opportunities").closest("a");
+      expect(link?.className).toContain("text-gray-900");
+      expect(link?.className).toContain("border-b-4");
+      expect(link?.className).toContain("border-b-gray-900");
+    });
+
+    it("should apply active styles to community projects link when on main page", () => {
+      mockUsePathname.mockReturnValue("/community/test-community");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText(/View.*community projects/).closest("a");
+      expect(link?.className).toContain("text-gray-900");
+    });
+
+    it("should apply active styles to updates link", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/updates");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Milestone updates").closest("a");
+      expect(link?.className).toContain("text-gray-900");
+    });
+
+    it("should apply active styles to impact link", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/impact");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Impact").closest("a");
+      expect(link?.className).toContain("text-gray-900");
+    });
+
+    it("should apply inactive styles to non-active links", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/funding-opportunities");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const impactLink = screen.getByText("Impact").closest("a");
+      expect(impactLink?.className).toContain("text-gray-500");
+      expect(impactLink?.className).toContain("border-b-transparent");
+    });
+  });
+
+  describe("Admin Page", () => {
+    it("should return null when on admin page", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/admin");
+
+      const { container } = render(<CommunityPageNavigator />, { wrapper });
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should return null when on admin subpage", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/admin/project/milestones");
+
+      const { container } = render(<CommunityPageNavigator />, { wrapper });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("Community Name", () => {
+    it("should include community name in projects link text", () => {
+      mockUseCommunityDetails.mockReturnValue({
+        data: {
+          details: {
+            name: "Optimism",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      expect(screen.getByText("View Optimism community projects")).toBeInTheDocument();
+    });
+
+    it("should handle missing community name gracefully", () => {
+      mockUseCommunityDetails.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as any);
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      // When community name is empty, it renders with double space
+      const link = screen.getByTestId("square-user-icon").closest("a");
+      expect(link?.textContent).toContain("community projects");
+    });
+  });
+
+  describe("Program ID", () => {
+    it("should append programId to links when present", () => {
+      mockUseSearchParams.mockReturnValue({
+        get: (key: string) => (key === "programId" ? "program-123" : null),
+      });
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const fundingLink = screen.getByText("Funding opportunities").closest("a");
+      expect(fundingLink).toHaveAttribute(
+        "href",
+        "/community/test-community/funding-opportunities?programId=program-123"
+      );
+
+      const impactLink = screen.getByText("Impact").closest("a");
+      expect(impactLink).toHaveAttribute(
+        "href",
+        "/community/test-community/impact?programId=program-123"
+      );
+    });
+
+    it("should not append programId when not present", () => {
+      mockUseSearchParams.mockReturnValue({
+        get: () => null,
+      });
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const fundingLink = screen.getByText("Funding opportunities").closest("a");
+      expect(fundingLink).toHaveAttribute(
+        "href",
+        "/community/test-community/funding-opportunities"
+      );
+    });
+  });
+
+  describe("Styling", () => {
+    it("should have container with correct classes", () => {
+      const { container } = render(<CommunityPageNavigator />, { wrapper });
+
+      const nav = container.firstChild;
+      expect(nav).toHaveClass("flex");
+      expect(nav).toHaveClass("flex-row");
+      expect(nav).toHaveClass("pt-8");
+      expect(nav).toHaveClass("border-b");
+    });
+
+    it("should have links with gap between icon and text", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Funding opportunities").closest("a");
+      expect(link?.className).toContain("gap-3");
+    });
+
+    it("should have icons with correct size", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const icon = screen.getByTestId("coins-icon");
+      expect(icon).toHaveClass("w-6");
+      expect(icon).toHaveClass("h-6");
+    });
+
+    it("should have dark mode classes on container", () => {
+      const { container } = render(<CommunityPageNavigator />, { wrapper });
+
+      const nav = container.firstChild;
+      expect(nav).toHaveClass("dark:border-zinc-700");
+    });
+
+    it("should have dark mode classes on links", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Funding opportunities").closest("a");
+      // Inactive links have dark:text-zinc-400
+      expect(link?.className).toContain("dark:text-zinc-400");
+    });
+  });
+
+  describe("isActive Logic", () => {
+    it("should mark funding opportunities as active when path includes /funding-opportunities", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/funding-opportunities");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Funding opportunities").closest("a");
+      expect(link?.className).toContain("text-gray-900");
+    });
+
+    it("should mark community projects as active when on main page (not impact, updates, donate, funding-opportunities, or project-discovery)", () => {
+      mockUsePathname.mockReturnValue("/community/test-community");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText(/View.*community projects/).closest("a");
+      expect(link?.className).toContain("text-gray-900");
+    });
+
+    it("should not mark community projects as active on impact page", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/impact");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText(/View.*community projects/).closest("a");
+      expect(link?.className).toContain("text-gray-500");
+    });
+
+    it("should not mark community projects as active on updates page", () => {
+      mockUsePathname.mockReturnValue("/community/test-community/updates");
+
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText(/View.*community projects/).closest("a");
+      expect(link?.className).toContain("text-gray-500");
+    });
+  });
+
+  describe("Transition Effects", () => {
+    it("should have transition classes on links", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const link = screen.getByText("Funding opportunities").closest("a");
+      expect(link?.className).toContain("transition-colors");
+      expect(link?.className).toContain("duration-200");
+    });
+
+    it("should have transition classes on icons", () => {
+      render(<CommunityPageNavigator />, { wrapper });
+
+      const icon = screen.getByTestId("coins-icon");
+      expect(icon).toHaveClass("transition-colors");
+      expect(icon).toHaveClass("duration-200");
+    });
+  });
+});

--- a/__tests__/components/Pages/Communities/Impact/StatCards.test.tsx
+++ b/__tests__/components/Pages/Communities/Impact/StatCards.test.tsx
@@ -1,0 +1,437 @@
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  CommunityImpactStatCards,
+  CommunityStatCards,
+  ImpactStatCards,
+} from "@/components/Pages/Communities/Impact/StatCards";
+import { useImpactMeasurement } from "@/hooks/useImpactMeasurement";
+import { useCommunityStore } from "@/store/community";
+import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
+
+// Mock hooks and services
+jest.mock("@/hooks/useImpactMeasurement");
+jest.mock("@/utilities/queries/v2/getCommunityData");
+jest.mock("@/store/community");
+
+// Mock useQuery for CommunityStatCards
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useQuery: jest.fn(),
+}));
+
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn(() => ({ communityId: "test-community" })),
+  usePathname: jest.fn(() => "/community/test-community"),
+  useSearchParams: jest.fn(() => ({
+    get: jest.fn((key: string) => null),
+  })),
+}));
+
+// Mock Skeleton
+jest.mock("@/components/Utilities/Skeleton", () => ({
+  Skeleton: ({ className }: { className: string }) => (
+    <div data-testid="skeleton" className={className}>
+      Loading...
+    </div>
+  ),
+}));
+
+// Mock InfoTooltip
+jest.mock("@/components/Utilities/InfoTooltip", () => ({
+  InfoTooltip: ({ content }: { content: ReactNode }) => (
+    <div data-testid="info-tooltip">{content}</div>
+  ),
+}));
+
+const mockUseImpactMeasurement = useImpactMeasurement as jest.MockedFunction<
+  typeof useImpactMeasurement
+>;
+
+const mockGetCommunityStats = getCommunityStats as jest.MockedFunction<typeof getCommunityStats>;
+
+const mockUseCommunityStore = useCommunityStore as jest.MockedFunction<typeof useCommunityStore>;
+
+describe("StatCards", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+
+    // Default mock for community store
+    mockUseCommunityStore.mockReturnValue({
+      totalProjects: 10,
+      totalGrants: 5,
+      totalMilestones: 20,
+      isLoadingFilters: false,
+    } as any);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("ImpactStatCards", () => {
+    it("should render three stat cards", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<ImpactStatCards />, { wrapper });
+
+      expect(screen.getByText("Total Projects")).toBeInTheDocument();
+      expect(screen.getByText("Total Categories")).toBeInTheDocument();
+      expect(screen.getByText("Total Funding Allocated (with available data)")).toBeInTheDocument();
+    });
+
+    it("should display formatted values", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 1234,
+            totalCategories: 56,
+            totalFundingAllocated: "$1,500,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<ImpactStatCards />, { wrapper });
+
+      // formatCurrency uses abbreviated format for large numbers (1.2K)
+      expect(screen.getByText("1.2K")).toBeInTheDocument();
+      expect(screen.getByText("56")).toBeInTheDocument();
+      expect(screen.getByText("$1,500,000")).toBeInTheDocument();
+    });
+
+    it("should show skeletons when loading", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as any);
+
+      render(<ImpactStatCards />, { wrapper });
+
+      expect(screen.getAllByTestId("skeleton")).toHaveLength(3);
+    });
+
+    it("should show dash for missing values", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 0,
+            totalCategories: undefined,
+            totalFundingAllocated: "NaN",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<ImpactStatCards />, { wrapper });
+
+      // Zero should show "0"
+      expect(screen.getByText("0")).toBeInTheDocument();
+      // Undefined and NaN should show "-"
+      const dashes = screen.getAllByText("-");
+      expect(dashes.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should apply correct colors to stat cards", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      const { container } = render(<ImpactStatCards />, { wrapper });
+
+      // Check for color indicators
+      const colorIndicators = container.querySelectorAll('[style*="background"]');
+      expect(colorIndicators.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("CommunityStatCards", () => {
+    const mockCommunityStatsData = {
+      totalGrants: 50,
+      projectUpdates: 200,
+      projectUpdatesBreakdown: {
+        projectMilestones: 30,
+        projectCompletedMilestones: 20,
+        projectUpdates: 40,
+        grantMilestones: 35,
+        grantCompletedMilestones: 25,
+        grantUpdates: 50,
+      },
+    };
+
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({
+        data: mockCommunityStatsData,
+        isLoading: false,
+        error: null,
+      } as any);
+    });
+
+    it("should render stat cards", async () => {
+      render(<CommunityStatCards />, { wrapper });
+
+      expect(screen.getByText("Total Projects")).toBeInTheDocument();
+      expect(screen.getByText("Total Grants")).toBeInTheDocument();
+      // There are multiple "Project Updates" elements (card title + breakdown)
+      expect(screen.getAllByText("Project Updates").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should display values from community store", () => {
+      mockUseCommunityStore.mockReturnValue({
+        totalProjects: 42,
+        totalGrants: 15,
+        totalMilestones: 30,
+        isLoadingFilters: false,
+      } as any);
+
+      render(<CommunityStatCards />, { wrapper });
+
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+
+    it("should show skeletons when loading filters", () => {
+      mockUseCommunityStore.mockReturnValue({
+        totalProjects: 10,
+        totalGrants: 5,
+        totalMilestones: 20,
+        isLoadingFilters: true,
+      } as any);
+
+      render(<CommunityStatCards />, { wrapper });
+
+      expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should show skeletons when query is loading", () => {
+      mockUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as any);
+
+      render(<CommunityStatCards />, { wrapper });
+
+      expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should show dash for zero or undefined values", () => {
+      mockUseCommunityStore.mockReturnValue({
+        totalProjects: 0,
+        totalGrants: 0,
+        totalMilestones: 0,
+        isLoadingFilters: false,
+      } as any);
+
+      mockUseQuery.mockReturnValue({
+        data: {
+          totalGrants: 0,
+          projectUpdates: 0,
+        },
+        isLoading: false,
+        error: null,
+      } as any);
+
+      render(<CommunityStatCards />, { wrapper });
+
+      const dashes = screen.getAllByText("-");
+      expect(dashes.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("CommunityImpactStatCards", () => {
+    const { usePathname } = require("next/navigation");
+
+    it("should render ImpactStatCards when on impact page", () => {
+      usePathname.mockReturnValue("/community/test-community/impact");
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<CommunityImpactStatCards />, { wrapper });
+
+      expect(screen.getByText("Total Categories")).toBeInTheDocument();
+    });
+
+    it("should render CommunityStatCards when not on impact page", () => {
+      usePathname.mockReturnValue("/community/test-community");
+      mockUseCommunityStore.mockReturnValue({
+        totalProjects: 10,
+        totalGrants: 5,
+        totalMilestones: 20,
+        isLoadingFilters: false,
+      } as any);
+
+      render(<CommunityImpactStatCards />, { wrapper });
+
+      expect(screen.getByText("Total Grants")).toBeInTheDocument();
+    });
+
+    it("should have correct container styling", () => {
+      usePathname.mockReturnValue("/community/test-community");
+      mockUseCommunityStore.mockReturnValue({
+        totalProjects: 10,
+        totalGrants: 5,
+        totalMilestones: 20,
+        isLoadingFilters: false,
+      } as any);
+
+      const { container } = render(<CommunityImpactStatCards />, { wrapper });
+
+      const mainContainer = container.firstChild;
+      expect(mainContainer).toHaveClass("flex");
+      expect(mainContainer).toHaveClass("flex-1");
+      expect(mainContainer).toHaveClass("gap-6");
+    });
+  });
+
+  describe("StatCard Component", () => {
+    it("should display title and value", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 500,
+            totalCategories: 30,
+            totalFundingAllocated: "$2,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      render(<ImpactStatCards />, { wrapper });
+
+      expect(screen.getByText("500")).toBeInTheDocument();
+      expect(screen.getByText("Total Projects")).toBeInTheDocument();
+    });
+
+    it("should have dark mode classes", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      const { container } = render(<ImpactStatCards />, { wrapper });
+
+      // Check for dark mode classes on card container
+      const cards = container.querySelectorAll(".dark\\:bg-zinc-900");
+      expect(cards.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should have rounded corners and border", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      const { container } = render(<ImpactStatCards />, { wrapper });
+
+      const cards = container.querySelectorAll(".rounded-lg");
+      expect(cards.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("Tooltip", () => {
+    it("should show tooltip for Project Updates when breakdown is available", async () => {
+      mockGetCommunityStats.mockResolvedValue({
+        totalGrants: 50,
+        projectUpdates: 200,
+        projectUpdatesBreakdown: {
+          projectMilestones: 30,
+          projectCompletedMilestones: 20,
+          projectUpdates: 40,
+          grantMilestones: 35,
+          grantCompletedMilestones: 25,
+          grantUpdates: 50,
+        },
+      });
+
+      const { usePathname } = require("next/navigation");
+      usePathname.mockReturnValue("/community/test-community");
+
+      render(<CommunityStatCards />, { wrapper });
+
+      // Wait for the query to resolve
+      await screen.findByText("Project Updates");
+    });
+  });
+
+  describe("Color Indicators", () => {
+    it("should apply correct colors for Impact stat cards", () => {
+      mockUseImpactMeasurement.mockReturnValue({
+        data: {
+          stats: {
+            totalProjects: 100,
+            totalCategories: 25,
+            totalFundingAllocated: "$1,000,000",
+          },
+        },
+        isLoading: false,
+      } as any);
+
+      const { container } = render(<ImpactStatCards />, { wrapper });
+
+      // Check for color indicator elements - colors are converted to RGB by the browser
+      // rgb(132, 173, 255) = #84ADFF, rgb(103, 227, 249) = #67E3F9, rgb(166, 239, 103) = #A6EF67
+      const colorIndicators = container.querySelectorAll('[style*="background"]');
+      expect(colorIndicators.length).toBe(3);
+
+      // Verify indicators exist and have the rounded-full class
+      colorIndicators.forEach((indicator) => {
+        expect(indicator).toHaveClass("rounded-full");
+        expect(indicator).toHaveClass("w-1");
+        expect(indicator).toHaveClass("h-full");
+      });
+    });
+  });
+});

--- a/app/community/[communityId]/funding-opportunities/loading.tsx
+++ b/app/community/[communityId]/funding-opportunities/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/funding-opportunities/page.tsx
@@ -1,0 +1,37 @@
+import { FundingOpportunities } from "@/components/CommunityGrants/FundingOpportunities";
+import { pagesOnRoot } from "@/utilities/pagesOnRoot";
+import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
+import { getFundingOpportunities } from "@/utilities/queries/v2/getFundingOpportunities";
+
+type Props = {
+  params: Promise<{
+    communityId: string;
+  }>;
+};
+
+export default async function FundingOpportunitiesPage(props: Props) {
+  const { communityId } = await props.params;
+
+  if (pagesOnRoot.includes(communityId)) {
+    return undefined;
+  }
+
+  const communityDetails = await getCommunityDetails(communityId);
+
+  if (!communityDetails) {
+    return null;
+  }
+
+  // Use community UID for the API filter (communityRef stores UIDs, not slugs)
+  const fundingOpportunities = await getFundingOpportunities(communityDetails.uid);
+
+  return (
+    <div className="-my-4 flex flex-col w-full max-w-full py-2">
+      <FundingOpportunities
+        communityUid={communityDetails.uid}
+        communitySlug={communityId}
+        initialData={fundingOpportunities}
+      />
+    </div>
+  );
+}

--- a/components/CommunityGrants/FundingOpportunities/AlreadyAppliedBanner.tsx
+++ b/components/CommunityGrants/FundingOpportunities/AlreadyAppliedBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { ExternalLink } from "@/components/Utilities/ExternalLink";
+import { FUNDING_PLATFORM_DOMAINS } from "@/src/features/funding-map/utils/funding-platform-domains";
+import { envVars } from "@/utilities/enviromentVars";
+import { FUNDING_PLATFORM_PAGES } from "@/utilities/pages";
+
+interface AlreadyAppliedBannerProps {
+  communitySlug: string;
+}
+
+export const AlreadyAppliedBanner = ({ communitySlug }: AlreadyAppliedBannerProps) => {
+  const { authenticated, login } = usePrivy();
+
+  const exclusiveDomain =
+    FUNDING_PLATFORM_DOMAINS[communitySlug as keyof typeof FUNDING_PLATFORM_DOMAINS];
+  const domain = exclusiveDomain
+    ? envVars.isDev
+      ? exclusiveDomain.dev
+      : exclusiveDomain.prod
+    : undefined;
+
+  const dashboardUrl = FUNDING_PLATFORM_PAGES(communitySlug, domain).HOME;
+
+  const handleClick = () => {
+    if (!authenticated) {
+      login();
+    }
+  };
+
+  return (
+    <div className="w-full rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-gradient-to-r from-slate-50 to-blue-50 dark:from-zinc-900 dark:to-zinc-800 p-8">
+      <div className="flex flex-col items-center justify-center text-center gap-4">
+        <h3 className="text-xl font-semibold text-gray-900 dark:text-white">Already applied?</h3>
+        <p className="text-gray-600 dark:text-gray-400 max-w-md">
+          Sign in to access your Application Dashboard, track submission status, and manage your
+          applications.
+        </p>
+        {authenticated ? (
+          <ExternalLink
+            href={dashboardUrl}
+            className="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand-blue hover:bg-brand-blue/90 text-white font-medium transition-colors"
+          >
+            Go to Dashboard
+          </ExternalLink>
+        ) : (
+          <button
+            type="button"
+            onClick={handleClick}
+            className="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand-blue hover:bg-brand-blue/90 text-white font-medium transition-colors"
+          >
+            Sign in to Dashboard
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/CommunityGrants/FundingOpportunities/FundingOpportunitiesGrid.tsx
+++ b/components/CommunityGrants/FundingOpportunities/FundingOpportunitiesGrid.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { FundingMapCard } from "@/src/features/funding-map/components/funding-map-card";
+import type { FundingProgramResponse } from "@/src/features/funding-map/types/funding-program";
+
+interface FundingOpportunitiesGridProps {
+  programs: FundingProgramResponse[];
+}
+
+export const FundingOpportunitiesGrid = ({ programs }: FundingOpportunitiesGridProps) => {
+  const router = useRouter();
+
+  const handleProgramClick = (program: FundingProgramResponse) => {
+    const programId = program.programId || program._id?.toString();
+    router.push(`/funding-map?programId=${programId}`);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+      {programs.map((program) => (
+        <FundingMapCard
+          key={program.programId || program._id?.toString()}
+          program={program}
+          onClick={() => handleProgramClick(program)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/components/CommunityGrants/FundingOpportunities/index.tsx
+++ b/components/CommunityGrants/FundingOpportunities/index.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Coins } from "lucide-react";
+import { useCallback, useEffect, useMemo } from "react";
+import InfiniteScroll from "react-infinite-scroll-component";
+import { Spinner } from "@/components/Utilities/Spinner";
+import { useFundingOpportunities } from "@/hooks/useFundingOpportunities";
+import type { PaginatedFundingPrograms } from "@/src/features/funding-map/types/funding-program";
+import { AlreadyAppliedBanner } from "./AlreadyAppliedBanner";
+import { FundingOpportunitiesGrid } from "./FundingOpportunitiesGrid";
+
+interface FundingOpportunitiesProps {
+  communityUid: string;
+  communitySlug: string;
+  initialData?: PaginatedFundingPrograms;
+}
+
+const EmptyState = () => (
+  <div className="flex flex-col items-center justify-center py-16">
+    <Coins className="w-16 h-16 text-gray-300 dark:text-gray-600 mb-4" />
+    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+      No funding opportunities available
+    </h3>
+    <p className="text-gray-500 dark:text-gray-400 text-center max-w-md">
+      There are no active funding programs in this community at the moment. Check back later for new
+      opportunities.
+    </p>
+  </div>
+);
+
+const LoadingMore = () => (
+  <div className="flex items-center justify-center py-8">
+    <Spinner />
+  </div>
+);
+
+export const FundingOpportunities = ({
+  communityUid,
+  communitySlug,
+  initialData,
+}: FundingOpportunitiesProps) => {
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useFundingOpportunities({
+      communityUid,
+    });
+
+  const programs = useMemo(() => {
+    if (!data?.pages) {
+      return initialData?.programs ?? [];
+    }
+    return data.pages.flatMap((page) => page.programs);
+  }, [data?.pages, initialData?.programs]);
+
+  const loadMore = useCallback(() => {
+    if (!isFetchingNextPage && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  // Auto-load more if content doesn't fill the viewport
+  useEffect(() => {
+    if (isLoading || isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    const handleScroll = () => {
+      if (document.documentElement.scrollHeight <= window.innerHeight) {
+        loadMore();
+      }
+    };
+
+    const timeoutId = setTimeout(handleScroll, 200);
+    return () => clearTimeout(timeoutId);
+  }, [hasNextPage, loadMore, isLoading, isFetchingNextPage]);
+
+  if (isLoading && !initialData) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (programs.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="flex flex-col gap-6 w-full">
+      <InfiniteScroll
+        dataLength={programs.length}
+        next={loadMore}
+        hasMore={hasNextPage ?? false}
+        loader={<LoadingMore />}
+        style={{ overflow: "visible" }}
+      >
+        <FundingOpportunitiesGrid programs={programs} />
+      </InfiniteScroll>
+      <AlreadyAppliedBanner communitySlug={communitySlug} />
+    </div>
+  );
+};

--- a/components/Pages/Communities/CommunityPageNavigator.tsx
+++ b/components/Pages/Communities/CommunityPageNavigator.tsx
@@ -1,19 +1,17 @@
 "use client";
-import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
+import { ChartLine, Coins, LandPlot, SquareUser } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { FolderIcon } from "@/components/Icons/Folder";
-import { Target2Icon } from "@/components/Icons/Target2";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 
 const activeLinkStyle =
-  "text-brand-darkblue dark:text-white font-bold border-b border-b-4 border-b-brand-blue dark:border-b-brand-blue";
+  "text-gray-900 dark:text-white border-b-4 border-b-gray-900 dark:border-b-white";
 const inactiveLinkStyle =
-  "text-gray-600 dark:text-zinc-400 font-normal hover:text-brand-darkblue dark:hover:text-white border-b border-b-4 border-b-transparent";
+  "text-gray-500 dark:text-zinc-400 border-b-4 border-b-transparent hover:text-gray-700 dark:hover:text-zinc-300";
 const baseLinkStyle =
-  "flex flex-row items-center gap-2 px-3 py-2 max-lg:w-full rounded-none text-base font-semibold font-['Inter'] leading-normal w-max transition-colors duration-200";
+  "flex flex-row items-center gap-3 p-3 max-lg:w-full rounded-none text-base font-normal leading-6 w-max transition-colors duration-200";
 
 const NewTag = () => {
   return (
@@ -33,34 +31,34 @@ type NavigationItem = {
 
 const NAVIGATION_ITEMS: readonly NavigationItem[] = [
   {
+    path: (communityId: string) => PAGES.COMMUNITY.FUNDING_OPPORTUNITIES(communityId),
+    title: () => "Funding opportunities",
+    Icon: Coins,
+    isActive: (pathname: string) => pathname.includes("/funding-opportunities"),
+  },
+  {
     path: (communityId: string) => PAGES.COMMUNITY.ALL_GRANTS(communityId),
-    title: (communityName: string) => `View all ${communityName} Community Projects`,
-    Icon: FolderIcon,
+    title: (communityName: string) => `View ${communityName} community projects`,
+    Icon: SquareUser,
     isActive: (pathname: string) =>
       !pathname.includes("/impact") &&
       !pathname.includes("/project-discovery") &&
       !pathname.includes("/updates") &&
-      !pathname.includes("/donate"),
+      !pathname.includes("/donate") &&
+      !pathname.includes("/funding-opportunities"),
   },
   {
     path: (communityId: string) => PAGES.COMMUNITY.UPDATES(communityId),
-    title: () => "Milestone Updates",
-    Icon: ClipboardDocumentListIcon,
+    title: () => "Milestone updates",
+    Icon: LandPlot,
     isActive: (pathname: string) => pathname.includes("/updates"),
   },
   {
     path: (communityId: string) => PAGES.COMMUNITY.IMPACT(communityId),
-    title: () => "Learn about their impact",
-    Icon: Target2Icon,
+    title: () => "Impact",
+    Icon: ChartLine,
     isActive: (pathname: string) => pathname.includes("/impact"),
-    showNewTag: false,
   },
-  // {
-  //   path: (communityId: string) => `/community/${communityId}/karma-ai`,
-  //   title: () => "Ask Karma AI",
-  //   Icon: SparklesIcon,
-  //   isActive: (pathname: string) => pathname.includes("/karma-ai"),
-  // },
 ] as const;
 
 const getPathWithProgramId = (program: string | null, basePath: string) => {
@@ -79,7 +77,7 @@ export const CommunityPageNavigator = () => {
   if (isAdminPage) return null;
 
   return (
-    <div className="flex-row max-md:flex-col flex-wrap px-1.5 pt-2 mb-[-1px] rounded-lg justify-start items-center gap-4 flex h-max">
+    <div className="flex flex-row max-md:flex-col flex-wrap pt-8 border-b border-gray-200 dark:border-zinc-700 justify-start items-center gap-6 h-max">
       {NAVIGATION_ITEMS.map(({ path, title, Icon, isActive, showNewTag }) => (
         <Link
           key={path(communityId)}
@@ -90,8 +88,8 @@ export const CommunityPageNavigator = () => {
             className={cn(
               "w-6 h-6 transition-colors duration-200",
               isActive(pathname)
-                ? "text-brand-blue dark:text-brand-blue"
-                : "text-brand-darkblue dark:text-zinc-400"
+                ? "text-gray-900 dark:text-white"
+                : "text-gray-500 dark:text-zinc-400"
             )}
           />
           {title(community?.details?.name || "")}

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { Skeleton } from "@/components/Utilities/Skeleton";
@@ -8,6 +9,39 @@ import { useImpactMeasurement } from "@/hooks/useImpactMeasurement";
 import { useCommunityStore } from "@/store/community";
 import formatCurrency from "@/utilities/formatCurrency";
 import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
+
+interface StatCardProps {
+  title: string;
+  value: string;
+  color: string;
+  isLoading?: boolean;
+  tooltip?: ReactNode;
+}
+
+const StatCard = ({ title, value, color, isLoading, tooltip }: StatCardProps) => (
+  <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
+    <div className="py-3 pl-3">
+      <div className="w-1 h-full rounded-full" style={{ background: color }} />
+    </div>
+    <div className="flex flex-col items-start justify-center py-3 pl-2 pr-4">
+      {isLoading ? (
+        <Skeleton className="w-12 h-8 mb-1" />
+      ) : (
+        <p className="text-gray-900 dark:text-zinc-100 text-[30px] font-semibold leading-none tracking-tight">
+          {value}
+        </p>
+      )}
+      <div className="flex items-center gap-1">
+        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-normal">
+          {title}
+        </span>
+        {tooltip && (
+          <InfoTooltip content={tooltip} side="top" align="start" contentClassName="max-w-sm" />
+        )}
+      </div>
+    </div>
+  </div>
+);
 
 export const ImpactStatCards = () => {
   const { data, isLoading } = useImpactMeasurement();
@@ -40,31 +74,13 @@ export const ImpactStatCards = () => {
   ];
 
   return stats.map((item) => (
-    <div
+    <StatCard
       key={item.title}
-      className="flex flex-1 rounded-lg border border-gray-300 dark:border-zinc-600"
-    >
-      <div className="px-3 py-3 rounded-full">
-        <div
-          className="w-1 h-[84px] max-sm:h-full rounded-full"
-          style={{
-            background: item.color,
-          }}
-        />
-      </div>
-      <div className="h-full flex flex-col items-start justify-end py-2">
-        <h3 className="text-slate-800 dark:text-zinc-100 text-base font-semibold font-['Inter']">
-          {item.title}
-        </h3>
-        {isLoading ? (
-          <Skeleton className="w-10 h-10" />
-        ) : (
-          <p className="text-center text-slate-800 dark:text-zinc-100 text-2xl font-bold font-['Inter']">
-            {item.value}
-          </p>
-        )}
-      </div>
-    </div>
+      title={item.title}
+      value={item.value}
+      color={item.color}
+      isLoading={isLoading}
+    />
   ));
 };
 
@@ -90,7 +106,7 @@ export const CommunityStatCards = () => {
       title: "Total Projects",
       value: filteredProjectsCount,
       displayValue: filteredProjectsCount ? formatCurrency(filteredProjectsCount) : "-",
-      color: "#9b59b6",
+      color: "#84ADFF",
       showLoading: isLoadingFilters,
       tooltip: null,
     },
@@ -98,7 +114,7 @@ export const CommunityStatCards = () => {
       title: "Total Grants",
       value: data?.totalGrants,
       displayValue: data?.totalGrants ? formatCurrency(data.totalGrants) : "-",
-      color: "#e67e22",
+      color: "#5FE9D0",
       showLoading: isLoadingFilters,
       tooltip: null,
     },
@@ -106,7 +122,7 @@ export const CommunityStatCards = () => {
       title: "Project Updates",
       value: data?.projectUpdates,
       displayValue: data?.projectUpdates ? formatCurrency(data.projectUpdates) : "-",
-      color: "#3498db",
+      color: "#FDB022",
       showLoading: isLoadingFilters,
       tooltip: data?.projectUpdatesBreakdown ? (
         <div className="flex flex-col gap-1.5 p-1">
@@ -161,41 +177,14 @@ export const CommunityStatCards = () => {
   );
 
   return filteredStats.map((item) => (
-    <div
+    <StatCard
       key={item.title}
-      className="flex flex-1 rounded-lg border border-gray-300 dark:border-zinc-600"
-    >
-      <div className="px-3 py-3 rounded-full">
-        <div
-          className="w-1 h-[84px] max-sm:h-full rounded-full"
-          style={{
-            background: item.color,
-          }}
-        />
-      </div>
-      <div className="h-full flex flex-col items-start justify-end py-2 pr-2">
-        <div className="flex items-center gap-1">
-          <h3 className="text-slate-800 dark:text-zinc-100 text-base font-semibold font-['Inter']">
-            {item.title}
-          </h3>
-          {item.tooltip && (
-            <InfoTooltip
-              content={item.tooltip}
-              side="top"
-              align="start"
-              contentClassName="max-w-sm"
-            />
-          )}
-        </div>
-        {isLoading || item.showLoading ? (
-          <Skeleton className="w-10 h-10" />
-        ) : (
-          <p className="text-center text-slate-800 dark:text-zinc-100 text-2xl font-bold font-['Inter']">
-            {item.displayValue}
-          </p>
-        )}
-      </div>
-    </div>
+      title={item.title}
+      value={item.displayValue}
+      color={item.color}
+      isLoading={isLoading || item.showLoading}
+      tooltip={item.tooltip}
+    />
   ));
 };
 

--- a/hooks/__tests__/useFundingOpportunities.test.tsx
+++ b/hooks/__tests__/useFundingOpportunities.test.tsx
@@ -1,0 +1,402 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { fundingProgramsService } from "@/src/features/funding-map/services/funding-programs.service";
+import type { FundingProgram } from "@/src/features/funding-map/types/funding-program";
+import { useFundingOpportunities } from "../useFundingOpportunities";
+
+// Mock the service
+jest.mock("@/src/features/funding-map/services/funding-programs.service");
+
+const mockGetAll = fundingProgramsService.getAll as jest.MockedFunction<
+  typeof fundingProgramsService.getAll
+>;
+
+describe("useFundingOpportunities", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const createMockProgram = (overrides: Partial<FundingProgram> = {}): FundingProgram =>
+    ({
+      _id: "program-123",
+      programId: "program-123",
+      name: "Test Program",
+      description: "Test program description",
+      status: "Active",
+      chainId: 1,
+      chainName: "Ethereum",
+      organizationName: "Test Org",
+      communityName: "Test Community",
+      ...overrides,
+    }) as FundingProgram;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("successful data fetching", () => {
+    it("should fetch funding opportunities for a community", async () => {
+      const mockPrograms = [createMockProgram(), createMockProgram({ _id: "program-2" })];
+      mockGetAll.mockResolvedValue({
+        programs: mockPrograms,
+        count: 2,
+        totalPages: 1,
+      });
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        {
+          wrapper,
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledWith({
+        communityUid: "test-community",
+        onlyOnKarma: true,
+        status: "Active",
+        page: 1,
+        pageSize: 50,
+      });
+      expect(result.current.data?.pages[0].programs).toEqual(mockPrograms);
+    });
+
+    it("should return empty array when no programs exist", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [],
+        count: 0,
+        totalPages: 0,
+      });
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "empty-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data?.pages[0].programs).toEqual([]);
+    });
+  });
+
+  describe("loading state", () => {
+    it("should have loading state while fetching", async () => {
+      mockGetAll.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  programs: [createMockProgram()],
+                  count: 1,
+                  totalPages: 1,
+                }),
+              100
+            )
+          )
+      );
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data?.pages[0].programs).toHaveLength(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle fetch errors", async () => {
+      mockGetAll.mockRejectedValue(new Error("API Error"));
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe("enabled state", () => {
+    it("should not fetch when communityUid is empty", () => {
+      const { result } = renderHook(() => useFundingOpportunities({ communityUid: "" }), {
+        wrapper,
+      });
+
+      expect(mockGetAll).not.toHaveBeenCalled();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("should not fetch when enabled is false", () => {
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community", enabled: false }),
+        { wrapper }
+      );
+
+      expect(mockGetAll).not.toHaveBeenCalled();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("should fetch when communityUid is provided", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [createMockProgram()],
+        count: 1,
+        totalPages: 1,
+      });
+
+      const { result } = renderHook(() => useFundingOpportunities({ communityUid: "optimism" }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledWith(
+        expect.objectContaining({ communityUid: "optimism" })
+      );
+    });
+  });
+
+  describe("pagination", () => {
+    it("should fetch next page when hasNextPage is true", async () => {
+      mockGetAll
+        .mockResolvedValueOnce({
+          programs: [createMockProgram({ _id: "program-1" })],
+          count: 100,
+          totalPages: 2,
+        })
+        .mockResolvedValueOnce({
+          programs: [createMockProgram({ _id: "program-2" })],
+          count: 100,
+          totalPages: 2,
+        });
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(true);
+
+      // Fetch next page
+      await result.current.fetchNextPage();
+
+      await waitFor(() => {
+        expect(result.current.data?.pages).toHaveLength(2);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledTimes(2);
+      expect(mockGetAll).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }));
+    });
+
+    it("should not have next page when on last page", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [createMockProgram()],
+        count: 1,
+        totalPages: 1,
+      });
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(false);
+    });
+
+    it("should flatten pages correctly", async () => {
+      const page1Programs = [
+        createMockProgram({ _id: "program-1" }),
+        createMockProgram({ _id: "program-2" }),
+      ];
+      const page2Programs = [
+        createMockProgram({ _id: "program-3" }),
+        createMockProgram({ _id: "program-4" }),
+      ];
+
+      mockGetAll
+        .mockResolvedValueOnce({
+          programs: page1Programs,
+          count: 4,
+          totalPages: 2,
+        })
+        .mockResolvedValueOnce({
+          programs: page2Programs,
+          count: 4,
+          totalPages: 2,
+        });
+
+      const { result } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Fetch the next page
+      result.current.fetchNextPage();
+
+      // Wait for pages to be loaded
+      await waitFor(
+        () => {
+          expect(result.current.data?.pages).toHaveLength(2);
+        },
+        { timeout: 3000 }
+      );
+
+      const allPrograms = result.current.data?.pages.flatMap((page) => page.programs);
+      expect(allPrograms).toHaveLength(4);
+      expect(allPrograms?.[0]._id).toBe("program-1");
+      expect(allPrograms?.[3]._id).toBe("program-4");
+    });
+  });
+
+  describe("caching", () => {
+    it("should use cache on subsequent renders", async () => {
+      const mockPrograms = [createMockProgram()];
+      mockGetAll.mockResolvedValue({
+        programs: mockPrograms,
+        count: 1,
+        totalPages: 1,
+      });
+
+      const { result, rerender } = renderHook(
+        () => useFundingOpportunities({ communityUid: "test-community" }),
+        { wrapper }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledTimes(1);
+
+      // Rerender - should use cache
+      rerender();
+
+      expect(mockGetAll).toHaveBeenCalledTimes(1);
+      expect(result.current.data?.pages[0].programs).toEqual(mockPrograms);
+    });
+
+    it("should fetch again when communityUid changes", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [createMockProgram()],
+        count: 1,
+        totalPages: 1,
+      });
+
+      const { result, rerender } = renderHook(
+        ({ uid }) => useFundingOpportunities({ communityUid: uid }),
+        {
+          wrapper,
+          initialProps: { uid: "community-1" },
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledWith(
+        expect.objectContaining({ communityUid: "community-1" })
+      );
+
+      // Change community uid
+      rerender({ uid: "community-2" });
+
+      await waitFor(() => {
+        expect(mockGetAll).toHaveBeenCalledWith(
+          expect.objectContaining({ communityUid: "community-2" })
+        );
+      });
+
+      expect(mockGetAll).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("query configuration", () => {
+    it("should use correct query key structure", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [],
+        count: 0,
+        totalPages: 0,
+      });
+
+      const { result } = renderHook(() => useFundingOpportunities({ communityUid: "test-slug" }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify the query is cached with the right key
+      const cachedData = queryClient.getQueryData(["funding-opportunities-infinite", "test-slug"]);
+      expect(cachedData).toBeDefined();
+    });
+
+    it("should request only active programs with onlyOnKarma flag", async () => {
+      mockGetAll.mockResolvedValue({
+        programs: [],
+        count: 0,
+        totalPages: 0,
+      });
+
+      renderHook(() => useFundingOpportunities({ communityUid: "test-community" }), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(mockGetAll).toHaveBeenCalled();
+      });
+
+      expect(mockGetAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onlyOnKarma: true,
+          status: "Active",
+        })
+      );
+    });
+  });
+});

--- a/hooks/useFundingOpportunities.ts
+++ b/hooks/useFundingOpportunities.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fundingProgramsService } from "@/src/features/funding-map/services/funding-programs.service";
+import type { PaginatedFundingProgramsResponse } from "@/src/features/funding-map/types/funding-program";
+
+const FUNDING_OPPORTUNITIES_PAGE_SIZE = 50;
+
+interface UseFundingOpportunitiesOptions {
+  communityUid: string;
+  enabled?: boolean;
+}
+
+export function useFundingOpportunities({
+  communityUid,
+  enabled = true,
+}: UseFundingOpportunitiesOptions) {
+  return useInfiniteQuery<PaginatedFundingProgramsResponse, Error>({
+    queryKey: ["funding-opportunities-infinite", communityUid],
+    queryFn: async ({ pageParam = 1 }) => {
+      const result = await fundingProgramsService.getAll({
+        communityUid,
+        onlyOnKarma: true,
+        status: "Active",
+        page: pageParam as number,
+        pageSize: FUNDING_OPPORTUNITIES_PAGE_SIZE,
+      });
+
+      return {
+        programs: result.programs,
+        count: result.count,
+        totalPages: result.totalPages,
+        currentPage: pageParam as number,
+        hasNext: (pageParam as number) < result.totalPages,
+        hasPrevious: (pageParam as number) > 1,
+      };
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage.hasNext ? lastPage.currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
+    enabled: enabled && !!communityUid,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+}

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -11,6 +11,7 @@ export const PAGES = {
   COMMUNITY: {
     ALL_GRANTS: (community: string, programId?: string) =>
       `/community/${community}${programId ? `?programId=${programId}` : ""}`,
+    FUNDING_OPPORTUNITIES: (community: string) => `/community/${community}/funding-opportunities`,
     IMPACT: (community: string) => `/community/${community}/impact`,
     DONATE: (community: string) => `/community/${community}/donate`,
     DONATE_PROGRAM: (community: string, programId: string) =>

--- a/utilities/queries/v2/getFundingOpportunities.ts
+++ b/utilities/queries/v2/getFundingOpportunities.ts
@@ -1,0 +1,42 @@
+import { cache } from "react";
+import type {
+  PaginatedFundingPrograms,
+  PaginatedFundingProgramsResponse,
+} from "@/src/features/funding-map/types/funding-program";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+const DEFAULT_RESPONSE: PaginatedFundingPrograms = {
+  programs: [],
+  count: 0,
+  totalPages: 0,
+};
+
+export const getFundingOpportunities = cache(
+  async (communityId: string): Promise<PaginatedFundingPrograms> => {
+    try {
+      const params = new URLSearchParams({
+        communityUid: communityId,
+        onlyOnKarma: "true",
+        status: "active",
+        limit: "50",
+      });
+
+      const [response, error] = await fetchData<PaginatedFundingProgramsResponse>(
+        `${INDEXER.V2.REGISTRY.GET_ALL}?${params.toString()}`
+      );
+
+      if (error || !response) {
+        return DEFAULT_RESPONSE;
+      }
+
+      return {
+        programs: response.programs,
+        count: response.count,
+        totalPages: response.totalPages,
+      };
+    } catch {
+      return DEFAULT_RESPONSE;
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- Add new funding opportunities page at `/community/[communityId]/funding-opportunities`
- Implement infinite scrolling pagination for funding opportunities
- Update stat cards design to match Figma specifications
- Update community page navigator design to match Figma specifications

## Changes

### Funding Opportunities Page
- New page component with server-side data fetching
- Client-side infinite scrolling with 50 items per page
- Uses the same `FundingMapCard` component as `/funding-map` for consistency
- "Already Applied?" banner with link to funding platform dashboard

### Stat Cards (`StatCards.tsx`)
- Updated layout: large value first, label below (matching Figma)
- Updated colors to match Figma design:
  - Total Projects: `#84ADFF` (blue)
  - Total Grants: `#5FE9D0` (teal)
  - Project Updates: `#FDB022` (yellow)
- Proper dark mode support

### Community Page Navigator (`CommunityPageNavigator.tsx`)
- Updated icons to match Figma:
  - Funding opportunities: `Coins`
  - View community projects: `SquareUser`
  - Milestone updates: `LandPlot`
  - Impact: `ChartLine`
- Updated colors:
  - Active: `text-gray-900 dark:text-white` with `border-b-gray-900`
  - Inactive: `text-gray-500 dark:text-zinc-400`
- Updated spacing: `gap-3` between icon/text, `gap-6` between tabs
- Added bottom border on container

## Test plan
- [x] Navigate to `/community/[communityId]/funding-opportunities` and verify cards load
- [x] Scroll down to test infinite scrolling pagination
- [x] Verify stat cards display correctly with new design
- [x] Verify community page navigator styling matches Figma
- [x] Test dark mode for all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)