### PR TITLE
fix(sentry): ignore project and community not found errors

### DIFF
--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -23,6 +23,11 @@ const browserExtensionErrors = [
   "chrome.runtime.sendMessage() called from a webpage must specify an Extension ID",
 ];
 
+// Expected "not found" errors when users access non-existent resources (e.g., deleted projects, old URLs)
+// These are normal 404-type scenarios, not bugs worth tracking
+// See https://karma-crypto-inc.sentry.io/issues/7205405990
+const notFoundErrors = ["Project not found", "Community not found"];
+
 export const sentryIgnoreErrors = [
   // user rejected a confirmation in the wallet
   "rejected the request",
@@ -36,4 +41,5 @@ export const sentryIgnoreErrors = [
   ...unsupportedWalletErrors,
   ...walletConnectErrors,
   ...browserExtensionErrors,
+  ...notFoundErrors,
 ];


### PR DESCRIPTION
## Summary
- Add "Project not found" and "Community not found" to Sentry ignore list
- These are expected errors when users access non-existent resources (deleted projects, old URLs)
- Reduces noise in Sentry alerts for non-actionable errors

## Related Issue
https://karma-crypto-inc.sentry.io/issues/7205405990

## Test plan
- [ ] Verify Sentry configuration loads without errors
- [ ] Confirm "Project not found" errors no longer appear in Sentry after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212891275354210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error monitoring configuration to ignore expected "not found" scenarios for projects and communities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->