### PR TITLE
feat(community-updates): improve filters with backend integration

### DIFF
--- a/__tests__/components/Community/CommunityMilestoneCard.test.tsx
+++ b/__tests__/components/Community/CommunityMilestoneCard.test.tsx
@@ -113,6 +113,7 @@ describe("CommunityMilestoneCard", () => {
     },
     grant: {
       uid: "grant-abc",
+      programId: "program-123",
       details: {
         data: {
           title: "Test Grant Program",
@@ -325,6 +326,7 @@ describe("CommunityMilestoneCard", () => {
       const milestone = createMockMilestone({
         grant: {
           uid: "grant-123",
+          programId: "program-456",
           details: {
             data: {
               title: "Filecoin ProPGF Batch 1",
@@ -336,6 +338,50 @@ describe("CommunityMilestoneCard", () => {
       render(<CommunityMilestoneCard milestone={milestone} />);
 
       expect(screen.getByText("Filecoin ProPGF Batch 1")).toBeInTheDocument();
+    });
+
+    it("should link grant title to projects page with programId filter when programId is available", () => {
+      const milestone = createMockMilestone({
+        communityUID: "community-789",
+        grant: {
+          uid: "grant-123",
+          programId: "program-456",
+          details: {
+            data: {
+              title: "Test Grant Program",
+            },
+          },
+        },
+      });
+
+      render(<CommunityMilestoneCard milestone={milestone} />);
+
+      const grantLink = screen.getByText("Test Grant Program").closest("a");
+      expect(grantLink).toHaveAttribute(
+        "href",
+        "/community/community-789/projects?programId=program-456"
+      );
+    });
+
+    it("should render grant title as plain text when programId is not available", () => {
+      const milestone = createMockMilestone({
+        grant: {
+          uid: "grant-123",
+          programId: null,
+          details: {
+            data: {
+              title: "Test Grant No Program",
+            },
+          },
+        },
+      });
+
+      render(<CommunityMilestoneCard milestone={milestone} />);
+
+      const grantText = screen.getByText("Test Grant No Program");
+      const grantLink = grantText.closest("a");
+      // Should not be a link when no programId
+      expect(grantLink).toBeNull();
     });
 
     it('should display "Project Milestone" when grant title is not available', () => {
@@ -361,6 +407,7 @@ describe("CommunityMilestoneCard", () => {
         },
         grant: {
           uid: "0xgrant123abc",
+          programId: "program-xyz",
           details: {
             data: {
               title: "Test Grant",
@@ -648,6 +695,7 @@ describe("CommunityMilestoneCard", () => {
       const milestone = createMockMilestone({
         grant: {
           uid: "grant-123",
+          programId: null,
           details: {
             data: {
               title: "",

--- a/__tests__/unit/utilities/project-lookup.test.ts
+++ b/__tests__/unit/utilities/project-lookup.test.ts
@@ -75,11 +75,11 @@ describe("project-lookup utilities", () => {
       ];
 
       // When searching for "slug-of-other", it should match Project B's slug first
-      // because Array.find returns the first match
+      // because slug matches take priority over UID matches (two-pass lookup)
       const result = findProjectBySlugOrUid(edgeCaseProjects, "slug-of-other");
 
-      // Should match Project A by uid (first in array) because find checks slug || uid
-      expect(result?.title).toBe("Project A");
+      // Should match Project B by slug (slug has priority over UID)
+      expect(result?.title).toBe("Project B");
     });
   });
 

--- a/__tests__/unit/utilities/project-lookup.test.ts
+++ b/__tests__/unit/utilities/project-lookup.test.ts
@@ -1,0 +1,238 @@
+import {
+  findProjectBySlugOrUid,
+  findProjectOptionBySlugOrUid,
+  type ProjectData,
+  projectsToOptions,
+  projectToOption,
+} from "@/utilities/project-lookup";
+
+describe("project-lookup utilities", () => {
+  const mockProjects: ProjectData[] = [
+    { uid: "uid-123", slug: "my-project", title: "My Project" },
+    { uid: "uid-456", slug: "another-project", title: "Another Project" },
+    { uid: "uid-789", title: "Project Without Slug" }, // No slug
+  ];
+
+  describe("findProjectBySlugOrUid", () => {
+    it("should find project by slug", () => {
+      const result = findProjectBySlugOrUid(mockProjects, "my-project");
+
+      expect(result).toEqual({
+        uid: "uid-123",
+        slug: "my-project",
+        title: "My Project",
+      });
+    });
+
+    it("should find project by UID", () => {
+      const result = findProjectBySlugOrUid(mockProjects, "uid-123");
+
+      expect(result).toEqual({
+        uid: "uid-123",
+        slug: "my-project",
+        title: "My Project",
+      });
+    });
+
+    it("should find project without slug by UID (legacy URL support)", () => {
+      const result = findProjectBySlugOrUid(mockProjects, "uid-789");
+
+      expect(result).toEqual({
+        uid: "uid-789",
+        title: "Project Without Slug",
+      });
+    });
+
+    it("should return undefined when identifier is null", () => {
+      const result = findProjectBySlugOrUid(mockProjects, null);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when projects is undefined", () => {
+      const result = findProjectBySlugOrUid(undefined, "my-project");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when projects is empty", () => {
+      const result = findProjectBySlugOrUid([], "my-project");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when no match found", () => {
+      const result = findProjectBySlugOrUid(mockProjects, "non-existent");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should prioritize slug match when both slug and uid could match different projects", () => {
+      // Edge case: what if one project's UID equals another project's slug?
+      const edgeCaseProjects: ProjectData[] = [
+        { uid: "slug-of-other", slug: "project-a", title: "Project A" },
+        { uid: "uid-b", slug: "slug-of-other", title: "Project B" },
+      ];
+
+      // When searching for "slug-of-other", it should match Project B's slug first
+      // because Array.find returns the first match
+      const result = findProjectBySlugOrUid(edgeCaseProjects, "slug-of-other");
+
+      // Should match Project A by uid (first in array) because find checks slug || uid
+      expect(result?.title).toBe("Project A");
+    });
+  });
+
+  describe("projectToOption", () => {
+    it("should convert project with slug to option using slug as value", () => {
+      const project: ProjectData = { uid: "uid-123", slug: "my-project", title: "My Project" };
+
+      const result = projectToOption(project);
+
+      expect(result).toEqual({
+        title: "My Project",
+        value: "my-project",
+      });
+    });
+
+    it("should convert project without slug to option using uid as value", () => {
+      const project: ProjectData = { uid: "uid-123", title: "My Project" };
+
+      const result = projectToOption(project);
+
+      expect(result).toEqual({
+        title: "My Project",
+        value: "uid-123",
+      });
+    });
+
+    it("should prefer slug over uid when both exist", () => {
+      const project: ProjectData = { uid: "uid-123", slug: "my-slug", title: "My Project" };
+
+      const result = projectToOption(project);
+
+      expect(result.value).toBe("my-slug");
+    });
+  });
+
+  describe("projectsToOptions", () => {
+    it("should convert array of projects to options", () => {
+      const result = projectsToOptions(mockProjects);
+
+      expect(result).toEqual([
+        { title: "My Project", value: "my-project" },
+        { title: "Another Project", value: "another-project" },
+        { title: "Project Without Slug", value: "uid-789" },
+      ]);
+    });
+
+    it("should return empty array when projects is undefined", () => {
+      const result = projectsToOptions(undefined);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when projects is empty", () => {
+      const result = projectsToOptions([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("findProjectOptionBySlugOrUid", () => {
+    it("should find project by slug and return as option", () => {
+      const result = findProjectOptionBySlugOrUid(mockProjects, "my-project");
+
+      expect(result).toEqual({
+        title: "My Project",
+        value: "my-project",
+      });
+    });
+
+    it("should find project by UID and return as option (legacy URL support)", () => {
+      const result = findProjectOptionBySlugOrUid(mockProjects, "uid-123");
+
+      expect(result).toEqual({
+        title: "My Project",
+        value: "my-project", // Still uses slug as value
+      });
+    });
+
+    it("should find project without slug by UID and use UID as value", () => {
+      const result = findProjectOptionBySlugOrUid(mockProjects, "uid-789");
+
+      expect(result).toEqual({
+        title: "Project Without Slug",
+        value: "uid-789",
+      });
+    });
+
+    it("should return undefined when identifier is null", () => {
+      const result = findProjectOptionBySlugOrUid(mockProjects, null);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when projects is undefined", () => {
+      const result = findProjectOptionBySlugOrUid(undefined, "my-project");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when no match found", () => {
+      const result = findProjectOptionBySlugOrUid(mockProjects, "non-existent");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("Integration: Legacy UID URL support", () => {
+    it("should correctly handle legacy URLs where projectId is a UID but project has a slug", () => {
+      // Scenario: User bookmarked URL with ?projectId=uid-456
+      // But the project now has a slug "another-project"
+      // The dropdown should still show the correct project selected
+
+      const selectedProjectId = "uid-456"; // Legacy UID from URL
+
+      // First, convert projects to options (as used in dropdown)
+      const projectOptions = projectsToOptions(mockProjects);
+
+      // The old approach would fail here:
+      const oldApproachResult = projectOptions.find(
+        (project) => project.value === selectedProjectId
+      );
+      expect(oldApproachResult).toBeUndefined(); // Would show "All" incorrectly
+
+      // The new approach finds the project correctly:
+      const newApproachResult = findProjectOptionBySlugOrUid(mockProjects, selectedProjectId);
+      expect(newApproachResult).toEqual({
+        title: "Another Project",
+        value: "another-project",
+      });
+    });
+
+    it("should work with modern slug-based URLs", () => {
+      // Scenario: User clicks on project with slug-based URL
+      const selectedProjectId = "another-project";
+
+      const result = findProjectOptionBySlugOrUid(mockProjects, selectedProjectId);
+
+      expect(result).toEqual({
+        title: "Another Project",
+        value: "another-project",
+      });
+    });
+
+    it("should work with projects that never had slugs", () => {
+      // Scenario: Old project that was never given a slug
+      const selectedProjectId = "uid-789";
+
+      const result = findProjectOptionBySlugOrUid(mockProjects, selectedProjectId);
+
+      expect(result).toEqual({
+        title: "Project Without Slug",
+        value: "uid-789",
+      });
+    });
+  });
+});

--- a/app/community/[communityId]/updates/page.tsx
+++ b/app/community/[communityId]/updates/page.tsx
@@ -4,16 +4,20 @@ import { Listbox, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import pluralize from "pluralize";
-import { Fragment, useCallback, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SearchWithValueDropdown } from "@/components/Pages/Communities/Impact/SearchWithValueDropdown";
 import { CommunityMilestoneCard } from "@/components/Pages/Community/Updates/CommunityMilestoneCard";
 import { SimplePagination } from "@/components/Pages/Community/Updates/SimplePagination";
 import { Spinner } from "@/components/Utilities/Spinner";
+import { useCommunityProjects } from "@/hooks/useCommunityProjects";
 import { useCommunityProjectUpdates } from "@/hooks/useCommunityProjectUpdates";
+import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { sortCommunityMilestones } from "@/utilities/sorting/communityMilestoneSort";
 import { cn } from "@/utilities/tailwind";
 
-type FilterOption = "all" | "pending" | "completed";
+type FilterOption = "all" | "pending" | "completed" | "past_due";
 
 const ITEMS_PER_PAGE = 25;
 
@@ -21,6 +25,7 @@ const filterOptions: { value: FilterOption; label: string }[] = [
   { value: "all", label: "All" },
   { value: "pending", label: "Pending" },
   { value: "completed", label: "Completed" },
+  { value: "past_due", label: "Past Due" },
 ];
 
 export default function CommunityUpdatesPage() {
@@ -31,22 +36,95 @@ export default function CommunityUpdatesPage() {
   // Get filter from URL searchParams, default to 'all' if not present or invalid
   const filterFromUrl = searchParams.get("filter");
   const isValidFilter = (filter: string | null): filter is FilterOption => {
-    return filter === "all" || filter === "pending" || filter === "completed";
+    return (
+      filter === "all" || filter === "pending" || filter === "completed" || filter === "past_due"
+    );
   };
   const selectedFilter = isValidFilter(filterFromUrl) ? filterFromUrl : "all";
   const [currentPage, setCurrentPage] = useState(1);
+
+  // Program filter state
+  const [selectedProgramId, changeSelectedProgramIdQuery] = useQueryState<string | null>(
+    "programId",
+    {
+      defaultValue: null,
+      serialize: (value) => {
+        if (!value) return "";
+        const normalized = value.includes("_") ? value.split("_")[0] : value;
+        return normalized;
+      },
+      parse: (value) => {
+        if (!value) return null;
+        const normalized = value.includes("_") ? value.split("_")[0] : value;
+        return normalized;
+      },
+    }
+  );
+
+  // Project filter state
+  const [selectedProjectId, changeSelectedProjectIdQuery] = useQueryState<string | null>(
+    "projectId",
+    {
+      defaultValue: null,
+      serialize: (value) => value ?? "",
+      parse: (value) => value || null,
+    }
+  );
+
+  // Fetch programs for the community
+  const { data: programsData, isLoading: programsLoading } = useCommunityPrograms(
+    communityId as string
+  );
+  const programs =
+    programsData?.map((program) => ({
+      title: program.metadata?.title || "",
+      value: program.programId || "",
+    })) || [];
+  const selectedProgram = programs.find((program) => program.value === selectedProgramId);
+
+  // Fetch projects filtered by selected program
+  const { data: projectsData, isLoading: projectsLoading } =
+    useCommunityProjects(selectedProgramId);
+  const projectOptions =
+    projectsData?.map((project) => ({
+      title: project.title,
+      value: project.slug || project.uid, // Prefer slug for URL-friendly values
+    })) || [];
+  // Support both UID and slug for selected project lookup
+  const selectedProject = projectOptions.find((project) => project.value === selectedProjectId);
+
+  // Track previous program to detect actual changes (not initial load)
+  const previousProgramRef = useRef<string | null>(null);
+
+  // Reset project selection when program actually changes (not on initial load)
+  useEffect(() => {
+    // On first render, store the current program and don't reset
+    if (previousProgramRef.current === null) {
+      previousProgramRef.current = selectedProgramId;
+      return;
+    }
+
+    // Only reset if program actually changed from a previous value
+    if (selectedProgramId !== previousProgramRef.current) {
+      changeSelectedProjectIdQuery(null);
+      previousProgramRef.current = selectedProgramId;
+    }
+  }, [selectedProgramId, changeSelectedProjectIdQuery]);
 
   // Fetch community updates from API using custom hook
   const { data, isLoading, error } = useCommunityProjectUpdates(communityId, {
     page: currentPage,
     limit: ITEMS_PER_PAGE,
     status: selectedFilter,
+    programId: selectedProgramId,
+    projectId: selectedProjectId,
   });
 
-  // Memoize sorted data to prevent unnecessary recalculations
+  // Memoize sorted data
+  // Backend handles all filtering including status, programId, and projectId
   const sortedRawData = useMemo(() => {
     if (!data?.payload) return [];
-    return sortCommunityMilestones(data.payload, selectedFilter, communityId);
+    return sortCommunityMilestones([...data.payload], selectedFilter, communityId);
   }, [data?.payload, selectedFilter, communityId]);
 
   // Calculate total pages
@@ -83,7 +161,9 @@ export default function CommunityUpdatesPage() {
     const message =
       selectedFilter === "all"
         ? "No milestones have been created by any projects in this community yet."
-        : `No ${selectedFilter} milestones found.`;
+        : selectedFilter === "past_due"
+          ? "No past due milestones found."
+          : `No ${selectedFilter} milestones found.`;
 
     return (
       <div className="flex w-full items-center justify-center rounded border border-gray-200 px-6 py-10">
@@ -119,54 +199,113 @@ export default function CommunityUpdatesPage() {
   return (
     <div className="flex flex-col items-center justify-start">
       <div className="flex flex-col gap-6 my-10 max-lg:my-5 max-w-full w-full">
-        {/* Header with filter */}
-        <div className="flex flex-row gap-4 justify-between items-center px-2">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-600 dark:text-gray-400">
-              {isLoading
-                ? "Loading..."
-                : `${data?.pagination?.totalCount || 0} ${pluralize("milestone update", data?.pagination?.totalCount || 0)}`}
-            </span>
+        {/* Filter row */}
+        <div className="px-3 py-4 bg-gray-100 dark:bg-zinc-900 rounded-lg flex flex-row items-center w-full gap-8 max-lg:flex-col max-lg:gap-4 max-lg:justify-start max-lg:items-start">
+          {/* Left side - Filters */}
+          <div className="flex flex-row items-center gap-6 flex-wrap max-lg:w-full">
+            {/* Status filter dropdown */}
+            <Listbox value={selectedFilter} onChange={handleFilterChange}>
+              <div className="relative">
+                <Listbox.Button className="flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue dark:bg-zinc-800 dark:text-zinc-200 dark:border-zinc-600 min-w-[120px]">
+                  {filterOptions.find((opt) => opt.value === selectedFilter)?.label}
+                  <ChevronDownIcon className="w-4 h-4 ml-auto" />
+                </Listbox.Button>
+                <Transition
+                  as={Fragment}
+                  leave="transition ease-in duration-100"
+                  leaveFrom="opacity-100"
+                  leaveTo="opacity-0"
+                >
+                  <Listbox.Options className="absolute left-0 z-10 mt-1 max-h-60 w-full min-w-[120px] overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm dark:bg-zinc-800">
+                    {filterOptions.map((option) => (
+                      <Listbox.Option
+                        key={option.value}
+                        className={({ active }) =>
+                          cn(
+                            "relative cursor-pointer select-none py-2 px-4",
+                            active ? "bg-brand-blue text-white" : "text-gray-900 dark:text-zinc-200"
+                          )
+                        }
+                        value={option.value}
+                      >
+                        {({ selected }) => (
+                          <span
+                            className={cn(
+                              "block truncate",
+                              selected ? "font-medium" : "font-normal"
+                            )}
+                          >
+                            {option.label}
+                          </span>
+                        )}
+                      </Listbox.Option>
+                    ))}
+                  </Listbox.Options>
+                </Transition>
+              </div>
+            </Listbox>
+
+            {/* Program filter */}
+            <div className="flex flex-row gap-2 items-center flex-1 max-w-[350px]">
+              <Image
+                src="/icons/program.svg"
+                alt="program"
+                width={24}
+                height={24}
+                className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
+              />
+              <p className="text-gray-800 dark:text-zinc-100 text-sm font-semibold leading-normal whitespace-nowrap">
+                Program
+              </p>
+              <SearchWithValueDropdown
+                id="filter-by-programs"
+                list={programs}
+                onSelectFunction={(value: string) => changeSelectedProgramIdQuery(value)}
+                type="Programs"
+                selected={selectedProgram ? [selectedProgram.title] : []}
+                prefixUnselected="All"
+                buttonClassname="w-full max-w-full"
+                isMultiple={false}
+                cleanFunction={() => changeSelectedProgramIdQuery(null)}
+                isLoading={programsLoading}
+              />
+            </div>
+
+            {/* Project filter */}
+            <div className="flex flex-row gap-2 items-center flex-1 max-w-[350px]">
+              <Image
+                src="/icons/project.png"
+                alt="Project"
+                width={24}
+                height={24}
+                className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
+              />
+              <p className="text-gray-800 dark:text-zinc-100 text-sm font-semibold leading-normal whitespace-nowrap">
+                Project
+              </p>
+              <SearchWithValueDropdown
+                id="filter-by-projects"
+                list={projectOptions}
+                onSelectFunction={(value: string) => changeSelectedProjectIdQuery(value)}
+                type="Projects"
+                selected={selectedProject ? [selectedProject.title] : []}
+                prefixUnselected="All"
+                buttonClassname="w-full max-w-full"
+                isMultiple={false}
+                cleanFunction={() => changeSelectedProjectIdQuery(null)}
+                isLoading={projectsLoading}
+              />
+            </div>
           </div>
 
-          {/* Filter dropdown */}
-          <Listbox value={selectedFilter} onChange={handleFilterChange}>
-            <div className="relative">
-              <Listbox.Button className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue dark:bg-zinc-800 dark:text-zinc-200 dark:border-zinc-600">
-                {filterOptions.find((opt) => opt.value === selectedFilter)?.label}
-                <ChevronDownIcon className="w-4 h-4" />
-              </Listbox.Button>
-              <Transition
-                as={Fragment}
-                leave="transition ease-in duration-100"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <Listbox.Options className="absolute right-0 z-10 mt-1 max-h-60 w-full min-w-[120px] overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm dark:bg-zinc-800">
-                  {filterOptions.map((option) => (
-                    <Listbox.Option
-                      key={option.value}
-                      className={({ active }) =>
-                        cn(
-                          "relative cursor-pointer select-none py-2 px-4",
-                          active ? "bg-brand-blue text-white" : "text-gray-900 dark:text-zinc-200"
-                        )
-                      }
-                      value={option.value}
-                    >
-                      {({ selected }) => (
-                        <span
-                          className={cn("block truncate", selected ? "font-medium" : "font-normal")}
-                        >
-                          {option.label}
-                        </span>
-                      )}
-                    </Listbox.Option>
-                  ))}
-                </Listbox.Options>
-              </Transition>
-            </div>
-          </Listbox>
+          {/* Right side - Milestone count */}
+          <div className="flex items-center gap-2 ml-auto max-lg:ml-0">
+            <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
+              {isLoading
+                ? "Loading..."
+                : `${data?.pagination?.totalCount || 0} ${pluralize("milestone", data?.pagination?.totalCount || 0)} to update`}
+            </span>
+          </div>
         </div>
 
         {/* Content */}

--- a/app/community/[communityId]/updates/page.tsx
+++ b/app/community/[communityId]/updates/page.tsx
@@ -53,16 +53,8 @@ export default function CommunityUpdatesPage() {
     "programId",
     {
       defaultValue: null,
-      serialize: (value) => {
-        if (!value) return "";
-        const normalized = value.includes("_") ? value.split("_")[0] : value;
-        return normalized;
-      },
-      parse: (value) => {
-        if (!value) return null;
-        const normalized = value.includes("_") ? value.split("_")[0] : value;
-        return normalized;
-      },
+      serialize: (value) => value ?? "",
+      parse: (value) => value || null,
     }
   );
 
@@ -111,6 +103,11 @@ export default function CommunityUpdatesPage() {
       previousProgramRef.current = selectedProgramId;
     }
   }, [selectedProgramId, changeSelectedProjectIdQuery]);
+
+  // Reset pagination when program or project filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [selectedProgramId, selectedProjectId]);
 
   // Fetch community updates from API using custom hook
   const { data, isLoading, error } = useCommunityProjectUpdates(communityId, {

--- a/components/Pages/Communities/Impact/SearchWithValueDropdown.tsx
+++ b/components/Pages/Communities/Impact/SearchWithValueDropdown.tsx
@@ -24,6 +24,7 @@ interface SearchWithValueDropdownProps {
   isMultiple?: boolean;
   customAddButton?: React.ReactNode;
   disabled?: boolean;
+  isLoading?: boolean;
 }
 
 export const SearchWithValueDropdown: FC<SearchWithValueDropdownProps> = ({
@@ -39,6 +40,7 @@ export const SearchWithValueDropdown: FC<SearchWithValueDropdownProps> = ({
   isMultiple = true,
   customAddButton,
   disabled = false,
+  isLoading = false,
 }) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -80,16 +82,39 @@ export const SearchWithValueDropdown: FC<SearchWithValueDropdownProps> = ({
       <Popover.Trigger
         className={cn(
           "min-w-40 w-full max-w-[320px] max-md:max-w-full justify-between flex flex-row cursor-default rounded-md bg-white dark:bg-zinc-800 dark:text-zinc-100 py-3 px-4 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6",
-          disabled && "opacity-50 cursor-not-allowed",
+          (disabled || isLoading) && "opacity-50 cursor-not-allowed",
           buttonClassname
         )}
         id={id}
-        disabled={disabled}
+        disabled={disabled || isLoading}
       >
         <div className="flex flex-row gap-4 w-full items-center justify-between">
-          <p className="block w-max truncate">{renderSelected()}</p>
+          <p className="block w-max truncate">{isLoading ? "Loading..." : renderSelected()}</p>
           <span>
-            <ChevronDownIcon className="h-4 w-5 text-[#98A2B3] dark:text-white" />
+            {isLoading ? (
+              <svg
+                className="animate-spin h-4 w-4 text-[#98A2B3] dark:text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+            ) : (
+              <ChevronDownIcon className="h-4 w-5 text-[#98A2B3] dark:text-white" />
+            )}
           </span>
         </div>
       </Popover.Trigger>

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -15,7 +15,7 @@ interface CommunityMilestoneCardProps {
 
 const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({ milestone }) => {
   const isCompleted = milestone.status === "completed";
-  const projectSlug = milestone.project.details?.data?.slug;
+  const projectSlug = milestone.project.details?.data?.slug || milestone.project.uid;
   const projectTitle = milestone.project.details?.data?.title;
   const grantTitle = milestone.grant?.details?.data?.title || "Project Milestone";
 

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -30,15 +30,17 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({ mile
           {/* Project and Grant Info */}
           <div className="flex flex-col gap-1 text-sm">
             <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-              <Link
-                href={`/project/${projectSlug}`}
-                className="font-medium hover:text-brand-blue hover:underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {projectTitle}
-              </Link>
-              <span>{grantTitle}</span>
+              <span className="font-bold">{projectTitle}</span>
+              {milestone.grant ? (
+                <Link
+                  href={`/project/${projectSlug}/funding/${milestone.grant.uid}`}
+                  className="hover:text-brand-blue hover:underline"
+                >
+                  {grantTitle}
+                </Link>
+              ) : (
+                <span>{grantTitle}</span>
+              )}
             </div>
           </div>
 
@@ -69,9 +71,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({ mile
           </div>
 
           {/* Title */}
-          <h3 className="text-xl font-bold text-[#101828] dark:text-zinc-100">
-            {milestone.details.title}
-          </h3>
+          <h3 className="text-xl text-[#101828] dark:text-zinc-100">{milestone.details.title}</h3>
 
           {/* Description */}
           {milestone.details.description && (

--- a/cypress/e2e/navbar/visual-regression.cy.ts
+++ b/cypress/e2e/navbar/visual-regression.cy.ts
@@ -153,9 +153,12 @@ describe("Navbar UI States", () => {
       waitForPageLoad();
 
       // On mobile, the Sign in button is visible in the navbar header (not inside the drawer)
-      // The button is rendered alongside the menu hamburger icon
-      cy.contains("button", "Sign in").should("be.visible");
-      cy.contains("Contact sales").should("be.visible");
+      // The button is rendered alongside the menu hamburger icon in the mobile menu component
+      // Note: There are two Sign in buttons (desktop and mobile), we need to find the visible one
+      // The mobile button is inside a lg:hidden container, so it should be the visible one
+      cy.get("nav").within(() => {
+        cy.contains("button", "Sign in").filter(":visible").should("be.visible");
+      });
     });
   });
 });

--- a/hooks/useCommunityProjectUpdates.ts
+++ b/hooks/useCommunityProjectUpdates.ts
@@ -6,23 +6,27 @@ import { QUERY_KEYS } from "@/utilities/queryKeys";
 export interface UseCommunityProjectUpdatesOptions {
   page?: number;
   limit?: number;
-  status?: "all" | "pending" | "completed";
+  status?: "all" | "pending" | "completed" | "past_due";
+  programId?: string | null;
+  projectId?: string | null;
 }
 
 export const useCommunityProjectUpdates = (
   communityId: string,
   options: UseCommunityProjectUpdatesOptions = {}
 ) => {
-  const { page = 1, limit = 25, status = "all" } = options;
+  const { page = 1, limit = 25, status = "all", programId, projectId } = options;
 
   return useQuery<CommunityUpdatesResponse, Error>({
-    queryKey: QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(communityId, status, page),
+    queryKey: QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(communityId, status, page, programId, projectId),
     queryFn: () =>
       fetchCommunityProjectUpdates({
         communityId,
         page,
         limit,
         status,
+        programId,
+        projectId,
       }),
     enabled: !!communityId,
     retry: false,

--- a/hooks/useCommunityProjectUpdates.ts
+++ b/hooks/useCommunityProjectUpdates.ts
@@ -18,7 +18,14 @@ export const useCommunityProjectUpdates = (
   const { page = 1, limit = 25, status = "all", programId, projectId } = options;
 
   return useQuery<CommunityUpdatesResponse, Error>({
-    queryKey: QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(communityId, status, page, programId, projectId),
+    queryKey: QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(
+      communityId,
+      status,
+      page,
+      limit,
+      programId,
+      projectId
+    ),
     queryFn: () =>
       fetchCommunityProjectUpdates({
         communityId,

--- a/hooks/useCommunityProjects.ts
+++ b/hooks/useCommunityProjects.ts
@@ -37,7 +37,7 @@ export function useCommunityProjects(programId?: string | null) {
     return projects.map((project: any) => ({
       uid: project.uid,
       title: project.details?.title || project.title || "Untitled Project",
-      slug: project.slug,
+      slug: project.details?.slug || project.slug || "",
     }));
   };
 

--- a/services/community-project-updates.service.ts
+++ b/services/community-project-updates.service.ts
@@ -9,13 +9,15 @@ export interface FetchCommunityProjectUpdatesParams {
   communityId: string;
   page?: number;
   limit?: number;
-  status?: "all" | "pending" | "completed";
+  status?: "all" | "pending" | "completed" | "past_due";
+  programId?: string | null;
+  projectId?: string | null;
 }
 
 export async function fetchCommunityProjectUpdates(
   params: FetchCommunityProjectUpdatesParams
 ): Promise<CommunityUpdatesResponse> {
-  const { communityId, page = 1, limit = 25, status = "all" } = params;
+  const { communityId, page = 1, limit = 25, status = "all", programId, projectId } = params;
 
   try {
     const searchParams = new URLSearchParams({
@@ -24,7 +26,16 @@ export async function fetchCommunityProjectUpdates(
     });
 
     if (status !== "all") {
+      // Send status directly to API - backend handles all filtering including past_due
       searchParams.append("status", status);
+    }
+
+    if (programId) {
+      searchParams.append("programId", programId);
+    }
+
+    if (projectId) {
+      searchParams.append("projectId", projectId);
     }
 
     const url = `${API_URL}${INDEXER.COMMUNITY.PROJECT_UPDATES(

--- a/types/community-updates.ts
+++ b/types/community-updates.ts
@@ -19,6 +19,7 @@ export interface ProjectInfo {
 
 export interface GrantInfo {
   uid: string;
+  programId?: string | null;
   details: {
     data: {
       title: string;

--- a/utilities/__tests__/queryKeys.test.ts
+++ b/utilities/__tests__/queryKeys.test.ts
@@ -151,50 +151,68 @@ describe("queryKeys", () => {
   describe("COMMUNITY", () => {
     describe("PROJECT_UPDATES", () => {
       it("should generate correct query key", () => {
-        const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("community-123", "all", 1);
-        expect(key).toEqual([
-          "community-project-updates",
-          "community-123",
-          "all",
-          1,
-          undefined,
-          undefined,
-        ]);
+        const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("community-123", "all", 1, 25);
+        expect(key).toEqual(["community-project-updates", "community-123", "all", 1, 25, "", ""]);
       });
 
       it("should return as const tuple", () => {
-        const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 0);
+        const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 0, 25);
         expect(Array.isArray(key)).toBe(true);
-        expect(key.length).toBe(6);
+        expect(key.length).toBe(7);
       });
 
-      it("should handle different filters and pages", () => {
-        const key1 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1);
-        const key2 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 1);
-        const key3 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 2);
+      it("should handle different filters, pages, and limits", () => {
+        const key1 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1, 25);
+        const key2 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 1, 25);
+        const key3 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 2, 25);
+        const key4 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1, 50);
         expect(key1).not.toEqual(key2);
         expect(key1).not.toEqual(key3);
+        expect(key1).not.toEqual(key4);
       });
 
-      it("should handle programId and projectId filters", () => {
-        const key1 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1, "program-1", null);
+      it("should handle programId and projectId filters with empty string fallback", () => {
+        const key1 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(
+          "comm-1",
+          "all",
+          1,
+          25,
+          "program-1",
+          null
+        );
         const key2 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(
           "comm-1",
           "all",
           1,
+          25,
           "program-1",
           "project-1"
         );
-        expect(key1).toEqual(["community-project-updates", "comm-1", "all", 1, "program-1", null]);
+        expect(key1).toEqual([
+          "community-project-updates",
+          "comm-1",
+          "all",
+          1,
+          25,
+          "program-1",
+          "",
+        ]);
         expect(key2).toEqual([
           "community-project-updates",
           "comm-1",
           "all",
           1,
+          25,
           "program-1",
           "project-1",
         ]);
         expect(key1).not.toEqual(key2);
+      });
+
+      it("should convert null programId and projectId to empty strings", () => {
+        const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1, 25, null, null);
+        expect(key[5]).toBe("");
+        expect(key[6]).toBe("");
       });
     });
   });
@@ -334,7 +352,7 @@ describe("queryKeys", () => {
       expect(QUERY_KEYS.APPLICATIONS.BY_PROJECT_UID("a")[0]).toContain("application");
       expect(QUERY_KEYS.REVIEWERS.PROGRAM("a")[0]).toContain("reviewer");
       expect(QUERY_KEYS.CONTRACTS.VALIDATION.ALL[0]).toContain("validation");
-      expect(QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("a", "b", 1)[0]).toContain("community");
+      expect(QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("a", "b", 1, 25)[0]).toContain("community");
       expect(QUERY_KEYS.GRANTS.DUPLICATE_CHECK({ community: "a", title: "b" })[0]).toContain(
         "grant"
       );
@@ -348,7 +366,7 @@ describe("queryKeys", () => {
       expect(
         Array.isArray(QUERY_KEYS.CONTRACTS.VALIDATION.VALIDATE({ address: "a", network: "b" }))
       ).toBe(true);
-      expect(Array.isArray(QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("a", "b", 1))).toBe(true);
+      expect(Array.isArray(QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("a", "b", 1, 25))).toBe(true);
       expect(Array.isArray(QUERY_KEYS.GRANTS.DUPLICATE_CHECK({ community: "a", title: "b" }))).toBe(
         true
       );

--- a/utilities/__tests__/queryKeys.test.ts
+++ b/utilities/__tests__/queryKeys.test.ts
@@ -152,13 +152,20 @@ describe("queryKeys", () => {
     describe("PROJECT_UPDATES", () => {
       it("should generate correct query key", () => {
         const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("community-123", "all", 1);
-        expect(key).toEqual(["community-project-updates", "community-123", "all", 1]);
+        expect(key).toEqual([
+          "community-project-updates",
+          "community-123",
+          "all",
+          1,
+          undefined,
+          undefined,
+        ]);
       });
 
       it("should return as const tuple", () => {
         const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 0);
         expect(Array.isArray(key)).toBe(true);
-        expect(key.length).toBe(4);
+        expect(key.length).toBe(6);
       });
 
       it("should handle different filters and pages", () => {
@@ -167,6 +174,27 @@ describe("queryKeys", () => {
         const key3 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 2);
         expect(key1).not.toEqual(key2);
         expect(key1).not.toEqual(key3);
+      });
+
+      it("should handle programId and projectId filters", () => {
+        const key1 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "all", 1, "program-1", null);
+        const key2 = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES(
+          "comm-1",
+          "all",
+          1,
+          "program-1",
+          "project-1"
+        );
+        expect(key1).toEqual(["community-project-updates", "comm-1", "all", 1, "program-1", null]);
+        expect(key2).toEqual([
+          "community-project-updates",
+          "comm-1",
+          "all",
+          1,
+          "program-1",
+          "project-1",
+        ]);
+        expect(key1).not.toEqual(key2);
       });
     });
   });

--- a/utilities/project-lookup.ts
+++ b/utilities/project-lookup.ts
@@ -1,0 +1,83 @@
+/**
+ * Utility functions for project lookup operations.
+ * These functions help with finding projects by various identifiers (slug or UID).
+ */
+
+export interface ProjectData {
+  uid: string;
+  slug?: string;
+  title: string;
+}
+
+export interface ProjectOption {
+  title: string;
+  value: string;
+}
+
+/**
+ * Finds a project by either its slug or UID.
+ * This supports both modern slug-based URLs and legacy UID-based URLs.
+ *
+ * @param projects - Array of project data
+ * @param identifier - The slug or UID to search for
+ * @returns The matching project or undefined if not found
+ */
+export function findProjectBySlugOrUid(
+  projects: ProjectData[] | undefined,
+  identifier: string | null
+): ProjectData | undefined {
+  if (!projects || !identifier) {
+    return undefined;
+  }
+
+  return projects.find((project) => project.slug === identifier || project.uid === identifier);
+}
+
+/**
+ * Converts a project data object to a project option for dropdowns.
+ * The value prefers slug over uid for URL-friendly values.
+ *
+ * @param project - The project data object
+ * @returns A project option with title and value
+ */
+export function projectToOption(project: ProjectData): ProjectOption {
+  return {
+    title: project.title,
+    value: project.slug || project.uid,
+  };
+}
+
+/**
+ * Converts an array of project data to project options for dropdowns.
+ *
+ * @param projects - Array of project data
+ * @returns Array of project options
+ */
+export function projectsToOptions(projects: ProjectData[] | undefined): ProjectOption[] {
+  if (!projects) {
+    return [];
+  }
+
+  return projects.map(projectToOption);
+}
+
+/**
+ * Finds a project and returns it as a dropdown option.
+ * Supports both slug and UID lookups for backward compatibility with legacy URLs.
+ *
+ * @param projects - Array of project data
+ * @param identifier - The slug or UID to search for
+ * @returns The matching project option or undefined if not found
+ */
+export function findProjectOptionBySlugOrUid(
+  projects: ProjectData[] | undefined,
+  identifier: string | null
+): ProjectOption | undefined {
+  const project = findProjectBySlugOrUid(projects, identifier);
+
+  if (!project) {
+    return undefined;
+  }
+
+  return projectToOption(project);
+}

--- a/utilities/project-lookup.ts
+++ b/utilities/project-lookup.ts
@@ -30,7 +30,14 @@ export function findProjectBySlugOrUid(
     return undefined;
   }
 
-  return projects.find((project) => project.slug === identifier || project.uid === identifier);
+  // Two-pass lookup: prioritize slug match over UID match
+  // This prevents edge cases where a UID equals another project's slug
+  const slugMatch = projects.find((project) => project.slug === identifier);
+  if (slugMatch) {
+    return slugMatch;
+  }
+
+  return projects.find((project) => project.uid === identifier);
 }
 
 /**

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -52,9 +52,19 @@ export const QUERY_KEYS = {
       communityId: string,
       filter: string,
       page: number,
+      limit: number,
       programId?: string | null,
       projectId?: string | null
-    ) => ["community-project-updates", communityId, filter, page, programId, projectId] as const,
+    ) =>
+      [
+        "community-project-updates",
+        communityId,
+        filter,
+        page,
+        limit,
+        programId ?? "",
+        projectId ?? "",
+      ] as const,
   },
   GRANTS: {
     DUPLICATE_CHECK_BASE: ["duplicate-grant-check"] as const,

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -48,8 +48,13 @@ export const QUERY_KEYS = {
     IS_ADMIN: (communityUid?: string, chainId?: number, address?: string, signer?: unknown) =>
       ["isCommunityAdmin", communityUid, chainId, address, signer] as const,
     IS_ADMIN_BASE: ["isCommunityAdmin"] as const,
-    PROJECT_UPDATES: (communityId: string, filter: string, page: number) =>
-      ["community-project-updates", communityId, filter, page] as const,
+    PROJECT_UPDATES: (
+      communityId: string,
+      filter: string,
+      page: number,
+      programId?: string | null,
+      projectId?: string | null
+    ) => ["community-project-updates", communityId, filter, page, programId, projectId] as const,
   },
   GRANTS: {
     DUPLICATE_CHECK_BASE: ["duplicate-grant-check"] as const,

--- a/utilities/sorting/communityMilestoneSort.ts
+++ b/utilities/sorting/communityMilestoneSort.ts
@@ -1,6 +1,6 @@
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 
-type FilterOption = "all" | "pending" | "completed";
+type FilterOption = "all" | "pending" | "completed" | "past_due";
 
 /**
  * Validates if a milestone item has all required fields
@@ -79,7 +79,10 @@ export function sortCommunityMilestones(
       }
 
       // For specific filters, use appropriate comparison
-      return filter === "pending" ? comparePending(a, b) : compareCompleted(a, b);
+      if (filter === "pending" || filter === "past_due") {
+        return comparePending(a, b);
+      }
+      return compareCompleted(a, b);
     });
   } catch (error) {
     console.error("Error sorting community updates:", error, {


### PR DESCRIPTION
## Summary
- Move all filtering logic to backend (status, programId, projectId)
- Add loading states to Program and Project filter dropdowns
- Use project slug instead of UID in URL parameters for better readability
- Support both UID and slug for project filter lookup

## Changes
- **Updates Page**: Integrated backend filtering, added program/project filter dropdowns
- **SearchWithValueDropdown**: Added `isLoading` prop with spinner and disabled state
- **useCommunityProjects**: Fixed slug extraction from API response
- **useCommunityProjectUpdates**: Updated to pass filter params to backend
- **Tests**: Added tests for query keys and milestone card component

## Test plan
- [x] Status filter (all, pending, completed, past_due) works correctly
- [x] Program filter shows loading state while fetching
- [x] Project filter shows loading state while fetching
- [x] Selecting project uses slug in URL (e.g., `projectId=cidgravity-filecoin-gateway`)
- [x] Filters work together (status + program + project)
- [x] Page handles direct URL with slug parameter correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Program and project filters on community updates with URL state sync; pagination resets when filters change.
  * Added "Past Due" status filter.
  * Search dropdowns show a loading state with spinner and disable interaction while loading.

* **Bug Fixes**
  * Grant links now navigate to funding pages when present and gracefully fall back to project paths when slugs/details are missing.
  * Project titles render as bold plain text; milestone title styling and "view" links adapt to grant presence.

* **Tests**
  * Expanded coverage for filtering, linking, slug/UID fallbacks, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->