### PR TITLE
Feat: Replace hardcoded autosynced indicators list with dynamic API fetch using `syncType=auto` filter.

### DIFF
--- a/components/Forms/Outputs/MetricsTable.tsx
+++ b/components/Forms/Outputs/MetricsTable.tsx
@@ -2,9 +2,9 @@
 
 import { TrashIcon } from "@heroicons/react/24/solid";
 import { useState } from "react";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import { cn } from "@/utilities/tailwind";
 // Temporarily comment out SearchWithValueDropdown to test
@@ -115,6 +115,9 @@ export const MetricsTable = ({
 }: MetricsTableProps) => {
   const [isOutputDialogOpen, setIsOutputDialogOpen] = useState(false);
   const [_selectedToCreate, setSelectedToCreate] = useState<number | undefined>(undefined);
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   const handleOutputChange = (index: number, field: keyof OutputData, value: any) => {
     const newOutputs = [...outputs];

--- a/components/Forms/ProjectUpdate.tsx
+++ b/components/Forms/ProjectUpdate.tsx
@@ -11,12 +11,12 @@ import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import { useAccount } from "wagmi";
 import { z } from "zod";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useGap } from "@/hooks/useGap";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
@@ -282,6 +282,9 @@ export const ProjectUpdateForm: FC<ProjectUpdateFormProps> = ({
   const { data: indicatorsData } = useImpactAnswers({
     projectIdentifier: project?.uid,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   // Get communities from selected grants
   const watchedGrantIds = watch("grants") || [];

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -4,8 +4,8 @@ import * as Popover from "@radix-ui/react-popover";
 import { type FC, Fragment, useEffect, useState } from "react";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { ImpactIndicator } from "@/types/impactMeasurement";
 
 interface IndicatorsDropdownProps {
@@ -36,6 +36,10 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
     unitOfMeasure: "int",
     programs: [],
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   // Combine the original indicators with any newly created ones
   const allIndicators = [...indicators, ...newIndicators];
@@ -282,12 +286,17 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                       id="indicators-dropdown-autosynced"
                       value={selectedAutosynced}
                       onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                      disabled={isLoadingAutosynced}
+                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
                     >
-                      <option value="">Create Custom Indicator</option>
+                      <option value="">
+                        {isLoadingAutosynced
+                          ? "Loading autosynced indicators..."
+                          : "Create Custom Indicator"}
+                      </option>
                       {autosyncedIndicators.map((indicator) => (
-                        <option key={indicator.name} value={indicator.name}>
-                          {indicator.description}
+                        <option key={indicator.id || indicator.name} value={indicator.name}>
+                          {indicator.name}
                         </option>
                       ))}
                     </select>

--- a/components/Pages/Admin/IndicatorsHub.tsx
+++ b/components/Pages/Admin/IndicatorsHub.tsx
@@ -8,6 +8,7 @@ import { DeleteDialog } from "@/components/DeleteDialog";
 import { IndicatorForm, type IndicatorFormData } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useIndicators } from "@/hooks/useIndicators";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
@@ -23,87 +24,6 @@ interface Program {
 type IndicatorWithPrograms = Indicator & {
   programs?: Program[];
 };
-
-export const autosyncedIndicators: IndicatorWithPrograms[] = [
-  {
-    name: "No. of Transactions",
-    id: "",
-    description: "No. of transactions",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "active_developers",
-    id: "",
-    description: "No. of active developers (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "PULL_REQUEST_MERGED",
-    id: "",
-    description: "Number of pull requests merged (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_OPENED",
-    id: "",
-    description: "Number of issues opened (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "FORKED",
-    id: "",
-    description: "Number of repository forks (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_CLOSED",
-    id: "",
-    description: "Number of issues closed (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_COMMENT",
-    id: "",
-    description: "Number of comments on issues (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "STARRED",
-    id: "",
-    description: "Number of repository stars (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "GitHub Commits",
-    id: "",
-    description: "Number of code commits (*github)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "PULL_REQUEST_OPENED",
-    id: "",
-    description: "Number of pull requests opened (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "GitHub Merged PRs",
-    id: "",
-    description: "Number of pull requests merged (*github)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "RELEASE_PUBLISHED",
-    id: "",
-    description: "Number of releases published (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "contributors",
-    id: "",
-    description: "No. of contributors (*oso)",
-    unitOfMeasure: "int",
-  },
-];
 
 interface IndicatorsHubProps {
   communitySlug: string;
@@ -125,6 +45,8 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
   const { data: rawIndicators = [], refetch } = useIndicators({
     communityId,
   });
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   const indicators = rawIndicators as IndicatorWithPrograms[];
 
@@ -233,12 +155,17 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
                 id="indicators-hub-autosynced"
                 value={selectedAutosynced}
                 onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                disabled={isLoadingAutosynced}
+                className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
               >
-                <option value="">Create Custom Indicator</option>
+                <option value="">
+                  {isLoadingAutosynced
+                    ? "Loading autosynced indicators..."
+                    : "Create Custom Indicator"}
+                </option>
                 {autosyncedIndicators.map((indicator) => (
-                  <option key={indicator.name} value={indicator.name}>
-                    {indicator.description}
+                  <option key={indicator.id || indicator.name} value={indicator.name}>
+                    {indicator.name}
                   </option>
                 ))}
               </select>

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -7,9 +7,9 @@ import { useAccount } from "wagmi";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useGroupedIndicators } from "@/hooks/useGroupedIndicators";
 import type { Category, ImpactIndicator, ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import fetchData from "@/utilities/fetchData";
@@ -120,6 +120,10 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
   } = useGroupedIndicators({
     communityId: communityId || "",
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   // Handle autosynced indicator selection
   const handleAutosyncedSelect = (name: string) => {
@@ -506,12 +510,17 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
                       id="indicators-view-autosynced"
                       value={selectedAutosynced}
                       onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                      disabled={isLoadingAutosynced}
+                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
                     >
-                      <option value="">Create Custom Indicator</option>
+                      <option value="">
+                        {isLoadingAutosynced
+                          ? "Loading autosynced indicators..."
+                          : "Create Custom Indicator"}
+                      </option>
                       {autosyncedIndicators.map((indicator) => (
-                        <option key={indicator.name} value={indicator.name}>
-                          {indicator.description}
+                        <option key={indicator.id || indicator.name} value={indicator.name}>
+                          {indicator.name}
                         </option>
                       ))}
                     </select>

--- a/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
@@ -5,8 +5,8 @@ import { AreaChart, Card, Title } from "@tremor/react";
 import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useCommunityAdminStore } from "@/store/communityAdmin";
@@ -86,6 +86,9 @@ export const FilteredOutputsAndOutcomes = ({
     projectIdentifier: project?.uid as string,
     enabled: !!project?.uid && !!indicatorIds?.length && !!indicatorNames?.length,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   // Filter indicators based on IDs and names
   const filteredAnswers = useMemo(() => {

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -6,8 +6,8 @@ import { AreaChart, Card, Title } from "@tremor/react";
 import { Fragment, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useCommunityAdminStore } from "@/store/communityAdmin";
@@ -50,6 +50,9 @@ export const OutputsAndOutcomes = () => {
     projectIdentifier: project?.uid as string,
     enabled: !!project?.uid,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   const handleSubmit = async (id: string) => {
     const form = forms.find((f) => f.id === id);

--- a/hooks/useAutosyncedIndicators.ts
+++ b/hooks/useAutosyncedIndicators.ts
@@ -1,69 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import fetchData from "@/utilities/fetchData";
-import { INDEXER } from "@/utilities/indexer";
-import type { Indicator, PaginatedResponse } from "@/utilities/queries/getIndicatorsByCommunity";
-
-interface V2Indicator {
-  id: string;
-  name: string;
-  description: string;
-  unitOfMeasure: string;
-  programs?: { programId: number; chainID: number }[] | null;
-  communityUID?: string | null;
-  syncType?: "auto" | "manual";
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-function transformIndicator(v2Indicator: V2Indicator): Indicator {
-  return {
-    ...v2Indicator,
-    programs:
-      v2Indicator.programs?.map((p) => ({
-        programId: String(p.programId),
-        chainID: p.chainID,
-      })) || undefined,
-  };
-}
+import {
+  getAutosyncedIndicators,
+  type Indicator,
+} from "@/utilities/queries/getIndicatorsByCommunity";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 /**
- * Fetch all auto-synced (system) indicators
+ * Hook to fetch auto-synced (system) indicators from the API
  * These are indicators with syncType='auto' that are managed by the system
- */
-async function fetchAutosyncedIndicators(): Promise<Indicator[]> {
-  const allIndicators: Indicator[] = [];
-  let currentPage = 1;
-  let hasMore = true;
-  const pageSize = 100;
-  const maxPages = 10; // Safety limit
-
-  while (hasMore && currentPage <= maxPages) {
-    const [data, error] = await fetchData(
-      INDEXER.INDICATORS.V2.LIST({ syncType: "auto", page: currentPage, limit: pageSize })
-    );
-
-    if (error) {
-      throw error;
-    }
-
-    const paginatedData = data as PaginatedResponse<V2Indicator>;
-    const indicators = (paginatedData.payload || []).map(transformIndicator);
-    allIndicators.push(...indicators);
-
-    hasMore = paginatedData.pagination.hasNextPage;
-    currentPage++;
-  }
-
-  return allIndicators;
-}
-
-/**
- * Hook to fetch auto-synced indicators from the API
  */
 export const useAutosyncedIndicators = () => {
   return useQuery<Indicator[]>({
-    queryKey: ["indicators", "autosynced"],
-    queryFn: fetchAutosyncedIndicators,
+    queryKey: QUERY_KEYS.INDICATORS.AUTOSYNCED,
+    queryFn: getAutosyncedIndicators,
     staleTime: 5 * 60 * 1000, // 5 minutes - these don't change often
   });
 };

--- a/hooks/useAutosyncedIndicators.ts
+++ b/hooks/useAutosyncedIndicators.ts
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type { Indicator, PaginatedResponse } from "@/utilities/queries/getIndicatorsByCommunity";
+
+interface V2Indicator {
+  id: string;
+  name: string;
+  description: string;
+  unitOfMeasure: string;
+  programs?: { programId: number; chainID: number }[] | null;
+  communityUID?: string | null;
+  syncType?: "auto" | "manual";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function transformIndicator(v2Indicator: V2Indicator): Indicator {
+  return {
+    ...v2Indicator,
+    programs:
+      v2Indicator.programs?.map((p) => ({
+        programId: String(p.programId),
+        chainID: p.chainID,
+      })) || undefined,
+  };
+}
+
+/**
+ * Fetch all auto-synced (system) indicators
+ * These are indicators with syncType='auto' that are managed by the system
+ */
+async function fetchAutosyncedIndicators(): Promise<Indicator[]> {
+  const allIndicators: Indicator[] = [];
+  let currentPage = 1;
+  let hasMore = true;
+  const pageSize = 100;
+  const maxPages = 10; // Safety limit
+
+  while (hasMore && currentPage <= maxPages) {
+    const [data, error] = await fetchData(
+      INDEXER.INDICATORS.V2.LIST({ syncType: "auto", page: currentPage, limit: pageSize })
+    );
+
+    if (error) {
+      throw error;
+    }
+
+    const paginatedData = data as PaginatedResponse<V2Indicator>;
+    const indicators = (paginatedData.payload || []).map(transformIndicator);
+    allIndicators.push(...indicators);
+
+    hasMore = paginatedData.pagination.hasNextPage;
+    currentPage++;
+  }
+
+  return allIndicators;
+}
+
+/**
+ * Hook to fetch auto-synced indicators from the API
+ */
+export const useAutosyncedIndicators = () => {
+  return useQuery<Indicator[]>({
+    queryKey: ["indicators", "autosynced"],
+    queryFn: fetchAutosyncedIndicators,
+    staleTime: 5 * 60 * 1000, // 5 minutes - these don't change often
+  });
+};

--- a/utilities/queries/getIndicatorsByCommunity.ts
+++ b/utilities/queries/getIndicatorsByCommunity.ts
@@ -196,3 +196,16 @@ export const getIndicatorById = async (indicatorId: string): Promise<Indicator |
     return null;
   }
 };
+
+/**
+ * Get all auto-synced (system) indicators
+ * These are indicators with syncType='auto' that are managed by the system
+ */
+export const getAutosyncedIndicators = async (): Promise<Indicator[]> => {
+  try {
+    return await fetchAllIndicatorPages({ syncType: "auto" });
+  } catch (error) {
+    errorManager("Error fetching autosynced indicators", error);
+    return [];
+  }
+};

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -68,6 +68,9 @@ export const QUERY_KEYS = {
     MILESTONES: (projectIdOrSlug: string) => ["project-milestones", projectIdOrSlug] as const,
     GRANTS: (projectIdOrSlug: string) => ["project-grants", projectIdOrSlug] as const,
   },
+  INDICATORS: {
+    AUTOSYNCED: ["indicators", "autosynced"] as const,
+  },
   FUNDING_PLATFORM: {
     APPLICATIONS: (programId: string, chainId: number, filters?: unknown) =>
       ["applications", programId, chainId, filters] as const,


### PR DESCRIPTION
## Summary

Replace hardcoded autosynced indicators list with dynamic API fetch using `syncType=auto` filter.

## Changes Made

- `hooks/useAutosyncedIndicators.ts` - New hook to fetch indicators with `syncType=auto`
- `components/Pages/Admin/IndicatorsHub.tsx` - Replaced hardcoded array with API hook
- `components/Pages/Admin/IndicatorsView.tsx` - Replaced hardcoded array with API hook
- `components/Pages/Admin/IndicatorsDropdown.tsx` - Replaced hardcoded array with API hook
- `components/Pages/Project/Impact/OutputsAndOutcomes.tsx` - Replaced hardcoded array with API hook
- `components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx` - Replaced hardcoded array with API hook
- `components/Forms/ProjectUpdate.tsx` - Replaced hardcoded array with API hook
- `components/Forms/Outputs/MetricsTable.tsx` - Replaced hardcoded array with API hook

## Test Plan

- [ ] Verify frontend dropdowns load autosynced indicators dynamically
- [ ] Verify "Autosynced" badge displays correctly for system indicators
- [ ] Verify loading state shows while fetching indicators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic fetching of auto-synced indicators from the API for fresher data
  * Shows loading state in indicator dropdowns and disables selection while loading
  * Displays an "Auto-synced" badge where applicable

* **Bug Fixes / UX**
  * Input fields for auto-synced indicators are read-only to prevent edits during sync

* **Refactor**
  * Migrated from static indicator definitions to an API-driven data source

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->