### PR TITLE
fix: improve impact chart number and date formatting

### DIFF
--- a/components/Pages/Communities/Impact/AggregateCategoryRow.tsx
+++ b/components/Pages/Communities/Impact/AggregateCategoryRow.tsx
@@ -24,6 +24,7 @@ export const prepareChartData = (
   const timestampsData = timestamps
     .map((timestamp, index) => {
       return {
+        rawTimestamp: timestamp, // Keep original for sorting
         date: formatDate(new Date(timestamp), "UTC"),
         Avg: Number(avg_values[index]) || 0,
         Total: Number(total_values[index]) || 0,
@@ -31,7 +32,8 @@ export const prepareChartData = (
         Max: Number(max_values[index]) || 0,
       };
     })
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .sort((a, b) => new Date(a.rawTimestamp).getTime() - new Date(b.rawTimestamp).getTime())
+    .map(({ rawTimestamp: _, ...rest }) => rest); // Remove rawTimestamp from output
   return timestampsData;
 };
 
@@ -83,8 +85,8 @@ const AggregateMetricCard = ({
       index={"date"}
       categories={["Avg", "Total", "Min", "Max"]}
       colors={["blue", "green", "red", "yellow"]}
-      valueFormatter={(value) => `${formatCurrency(value)}`}
-      yAxisWidth={40}
+      valueFormatter={(value) => formatCurrency(value)}
+      yAxisWidth={80}
       enableLegendSlider
       noDataText="Awaiting grantees to submit values"
     />

--- a/components/Pages/Communities/Impact/CategoryRow.tsx
+++ b/components/Pages/Communities/Impact/CategoryRow.tsx
@@ -9,6 +9,7 @@ import { useAggregatedIndicators } from "@/hooks/useAggregatedIndicators";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import type { ProgramImpactDataResponse, ProgramImpactSegment } from "@/types/programs";
 import formatCurrency from "@/utilities/formatCurrency";
+import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { SegmentSkeleton } from "./SegmentSkeleton";
 import { type TimeframeOption, TimeframeSelector, timeframeOptions } from "./TimeframeSelector";
@@ -26,26 +27,31 @@ const prepareAggregatedChartData = (indicators: any[]) => {
   if (!indicators.length) return [];
 
   // Combine all datapoints from all indicators into a single timeline
+  // Use rawDate for sorting and date for display
   const allDatapoints: any[] = [];
 
   indicators.forEach((indicator) => {
     indicator.aggregatedData.forEach((datapoint: any) => {
-      const existingIndex = allDatapoints.findIndex((dp) => dp.date === datapoint.timestamp);
+      const formattedDate = formatDate(new Date(datapoint.timestamp), "UTC");
+      const existingIndex = allDatapoints.findIndex((dp) => dp.rawDate === datapoint.timestamp);
       if (existingIndex >= 0) {
         // Add this indicator's value to existing timestamp
         allDatapoints[existingIndex][indicator.name] = datapoint.value;
       } else {
-        // Create new datapoint entry
-        const newDatapoint: any = { date: datapoint.timestamp };
+        // Create new datapoint entry with formatted date for display
+        const newDatapoint: any = {
+          rawDate: datapoint.timestamp,
+          date: formattedDate,
+        };
         newDatapoint[indicator.name] = datapoint.value;
         allDatapoints.push(newDatapoint);
       }
     });
   });
 
-  // Sort by date and fill missing values with 0
+  // Sort by rawDate (original timestamp) and fill missing values with 0
   const sortedData = allDatapoints.sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    (a, b) => new Date(a.rawDate).getTime() - new Date(b.rawDate).getTime()
   );
   const indicatorNames = indicators.map((ind) => ind.name);
 
@@ -56,7 +62,9 @@ const prepareAggregatedChartData = (indicators: any[]) => {
         filledDatapoint[name] = 0;
       }
     });
-    return filledDatapoint;
+    // Remove rawDate from final output, keep only formatted date
+    const { rawDate: _, ...displayDatapoint } = filledDatapoint;
+    return displayDatapoint;
   });
 };
 
@@ -196,8 +204,8 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
                 index="date"
                 categories={indicatorNames}
                 colors={colors.slice(0, indicatorNames.length)}
-                valueFormatter={(value) => `${formatCurrency(value)}`}
-                yAxisWidth={60}
+                valueFormatter={(value) => formatCurrency(value)}
+                yAxisWidth={80}
                 enableLegendSlider
                 noDataText="No data available for the selected period"
                 className="h-72"

--- a/components/Pages/Communities/Impact/ImpactCharts.tsx
+++ b/components/Pages/Communities/Impact/ImpactCharts.tsx
@@ -19,6 +19,7 @@ export const prepareChartData = (
     .map((timestamp, index) => {
       if (runningValues?.length) {
         return {
+          rawTimestamp: timestamp, // Keep original for sorting
           date: formatDate(new Date(timestamp), "UTC"),
           [name]: Number(values[index]) || 0,
           Cumulative: Number(runningValues[index]) || 0,
@@ -26,12 +27,14 @@ export const prepareChartData = (
         };
       }
       return {
+        rawTimestamp: timestamp, // Keep original for sorting
         date: formatDate(new Date(timestamp), "UTC"),
         [name]: Number(values[index]) || 0,
         proof: proofs?.[index] || "",
       };
     })
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .sort((a, b) => new Date(a.rawTimestamp).getTime() - new Date(b.rawTimestamp).getTime())
+    .map(({ rawTimestamp: _, ...rest }) => rest); // Remove rawTimestamp from output
   return chartData;
 };
 

--- a/utilities/__tests__/formatCurrency.test.ts
+++ b/utilities/__tests__/formatCurrency.test.ts
@@ -104,11 +104,19 @@ describe("formatCurrency", () => {
   describe("Very large numbers", () => {
     it("should handle quadrillions (P)", () => {
       expect(formatCurrency(1000000000000000)).toBe("1P");
+      expect(formatCurrency(1500000000000000)).toBe("1.5P");
     });
 
     it("should handle quintillions (E)", () => {
-      // JavaScript number precision limit reached - formatted as string
-      expect(formatCurrency(1000000000000000000)).toBe("1000000000000000000");
+      // Exa range (10^18) - common for blockchain Wei values
+      expect(formatCurrency(1000000000000000000)).toBe("1E");
+      expect(formatCurrency(3700000000000000000)).toBe("3.7E");
+    });
+
+    it("should handle very large Wei-scale values", () => {
+      // Real-world example: Transaction fees in Wei
+      // 3724584981882890000 is approximately 3.72 ETH worth of Wei
+      expect(formatCurrency(3724584981882890000)).toBe("3.7E");
     });
   });
 

--- a/utilities/formatCurrency.ts
+++ b/utilities/formatCurrency.ts
@@ -1,32 +1,77 @@
 import millify from "millify";
 
+/**
+ * Format large numbers for display using K, M, B, T, P, E suffixes.
+ * Handles very large numbers (up to Exa = 10^18) which are common for
+ * blockchain values like Wei.
+ */
 export default function formatCurrency(value: number) {
-  let result = "";
   if (value === 0) {
-    result = "0";
-  } else if (value < 1) {
-    result = Number(value)?.toFixed(2);
-  } else {
-    try {
-      result = millify(value, {
-        precision: 1,
-        units: ["", "K", "M", "B", "T", "P", "E"],
-        lowercase: false,
-      });
-    } catch (_error) {
-      // Fallback if millify fails (e.g., locale issues in test environments)
-      if (value >= 1000000000000) {
-        result = `${(value / 1000000000000).toFixed(1)}T`;
-      } else if (value >= 1000000000) {
-        result = `${(value / 1000000000).toFixed(1)}B`;
-      } else if (value >= 1000000) {
-        result = `${(value / 1000000).toFixed(1)}M`;
-      } else if (value >= 1000) {
-        result = `${(value / 1000).toFixed(1)}K`;
-      } else {
-        result = value.toString();
+    return "0";
+  }
+
+  if (value < 1) {
+    return Number(value)?.toFixed(2);
+  }
+
+  // Use custom formatting for very large numbers to avoid precision issues
+  // JavaScript's MAX_SAFE_INTEGER is ~9 * 10^15, so we handle large numbers manually
+  return formatLargeNumber(value);
+}
+
+/**
+ * Format large numbers with K, M, B, T, P, E suffixes.
+ * Handles numbers up to 10^18 (Exa) range.
+ */
+function formatLargeNumber(value: number): string {
+  // Define thresholds and suffixes (ordered from largest to smallest)
+  const tiers = [
+    { threshold: 1e18, suffix: "E" }, // Exa (10^18)
+    { threshold: 1e15, suffix: "P" }, // Peta (10^15)
+    { threshold: 1e12, suffix: "T" }, // Tera (10^12)
+    { threshold: 1e9, suffix: "B" }, // Billion (10^9)
+    { threshold: 1e6, suffix: "M" }, // Million (10^6)
+    { threshold: 1e3, suffix: "K" }, // Thousand (10^3)
+  ];
+
+  for (let i = 0; i < tiers.length; i++) {
+    const tier = tiers[i];
+    if (value >= tier.threshold) {
+      const scaled = value / tier.threshold;
+
+      // Check if rounding would push us to 1000 (next tier boundary)
+      const rounded = Math.round(scaled * 10) / 10;
+      if (rounded >= 1000 && i > 0) {
+        // Move to the next higher tier
+        const higherTier = tiers[i - 1];
+        return `1${higherTier.suffix}`;
       }
+
+      // Use 1 decimal place, but drop .0 for cleaner display
+      const formatted = scaled.toFixed(1);
+      return formatted.endsWith(".0")
+        ? `${Math.round(scaled)}${tier.suffix}`
+        : `${formatted}${tier.suffix}`;
     }
   }
-  return result;
+
+  // Handle values that would round up to the next tier (e.g., 999.99 -> 1K)
+  if (value >= 999.5) {
+    return "1K";
+  }
+
+  // For values < 1000, show with appropriate precision
+  if (value >= 100) {
+    return Math.round(value).toString();
+  }
+
+  // For values 10-99, preserve 1 decimal if meaningful
+  if (value >= 10) {
+    const rounded = Math.round(value * 10) / 10;
+    return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
+  }
+
+  // For values 1-9.99, show integer if whole, otherwise 1 decimal
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
 }


### PR DESCRIPTION
## Summary

Fixes display issues in the Aggregated Impact Metrics charts on the community impact page where:
- Very large numbers (like Transaction Fees in Wei) showed as broken/raw numbers
- Tooltip dates showed raw ISO format instead of human-readable dates
- Y-axis labels were truncated or displayed incorrectly

## Changes

### formatCurrency.ts
- **Added Peta (P = 10^15) and Exa (E = 10^18) tier support** to handle blockchain-scale values
- Rewrote the function to avoid precision issues with very large numbers
- Properly handles tier boundary rounding (e.g., 999999 → 1M, not 1000K)

### Chart Components
- **CategoryRow.tsx**: Format dates using `formatDate()` for readable tooltip dates
- **AggregateCategoryRow.tsx**: Fixed sorting bug (was sorting by formatted date strings)
- **ImpactCharts.tsx**: Fixed same sorting bug in `prepareChartData`
- Increased `yAxisWidth` from 60→80 for better display of formatted numbers

### Tests
- Updated test expectations for quintillions (now correctly shows "1E")
- Added tests for Wei-scale values like `3724584981882890000` → `3.7E`

## Before/After

| Element | Before | After |
|---------|--------|-------|
| Date tooltip | `2025-12-01T00:00:00.000Z` | `Dec 1, 2025` |
| Transaction Fees | `3724584981882890000` (broken) | `3.7E` |
| Y-axis labels | Truncated/repeated values | Proper K/M/B/T/P/E formatting |

## Test Plan

- [x] All 36 formatCurrency tests pass
- [ ] Verify chart displays correctly on `/community/optimism/impact?programId=959`
- [ ] Verify tooltip shows formatted date and value on hover
- [ ] Verify Y-axis shows proper labels (K, M, B, T, P, E)

## Notes

The Transaction Fees values are in Wei format (1 ETH = 10^18 Wei). The display `3.7E` means 3.7 Exa-Wei, which equals approximately 3.7 ETH. If a future change is needed to display as ETH, that would require backend conversion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chronological sorting of impact chart data to display dates in correct order.
  * Improved large number currency formatting with refined suffix display and consistency.

* **Improvements**
  * Enhanced chart y-axis label spacing for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->