### PR TITLE
Feat: Auto indicators integration modal improvements

### DIFF
--- a/components/DeleteDialog.tsx
+++ b/components/DeleteDialog.tsx
@@ -35,15 +35,25 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
   externalIsOpen,
   externalSetIsOpen,
 }) => {
-  const [isOpen, setIsOpen] = useState(externalIsOpen || false);
+  const [internalIsOpen, setInternalIsOpen] = useState(false);
+
+  // Use external state if provided, otherwise use internal state
+  const isControlled = externalIsOpen !== undefined;
+  const isOpen = isControlled ? externalIsOpen : internalIsOpen;
 
   function closeModal() {
-    setIsOpen(false);
-    externalSetIsOpen?.(false);
+    if (isControlled) {
+      externalSetIsOpen?.(false);
+    } else {
+      setInternalIsOpen(false);
+    }
   }
   function openModal() {
-    setIsOpen(true);
-    externalSetIsOpen?.(true);
+    if (isControlled) {
+      externalSetIsOpen?.(true);
+    } else {
+      setInternalIsOpen(true);
+    }
   }
 
   const handleFunction = async () => {
@@ -59,7 +69,11 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
     <>
       {buttonElement ? (
         <Button
-          onClick={openModal}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            openModal();
+          }}
           className={cn(
             "flex w-max h-max justify-center items-center gap-x-1 rounded-md px-3 py-2 text-sm font-semibold",
             buttonElement.styleClass

--- a/components/DeleteDialog.tsx
+++ b/components/DeleteDialog.tsx
@@ -58,11 +58,12 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 
   const handleFunction = async () => {
     try {
-      await deleteFunction().then(() => {
-        afterFunction?.();
-      });
+      await deleteFunction();
+      afterFunction?.();
       closeModal();
-    } catch (_error: any) {}
+    } catch (error) {
+      console.error("Delete operation failed:", error);
+    }
   };
 
   return (

--- a/components/Forms/Outputs/MetricsTable.tsx
+++ b/components/Forms/Outputs/MetricsTable.tsx
@@ -2,9 +2,9 @@
 
 import { TrashIcon } from "@heroicons/react/24/solid";
 import { useState } from "react";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import { cn } from "@/utilities/tailwind";
 // Temporarily comment out SearchWithValueDropdown to test
@@ -115,6 +115,9 @@ export const MetricsTable = ({
 }: MetricsTableProps) => {
   const [isOutputDialogOpen, setIsOutputDialogOpen] = useState(false);
   const [_selectedToCreate, setSelectedToCreate] = useState<number | undefined>(undefined);
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   const handleOutputChange = (index: number, field: keyof OutputData, value: any) => {
     const newOutputs = [...outputs];

--- a/components/Forms/ProjectUpdate.tsx
+++ b/components/Forms/ProjectUpdate.tsx
@@ -11,12 +11,12 @@ import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import { useAccount } from "wagmi";
 import { z } from "zod";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useGap } from "@/hooks/useGap";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
@@ -282,6 +282,9 @@ export const ProjectUpdateForm: FC<ProjectUpdateFormProps> = ({
   const { data: indicatorsData } = useImpactAnswers({
     projectIdentifier: project?.uid,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   // Get communities from selected grants
   const watchedGrantIds = watch("grants") || [];

--- a/components/Pages/Admin/CategoryView.tsx
+++ b/components/Pages/Admin/CategoryView.tsx
@@ -111,6 +111,7 @@ export const CategoryView = ({
   const [initialModalType, setInitialModalType] = useState<"output" | "outcome">("output");
   const [editingSegment, setEditingSegment] = useState<ImpactSegment | null>(null);
   const [isDeletingSegment, setIsDeletingSegment] = useState<string | null>(null);
+  const [segmentToDelete, setSegmentToDelete] = useState<ImpactSegment | null>(null);
 
   const {
     data: groupedIndicators = { communityAdminCreated: [], projectOwnerCreated: [] },
@@ -354,18 +355,15 @@ export const CategoryView = ({
                         </Menu.Item>
                         <Menu.Item>
                           {({ active }) => (
-                            <DeleteDialog
-                              title={`Are you sure you want to delete ${segment.name}?`}
-                              deleteFunction={() => handleDeleteSegment(segment.id)}
-                              isLoading={isDeletingSegment === segment.id}
-                              buttonElement={{
-                                icon: <TrashIcon className="h-4 w-4 mr-2" />,
-                                text: "Delete",
-                                styleClass: `${
-                                  active ? "bg-gray-100 dark:bg-zinc-700" : "bg-transparent"
-                                } hover:bg-gray-100 dark:hover:bg-zinc-700 font-normal w-full px-4 py-2 text-left flex items-center text-sm text-red-500`,
-                              }}
-                            />
+                            <button
+                              className={`${
+                                active ? "bg-gray-100 dark:bg-zinc-700" : ""
+                              } w-full px-4 py-2 text-left flex items-center text-sm text-red-500`}
+                              onClick={() => setSegmentToDelete(segment)}
+                            >
+                              <TrashIcon className="h-4 w-4 mr-2" />
+                              Delete
+                            </button>
                           )}
                         </Menu.Item>
                       </div>
@@ -444,6 +442,23 @@ export const CategoryView = ({
         }}
         initialType={initialModalType}
         editingSegment={editingSegment}
+      />
+
+      {/* Delete confirmation dialog - rendered outside Menu to prevent unmounting */}
+      <DeleteDialog
+        title={`Are you sure you want to delete ${segmentToDelete?.name}?`}
+        deleteFunction={async () => {
+          if (segmentToDelete) {
+            await handleDeleteSegment(segmentToDelete.id);
+            setSegmentToDelete(null);
+          }
+        }}
+        isLoading={isDeletingSegment === segmentToDelete?.id}
+        buttonElement={null}
+        externalIsOpen={!!segmentToDelete}
+        externalSetIsOpen={(isOpen) => {
+          if (!isOpen) setSegmentToDelete(null);
+        }}
       />
     </div>
   );

--- a/components/Pages/Admin/CategoryView.tsx
+++ b/components/Pages/Admin/CategoryView.tsx
@@ -1,20 +1,16 @@
 import { Menu, Transition } from "@headlessui/react";
-import {
-  ChevronDownIcon,
-  EllipsisVerticalIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline";
+import { EllipsisVerticalIcon, PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { PencilSquareIcon } from "@heroicons/react/24/solid";
 import Image from "next/image";
 import pluralize from "pluralize";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { pickColor } from "@/components/GrantCard";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { SelectDropdown } from "@/components/ui/select-dropdown";
 import { useGroupedIndicators } from "@/hooks/useGroupedIndicators";
 import type { Category, ImpactSegment } from "@/types/impactMeasurement";
 import fetchData from "@/utilities/fetchData";
@@ -30,74 +26,6 @@ interface CategoryViewProps {
   onRefreshCategory?: () => void;
   communityId: string;
 }
-
-// Custom Dropdown Menu Component
-const DropdownMenu = ({
-  value,
-  onChange,
-  options,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  options: { value: string; label: string }[];
-}) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  const selectedOption = options.find((option) => option.value === value);
-
-  return (
-    <div className="relative" ref={dropdownRef}>
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full px-3 py-2 text-sm font-medium bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-zinc-700 focus:outline-none"
-      >
-        <span>{selectedOption?.label || "Select option"}</span>
-        <ChevronDownIcon
-          className={`ml-2 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
-        />
-      </button>
-
-      {isOpen && (
-        <div className="absolute right-0 z-10 mt-1 w-full bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-lg">
-          <div className="py-1">
-            {options.map((option) => (
-              <button
-                key={option.value}
-                onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
-                }}
-                className={`block w-full text-left px-4 py-2 text-sm ${
-                  value === option.value
-                    ? "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
-                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
 
 export const CategoryView = ({
   selectedCategory,
@@ -255,7 +183,7 @@ export const CategoryView = ({
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">View</span>
             <div className="w-36">
-              <DropdownMenu
+              <SelectDropdown
                 value={viewType}
                 onChange={(value) => setViewType(value as "all" | "output" | "outcome")}
                 options={filterOptions}

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -391,14 +391,11 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                       // Add the new indicator to local state
                       setNewIndicators((prev) => [...prev, indicator]);
 
-                      // Notify parent
-                      if (onIndicatorCreated) {
-                        setTimeout(() => onIndicatorCreated(indicator), 0);
-                      }
+                      // Notify parent callback
+                      onIndicatorCreated?.(indicator);
 
-                      // Close modal and reopen dropdown
+                      // Close modal - dropdown will stay in its current state
                       setIsFormModalOpen(false);
-                      setTimeout(() => setOpen(true), 10);
                     }}
                     onError={(error) => {
                       toast.error(

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -4,8 +4,8 @@ import * as Popover from "@radix-ui/react-popover";
 import { type FC, Fragment, useEffect, useState } from "react";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { ImpactIndicator } from "@/types/impactMeasurement";
 
 interface IndicatorsDropdownProps {
@@ -36,6 +36,10 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
     unitOfMeasure: "int",
     programs: [],
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   // Combine the original indicators with any newly created ones
   const allIndicators = [...indicators, ...newIndicators];
@@ -282,12 +286,17 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                       id="indicators-dropdown-autosynced"
                       value={selectedAutosynced}
                       onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                      disabled={isLoadingAutosynced}
+                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
                     >
-                      <option value="">Create Custom Indicator</option>
+                      <option value="">
+                        {isLoadingAutosynced
+                          ? "Loading autosynced indicators..."
+                          : "Create Custom Indicator"}
+                      </option>
                       {autosyncedIndicators.map((indicator) => (
-                        <option key={indicator.name} value={indicator.name}>
-                          {indicator.description}
+                        <option key={indicator.id || indicator.name} value={indicator.name}>
+                          {indicator.name}
                         </option>
                       ))}
                     </select>

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Switch, Transition } from "@headlessui/react";
+import { Dialog, Transition } from "@headlessui/react";
 import {
   ChevronDownIcon,
   MagnifyingGlassIcon,
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import * as Popover from "@radix-ui/react-popover";
 import { type FC, Fragment, useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
@@ -95,10 +96,10 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
       <button
         key={indicator.id}
         type="button"
-        className="px-4 py-3 w-full hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer flex justify-between items-center gap-3"
+        className="px-4 py-3 w-full hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer flex justify-between items-center gap-3 text-left"
         onClick={() => onIndicatorChange(indicator.id)}
       >
-        <div className="flex-1 text-left min-w-0">
+        <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <p className="font-medium text-sm truncate">{indicator.name}</p>
             {isDefault && (
@@ -114,19 +115,18 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
             </p>
           )}
         </div>
-        <Switch
-          checked={isSelected}
-          onChange={() => onIndicatorChange(indicator.id)}
+        <div
           className={`${
             isSelected ? "bg-blue-600" : "bg-gray-200 dark:bg-zinc-700"
-          } relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2`}
+          } relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors`}
+          aria-hidden="true"
         >
           <span
             className={`${
               isSelected ? "translate-x-6" : "translate-x-1"
             } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
           />
-        </Switch>
+        </div>
       </button>
     );
   };
@@ -372,7 +372,11 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                       setIsFormModalOpen(false);
                       setTimeout(() => setOpen(true), 10);
                     }}
-                    onError={() => {}}
+                    onError={(error) => {
+                      toast.error(
+                        error instanceof Error ? error.message : "Failed to create indicator"
+                      );
+                    }}
                     preventPropagation={true}
                   />
                 </Dialog.Panel>

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -1,7 +1,13 @@
 import { Dialog, Switch, Transition } from "@headlessui/react";
-import { ChevronDownIcon, MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  ChevronDownIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  SparklesIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import * as Popover from "@radix-ui/react-popover";
-import { type FC, Fragment, useEffect, useState } from "react";
+import { type FC, Fragment, useEffect, useMemo, useState } from "react";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
@@ -29,57 +35,51 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
   const [search, setSearch] = useState("");
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
   const [newIndicators, setNewIndicators] = useState<ImpactIndicator[]>([]);
-  const [selectedAutosynced, setSelectedAutosynced] = useState<string>("");
-  const [formDefaultValues, setFormDefaultValues] = useState<Partial<any>>({
-    name: "",
-    description: "",
-    unitOfMeasure: "int",
-    programs: [],
-  });
+  const [activeTab, setActiveTab] = useState<"community" | "default">("community");
 
   // Fetch auto-synced indicators from API
   const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
     useAutosyncedIndicators();
 
   // Combine the original indicators with any newly created ones
-  const allIndicators = [...indicators, ...newIndicators];
+  const allCommunityIndicators = useMemo(() => {
+    const combined = [...indicators, ...newIndicators];
+    // Sort alphabetically
+    return combined.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  }, [indicators, newIndicators]);
 
-  // Sort all indicators alphabetically by name
-  const sortedIndicators = [...allIndicators].sort((a, b) =>
-    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-  );
+  // Filter community indicators based on search
+  const filteredCommunityIndicators = useMemo(() => {
+    if (!search) return allCommunityIndicators;
+    const searchLower = search.toLowerCase();
+    return allCommunityIndicators.filter(
+      (indicator) =>
+        indicator.name.toLowerCase().includes(searchLower) ||
+        indicator.description?.toLowerCase().includes(searchLower)
+    );
+  }, [allCommunityIndicators, search]);
 
-  // Filter indicators based on search - use sorted indicators now
-  const filteredIndicators = sortedIndicators.filter(
-    (indicator) =>
-      indicator.name.toLowerCase().includes(search.toLowerCase()) ||
-      indicator.unitOfMeasure?.toLowerCase().includes(search.toLowerCase())
-  );
+  // Filter default/auto indicators based on search
+  const filteredDefaultIndicators = useMemo(() => {
+    const sorted = [...autosyncedIndicators].sort((a, b) =>
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    );
+    if (!search) return sorted;
+    const searchLower = search.toLowerCase();
+    return sorted.filter(
+      (indicator) =>
+        indicator.name.toLowerCase().includes(searchLower) ||
+        indicator.description?.toLowerCase().includes(searchLower)
+    );
+  }, [autosyncedIndicators, search]);
 
-  // Handle autosynced indicator selection
-  const handleAutosyncedSelect = (name: string) => {
-    if (!name) {
-      setFormDefaultValues({
-        name: "",
-        description: "",
-        unitOfMeasure: "int",
-        programs: [],
-      });
-      setSelectedAutosynced("");
-      return;
-    }
-
-    const selectedIndicator = autosyncedIndicators.find((i) => i.name === name);
-    if (selectedIndicator) {
-      setFormDefaultValues({
-        name: selectedIndicator.name,
-        description: selectedIndicator.description,
-        unitOfMeasure: selectedIndicator.unitOfMeasure as "float" | "int",
-        programs: [],
-      });
-      setSelectedAutosynced(name);
-    }
-  };
+  // Get selected indicator names for display
+  const selectedNames = useMemo(() => {
+    const allIndicators = [...allCommunityIndicators, ...autosyncedIndicators];
+    return selectedIndicators
+      .map((id) => allIndicators.find((i) => i.id === id)?.name)
+      .filter(Boolean);
+  }, [selectedIndicators, allCommunityIndicators, autosyncedIndicators]);
 
   // Clear search when dropdown closes
   useEffect(() => {
@@ -87,6 +87,76 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
       setSearch("");
     }
   }, [open]);
+
+  const renderIndicatorItem = (indicator: ImpactIndicator, isDefault = false) => {
+    const isSelected = selectedIndicators.includes(indicator.id);
+
+    return (
+      <button
+        key={indicator.id}
+        type="button"
+        className="px-4 py-3 w-full hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer flex justify-between items-center gap-3"
+        onClick={() => onIndicatorChange(indicator.id)}
+      >
+        <div className="flex-1 text-left min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="font-medium text-sm truncate">{indicator.name}</p>
+            {isDefault && (
+              <span className="flex-shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                <SparklesIcon className="w-3 h-3 mr-0.5" />
+                Auto
+              </span>
+            )}
+          </div>
+          {indicator.description && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+              {indicator.description}
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={isSelected}
+          onChange={() => onIndicatorChange(indicator.id)}
+          className={`${
+            isSelected ? "bg-blue-600" : "bg-gray-200 dark:bg-zinc-700"
+          } relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2`}
+        >
+          <span
+            className={`${
+              isSelected ? "translate-x-6" : "translate-x-1"
+            } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+          />
+        </Switch>
+      </button>
+    );
+  };
+
+  const renderEmptyState = (isDefault: boolean) => (
+    <div className="px-4 py-8 text-sm text-gray-500 dark:text-gray-400 text-center flex flex-col items-center">
+      <MagnifyingGlassIcon className="h-8 w-8 mb-2 text-gray-300 dark:text-gray-600" />
+      <p className="font-medium">No indicators found</p>
+      <p className="text-xs mt-1">
+        {search
+          ? "Try a different search term"
+          : isDefault
+            ? "No default indicators available"
+            : "Create a custom indicator to get started"}
+      </p>
+      {!isDefault && !search && (
+        <Button
+          onClick={() => {
+            setOpen(false);
+            setIsFormModalOpen(true);
+          }}
+          variant="secondary"
+          className="mt-4 text-xs py-1.5 px-4"
+        >
+          <PlusIcon className="w-4 h-4 mr-1" />
+          Create Custom Indicator
+        </Button>
+      )}
+    </div>
+  );
 
   return (
     <div className="flex flex-col gap-2 w-full">
@@ -104,11 +174,13 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                   Loading indicators...
                 </span>
               ) : selectedIndicators.length > 0 ? (
-                `${selectedIndicators.length} indicator${
-                  selectedIndicators.length > 1 ? "s" : ""
-                } selected`
+                selectedNames.length <= 2 ? (
+                  selectedNames.join(", ")
+                ) : (
+                  `${selectedIndicators.length} indicators selected`
+                )
               ) : (
-                "Search for indicators"
+                "Select indicators"
               )}
             </span>
             <ChevronDownIcon
@@ -121,32 +193,44 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
 
         <Popover.Portal>
           <Popover.Content
-            className="mt-1 w-[var(--radix-popover-trigger-width)] z-50 bg-white border border-zinc-200 dark:border-zinc-700 rounded-md dark:text-white dark:bg-zinc-800 overflow-hidden shadow-lg"
+            className="mt-1 w-[var(--radix-popover-trigger-width)] z-50 bg-white border border-zinc-200 dark:border-zinc-700 rounded-lg dark:text-white dark:bg-zinc-800 overflow-hidden shadow-xl"
             align="start"
             side="bottom"
             sideOffset={5}
             sticky="always"
           >
-            <div className="flex justify-between items-center p-3 border-b border-gray-200 dark:border-gray-700">
-              <span className="text-slate-700 text-sm font-bold dark:text-gray-300">
-                Selected Indicators ({selectedIndicators.length})
+            {/* Header */}
+            <div className="flex justify-between items-center p-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-zinc-900">
+              <span className="text-slate-700 text-sm font-semibold dark:text-gray-300">
+                Assign Indicators
+                {selectedIndicators.length > 0 && (
+                  <span className="ml-2 text-blue-600 dark:text-blue-400">
+                    ({selectedIndicators.length} selected)
+                  </span>
+                )}
               </span>
               <button
-                onClick={() => setIsFormModalOpen(true)}
-                className="text-blue-600 dark:text-blue-200 text-sm font-semibold p-1"
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  setIsFormModalOpen(true);
+                }}
+                className="inline-flex items-center text-blue-600 dark:text-blue-400 text-sm font-medium hover:text-blue-700 dark:hover:text-blue-300"
               >
-                Add indicator
+                <PlusIcon className="w-4 h-4 mr-1" />
+                Create Custom
               </button>
             </div>
 
+            {/* Search */}
             <div className="p-2 border-b border-gray-200 dark:border-gray-700">
               <div className="relative">
                 <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
                   <MagnifyingGlassIcon className="h-4 w-4 text-gray-400" />
                 </div>
                 <input
-                  className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-zinc-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  placeholder="Search for indicators"
+                  className="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-700 rounded-md bg-white dark:bg-zinc-800 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Search indicators..."
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   disabled={isLoading}
@@ -154,53 +238,63 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
               </div>
             </div>
 
-            <div className="max-h-60 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
-              {isLoading ? (
-                <LoadingSpinner size="md" color="blue" message="Loading indicators..." />
-              ) : filteredIndicators.length === 0 ? (
-                <div className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400 text-center flex flex-col items-center">
-                  <MagnifyingGlassIcon className="h-6 w-6 mb-2 text-gray-400" />
-                  <p>No indicators found</p>
-                  <Button
-                    onClick={() => {
-                      setOpen(false);
-                      setIsFormModalOpen(true);
-                    }}
-                    variant="secondary"
-                    className="mt-3 text-xs py-1 px-3"
-                  >
-                    Create new indicator
-                  </Button>
+            {/* Tabs */}
+            <div className="flex border-b border-gray-200 dark:border-gray-700">
+              <button
+                type="button"
+                onClick={() => setActiveTab("community")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+                  activeTab === "community"
+                    ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/20"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                }`}
+              >
+                Community
+                <span className="ml-1.5 text-xs text-gray-400">
+                  ({filteredCommunityIndicators.length})
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("default")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors ${
+                  activeTab === "default"
+                    ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/20"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                }`}
+              >
+                <SparklesIcon className="w-4 h-4 inline mr-1" />
+                Default
+                <span className="ml-1.5 text-xs text-gray-400">
+                  ({filteredDefaultIndicators.length})
+                </span>
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="max-h-64 overflow-y-auto">
+              {isLoading || isLoadingAutosynced ? (
+                <div className="py-8">
+                  <LoadingSpinner size="md" color="blue" message="Loading indicators..." />
                 </div>
+              ) : activeTab === "community" ? (
+                filteredCommunityIndicators.length === 0 ? (
+                  renderEmptyState(false)
+                ) : (
+                  <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                    {filteredCommunityIndicators.map((indicator) =>
+                      renderIndicatorItem(indicator, false)
+                    )}
+                  </div>
+                )
+              ) : filteredDefaultIndicators.length === 0 ? (
+                renderEmptyState(true)
               ) : (
-                filteredIndicators.map((indicator) => (
-                  <button
-                    key={indicator.id}
-                    className="px-4 py-3 w-full flex-1 hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer flex justify-between items-center"
-                    onClick={() => onIndicatorChange(indicator.id)}
-                  >
-                    <div className="flex-1 text-left">
-                      <p className="font-medium text-sm">{indicator.name}</p>
-                    </div>
-                    <Switch
-                      checked={selectedIndicators.includes(indicator.id)}
-                      onChange={() => onIndicatorChange(indicator.id)}
-                      className={`${
-                        selectedIndicators.includes(indicator.id)
-                          ? "bg-blue-600"
-                          : "bg-gray-200 dark:bg-zinc-700"
-                      } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2`}
-                    >
-                      <span
-                        className={`${
-                          selectedIndicators.includes(indicator.id)
-                            ? "translate-x-6"
-                            : "translate-x-1"
-                        } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
-                      />
-                    </Switch>
-                  </button>
-                ))
+                <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                  {filteredDefaultIndicators.map((indicator) =>
+                    renderIndicatorItem(indicator, true)
+                  )}
+                </div>
               )}
             </div>
 
@@ -209,23 +303,9 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
         </Popover.Portal>
       </Popover.Root>
 
-      {/* Modal for creating new indicator */}
+      {/* Modal for creating CUSTOM indicator only */}
       <Transition appear show={isFormModalOpen} as={Fragment}>
-        <Dialog
-          as="div"
-          className="relative z-50"
-          onClose={() => {
-            setIsFormModalOpen(false);
-            // Reset form values and selected autosynced when closing modal
-            setFormDefaultValues({
-              name: "",
-              description: "",
-              unitOfMeasure: "int",
-              programs: [],
-            });
-            setSelectedAutosynced("");
-          }}
-        >
+        <Dialog as="div" className="relative z-50" onClose={() => setIsFormModalOpen(false)}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -253,101 +333,46 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                   <div className="flex justify-between items-center mb-4">
                     <Dialog.Title
                       as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900 dark:text-white"
+                      className="text-lg font-semibold text-gray-900 dark:text-white"
                     >
-                      Create New Indicator
+                      Create Custom Indicator
                     </Dialog.Title>
                     <button
-                      onClick={() => {
-                        setIsFormModalOpen(false);
-                        setFormDefaultValues({
-                          name: "",
-                          description: "",
-                          unitOfMeasure: "int",
-                          programs: [],
-                        });
-                        setSelectedAutosynced("");
-                      }}
-                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                      type="button"
+                      onClick={() => setIsFormModalOpen(false)}
+                      className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
                     >
                       <XMarkIcon className="h-5 w-5" />
                     </button>
                   </div>
 
-                  {/* Add autosynced indicator selector */}
-                  <div className="mb-4">
-                    <label
-                      htmlFor="indicators-dropdown-autosynced"
-                      className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300"
-                    >
-                      Select Autosynced Indicator (Optional)
-                    </label>
-                    <select
-                      id="indicators-dropdown-autosynced"
-                      value={selectedAutosynced}
-                      onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                      disabled={isLoadingAutosynced}
-                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
-                    >
-                      <option value="">
-                        {isLoadingAutosynced
-                          ? "Loading autosynced indicators..."
-                          : "Create Custom Indicator"}
-                      </option>
-                      {autosyncedIndicators.map((indicator) => (
-                        <option key={indicator.id || indicator.name} value={indicator.name}>
-                          {indicator.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                    Create a new custom indicator for your community. For system metrics like GitHub
+                    stats or transactions, use the &quot;Default&quot; tab instead.
+                  </p>
 
                   <IndicatorForm
                     communityId={communityId}
-                    defaultValues={formDefaultValues}
-                    readOnlyFields={{
-                      name: !!selectedAutosynced,
-                      description: !!selectedAutosynced,
-                      unitOfMeasure: !!selectedAutosynced,
+                    defaultValues={{
+                      name: "",
+                      description: "",
+                      unitOfMeasure: "int",
+                      programs: [],
                     }}
                     onSuccess={(indicator) => {
-                      // Prevent event bubbling if any
-                      if (event) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                      }
-
-                      // Add the new indicator to our local state
+                      // Add the new indicator to local state
                       setNewIndicators((prev) => [...prev, indicator]);
 
-                      // Reset form values and selected autosynced
-                      setFormDefaultValues({
-                        name: "",
-                        description: "",
-                        unitOfMeasure: "int",
-                        programs: [],
-                      });
-                      setSelectedAutosynced("");
-
-                      // Only notify parent of new indicator without causing form submission
+                      // Notify parent
                       if (onIndicatorCreated) {
-                        // Use setTimeout to break the event chain
-                        setTimeout(() => {
-                          onIndicatorCreated(indicator);
-                        }, 0);
+                        setTimeout(() => onIndicatorCreated(indicator), 0);
                       }
 
-                      // Close the form modal
+                      // Close modal and reopen dropdown
                       setIsFormModalOpen(false);
-
-                      // Keep dropdown open
-                      setTimeout(() => {
-                        setOpen(true);
-                      }, 10);
+                      setTimeout(() => setOpen(true), 10);
                     }}
-                    onError={() => {
-                      // Handle error
-                    }}
+                    onError={() => {}}
                     preventPropagation={true}
                   />
                 </Dialog.Panel>

--- a/components/Pages/Admin/IndicatorsHub.tsx
+++ b/components/Pages/Admin/IndicatorsHub.tsx
@@ -118,7 +118,7 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
         </h3>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
           Create a custom indicator specific to your community. For system metrics like GitHub stats
-          or transactions, use the &quot;Default&quot; indicators when creating activities or
+          or transactions, use the &quot;System&quot; indicators when creating activities or
           outcomes.
         </p>
         <div className="space-y-4">

--- a/components/Pages/Admin/IndicatorsHub.tsx
+++ b/components/Pages/Admin/IndicatorsHub.tsx
@@ -8,6 +8,7 @@ import { DeleteDialog } from "@/components/DeleteDialog";
 import { IndicatorForm, type IndicatorFormData } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useIndicators } from "@/hooks/useIndicators";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
@@ -23,87 +24,6 @@ interface Program {
 type IndicatorWithPrograms = Indicator & {
   programs?: Program[];
 };
-
-export const autosyncedIndicators: IndicatorWithPrograms[] = [
-  {
-    name: "No. of Transactions",
-    id: "",
-    description: "No. of transactions",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "active_developers",
-    id: "",
-    description: "No. of active developers (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "PULL_REQUEST_MERGED",
-    id: "",
-    description: "Number of pull requests merged (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_OPENED",
-    id: "",
-    description: "Number of issues opened (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "FORKED",
-    id: "",
-    description: "Number of repository forks (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_CLOSED",
-    id: "",
-    description: "Number of issues closed (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "ISSUE_COMMENT",
-    id: "",
-    description: "Number of comments on issues (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "STARRED",
-    id: "",
-    description: "Number of repository stars (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "GitHub Commits",
-    id: "",
-    description: "Number of code commits (*github)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "PULL_REQUEST_OPENED",
-    id: "",
-    description: "Number of pull requests opened (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "GitHub Merged PRs",
-    id: "",
-    description: "Number of pull requests merged (*github)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "RELEASE_PUBLISHED",
-    id: "",
-    description: "Number of releases published (*oso)",
-    unitOfMeasure: "int",
-  },
-  {
-    name: "contributors",
-    id: "",
-    description: "No. of contributors (*oso)",
-    unitOfMeasure: "int",
-  },
-];
 
 interface IndicatorsHubProps {
   communitySlug: string;
@@ -125,6 +45,8 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
   const { data: rawIndicators = [], refetch } = useIndicators({
     communityId,
   });
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   const indicators = rawIndicators as IndicatorWithPrograms[];
 
@@ -233,12 +155,17 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
                 id="indicators-hub-autosynced"
                 value={selectedAutosynced}
                 onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                disabled={isLoadingAutosynced}
+                className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
               >
-                <option value="">Create Custom Indicator</option>
+                <option value="">
+                  {isLoadingAutosynced
+                    ? "Loading autosynced indicators..."
+                    : "Create Custom Indicator"}
+                </option>
                 {autosyncedIndicators.map((indicator) => (
-                  <option key={indicator.name} value={indicator.name}>
-                    {indicator.description}
+                  <option key={indicator.id || indicator.name} value={indicator.name}>
+                    {indicator.name}
                   </option>
                 ))}
               </select>

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -172,7 +172,7 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
 
   // Check if an indicator is autosynced (based on syncType field)
   const isAutosyncedIndicator = (indicator: ImpactIndicator) => {
-    return (indicator as any).syncType === "auto";
+    return indicator.syncType === "auto";
   };
 
   // Filter indicators based on search and view type
@@ -241,7 +241,7 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
                     <span className="text-xs bg-white dark:bg-zinc-800 px-2 py-0.5 rounded-full border border-gray-200 dark:border-zinc-700 inline-block">
                       {indicator.unitOfMeasure || "N/A"}
                     </span>
-                    {(indicator as any).syncType === "auto" && (
+                    {indicator.syncType === "auto" && (
                       <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 rounded-full inline-block">
                         Auto
                       </span>
@@ -475,12 +475,6 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
                     communityId={communityId}
                     defaultValues={formDefaultValues}
                     onSuccess={(indicator) => {
-                      // Prevent event bubbling if any
-                      if (event) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                      }
-
                       // Add the new indicator to our local state
                       setNewIndicators((prev) => [...prev, indicator]);
 

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -1,87 +1,20 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { ChevronDownIcon, PlusIcon, TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { PlusIcon, TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
-import { IndicatorForm } from "@/components/Forms/IndicatorForm";
+import { IndicatorForm, type IndicatorFormData } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { SelectDropdown } from "@/components/ui/select-dropdown";
 import { useGroupedIndicators } from "@/hooks/useGroupedIndicators";
 import type { Category, ImpactIndicator, ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
-
-// Custom Dropdown Menu Component - copied from CategoryView.tsx
-const DropdownMenu = ({
-  value,
-  onChange,
-  options,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  options: { value: string; label: string }[];
-}) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  const selectedOption = options.find((option) => option.value === value);
-
-  return (
-    <div className="relative" ref={dropdownRef}>
-      <button
-        type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full px-3 py-2 text-sm font-medium bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-zinc-700 focus:outline-none"
-      >
-        <span>{selectedOption?.label || "Select option"}</span>
-        <ChevronDownIcon
-          className={`ml-2 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
-        />
-      </button>
-
-      {isOpen && (
-        <div className="absolute right-0 z-10 mt-1 w-full bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-lg">
-          <div className="py-1">
-            {options.map((option) => (
-              <button
-                key={option.value}
-                onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
-                }}
-                className={`block w-full text-left px-4 py-2 text-sm ${
-                  value === option.value
-                    ? "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
-                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
 
 interface IndicatorsViewProps {
   categories: Category[];
@@ -94,7 +27,7 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
   const [indicatorViewType, setIndicatorViewType] = useState<"all" | "automated" | "manual">("all");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
-  const [formDefaultValues, setFormDefaultValues] = useState<Partial<any>>({
+  const [formDefaultValues, setFormDefaultValues] = useState<Partial<IndicatorFormData>>({
     name: "",
     description: "",
     unitOfMeasure: "int",
@@ -318,9 +251,9 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">View</span>
                 <div className="w-36">
-                  <DropdownMenu
+                  <SelectDropdown
                     value={indicatorViewType}
-                    onChange={(value: any) =>
+                    onChange={(value) =>
                       setIndicatorViewType(value as "all" | "automated" | "manual")
                     }
                     options={filterOptions}
@@ -467,7 +400,7 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
 
                   <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
                     Create a custom indicator for your community. For system metrics like GitHub
-                    stats or transactions, use the &quot;Default&quot; indicators when creating
+                    stats or transactions, use the &quot;System&quot; indicators when creating
                     activities or outcomes.
                   </p>
 

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Dialog, Transition } from "@headlessui/react";
 import { PlusIcon, TrashIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -7,9 +7,9 @@ import { useAccount } from "wagmi";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { LoadingSpinner } from "@/components/Disbursement/components/LoadingSpinner";
 import { IndicatorForm } from "@/components/Forms/IndicatorForm";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useGroupedIndicators } from "@/hooks/useGroupedIndicators";
 import type { Category, ImpactIndicator, ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import fetchData from "@/utilities/fetchData";
@@ -120,6 +120,10 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
   } = useGroupedIndicators({
     communityId: communityId || "",
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [], isLoading: isLoadingAutosynced } =
+    useAutosyncedIndicators();
 
   // Handle autosynced indicator selection
   const handleAutosyncedSelect = (name: string) => {
@@ -506,12 +510,17 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
                       id="indicators-view-autosynced"
                       value={selectedAutosynced}
                       onChange={(e) => handleAutosyncedSelect(e.target.value)}
-                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700"
+                      disabled={isLoadingAutosynced}
+                      className="w-full p-2 border rounded-md bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-700 disabled:opacity-50"
                     >
-                      <option value="">Create Custom Indicator</option>
+                      <option value="">
+                        {isLoadingAutosynced
+                          ? "Loading autosynced indicators..."
+                          : "Create Custom Indicator"}
+                      </option>
                       {autosyncedIndicators.map((indicator) => (
-                        <option key={indicator.name} value={indicator.name}>
-                          {indicator.description}
+                        <option key={indicator.id || indicator.name} value={indicator.name}>
+                          {indicator.name}
                         </option>
                       ))}
                     </select>

--- a/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
@@ -131,7 +131,7 @@ export const FilteredOutputsAndOutcomes = ({
         }))
       );
     }
-  }, [filteredAnswers, forms.reduce]);
+  }, [filteredAnswers, forms.length]);
 
   const handleSubmit = async (id: string) => {
     const form = forms.find((f) => f.id === id);
@@ -592,8 +592,16 @@ export const FilteredOutputsAndOutcomes = ({
                                       </td>
                                       <td className="px-4 py-2">
                                         {form?.isEditing && isAuthorized ? (
-                                          <button onClick={() => handleDeleteEntry(item.id, index)}>
-                                            <TrashIcon className="w-4 h-4 text-red-500" />
+                                          <button
+                                            type="button"
+                                            onClick={() => handleDeleteEntry(item.id, index)}
+                                            aria-label={`Delete entry ${index + 1}`}
+                                            className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/20 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
+                                          >
+                                            <TrashIcon
+                                              className="w-4 h-4 text-red-500"
+                                              aria-hidden="true"
+                                            />
                                           </button>
                                         ) : null}
                                       </td>

--- a/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
@@ -5,8 +5,8 @@ import { AreaChart, Card, Title } from "@tremor/react";
 import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useCommunityAdminStore } from "@/store/communityAdmin";
@@ -86,6 +86,9 @@ export const FilteredOutputsAndOutcomes = ({
     projectIdentifier: project?.uid as string,
     enabled: !!project?.uid && !!indicatorIds?.length && !!indicatorNames?.length,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   // Filter indicators based on IDs and names
   const filteredAnswers = useMemo(() => {

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -6,8 +6,8 @@ import { AreaChart, Card, Title } from "@tremor/react";
 import { Fragment, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
-import { autosyncedIndicators } from "@/components/Pages/Admin/IndicatorsHub";
 import { Button } from "@/components/Utilities/Button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import { useImpactAnswers } from "@/hooks/useImpactAnswers";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useCommunityAdminStore } from "@/store/communityAdmin";
@@ -50,6 +50,9 @@ export const OutputsAndOutcomes = () => {
     projectIdentifier: project?.uid as string,
     enabled: !!project?.uid,
   });
+
+  // Fetch auto-synced indicators from API
+  const { data: autosyncedIndicators = [] } = useAutosyncedIndicators();
 
   const handleSubmit = async (id: string) => {
     const form = forms.find((f) => f.id === id);

--- a/components/ui/select-dropdown.tsx
+++ b/components/ui/select-dropdown.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/utilities/tailwind";
+
+export interface SelectDropdownOption {
+  value: string;
+  label: string;
+}
+
+interface SelectDropdownProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectDropdownOption[];
+  placeholder?: string;
+  className?: string;
+}
+
+export const SelectDropdown = ({
+  value,
+  onChange,
+  options,
+  placeholder = "Select option",
+  className,
+}: SelectDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <div className={cn("relative", className)} ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full px-3 py-2 text-sm font-medium bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-zinc-700 focus:outline-none"
+      >
+        <span>{selectedOption?.label || placeholder}</span>
+        <ChevronDownIcon
+          className={`ml-2 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-10 mt-1 w-full bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-md shadow-lg">
+          <div className="py-1">
+            {options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+                className={`block w-full text-left px-4 py-2 text-sm ${
+                  value === option.value
+                    ? "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-700"
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/cypress/e2e/navbar/visual-regression.cy.ts
+++ b/cypress/e2e/navbar/visual-regression.cy.ts
@@ -152,7 +152,8 @@ describe("Navbar UI States", () => {
       cy.visit("/");
       waitForPageLoad();
 
-      cy.contains("Sign in").should("be.visible");
+      // Use filter to find the visible Sign in button (mobile has its own button separate from desktop)
+      cy.contains("button", "Sign in").filter(":visible").should("exist");
     });
   });
 });

--- a/hooks/useAutosyncedIndicators.ts
+++ b/hooks/useAutosyncedIndicators.ts
@@ -1,69 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import fetchData from "@/utilities/fetchData";
-import { INDEXER } from "@/utilities/indexer";
-import type { Indicator, PaginatedResponse } from "@/utilities/queries/getIndicatorsByCommunity";
-
-interface V2Indicator {
-  id: string;
-  name: string;
-  description: string;
-  unitOfMeasure: string;
-  programs?: { programId: number; chainID: number }[] | null;
-  communityUID?: string | null;
-  syncType?: "auto" | "manual";
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-function transformIndicator(v2Indicator: V2Indicator): Indicator {
-  return {
-    ...v2Indicator,
-    programs:
-      v2Indicator.programs?.map((p) => ({
-        programId: String(p.programId),
-        chainID: p.chainID,
-      })) || undefined,
-  };
-}
+import {
+  getAutosyncedIndicators,
+  type Indicator,
+} from "@/utilities/queries/getIndicatorsByCommunity";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 /**
- * Fetch all auto-synced (system) indicators
+ * Hook to fetch auto-synced (system) indicators from the API
  * These are indicators with syncType='auto' that are managed by the system
- */
-async function fetchAutosyncedIndicators(): Promise<Indicator[]> {
-  const allIndicators: Indicator[] = [];
-  let currentPage = 1;
-  let hasMore = true;
-  const pageSize = 100;
-  const maxPages = 10; // Safety limit
-
-  while (hasMore && currentPage <= maxPages) {
-    const [data, error] = await fetchData(
-      INDEXER.INDICATORS.V2.LIST({ syncType: "auto", page: currentPage, limit: pageSize })
-    );
-
-    if (error) {
-      throw error;
-    }
-
-    const paginatedData = data as PaginatedResponse<V2Indicator>;
-    const indicators = (paginatedData.payload || []).map(transformIndicator);
-    allIndicators.push(...indicators);
-
-    hasMore = paginatedData.pagination.hasNextPage;
-    currentPage++;
-  }
-
-  return allIndicators;
-}
-
-/**
- * Hook to fetch auto-synced indicators from the API
  */
 export const useAutosyncedIndicators = () => {
   return useQuery<Indicator[]>({
-    queryKey: ["indicators", "autosynced"],
-    queryFn: fetchAutosyncedIndicators,
+    queryKey: QUERY_KEYS.INDICATORS.AUTOSYNCED,
+    queryFn: getAutosyncedIndicators,
     staleTime: 5 * 60 * 1000, // 5 minutes - these don't change often
   });
 };

--- a/hooks/useAutosyncedIndicators.ts
+++ b/hooks/useAutosyncedIndicators.ts
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type { Indicator, PaginatedResponse } from "@/utilities/queries/getIndicatorsByCommunity";
+
+interface V2Indicator {
+  id: string;
+  name: string;
+  description: string;
+  unitOfMeasure: string;
+  programs?: { programId: number; chainID: number }[] | null;
+  communityUID?: string | null;
+  syncType?: "auto" | "manual";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function transformIndicator(v2Indicator: V2Indicator): Indicator {
+  return {
+    ...v2Indicator,
+    programs:
+      v2Indicator.programs?.map((p) => ({
+        programId: String(p.programId),
+        chainID: p.chainID,
+      })) || undefined,
+  };
+}
+
+/**
+ * Fetch all auto-synced (system) indicators
+ * These are indicators with syncType='auto' that are managed by the system
+ */
+async function fetchAutosyncedIndicators(): Promise<Indicator[]> {
+  const allIndicators: Indicator[] = [];
+  let currentPage = 1;
+  let hasMore = true;
+  const pageSize = 100;
+  const maxPages = 10; // Safety limit
+
+  while (hasMore && currentPage <= maxPages) {
+    const [data, error] = await fetchData(
+      INDEXER.INDICATORS.V2.LIST({ syncType: "auto", page: currentPage, limit: pageSize })
+    );
+
+    if (error) {
+      throw error;
+    }
+
+    const paginatedData = data as PaginatedResponse<V2Indicator>;
+    const indicators = (paginatedData.payload || []).map(transformIndicator);
+    allIndicators.push(...indicators);
+
+    hasMore = paginatedData.pagination.hasNextPage;
+    currentPage++;
+  }
+
+  return allIndicators;
+}
+
+/**
+ * Hook to fetch auto-synced indicators from the API
+ */
+export const useAutosyncedIndicators = () => {
+  return useQuery<Indicator[]>({
+    queryKey: ["indicators", "autosynced"],
+    queryFn: fetchAutosyncedIndicators,
+    staleTime: 5 * 60 * 1000, // 5 minutes - these don't change often
+  });
+};

--- a/types/impactMeasurement.ts
+++ b/types/impactMeasurement.ts
@@ -52,6 +52,7 @@ export interface ImpactIndicator {
     chainID: number;
   }[];
   unitOfMeasure: string;
+  syncType?: "auto" | "manual";
   createdAt?: string;
   updatedAt?: string;
 }

--- a/utilities/queries/getIndicatorsByCommunity.ts
+++ b/utilities/queries/getIndicatorsByCommunity.ts
@@ -196,3 +196,16 @@ export const getIndicatorById = async (indicatorId: string): Promise<Indicator |
     return null;
   }
 };
+
+/**
+ * Get all auto-synced (system) indicators
+ * These are indicators with syncType='auto' that are managed by the system
+ */
+export const getAutosyncedIndicators = async (): Promise<Indicator[]> => {
+  try {
+    return await fetchAllIndicatorPages({ syncType: "auto" });
+  } catch (error) {
+    errorManager("Error fetching autosynced indicators", error);
+    return [];
+  }
+};

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -62,23 +62,6 @@ export const QUERY_KEYS = {
   SEARCH: {
     PROJECTS: (query: string) => ["search-projects", query] as const,
   },
-  INDICATORS: {
-    AGGREGATED: (params: {
-      indicatorIds: string;
-      communityId: string;
-      programId: string;
-      projectUID: string;
-      timeframe: string;
-    }) =>
-      [
-        "aggregated-indicators",
-        params.indicatorIds,
-        params.communityId,
-        params.programId,
-        params.projectUID,
-        params.timeframe,
-      ] as const,
-  },
   PROJECT: {
     UPDATES: (projectIdOrSlug: string) => ["project-updates", projectIdOrSlug] as const,
     IMPACTS: (projectIdOrSlug: string) => ["project-impacts", projectIdOrSlug] as const,

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -85,6 +85,9 @@ export const QUERY_KEYS = {
     MILESTONES: (projectIdOrSlug: string) => ["project-milestones", projectIdOrSlug] as const,
     GRANTS: (projectIdOrSlug: string) => ["project-grants", projectIdOrSlug] as const,
   },
+  INDICATORS: {
+    AUTOSYNCED: ["indicators", "autosynced"] as const,
+  },
   FUNDING_PLATFORM: {
     APPLICATIONS: (programId: string, chainId: number, filters?: unknown) =>
       ["applications", programId, chainId, filters] as const,

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -87,6 +87,21 @@ export const QUERY_KEYS = {
   },
   INDICATORS: {
     AUTOSYNCED: ["indicators", "autosynced"] as const,
+    AGGREGATED: (params: {
+      indicatorIds: string;
+      communityId: string;
+      programId: string;
+      projectUID: string;
+      timeframe: string;
+    }) =>
+      [
+        "aggregated-indicators",
+        params.indicatorIds,
+        params.communityId,
+        params.programId,
+        params.projectUID,
+        params.timeframe,
+      ] as const,
   },
   FUNDING_PLATFORM: {
     APPLICATIONS: (programId: string, chainId: number, filters?: unknown) =>


### PR DESCRIPTION
## Summary

- Integrated dynamic auto-synced indicators fetching from `/v2/indicators/autosynced` endpoint, replacing hardcoded indicator lists
- Improved the "Add Activity/Outcome" modal UX with a cleaner two-tab design for indicator selection
- Fixed the delete confirmation modal blinking issue when deleting segments

## Changes Made

### Auto-Synced Indicators Integration
- Created `useAutosyncedIndicators` hook to fetch indicators with `syncType: "auto"` from the backend
- Updated `IndicatorsDropdown.tsx` with a two-tab design:
  - **Community tab**: Shows indicators created specifically for the community
  - **Default tab**: Shows system-wide auto-synced indicators (OSO, GitHub, Etherscan metrics)
- Selecting a default indicator now directly uses its existing ID instead of creating a duplicate

### Admin Pages Cleanup
- `IndicatorsHub.tsx` (Manage Indicators): Removed autosynced dropdown from creation form - now only allows creating custom indicators
- `IndicatorsView.tsx` (View All): Removed autosynced dropdown - displays "Auto" badge based on `indicator.syncType` property
- Added helper text guiding users to use the "Default" tab when creating activities/outcomes

### Delete Modal Fix
- Fixed `DeleteDialog.tsx` to properly support controlled state via `externalIsOpen` prop
- Added `stopPropagation` to prevent event bubbling in nested menu contexts
- Refactored `CategoryView.tsx` to render the delete dialog outside the dropdown menu, preventing unmount issues

## Files Modified

- `components/DeleteDialog.tsx` - Fixed controlled state handling and event propagation
- `components/Pages/Admin/CategoryView.tsx` - Lifted delete dialog state out of menu
- `components/Pages/Admin/IndicatorsDropdown.tsx` - New two-tab indicator selection UI
- `components/Pages/Admin/IndicatorsHub.tsx` - Removed autosynced dropdown, custom-only creation
- `components/Pages/Admin/IndicatorsView.tsx` - Removed autosynced dropdown, syncType-based badge
- `hooks/useAutosyncedIndicators.ts` - New hook for fetching auto-synced indicators

## Testing Notes

- [ ] Verify "Add Activity/Outcome" modal shows two tabs (Community/Default)
- [ ] Verify selecting a Default indicator uses existing ID (no duplicate created)
- [ ] Verify delete confirmation modal opens and stays open until action is taken
- [ ] Verify "Manage Indicators" page only allows custom indicator creation
- [ ] Verify "Auto" badge displays correctly for auto-synced indicators

## Breaking Changes

None - this is a UX improvement and bug fix release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Central autosynced indicators source and "Auto" badges across the app
  * New dropdown + tabbed indicator picker with debounced search and improved indicator creation flow

* **Improvements**
  * Clearer separation of autosynced vs custom indicators; UI text updated (e.g., "Create Custom Indicator")
  * Autosynced indicators excluded from project update submissions
  * Delete confirmation dialog moved out of menus to prevent accidental dismissal

* **Other**
  * Indicators now include optional metadata to mark auto vs manual sync status

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->