### PR TITLE
feat: add post-approval completion icon to applications list

### DIFF
--- a/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { type FC, useState } from "react";
+import { ClipboardDocumentCheckIcon } from "@heroicons/react/24/solid";
 import { ReviewerType } from "@/hooks/useReviewerAssignment";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
@@ -116,7 +117,19 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
         <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
           {application.applicantEmail}
         </td>
-        <td className="px-4 py-4 whitespace-nowrap">{getStatusBadge(application.status)}</td>
+        <td className="px-4 py-4 whitespace-nowrap">
+          <div className="flex items-center gap-2">
+            {getStatusBadge(application.status)}
+            {application.status === "approved" && application.postApprovalCompleted && (
+              <span
+                title="Post-approval form completed"
+                className="inline-flex items-center text-emerald-600 dark:text-emerald-400"
+              >
+                <ClipboardDocumentCheckIcon className="h-5 w-5" aria-hidden="true" />
+              </span>
+            )}
+          </div>
+        </td>
         {showAIScoreColumn && (
           <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 text-center">
             {application.aiEvaluation?.evaluation ? (

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -146,6 +146,7 @@ export interface IFundingApplication {
   };
   appReviewers?: string[]; // Array of program reviewer addresses assigned to this application
   milestoneReviewers?: string[]; // Array of milestone reviewer addresses assigned to this application
+  postApprovalCompleted?: boolean; // Indicates if post-approval form has been completed
   createdAt: string | Date;
   updatedAt: string | Date;
 }


### PR DESCRIPTION
## Summary
- Add `postApprovalCompleted` field to `IFundingApplication` type to consume the existing backend field
- Display a clipboard-check icon next to the "Approved" status badge when an application has completed its post-approval form
- Icon provides visual feedback to admins without exposing sensitive form data

## Test plan
- [ ] Navigate to a funding platform's applications list page
- [ ] Verify approved applications with completed post-approval forms show the clipboard icon
- [ ] Verify the icon has a tooltip "Post-approval form completed" on hover
- [ ] Verify the icon does not appear for non-approved applications
- [ ] Verify the icon does not appear for approved applications without completed post-approval forms

<img width="195" height="143" alt="image" src="https://github.com/user-attachments/assets/58beb4ce-5034-44ba-95b1-84a7b0cfd795" />
