### PR TITLE
fix(program-details): use DateTimePicker for proper UTC end date handling

### DIFF
--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -128,6 +128,39 @@ jest.mock("@/components/Utilities/DatePicker", () => ({
   ),
 }));
 
+jest.mock("@/components/Utilities/DateTimePicker", () => ({
+  DateTimePicker: ({
+    selected,
+    onSelect,
+    placeholder,
+    buttonClassName,
+    clearButtonFn,
+    timeMode,
+  }: any) => (
+    <div data-testid="date-picker">
+      <button
+        data-testid={`date-picker-${placeholder?.toLowerCase().replace(/\s+/g, "-") || "default"}`}
+        onClick={() => {
+          if (onSelect) {
+            onSelect(selected || new Date("2024-06-01T00:00:00Z"));
+          }
+        }}
+        className={buttonClassName}
+      >
+        {selected ? selected.toISOString() : placeholder || "Pick a date"}
+      </button>
+      {clearButtonFn && (
+        <button
+          data-testid={`clear-date-${placeholder?.toLowerCase().replace(/\s+/g, "-") || "default"}`}
+          onClick={clearButtonFn}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 // Import mocked modules
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -6,7 +6,7 @@ import { Controller, useForm, useWatch } from "react-hook-form";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
-import { DatePicker } from "@/components/Utilities/DatePicker";
+import { DateTimePicker } from "@/components/Utilities/DateTimePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { Button } from "@/components/ui/button";
@@ -441,10 +441,11 @@ export function ProgramDetailsTab({
                 return (
                   <div className="flex w-full flex-col gap-2">
                     <Label htmlFor="start-date">Start Date (optional)</Label>
-                    <DatePicker
+                    <DateTimePicker
                       selected={field.value}
                       onSelect={datePickerProps.onSelect}
-                      placeholder="Pick a date"
+                      timeMode="start"
+                      placeholder="Pick a date (UTC)"
                       buttonClassName={cn(
                         DATE_PICKER_BUTTON_CLASS,
                         isDisabled && "opacity-50 cursor-not-allowed"
@@ -470,11 +471,12 @@ export function ProgramDetailsTab({
                 return (
                   <div className="flex w-full flex-col gap-2">
                     <Label htmlFor="end-date">End Date (optional)</Label>
-                    <DatePicker
+                    <DateTimePicker
                       selected={field.value}
                       onSelect={datePickerProps.onSelect}
+                      timeMode="end"
                       minDate={startDate}
-                      placeholder="Pick a date"
+                      placeholder="Pick a date (UTC)"
                       buttonClassName={cn(
                         DATE_PICKER_BUTTON_CLASS,
                         isDisabled && "opacity-50 cursor-not-allowed"


### PR DESCRIPTION
## Summary
- Fixes program end date being set to 00:00 UTC instead of 23:59 UTC in the Program Details tab
- Programs would appear closed on their end date because the time was set to midnight UTC
- Now uses the shared `DateTimePicker` component (same as AddProgram page) with proper `timeMode`

## Changes
- Replaced `DatePicker` with `DateTimePicker` in `ProgramDetailsTab.tsx`
- Start date uses `timeMode="start"` (00:00 UTC)
- End date uses `timeMode="end"` (23:59 UTC)

## Test plan
- [ ] Go to Admin > Funding Platform > Program Details tab
- [ ] Set end date to today
- [ ] Verify the date shows "at 23:59 UTC" in the picker
- [ ] Save and confirm the program remains open throughout the day


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced date fields to support time selection in addition to date selection for start and end dates.
  * Added UTC timezone notation to date picker placeholders for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->