### PR TITLE
fix: use grant.data.communityUID for community admin check

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerificationsDialog.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerificationsDialog.tsx
@@ -67,7 +67,10 @@ export const VerificationsDialog: FC<VerificationsDialogProps> = ({
   const _project = useProjectStore((state) => state.project);
   const grant = useGrant();
 
-  const communityUid = useMemo(() => grant?.data?.communityUID || grant?.communityUID, [grant]);
+  const communityUid = useMemo(
+    () => grant?.data?.communityUID || grant?.community?.uid || grant?.communityUID,
+    [grant]
+  );
   const [communityAdmins, setCommunityAdmins] = useState<string[]>();
 
   const { populateEns } = useENS();

--- a/components/Pages/Project/Grants/Layout.tsx
+++ b/components/Pages/Project/Grants/Layout.tsx
@@ -83,8 +83,11 @@ export const GrantsLayout = ({ children, fetchedProject }: GrantsLayoutProps) =>
   const { address } = useAccount();
   const setIsCommunityAdmin = useCommunityAdminStore((state) => state.setIsCommunityAdmin);
 
+  // Get communityUID - prefer grant.data.communityUID, fallback to grant.community.uid
+  const communityUID = grant?.data?.communityUID || grant?.community?.uid;
+
   // Use React Query hook to check admin status with Zustand sync
-  useIsCommunityAdmin(grant?.community?.uid || grant?.data?.communityUID, address, {
+  useIsCommunityAdmin(communityUID, address, {
     zustandSync: { setIsCommunityAdmin },
   });
 


### PR DESCRIPTION
## Summary

- Use `grant.data.communityUID` as the source for community admin check
- Removes fallback to `grant.community?.uid` for more consistent UID resolution

## Changes

**File:** `components/Pages/Project/Grants/Layout.tsx`

```diff
-  useIsCommunityAdmin(grant?.community?.uid || grant?.data?.communityUID, address, {
+  const communityUID = grant?.data?.communityUID;
+
+  useIsCommunityAdmin(communityUID, address, {
```

## Context

The `grant.data.communityUID` is the canonical source for the community UID. Using it directly ensures consistent community admin authorization checks on the grants/milestones pages.

## Test plan

- [ ] Verify community admin check works correctly on grant milestones page
- [ ] Verify authorized users can still post updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how the app derives a community identifier for permission checks.
* **Bug Fix**
  * More reliably detects community admins when identifier is present in alternate data locations, reducing incorrect permission/visibility results for grants and verifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->