### PR TITLE
fix: impact counter filtering by program and project

### DIFF
--- a/hooks/useAggregatedIndicators.ts
+++ b/hooks/useAggregatedIndicators.ts
@@ -5,6 +5,7 @@ import type { CommunityAggregateResponse } from "@/types/indicator";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 export interface AggregatedIndicator {
   id: string;
@@ -43,17 +44,20 @@ export function useAggregatedIndicators(
 ) {
   const { communityId } = useParams();
   const searchParams = useSearchParams();
-  const projectUID = searchParams.get("projectId");
-  const programId = searchParams.get("programId");
+  const projectUID = searchParams.get("projectId")?.trim() || null;
+  const programIdParam = searchParams.get("programId")?.trim() || null;
 
-  const queryKey = [
-    "aggregated-indicators",
-    indicatorIds.join(","),
-    communityId,
-    programId || "all",
-    projectUID || "all",
-    `last-${timeframeMonths}-months`,
-  ];
+  // Parse programId safely - handle invalid input
+  const programIdNum = programIdParam ? parseInt(programIdParam, 10) : NaN;
+  const parsedProgramId = Number.isNaN(programIdNum) ? undefined : programIdNum;
+
+  const queryKey = QUERY_KEYS.INDICATORS.AGGREGATED({
+    indicatorIds: indicatorIds.join(","),
+    communityId: String(communityId || ""),
+    programId: programIdParam || "all",
+    projectUID: projectUID || "all",
+    timeframe: `last-${timeframeMonths}-months`,
+  });
 
   const queryFn = async (): Promise<AggregatedIndicator[]> => {
     if (!indicatorIds.length) return [];
@@ -71,14 +75,11 @@ export function useAggregatedIndicators(
     const startDate = startDateObj.toISOString();
     const endDate = new Date().toISOString();
 
-    // Parse programId as number
-    const parsedProgramId = programId ? parseInt(programId, 10) : undefined;
-
     // Fetch community aggregate indicators
     const [data, error] = await fetchData(
       INDEXER.INDICATORS.V2.COMMUNITY_AGGREGATE(communityDetails.uid, {
         indicatorIds: indicatorIds.join(","),
-        programId: Number.isNaN(parsedProgramId) ? undefined : parsedProgramId,
+        programId: parsedProgramId,
         projectUID: projectUID || undefined,
         startDate,
         endDate,

--- a/hooks/useAggregatedIndicators.ts
+++ b/hooks/useAggregatedIndicators.ts
@@ -79,6 +79,7 @@ export function useAggregatedIndicators(
       INDEXER.INDICATORS.V2.COMMUNITY_AGGREGATE(communityDetails.uid, {
         indicatorIds: indicatorIds.join(","),
         programId: Number.isNaN(parsedProgramId) ? undefined : parsedProgramId,
+        projectUID: projectUID || undefined,
         startDate,
         endDate,
         granularity: "monthly",

--- a/hooks/useAggregatedIndicators.ts
+++ b/hooks/useAggregatedIndicators.ts
@@ -71,27 +71,14 @@ export function useAggregatedIndicators(
     const startDate = startDateObj.toISOString();
     const endDate = new Date().toISOString();
 
-    // Parse programId to extract programId and chainId if in format "programId_chainId"
-    let parsedProgramId: number | undefined;
-    let parsedChainId: number | undefined;
-    if (programId) {
-      const parts = programId.split("_");
-      if (parts.length === 2) {
-        const programIdNum = parseInt(parts[0], 10);
-        const chainIdNum = parseInt(parts[1], 10);
-        if (!isNaN(programIdNum) && !isNaN(chainIdNum)) {
-          parsedProgramId = programIdNum;
-          parsedChainId = chainIdNum;
-        }
-      }
-    }
+    // Parse programId as number
+    const parsedProgramId = programId ? parseInt(programId, 10) : undefined;
 
     // Fetch community aggregate indicators
     const [data, error] = await fetchData(
       INDEXER.INDICATORS.V2.COMMUNITY_AGGREGATE(communityDetails.uid, {
         indicatorIds: indicatorIds.join(","),
-        programId: parsedProgramId,
-        chainId: parsedChainId,
+        programId: Number.isNaN(parsedProgramId) ? undefined : parsedProgramId,
         startDate,
         endDate,
         granularity: "monthly",

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -321,7 +321,7 @@ export const INDEXER = {
         params?: {
           indicatorIds?: string;
           programId?: number;
-          chainId?: number;
+          projectUID?: string;
           startDate?: string;
           endDate?: string;
           granularity?: "weekly" | "monthly";
@@ -330,7 +330,7 @@ export const INDEXER = {
         const queryParams = new URLSearchParams();
         if (params?.indicatorIds) queryParams.set("indicatorIds", params.indicatorIds);
         if (params?.programId) queryParams.set("programId", params.programId.toString());
-        if (params?.chainId) queryParams.set("chainId", params.chainId.toString());
+        if (params?.projectUID) queryParams.set("projectUID", params.projectUID);
         if (params?.startDate) queryParams.set("startDate", params.startDate);
         if (params?.endDate) queryParams.set("endDate", params.endDate);
         if (params?.granularity) queryParams.set("granularity", params.granularity);

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -62,6 +62,23 @@ export const QUERY_KEYS = {
   SEARCH: {
     PROJECTS: (query: string) => ["search-projects", query] as const,
   },
+  INDICATORS: {
+    AGGREGATED: (params: {
+      indicatorIds: string;
+      communityId: string;
+      programId: string;
+      projectUID: string;
+      timeframe: string;
+    }) =>
+      [
+        "aggregated-indicators",
+        params.indicatorIds,
+        params.communityId,
+        params.programId,
+        params.projectUID,
+        params.timeframe,
+      ] as const,
+  },
   PROJECT: {
     UPDATES: (projectIdOrSlug: string) => ["project-updates", projectIdOrSlug] as const,
     IMPACTS: (projectIdOrSlug: string) => ["project-impacts", projectIdOrSlug] as const,


### PR DESCRIPTION
## Overview

Update frontend to use simplified program ID filtering and add project UID support for impact indicator aggregation.

## Problem

The frontend was using a complex composite format (`programId_chainId`) to filter impact indicators, which:
- Required parsing logic in the frontend that duplicated backend logic
- Did not support filtering by specific project UID
- Was fragile and dependent on specific data format assumptions

## Solution

1. **Simplified programId parsing** - Removed complex `programId_chainId` parsing logic from `useAggregatedIndicators` hook. Now passes programId directly as a number.

2. **Added projectUID support** - Added `projectUID` parameter to the API call, enabling direct filtering by project.

3. **Updated indexer utility** - Changed parameter from `chainId` to `projectUID` in the `COMMUNITY_AGGREGATE` endpoint configuration.

### Files Changed

- `hooks/useAggregatedIndicators.ts` - Simplified programId handling, added projectUID parameter
- `utilities/indexer.ts` - Updated API params type and query string building

## Why This Approach

- **Separation of concerns**: Backend handles the complexity of program ID resolution
- **Cleaner frontend code**: Removed parsing logic that belonged in the backend
- **Feature parity**: Enables filtering by both program and project in the UI

## Testing Steps

1. Navigate to a community's impact page
2. Select a program filter - verify indicators update correctly
3. Select a project filter - verify indicators update correctly  
4. Clear filters - verify all community indicators display
5. Verify no console errors during filtering operations

## Related PRs

- Backend: https://github.com/show-karma/gap-indexer/pull/810

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified program and project identifier handling for aggregated community indicators, aligning payloads and results.
  * Switched aggregation pathways to use a stable project identifier (projectUID) for more consistent data retrieval.

* **Chores**
  * Introduced a standardized query key for aggregated indicators to ensure consistent caching and fetching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->