### PR TITLE
feat(impact): convert wei values to ETH in impact charts

### DIFF
--- a/components/Pages/Communities/Impact/CategoryRow.tsx
+++ b/components/Pages/Communities/Impact/CategoryRow.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useAggregatedIndicators } from "@/hooks/useAggregatedIndicators";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import type { ProgramImpactDataResponse, ProgramImpactSegment } from "@/types/programs";
-import formatCurrency from "@/utilities/formatCurrency";
+import formatCurrency, { formatWeiToEth } from "@/utilities/formatCurrency";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { SegmentSkeleton } from "./SegmentSkeleton";
@@ -105,6 +105,16 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
   const chartData = aggregatedIndicators ? prepareAggregatedChartData(aggregatedIndicators) : [];
   const indicatorNames = aggregatedIndicators?.map((ind) => ind.name) || [];
   const colors = ["blue", "green", "yellow", "purple", "red", "pink"];
+
+  // Check if any indicator has wei as unit of measure
+  const hasWeiUnit = aggregatedIndicators?.some(
+    (ind) => ind.unitOfMeasure?.toLowerCase() === "wei"
+  );
+
+  // Use ETH formatter for wei values, otherwise use default currency formatter
+  const valueFormatter = hasWeiUnit
+    ? (value: number) => formatWeiToEth(value)
+    : (value: number) => formatCurrency(value);
 
   // If not visible yet, show skeleton
   if (!isVisible) {
@@ -204,7 +214,7 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
                 index="date"
                 categories={indicatorNames}
                 colors={colors.slice(0, indicatorNames.length)}
-                valueFormatter={(value) => formatCurrency(value)}
+                valueFormatter={valueFormatter}
                 yAxisWidth={80}
                 enableLegendSlider
                 noDataText="No data available for the selected period"

--- a/utilities/formatCurrency.ts
+++ b/utilities/formatCurrency.ts
@@ -1,5 +1,40 @@
 import millify from "millify";
 
+const WEI_PER_ETH = 1e18;
+
+/**
+ * Convert wei to ETH and format for display.
+ * @param weiValue - Value in wei (10^18 wei = 1 ETH)
+ * @returns Formatted string with ETH suffix
+ */
+export function formatWeiToEth(weiValue: number): string {
+  if (weiValue === 0) return "0 ETH";
+
+  const ethValue = weiValue / WEI_PER_ETH;
+
+  // For very small ETH values, show more precision
+  if (ethValue < 0.0001) {
+    return `${ethValue.toExponential(2)} ETH`;
+  }
+
+  if (ethValue < 0.01) {
+    return `${ethValue.toFixed(6)} ETH`;
+  }
+
+  if (ethValue < 1) {
+    return `${ethValue.toFixed(4)} ETH`;
+  }
+
+  if (ethValue < 1000) {
+    // Show 2 decimals for values < 1000
+    const formatted = ethValue.toFixed(2);
+    return formatted.endsWith(".00") ? `${Math.round(ethValue)} ETH` : `${formatted} ETH`;
+  }
+
+  // For large ETH values, use K, M, B suffixes
+  return `${formatLargeNumber(ethValue)} ETH`;
+}
+
 /**
  * Format large numbers for display using K, M, B, T, P, E suffixes.
  * Handles very large numbers (up to Exa = 10^18) which are common for


### PR DESCRIPTION
## Summary
- Add `formatWeiToEth` utility function that converts wei values to ETH (dividing by 10^18) with appropriate precision handling for different value ranges
- Update `CategoryRow` component to detect when indicators have `unitOfMeasure: "wei"` and use the ETH formatter instead of the default currency formatter
- Charts now display values like "1.5 ETH" or "250K ETH" instead of raw wei numbers with "E" suffix

## Test plan
- [ ] Navigate to a community impact page (`/community/:communityId/impact`)
- [ ] Verify that charts with wei-based indicators display values in ETH format
- [ ] Verify that charts with non-wei indicators still display values normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)