### PR TITLE
fix: add badge validity toggle for kyc

### DIFF
--- a/components/KycStatusIcon.tsx
+++ b/components/KycStatusIcon.tsx
@@ -163,14 +163,19 @@ const badgeColors: Record<KycVerificationStatus, string> = {
  */
 function getBadgeLabel(
   status: KycStatusResponse | null,
-  effectiveStatus: KycVerificationStatus
+  effectiveStatus: KycVerificationStatus,
+  showValidityInLabel: boolean
 ): string {
   const config = statusConfig[effectiveStatus];
   const verificationType = status?.verificationType ?? "KYC/KYB";
   const statusLabel = config.label.toLowerCase();
 
   // For VERIFIED status, include validity date
-  if (effectiveStatus === KycVerificationStatus.VERIFIED && status?.expiresAt) {
+  if (
+    effectiveStatus === KycVerificationStatus.VERIFIED &&
+    status?.expiresAt &&
+    showValidityInLabel
+  ) {
     const expiresDate = formatDate(status.expiresAt);
     return `${verificationType} ${statusLabel} (valid until ${expiresDate})`;
   }
@@ -190,12 +195,14 @@ function getBadgeLabel(
 export function KycStatusBadge({
   status,
   className,
+  showValidityInLabel = true,
 }: {
   status: KycStatusResponse | null;
   className?: string;
+  showValidityInLabel?: boolean;
 }) {
   const effectiveStatus = getEffectiveKycStatus(status);
-  const badgeLabel = getBadgeLabel(status, effectiveStatus);
+  const badgeLabel = getBadgeLabel(status, effectiveStatus, showValidityInLabel);
 
   return (
     <TooltipProvider>
@@ -213,7 +220,7 @@ export function KycStatusBadge({
           </span>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-xs">
-          <KycTooltipContent status={status} showDates={false} />
+          <KycTooltipContent status={status} showDates={!showValidityInLabel} />
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/components/Pages/Admin/PayoutsAdminPage.tsx
+++ b/components/Pages/Admin/PayoutsAdminPage.tsx
@@ -1154,7 +1154,10 @@ export default function PayoutsAdminPage() {
                           {isLoadingKycStatuses ? (
                             <Spinner className="w-4 h-4" />
                           ) : (
-                            <KycStatusBadge status={kycStatuses.get(item.projectUid) ?? null} />
+                            <KycStatusBadge
+                              status={kycStatuses.get(item.projectUid) ?? null}
+                              showValidityInLabel={false}
+                            />
                           )}
                         </td>
                       )}

--- a/components/__tests__/KycStatusIcon.test.tsx
+++ b/components/__tests__/KycStatusIcon.test.tsx
@@ -237,6 +237,18 @@ describe("KycStatusBadge", () => {
       const tooltipTexts = await screen.findAllByText("KYC verification completed successfully");
       expect(tooltipTexts.length).toBeGreaterThanOrEqual(1);
     });
+
+    it("should show validity in tooltip when validity is hidden in label", async () => {
+      const user = userEvent.setup();
+
+      render(<KycStatusBadge status={createMockStatus()} showValidityInLabel={false} />);
+
+      const badge = screen.getByText("KYC verified").closest("span");
+      await user.hover(badge!);
+
+      const expiresRows = await screen.findAllByText(/Expires:/);
+      expect(expiresRows.length).toBeGreaterThanOrEqual(1);
+    });
   });
 
   describe("custom className", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KYC status badges now support configurable display of validity dates in labels via an optional flag.
  * Payouts Admin page updated to hide KYC validity dates from badge labels for cleaner presentation, while expiration details remain accessible in tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->