### PR TITLE
fix(sentry): ignore third-party browser extension and WalletConnect errors

### DIFF
--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -9,6 +9,18 @@ const walletConnectErrors = [
   "this.provider.disconnect is not a function",
   "n.disconnect is not a function",
   "indexedDB is not defined",
+  // WalletConnect WebSocket origin rejection - not caused by our code
+  // See https://karma-crypto-inc.sentry.io/issues/KARMA-GAP-WHITELABEL-28
+  "WebSocket connection closed abnormally with code: 3000",
+];
+
+const browserExtensionErrors = [
+  // Browser extensions disconnecting ports (Chrome extensions, wallet extensions)
+  // See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1BA
+  "Attempting to use a disconnected port object",
+  // Wallet extensions calling chrome.runtime without proper Extension ID
+  // See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1B8
+  "chrome.runtime.sendMessage() called from a webpage must specify an Extension ID",
 ];
 
 export const sentryIgnoreErrors = [
@@ -23,4 +35,5 @@ export const sentryIgnoreErrors = [
   `TypeError: can't access dead object`,
   ...unsupportedWalletErrors,
   ...walletConnectErrors,
+  ...browserExtensionErrors,
 ];


### PR DESCRIPTION
## Summary
- Add filters to ignore browser extension errors that are not caused by our application code
- Filter out WalletConnect WebSocket origin rejection errors
- These errors were generating significant noise in Sentry (30k+ events)

## Errors Being Filtered

| Issue | Error | Occurrences |
|-------|-------|-------------|
| [GAP-FRONTEND-1BA](https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1BA) | `Attempting to use a disconnected port object` | 20,408 |
| [GAP-FRONTEND-1B8](https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1B8) | `chrome.runtime.sendMessage() called from a webpage must specify an Extension ID` | 4,150 |

These errors originate from:
- `extensionServiceWorker.js` - Browser extension service workers
- `inpage.js` - Wallet extensions (MetaMask, etc.)
- `@walletconnect/jsonrpc-ws-connection` - WalletConnect library

## Test plan
- [ ] Deploy to staging and verify errors are no longer reported to Sentry
- [ ] Verify legitimate application errors are still captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error tracking by configuring the system to properly ignore browser extension-related errors, resulting in cleaner error logs and more accurate error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->