### PR TITLE
feat: Add copy wallet address to clipboard feature

### DIFF
--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircle2,
   CircleHelp,
   CircleUser,
+  Copy,
   FolderKanban,
   Heart,
   LogOutIcon,
@@ -27,6 +28,7 @@ import {
   MenubarTrigger,
 } from "@/components/ui/menubar";
 import { useAuth } from "@/hooks/useAuth";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useContributorProfile } from "@/hooks/useContributorProfile";
 import { useReviewerPrograms } from "@/hooks/usePermissions";
 import { useStaff } from "@/hooks/useStaff";
@@ -86,6 +88,7 @@ export function NavbarUserMenu() {
   const { profile } = useContributorProfile(address);
 
   const { openModal: openProfileModal } = useContributorProfileModalStore();
+  const [, copyToClipboard] = useCopyToClipboard();
 
   // Check admin and reviewer permissions
   const { communities } = useCommunitiesStore();
@@ -139,12 +142,22 @@ export function NavbarUserMenu() {
             </MenubarTrigger>
             <MenubarContent align="end" className="flex flex-col gap-4 px-4 py-4 w-max">
               <div className="flex flex-col w-full">
-                <MenubarItem className="w-full hover:bg-transparent focus:bg-transparent text-muted-foreground cursor-pointer">
-                  <div className="flex flex-row items-center gap-2">
+                <MenubarItem
+                  className="w-full cursor-pointer"
+                  onClick={() => {
+                    if (address) {
+                      copyToClipboard(address, "Wallet address copied to clipboard");
+                    }
+                  }}
+                >
+                  <div className="flex flex-row items-center gap-2 justify-between w-full">
                     {address ? (
-                      <span className="text-sm break-all max-w-40 text-muted-foreground font-medium hover:text-muted-foreground">
-                        {address}
-                      </span>
+                      <>
+                        <span className="text-sm break-all max-w-40 text-muted-foreground font-medium">
+                          {address}
+                        </span>
+                        <Copy className={menuStyles.itemIcon} />
+                      </>
                     ) : (
                       <span className={menuStyles.itemText}>No wallet connected</span>
                     )}


### PR DESCRIPTION
When clicking on the wallet address in the navbar dropdown menu, the address is now automatically copied to clipboard with a toast notification confirming the action.