### PR TITLE
claude/fix-funding-card-nav-A0IQ4

### DIFF
--- a/components/CommunityGrants/FundingOpportunities/FundingOpportunitiesGrid.tsx
+++ b/components/CommunityGrants/FundingOpportunities/FundingOpportunitiesGrid.tsx
@@ -1,30 +1,44 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { FundingMapCard } from "@/src/features/funding-map/components/funding-map-card";
 import type { FundingProgramResponse } from "@/src/features/funding-map/types/funding-program";
+import { FUNDING_PLATFORM_DOMAINS } from "@/src/features/funding-map/utils/funding-platform-domains";
+import { envVars } from "@/utilities/enviromentVars";
+import { FUNDING_PLATFORM_PAGES } from "@/utilities/pages";
 
 interface FundingOpportunitiesGridProps {
   programs: FundingProgramResponse[];
+  communitySlug: string;
 }
 
-export const FundingOpportunitiesGrid = ({ programs }: FundingOpportunitiesGridProps) => {
-  const router = useRouter();
+const getProgramPageUrl = (communitySlug: string, programId: string): string => {
+  const exclusiveDomain =
+    FUNDING_PLATFORM_DOMAINS[communitySlug as keyof typeof FUNDING_PLATFORM_DOMAINS];
+  const domain = exclusiveDomain
+    ? envVars.isDev
+      ? exclusiveDomain.dev
+      : exclusiveDomain.prod
+    : undefined;
 
-  const handleProgramClick = (program: FundingProgramResponse) => {
-    const programId = program.programId || program._id?.toString();
-    router.push(`/funding-map?programId=${programId}`);
-  };
+  return FUNDING_PLATFORM_PAGES(communitySlug, domain).PROGRAM_PAGE(programId);
+};
 
+export const FundingOpportunitiesGrid = ({
+  programs,
+  communitySlug,
+}: FundingOpportunitiesGridProps) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-      {programs.map((program) => (
-        <FundingMapCard
-          key={program.programId || program._id?.toString()}
-          program={program}
-          onClick={() => handleProgramClick(program)}
-        />
-      ))}
+      {programs.map((program) => {
+        const programId = program.programId || program._id?.toString();
+        return (
+          <FundingMapCard
+            key={programId}
+            program={program}
+            href={programId ? getProgramPageUrl(communitySlug, programId) : undefined}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/components/CommunityGrants/FundingOpportunities/index.tsx
+++ b/components/CommunityGrants/FundingOpportunities/index.tsx
@@ -94,7 +94,7 @@ export const FundingOpportunities = ({
         loader={<LoadingMore />}
         style={{ overflow: "visible" }}
       >
-        <FundingOpportunitiesGrid programs={programs} />
+        <FundingOpportunitiesGrid programs={programs} communitySlug={communitySlug} />
       </InfiniteScroll>
       <AlreadyAppliedBanner communitySlug={communitySlug} />
     </div>

--- a/hooks/useFundingOpportunitiesCount.ts
+++ b/hooks/useFundingOpportunitiesCount.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fundingProgramsService } from "@/src/features/funding-map/services/funding-programs.service";
+
+interface UseFundingOpportunitiesCountOptions {
+  communityUid?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Hook to check if a community has any active funding opportunities
+ * Returns the count of active funding programs
+ */
+export function useFundingOpportunitiesCount({
+  communityUid,
+  enabled = true,
+}: UseFundingOpportunitiesCountOptions) {
+  return useQuery({
+    queryKey: ["funding-opportunities-count", communityUid],
+    queryFn: async () => {
+      const result = await fundingProgramsService.getAll({
+        communityUid,
+        onlyOnKarma: true,
+        status: "Active",
+        page: 1,
+        pageSize: 1, // We only need the count, not the full list
+      });
+
+      return result.count;
+    },
+    enabled: enabled && !!communityUid,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+  });
+}

--- a/src/features/funding-map/components/funding-map-card.tsx
+++ b/src/features/funding-map/components/funding-map-card.tsx
@@ -1,5 +1,6 @@
 import { Calendar, Coins } from "lucide-react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import type { KeyboardEvent } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -15,6 +16,8 @@ import { OnKarmaBadge } from "./on-karma-badge";
 interface FundingMapCardProps {
   program: FundingProgramResponse;
   onClick?: () => void;
+  /** URL to navigate to when the card is clicked (takes precedence over onClick) */
+  href?: string;
   /** Hide the description section */
   hideDescription?: boolean;
   /** Hide the categories section */
@@ -37,10 +40,12 @@ function isPendingReview(program: FundingProgramResponse): boolean {
 export function FundingMapCard({
   program,
   onClick,
+  href,
   hideDescription = false,
   hideCategories = false,
   className,
 }: FundingMapCardProps & { className?: string }) {
+  const router = useRouter();
   const { metadata, isOnKarma, communities } = program;
 
   const title = metadata?.title;
@@ -63,13 +68,21 @@ export function FundingMapCard({
   const budget = metadata?.programBudget;
   const formattedBudget = formatBudgetValue(budget);
 
+  const handleClick = () => {
+    if (href) {
+      router.push(href);
+    } else {
+      onClick?.();
+    }
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
       // Prevent Space from scrolling the page
       if (event.key === " ") {
         event.preventDefault();
       }
-      onClick?.();
+      handleClick();
     }
   };
 
@@ -82,7 +95,7 @@ export function FundingMapCard({
         isPendingReview(program) && "ring-1 ring-gray-200",
         className
       )}
-      onClick={onClick}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="button"


### PR DESCRIPTION
- Add href prop to FundingMapCard for direct program page navigation
- Update FundingOpportunitiesGrid to navigate to program page instead of funding-map
- Change funding opportunities tab icon from Coins to DollarSign
- Hide funding opportunities tab when community has no active programs
- Add useFundingOpportunitiesCount hook for checking program availability
- Update CommunityPageNavigator tests for new icon and visibility behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Funding opportunities tab now displays conditionally based on the number of available opportunities
  * Navigation to funding opportunity details now uses direct URLs for improved accessibility

* **Tests**
  * Expanded test suite to cover funding opportunities visibility scenarios during loading and data states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->