### PR TITLE
fix: prefer PostgreSQL UUID over MongoDB ID for indicators

### DIFF
--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -102,11 +102,19 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
     [indicators, newIndicators]
   );
 
+  /**
+   * Get the effective ID for an indicator (uuid preferred, fallback to id)
+   * This ensures we use PostgreSQL UUIDs for impact segments when available
+   */
+  const getIndicatorEffectiveId = (indicator: ImpactIndicator): string => {
+    return indicator.uuid || indicator.id;
+  };
+
   // Get selected indicator names for display
   const selectedNames = useMemo(() => {
     const allIndicators = [...allCommunityIndicators, ...autosyncedIndicators];
     return selectedIndicators
-      .map((id) => allIndicators.find((i) => i.id === id)?.name)
+      .map((id) => allIndicators.find((i) => getIndicatorEffectiveId(i) === id)?.name)
       .filter(Boolean);
   }, [selectedIndicators, allCommunityIndicators, autosyncedIndicators]);
 
@@ -118,14 +126,15 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
   }, [open]);
 
   const renderIndicatorItem = (indicator: ImpactIndicator, isDefault = false) => {
-    const isSelected = selectedIndicators.includes(indicator.id);
+    const effectiveId = getIndicatorEffectiveId(indicator);
+    const isSelected = selectedIndicators.includes(effectiveId);
 
     return (
       <button
-        key={indicator.id}
+        key={effectiveId}
         type="button"
         className="px-4 py-3 w-full hover:bg-gray-50 dark:hover:bg-zinc-700 cursor-pointer flex justify-between items-center gap-3 text-left"
-        onClick={() => handleIndicatorChange(indicator.id)}
+        onClick={() => handleIndicatorChange(effectiveId)}
       >
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -14,6 +14,7 @@ import { IndicatorForm } from "@/components/Forms/IndicatorForm";
 import { Button } from "@/components/Utilities/Button";
 import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { ImpactIndicator } from "@/types/impactMeasurement";
+import { getIndicatorEffectiveId } from "@/utilities/indicatorUtils";
 
 // Debounce hook for search performance
 const useDebouncedValue = (value: string, delay: number) => {
@@ -101,14 +102,6 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
     () => [...indicators, ...newIndicators],
     [indicators, newIndicators]
   );
-
-  /**
-   * Get the effective ID for an indicator (uuid preferred, fallback to id)
-   * This ensures we use PostgreSQL UUIDs for impact segments when available
-   */
-  const getIndicatorEffectiveId = (indicator: ImpactIndicator): string => {
-    return indicator.uuid || indicator.id;
-  };
 
   // Get selected indicator names for display
   const selectedNames = useMemo(() => {

--- a/types/impactMeasurement.ts
+++ b/types/impactMeasurement.ts
@@ -12,6 +12,8 @@ export interface AggregatedDatapoint {
 
 export interface ImpactIndicatorWithData {
   id: string;
+  /** PostgreSQL UUID - use this for impact segments when available */
+  uuid?: string | null;
   name: string;
   description: string;
   unitOfMeasure: string;
@@ -45,6 +47,8 @@ export interface ImpactIndicatorWithData {
 
 export interface ImpactIndicator {
   id: string;
+  /** PostgreSQL UUID - use this for impact segments when available */
+  uuid?: string | null;
   name: string;
   description: string;
   programs?: {

--- a/utilities/indicatorUtils.ts
+++ b/utilities/indicatorUtils.ts
@@ -1,0 +1,10 @@
+import type { ImpactIndicator } from "@/types/impactMeasurement";
+import type { Indicator } from "./queries/getIndicatorsByCommunity";
+
+/**
+ * Get the effective ID for an indicator (uuid preferred, fallback to id)
+ * This ensures we use PostgreSQL UUIDs for impact segments when available
+ */
+export const getIndicatorEffectiveId = (indicator: ImpactIndicator | Indicator): string => {
+  return indicator.uuid || indicator.id;
+};

--- a/utilities/queries/getIndicatorsByCommunity.ts
+++ b/utilities/queries/getIndicatorsByCommunity.ts
@@ -9,6 +9,8 @@ export interface ProgramReference {
 
 export interface Indicator {
   id: string;
+  /** PostgreSQL UUID - use this for impact segments when available */
+  uuid?: string | null;
   name: string;
   description: string;
   unitOfMeasure: string;
@@ -41,6 +43,7 @@ export interface GroupedIndicators {
 // V2 API response type (programId is number from backend)
 interface V2Indicator {
   id: string;
+  uuid?: string | null;
   name: string;
   description: string;
   unitOfMeasure: string;
@@ -57,6 +60,7 @@ interface V2Indicator {
 function transformIndicator(v2Indicator: V2Indicator): Indicator {
   return {
     ...v2Indicator,
+    uuid: v2Indicator.uuid || null,
     programs:
       v2Indicator.programs?.map((p) => ({
         programId: String(p.programId),


### PR DESCRIPTION
## Overview

Updates indicator selection to use PostgreSQL `uuid` when available, ensuring custom indicators work correctly with impact segments.

## Problem

When adding custom indicators to impact segments on the manage-indicators page (`community/[communityId]/admin/manage-indicators`):
- The V2 API returns PostgreSQL UUIDs as `id`
- The create indicator endpoint (`POST /indicators`) returns MongoDB ObjectID as `id`
- Impact segments endpoint expects PostgreSQL UUIDs

This mismatch causes newly created custom indicators to fail when added to activities/outcomes.

## Solution

1. **Added `uuid` field to indicator types** - All indicator interfaces now include `uuid?: string | null`

2. **Prefer UUID over ID** - Components use `getIndicatorEffectiveId()` which returns `uuid || id`:
   - For V2 API indicators: uses `id` (already a PostgreSQL UUID)
   - For newly created indicators: uses `uuid` (PostgreSQL UUID from backend)

## Why This Approach

- **Backward Compatible**: Falls back to `id` if `uuid` is not present
- **Minimal Changes**: Only affects indicator selection logic
- **Works with Both APIs**: Handles V2 API (UUID as id) and create API (UUID as separate field)

## Testing Steps

1. Navigate to `community/filecoin/admin/manage-indicators`
2. Create a new Activity/Outcome
3. Click "Create Custom" to add a new custom indicator
4. Select both the new custom indicator AND system indicators
5. Save the activity
6. Verify the activity is created successfully with all indicators

## Files Changed

| File | Change |
|------|--------|
| `types/impactMeasurement.ts` | Added `uuid` to `ImpactIndicator` and `ImpactIndicatorWithData` |
| `utilities/queries/getIndicatorsByCommunity.ts` | Added `uuid` to `Indicator` and `V2Indicator` types |
| `components/Pages/Admin/IndicatorsDropdown.tsx` | Use effective ID for selection and display |
| `components/Pages/Admin/ActivityOutcomeModal.tsx` | Use effective ID when editing segments |

## Related PRs

- Backend: show-karma/gap-indexer#847 (returns `uuid` in create response)

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Indicator selection and matching now prefer unique identifiers when available, improving selection accuracy.
  * Data models and queries include optional unique identifier fields to enhance compatibility and reliability across indicator-related features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->