### PR TITLE
feat(prompt-management): add LLM prompt management UI with testing an…

### DIFF
--- a/__tests__/features/prompt-management/components/PromptEditor.test.tsx
+++ b/__tests__/features/prompt-management/components/PromptEditor.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import toast from "react-hot-toast";
 import { PromptEditor } from "@/features/prompt-management/components/PromptEditor";
 import {
+  useBulkEvaluationJobPolling,
   useSavePrompt,
   useTestPrompt,
   useTriggerBulkEvaluation,
@@ -15,6 +16,7 @@ jest.mock("@/features/prompt-management/hooks/use-program-prompts", () => ({
   useSavePrompt: jest.fn(),
   useTestPrompt: jest.fn(),
   useTriggerBulkEvaluation: jest.fn(),
+  useBulkEvaluationJobPolling: jest.fn(),
 }));
 
 jest.mock("@/hooks/useAvailableAIModels", () => ({
@@ -101,6 +103,10 @@ describe("PromptEditor", () => {
     (useTriggerBulkEvaluation as jest.Mock).mockReturnValue({
       mutate: mockTriggerBulkEvaluation,
       isPending: false,
+    });
+
+    (useBulkEvaluationJobPolling as jest.Mock).mockReturnValue({
+      data: null,
     });
   });
 

--- a/__tests__/features/prompt-management/components/PromptEditor.test.tsx
+++ b/__tests__/features/prompt-management/components/PromptEditor.test.tsx
@@ -1,0 +1,449 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import toast from "react-hot-toast";
+import { PromptEditor } from "@/features/prompt-management/components/PromptEditor";
+import {
+  useSavePrompt,
+  useTestPrompt,
+  useTriggerBulkEvaluation,
+} from "@/features/prompt-management/hooks/use-program-prompts";
+import type { ProgramPrompt } from "@/features/prompt-management/types/program-prompt";
+import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
+
+// Mock hooks
+jest.mock("@/features/prompt-management/hooks/use-program-prompts", () => ({
+  useSavePrompt: jest.fn(),
+  useTestPrompt: jest.fn(),
+  useTriggerBulkEvaluation: jest.fn(),
+}));
+
+jest.mock("@/hooks/useAvailableAIModels", () => ({
+  useAvailableAIModels: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// Mock MarkdownEditor
+jest.mock("@/components/Utilities/MarkdownEditor", () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    label,
+    placeholder,
+    isDisabled,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    label?: string;
+    placeholder?: string;
+    isDisabled?: boolean;
+  }) => (
+    <div data-testid="markdown-editor">
+      <label htmlFor="mock-md-editor">{label}</label>
+      <textarea
+        id="mock-md-editor"
+        data-testid="markdown-textarea"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={isDisabled}
+      />
+    </div>
+  ),
+}));
+
+// Mock BulkEvaluationProgress
+jest.mock("@/features/prompt-management/components/BulkEvaluationProgress", () => ({
+  BulkEvaluationProgress: () => <div data-testid="bulk-evaluation-progress" />,
+}));
+
+// Mock PromptTestPanel
+jest.mock("@/features/prompt-management/components/PromptTestPanel", () => ({
+  PromptTestPanel: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="prompt-test-panel">Test Panel</div> : null,
+}));
+
+describe("PromptEditor", () => {
+  const mockSavePrompt = jest.fn();
+  const mockTestPrompt = jest.fn();
+  const mockTriggerBulkEvaluation = jest.fn();
+
+  const defaultProps = {
+    programId: "program-123",
+    promptType: "external" as const,
+    existingPrompt: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useAvailableAIModels as jest.Mock).mockReturnValue({
+      data: ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"],
+      isLoading: false,
+    });
+
+    (useSavePrompt as jest.Mock).mockReturnValue({
+      mutate: mockSavePrompt,
+      isPending: false,
+    });
+
+    (useTestPrompt as jest.Mock).mockReturnValue({
+      mutate: mockTestPrompt,
+      isPending: false,
+    });
+
+    (useTriggerBulkEvaluation as jest.Mock).mockReturnValue({
+      mutate: mockTriggerBulkEvaluation,
+      isPending: false,
+    });
+  });
+
+  describe("Rendering", () => {
+    it("should render all form fields", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      expect(screen.getByLabelText(/Prompt Name/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/AI Model/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/System Message/i)).toBeInTheDocument();
+      expect(screen.getByTestId("markdown-editor")).toBeInTheDocument();
+    });
+
+    it("should render available AI models in dropdown", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      const modelSelect = screen.getByLabelText(/AI Model/i);
+      expect(modelSelect).toBeInTheDocument();
+
+      // Check options
+      expect(screen.getByText("gpt-4")).toBeInTheDocument();
+      expect(screen.getByText("gpt-3.5-turbo")).toBeInTheDocument();
+      expect(screen.getByText("claude-3-opus")).toBeInTheDocument();
+    });
+
+    it("should show Create Prompt button for new prompt", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      expect(screen.getByRole("button", { name: /Create Prompt/i })).toBeInTheDocument();
+    });
+
+    it("should show Save Changes button for existing prompt", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: null,
+        content: "Existing content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 1,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      expect(screen.getByRole("button", { name: /Save Changes/i })).toBeInTheDocument();
+    });
+
+    it("should show Test Prompt button when prompt exists and not dirty", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: null,
+        content: "Existing content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 1,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      expect(screen.getByRole("button", { name: /Test Prompt/i })).toBeInTheDocument();
+    });
+
+    it("should show Evaluate All Applications button for existing prompt", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "internal",
+        name: "internal-prompt",
+        systemMessage: null,
+        content: "Content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 1,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(
+        <PromptEditor {...defaultProps} promptType="internal" existingPrompt={existingPrompt} />
+      );
+
+      expect(
+        screen.getByRole("button", { name: /Evaluate All Applications/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Form Validation", () => {
+    it("should disable save button when name is empty", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      // Fill content but leave name empty
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, { target: { value: "Some content with json" } });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      expect(saveButton).toBeDisabled();
+    });
+
+    it("should disable save button when content is empty", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      // Fill name but leave content empty
+      const nameInput = screen.getByLabelText(/Prompt Name/i);
+      fireEvent.change(nameInput, { target: { value: "test-prompt" } });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      expect(saveButton).toBeDisabled();
+    });
+
+    it("should enable save button when both name and content are filled", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText(/Prompt Name/i);
+      fireEvent.change(nameInput, { target: { value: "test-prompt" } });
+
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, { target: { value: "Content with json" } });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      expect(saveButton).toBeEnabled();
+    });
+
+    it("should show error when json is not in prompt", async () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText(/Prompt Name/i);
+      fireEvent.change(nameInput, { target: { value: "test-prompt" } });
+
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, { target: { value: "Content without the j word" } });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("json"));
+      });
+    });
+  });
+
+  describe("Saving Prompt", () => {
+    it("should call save mutation with correct data", async () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      // Fill form
+      const nameInput = screen.getByLabelText(/Prompt Name/i);
+      fireEvent.change(nameInput, { target: { value: "my-prompt" } });
+
+      const systemMessageInput = screen.getByLabelText(/System Message/i);
+      fireEvent.change(systemMessageInput, {
+        target: { value: "You are a helpful assistant" },
+      });
+
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, {
+        target: { value: "Evaluate in json format" },
+      });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockSavePrompt).toHaveBeenCalledWith({
+          name: "my-prompt",
+          systemMessage: "You are a helpful assistant",
+          content: "Evaluate in json format",
+          modelId: "gpt-4",
+        });
+      });
+    });
+
+    it("should not include systemMessage if empty", async () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      const nameInput = screen.getByLabelText(/Prompt Name/i);
+      fireEvent.change(nameInput, { target: { value: "my-prompt" } });
+
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, {
+        target: { value: "Evaluate in json format" },
+      });
+
+      const saveButton = screen.getByRole("button", { name: /Create Prompt/i });
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockSavePrompt).toHaveBeenCalledWith({
+          name: "my-prompt",
+          systemMessage: undefined,
+          content: "Evaluate in json format",
+          modelId: "gpt-4",
+        });
+      });
+    });
+  });
+
+  describe("Existing Prompt", () => {
+    it("should populate form with existing prompt data", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: "System message here",
+        content: "Existing content",
+        modelId: "gpt-3.5-turbo",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 3,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-02T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x456",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      expect(screen.getByLabelText(/Prompt Name/i)).toHaveValue("existing-prompt");
+      expect(screen.getByLabelText(/System Message/i)).toHaveValue("System message here");
+      expect(screen.getByTestId("markdown-textarea")).toHaveValue("Existing content");
+      expect(screen.getByLabelText(/AI Model/i)).toHaveValue("gpt-3.5-turbo");
+    });
+
+    it("should disable name field for existing prompt", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: null,
+        content: "Content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 1,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      expect(screen.getByLabelText(/Prompt Name/i)).toBeDisabled();
+    });
+
+    it("should show Langfuse version for existing prompt", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: null,
+        content: "Content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 5,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      expect(screen.getByText(/Langfuse Version:/i)).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
+    });
+  });
+
+  describe("Dirty State", () => {
+    it("should show unsaved changes warning when dirty", () => {
+      render(<PromptEditor {...defaultProps} />);
+
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, { target: { value: "New content" } });
+
+      expect(screen.getByText(/unsaved changes/i)).toBeInTheDocument();
+    });
+
+    it("should hide Test Prompt button when dirty", () => {
+      const existingPrompt: ProgramPrompt = {
+        id: "prompt-123",
+        programId: "program-123",
+        promptType: "external",
+        name: "existing-prompt",
+        systemMessage: null,
+        content: "Content",
+        modelId: "gpt-4",
+        langfusePromptId: "langfuse-123",
+        langfuseVersion: 1,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        createdBy: "0x123",
+        updatedBy: "0x123",
+      };
+
+      render(<PromptEditor {...defaultProps} existingPrompt={existingPrompt} />);
+
+      // Initially Test Prompt should be visible
+      expect(screen.getByRole("button", { name: /Test Prompt/i })).toBeInTheDocument();
+
+      // Make form dirty
+      const textarea = screen.getByTestId("markdown-textarea");
+      fireEvent.change(textarea, { target: { value: "Modified content" } });
+
+      // Test Prompt should be hidden
+      expect(screen.queryByRole("button", { name: /Test Prompt/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Read Only Mode", () => {
+    it("should disable all inputs when readOnly", () => {
+      render(<PromptEditor {...defaultProps} readOnly={true} />);
+
+      expect(screen.getByLabelText(/Prompt Name/i)).toBeDisabled();
+      expect(screen.getByLabelText(/System Message/i)).toBeDisabled();
+      expect(screen.getByLabelText(/AI Model/i)).toBeDisabled();
+    });
+  });
+
+  describe("Legacy Prompt Info", () => {
+    it("should show legacy prompt banner when legacyPromptId provided for new prompt", () => {
+      render(
+        <PromptEditor {...defaultProps} existingPrompt={null} legacyPromptId="legacy-langfuse-id" />
+      );
+
+      expect(screen.getByText(/Legacy Langfuse Prompt/i)).toBeInTheDocument();
+      expect(screen.getByText("legacy-langfuse-id")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/QuestionBuilder/AIPromptConfiguration.tsx
+++ b/components/QuestionBuilder/AIPromptConfiguration.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
 import { useProgram } from "@/hooks/usePrograms";
+import { MigrationBanner, PromptEditor, useProgramPrompts } from "@/src/features/prompt-management";
 import type { FormSchema } from "@/types/question-builder";
+import { TabContent } from "../Utilities/Tabs/TabContent";
+import { Tabs } from "../Utilities/Tabs/Tabs";
+import { TabTrigger } from "../Utilities/Tabs/TabTrigger";
+
+const DEFAULT_AI_MODEL = "gpt-4o";
 
 const aiConfigSchema = z.object({
-  // systemPrompt: z.string().min(10, 'System prompt must be at least 10 characters'),
-  // detailedPrompt: z.string().optional(),
   aiModel: z.string().min(1, "AI model is required"),
   enableRealTimeEvaluation: z.boolean(),
   langfusePromptId: z.string().optional(),
@@ -28,6 +32,82 @@ interface AIPromptConfigurationProps {
   readOnly?: boolean;
 }
 
+function PromptTabs({ programId, readOnly }: { programId: string; readOnly: boolean }) {
+  // Fetch prompts from the new API
+  const {
+    data: promptsData,
+    isLoading: isLoadingPrompts,
+    isError,
+    error,
+    refetch,
+  } = useProgramPrompts(programId, {
+    enabled: !!programId,
+  });
+
+  if (isLoadingPrompts) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+        <p className="text-red-700 dark:text-red-400 mb-2">
+          Failed to load prompts: {error?.message || "Unknown error"}
+        </p>
+        <button
+          onClick={() => refetch()}
+          className="text-red-600 dark:text-red-400 underline text-sm hover:no-underline"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  const showMigrationBanner =
+    promptsData?.migrationRequired &&
+    (promptsData.legacyPromptIds.external || promptsData.legacyPromptIds.internal);
+
+  return (
+    <>
+      {showMigrationBanner && <MigrationBanner legacyPromptIds={promptsData.legacyPromptIds} />}
+
+      <div className="flex flex-row gap-1 bg-zinc-100 dark:bg-zinc-800 p-1 rounded-lg w-fit mb-6">
+        <TabTrigger value="external" className="rounded-md">
+          External AI Prompt
+        </TabTrigger>
+        <TabTrigger value="internal" className="rounded-md">
+          Internal Evaluation Prompt
+        </TabTrigger>
+      </div>
+
+      <TabContent value="external">
+        <PromptEditor
+          programId={programId}
+          promptType="external"
+          existingPrompt={promptsData?.external || null}
+          legacyPromptId={promptsData?.legacyPromptIds.external}
+          readOnly={readOnly}
+        />
+      </TabContent>
+
+      <TabContent value="internal">
+        <PromptEditor
+          programId={programId}
+          promptType="internal"
+          existingPrompt={promptsData?.internal || null}
+          legacyPromptId={promptsData?.legacyPromptIds.internal}
+          readOnly={readOnly}
+        />
+      </TabContent>
+    </>
+  );
+}
+
 export function AIPromptConfiguration({
   schema,
   onUpdate,
@@ -40,13 +120,12 @@ export function AIPromptConfiguration({
   const { data: program } = useProgram(programId || "");
 
   // Fetch available AI models from backend
-  const { data: availableModels = ["gpt-5.2"], isLoading: isLoadingModels } =
+  const { data: availableModels = [DEFAULT_AI_MODEL], isLoading: isLoadingModels } =
     useAvailableAIModels();
 
   // Get default langfusePromptId from program registry if not set in schema
   const defaultLangfusePromptId =
     schema.aiConfig?.langfusePromptId || program?.langfusePromptId || "";
-  const recommendedPrompt = "";
 
   // Get default model - use schema value if valid, otherwise use first available model
   const defaultModel = useMemo(() => {
@@ -54,60 +133,36 @@ export function AIPromptConfiguration({
     if (schemaModel && availableModels.includes(schemaModel)) {
       return schemaModel;
     }
-    return availableModels[0] || "gpt-5.2";
+    return availableModels[0] || DEFAULT_AI_MODEL;
   }, [schema.aiConfig?.aiModel, availableModels]);
-
-  // Track if initial sync has been performed to prevent overwriting user selections
-  const hasInitialSyncedRef = useRef(false);
 
   const {
     register,
-    handleSubmit,
     watch,
     setValue,
     getValues,
-    formState: { errors, isDirty },
+    formState: { errors },
   } = useForm<AIConfigFormData>({
     resolver: zodResolver(aiConfigSchema),
     defaultValues: {
-      // systemPrompt: schema.aiConfig?.systemPrompt || '',
-      // detailedPrompt: schema.aiConfig?.detailedPrompt || '',
       aiModel: defaultModel,
       enableRealTimeEvaluation: schema.aiConfig?.enableRealTimeEvaluation || false,
-      langfusePromptId: defaultLangfusePromptId || recommendedPrompt,
+      langfusePromptId: defaultLangfusePromptId,
       internalLangfusePromptId: schema.aiConfig?.internalLangfusePromptId || "",
     },
   });
 
   // Update form value when availableModels loads and current value is invalid
-  // Prevents race conditions: only updates invalid values, preserving valid user selections
   useEffect(() => {
     if (!isLoadingModels && availableModels.length > 0) {
       const currentValue = getValues("aiModel");
       const isCurrentValueInvalid = !currentValue || !availableModels.includes(currentValue);
 
-      // Only update if value is invalid (not in availableModels list)
-      // This handles:
-      // - Initial load with invalid value
-      // - Value becoming invalid after availableModels changes
-      // - But preserves valid user selections (won't overwrite if value is in the list)
       if (isCurrentValueInvalid) {
         setValue("aiModel", defaultModel, { shouldValidate: false });
       }
-
-      // Mark as synced after first check
-      if (!hasInitialSyncedRef.current) {
-        hasInitialSyncedRef.current = true;
-      }
     }
   }, [availableModels, isLoadingModels, defaultModel, getValues, setValue]);
-
-  const watchedValues = watch();
-  const currentLangfusePromptId = watchedValues.langfusePromptId || "";
-  const currentInternalLangfusePromptId = watchedValues.internalLangfusePromptId || "";
-
-  const displayValue =
-    currentLangfusePromptId === recommendedPrompt ? recommendedPrompt : currentLangfusePromptId;
 
   // Update form value when program data loads and no langfusePromptId is set
   useEffect(() => {
@@ -118,16 +173,13 @@ export function AIPromptConfiguration({
 
   // Auto-update the schema when form values change
   useEffect(() => {
-    if (readOnly || !onUpdate) return; // Don't update in read-only mode
+    if (readOnly || !onUpdate) return;
 
     const subscription = watch((data) => {
-      // Only update if we have a valid system prompt (minimum requirement)
       const updatedSchema: FormSchema = {
         ...schema,
         aiConfig: {
-          // systemPrompt: data.systemPrompt || '',
-          // detailedPrompt: data.detailedPrompt || '',
-          aiModel: data.aiModel || availableModels[0] || "gpt-5.2",
+          aiModel: data.aiModel || availableModels[0] || DEFAULT_AI_MODEL,
           enableRealTimeEvaluation: data.enableRealTimeEvaluation || false,
           langfusePromptId: data.langfusePromptId || "",
           internalLangfusePromptId: data.internalLangfusePromptId || "",
@@ -153,94 +205,55 @@ export function AIPromptConfiguration({
       </div>
 
       <div className="space-y-6">
-        {/* AI Model Selection */}
-        <div>
-          <label
-            htmlFor="ai-model"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
-            AI Model *
-          </label>
-          <select
-            id="ai-model"
-            {...register("aiModel")}
-            disabled={readOnly || isLoadingModels}
-            className={`w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 ${readOnly || isLoadingModels ? "opacity-50 cursor-not-allowed" : ""}`}
-          >
-            {isLoadingModels ? (
-              <option value="">Loading models...</option>
-            ) : (
-              availableModels.map((model) => (
-                <option key={model} value={model}>
-                  {model}
-                </option>
-              ))
+        {/* Prompt Management Section */}
+        {programId && (
+          <div className="border-b border-gray-200 dark:border-gray-700 pb-6 mb-6">
+            <Tabs defaultTab="external">
+              <PromptTabs programId={programId} readOnly={readOnly} />
+            </Tabs>
+          </div>
+        )}
+
+        {/* Legacy Configuration (kept for backwards compatibility) */}
+        <div className="pt-4 border-t border-gray-200 dark:border-gray-600">
+          <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-4">
+            Legacy Settings
+          </h4>
+
+          {/* AI Model Selection */}
+          <div className="mb-4">
+            <label
+              htmlFor="ai-model"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+            >
+              Default AI Model *
+            </label>
+            <select
+              id="ai-model"
+              {...register("aiModel")}
+              disabled={readOnly || isLoadingModels}
+              className={`w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 ${readOnly || isLoadingModels ? "opacity-50 cursor-not-allowed" : ""}`}
+            >
+              {isLoadingModels ? (
+                <option value="">Loading models...</option>
+              ) : (
+                availableModels.map((model) => (
+                  <option key={model} value={model}>
+                    {model}
+                  </option>
+                ))
+              )}
+            </select>
+            {errors.aiModel && (
+              <p className="text-red-500 text-sm mt-1">{errors.aiModel.message}</p>
             )}
-          </select>
-          {errors.aiModel && <p className="text-red-500 text-sm mt-1">{errors.aiModel.message}</p>}
-        </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              This model is used for legacy configurations. New prompts use their own model
+              selection.
+            </p>
+          </div>
 
-        {/* Langfuse Prompt Name */}
-        <div>
-          <label
-            htmlFor="langfuse-prompt"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
-            Langfuse Prompt Name
-          </label>
-          <input
-            id="langfuse-prompt"
-            type="text"
-            value={displayValue}
-            disabled={readOnly}
-            onChange={(e) => {
-              const value = e.target.value;
-              const cleanValue = value.replace(/ \(Recommended\)$/, "");
-              setValue("langfusePromptId", cleanValue);
-            }}
-            className={`w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-900 placeholder:text-gray-300 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 dark:placeholder-zinc-300 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
-            placeholder=""
-          />
-          {errors.langfusePromptId && (
-            <p className="text-red-500 text-sm mt-1">{errors.langfusePromptId.message}</p>
-          )}
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-            The name of the Langfuse prompt to use for AI evaluation. If not specified, the default
-            prompt from the program registry will be used.
-          </p>
-        </div>
-
-        {/* Internal AI Evaluation Prompt Name */}
-        <div>
-          <label
-            htmlFor="internal-langfuse-prompt"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-          >
-            Internal AI Evaluation Prompt Name
-          </label>
-          <input
-            id="internal-langfuse-prompt"
-            type="text"
-            value={currentInternalLangfusePromptId}
-            disabled={readOnly}
-            onChange={(e) => {
-              const value = e.target.value;
-              setValue("internalLangfusePromptId", value);
-            }}
-            className={`w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-900 placeholder:text-gray-300 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 dark:placeholder-zinc-300 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
-            placeholder=""
-          />
-          {errors.internalLangfusePromptId && (
-            <p className="text-red-500 text-sm mt-1">{errors.internalLangfusePromptId.message}</p>
-          )}
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-            Langfuse prompt name for internal reviewer evaluation (not visible to applicants). This
-            evaluation runs automatically after application submission.
-          </p>
-        </div>
-
-        {/* Real-time Evaluation Toggle */}
-        <div className="border-t border-gray-200 dark:border-gray-600 pt-4">
+          {/* Real-time Evaluation Toggle */}
           <div className="flex items-center justify-between">
             <div>
               <div className="flex items-center">
@@ -259,8 +272,7 @@ export function AIPromptConfiguration({
                 </label>
               </div>
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
-                Provide instant feedback to applicants as they complete form fields. This uses only
-                the system prompt for faster responses.
+                Provide instant feedback to applicants as they complete form fields.
               </p>
             </div>
           </div>
@@ -295,18 +307,6 @@ export function AIPromptConfiguration({
                 <dt className="text-gray-600 dark:text-gray-400">Internal Prompt:</dt>
                 <dd className="text-gray-900 dark:text-white font-mono text-xs">
                   {schema.aiConfig.internalLangfusePromptId || "Not configured"}
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-600 dark:text-gray-400">System Prompt Length:</dt>
-                <dd className="text-gray-900 dark:text-white">
-                  {schema.aiConfig.systemPrompt?.length || 0} characters
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-gray-600 dark:text-gray-400">Detailed Prompt Length:</dt>
-                <dd className="text-gray-900 dark:text-white">
-                  {schema.aiConfig.detailedPrompt?.length || 0} characters
                 </dd>
               </div>
             </dl>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,6 +35,7 @@ const config: Config = {
     "^@/app/(.*)$": "<rootDir>/app/$1",
     "^@/components/(.*)$": "<rootDir>/components/$1",
     "^@/contexts/(.*)$": "<rootDir>/contexts/$1",
+    "^@/features/(.*)$": "<rootDir>/src/features/$1",
     "^@/hooks/(.*)$": "<rootDir>/hooks/$1",
     "^@/lib/(.*)$": "<rootDir>/lib/$1",
     "^@/store$": "<rootDir>/store/index.ts",

--- a/src/features/prompt-management/components/BulkEvaluationProgress.tsx
+++ b/src/features/prompt-management/components/BulkEvaluationProgress.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import type { BulkEvaluationJob } from "../types/program-prompt";
+
+interface BulkEvaluationProgressProps {
+  job: BulkEvaluationJob;
+  onRetry?: () => void;
+}
+
+export function BulkEvaluationProgress({ job, onRetry }: BulkEvaluationProgressProps) {
+  const progress =
+    job.totalApplications > 0
+      ? Math.round((job.completedApplications / job.totalApplications) * 100)
+      : 0;
+
+  const isRunning = job.status === "pending" || job.status === "running";
+  const isCompleted = job.status === "completed";
+  const isFailed = job.status === "failed";
+
+  return (
+    <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+      <div className="flex items-center gap-3 mb-3">
+        {isRunning && <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />}
+        {isCompleted && <CheckCircle2 className="w-5 h-5 text-green-500" />}
+        {isFailed && <AlertCircle className="w-5 h-5 text-red-500" />}
+
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">
+            {isRunning && "Evaluating Applications..."}
+            {isCompleted && "Bulk Evaluation Complete"}
+            {isFailed && "Evaluation Failed"}
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {job.completedApplications} of {job.totalApplications} applications processed
+          </p>
+        </div>
+
+        {isFailed && onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Retry
+          </button>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-300 ${
+            isFailed ? "bg-red-500" : isCompleted ? "bg-green-500" : "bg-blue-500"
+          }`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* Error message */}
+      {isFailed && job.errorMessage && (
+        <div className="mt-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+          <p className="text-xs text-red-700 dark:text-red-300">
+            <span className="font-medium">Error:</span> {job.errorMessage}
+          </p>
+          {job.errorApplicationId && (
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+              <span className="font-medium">Application ID:</span>{" "}
+              <code className="bg-red-100 dark:bg-red-900/40 px-1 rounded">
+                {job.errorApplicationId}
+              </code>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/MigrationBanner.tsx
+++ b/src/features/prompt-management/components/MigrationBanner.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { AlertTriangle, ExternalLink, X } from "lucide-react";
+import { useState } from "react";
+
+interface MigrationBannerProps {
+  legacyPromptIds: {
+    external: string | null;
+    internal: string | null;
+  };
+  onDismiss?: () => void;
+}
+
+export function MigrationBanner({ legacyPromptIds, onDismiss }: MigrationBannerProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (isDismissed) {
+    return null;
+  }
+
+  const hasLegacyExternal = !!legacyPromptIds.external;
+  const hasLegacyInternal = !!legacyPromptIds.internal;
+
+  const handleDismiss = () => {
+    setIsDismissed(true);
+    onDismiss?.();
+  };
+
+  return (
+    <div className="relative bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-6">
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="absolute top-2 right-2 p-1 text-yellow-600 dark:text-yellow-400 hover:text-yellow-800 dark:hover:text-yellow-200 transition-colors"
+        aria-label="Dismiss migration banner"
+      >
+        <X className="w-4 h-4" />
+      </button>
+
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" />
+        <div className="flex-1 pr-6">
+          <h4 className="text-sm font-semibold text-yellow-800 dark:text-yellow-200 mb-1">
+            Prompt Migration Required
+          </h4>
+          <p className="text-sm text-yellow-700 dark:text-yellow-300 mb-3">
+            Your program is using legacy Langfuse prompt references. To enable full prompt editing,
+            please copy your prompt content from Langfuse and save it here.
+          </p>
+
+          <div className="text-xs text-yellow-600 dark:text-yellow-400 space-y-1 mb-3">
+            {hasLegacyExternal && (
+              <p>
+                <span className="font-medium">External AI Prompt:</span>{" "}
+                <code className="bg-yellow-100 dark:bg-yellow-900/40 px-1 rounded">
+                  {legacyPromptIds.external}
+                </code>
+              </p>
+            )}
+            {hasLegacyInternal && (
+              <p>
+                <span className="font-medium">Internal Evaluation Prompt:</span>{" "}
+                <code className="bg-yellow-100 dark:bg-yellow-900/40 px-1 rounded">
+                  {legacyPromptIds.internal}
+                </code>
+              </p>
+            )}
+          </div>
+
+          <a
+            href="https://cloud.langfuse.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-yellow-700 dark:text-yellow-300 hover:text-yellow-900 dark:hover:text-yellow-100 font-medium transition-colors"
+          >
+            Open Langfuse Dashboard
+            <ExternalLink className="w-3.5 h-3.5" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/PromptEditor.tsx
+++ b/src/features/prompt-management/components/PromptEditor.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { ChevronDown, FlaskConical, Loader2, Play, Save } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
+import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
+import { cn } from "@/utilities/tailwind";
+import {
+  useSavePrompt,
+  useTestPrompt,
+  useTriggerBulkEvaluation,
+} from "../hooks/use-program-prompts";
+import type { ProgramPrompt, PromptType, TestProgramPromptResult } from "../types/program-prompt";
+import { BulkEvaluationProgress } from "./BulkEvaluationProgress";
+import { PromptTestPanel } from "./PromptTestPanel";
+
+interface PromptEditorProps {
+  programId: string;
+  promptType: PromptType;
+  existingPrompt: ProgramPrompt | null;
+  legacyPromptId?: string | null;
+  onSaveSuccess?: (prompt: ProgramPrompt) => void;
+  readOnly?: boolean;
+  bulkEvaluationJob?: {
+    id: string;
+    status: "pending" | "running" | "completed" | "failed";
+    totalApplications: number;
+    completedApplications: number;
+    failedApplications: number;
+    errorApplicationId?: string | null;
+    errorMessage?: string | null;
+    startedAt: string;
+    completedAt?: string | null;
+    triggeredBy: string;
+    programId: string;
+    promptType: PromptType;
+  } | null;
+}
+
+export function PromptEditor({
+  programId,
+  promptType,
+  existingPrompt,
+  legacyPromptId,
+  onSaveSuccess,
+  readOnly = false,
+  bulkEvaluationJob,
+}: PromptEditorProps) {
+  // Form state
+  const [name, setName] = useState(existingPrompt?.name || "");
+  const [systemMessage, setSystemMessage] = useState(existingPrompt?.systemMessage || "");
+  const [content, setContent] = useState(existingPrompt?.content || "");
+  const [modelId, setModelId] = useState(existingPrompt?.modelId || "");
+  const [isDirty, setIsDirty] = useState(false);
+  const [isTestPanelOpen, setIsTestPanelOpen] = useState(false);
+  const [currentJobId, setCurrentJobId] = useState<string | null>(bulkEvaluationJob?.id || null);
+
+  // Fetch available AI models
+  const { data: availableModels = [], isLoading: isLoadingModels } = useAvailableAIModels();
+
+  // Mutations
+  const savePromptMutation = useSavePrompt(programId, promptType, {
+    onSuccess: (data) => {
+      toast.success("Prompt saved successfully");
+      setIsDirty(false);
+      onSaveSuccess?.(data);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to save prompt");
+    },
+  });
+
+  const testPromptMutation = useTestPrompt(programId, promptType);
+
+  const bulkEvaluationMutation = useTriggerBulkEvaluation(programId, {
+    onSuccess: (data) => {
+      setCurrentJobId(data.jobId);
+      toast.success(`Bulk evaluation started for ${data.totalApplications} applications`);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to start bulk evaluation");
+    },
+  });
+
+  // Initialize model when models load
+  useEffect(() => {
+    if (availableModels.length > 0 && !modelId) {
+      setModelId(existingPrompt?.modelId || availableModels[0]);
+    }
+  }, [availableModels, modelId, existingPrompt?.modelId]);
+
+  // Sync with existing prompt when it changes
+  useEffect(() => {
+    if (existingPrompt) {
+      setName(existingPrompt.name);
+      setSystemMessage(existingPrompt.systemMessage || "");
+      setContent(existingPrompt.content);
+      setModelId(existingPrompt.modelId);
+      setIsDirty(false);
+    }
+  }, [existingPrompt]);
+
+  const handleSystemMessageChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setSystemMessage(e.target.value);
+    setIsDirty(true);
+  }, []);
+
+  const handleContentChange = useCallback((value: string) => {
+    setContent(value);
+    setIsDirty(true);
+  }, []);
+
+  const handleModelChange = useCallback((value: string) => {
+    setModelId(value);
+    setIsDirty(true);
+  }, []);
+
+  const handleNameChange = useCallback(
+    (value: string) => {
+      // Only allow name change if there's no existing prompt
+      if (!existingPrompt) {
+        setName(value);
+        setIsDirty(true);
+      }
+    },
+    [existingPrompt]
+  );
+
+  const handleSave = useCallback(() => {
+    if (!name.trim()) {
+      toast.error("Prompt name is required");
+      return;
+    }
+    if (!content.trim()) {
+      toast.error("Prompt content is required");
+      return;
+    }
+    if (!modelId) {
+      toast.error("Please select an AI model");
+      return;
+    }
+
+    // Check if "json" appears in system message or content (OpenAI requirement for JSON response format)
+    const combinedText = `${systemMessage} ${content}`.toLowerCase();
+    if (!combinedText.includes("json")) {
+      toast.error(
+        "Prompt must include the word 'json' for JSON response format (e.g., 'Respond in JSON format')"
+      );
+      return;
+    }
+
+    savePromptMutation.mutate({
+      name: name.trim(),
+      systemMessage: systemMessage.trim() || undefined,
+      content: content.trim(),
+      modelId,
+    });
+  }, [name, systemMessage, content, modelId, savePromptMutation]);
+
+  const handleTest = useCallback(
+    async (applicationId: string): Promise<TestProgramPromptResult> => {
+      return new Promise((resolve, reject) => {
+        testPromptMutation.mutate(
+          { applicationId },
+          {
+            onSuccess: resolve,
+            onError: reject,
+          }
+        );
+      });
+    },
+    [testPromptMutation]
+  );
+
+  const handleBulkEvaluate = useCallback(() => {
+    bulkEvaluationMutation.mutate(promptType);
+  }, [bulkEvaluationMutation, promptType]);
+
+  const isNewPrompt = !existingPrompt;
+  const canSave = isDirty && name.trim() && content.trim() && modelId && !readOnly;
+  const canTest = existingPrompt && !isDirty;
+  const canBulkEvaluate = existingPrompt && !isDirty;
+
+  // Show running job - prefer passed job, fall back to current job ID from mutation
+  const activeJob = bulkEvaluationJob ?? null;
+  const isJobRunning =
+    activeJob?.status === "pending" ||
+    activeJob?.status === "running" ||
+    Boolean(currentJobId && !bulkEvaluationJob);
+
+  return (
+    <div className="space-y-6">
+      {/* Legacy prompt info */}
+      {legacyPromptId && isNewPrompt && (
+        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            <span className="font-medium">Legacy Langfuse Prompt:</span>{" "}
+            <code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">{legacyPromptId}</code>
+          </p>
+          <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+            Copy your prompt content from Langfuse to enable full editing capabilities.
+          </p>
+        </div>
+      )}
+
+      {/* Prompt Name */}
+      <div>
+        <label
+          htmlFor={`prompt-name-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          Prompt Name *
+          {existingPrompt && (
+            <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
+              (Cannot be changed after creation)
+            </span>
+          )}
+        </label>
+        <input
+          id={`prompt-name-${promptType}`}
+          type="text"
+          value={name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          disabled={readOnly || !!existingPrompt}
+          placeholder={`e.g., ${promptType === "external" ? "grant-review" : "internal-evaluation"}-prompt`}
+          className={cn(
+            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "focus:outline-none focus:ring-2 focus:ring-blue-500",
+            (readOnly || existingPrompt) &&
+              "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
+          )}
+        />
+      </div>
+
+      {/* AI Model Selection */}
+      <div>
+        <label
+          htmlFor={`ai-model-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          AI Model *
+        </label>
+        <div className="relative">
+          <select
+            id={`ai-model-${promptType}`}
+            value={modelId}
+            onChange={(e) => handleModelChange(e.target.value)}
+            disabled={readOnly || isLoadingModels}
+            className={cn(
+              "w-full appearance-none rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 pr-10 text-gray-900 dark:text-white text-sm",
+              "focus:outline-none focus:ring-2 focus:ring-blue-500",
+              (readOnly || isLoadingModels) && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            {isLoadingModels ? (
+              <option value="">Loading models...</option>
+            ) : (
+              availableModels.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))
+            )}
+          </select>
+          <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+        </div>
+      </div>
+
+      {/* System Message */}
+      <div>
+        <label
+          htmlFor={`system-message-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          System Message
+          <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
+            (Optional - Sets the AI's behavior and context)
+          </span>
+        </label>
+        <textarea
+          id={`system-message-${promptType}`}
+          value={systemMessage}
+          onChange={handleSystemMessageChange}
+          disabled={readOnly}
+          placeholder="You are a grant evaluator responsible for evaluating the incoming applications."
+          rows={4}
+          className={cn(
+            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y",
+            readOnly && "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
+          )}
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          The system message defines the AI's role and behavior. It's sent as a separate "system"
+          message in the LLM conversation.
+        </p>
+      </div>
+
+      {/* Prompt Content (User Message) */}
+      <div>
+        <MarkdownEditor
+          label="Prompt Content (User Message)"
+          value={content}
+          onChange={handleContentChange}
+          isRequired
+          isDisabled={readOnly}
+          placeholder="Evaluate the application based on criteria below"
+          height={400}
+          showCharacterCount
+          maxLength={100000}
+        />
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Use{" "}
+          <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
+            {"{{grant_application}}"}
+          </code>{" "}
+          to control where application data appears. If not included, application data will be
+          automatically appended at the end.
+        </p>
+        <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+          Important: Include the word "json" in your prompt (e.g., "Respond in JSON format") for
+          proper response parsing.
+        </p>
+      </div>
+
+      {/* Langfuse Version Info */}
+      {existingPrompt && (
+        <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+          <span>
+            <span className="font-medium">Langfuse Version:</span> {existingPrompt.langfuseVersion}
+          </span>
+          <span>
+            <span className="font-medium">Last Updated:</span>{" "}
+            {new Date(existingPrompt.updatedAt).toLocaleString()}
+          </span>
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className="flex flex-wrap items-center gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!canSave || savePromptMutation.isPending}
+          className={cn(
+            "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
+            "bg-blue-600 text-white hover:bg-blue-700",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {savePromptMutation.isPending ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save className="w-4 h-4" />
+              {isNewPrompt ? "Create Prompt" : "Save Changes"}
+            </>
+          )}
+        </button>
+
+        {canTest && (
+          <button
+            type="button"
+            onClick={() => setIsTestPanelOpen(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            <FlaskConical className="w-4 h-4" />
+            Test Prompt
+          </button>
+        )}
+
+        {canBulkEvaluate && (
+          <button
+            type="button"
+            onClick={handleBulkEvaluate}
+            disabled={bulkEvaluationMutation.isPending || isJobRunning}
+            className={cn(
+              "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
+              "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600",
+              "hover:bg-gray-50 dark:hover:bg-gray-700",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            {bulkEvaluationMutation.isPending ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Starting...
+              </>
+            ) : (
+              <>
+                <Play className="w-4 h-4" />
+                Evaluate All Applications
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Dirty state warning */}
+      {isDirty && (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          You have unsaved changes. Save before testing or running bulk evaluation.
+        </p>
+      )}
+
+      {/* Bulk evaluation progress */}
+      {activeJob && activeJob.status && (
+        <BulkEvaluationProgress
+          job={{
+            id: activeJob.id,
+            programId,
+            promptType,
+            status: activeJob.status,
+            totalApplications: activeJob.totalApplications || 0,
+            completedApplications: activeJob.completedApplications || 0,
+            failedApplications: activeJob.failedApplications || 0,
+            errorApplicationId: activeJob.errorApplicationId,
+            errorMessage: activeJob.errorMessage,
+            startedAt: activeJob.startedAt || new Date().toISOString(),
+            completedAt: activeJob.completedAt,
+            triggeredBy: activeJob.triggeredBy || "",
+          }}
+          onRetry={handleBulkEvaluate}
+        />
+      )}
+
+      {/* Test Panel */}
+      <PromptTestPanel
+        programId={programId}
+        promptType={promptType}
+        isOpen={isTestPanelOpen}
+        onClose={() => setIsTestPanelOpen(false)}
+        onTest={handleTest}
+        isLoading={testPromptMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/PromptEditor.tsx
+++ b/src/features/prompt-management/components/PromptEditor.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { ChevronDown, FlaskConical, Loader2, Play, Save } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import toast from "react-hot-toast";
-import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
-import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
-import { cn } from "@/utilities/tailwind";
-import {
-  useBulkEvaluationJobPolling,
-  useSavePrompt,
-  useTestPrompt,
-  useTriggerBulkEvaluation,
-} from "../hooks/use-program-prompts";
-import type { ProgramPrompt, PromptType, TestProgramPromptResult } from "../types/program-prompt";
-import { BulkEvaluationProgress } from "./BulkEvaluationProgress";
+import type { ProgramPrompt, PromptType } from "../types/program-prompt";
 import { PromptTestPanel } from "./PromptTestPanel";
+import {
+  BulkEvaluationSection,
+  PromptEditorActions,
+  PromptEditorForm,
+  PromptVersionInfo,
+  usePromptEditorState,
+} from "./prompt-editor";
 
 interface PromptEditorProps {
   programId: string;
@@ -48,405 +42,89 @@ export function PromptEditor({
   readOnly = false,
   bulkEvaluationJob,
 }: PromptEditorProps) {
-  // Form state
-  const [name, setName] = useState(existingPrompt?.name || "");
-  const [systemMessage, setSystemMessage] = useState(existingPrompt?.systemMessage || "");
-  const [content, setContent] = useState(existingPrompt?.content || "");
-  const [modelId, setModelId] = useState(existingPrompt?.modelId || "");
-  const [isDirty, setIsDirty] = useState(false);
-  const [isTestPanelOpen, setIsTestPanelOpen] = useState(false);
-  const [currentJobId, setCurrentJobId] = useState<string | null>(bulkEvaluationJob?.id || null);
-
-  // Fetch available AI models
-  const { data: availableModels = [], isLoading: isLoadingModels } = useAvailableAIModels();
-
-  // Mutations
-  const savePromptMutation = useSavePrompt(programId, promptType, {
-    onSuccess: (data) => {
-      toast.success("Prompt saved successfully");
-      setIsDirty(false);
-      onSaveSuccess?.(data);
-    },
-    onError: (error) => {
-      toast.error(error.message || "Failed to save prompt");
-    },
+  const {
+    name,
+    systemMessage,
+    content,
+    modelId,
+    isDirty,
+    isTestPanelOpen,
+    setIsTestPanelOpen,
+    availableModels,
+    isLoadingModels,
+    savePromptMutation,
+    testPromptMutation,
+    bulkEvaluationMutation,
+    polledJobData,
+    handleNameChange,
+    handleSystemMessageChange,
+    handleContentChange,
+    handleModelChange,
+    handleSave,
+    handleTest,
+    handleBulkEvaluate,
+    isNewPrompt,
+    canSave,
+    canTest,
+    canBulkEvaluate,
+    isJobRunning,
+  } = usePromptEditorState({
+    programId,
+    promptType,
+    existingPrompt,
+    initialJobId: bulkEvaluationJob?.id ?? null,
+    onSaveSuccess,
+    readOnly,
   });
-
-  const testPromptMutation = useTestPrompt(programId, promptType);
-
-  const bulkEvaluationMutation = useTriggerBulkEvaluation(programId, {
-    onSuccess: (data) => {
-      setCurrentJobId(data.jobId);
-      toast.success(`Bulk evaluation started for ${data.totalApplications} applications`);
-    },
-    onError: (error) => {
-      toast.error(error.message || "Failed to start bulk evaluation");
-    },
-  });
-
-  // Poll for job status when we have a job ID
-  const { data: polledJobData } = useBulkEvaluationJobPolling(programId, currentJobId, {
-    onComplete: (job) => {
-      if (job.status === "completed") {
-        toast.success(
-          `Evaluation complete: ${job.completedApplications} of ${job.totalApplications} applications processed`
-        );
-      } else if (job.status === "failed") {
-        toast.error(`Evaluation failed: ${job.errorMessage || "Unknown error"}`);
-      }
-      // Clear job ID after completion to stop polling
-      setCurrentJobId(null);
-    },
-  });
-
-  // Initialize model when models load
-  useEffect(() => {
-    if (availableModels.length > 0 && !modelId) {
-      setModelId(existingPrompt?.modelId || availableModels[0]);
-    }
-  }, [availableModels, modelId, existingPrompt?.modelId]);
-
-  // Sync with existing prompt when it changes
-  useEffect(() => {
-    if (existingPrompt) {
-      setName(existingPrompt.name);
-      setSystemMessage(existingPrompt.systemMessage || "");
-      setContent(existingPrompt.content);
-      setModelId(existingPrompt.modelId);
-      setIsDirty(false);
-    }
-  }, [existingPrompt]);
-
-  const handleSystemMessageChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setSystemMessage(e.target.value);
-    setIsDirty(true);
-  }, []);
-
-  const handleContentChange = useCallback((value: string) => {
-    setContent(value);
-    setIsDirty(true);
-  }, []);
-
-  const handleModelChange = useCallback((value: string) => {
-    setModelId(value);
-    setIsDirty(true);
-  }, []);
-
-  const handleNameChange = useCallback(
-    (value: string) => {
-      // Only allow name change if there's no existing prompt
-      if (!existingPrompt) {
-        setName(value);
-        setIsDirty(true);
-      }
-    },
-    [existingPrompt]
-  );
-
-  const handleSave = useCallback(() => {
-    if (!name.trim()) {
-      toast.error("Prompt name is required");
-      return;
-    }
-    if (!content.trim()) {
-      toast.error("Prompt content is required");
-      return;
-    }
-    if (!modelId) {
-      toast.error("Please select an AI model");
-      return;
-    }
-
-    // Check if "json" appears in system message or content (OpenAI requirement for JSON response format)
-    const combinedText = `${systemMessage} ${content}`.toLowerCase();
-    if (!combinedText.includes("json")) {
-      toast.error(
-        "Prompt must include the word 'json' for JSON response format (e.g., 'Respond in JSON format')"
-      );
-      return;
-    }
-
-    savePromptMutation.mutate({
-      name: name.trim(),
-      systemMessage: systemMessage.trim() || undefined,
-      content: content.trim(),
-      modelId,
-    });
-  }, [name, systemMessage, content, modelId, savePromptMutation]);
-
-  const handleTest = useCallback(
-    async (applicationId: string): Promise<TestProgramPromptResult> => {
-      return new Promise((resolve, reject) => {
-        testPromptMutation.mutate(
-          { applicationId },
-          {
-            onSuccess: resolve,
-            onError: reject,
-          }
-        );
-      });
-    },
-    [testPromptMutation]
-  );
-
-  const handleBulkEvaluate = useCallback(() => {
-    bulkEvaluationMutation.mutate(promptType);
-  }, [bulkEvaluationMutation, promptType]);
-
-  const isNewPrompt = !existingPrompt;
-  const canSave = isDirty && name.trim() && content.trim() && modelId && !readOnly;
-  const canTest = existingPrompt && !isDirty;
-  const canBulkEvaluate = existingPrompt && !isDirty;
-
-  // Show running job - prefer polled data, then passed prop, then check if job is starting
-  const activeJob = polledJobData ?? bulkEvaluationJob ?? null;
-  const isJobRunning =
-    activeJob?.status === "pending" ||
-    activeJob?.status === "running" ||
-    Boolean(currentJobId && !activeJob);
 
   return (
     <div className="space-y-6">
-      {/* Legacy prompt info */}
-      {legacyPromptId && isNewPrompt && (
-        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-          <p className="text-sm text-blue-700 dark:text-blue-300">
-            <span className="font-medium">Legacy Langfuse Prompt:</span>{" "}
-            <code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">{legacyPromptId}</code>
-          </p>
-          <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
-            Copy your prompt content from Langfuse to enable full editing capabilities.
-          </p>
-        </div>
-      )}
+      <PromptEditorForm
+        promptType={promptType}
+        existingPrompt={existingPrompt}
+        legacyPromptId={legacyPromptId}
+        readOnly={readOnly}
+        name={name}
+        systemMessage={systemMessage}
+        content={content}
+        modelId={modelId}
+        availableModels={availableModels}
+        isLoadingModels={isLoadingModels}
+        onNameChange={handleNameChange}
+        onSystemMessageChange={handleSystemMessageChange}
+        onContentChange={handleContentChange}
+        onModelChange={handleModelChange}
+      />
 
-      {/* Prompt Name */}
-      <div>
-        <label
-          htmlFor={`prompt-name-${promptType}`}
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
-          Prompt Name *
-          {existingPrompt && (
-            <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
-              (Cannot be changed after creation)
-            </span>
-          )}
-        </label>
-        <input
-          id={`prompt-name-${promptType}`}
-          type="text"
-          value={name}
-          onChange={(e) => handleNameChange(e.target.value)}
-          disabled={readOnly || !!existingPrompt}
-          placeholder={`e.g., ${promptType === "external" ? "grant-review" : "internal-evaluation"}-prompt`}
-          className={cn(
-            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
-            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
-            "focus:outline-none focus:ring-2 focus:ring-blue-500",
-            (readOnly || existingPrompt) &&
-              "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
-          )}
-        />
-      </div>
+      <PromptVersionInfo existingPrompt={existingPrompt} />
 
-      {/* AI Model Selection */}
-      <div>
-        <label
-          htmlFor={`ai-model-${promptType}`}
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
-          AI Model *
-        </label>
-        <div className="relative">
-          <select
-            id={`ai-model-${promptType}`}
-            value={modelId}
-            onChange={(e) => handleModelChange(e.target.value)}
-            disabled={readOnly || isLoadingModels}
-            className={cn(
-              "w-full appearance-none rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 pr-10 text-gray-900 dark:text-white text-sm",
-              "focus:outline-none focus:ring-2 focus:ring-blue-500",
-              (readOnly || isLoadingModels) && "opacity-50 cursor-not-allowed"
-            )}
-          >
-            {isLoadingModels ? (
-              <option value="">Loading models...</option>
-            ) : (
-              availableModels.map((model) => (
-                <option key={model} value={model}>
-                  {model}
-                </option>
-              ))
-            )}
-          </select>
-          <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
-        </div>
-      </div>
+      <PromptEditorActions
+        isNewPrompt={isNewPrompt}
+        canSave={canSave}
+        canTest={canTest}
+        canBulkEvaluate={canBulkEvaluate}
+        isSaving={savePromptMutation.isPending}
+        isBulkEvaluating={bulkEvaluationMutation.isPending}
+        isJobRunning={isJobRunning}
+        onSave={handleSave}
+        onOpenTestPanel={() => setIsTestPanelOpen(true)}
+        onBulkEvaluate={handleBulkEvaluate}
+      />
 
-      {/* System Message */}
-      <div>
-        <label
-          htmlFor={`system-message-${promptType}`}
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
-          System Message
-          <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
-            (Optional - Sets the AI's behavior and context)
-          </span>
-        </label>
-        <textarea
-          id={`system-message-${promptType}`}
-          value={systemMessage}
-          onChange={handleSystemMessageChange}
-          disabled={readOnly}
-          placeholder="You are a grant evaluator responsible for evaluating the incoming applications."
-          rows={4}
-          className={cn(
-            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
-            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
-            "focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y",
-            readOnly && "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
-          )}
-        />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          The system message defines the AI's role and behavior. It's sent as a separate "system"
-          message in the LLM conversation.
-        </p>
-      </div>
-
-      {/* Prompt Content (User Message) */}
-      <div>
-        <MarkdownEditor
-          label="Prompt Content (User Message)"
-          value={content}
-          onChange={handleContentChange}
-          isRequired
-          isDisabled={readOnly}
-          placeholder="Evaluate the application based on criteria below"
-          height={400}
-          showCharacterCount
-          maxLength={100000}
-        />
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          Use{" "}
-          <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
-            {"{{grant_application}}"}
-          </code>{" "}
-          to control where application data appears. If not included, application data will be
-          automatically appended at the end.
-        </p>
-        <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-          Important: Include the word "json" in your prompt (e.g., "Respond in JSON format") for
-          proper response parsing.
-        </p>
-      </div>
-
-      {/* Langfuse Version Info */}
-      {existingPrompt && (
-        <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
-          <span>
-            <span className="font-medium">Langfuse Version:</span> {existingPrompt.langfuseVersion}
-          </span>
-          <span>
-            <span className="font-medium">Last Updated:</span>{" "}
-            {new Date(existingPrompt.updatedAt).toLocaleString()}
-          </span>
-        </div>
-      )}
-
-      {/* Action Buttons */}
-      <div className="flex flex-wrap items-center gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!canSave || savePromptMutation.isPending}
-          className={cn(
-            "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
-            "bg-blue-600 text-white hover:bg-blue-700",
-            "disabled:opacity-50 disabled:cursor-not-allowed"
-          )}
-        >
-          {savePromptMutation.isPending ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            <>
-              <Save className="w-4 h-4" />
-              {isNewPrompt ? "Create Prompt" : "Save Changes"}
-            </>
-          )}
-        </button>
-
-        {canTest && (
-          <button
-            type="button"
-            onClick={() => setIsTestPanelOpen(true)}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <FlaskConical className="w-4 h-4" />
-            Test Prompt
-          </button>
-        )}
-
-        {canBulkEvaluate && (
-          <button
-            type="button"
-            onClick={handleBulkEvaluate}
-            disabled={bulkEvaluationMutation.isPending || isJobRunning}
-            className={cn(
-              "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
-              "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600",
-              "hover:bg-gray-50 dark:hover:bg-gray-700",
-              "disabled:opacity-50 disabled:cursor-not-allowed"
-            )}
-          >
-            {bulkEvaluationMutation.isPending ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" />
-                Starting...
-              </>
-            ) : (
-              <>
-                <Play className="w-4 h-4" />
-                Evaluate All Applications
-              </>
-            )}
-          </button>
-        )}
-      </div>
-
-      {/* Dirty state warning */}
       {isDirty && (
         <p className="text-xs text-amber-600 dark:text-amber-400">
           You have unsaved changes. Save before testing or running bulk evaluation.
         </p>
       )}
 
-      {/* Bulk evaluation progress */}
-      {activeJob && activeJob.status && (
-        <BulkEvaluationProgress
-          job={{
-            id: activeJob.id,
-            programId,
-            promptType,
-            status: activeJob.status,
-            totalApplications: activeJob.totalApplications || 0,
-            completedApplications: activeJob.completedApplications || 0,
-            failedApplications: activeJob.failedApplications || 0,
-            errorApplicationId: activeJob.errorApplicationId,
-            errorMessage: activeJob.errorMessage,
-            startedAt: activeJob.startedAt || new Date().toISOString(),
-            completedAt: activeJob.completedAt,
-            triggeredBy: activeJob.triggeredBy || "",
-          }}
-          onRetry={handleBulkEvaluate}
-        />
-      )}
+      <BulkEvaluationSection
+        programId={programId}
+        promptType={promptType}
+        activeJob={polledJobData ?? null}
+        bulkEvaluationJob={bulkEvaluationJob}
+        onRetry={handleBulkEvaluate}
+      />
 
-      {/* Test Panel */}
       <PromptTestPanel
         programId={programId}
         promptType={promptType}

--- a/src/features/prompt-management/components/PromptTestPanel.tsx
+++ b/src/features/prompt-management/components/PromptTestPanel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { AlertCircle, ChevronDown, Loader2, Play, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useFundingApplications } from "@/hooks/useFundingPlatform";
+import { cn } from "@/utilities/tailwind";
+import type { PromptType, TestProgramPromptResult } from "../types/program-prompt";
+
+interface PromptTestPanelProps {
+  programId: string;
+  promptType: PromptType;
+  isOpen: boolean;
+  onClose: () => void;
+  onTest: (applicationId: string) => Promise<TestProgramPromptResult>;
+  isLoading: boolean;
+}
+
+export function PromptTestPanel({
+  programId,
+  promptType,
+  isOpen,
+  onClose,
+  onTest,
+  isLoading,
+}: PromptTestPanelProps) {
+  const [selectedApplicationId, setSelectedApplicationId] = useState<string>("");
+  const [testResult, setTestResult] = useState<TestProgramPromptResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showCompiledPrompt, setShowCompiledPrompt] = useState(false);
+
+  const { applications, isLoading: isLoadingApplications } = useFundingApplications(programId, {
+    limit: 100,
+  });
+
+  const applicationOptions = useMemo(() => {
+    return applications.map((app) => ({
+      value: app.referenceNumber,
+      label: `${app.referenceNumber} - ${app.applicantEmail || "Unknown"}`,
+    }));
+  }, [applications]);
+
+  const handleTest = async () => {
+    if (!selectedApplicationId) {
+      setError("Please select an application to test with");
+      return;
+    }
+
+    setError(null);
+    setTestResult(null);
+
+    try {
+      const result = await onTest(selectedApplicationId);
+      setTestResult(result);
+    } catch (err) {
+      // Preserve error context for better debugging
+      let errorMessage = "Failed to test prompt";
+      if (err instanceof Error) {
+        errorMessage = err.message;
+        // Include cause if available (for chained errors)
+        if (err.cause && err.cause instanceof Error) {
+          errorMessage = `${errorMessage}: ${err.cause.message}`;
+        }
+      } else if (typeof err === "object" && err !== null) {
+        // Handle API error responses with additional context
+        const errObj = err as Record<string, unknown>;
+        if (errObj.message) {
+          errorMessage = String(errObj.message);
+        }
+        if (errObj.status) {
+          errorMessage = `[${errObj.status}] ${errorMessage}`;
+        }
+      }
+      setError(errorMessage);
+
+      // Log full error for debugging in development
+      if (process.env.NODE_ENV === "development") {
+        console.error("Prompt test error:", err);
+      }
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-y-0 right-0 z-50 w-full max-w-xl bg-white dark:bg-gray-900 shadow-2xl border-l border-gray-200 dark:border-gray-700 flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Test Prompt</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {promptType === "external" ? "External AI Prompt" : "Internal Evaluation Prompt"}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
+          aria-label="Close panel"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        {/* Application selector */}
+        <div>
+          <label
+            htmlFor="test-application"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+          >
+            Select Application to Test
+          </label>
+          <div className="relative">
+            <select
+              id="test-application"
+              value={selectedApplicationId}
+              onChange={(e) => setSelectedApplicationId(e.target.value)}
+              disabled={isLoadingApplications}
+              className="w-full appearance-none rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 pr-10 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">
+                {isLoadingApplications ? "Loading applications..." : "Select an application"}
+              </option>
+              {applicationOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          </div>
+          {applications.length === 0 && !isLoadingApplications && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              No applications found for this program.
+            </p>
+          )}
+        </div>
+
+        {/* Test button */}
+        <button
+          type="button"
+          onClick={handleTest}
+          disabled={isLoading || !selectedApplicationId}
+          className={cn(
+            "w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium text-sm transition-colors",
+            "bg-blue-600 text-white hover:bg-blue-700",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Running Test...
+            </>
+          ) : (
+            <>
+              <Play className="w-4 h-4" />
+              Run Test
+            </>
+          )}
+        </button>
+
+        {/* Error display */}
+        {error && (
+          <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+            <AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+          </div>
+        )}
+
+        {/* Test result */}
+        {testResult && (
+          <div className="space-y-4">
+            {/* Status */}
+            <div
+              className={cn(
+                "p-3 rounded-lg border",
+                testResult.success
+                  ? "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800"
+                  : "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800"
+              )}
+            >
+              <p
+                className={cn(
+                  "text-sm font-medium",
+                  testResult.success
+                    ? "text-green-700 dark:text-green-300"
+                    : "text-red-700 dark:text-red-300"
+                )}
+              >
+                {testResult.success ? "Test Passed" : "Test Failed"}
+              </p>
+              {testResult.error && (
+                <p className="text-sm text-red-600 dark:text-red-400 mt-1">{testResult.error}</p>
+              )}
+            </div>
+
+            {/* Result */}
+            {testResult.result && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Result
+                </h4>
+                <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 max-h-60 overflow-y-auto">
+                  <pre className="text-sm text-gray-900 dark:text-white whitespace-pre-wrap font-mono">
+                    {testResult.result}
+                  </pre>
+                </div>
+              </div>
+            )}
+
+            {/* Compiled prompt toggle */}
+            {testResult.compiledPrompt && (
+              <div>
+                <button
+                  type="button"
+                  onClick={() => setShowCompiledPrompt(!showCompiledPrompt)}
+                  className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {showCompiledPrompt ? "Hide" : "Show"} Compiled Prompt
+                </button>
+                {showCompiledPrompt && (
+                  <div className="mt-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 max-h-60 overflow-y-auto">
+                    <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono">
+                      {testResult.compiledPrompt}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Raw response */}
+            {testResult.rawResponse !== undefined && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Raw Response
+                </h4>
+                <div className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 max-h-60 overflow-y-auto">
+                  <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono">
+                    {JSON.stringify(testResult.rawResponse, null, 2)}
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/index.ts
+++ b/src/features/prompt-management/components/index.ts
@@ -1,0 +1,4 @@
+export { BulkEvaluationProgress } from "./BulkEvaluationProgress";
+export { MigrationBanner } from "./MigrationBanner";
+export { PromptEditor } from "./PromptEditor";
+export { PromptTestPanel } from "./PromptTestPanel";

--- a/src/features/prompt-management/components/prompt-editor/BulkEvaluationSection.tsx
+++ b/src/features/prompt-management/components/prompt-editor/BulkEvaluationSection.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { BulkEvaluationJob, PromptType } from "../../types/program-prompt";
+import { BulkEvaluationProgress } from "../BulkEvaluationProgress";
+
+interface BulkEvaluationSectionProps {
+  programId: string;
+  promptType: PromptType;
+  activeJob: BulkEvaluationJob | null;
+  bulkEvaluationJob?: {
+    id: string;
+    status: "pending" | "running" | "completed" | "failed";
+    totalApplications: number;
+    completedApplications: number;
+    failedApplications: number;
+    errorApplicationId?: string | null;
+    errorMessage?: string | null;
+    startedAt: string;
+    completedAt?: string | null;
+    triggeredBy: string;
+    programId: string;
+    promptType: PromptType;
+  } | null;
+  onRetry: () => void;
+}
+
+export function BulkEvaluationSection({
+  programId,
+  promptType,
+  activeJob,
+  bulkEvaluationJob,
+  onRetry,
+}: BulkEvaluationSectionProps) {
+  const job = activeJob ?? bulkEvaluationJob ?? null;
+
+  if (!job || !job.status) {
+    return null;
+  }
+
+  return (
+    <BulkEvaluationProgress
+      job={{
+        id: job.id,
+        programId,
+        promptType,
+        status: job.status,
+        totalApplications: job.totalApplications || 0,
+        completedApplications: job.completedApplications || 0,
+        failedApplications: job.failedApplications || 0,
+        errorApplicationId: job.errorApplicationId,
+        errorMessage: job.errorMessage,
+        startedAt: job.startedAt || new Date().toISOString(),
+        completedAt: job.completedAt,
+        triggeredBy: job.triggeredBy || "",
+      }}
+      onRetry={onRetry}
+    />
+  );
+}

--- a/src/features/prompt-management/components/prompt-editor/PromptEditorActions.tsx
+++ b/src/features/prompt-management/components/prompt-editor/PromptEditorActions.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { FlaskConical, Loader2, Play, Save } from "lucide-react";
+import { cn } from "@/utilities/tailwind";
+
+interface PromptEditorActionsProps {
+  isNewPrompt: boolean;
+  canSave: boolean;
+  canTest: boolean;
+  canBulkEvaluate: boolean;
+  isSaving: boolean;
+  isBulkEvaluating: boolean;
+  isJobRunning: boolean;
+  onSave: () => void;
+  onOpenTestPanel: () => void;
+  onBulkEvaluate: () => void;
+}
+
+export function PromptEditorActions({
+  isNewPrompt,
+  canSave,
+  canTest,
+  canBulkEvaluate,
+  isSaving,
+  isBulkEvaluating,
+  isJobRunning,
+  onSave,
+  onOpenTestPanel,
+  onBulkEvaluate,
+}: PromptEditorActionsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={!canSave || isSaving}
+        className={cn(
+          "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
+          "bg-blue-600 text-white hover:bg-blue-700",
+          "disabled:opacity-50 disabled:cursor-not-allowed"
+        )}
+      >
+        {isSaving ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          <>
+            <Save className="w-4 h-4" />
+            {isNewPrompt ? "Create Prompt" : "Save Changes"}
+          </>
+        )}
+      </button>
+
+      {canTest && (
+        <button
+          type="button"
+          onClick={onOpenTestPanel}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >
+          <FlaskConical className="w-4 h-4" />
+          Test Prompt
+        </button>
+      )}
+
+      {canBulkEvaluate && (
+        <button
+          type="button"
+          onClick={onBulkEvaluate}
+          disabled={isBulkEvaluating || isJobRunning}
+          className={cn(
+            "inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-colors",
+            "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600",
+            "hover:bg-gray-50 dark:hover:bg-gray-700",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {isBulkEvaluating ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Starting...
+            </>
+          ) : (
+            <>
+              <Play className="w-4 h-4" />
+              Evaluate All Applications
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/prompt-editor/PromptEditorForm.tsx
+++ b/src/features/prompt-management/components/prompt-editor/PromptEditorForm.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
+import { cn } from "@/utilities/tailwind";
+import type { ProgramPrompt, PromptType } from "../../types/program-prompt";
+
+interface PromptEditorFormProps {
+  promptType: PromptType;
+  existingPrompt: ProgramPrompt | null;
+  legacyPromptId?: string | null;
+  readOnly: boolean;
+  // Form state
+  name: string;
+  systemMessage: string;
+  content: string;
+  modelId: string;
+  availableModels: string[];
+  isLoadingModels: boolean;
+  // Handlers
+  onNameChange: (value: string) => void;
+  onSystemMessageChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onContentChange: (value: string) => void;
+  onModelChange: (value: string) => void;
+}
+
+export function PromptEditorForm({
+  promptType,
+  existingPrompt,
+  legacyPromptId,
+  readOnly,
+  name,
+  systemMessage,
+  content,
+  modelId,
+  availableModels,
+  isLoadingModels,
+  onNameChange,
+  onSystemMessageChange,
+  onContentChange,
+  onModelChange,
+}: PromptEditorFormProps) {
+  const isNewPrompt = !existingPrompt;
+
+  return (
+    <>
+      {/* Legacy prompt info */}
+      {legacyPromptId && isNewPrompt && (
+        <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            <span className="font-medium">Legacy Langfuse Prompt:</span>{" "}
+            <code className="bg-blue-100 dark:bg-blue-900/40 px-1 rounded">{legacyPromptId}</code>
+          </p>
+          <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+            Copy your prompt content from Langfuse to enable full editing capabilities.
+          </p>
+        </div>
+      )}
+
+      {/* Prompt Name */}
+      <div>
+        <label
+          htmlFor={`prompt-name-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          Prompt Name *
+          {existingPrompt && (
+            <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
+              (Cannot be changed after creation)
+            </span>
+          )}
+        </label>
+        <input
+          id={`prompt-name-${promptType}`}
+          type="text"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          disabled={readOnly || !!existingPrompt}
+          placeholder={`e.g., ${promptType === "external" ? "grant-review" : "internal-evaluation"}-prompt`}
+          className={cn(
+            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "focus:outline-none focus:ring-2 focus:ring-blue-500",
+            (readOnly || existingPrompt) &&
+              "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
+          )}
+        />
+      </div>
+
+      {/* AI Model Selection */}
+      <div>
+        <label
+          htmlFor={`ai-model-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          AI Model *
+        </label>
+        <div className="relative">
+          <select
+            id={`ai-model-${promptType}`}
+            value={modelId}
+            onChange={(e) => onModelChange(e.target.value)}
+            disabled={readOnly || isLoadingModels}
+            className={cn(
+              "w-full appearance-none rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 pr-10 text-gray-900 dark:text-white text-sm",
+              "focus:outline-none focus:ring-2 focus:ring-blue-500",
+              (readOnly || isLoadingModels) && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            {isLoadingModels ? (
+              <option value="">Loading models...</option>
+            ) : (
+              availableModels.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))
+            )}
+          </select>
+          <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+        </div>
+      </div>
+
+      {/* System Message */}
+      <div>
+        <label
+          htmlFor={`system-message-${promptType}`}
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          System Message
+          <span className="ml-2 text-xs text-gray-500 dark:text-gray-400 font-normal">
+            (Optional - Sets the AI's behavior and context)
+          </span>
+        </label>
+        <textarea
+          id={`system-message-${promptType}`}
+          value={systemMessage}
+          onChange={onSystemMessageChange}
+          disabled={readOnly}
+          placeholder="You are a grant evaluator responsible for evaluating the incoming applications."
+          rows={4}
+          className={cn(
+            "w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white text-sm",
+            "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+            "focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y",
+            readOnly && "opacity-60 cursor-not-allowed bg-gray-50 dark:bg-gray-900"
+          )}
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          The system message defines the AI's role and behavior. It's sent as a separate "system"
+          message in the LLM conversation.
+        </p>
+      </div>
+
+      {/* Prompt Content (User Message) */}
+      <div>
+        <MarkdownEditor
+          label="Prompt Content (User Message)"
+          value={content}
+          onChange={onContentChange}
+          isRequired
+          isDisabled={readOnly}
+          placeholder="Evaluate the application based on criteria below"
+          height={400}
+          showCharacterCount
+          maxLength={100000}
+        />
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Use{" "}
+          <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
+            {"{{grant_application}}"}
+          </code>{" "}
+          to control where application data appears. If not included, application data will be
+          automatically appended at the end.
+        </p>
+        <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+          Important: Include the word "json" in your prompt (e.g., "Respond in JSON format") for
+          proper response parsing.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/src/features/prompt-management/components/prompt-editor/PromptVersionInfo.tsx
+++ b/src/features/prompt-management/components/prompt-editor/PromptVersionInfo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ProgramPrompt } from "../../types/program-prompt";
+
+interface PromptVersionInfoProps {
+  existingPrompt: ProgramPrompt | null;
+}
+
+export function PromptVersionInfo({ existingPrompt }: PromptVersionInfoProps) {
+  if (!existingPrompt) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+      <span>
+        <span className="font-medium">Langfuse Version:</span> {existingPrompt.langfuseVersion}
+      </span>
+      <span>
+        <span className="font-medium">Last Updated:</span>{" "}
+        {new Date(existingPrompt.updatedAt).toLocaleString()}
+      </span>
+    </div>
+  );
+}

--- a/src/features/prompt-management/components/prompt-editor/hooks/usePromptEditorState.ts
+++ b/src/features/prompt-management/components/prompt-editor/hooks/usePromptEditorState.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
+import {
+  useBulkEvaluationJobPolling,
+  useSavePrompt,
+  useTestPrompt,
+  useTriggerBulkEvaluation,
+} from "../../../hooks/use-program-prompts";
+import type {
+  ProgramPrompt,
+  PromptType,
+  TestProgramPromptResult,
+} from "../../../types/program-prompt";
+
+interface UsePromptEditorStateProps {
+  programId: string;
+  promptType: PromptType;
+  existingPrompt: ProgramPrompt | null;
+  initialJobId?: string | null;
+  onSaveSuccess?: (prompt: ProgramPrompt) => void;
+  readOnly?: boolean;
+}
+
+export function usePromptEditorState({
+  programId,
+  promptType,
+  existingPrompt,
+  initialJobId = null,
+  onSaveSuccess,
+  readOnly = false,
+}: UsePromptEditorStateProps) {
+  // Form state
+  const [name, setName] = useState(existingPrompt?.name || "");
+  const [systemMessage, setSystemMessage] = useState(existingPrompt?.systemMessage || "");
+  const [content, setContent] = useState(existingPrompt?.content || "");
+  const [modelId, setModelId] = useState(existingPrompt?.modelId || "");
+  const [isDirty, setIsDirty] = useState(false);
+  const [isTestPanelOpen, setIsTestPanelOpen] = useState(false);
+  const [currentJobId, setCurrentJobId] = useState<string | null>(initialJobId);
+
+  // Fetch available AI models
+  const { data: availableModels = [], isLoading: isLoadingModels } = useAvailableAIModels();
+
+  // Mutations
+  const savePromptMutation = useSavePrompt(programId, promptType, {
+    onSuccess: (data) => {
+      toast.success("Prompt saved successfully");
+      setIsDirty(false);
+      onSaveSuccess?.(data);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to save prompt");
+    },
+  });
+
+  const testPromptMutation = useTestPrompt(programId, promptType);
+
+  const bulkEvaluationMutation = useTriggerBulkEvaluation(programId, {
+    onSuccess: (data) => {
+      setCurrentJobId(data.jobId);
+      toast.success(`Bulk evaluation started for ${data.totalApplications} applications`);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to start bulk evaluation");
+    },
+  });
+
+  // Poll for job status when we have a job ID
+  const { data: polledJobData } = useBulkEvaluationJobPolling(programId, currentJobId, {
+    onComplete: (job) => {
+      if (job.status === "completed") {
+        toast.success(
+          `Evaluation complete: ${job.completedApplications} of ${job.totalApplications} applications processed`
+        );
+      } else if (job.status === "failed") {
+        toast.error(`Evaluation failed: ${job.errorMessage || "Unknown error"}`);
+      }
+      setCurrentJobId(null);
+    },
+  });
+
+  // Initialize model when models load
+  useEffect(() => {
+    if (availableModels.length > 0 && !modelId) {
+      setModelId(existingPrompt?.modelId || availableModels[0]);
+    }
+  }, [availableModels, modelId, existingPrompt?.modelId]);
+
+  // Sync with existing prompt when it changes
+  useEffect(() => {
+    if (existingPrompt) {
+      setName(existingPrompt.name);
+      setSystemMessage(existingPrompt.systemMessage || "");
+      setContent(existingPrompt.content);
+      setModelId(existingPrompt.modelId);
+      setIsDirty(false);
+    }
+  }, [existingPrompt]);
+
+  // Handlers
+  const handleSystemMessageChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setSystemMessage(e.target.value);
+    setIsDirty(true);
+  }, []);
+
+  const handleContentChange = useCallback((value: string) => {
+    setContent(value);
+    setIsDirty(true);
+  }, []);
+
+  const handleModelChange = useCallback((value: string) => {
+    setModelId(value);
+    setIsDirty(true);
+  }, []);
+
+  const handleNameChange = useCallback(
+    (value: string) => {
+      if (!existingPrompt) {
+        setName(value);
+        setIsDirty(true);
+      }
+    },
+    [existingPrompt]
+  );
+
+  const handleSave = useCallback(() => {
+    if (!name.trim()) {
+      toast.error("Prompt name is required");
+      return;
+    }
+    if (!content.trim()) {
+      toast.error("Prompt content is required");
+      return;
+    }
+    if (!modelId) {
+      toast.error("Please select an AI model");
+      return;
+    }
+
+    const combinedText = `${systemMessage} ${content}`.toLowerCase();
+    if (!combinedText.includes("json")) {
+      toast.error(
+        "Prompt must include the word 'json' for JSON response format (e.g., 'Respond in JSON format')"
+      );
+      return;
+    }
+
+    savePromptMutation.mutate({
+      name: name.trim(),
+      systemMessage: systemMessage.trim() || undefined,
+      content: content.trim(),
+      modelId,
+    });
+  }, [name, systemMessage, content, modelId, savePromptMutation]);
+
+  const handleTest = useCallback(
+    async (applicationId: string): Promise<TestProgramPromptResult> => {
+      return new Promise((resolve, reject) => {
+        testPromptMutation.mutate(
+          { applicationId },
+          {
+            onSuccess: resolve,
+            onError: reject,
+          }
+        );
+      });
+    },
+    [testPromptMutation]
+  );
+
+  const handleBulkEvaluate = useCallback(() => {
+    bulkEvaluationMutation.mutate(promptType);
+  }, [bulkEvaluationMutation, promptType]);
+
+  // Derived state
+  const isNewPrompt = !existingPrompt;
+  const canSave = isDirty && !!name.trim() && !!content.trim() && !!modelId && !readOnly;
+  const canTest = !!existingPrompt && !isDirty;
+  const canBulkEvaluate = !!existingPrompt && !isDirty;
+  const isJobRunning = Boolean(currentJobId && !polledJobData);
+
+  return {
+    // Form state
+    name,
+    systemMessage,
+    content,
+    modelId,
+    isDirty,
+    isTestPanelOpen,
+    setIsTestPanelOpen,
+
+    // Models
+    availableModels,
+    isLoadingModels,
+
+    // Mutations
+    savePromptMutation,
+    testPromptMutation,
+    bulkEvaluationMutation,
+
+    // Job data
+    polledJobData,
+    currentJobId,
+
+    // Handlers
+    handleNameChange,
+    handleSystemMessageChange,
+    handleContentChange,
+    handleModelChange,
+    handleSave,
+    handleTest,
+    handleBulkEvaluate,
+
+    // Derived state
+    isNewPrompt,
+    canSave,
+    canTest,
+    canBulkEvaluate,
+    isJobRunning,
+  };
+}

--- a/src/features/prompt-management/components/prompt-editor/hooks/usePromptEditorState.ts
+++ b/src/features/prompt-management/components/prompt-editor/hooks/usePromptEditorState.ts
@@ -180,7 +180,10 @@ export function usePromptEditorState({
   const canSave = isDirty && !!name.trim() && !!content.trim() && !!modelId && !readOnly;
   const canTest = !!existingPrompt && !isDirty;
   const canBulkEvaluate = !!existingPrompt && !isDirty;
-  const isJobRunning = Boolean(currentJobId && !polledJobData);
+  const isJobRunning = Boolean(
+    currentJobId &&
+      (!polledJobData || polledJobData.status === "pending" || polledJobData.status === "running")
+  );
 
   return {
     // Form state

--- a/src/features/prompt-management/components/prompt-editor/index.ts
+++ b/src/features/prompt-management/components/prompt-editor/index.ts
@@ -1,0 +1,5 @@
+export { BulkEvaluationSection } from "./BulkEvaluationSection";
+export { usePromptEditorState } from "./hooks/usePromptEditorState";
+export { PromptEditorActions } from "./PromptEditorActions";
+export { PromptEditorForm } from "./PromptEditorForm";
+export { PromptVersionInfo } from "./PromptVersionInfo";

--- a/src/features/prompt-management/hooks/use-program-prompts.ts
+++ b/src/features/prompt-management/hooks/use-program-prompts.ts
@@ -170,12 +170,12 @@ export function useBulkEvaluationJobPolling(
     enabled: !!jobId,
     refetchInterval: (query) => {
       const data = query.state.data;
-      if (!data) return 2000;
+      if (!data) return 5000;
       if (data.status === "completed" || data.status === "failed") {
         options?.onComplete?.(data);
         return false;
       }
-      return 2000;
+      return 5000;
     },
   });
 }

--- a/src/features/prompt-management/hooks/use-program-prompts.ts
+++ b/src/features/prompt-management/hooks/use-program-prompts.ts
@@ -169,7 +169,6 @@ export function useBulkEvaluationJobPolling(
   jobId: string | null,
   options?: {
     onComplete?: (job: BulkEvaluationJob) => void;
-    onError?: (error: Error) => void;
   }
 ) {
   // Use refs to hold latest callback values without causing stale closures

--- a/src/features/prompt-management/hooks/use-program-prompts.ts
+++ b/src/features/prompt-management/hooks/use-program-prompts.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { programPromptService } from "../services/program-prompt.service";
+import type {
+  BulkEvaluationJob,
+  ProgramPrompt,
+  PromptType,
+  SaveProgramPromptRequest,
+  TestProgramPromptRequest,
+  TestProgramPromptResult,
+  TriggerBulkEvaluationResult,
+} from "../types/program-prompt";
+
+/**
+ * Query key factory for program prompt queries
+ */
+export const promptKeys = {
+  all: ["prompts"] as const,
+  program: (programId: string) => [...promptKeys.all, programId] as const,
+  jobs: ["prompt-jobs"] as const,
+  job: (programId: string, jobId: string) => [...promptKeys.jobs, programId, jobId] as const,
+} as const;
+
+/**
+ * Hook for fetching program prompts
+ *
+ * @param programId - The program ID
+ * @param options - Optional settings
+ */
+export function useProgramPrompts(
+  programId: string,
+  options?: {
+    enabled?: boolean;
+  }
+) {
+  return useQuery({
+    queryKey: promptKeys.program(programId),
+    queryFn: () => programPromptService.getPrompts(programId),
+    enabled: options?.enabled ?? !!programId,
+  });
+}
+
+/**
+ * Hook for saving a program prompt
+ *
+ * @param programId - The program ID
+ * @param promptType - Either 'external' or 'internal'
+ * @param options - Optional callbacks
+ */
+export function useSavePrompt(
+  programId: string,
+  promptType: PromptType,
+  options?: {
+    onSuccess?: (data: ProgramPrompt) => void;
+    onError?: (error: Error) => void;
+  }
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: SaveProgramPromptRequest) =>
+      programPromptService.savePrompt(programId, promptType, data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: promptKeys.program(programId) });
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}
+
+/**
+ * Hook for testing a prompt
+ *
+ * @param programId - The program ID
+ * @param promptType - Either 'external' or 'internal'
+ * @param options - Optional callbacks
+ */
+export function useTestPrompt(
+  programId: string,
+  promptType: PromptType,
+  options?: {
+    onSuccess?: (data: TestProgramPromptResult) => void;
+    onError?: (error: Error) => void;
+  }
+) {
+  return useMutation({
+    mutationFn: (data: TestProgramPromptRequest) =>
+      programPromptService.testPrompt(programId, promptType, data),
+    onSuccess: (data) => {
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}
+
+/**
+ * Hook for triggering bulk evaluation
+ *
+ * @param programId - The program ID
+ * @param options - Optional callbacks
+ */
+export function useTriggerBulkEvaluation(
+  programId: string,
+  options?: {
+    onSuccess?: (data: TriggerBulkEvaluationResult) => void;
+    onError?: (error: Error) => void;
+  }
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (promptType: PromptType) =>
+      programPromptService.triggerBulkEvaluation(programId, promptType),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: promptKeys.jobs });
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}
+
+/**
+ * Hook for fetching bulk evaluation job status
+ *
+ * @param programId - The program ID
+ * @param jobId - The job ID
+ * @param options - Optional settings
+ */
+export function useBulkEvaluationJob(
+  programId: string,
+  jobId: string | null,
+  options?: {
+    enabled?: boolean;
+    refetchInterval?: number | false;
+  }
+) {
+  return useQuery({
+    queryKey: promptKeys.job(programId, jobId ?? ""),
+    queryFn: () => programPromptService.getJobStatus(programId, jobId!),
+    enabled: !!jobId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval ?? false,
+  });
+}
+
+/**
+ * Hook for polling bulk evaluation job status
+ *
+ * @param programId - The program ID
+ * @param jobId - The job ID
+ * @param options - Optional settings
+ */
+export function useBulkEvaluationJobPolling(
+  programId: string,
+  jobId: string | null,
+  options?: {
+    onComplete?: (job: BulkEvaluationJob) => void;
+    onError?: (error: Error) => void;
+  }
+) {
+  return useQuery({
+    queryKey: promptKeys.job(programId, jobId ?? ""),
+    queryFn: () => programPromptService.getJobStatus(programId, jobId!),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 2000;
+      if (data.status === "completed" || data.status === "failed") {
+        options?.onComplete?.(data);
+        return false;
+      }
+      return 2000;
+    },
+  });
+}

--- a/src/features/prompt-management/index.ts
+++ b/src/features/prompt-management/index.ts
@@ -1,0 +1,22 @@
+// Types
+
+// Components
+export {
+  BulkEvaluationProgress,
+  MigrationBanner,
+  PromptEditor,
+  PromptTestPanel,
+} from "./components";
+// Hooks
+export {
+  promptKeys,
+  useBulkEvaluationJob,
+  useBulkEvaluationJobPolling,
+  useProgramPrompts,
+  useSavePrompt,
+  useTestPrompt,
+  useTriggerBulkEvaluation,
+} from "./hooks/use-program-prompts";
+// Services
+export { programPromptService } from "./services/program-prompt.service";
+export * from "./types/program-prompt";

--- a/src/features/prompt-management/services/program-prompt.service.ts
+++ b/src/features/prompt-management/services/program-prompt.service.ts
@@ -1,0 +1,118 @@
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type {
+  BulkEvaluationJob,
+  ProgramPrompt,
+  ProgramPromptsResponse,
+  PromptType,
+  SaveProgramPromptRequest,
+  TestProgramPromptRequest,
+  TestProgramPromptResult,
+  TriggerBulkEvaluationResult,
+} from "../types/program-prompt";
+
+function unwrapResponse<T>(response: T | null, error: string | null): T {
+  if (error) {
+    throw new Error(error);
+  }
+  if (!response) {
+    throw new Error("No response from server");
+  }
+  return response;
+}
+
+/**
+ * Service for managing program prompts (LLM prompt management)
+ */
+export const programPromptService = {
+  /**
+   * Get all prompts for a program
+   *
+   * @param programId - The program ID
+   * @returns Both external and internal prompts with migration info
+   */
+  async getPrompts(programId: string): Promise<ProgramPromptsResponse> {
+    const [response, error] = await fetchData<ProgramPromptsResponse>(
+      INDEXER.V2.FUNDING_PROGRAMS.PROMPTS.GET(programId),
+      "GET"
+    );
+    return unwrapResponse(response, error);
+  },
+
+  /**
+   * Save or update a prompt for a program
+   * Note: Name cannot be changed after creation
+   *
+   * @param programId - The program ID
+   * @param promptType - Either 'external' or 'internal'
+   * @param data - The prompt data to save
+   * @returns The saved prompt
+   */
+  async savePrompt(
+    programId: string,
+    promptType: PromptType,
+    data: SaveProgramPromptRequest
+  ): Promise<ProgramPrompt> {
+    const [response, error] = await fetchData<ProgramPrompt>(
+      INDEXER.V2.FUNDING_PROGRAMS.PROMPTS.SAVE(programId, promptType),
+      "PUT",
+      data
+    );
+    return unwrapResponse(response, error);
+  },
+
+  /**
+   * Test a prompt with a specific application
+   *
+   * @param programId - The program ID
+   * @param promptType - Either 'external' or 'internal'
+   * @param data - The application ID to test with
+   * @returns Test result including compiled prompt and response
+   */
+  async testPrompt(
+    programId: string,
+    promptType: PromptType,
+    data: TestProgramPromptRequest
+  ): Promise<TestProgramPromptResult> {
+    const [response, error] = await fetchData<TestProgramPromptResult>(
+      INDEXER.V2.FUNDING_PROGRAMS.PROMPTS.TEST(programId, promptType),
+      "POST",
+      data
+    );
+    return unwrapResponse(response, error);
+  },
+
+  /**
+   * Trigger bulk re-evaluation of all applications
+   *
+   * @param programId - The program ID
+   * @param promptType - Either 'external' or 'internal'
+   * @returns Job info including job ID and total applications
+   */
+  async triggerBulkEvaluation(
+    programId: string,
+    promptType: PromptType
+  ): Promise<TriggerBulkEvaluationResult> {
+    const [response, error] = await fetchData<TriggerBulkEvaluationResult>(
+      INDEXER.V2.FUNDING_PROGRAMS.PROMPTS.BULK_EVALUATE(programId),
+      "POST",
+      { promptType }
+    );
+    return unwrapResponse(response, error);
+  },
+
+  /**
+   * Get the status of a bulk evaluation job
+   *
+   * @param programId - The program ID
+   * @param jobId - The job ID
+   * @returns Job status including progress
+   */
+  async getJobStatus(programId: string, jobId: string): Promise<BulkEvaluationJob> {
+    const [response, error] = await fetchData<BulkEvaluationJob>(
+      INDEXER.V2.FUNDING_PROGRAMS.PROMPTS.JOB_STATUS(programId, jobId),
+      "GET"
+    );
+    return unwrapResponse(response, error);
+  },
+};

--- a/src/features/prompt-management/types/program-prompt.ts
+++ b/src/features/prompt-management/types/program-prompt.ts
@@ -1,0 +1,72 @@
+export type PromptType = "external" | "internal";
+
+export interface ProgramPrompt {
+  id: string;
+  programId: string;
+  promptType: PromptType;
+  name: string;
+  systemMessage: string | null;
+  content: string;
+  modelId: string;
+  langfusePromptId: string;
+  langfuseVersion: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+}
+
+export interface ProgramPromptsResponse {
+  external: ProgramPrompt | null;
+  internal: ProgramPrompt | null;
+  migrationRequired: boolean;
+  legacyPromptIds: {
+    external: string | null;
+    internal: string | null;
+  };
+}
+
+export interface SaveProgramPromptRequest {
+  name: string;
+  systemMessage?: string;
+  content: string;
+  modelId: string;
+}
+
+export interface TestProgramPromptRequest {
+  applicationId: string;
+}
+
+export interface TestProgramPromptResult {
+  success: boolean;
+  result?: string;
+  rawResponse?: unknown;
+  compiledPrompt?: string;
+  error?: string;
+}
+
+export interface TriggerBulkEvaluationRequest {
+  promptType: PromptType;
+}
+
+export interface TriggerBulkEvaluationResult {
+  jobId: string;
+  totalApplications: number;
+}
+
+export type BulkEvaluationStatus = "pending" | "running" | "completed" | "failed";
+
+export interface BulkEvaluationJob {
+  id: string;
+  programId: string;
+  promptType: PromptType;
+  status: BulkEvaluationStatus;
+  totalApplications: number;
+  completedApplications: number;
+  failedApplications: number;
+  errorApplicationId?: string | null;
+  errorMessage?: string | null;
+  startedAt: string;
+  completedAt?: string | null;
+  triggeredBy: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
+      "@/features/*": ["./src/features/*"],
+      "@/src/*": ["./src/*"],
       "@/*": ["./*"]
     },
     "plugins": [

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -108,6 +108,17 @@ export const INDEXER = {
         return `/v2/funding-program-configs/${programId}/check-permission?${params.toString()}`;
       },
       MY_REVIEWER_PROGRAMS: () => `/v2/funding-program-configs/my-reviewer-programs`,
+      PROMPTS: {
+        GET: (programId: string) => `/v2/funding-program-configs/${programId}/prompts`,
+        SAVE: (programId: string, promptType: "external" | "internal") =>
+          `/v2/funding-program-configs/${programId}/prompts/${promptType}`,
+        TEST: (programId: string, promptType: "external" | "internal") =>
+          `/v2/funding-program-configs/${programId}/prompts/${promptType}/test`,
+        BULK_EVALUATE: (programId: string) =>
+          `/v2/funding-program-configs/${programId}/evaluate-all`,
+        JOB_STATUS: (programId: string, jobId: string) =>
+          `/v2/funding-program-configs/${programId}/evaluate-all/${jobId}`,
+      },
     },
     FUNDING_APPLICATIONS: {
       GET: (applicationId: string) => `/v2/funding-applications/${applicationId}`,


### PR DESCRIPTION
…d bulk evaluation

Add full prompt management feature to the frontend for managing External AI and Internal Evaluation prompts:

- Create PromptEditor component with model selection, system message, and content
- Add PromptTestPanel for testing prompts against specific applications
- Implement BulkEvaluationProgress component for tracking evaluation jobs
- Create MigrationBanner for legacy Langfuse prompt migration guidance
- Add React Query hooks for prompt CRUD, testing, and bulk evaluation
- Create programPromptService for API integration
- Update AIPromptConfiguration to use new prompt management system
- Add comprehensive unit tests for PromptEditor component

The feature allows platform administrators to:
- Create and edit prompts with full content editing
- Select AI models from available options
- Test prompts against individual applications
- Trigger bulk evaluation of all applications
- Track evaluation progress in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt editor with AI model selection, validation, JSON-response guidance, legacy prompt info, dirty/save flow, version info, and action controls.
  * Prompt testing panel to run prompts against individual applications with result views.
  * Bulk evaluation across all applications with progress UI, status, retry, and job polling.
  * Migration banner and tabbed UI for external/internal prompt management; improved loading, error and retry UX.

* **Tests**
  * Comprehensive unit tests covering Prompt Editor behaviors, validation, saving, and flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->