### PR TITLE
feat: add URL parameter support to auto-open edit modal

### DIFF
--- a/__tests__/pages/admin/applications/ApplicationDetailPage.editParam.test.tsx
+++ b/__tests__/pages/admin/applications/ApplicationDetailPage.editParam.test.tsx
@@ -1,0 +1,174 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import type { IFundingApplication } from "@/types/funding-platform";
+
+/**
+ * Test the edit parameter URL handling logic for the ApplicationDetailPage
+ *
+ * The page should auto-open the edit modal when ?edit=true is present in the URL
+ * but only if the application can be edited (status restrictions)
+ */
+
+// Helper function that mirrors the canEditApplication logic in the page
+const canEditApplication = (app: IFundingApplication) => {
+  const restrictedStatuses = ["under_review", "approved"];
+  return !restrictedStatuses.includes(app.status.toLowerCase());
+};
+
+describe("ApplicationDetailPage - Edit URL Parameter", () => {
+  describe("canEditApplication", () => {
+    it("should return true for pending applications", () => {
+      const app = { status: "pending" } as IFundingApplication;
+      expect(canEditApplication(app)).toBe(true);
+    });
+
+    it("should return true for rejected applications", () => {
+      const app = { status: "rejected" } as IFundingApplication;
+      expect(canEditApplication(app)).toBe(true);
+    });
+
+    it("should return true for revision_requested applications", () => {
+      const app = { status: "revision_requested" } as IFundingApplication;
+      expect(canEditApplication(app)).toBe(true);
+    });
+
+    it("should return false for approved applications", () => {
+      const app = { status: "approved" } as IFundingApplication;
+      expect(canEditApplication(app)).toBe(false);
+    });
+
+    it("should return false for under_review applications", () => {
+      const app = { status: "under_review" } as IFundingApplication;
+      expect(canEditApplication(app)).toBe(false);
+    });
+
+    it("should handle case-insensitive status comparison", () => {
+      const approvedUppercase = { status: "APPROVED" } as IFundingApplication;
+      const underReviewMixed = { status: "Under_Review" } as IFundingApplication;
+
+      expect(canEditApplication(approvedUppercase)).toBe(false);
+      expect(canEditApplication(underReviewMixed)).toBe(false);
+    });
+  });
+
+  describe("Edit modal auto-open logic", () => {
+    /**
+     * Hook to simulate the auto-open edit modal behavior
+     */
+    function useEditModalAutoOpen(
+      shouldOpenEdit: boolean,
+      application: IFundingApplication | null,
+      hasAccess: boolean
+    ) {
+      const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+      useEffect(() => {
+        if (shouldOpenEdit && application && hasAccess && canEditApplication(application)) {
+          setIsEditModalOpen(true);
+        }
+      }, [shouldOpenEdit, application, hasAccess]);
+
+      return { isEditModalOpen, setIsEditModalOpen };
+    }
+
+    it("should open edit modal when edit=true and application can be edited", () => {
+      const application = { status: "pending" } as IFundingApplication;
+
+      const { result } = renderHook(() => useEditModalAutoOpen(true, application, true));
+
+      expect(result.current.isEditModalOpen).toBe(true);
+    });
+
+    it("should NOT open edit modal when edit=true but application cannot be edited (approved)", () => {
+      const application = { status: "approved" } as IFundingApplication;
+
+      const { result } = renderHook(() => useEditModalAutoOpen(true, application, true));
+
+      expect(result.current.isEditModalOpen).toBe(false);
+    });
+
+    it("should NOT open edit modal when edit=true but application cannot be edited (under_review)", () => {
+      const application = { status: "under_review" } as IFundingApplication;
+
+      const { result } = renderHook(() => useEditModalAutoOpen(true, application, true));
+
+      expect(result.current.isEditModalOpen).toBe(false);
+    });
+
+    it("should NOT open edit modal when edit=true but user has no access", () => {
+      const application = { status: "pending" } as IFundingApplication;
+
+      const { result } = renderHook(
+        () => useEditModalAutoOpen(true, application, false) // hasAccess = false
+      );
+
+      expect(result.current.isEditModalOpen).toBe(false);
+    });
+
+    it("should NOT open edit modal when edit=false", () => {
+      const application = { status: "pending" } as IFundingApplication;
+
+      const { result } = renderHook(
+        () => useEditModalAutoOpen(false, application, true) // shouldOpenEdit = false
+      );
+
+      expect(result.current.isEditModalOpen).toBe(false);
+    });
+
+    it("should NOT open edit modal when application is null (still loading)", () => {
+      const { result } = renderHook(
+        () => useEditModalAutoOpen(true, null, true) // application = null
+      );
+
+      expect(result.current.isEditModalOpen).toBe(false);
+    });
+
+    it("should open edit modal when application loads and all conditions are met", async () => {
+      let application: IFundingApplication | null = null;
+
+      const { result, rerender } = renderHook(
+        ({ app, hasAccess }) => useEditModalAutoOpen(true, app, hasAccess),
+        {
+          initialProps: { app: application, hasAccess: true },
+        }
+      );
+
+      // Initially, modal should be closed (no application)
+      expect(result.current.isEditModalOpen).toBe(false);
+
+      // Simulate application loading
+      application = { status: "pending" } as IFundingApplication;
+      rerender({ app: application, hasAccess: true });
+
+      // Modal should now be open
+      expect(result.current.isEditModalOpen).toBe(true);
+    });
+  });
+
+  describe("URL search params parsing", () => {
+    it("should correctly identify edit=true from URL params", () => {
+      const searchParams = new URLSearchParams("?edit=true");
+      expect(searchParams.get("edit")).toBe("true");
+      expect(searchParams.get("edit") === "true").toBe(true);
+    });
+
+    it("should correctly identify when edit param is not present", () => {
+      const searchParams = new URLSearchParams("");
+      expect(searchParams.get("edit")).toBe(null);
+      expect(searchParams.get("edit") === "true").toBe(false);
+    });
+
+    it("should correctly identify edit=false from URL params", () => {
+      const searchParams = new URLSearchParams("?edit=false");
+      expect(searchParams.get("edit")).toBe("false");
+      expect(searchParams.get("edit") === "true").toBe(false);
+    });
+
+    it("should handle other query params without affecting edit", () => {
+      const searchParams = new URLSearchParams("?tab=comments&edit=true&view=details");
+      expect(searchParams.get("edit") === "true").toBe(true);
+      expect(searchParams.get("tab")).toBe("comments");
+      expect(searchParams.get("view")).toBe("details");
+    });
+  });
+});

--- a/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -2,8 +2,8 @@
 
 import { ArrowLeftIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { AIAnalysisTab } from "@/components/FundingPlatform/ApplicationView/AIAnalysisTab";
@@ -58,6 +58,10 @@ export default function ApplicationDetailPage() {
   const programId = combinedProgramId.includes("_")
     ? combinedProgramId.split("_")[0]
     : combinedProgramId;
+
+  // Check for edit parameter in URL
+  const searchParams = useSearchParams();
+  const shouldOpenEdit = searchParams.get("edit") === "true";
 
   const { hasAccess, isLoading: isLoadingAdmin, checks } = useCommunityAdminAccess(communityId);
 
@@ -222,6 +226,17 @@ export default function ApplicationDetailPage() {
     const restrictedStatuses = ["under_review", "approved"];
     return !restrictedStatuses.includes(app.status.toLowerCase());
   };
+
+  // Auto-open edit modal when ?edit=true is present in URL
+  useEffect(() => {
+    if (shouldOpenEdit && application && hasAccess && canEditApplication(application)) {
+      setIsEditModalOpen(true);
+      // Clean up URL by removing the edit param
+      const url = new URL(window.location.href);
+      url.searchParams.delete("edit");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [shouldOpenEdit, application, hasAccess]);
 
   // Handle edit application
   const handleEditClick = () => {

--- a/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/admin/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -231,20 +231,24 @@ export default function ApplicationDetailPage() {
   useEffect(() => {
     if (shouldOpenEdit && application && hasAccess && canEditApplication(application)) {
       setIsEditModalOpen(true);
-      // Clean up URL by removing the edit param
-      const url = new URL(window.location.href);
-      url.searchParams.delete("edit");
-      window.history.replaceState({}, "", url.toString());
     }
   }, [shouldOpenEdit, application, hasAccess]);
 
   // Handle edit application
   const handleEditClick = () => {
     setIsEditModalOpen(true);
+    // Add edit=true to URL
+    const url = new URL(window.location.href);
+    url.searchParams.set("edit", "true");
+    window.history.replaceState({}, "", url.toString());
   };
 
   const handleEditClose = () => {
     setIsEditModalOpen(false);
+    // Remove edit param from URL
+    const url = new URL(window.location.href);
+    url.searchParams.delete("edit");
+    window.history.replaceState({}, "", url.toString());
   };
 
   const handleEditSuccess = async () => {


### PR DESCRIPTION
## Summary
- Add support for `?edit=true` URL parameter that automatically opens the edit modal when navigating to the application detail page
- This enables the whitelabel app to link directly to edit mode for admins

## Changes
- Added `useSearchParams` to read URL parameters
- Added `useEffect` to auto-open edit modal when `?edit=true` is present
- Modal only opens when user has access and application can be edited (not `under_review` or `approved`)
- URL is cleaned up after modal opens

## Test plan
- [ ] Navigate to application page without `?edit=true` - edit modal should not open
- [ ] Navigate to application page with `?edit=true` and editable status - edit modal should open
- [ ] Navigate with `?edit=true` but `approved` status - edit modal should NOT open
- [ ] Navigate with `?edit=true` but no admin access - edit modal should NOT open
- [ ] Run tests: `pnpm test -- "ApplicationDetailPage.editParam"`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit Application modal auto-opens when the URL contains edit=true (if user has access and application status permits editing); the edit parameter is removed after the modal opens.
  * Edit button now sets edit=true in the URL; closing the modal removes it.
  * Modal auto-opens once application data loads if conditions become satisfied.

* **Tests**
  * Added tests covering edit eligibility across statuses (including case-insensitive inputs), URL parsing with other parameters, positive/negative edit paths, and dynamic loading edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->