### PR TITLE
feat: add Karma Seeds frontend integration

### DIFF
--- a/components/Dialogs/LaunchKarmaSeedsDialog.tsx
+++ b/components/Dialogs/LaunchKarmaSeedsDialog.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { Dialog, Transition } from "@headlessui/react";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type FC, Fragment, useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useAccount } from "wagmi";
+import { z } from "zod";
+import { useCreateKarmaSeeds } from "@/hooks/useKarmaSeeds";
+import { type LaunchSeedsParams, useLaunchKarmaSeeds } from "@/hooks/useKarmaSeedsContract";
+import { getPayoutAddressForChain } from "@/src/features/chain-payout-address/hooks/use-chain-payout-address";
+import { useProjectStore } from "@/store";
+import { useKarmaSeedsModalStore } from "@/store/modals/karmaSeeds";
+import { DEFAULT_MAX_SUPPLY, KARMA_SEEDS_CONFIG } from "@/types/karmaSeeds";
+import { cn } from "@/utilities/tailwind";
+import { errorManager } from "../Utilities/errorManager";
+import { Button } from "../ui/button";
+
+const inputStyle = "bg-gray-100 border border-gray-400 rounded-md p-2 dark:bg-zinc-900 w-full";
+const labelStyle = "text-slate-700 text-sm font-bold leading-tight dark:text-slate-200";
+const errorStyle = "text-red-500 text-sm mt-1";
+
+const launchFormSchema = z.object({
+  tokenName: z
+    .string()
+    .min(1, { message: "Token name is required" })
+    .max(32, { message: "Token name must be 32 characters or less" }),
+  tokenSymbol: z
+    .string()
+    .min(1, { message: "Token symbol is required" })
+    .max(10, { message: "Token symbol must be 10 characters or less" }),
+  maxSupply: z
+    .string()
+    .min(1, { message: "Max supply is required" })
+    .refine((val) => !isNaN(Number(val)) && Number(val) >= 1000, {
+      message: "Minimum supply is 1,000 tokens",
+    })
+    .refine((val) => !isNaN(Number(val)) && Number(val) <= 1000000000, {
+      message: "Maximum supply is 1 billion tokens",
+    }),
+});
+
+type LaunchFormSchema = z.infer<typeof launchFormSchema>;
+
+type TransactionStep = "idle" | "deploying" | "registering" | "success" | "error";
+
+export const LaunchKarmaSeedsDialog: FC = () => {
+  const {
+    isLaunchModalOpen: isOpen,
+    closeLaunchModal: closeModal,
+    defaultTokenName,
+    defaultTokenSymbol,
+    setDefaults,
+  } = useKarmaSeedsModalStore();
+
+  const project = useProjectStore((state) => state.project);
+  const { address, chain } = useAccount();
+
+  const [step, setStep] = useState<TransactionStep>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const { launch, state: launchState, reset: resetLaunch } = useLaunchKarmaSeeds();
+  const { mutateAsync: createKarmaSeedsRecord } = useCreateKarmaSeeds();
+
+  const treasuryAddress = useMemo(() => {
+    if (!project?.chainPayoutAddress) {
+      return project?.payoutAddress || project?.owner;
+    }
+    const baseAddress = getPayoutAddressForChain(
+      project.chainPayoutAddress,
+      KARMA_SEEDS_CONFIG.chainID
+    );
+    return baseAddress || project?.payoutAddress || project?.owner;
+  }, [project]);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+    setValue,
+  } = useForm<LaunchFormSchema>({
+    resolver: zodResolver(launchFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      tokenName: defaultTokenName,
+      tokenSymbol: defaultTokenSymbol,
+      maxSupply: DEFAULT_MAX_SUPPLY,
+    },
+  });
+
+  useEffect(() => {
+    if (project?.details?.title) {
+      setDefaults(project.details.title);
+    }
+  }, [project?.details?.title, setDefaults]);
+
+  useEffect(() => {
+    if (defaultTokenName) {
+      setValue("tokenName", defaultTokenName);
+    }
+    if (defaultTokenSymbol) {
+      setValue("tokenSymbol", defaultTokenSymbol);
+    }
+  }, [defaultTokenName, defaultTokenSymbol, setValue]);
+
+  const handleClose = () => {
+    if (step === "deploying" || step === "registering") {
+      return;
+    }
+    closeModal();
+    resetForm();
+  };
+
+  const resetForm = () => {
+    setStep("idle");
+    setErrorMessage("");
+    resetLaunch();
+    reset({
+      tokenName: defaultTokenName,
+      tokenSymbol: defaultTokenSymbol,
+      maxSupply: DEFAULT_MAX_SUPPLY,
+    });
+  };
+
+  const onSubmit = async (data: LaunchFormSchema) => {
+    if (!project || !address || !treasuryAddress) {
+      setErrorMessage("Missing required data. Please try again.");
+      return;
+    }
+
+    if (KARMA_SEEDS_CONFIG.factoryAddress === "0x0000000000000000000000000000000000000000") {
+      setErrorMessage("Karma Seeds factory contract is not yet deployed. Please check back later.");
+      return;
+    }
+
+    setStep("deploying");
+    setErrorMessage("");
+
+    try {
+      const launchParams: LaunchSeedsParams = {
+        projectName: project.uid,
+        tokenName: data.tokenName,
+        tokenSymbol: data.tokenSymbol,
+        treasury: treasuryAddress as `0x${string}`,
+        maxSupply: data.maxSupply,
+      };
+
+      const result = await launch(launchParams);
+
+      setStep("registering");
+
+      await createKarmaSeedsRecord({
+        projectUID: project.uid,
+        request: {
+          tokenName: data.tokenName,
+          tokenSymbol: data.tokenSymbol,
+          maxSupply: data.maxSupply,
+          treasuryAddress: treasuryAddress,
+          contractAddress: result.tokenAddress,
+          factoryAddress: KARMA_SEEDS_CONFIG.factoryAddress,
+          deploymentTxHash: result.txHash,
+          chainID: KARMA_SEEDS_CONFIG.chainID,
+        },
+      });
+
+      setStep("success");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error occurred";
+      setErrorMessage(message);
+      setStep("error");
+      errorManager("Error launching Karma Seeds", error, {
+        project: project?.details?.slug || project?.uid,
+        address,
+      });
+    }
+  };
+
+  const getStepContent = () => {
+    switch (step) {
+      case "deploying":
+        return (
+          <div className="flex flex-col items-center justify-center py-8 gap-4">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+            <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">
+              Deploying Karma Seeds Contract...
+            </p>
+            <p className="text-sm text-gray-500 dark:text-zinc-400">
+              Please confirm the transaction in your wallet
+            </p>
+          </div>
+        );
+      case "registering":
+        return (
+          <div className="flex flex-col items-center justify-center py-8 gap-4">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+            <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">
+              Registering Karma Seeds...
+            </p>
+            <p className="text-sm text-gray-500 dark:text-zinc-400">
+              Saving your token information
+            </p>
+          </div>
+        );
+      case "success":
+        return (
+          <div className="flex flex-col items-center justify-center py-8 gap-4">
+            <div className="rounded-full h-12 w-12 bg-green-100 dark:bg-green-900 flex items-center justify-center">
+              <svg
+                className="h-6 w-6 text-green-600 dark:text-green-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">
+              Karma Seeds Launched!
+            </p>
+            <p className="text-sm text-gray-500 dark:text-zinc-400 text-center">
+              Your supporters can now buy Karma Seeds to fund your project.
+            </p>
+            <Button onClick={handleClose} className="mt-4">
+              Close
+            </Button>
+          </div>
+        );
+      case "error":
+        return (
+          <div className="flex flex-col items-center justify-center py-8 gap-4">
+            <div className="rounded-full h-12 w-12 bg-red-100 dark:bg-red-900 flex items-center justify-center">
+              <svg
+                className="h-6 w-6 text-red-600 dark:text-red-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </div>
+            <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">Launch Failed</p>
+            <p className="text-sm text-red-500 text-center max-w-md">
+              {errorMessage || "An error occurred while launching Karma Seeds."}
+            </p>
+            <div className="flex gap-3 mt-4">
+              <Button variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button onClick={resetForm}>Try Again</Button>
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  if (!project) return null;
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-2xl dark:bg-zinc-800 bg-white p-6 text-left align-middle transition-all">
+                {step !== "idle" ? (
+                  getStepContent()
+                ) : (
+                  <>
+                    <div className="flex justify-between items-center mb-6">
+                      <Dialog.Title
+                        as="h3"
+                        className="text-xl font-semibold leading-6 text-gray-900 dark:text-zinc-100"
+                      >
+                        Launch Karma Seeds
+                      </Dialog.Title>
+                      <button
+                        type="button"
+                        onClick={handleClose}
+                        className="text-gray-400 hover:text-gray-500"
+                      >
+                        <XMarkIcon className="h-6 w-6" />
+                      </button>
+                    </div>
+
+                    <p className="text-sm text-gray-500 dark:text-zinc-400 mb-6">
+                      Launch a token for your project that supporters can purchase to fund your
+                      work. Each token costs $1 USD equivalent.
+                    </p>
+
+                    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+                      <div>
+                        <label htmlFor="tokenName" className={labelStyle}>
+                          Token Name
+                        </label>
+                        <input
+                          {...register("tokenName")}
+                          id="tokenName"
+                          type="text"
+                          placeholder="e.g., KSEED-MyProject"
+                          className={cn(inputStyle, errors.tokenName && "border-red-500")}
+                        />
+                        {errors.tokenName && (
+                          <p className={errorStyle}>{errors.tokenName.message}</p>
+                        )}
+                      </div>
+
+                      <div>
+                        <label htmlFor="tokenSymbol" className={labelStyle}>
+                          Token Symbol
+                        </label>
+                        <input
+                          {...register("tokenSymbol")}
+                          id="tokenSymbol"
+                          type="text"
+                          placeholder="e.g., KS-MP"
+                          className={cn(inputStyle, errors.tokenSymbol && "border-red-500")}
+                        />
+                        {errors.tokenSymbol && (
+                          <p className={errorStyle}>{errors.tokenSymbol.message}</p>
+                        )}
+                      </div>
+
+                      <div>
+                        <label htmlFor="maxSupply" className={labelStyle}>
+                          Max Supply
+                        </label>
+                        <input
+                          {...register("maxSupply")}
+                          id="maxSupply"
+                          type="text"
+                          placeholder="1000000"
+                          className={cn(inputStyle, errors.maxSupply && "border-red-500")}
+                        />
+                        {errors.maxSupply && (
+                          <p className={errorStyle}>{errors.maxSupply.message}</p>
+                        )}
+                        <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1">
+                          Maximum number of tokens that can be minted (each worth $1 USD)
+                        </p>
+                      </div>
+
+                      <div>
+                        <span className={labelStyle}>Treasury Address</span>
+                        <div className="bg-gray-50 dark:bg-zinc-900 border border-gray-300 dark:border-zinc-700 rounded-md p-3 mt-1">
+                          <p className="text-sm text-gray-700 dark:text-zinc-300 font-mono break-all">
+                            {treasuryAddress || "Not configured"}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1">
+                            97% of proceeds will be sent to this address
+                          </p>
+                        </div>
+                        {!treasuryAddress && (
+                          <p className={errorStyle}>
+                            Please configure a payout address for Base network in project settings
+                          </p>
+                        )}
+                      </div>
+
+                      <div>
+                        <span className={labelStyle}>Network</span>
+                        <div className="bg-gray-50 dark:bg-zinc-900 border border-gray-300 dark:border-zinc-700 rounded-md p-3 mt-1">
+                          <p className="text-sm text-gray-700 dark:text-zinc-300">
+                            Base (Chain ID: {KARMA_SEEDS_CONFIG.chainID})
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-row gap-4 mt-8 justify-end">
+                        <Button type="button" variant="outline" onClick={handleClose}>
+                          Cancel
+                        </Button>
+                        <Button type="submit" disabled={!isValid || !treasuryAddress}>
+                          Launch Karma Seeds
+                        </Button>
+                      </div>
+                    </form>
+                  </>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default LaunchKarmaSeedsDialog;

--- a/components/KarmaSeeds/BuySeedsDialog.tsx
+++ b/components/KarmaSeeds/BuySeedsDialog.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { Dialog, Transition } from "@headlessui/react";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { type FC, Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { type Address, formatUnits, parseUnits } from "viem";
+import { base } from "viem/chains";
+import { useAccount, useBalance, useSwitchChain } from "wagmi";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { Button } from "@/components/ui/button";
+import { useKarmaSeeds } from "@/hooks/useKarmaSeeds";
+import {
+  useBuyKarmaSeeds,
+  useKarmaSeedsTokenData,
+  usePreviewBuySeeds,
+} from "@/hooks/useKarmaSeedsContract";
+import { useProjectStore } from "@/store";
+import { useKarmaSeedsModalStore } from "@/store/modals/karmaSeeds";
+import { KARMA_SEEDS_CONFIG } from "@/types/karmaSeeds";
+import { cn } from "@/utilities/tailwind";
+
+const inputStyle =
+  "bg-gray-100 border border-gray-400 rounded-md p-3 dark:bg-zinc-900 w-full text-lg";
+const labelStyle = "text-slate-700 text-sm font-bold leading-tight dark:text-slate-200";
+
+type PaymentMethod = "eth" | "usdc";
+
+interface PaymentOption {
+  id: PaymentMethod;
+  name: string;
+  symbol: string;
+  decimals: number;
+  address?: Address;
+}
+
+const PAYMENT_OPTIONS: PaymentOption[] = [
+  {
+    id: "eth",
+    name: "Ethereum",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  {
+    id: "usdc",
+    name: "USD Coin",
+    symbol: "USDC",
+    decimals: 6,
+    address: KARMA_SEEDS_CONFIG.usdc,
+  },
+];
+
+type TransactionStep = "idle" | "approving" | "pending" | "confirming" | "success" | "error";
+
+export const BuySeedsDialog: FC = () => {
+  const { isBuyModalOpen: isOpen, closeBuyModal: closeModal } = useKarmaSeedsModalStore();
+
+  const project = useProjectStore((state) => state.project);
+  const { address, chain } = useAccount();
+  const { switchChain } = useSwitchChain();
+
+  // Auto-switch to Base when dialog opens
+  useEffect(() => {
+    if (isOpen && chain?.id !== KARMA_SEEDS_CONFIG.chainID) {
+      switchChain?.({ chainId: KARMA_SEEDS_CONFIG.chainID });
+    }
+  }, [isOpen, chain?.id, switchChain]);
+
+  const [amount, setAmount] = useState<string>("");
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("eth");
+  const [previewTokens, setPreviewTokens] = useState<string>("0");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const { data: karmaSeeds } = useKarmaSeeds(project?.uid);
+
+  const contractAddress = karmaSeeds?.contractAddress as Address | undefined;
+
+  const {
+    buyWithEth,
+    buyWithStablecoin,
+    state: buyState,
+    reset: resetBuy,
+    isLoading: isBuying,
+  } = useBuyKarmaSeeds(contractAddress);
+
+  const { previewBuyWithEth, previewBuyWithStablecoin } = usePreviewBuySeeds(contractAddress);
+
+  const { totalSupply, maxSupply, remainingSupply, ethPrice } =
+    useKarmaSeedsTokenData(contractAddress);
+
+  const { data: ethBalance, refetch: refetchEthBalance } = useBalance({
+    address,
+    chainId: KARMA_SEEDS_CONFIG.chainID,
+    query: {
+      enabled: !!address && paymentMethod === "eth",
+      refetchInterval: 10000, // Refetch every 10 seconds
+    },
+  });
+
+  const { data: usdcBalance, refetch: refetchUsdcBalance } = useBalance({
+    address,
+    token: KARMA_SEEDS_CONFIG.usdc,
+    chainId: KARMA_SEEDS_CONFIG.chainID,
+    query: {
+      enabled: !!address && paymentMethod === "usdc",
+      refetchInterval: 10000,
+    },
+  });
+
+  // Refetch balances when chain changes to Base
+  useEffect(() => {
+    if (chain?.id === KARMA_SEEDS_CONFIG.chainID) {
+      refetchEthBalance();
+      refetchUsdcBalance();
+    }
+  }, [chain?.id, refetchEthBalance, refetchUsdcBalance]);
+
+  const selectedPaymentOption = useMemo(
+    () => PAYMENT_OPTIONS.find((opt) => opt.id === paymentMethod) || PAYMENT_OPTIONS[0],
+    [paymentMethod]
+  );
+
+  const currentBalance = useMemo(() => {
+    if (paymentMethod === "eth" && ethBalance) {
+      return formatUnits(ethBalance.value, 18);
+    }
+    if (paymentMethod === "usdc" && usdcBalance) {
+      return formatUnits(usdcBalance.value, 6);
+    }
+    return "0";
+  }, [paymentMethod, ethBalance, usdcBalance]);
+
+  const updatePreview = useCallback(
+    async (inputAmount: string) => {
+      if (!inputAmount || parseFloat(inputAmount) <= 0) {
+        setPreviewTokens("0");
+        return;
+      }
+
+      try {
+        let tokens: string;
+        if (paymentMethod === "eth") {
+          tokens = await previewBuyWithEth(inputAmount);
+        } else {
+          tokens = await previewBuyWithStablecoin(inputAmount, selectedPaymentOption.decimals);
+        }
+        setPreviewTokens(tokens);
+      } catch (error) {
+        setPreviewTokens("0");
+      }
+    },
+    [paymentMethod, previewBuyWithEth, previewBuyWithStablecoin, selectedPaymentOption.decimals]
+  );
+
+  const handleAmountChange = useCallback(
+    (value: string) => {
+      const sanitized = value.replace(/[^0-9.]/g, "");
+      const parts = sanitized.split(".");
+      const formatted = parts.length > 2 ? parts[0] + "." + parts.slice(1).join("") : sanitized;
+      setAmount(formatted);
+      setErrorMessage("");
+      updatePreview(formatted);
+    },
+    [updatePreview]
+  );
+
+  const handlePaymentMethodChange = useCallback((method: PaymentMethod) => {
+    setPaymentMethod(method);
+    setAmount("");
+    setPreviewTokens("0");
+    setErrorMessage("");
+  }, []);
+
+  const handleClose = () => {
+    if (isBuying) {
+      return;
+    }
+    closeModal();
+    resetForm();
+  };
+
+  const resetForm = () => {
+    setAmount("");
+    setPaymentMethod("eth");
+    setPreviewTokens("0");
+    setErrorMessage("");
+    resetBuy();
+  };
+
+  const handleBuy = async () => {
+    if (!amount || parseFloat(amount) <= 0) {
+      setErrorMessage("Please enter a valid amount");
+      return;
+    }
+
+    if (parseFloat(amount) > parseFloat(currentBalance)) {
+      setErrorMessage("Insufficient balance");
+      return;
+    }
+
+    if (chain?.id !== KARMA_SEEDS_CONFIG.chainID) {
+      setErrorMessage("Please switch to Base network");
+      return;
+    }
+
+    setErrorMessage("");
+
+    try {
+      if (paymentMethod === "eth") {
+        await buyWithEth({ ethAmount: amount });
+      } else {
+        await buyWithStablecoin({
+          stablecoinAddress: KARMA_SEEDS_CONFIG.usdc,
+          amount,
+          decimals: 6,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Transaction failed";
+      setErrorMessage(message);
+      errorManager("Error buying Karma Seeds", error, {
+        project: project?.details?.slug || project?.uid,
+        amount,
+        paymentMethod,
+        address,
+      });
+    }
+  };
+
+  const getStatusContent = () => {
+    if (buyState.phase === "approving") {
+      return (
+        <div className="flex flex-col items-center justify-center py-8 gap-4">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+          <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">Approving USDC...</p>
+          <p className="text-sm text-gray-500 dark:text-zinc-400">
+            Please confirm the approval in your wallet
+          </p>
+        </div>
+      );
+    }
+
+    if (buyState.phase === "pending" || buyState.phase === "confirming") {
+      return (
+        <div className="flex flex-col items-center justify-center py-8 gap-4">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+          <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">
+            Buying Karma Seeds...
+          </p>
+          <p className="text-sm text-gray-500 dark:text-zinc-400">
+            {buyState.phase === "pending"
+              ? "Please confirm the transaction in your wallet"
+              : "Waiting for confirmation..."}
+          </p>
+        </div>
+      );
+    }
+
+    if (buyState.phase === "success") {
+      return (
+        <div className="flex flex-col items-center justify-center py-8 gap-4">
+          <div className="rounded-full h-12 w-12 bg-green-100 dark:bg-green-900 flex items-center justify-center">
+            <svg
+              className="h-6 w-6 text-green-600 dark:text-green-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <p className="text-lg font-medium text-gray-900 dark:text-zinc-100">
+            Purchase Successful!
+          </p>
+          <p className="text-sm text-gray-500 dark:text-zinc-400 text-center">
+            You have successfully purchased Karma Seeds.
+          </p>
+          <Button onClick={handleClose} className="mt-4">
+            Close
+          </Button>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  if (!project || !karmaSeeds) return null;
+
+  const isProcessing = buyState.phase !== "idle" && buyState.phase !== "error";
+  const statusContent = getStatusContent();
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl dark:bg-zinc-800 bg-white p-6 text-left align-middle transition-all">
+                {statusContent ? (
+                  statusContent
+                ) : (
+                  <>
+                    <div className="flex justify-between items-center mb-6">
+                      <Dialog.Title
+                        as="h3"
+                        className="text-xl font-semibold leading-6 text-gray-900 dark:text-zinc-100"
+                      >
+                        Buy Karma Seeds
+                      </Dialog.Title>
+                      <button
+                        type="button"
+                        onClick={handleClose}
+                        className="text-gray-400 hover:text-gray-500"
+                        disabled={isProcessing}
+                      >
+                        <XMarkIcon className="h-6 w-6" />
+                      </button>
+                    </div>
+
+                    <div className="mb-4 p-3 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg">
+                      <p className="text-sm text-emerald-700 dark:text-emerald-300">
+                        Support <strong>{project.details?.title}</strong> by purchasing Karma Seeds.
+                        Each seed costs $1 USD equivalent.
+                      </p>
+                    </div>
+
+                    <div className="space-y-4">
+                      <div>
+                        <span className={labelStyle}>Payment Method</span>
+                        <div className="flex gap-2 mt-2">
+                          {PAYMENT_OPTIONS.map((option) => (
+                            <button
+                              key={option.id}
+                              type="button"
+                              onClick={() => handlePaymentMethodChange(option.id)}
+                              className={cn(
+                                "flex-1 py-2 px-4 rounded-lg border-2 transition-colors",
+                                paymentMethod === option.id
+                                  ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-900/30"
+                                  : "border-gray-200 dark:border-zinc-600 hover:border-gray-300"
+                              )}
+                            >
+                              <span className="font-medium text-gray-900 dark:text-zinc-100">
+                                {option.symbol}
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+
+                      <div>
+                        <div className="flex justify-between items-center mb-1">
+                          <label htmlFor="seeds-amount" className={labelStyle}>
+                            Amount ({selectedPaymentOption.symbol})
+                          </label>
+                          <span className="text-xs text-gray-500 dark:text-zinc-400">
+                            Balance: {parseFloat(currentBalance).toFixed(4)}{" "}
+                            {selectedPaymentOption.symbol}
+                          </span>
+                        </div>
+                        <div className="relative">
+                          <input
+                            id="seeds-amount"
+                            type="text"
+                            value={amount}
+                            onChange={(e) => handleAmountChange(e.target.value)}
+                            placeholder="0.00"
+                            className={cn(inputStyle, errorMessage && "border-red-500")}
+                            disabled={isProcessing}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => handleAmountChange(currentBalance)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-emerald-600 dark:text-emerald-400 font-medium hover:underline"
+                            disabled={isProcessing}
+                          >
+                            MAX
+                          </button>
+                        </div>
+                        {errorMessage && (
+                          <p className="text-red-500 text-sm mt-1">{errorMessage}</p>
+                        )}
+                      </div>
+
+                      <div className="bg-gray-50 dark:bg-zinc-900 rounded-lg p-4">
+                        <div className="flex justify-between items-center">
+                          <span className="text-sm text-gray-500 dark:text-zinc-400">
+                            You will receive
+                          </span>
+                          <span className="text-lg font-bold text-gray-900 dark:text-zinc-100">
+                            {parseFloat(previewTokens).toLocaleString(undefined, {
+                              maximumFractionDigits: 2,
+                            })}{" "}
+                            Seeds
+                          </span>
+                        </div>
+                        <div className="flex justify-between items-center mt-2 text-xs text-gray-500 dark:text-zinc-400">
+                          <span>Token</span>
+                          <span>{karmaSeeds.tokenSymbol}</span>
+                        </div>
+                        {paymentMethod === "eth" && ethPrice && (
+                          <div className="flex justify-between items-center mt-1 text-xs text-gray-500 dark:text-zinc-400">
+                            <span>ETH Price</span>
+                            <span>${parseFloat(ethPrice).toFixed(2)}</span>
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="text-xs text-gray-500 dark:text-zinc-400 space-y-1">
+                        <div className="flex justify-between">
+                          <span>Total Raised</span>
+                          <span>${parseFloat(totalSupply).toLocaleString()}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span>Max Supply</span>
+                          <span>
+                            {parseFloat(maxSupply) > 0
+                              ? `$${parseFloat(maxSupply).toLocaleString()}`
+                              : "Unlimited"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span>Network</span>
+                          <span>Base</span>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col gap-3 pt-4">
+                        <Button
+                          onClick={handleBuy}
+                          disabled={
+                            !amount ||
+                            parseFloat(amount) <= 0 ||
+                            isProcessing ||
+                            chain?.id !== KARMA_SEEDS_CONFIG.chainID
+                          }
+                          className="w-full bg-emerald-600 hover:bg-emerald-700"
+                        >
+                          {chain?.id !== KARMA_SEEDS_CONFIG.chainID
+                            ? "Switch to Base Network"
+                            : `Buy ${previewTokens !== "0" ? parseFloat(previewTokens).toFixed(2) : ""} Seeds`}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={handleClose}
+                          disabled={isProcessing}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default BuySeedsDialog;

--- a/components/KarmaSeeds/KarmaSeedsCard.tsx
+++ b/components/KarmaSeeds/KarmaSeedsCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import type { FC } from "react";
+import type { Address } from "viem";
+import { useKarmaSeeds } from "@/hooks/useKarmaSeeds";
+import { useKarmaSeedsTokenData } from "@/hooks/useKarmaSeedsContract";
+import { useKarmaSeedsModalStore } from "@/store/modals/karmaSeeds";
+
+interface KarmaSeedsCardProps {
+  projectUID: string;
+}
+
+export const KarmaSeedsCard: FC<KarmaSeedsCardProps> = ({ projectUID }) => {
+  const { data: karmaSeeds, isLoading: isLoadingSeeds } = useKarmaSeeds(projectUID);
+  const { openBuyModal } = useKarmaSeedsModalStore();
+
+  // Read total supply directly from the contract (real-time on-chain data)
+  const contractAddress = karmaSeeds?.contractAddress as Address | undefined;
+  const { totalSupply, refetchTotalSupply } = useKarmaSeedsTokenData(contractAddress);
+
+  // Format the total raised (totalSupply = USD raised since 1 token = $1)
+  const totalRaisedValue = totalSupply
+    ? parseFloat(totalSupply).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    : "0";
+  const totalRaised = `${totalRaisedValue}$`;
+
+  if (isLoadingSeeds) {
+    return null;
+  }
+
+  if (!karmaSeeds) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openBuyModal}
+      className="flex flex-1 rounded border border-[#EAECf0] dark:border-zinc-600 border-l-[#10B981] dark:border-l-[#10B981] border-l-[4px] p-4 justify-between items-center hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
+    >
+      <div className="flex flex-col gap-2">
+        <p className="text-black dark:text-zinc-300 dark:bg-zinc-800 text-2xl font-bold bg-[#D1FAE5] rounded-lg px-2 py-1 flex justify-center items-center min-h-[40px] min-w-[40px] w-max h-max">
+          {totalRaised}
+        </p>
+        <div className="flex flex-row gap-2">
+          <p className="font-normal text-brand-gray text-sm dark:text-zinc-300">
+            Raised via Karma Seeds
+          </p>
+          <img src="/icons/seed.svg" alt="Seeds" className="w-5 h-5" />
+        </div>
+      </div>
+      <div className="w-5 h-5 flex justify-center items-center">
+        <ChevronRightIcon className="w-5 h-5 text-[#1D2939] dark:text-zinc-200" />
+      </div>
+    </button>
+  );
+};
+
+export default KarmaSeedsCard;

--- a/components/KarmaSeeds/LaunchKarmaSeedsButton.tsx
+++ b/components/KarmaSeeds/LaunchKarmaSeedsButton.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { RocketLaunchIcon } from "@heroicons/react/24/outline";
+import type { FC } from "react";
+import { Button } from "@/components/ui/button";
+import { useKarmaSeedsExists } from "@/hooks/useKarmaSeeds";
+import { useProjectStore } from "@/store";
+import { useKarmaSeedsModalStore } from "@/store/modals/karmaSeeds";
+
+interface LaunchKarmaSeedsButtonProps {
+  projectUID: string;
+}
+
+export const LaunchKarmaSeedsButton: FC<LaunchKarmaSeedsButtonProps> = ({ projectUID }) => {
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const { openLaunchModal } = useKarmaSeedsModalStore();
+  const { data: exists, isLoading } = useKarmaSeedsExists(projectUID);
+
+  const canLaunch = isProjectOwner || isProjectAdmin;
+
+  if (!canLaunch || exists || isLoading) {
+    return null;
+  }
+
+  return (
+    <Button
+      onClick={openLaunchModal}
+      variant="outline"
+      className="flex items-center gap-2 w-full justify-center border-emerald-500 text-emerald-600 hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-400 dark:hover:bg-emerald-950"
+    >
+      <RocketLaunchIcon className="w-5 h-5" />
+      Launch Karma Seeds
+    </Button>
+  );
+};
+
+export default LaunchKarmaSeedsButton;

--- a/components/KarmaSeeds/index.tsx
+++ b/components/KarmaSeeds/index.tsx
@@ -1,0 +1,3 @@
+export { BuySeedsDialog } from "./BuySeedsDialog";
+export { KarmaSeedsCard } from "./KarmaSeedsCard";
+export { LaunchKarmaSeedsButton } from "./LaunchKarmaSeedsButton";

--- a/components/Pages/Project/ProjectPage/index.tsx
+++ b/components/Pages/Project/ProjectPage/index.tsx
@@ -11,12 +11,14 @@ import pluralize from "pluralize";
 import { useEffect } from "react";
 import type { Hex } from "viem";
 import { useAccount } from "wagmi";
+import { LaunchKarmaSeedsDialog } from "@/components/Dialogs/LaunchKarmaSeedsDialog";
 import { MemberDialog } from "@/components/Dialogs/Member";
 import { DeleteMemberDialog } from "@/components/Dialogs/Member/DeleteMember";
 import { DemoteMemberDialog } from "@/components/Dialogs/Member/DemoteMember";
 import { InviteMemberDialog } from "@/components/Dialogs/Member/InviteMember";
 import { PromoteMemberDialog } from "@/components/Dialogs/Member/PromoteMember";
 import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
+import { BuySeedsDialog, KarmaSeedsCard, LaunchKarmaSeedsButton } from "@/components/KarmaSeeds";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -285,6 +287,8 @@ function ProjectPage() {
   return (
     <div className="flex flex-row max-lg:flex-col gap-6 max-md:gap-4 py-5 mb-20">
       <ContributorProfileDialog />
+      <LaunchKarmaSeedsDialog />
+      <BuySeedsDialog />
 
       <div className="flex flex-[2.5] gap-6 flex-col w-full max-lg:hidden">
         <Team />
@@ -300,6 +304,9 @@ function ProjectPage() {
         <ProjectImpact projectId={projectId} />
 
         {project ? <ProjectSubscription project={project} /> : null}
+
+        {project?.uid ? <LaunchKarmaSeedsButton projectUID={project.uid} /> : null}
+
         <div className="flex flex-col gap-1">
           <p className="text-black dark:text-zinc-400 font-bold text-sm">
             This project has received
@@ -345,6 +352,7 @@ function ProjectPage() {
               </div>
             </button>
           </div>
+          {project?.uid ? <KarmaSeedsCard projectUID={project.uid} /> : null}
         </div>
 
         <div className="flex w-full">

--- a/hooks/useKarmaSeeds.ts
+++ b/hooks/useKarmaSeeds.ts
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { errorManager } from "@/components/Utilities/errorManager";
+import type {
+  CreateKarmaSeedsRequest,
+  KarmaSeeds,
+  KarmaSeedsExistsResponse,
+  TotalRaisedResponse,
+} from "@/types/karmaSeeds";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+/**
+ * Query key factory for Karma Seeds
+ */
+export const KARMA_SEEDS_QUERY_KEYS = {
+  all: ["karmaSeeds"] as const,
+  byProject: (projectUID: string) => [...KARMA_SEEDS_QUERY_KEYS.all, projectUID] as const,
+  totalRaised: (projectUID: string) =>
+    [...KARMA_SEEDS_QUERY_KEYS.all, "totalRaised", projectUID] as const,
+  exists: (projectUID: string) => [...KARMA_SEEDS_QUERY_KEYS.all, "exists", projectUID] as const,
+};
+
+/**
+ * Fetch Karma Seeds for a project
+ */
+async function fetchKarmaSeeds(projectUID: string): Promise<KarmaSeeds | null> {
+  const [data, error] = await fetchData<KarmaSeeds>(
+    INDEXER.KARMA_SEEDS.GET(projectUID),
+    "GET",
+    {},
+    {},
+    {},
+    false // Public endpoint, no auth required
+  );
+
+  if (error) {
+    // 404 means no Karma Seeds for this project (expected case)
+    if (error.includes("not found") || error.includes("404")) {
+      return null;
+    }
+    throw new Error(error);
+  }
+
+  return data;
+}
+
+/**
+ * Check if Karma Seeds exists for a project
+ */
+async function checkKarmaSeedsExists(projectUID: string): Promise<boolean> {
+  const [data, error] = await fetchData<KarmaSeedsExistsResponse>(
+    INDEXER.KARMA_SEEDS.EXISTS(projectUID),
+    "GET",
+    {},
+    {},
+    {},
+    false
+  );
+
+  if (error) {
+    console.error("Error checking Karma Seeds existence:", error);
+    return false;
+  }
+
+  return data?.exists ?? false;
+}
+
+/**
+ * Fetch total raised amount for a project
+ */
+async function fetchTotalRaised(projectUID: string): Promise<TotalRaisedResponse | null> {
+  const [data, error] = await fetchData<TotalRaisedResponse>(
+    INDEXER.KARMA_SEEDS.TOTAL_RAISED(projectUID),
+    "GET",
+    {},
+    {},
+    {},
+    false
+  );
+
+  if (error) {
+    if (error.includes("not found") || error.includes("404")) {
+      return null;
+    }
+    throw new Error(error);
+  }
+
+  return data;
+}
+
+/**
+ * Create Karma Seeds record (after contract deployment)
+ */
+async function createKarmaSeeds(
+  projectUID: string,
+  request: CreateKarmaSeedsRequest
+): Promise<KarmaSeeds> {
+  const [data, error] = await fetchData<KarmaSeeds>(
+    INDEXER.KARMA_SEEDS.CREATE(projectUID),
+    "POST",
+    request,
+    {},
+    {},
+    true // Requires authentication
+  );
+
+  if (error) {
+    throw new Error(error);
+  }
+
+  if (!data) {
+    throw new Error("Failed to create Karma Seeds record");
+  }
+
+  return data;
+}
+
+/**
+ * Hook to fetch Karma Seeds for a project
+ */
+export function useKarmaSeeds(projectUID: string | undefined) {
+  return useQuery({
+    queryKey: KARMA_SEEDS_QUERY_KEYS.byProject(projectUID || ""),
+    queryFn: () => fetchKarmaSeeds(projectUID!),
+    enabled: !!projectUID,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 1,
+  });
+}
+
+/**
+ * Hook to check if Karma Seeds exists for a project
+ */
+export function useKarmaSeedsExists(projectUID: string | undefined) {
+  return useQuery({
+    queryKey: KARMA_SEEDS_QUERY_KEYS.exists(projectUID || ""),
+    queryFn: () => checkKarmaSeedsExists(projectUID!),
+    enabled: !!projectUID,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+/**
+ * Hook to fetch total raised amount (with auto-refresh)
+ */
+export function useTotalRaised(projectUID: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: KARMA_SEEDS_QUERY_KEYS.totalRaised(projectUID || ""),
+    queryFn: () => fetchTotalRaised(projectUID!),
+    enabled: !!projectUID && enabled,
+    staleTime: 30 * 1000, // 30 seconds (refresh more frequently)
+    refetchInterval: 30 * 1000, // Auto-refresh every 30 seconds
+    retry: 1,
+  });
+}
+
+/**
+ * Hook to create Karma Seeds record
+ */
+export function useCreateKarmaSeeds() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      projectUID,
+      request,
+    }: {
+      projectUID: string;
+      request: CreateKarmaSeedsRequest;
+    }) => createKarmaSeeds(projectUID, request),
+    onSuccess: (data, variables) => {
+      // Invalidate and refetch queries
+      queryClient.invalidateQueries({
+        queryKey: KARMA_SEEDS_QUERY_KEYS.byProject(variables.projectUID),
+      });
+      queryClient.invalidateQueries({
+        queryKey: KARMA_SEEDS_QUERY_KEYS.exists(variables.projectUID),
+      });
+      queryClient.invalidateQueries({
+        queryKey: KARMA_SEEDS_QUERY_KEYS.totalRaised(variables.projectUID),
+      });
+    },
+    onError: (error: Error) => {
+      errorManager("Error creating Karma Seeds", error);
+    },
+  });
+}
+
+export type { KarmaSeeds, TotalRaisedResponse, CreateKarmaSeedsRequest };

--- a/hooks/useKarmaSeedsContract.ts
+++ b/hooks/useKarmaSeedsContract.ts
@@ -1,0 +1,632 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { type Address, formatUnits, getAddress, type Hash, parseUnits } from "viem";
+import {
+  useAccount,
+  usePublicClient,
+  useReadContract,
+  useSwitchChain,
+  useWaitForTransactionReceipt,
+  useWalletClient,
+  useWriteContract,
+} from "wagmi";
+import { base } from "wagmi/chains";
+import { KARMA_SEEDS_CONFIG, type KarmaSeedsConfig } from "@/types/karmaSeeds";
+import KarmaSeedFactoryABI from "@/utilities/abi/KarmaSeedFactoryV2.json";
+import KarmaSeedABI from "@/utilities/abi/KarmaSeedV2.json";
+import { getRPCClient } from "@/utilities/rpcClient";
+
+const ERC20_ABI = [
+  {
+    name: "approve",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    name: "allowance",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+export interface LaunchSeedsParams {
+  projectName: string;
+  tokenName: string;
+  tokenSymbol: string;
+  treasury: Address;
+  maxSupply: string;
+}
+
+export interface LaunchSeedsResult {
+  tokenAddress: Address;
+  txHash: Hash;
+}
+
+export interface BuySeedsWithEthParams {
+  ethAmount: string;
+}
+
+export interface BuySeedsWithStablecoinParams {
+  stablecoinAddress: Address;
+  amount: string;
+  decimals: number;
+}
+
+export interface BuySeedsWithTokenParams {
+  tokenAddress: Address;
+  amount: string;
+  decimals: number;
+}
+
+export interface BuySeedsResult {
+  txHash: Hash;
+  tokensMinted: string;
+}
+
+export type TransactionPhase =
+  | "idle"
+  | "approving"
+  | "pending"
+  | "confirming"
+  | "success"
+  | "error";
+
+export interface TransactionState {
+  phase: TransactionPhase;
+  txHash?: Hash;
+  error?: string;
+}
+
+/**
+ * Hook for launching Karma Seeds via factory contract
+ */
+export function useLaunchKarmaSeeds(config: KarmaSeedsConfig = KARMA_SEEDS_CONFIG) {
+  const { address, chainId: currentChainId } = useAccount();
+  const publicClient = usePublicClient();
+  const { writeContractAsync } = useWriteContract();
+  const { switchChainAsync } = useSwitchChain();
+  const [state, setState] = useState<TransactionState>({ phase: "idle" });
+
+  const launch = useCallback(
+    async (params: LaunchSeedsParams): Promise<LaunchSeedsResult> => {
+      if (!address) {
+        throw new Error("Wallet not connected");
+      }
+
+      if (config.factoryAddress === "0x0000000000000000000000000000000000000000") {
+        throw new Error("Factory contract not yet deployed");
+      }
+
+      setState({ phase: "pending" });
+
+      try {
+        // Switch to Base if not already on it
+        if (currentChainId !== config.chainID) {
+          await switchChainAsync({ chainId: config.chainID });
+        }
+
+        const maxSupplyWei = parseUnits(params.maxSupply, 18);
+
+        const txHash = await writeContractAsync({
+          address: config.factoryAddress,
+          abi: KarmaSeedFactoryABI,
+          functionName: "createKarmaSeed",
+          args: [
+            {
+              projectName: params.projectName,
+              tokenName: params.tokenName,
+              tokenSymbol: params.tokenSymbol,
+              treasury: params.treasury,
+              maxSupply: maxSupplyWei,
+            },
+          ],
+          chain: base,
+        });
+
+        setState({ phase: "confirming", txHash });
+
+        const chainClient =
+          publicClient?.chain?.id === config.chainID
+            ? publicClient
+            : await getRPCClient(config.chainID);
+
+        const receipt = await chainClient.waitForTransactionReceipt({
+          hash: txHash,
+          confirmations: 1,
+        });
+
+        if (receipt.status !== "success") {
+          throw new Error("Transaction failed");
+        }
+
+        const karmaSeedCreatedLog = receipt.logs.find((log) => {
+          return (
+            log.topics[0] === "0xc8d9d0ef7b62bda1a8bc556fbb9c35de0aefb1fa15df789fffecf3a0c83f5d0e"
+          );
+        });
+
+        let tokenAddress: Address;
+        if (karmaSeedCreatedLog && karmaSeedCreatedLog.topics[2]) {
+          tokenAddress = getAddress(`0x${karmaSeedCreatedLog.topics[2].slice(26)}`) as Address;
+        } else {
+          const projectAddress = (await chainClient.readContract({
+            address: config.factoryAddress,
+            abi: KarmaSeedFactoryABI,
+            functionName: "projects",
+            args: [params.projectName],
+          })) as Address;
+
+          if (!projectAddress || projectAddress === "0x0000000000000000000000000000000000000000") {
+            throw new Error("Failed to get deployed token address");
+          }
+
+          tokenAddress = projectAddress;
+        }
+
+        setState({ phase: "success", txHash });
+
+        return {
+          tokenAddress,
+          txHash,
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        setState({ phase: "error", error: errorMessage });
+        throw error;
+      }
+    },
+    [address, publicClient, writeContractAsync, config]
+  );
+
+  const reset = useCallback(() => {
+    setState({ phase: "idle" });
+  }, []);
+
+  return {
+    launch,
+    state,
+    reset,
+    isLoading: state.phase === "pending" || state.phase === "confirming",
+    isSuccess: state.phase === "success",
+    isError: state.phase === "error",
+  };
+}
+
+/**
+ * Hook for buying Karma Seeds tokens
+ */
+export function useBuyKarmaSeeds(
+  contractAddress: Address | undefined,
+  config: KarmaSeedsConfig = KARMA_SEEDS_CONFIG
+) {
+  const { address } = useAccount();
+  const publicClient = usePublicClient();
+  const { data: walletClient } = useWalletClient();
+  const { writeContractAsync } = useWriteContract();
+  const [state, setState] = useState<TransactionState>({ phase: "idle" });
+
+  const buyWithEth = useCallback(
+    async (params: BuySeedsWithEthParams): Promise<BuySeedsResult> => {
+      if (!address || !contractAddress) {
+        throw new Error("Wallet not connected or contract not set");
+      }
+
+      setState({ phase: "pending" });
+
+      try {
+        const ethAmountWei = parseUnits(params.ethAmount, 18);
+
+        const txHash = await writeContractAsync({
+          address: contractAddress,
+          abi: KarmaSeedABI,
+          functionName: "buy",
+          value: ethAmountWei,
+          chainId: config.chainID,
+        });
+
+        setState({ phase: "confirming", txHash });
+
+        const chainClient =
+          publicClient?.chain?.id === config.chainID
+            ? publicClient
+            : await getRPCClient(config.chainID);
+
+        const receipt = await chainClient.waitForTransactionReceipt({
+          hash: txHash,
+          confirmations: 1,
+        });
+
+        if (receipt.status !== "success") {
+          throw new Error("Transaction failed");
+        }
+
+        setState({ phase: "success", txHash });
+
+        return {
+          txHash,
+          tokensMinted: "0",
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        setState({ phase: "error", error: errorMessage });
+        throw error;
+      }
+    },
+    [address, contractAddress, publicClient, writeContractAsync, config]
+  );
+
+  const buyWithStablecoin = useCallback(
+    async (params: BuySeedsWithStablecoinParams): Promise<BuySeedsResult> => {
+      if (!address || !contractAddress || !walletClient) {
+        throw new Error("Wallet not connected or contract not set");
+      }
+
+      setState({ phase: "approving" });
+
+      try {
+        const amountWei = parseUnits(params.amount, params.decimals);
+        const chainClient =
+          publicClient?.chain?.id === config.chainID
+            ? publicClient
+            : await getRPCClient(config.chainID);
+
+        const allowance = (await chainClient.readContract({
+          address: params.stablecoinAddress,
+          abi: ERC20_ABI,
+          functionName: "allowance",
+          args: [address, contractAddress],
+        })) as bigint;
+
+        if (allowance < amountWei) {
+          const approveTxHash = await writeContractAsync({
+            address: params.stablecoinAddress,
+            abi: ERC20_ABI,
+            functionName: "approve",
+            args: [contractAddress, amountWei],
+            chainId: config.chainID,
+          });
+
+          await chainClient.waitForTransactionReceipt({
+            hash: approveTxHash,
+            confirmations: 1,
+          });
+        }
+
+        setState({ phase: "pending" });
+
+        const txHash = await writeContractAsync({
+          address: contractAddress,
+          abi: KarmaSeedABI,
+          functionName: "buyWithStablecoin",
+          args: [params.stablecoinAddress, amountWei],
+          chainId: config.chainID,
+        });
+
+        setState({ phase: "confirming", txHash });
+
+        const receipt = await chainClient.waitForTransactionReceipt({
+          hash: txHash,
+          confirmations: 1,
+        });
+
+        if (receipt.status !== "success") {
+          throw new Error("Transaction failed");
+        }
+
+        setState({ phase: "success", txHash });
+
+        return {
+          txHash,
+          tokensMinted: "0",
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        setState({ phase: "error", error: errorMessage });
+        throw error;
+      }
+    },
+    [address, contractAddress, publicClient, walletClient, writeContractAsync, config]
+  );
+
+  const buyWithToken = useCallback(
+    async (params: BuySeedsWithTokenParams): Promise<BuySeedsResult> => {
+      if (!address || !contractAddress || !walletClient) {
+        throw new Error("Wallet not connected or contract not set");
+      }
+
+      setState({ phase: "approving" });
+
+      try {
+        const amountWei = parseUnits(params.amount, params.decimals);
+        const chainClient =
+          publicClient?.chain?.id === config.chainID
+            ? publicClient
+            : await getRPCClient(config.chainID);
+
+        const allowance = (await chainClient.readContract({
+          address: params.tokenAddress,
+          abi: ERC20_ABI,
+          functionName: "allowance",
+          args: [address, contractAddress],
+        })) as bigint;
+
+        if (allowance < amountWei) {
+          const approveTxHash = await writeContractAsync({
+            address: params.tokenAddress,
+            abi: ERC20_ABI,
+            functionName: "approve",
+            args: [contractAddress, amountWei],
+            chainId: config.chainID,
+          });
+
+          await chainClient.waitForTransactionReceipt({
+            hash: approveTxHash,
+            confirmations: 1,
+          });
+        }
+
+        setState({ phase: "pending" });
+
+        const txHash = await writeContractAsync({
+          address: contractAddress,
+          abi: KarmaSeedABI,
+          functionName: "buyWithToken",
+          args: [params.tokenAddress, amountWei],
+          chainId: config.chainID,
+        });
+
+        setState({ phase: "confirming", txHash });
+
+        const receipt = await chainClient.waitForTransactionReceipt({
+          hash: txHash,
+          confirmations: 1,
+        });
+
+        if (receipt.status !== "success") {
+          throw new Error("Transaction failed");
+        }
+
+        setState({ phase: "success", txHash });
+
+        return {
+          txHash,
+          tokensMinted: "0",
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        setState({ phase: "error", error: errorMessage });
+        throw error;
+      }
+    },
+    [address, contractAddress, publicClient, walletClient, writeContractAsync, config]
+  );
+
+  const reset = useCallback(() => {
+    setState({ phase: "idle" });
+  }, []);
+
+  return {
+    buyWithEth,
+    buyWithStablecoin,
+    buyWithToken,
+    state,
+    reset,
+    isLoading:
+      state.phase === "approving" || state.phase === "pending" || state.phase === "confirming",
+    isSuccess: state.phase === "success",
+    isError: state.phase === "error",
+  };
+}
+
+/**
+ * Hook for reading Karma Seeds token data from the contract
+ */
+export function useKarmaSeedsTokenData(
+  contractAddress: Address | undefined,
+  config: KarmaSeedsConfig = KARMA_SEEDS_CONFIG
+) {
+  const { data: totalSupply, refetch: refetchTotalSupply } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "totalSupply",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  const { data: maxSupply } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "maxSupply",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  const { data: remainingSupply } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "remainingSupply",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  const { data: ethPrice } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "getEthPrice",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  const { data: tokenName } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "name",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  const { data: tokenSymbol } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "symbol",
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress,
+    },
+  });
+
+  return {
+    totalSupply: totalSupply ? formatUnits(totalSupply as bigint, 18) : "0",
+    totalSupplyRaw: totalSupply as bigint | undefined,
+    maxSupply: maxSupply ? formatUnits(maxSupply as bigint, 18) : "0",
+    maxSupplyRaw: maxSupply as bigint | undefined,
+    remainingSupply: remainingSupply ? formatUnits(remainingSupply as bigint, 18) : "0",
+    remainingSupplyRaw: remainingSupply as bigint | undefined,
+    ethPrice: ethPrice ? formatUnits(ethPrice as bigint, 8) : "0",
+    ethPriceRaw: ethPrice as bigint | undefined,
+    tokenName: tokenName as string | undefined,
+    tokenSymbol: tokenSymbol as string | undefined,
+    refetchTotalSupply,
+  };
+}
+
+/**
+ * Hook for previewing token purchase amounts
+ */
+export function usePreviewBuySeeds(
+  contractAddress: Address | undefined,
+  config: KarmaSeedsConfig = KARMA_SEEDS_CONFIG
+) {
+  const publicClient = usePublicClient();
+
+  const previewBuyWithEth = useCallback(
+    async (ethAmount: string): Promise<string> => {
+      if (!contractAddress) {
+        throw new Error("Contract address not set");
+      }
+
+      const chainClient =
+        publicClient?.chain?.id === config.chainID
+          ? publicClient
+          : await getRPCClient(config.chainID);
+
+      const ethAmountWei = parseUnits(ethAmount, 18);
+
+      const tokensAmount = (await chainClient.readContract({
+        address: contractAddress,
+        abi: KarmaSeedABI,
+        functionName: "previewBuyWithETH",
+        args: [ethAmountWei],
+      })) as bigint;
+
+      return formatUnits(tokensAmount, 18);
+    },
+    [contractAddress, publicClient, config]
+  );
+
+  const previewBuyWithStablecoin = useCallback(
+    async (amount: string, decimals: number): Promise<string> => {
+      if (!contractAddress) {
+        throw new Error("Contract address not set");
+      }
+
+      const chainClient =
+        publicClient?.chain?.id === config.chainID
+          ? publicClient
+          : await getRPCClient(config.chainID);
+
+      const amountWei = parseUnits(amount, decimals);
+
+      const tokensAmount = (await chainClient.readContract({
+        address: contractAddress,
+        abi: KarmaSeedABI,
+        functionName: "previewBuyWithStablecoin",
+        args: [amountWei],
+      })) as bigint;
+
+      return formatUnits(tokensAmount, 18);
+    },
+    [contractAddress, publicClient, config]
+  );
+
+  const previewBuyWithToken = useCallback(
+    async (tokenAddress: Address, amount: string, decimals: number): Promise<string> => {
+      if (!contractAddress) {
+        throw new Error("Contract address not set");
+      }
+
+      const chainClient =
+        publicClient?.chain?.id === config.chainID
+          ? publicClient
+          : await getRPCClient(config.chainID);
+
+      const amountWei = parseUnits(amount, decimals);
+
+      const tokensAmount = (await chainClient.readContract({
+        address: contractAddress,
+        abi: KarmaSeedABI,
+        functionName: "previewBuyWithToken",
+        args: [tokenAddress, amountWei],
+      })) as bigint;
+
+      return formatUnits(tokensAmount, 18);
+    },
+    [contractAddress, publicClient, config]
+  );
+
+  return {
+    previewBuyWithEth,
+    previewBuyWithStablecoin,
+    previewBuyWithToken,
+  };
+}
+
+/**
+ * Hook for getting user's Karma Seeds token balance
+ */
+export function useKarmaSeedsBalance(
+  contractAddress: Address | undefined,
+  config: KarmaSeedsConfig = KARMA_SEEDS_CONFIG
+) {
+  const { address } = useAccount();
+
+  const { data: balance, refetch } = useReadContract({
+    address: contractAddress,
+    abi: KarmaSeedABI,
+    functionName: "balanceOf",
+    args: address ? [address] : undefined,
+    chainId: config.chainID,
+    query: {
+      enabled: !!contractAddress && !!address,
+    },
+  });
+
+  return {
+    balance: balance ? formatUnits(balance as bigint, 18) : "0",
+    balanceRaw: balance as bigint | undefined,
+    refetch,
+  };
+}
+
+export { KARMA_SEEDS_CONFIG };

--- a/public/icons/seed.svg
+++ b/public/icons/seed.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 22c4-2 8-6 8-12a8 8 0 0 0-16 0c0 6 4 10 8 12z"/>
+  <path d="M12 22V8"/>
+  <path d="M8 12c2-2 4-2 4-2s2 0 4 2"/>
+</svg>

--- a/store/modals/karmaSeeds.ts
+++ b/store/modals/karmaSeeds.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { create } from "zustand";
+
+interface KarmaSeedsModalStore {
+  // Launch modal state
+  isLaunchModalOpen: boolean;
+  setLaunchModalOpen: (isOpen: boolean) => void;
+  openLaunchModal: () => void;
+  closeLaunchModal: () => void;
+
+  // Buy modal state
+  isBuyModalOpen: boolean;
+  setBuyModalOpen: (isOpen: boolean) => void;
+  openBuyModal: () => void;
+  closeBuyModal: () => void;
+
+  // Form defaults (set from project data)
+  defaultTokenName: string;
+  defaultTokenSymbol: string;
+  setDefaults: (projectName: string) => void;
+}
+
+/**
+ * Generate token name from project name
+ * e.g., "My Project" -> "KSEED-My Project"
+ */
+function generateTokenName(projectName: string): string {
+  return `KSEED-${projectName.slice(0, 24)}`;
+}
+
+/**
+ * Generate token symbol from project name
+ * Takes first letters of each word, max 6 chars
+ * e.g., "My Project" -> "KSEED-MP"
+ */
+function generateTokenSymbol(projectName: string): string {
+  const initials = projectName
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase())
+    .join("")
+    .slice(0, 4);
+  return `KS-${initials}`;
+}
+
+export const useKarmaSeedsModalStore = create<KarmaSeedsModalStore>((set) => ({
+  // Launch modal
+  isLaunchModalOpen: false,
+  setLaunchModalOpen: (isOpen) => set({ isLaunchModalOpen: isOpen }),
+  openLaunchModal: () => set({ isLaunchModalOpen: true }),
+  closeLaunchModal: () => set({ isLaunchModalOpen: false }),
+
+  // Buy modal
+  isBuyModalOpen: false,
+  setBuyModalOpen: (isOpen) => set({ isBuyModalOpen: isOpen }),
+  openBuyModal: () => set({ isBuyModalOpen: true }),
+  closeBuyModal: () => set({ isBuyModalOpen: false }),
+
+  // Form defaults
+  defaultTokenName: "",
+  defaultTokenSymbol: "",
+  setDefaults: (projectName: string) => {
+    set({
+      defaultTokenName: generateTokenName(projectName),
+      defaultTokenSymbol: generateTokenSymbol(projectName),
+    });
+  },
+}));

--- a/types/karmaSeeds.ts
+++ b/types/karmaSeeds.ts
@@ -1,0 +1,96 @@
+/**
+ * Karma Seeds - Project Funding via Token Sales
+ * Allows project owners to launch ERC-20 tokens for supporters to fund projects
+ */
+
+/**
+ * KarmaSeeds entity from the backend API
+ */
+export interface KarmaSeeds {
+  id: string;
+  projectUID: string;
+  chainID: number;
+  chainName: string;
+  contractAddress: string;
+  factoryAddress: string;
+  tokenName: string;
+  tokenSymbol: string;
+  maxSupply: string;
+  treasuryAddress: string;
+  creatorAddress: string;
+  deploymentTxHash: string;
+  totalRaised: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastSyncedAt: string | null;
+}
+
+/**
+ * Total raised response from the API
+ */
+export interface TotalRaisedResponse {
+  projectUID: string;
+  totalRaised: string;
+  lastSyncedAt: string | null;
+}
+
+/**
+ * Form data for launching Karma Seeds
+ */
+export interface LaunchKarmaSeedsForm {
+  tokenName: string;
+  tokenSymbol: string;
+  maxSupply: string;
+}
+
+/**
+ * Request body for creating Karma Seeds record
+ * (after contract deployment)
+ */
+export interface CreateKarmaSeedsRequest {
+  tokenName: string;
+  tokenSymbol: string;
+  maxSupply: string;
+  treasuryAddress: string;
+  contractAddress: string;
+  factoryAddress: string;
+  deploymentTxHash: string;
+  chainID?: number;
+}
+
+/**
+ * Exists check response
+ */
+export interface KarmaSeedsExistsResponse {
+  exists: boolean;
+}
+
+/**
+ * Configuration for Karma Seeds contracts on different chains
+ */
+export interface KarmaSeedsConfig {
+  chainID: number;
+  chainName: string;
+  factoryAddress: `0x${string}`;
+  ethUsdFeed: `0x${string}`;
+  usdc: `0x${string}`;
+  weth: `0x${string}`;
+}
+
+/**
+ * Base Mainnet Karma Seeds configuration
+ */
+export const KARMA_SEEDS_CONFIG: KarmaSeedsConfig = {
+  chainID: 8453,
+  chainName: "Base",
+  factoryAddress: "0x7c65DD7ddef0A4b5d97dc5d447894083f4e56d37" as `0x${string}`,
+  ethUsdFeed: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70" as `0x${string}`,
+  usdc: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`,
+  weth: "0x4200000000000000000000000000000000000006" as `0x${string}`,
+};
+
+/**
+ * Default max supply for Karma Seeds (1 million tokens)
+ */
+export const DEFAULT_MAX_SUPPLY = "1000000";
+export const DEFAULT_MAX_SUPPLY_WEI = "1000000000000000000000000";

--- a/utilities/abi/KarmaSeedFactoryV2.json
+++ b/utilities/abi/KarmaSeedFactoryV2.json
@@ -1,0 +1,184 @@
+[
+  {
+    "type": "function",
+    "name": "createKarmaSeed",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "components": [
+          { "name": "projectName", "type": "string" },
+          { "name": "tokenName", "type": "string" },
+          { "name": "tokenSymbol", "type": "string" },
+          { "name": "treasury", "type": "address" },
+          { "name": "maxSupply", "type": "uint256" }
+        ]
+      }
+    ],
+    "outputs": [{ "name": "tokenAddress", "type": "address" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "predictAddress",
+    "inputs": [
+      { "name": "projectName_", "type": "string" },
+      { "name": "creator_", "type": "address" },
+      { "name": "timestamp_", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "predicted", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "projectExists",
+    "inputs": [{ "name": "projectName_", "type": "string" }],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isValidKarmaSeed",
+    "inputs": [{ "name": "tokenAddress", "type": "address" }],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProjectInfo",
+    "inputs": [{ "name": "tokenAddress", "type": "address" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "components": [
+          { "name": "projectName", "type": "string" },
+          { "name": "tokenName", "type": "string" },
+          { "name": "tokenSymbol", "type": "string" },
+          { "name": "treasury", "type": "address" },
+          { "name": "tokenAddress", "type": "address" },
+          { "name": "creator", "type": "address" },
+          { "name": "createdAt", "type": "uint256" },
+          { "name": "maxSupply", "type": "uint256" }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTokenAddress",
+    "inputs": [{ "name": "projectName_", "type": "string" }],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStablecoins",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address[]" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "projects",
+    "inputs": [{ "name": "", "type": "string" }],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isStablecoin",
+    "inputs": [{ "name": "", "type": "address" }],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "karmaFeeCollector",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ethUsdFeed",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "uniswapV3Factory",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "weth",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "KarmaSeedCreated",
+    "inputs": [
+      { "name": "projectName", "type": "string", "indexed": true },
+      { "name": "tokenAddress", "type": "address", "indexed": true },
+      { "name": "creator", "type": "address", "indexed": true },
+      { "name": "treasury", "type": "address", "indexed": false },
+      { "name": "tokenName", "type": "string", "indexed": false },
+      { "name": "tokenSymbol", "type": "string", "indexed": false },
+      { "name": "maxSupply", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ProjectNameAlreadyExists",
+    "inputs": [{ "name": "projectName", "type": "string" }]
+  },
+  {
+    "type": "error",
+    "name": "InvalidProjectName",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidTokenName",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidTokenSymbol",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FeedNotSet",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKarmaProfile",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ImplementationNotSet",
+    "inputs": []
+  }
+]

--- a/utilities/abi/KarmaSeedV2.json
+++ b/utilities/abi/KarmaSeedV2.json
@@ -1,0 +1,271 @@
+[
+  {
+    "type": "function",
+    "name": "buy",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "buyWithStablecoin",
+    "inputs": [
+      { "name": "stablecoin", "type": "address" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "buyWithToken",
+    "inputs": [{ "name": "token", "type": "address" }, { "name": "amount", "type": "uint256" }],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "previewBuyWithETH",
+    "inputs": [{ "name": "ethAmount", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewBuyWithStablecoin",
+    "inputs": [{ "name": "amount", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "previewBuyWithToken",
+    "inputs": [{ "name": "token", "type": "address" }, { "name": "amount", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEthPrice",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setMaxSupply",
+    "inputs": [{ "name": "newMaxSupply", "type": "uint256" }],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [{ "name": "owner", "type": "address" }, { "name": "spender", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [{ "name": "spender", "type": "address" }, { "name": "amount", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [{ "name": "to", "type": "address" }, { "name": "amount", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "projectName",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "treasury",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxSupply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "remainingSupply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "KARMA_FEE_BPS",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "BPS_DENOMINATOR",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "TokensPurchased",
+    "inputs": [
+      { "name": "buyer", "type": "address", "indexed": true },
+      { "name": "paymentToken", "type": "address", "indexed": true },
+      { "name": "paymentAmount", "type": "uint256", "indexed": false },
+      { "name": "usdValue", "type": "uint256", "indexed": false },
+      { "name": "tokensMinted", "type": "uint256", "indexed": false },
+      { "name": "karmaFee", "type": "uint256", "indexed": false },
+      { "name": "treasuryAmount", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "MaxSupplyUpdated",
+    "inputs": [
+      { "name": "oldMaxSupply", "type": "uint256", "indexed": false },
+      { "name": "newMaxSupply", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      { "name": "from", "type": "address", "indexed": true },
+      { "name": "to", "type": "address", "indexed": true },
+      { "name": "value", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      { "name": "owner", "type": "address", "indexed": true },
+      { "name": "spender", "type": "address", "indexed": true },
+      { "name": "value", "type": "uint256", "indexed": false }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokenNotSupported",
+    "inputs": [{ "name": "token", "type": "address" }]
+  },
+  {
+    "type": "error",
+    "name": "ETHTransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StalePrice",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxSupplyExceeded",
+    "inputs": [
+      { "name": "requested", "type": "uint256" },
+      { "name": "available", "type": "uint256" }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotFactory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAuthorized",
+    "inputs": []
+  }
+]

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -599,4 +599,11 @@ export const INDEXER = {
       `/projects/${idOrSlug}/update/contact/${contactId}`,
     DELETE: (idOrSlug: string) => `/projects/${idOrSlug}/delete/contact`,
   },
+  KARMA_SEEDS: {
+    GET: (projectUID: string) => `/v2/projects/${projectUID}/karma-seeds`,
+    EXISTS: (projectUID: string) => `/v2/projects/${projectUID}/karma-seeds/exists`,
+    TOTAL_RAISED: (projectUID: string) => `/v2/projects/${projectUID}/karma-seeds/total-raised`,
+    CREATE: (projectUID: string) => `/v2/projects/${projectUID}/karma-seeds`,
+    SYNC: (projectUID: string) => `/v2/projects/${projectUID}/karma-seeds/sync`,
+  },
 };

--- a/utilities/wagmi/privy-config.ts
+++ b/utilities/wagmi/privy-config.ts
@@ -2,6 +2,7 @@ import { createConfig } from "@privy-io/wagmi";
 import { type Config, http } from "@wagmi/core";
 import {
   arbitrum,
+  base,
   baseSepolia,
   celo,
   lisk,
@@ -44,6 +45,7 @@ export const privyConfig = createConfig({
   transports: {
     [optimism.id]: http(envVars.RPC.OPTIMISM, httpTransportOptions),
     [arbitrum.id]: http(envVars.RPC.ARBITRUM, httpTransportOptions),
+    [base.id]: http(envVars.RPC.BASE, httpTransportOptions),
     [baseSepolia.id]: http(envVars.RPC.BASE_SEPOLIA, httpTransportOptions),
     [optimismSepolia.id]: http(envVars.RPC.OPT_SEPOLIA, httpTransportOptions),
     [celo.id]: http(envVars.RPC.CELO, httpTransportOptions),


### PR DESCRIPTION
Add frontend support for Karma Seeds project funding:

Components:
- LaunchKarmaSeedsDialog: Modal for project owners to deploy new tokens
- BuySeedsDialog: Checkout dialog for purchasing seeds with ETH/USDC
- KarmaSeedsCard: Display total raised with real-time on-chain data
- LaunchKarmaSeedsButton: Entry point for project owners

Hooks:
- useKarmaSeeds: React Query hooks for API interactions
- useKarmaSeedsContract: Wagmi hooks for contract interactions

Features:
- Auto chain switching to Base network
- Real-time balance and price display
- ETH and USDC payment methods
- Transaction state management with loading states

Config:
- Add Base mainnet to wagmi transport config
- Factory address: 0x7c65DD7ddef0A4b5d97dc5d447894083f4e56d37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Karma Seeds token fundraising—projects can now launch branded fundraising tokens; users can purchase via ETH or USDC with real-time token amount previews.
  * Integrated purchase dialogs, launch controls, and fundraising progress display throughout project pages.

* **Chores**
  * Added BASE chain network support for Karma Seeds functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->