### PR TITLE
fix: display ETH suffix for large blockchain values

### DIFF
--- a/utilities/formatCurrency.ts
+++ b/utilities/formatCurrency.ts
@@ -26,7 +26,7 @@ export default function formatCurrency(value: number) {
 function formatLargeNumber(value: number): string {
   // Define thresholds and suffixes (ordered from largest to smallest)
   const tiers = [
-    { threshold: 1e18, suffix: "E" }, // Exa (10^18)
+    { threshold: 1e18, suffix: "ETH" }, // Exa (10^18)
     { threshold: 1e15, suffix: "P" }, // Peta (10^15)
     { threshold: 1e12, suffix: "T" }, // Tera (10^12)
     { threshold: 1e9, suffix: "B" }, // Billion (10^9)


### PR DESCRIPTION
## Summary
- Changed the 10^18 (Exa) suffix from "E" to "ETH" in the `formatCurrency` utility
- Makes large blockchain values (like Wei) display more clearly with the ETH suffix

## Test plan
- [ ] Verify large numbers (10^18+) display with "ETH" suffix on the impact page
- [ ] Confirm other number tiers (K, M, B, T, P) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)