### PR TITLE
feat: pass RPC URLs to GAP SDK from environment configuration

### DIFF
--- a/components/Pages/Communities/Impact/CategoryRow.tsx
+++ b/components/Pages/Communities/Impact/CategoryRow.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useAggregatedIndicators } from "@/hooks/useAggregatedIndicators";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import type { ProgramImpactDataResponse, ProgramImpactSegment } from "@/types/programs";
-import formatCurrency from "@/utilities/formatCurrency";
+import formatCurrency, { formatWeiToEth } from "@/utilities/formatCurrency";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { SegmentSkeleton } from "./SegmentSkeleton";
@@ -105,6 +105,16 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
   const chartData = aggregatedIndicators ? prepareAggregatedChartData(aggregatedIndicators) : [];
   const indicatorNames = aggregatedIndicators?.map((ind) => ind.name) || [];
   const colors = ["blue", "green", "yellow", "purple", "red", "pink"];
+
+  // Check if any indicator has wei as unit of measure
+  const hasWeiUnit = aggregatedIndicators?.some(
+    (ind) => ind.unitOfMeasure?.toLowerCase() === "wei"
+  );
+
+  // Use ETH formatter for wei values, otherwise use default currency formatter
+  const valueFormatter = hasWeiUnit
+    ? (value: number) => formatWeiToEth(value)
+    : (value: number) => formatCurrency(value);
 
   // If not visible yet, show skeleton
   if (!isVisible) {
@@ -204,7 +214,7 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
                 index="date"
                 categories={indicatorNames}
                 colors={colors.slice(0, indicatorNames.length)}
-                valueFormatter={(value) => formatCurrency(value)}
+                valueFormatter={valueFormatter}
                 yAxisWidth={80}
                 enableLegendSlider
                 noDataText="No data available for the selected period"

--- a/hooks/useGap.ts
+++ b/hooks/useGap.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { TNetwork } from "@show-karma/karma-gap-sdk";
+import type { GAPRpcConfig, TNetwork } from "@show-karma/karma-gap-sdk";
 import { GAP } from "@show-karma/karma-gap-sdk/core/class/GAP";
 import { GapIndexerClient } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/GapIndexerClient";
 import { IpfsStorage } from "@show-karma/karma-gap-sdk/core/class/remote-storage/IpfsStorage";
@@ -23,6 +23,30 @@ const _gelatoOpts = {
   sponsorUrl: envVars.NEXT_PUBLIC_SPONSOR_URL || "/api/sponsored-txn",
   useGasless: false,
 };
+
+/**
+ * Builds the RPC configuration for GAP SDK from environment variables
+ */
+const buildRpcConfig = (): GAPRpcConfig => {
+  const config: GAPRpcConfig = {};
+
+  // Map environment RPC URLs to chain IDs
+  if (envVars.RPC.OPTIMISM) config[10] = envVars.RPC.OPTIMISM;
+  if (envVars.RPC.OPT_SEPOLIA) config[11155420] = envVars.RPC.OPT_SEPOLIA;
+  if (envVars.RPC.ARBITRUM) config[42161] = envVars.RPC.ARBITRUM;
+  if (envVars.RPC.SEPOLIA) config[11155111] = envVars.RPC.SEPOLIA;
+  if (envVars.RPC.BASE_SEPOLIA) config[84532] = envVars.RPC.BASE_SEPOLIA;
+  if (envVars.RPC.CELO) config[42220] = envVars.RPC.CELO;
+  if (envVars.RPC.SEI) config[1329] = envVars.RPC.SEI;
+  if (envVars.RPC.LISK) config[1135] = envVars.RPC.LISK;
+  if (envVars.RPC.SCROLL) config[534352] = envVars.RPC.SCROLL;
+  if (envVars.RPC.BASE) config[8453] = envVars.RPC.BASE;
+  if (envVars.RPC.POLYGON) config[137] = envVars.RPC.POLYGON;
+
+  return config;
+};
+
+const rpcConfig = buildRpcConfig();
 
 const gapClients: Record<number, GAP> = {};
 
@@ -60,6 +84,7 @@ export const getGapClient = (chainID: number): GAP => {
           }
         : {}),
       remoteStorage: ipfsClient,
+      rpcUrls: rpcConfig,
     });
     gapClients[networkChainId] = client;
     return client;

--- a/utilities/formatCurrency.ts
+++ b/utilities/formatCurrency.ts
@@ -1,5 +1,40 @@
 import millify from "millify";
 
+const WEI_PER_ETH = 1e18;
+
+/**
+ * Convert wei to ETH and format for display.
+ * @param weiValue - Value in wei (10^18 wei = 1 ETH)
+ * @returns Formatted string with ETH suffix
+ */
+export function formatWeiToEth(weiValue: number): string {
+  if (weiValue === 0) return "0 ETH";
+
+  const ethValue = weiValue / WEI_PER_ETH;
+
+  // For very small ETH values, show more precision
+  if (ethValue < 0.0001) {
+    return `${ethValue.toExponential(2)} ETH`;
+  }
+
+  if (ethValue < 0.01) {
+    return `${ethValue.toFixed(6)} ETH`;
+  }
+
+  if (ethValue < 1) {
+    return `${ethValue.toFixed(4)} ETH`;
+  }
+
+  if (ethValue < 1000) {
+    // Show 2 decimals for values < 1000
+    const formatted = ethValue.toFixed(2);
+    return formatted.endsWith(".00") ? `${Math.round(ethValue)} ETH` : `${formatted} ETH`;
+  }
+
+  // For large ETH values, use K, M, B suffixes
+  return `${formatLargeNumber(ethValue)} ETH`;
+}
+
 /**
  * Format large numbers for display using K, M, B, T, P, E suffixes.
  * Handles very large numbers (up to Exa = 10^18) which are common for


### PR DESCRIPTION
## Summary
- Import `GAPRpcConfig` type from karma-gap-sdk
- Add `buildRpcConfig()` function to map `envVars.RPC` to chain IDs
- Pass `rpcUrls` configuration to GAP constructor in `getGapClient()`

## Changes
Updated `hooks/useGap.ts` to pass RPC URLs from existing environment configuration to the GAP SDK.

## Chain ID Mapping
| Environment Variable | Chain ID |
|---------------------|----------|
| `NEXT_PUBLIC_RPC_OPTIMISM` | 10 |
| `NEXT_PUBLIC_RPC_OPTIMISM_SEPOLIA` | 11155420 |
| `NEXT_PUBLIC_RPC_ARBITRUM` | 42161 |
| `NEXT_PUBLIC_RPC_SEPOLIA` | 11155111 |
| `NEXT_PUBLIC_RPC_BASE_SEPOLIA` | 84532 |
| `NEXT_PUBLIC_RPC_CELO` | 42220 |
| `NEXT_PUBLIC_RPC_SEI` | 1329 |
| `NEXT_PUBLIC_RPC_LISK` | 1135 |
| `NEXT_PUBLIC_RPC_SCROLL` | 534352 |
| `NEXT_PUBLIC_RPC_BASE` | 8453 |
| `NEXT_PUBLIC_RPC_POLYGON` | 137 |

## Test plan
- [ ] Verify GAP client initializes correctly with RPC URLs
- [ ] Test attestation operations across different networks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented custom RPC endpoint configuration for network connectivity via environment variables
  * Enhanced impact chart display with improved wei-to-ETH value formatting, including automatic decimal precision based on value magnitude

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->