### PR TITLE
refactor(comments): remove authorName from create comment requests

### DIFF
--- a/__tests__/integration/features/application-comments-integration.test.ts
+++ b/__tests__/integration/features/application-comments-integration.test.ts
@@ -98,8 +98,7 @@ describe("Application Comments Integration", () => {
 
       const createdComment = await applicationCommentsService.createComment(
         applicationId,
-        "This is a test comment",
-        "Test User"
+        "This is a test comment"
       );
 
       expect(createdComment).toEqual(mockComment);
@@ -107,7 +106,6 @@ describe("Application Comments Integration", () => {
         expect.stringContaining(applicationId),
         expect.objectContaining({
           content: "This is a test comment",
-          authorName: "Test User",
         })
       );
 
@@ -178,8 +176,7 @@ describe("Application Comments Integration", () => {
 
       const created = await applicationCommentsService.createComment(
         applicationId,
-        "Admin review comment",
-        "Admin User"
+        "Admin review comment"
       );
 
       expect(created).toEqual(adminComment);
@@ -187,7 +184,6 @@ describe("Application Comments Integration", () => {
         expect.stringContaining(applicationId),
         expect.objectContaining({
           content: "Admin review comment",
-          authorName: "Admin User",
         })
       );
     });
@@ -216,7 +212,6 @@ describe("Application Comments Integration", () => {
         expect.stringContaining(applicationId),
         expect.objectContaining({
           content: "Test comment",
-          authorName: undefined,
         })
       );
     });

--- a/__tests__/unit/services/application-comments.service.test.ts
+++ b/__tests__/unit/services/application-comments.service.test.ts
@@ -81,14 +81,13 @@ describe("applicationCommentsService", () => {
       });
 
       // Call the service
-      await applicationCommentsService.createComment("app-123", "Test comment", "Test User");
+      await applicationCommentsService.createComment("app-123", "Test comment");
 
       // Verify axios.post was called with correct parameters
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         expect.stringContaining("app-123"),
         expect.objectContaining({
           content: "Test comment",
-          authorName: "Test User",
         })
       );
     });

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -806,8 +806,8 @@ export const useApplicationComments = (applicationId: string | null, _isAdmin: b
 
   // Mutation for creating comments
   const createCommentMutation = useMutation({
-    mutationFn: ({ content, authorName }: { content: string; authorName?: string }) =>
-      applicationCommentsService.createComment(applicationId!, content, authorName),
+    mutationFn: ({ content }: { content: string }) =>
+      applicationCommentsService.createComment(applicationId!, content),
     onSuccess: () => {
       // Invalidate and refetch comments after successful creation
       queryClient.invalidateQueries({

--- a/services/application-comments.service.ts
+++ b/services/application-comments.service.ts
@@ -37,14 +37,9 @@ export const applicationCommentsService = {
   /**
    * Create a new comment
    */
-  async createComment(
-    applicationId: string,
-    content: string,
-    authorName?: string
-  ): Promise<ApplicationComment> {
+  async createComment(applicationId: string, content: string): Promise<ApplicationComment> {
     const response = await apiClient.post(INDEXER.V2.APPLICATIONS.COMMENTS(applicationId), {
       content,
-      authorName,
     });
 
     return response.data.comment;


### PR DESCRIPTION
## Summary
Remove `authorName` parameter from comment creation - backend now computes this on read.

## Changes
- Remove `authorName` parameter from `createComment` service method
- Update mutation type in `useFundingPlatform` hook
- Update tests to match new API

## Related
- Depends on: show-karma/gap-indexer#864

## Test plan
- [x] Unit tests passing
- [x] Integration tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the comment creation workflow by removing the authorName parameter from the service API. Comments are now created with only application ID and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->