### PR TITLE
feat(program): add admin and finance contact emails

### DIFF
--- a/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
+++ b/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
@@ -55,6 +55,48 @@ jest.mock("react-hot-toast", () => ({
   },
 }));
 
+// Mock MultiEmailInput to render a simple input + button for testing
+jest.mock("@/components/Utilities/MultiEmailInput", () => ({
+  MultiEmailInput: ({
+    emails,
+    onChange,
+    placeholder,
+    disabled,
+    error,
+  }: {
+    emails: string[];
+    onChange: (emails: string[]) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    error?: string;
+  }) => {
+    const isAdmin = placeholder?.includes("admin");
+    const testId = isAdmin ? "admin" : "finance";
+    return (
+      <div>
+        <input
+          data-testid={`email-input-${testId}`}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          data-testid={`add-email-${testId}`}
+          onClick={() => onChange([...emails, `test-${testId}@example.com`])}
+        >
+          Add
+        </button>
+        {emails.map((email: string) => (
+          <span key={email} data-testid={`email-tag-${testId}`}>
+            {email}
+          </span>
+        ))}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    );
+  },
+}));
+
 // Mock MarkdownEditor to render a simple textarea for testing
 jest.mock("@/components/Utilities/MarkdownEditor", () => ({
   MarkdownEditor: ({
@@ -512,6 +554,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -553,6 +597,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -586,6 +632,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -623,6 +671,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -657,6 +707,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -686,6 +738,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -711,6 +765,8 @@ describe("CreateProgramModal", () => {
       await user.type(nameInput, "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -743,6 +799,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -772,6 +830,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });
@@ -806,6 +866,8 @@ describe("CreateProgramModal", () => {
       await user.type(screen.getByLabelText(/program name/i), "Test Program");
       await user.type(screen.getByLabelText(/program description/i), "Test Description");
       await user.type(screen.getByLabelText(/short description/i), "Short desc");
+      await user.click(screen.getByTestId("add-email-admin"));
+      await user.click(screen.getByTestId("add-email-finance"));
 
       // Submit
       const submitButton = screen.getByRole("button", { name: /create program/i });

--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -55,6 +55,48 @@ jest.mock("@/components/Utilities/errorManager", () => ({
   errorManager: jest.fn(),
 }));
 
+// Mock MultiEmailInput to render a simple input + button for testing
+jest.mock("@/components/Utilities/MultiEmailInput", () => ({
+  MultiEmailInput: ({
+    emails,
+    onChange,
+    placeholder,
+    disabled,
+    error,
+  }: {
+    emails: string[];
+    onChange: (emails: string[]) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    error?: string;
+  }) => {
+    const isAdmin = placeholder?.includes("admin");
+    const testId = isAdmin ? "admin" : "finance";
+    return (
+      <div>
+        <input
+          data-testid={`email-input-${testId}`}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          data-testid={`add-email-${testId}`}
+          onClick={() => onChange([...emails, `test-${testId}@example.com`])}
+        >
+          Add
+        </button>
+        {emails.map((email: string) => (
+          <span key={email} data-testid={`email-tag-${testId}`}>
+            {email}
+          </span>
+        ))}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    );
+  },
+}));
+
 // Mock MarkdownEditor to render a simple textarea for testing
 jest.mock("@/components/Utilities/MarkdownEditor", () => ({
   MarkdownEditor: ({
@@ -216,6 +258,8 @@ const mockProgram: GrantProgram = {
     bannerImgData: {},
     credentials: {},
     communityRef: [],
+    adminEmails: ["admin@example.com"],
+    financeEmails: ["finance@example.com"],
   },
 };
 

--- a/__tests__/schemas/programFormSchema.test.ts
+++ b/__tests__/schemas/programFormSchema.test.ts
@@ -5,6 +5,11 @@
 
 import { createProgramSchema } from "@/schemas/programFormSchema";
 
+const validEmails = {
+  adminEmails: ["admin@example.com"],
+  financeEmails: ["finance@example.com"],
+};
+
 describe("createProgramSchema", () => {
   describe("name validation", () => {
     it("should accept valid program name", () => {
@@ -13,6 +18,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -23,6 +29,7 @@ describe("createProgramSchema", () => {
         name: "ab",
         description: "Test description",
         shortDescription: "Short desc",
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -36,6 +43,7 @@ describe("createProgramSchema", () => {
         name: "a".repeat(51),
         description: "Test description",
         shortDescription: "Short desc",
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -50,6 +58,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -61,6 +70,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -74,6 +84,7 @@ describe("createProgramSchema", () => {
         description: "This is a valid description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -84,6 +95,7 @@ describe("createProgramSchema", () => {
         name: "Test Program",
         description: "ab",
         shortDescription: "Short desc",
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -98,6 +110,7 @@ describe("createProgramSchema", () => {
         description: "abc",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -111,6 +124,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short description",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -121,6 +135,7 @@ describe("createProgramSchema", () => {
         name: "Test Program",
         description: "Test description",
         shortDescription: "",
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -134,6 +149,7 @@ describe("createProgramSchema", () => {
         name: "Test Program",
         description: "Test description",
         shortDescription: "a".repeat(101),
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -150,6 +166,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "a".repeat(100),
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -161,6 +178,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "a",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -177,6 +195,7 @@ describe("createProgramSchema", () => {
           startsAt: new Date("2024-06-01"),
           endsAt: new Date("2024-12-31"),
         },
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -188,6 +207,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -201,6 +221,7 @@ describe("createProgramSchema", () => {
         dates: {
           startsAt: new Date("2024-06-01"),
         },
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -214,6 +235,7 @@ describe("createProgramSchema", () => {
         dates: {
           endsAt: new Date("2024-12-31"),
         },
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -228,6 +250,7 @@ describe("createProgramSchema", () => {
           startsAt: new Date("2024-12-31"),
           endsAt: new Date("2024-06-01"),
         },
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -247,6 +270,7 @@ describe("createProgramSchema", () => {
           startsAt: sameDate,
           endsAt: sameDate,
         },
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -261,6 +285,7 @@ describe("createProgramSchema", () => {
         shortDescription: "Short desc",
         dates: {},
         budget: 100000,
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -272,6 +297,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         dates: {},
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -284,6 +310,7 @@ describe("createProgramSchema", () => {
         shortDescription: "Short desc",
         dates: {},
         budget: 0,
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -296,6 +323,7 @@ describe("createProgramSchema", () => {
         shortDescription: "Short desc",
         dates: {},
         budget: -100,
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -315,6 +343,7 @@ describe("createProgramSchema", () => {
         shortDescription: "Short desc",
         dates: {},
         budget: "100000",
+        ...validEmails,
       });
 
       expect(result.success).toBe(true);
@@ -330,6 +359,7 @@ describe("createProgramSchema", () => {
         description: "Test description",
         shortDescription: "Short desc",
         budget: "not-a-number",
+        ...validEmails,
       });
 
       expect(result.success).toBe(false);
@@ -347,6 +377,8 @@ describe("createProgramSchema", () => {
           endsAt: new Date("2024-12-31"),
         },
         budget: 100000,
+        adminEmails: ["admin@example.com"],
+        financeEmails: ["finance@example.com"],
       });
 
       expect(result.success).toBe(true);
@@ -355,6 +387,8 @@ describe("createProgramSchema", () => {
         expect(result.data.description).toBe("This is a test program description");
         expect(result.data.shortDescription).toBe("Short test description");
         expect(result.data.budget).toBe(100000);
+        expect(result.data.adminEmails).toEqual(["admin@example.com"]);
+        expect(result.data.financeEmails).toEqual(["finance@example.com"]);
       }
     });
 
@@ -364,6 +398,97 @@ describe("createProgramSchema", () => {
         description: "abc",
         shortDescription: "a",
         dates: {},
+        ...validEmails,
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("adminEmails validation", () => {
+    it("should require at least one admin email", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        adminEmails: [],
+        financeEmails: ["finance@example.com"],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const emailError = result.error.errors.find((err) => err.path.includes("adminEmails"));
+        expect(emailError?.message).toBe("At least one admin email is required");
+      }
+    });
+
+    it("should reject invalid email addresses", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        adminEmails: ["not-an-email"],
+        financeEmails: ["finance@example.com"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept multiple valid admin emails", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        adminEmails: ["admin1@example.com", "admin2@example.com"],
+        financeEmails: ["finance@example.com"],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("financeEmails validation", () => {
+    it("should require at least one finance email", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        adminEmails: ["admin@example.com"],
+        financeEmails: [],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const emailError = result.error.errors.find((err) => err.path.includes("financeEmails"));
+        expect(emailError?.message).toBe("At least one finance email is required");
+      }
+    });
+
+    it("should reject invalid finance email addresses", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        ...validEmails,
+        financeEmails: ["not-an-email"],
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept valid finance emails", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "Test description",
+        shortDescription: "Short desc",
+        dates: {},
+        ...validEmails,
+        financeEmails: ["finance@example.com"],
       });
 
       expect(result.success).toBe(true);

--- a/components/FundingPlatform/CreateProgramModal.tsx
+++ b/components/FundingPlatform/CreateProgramModal.tsx
@@ -7,6 +7,7 @@ import { useAccount } from "wagmi";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
+import { MultiEmailInput } from "@/components/Utilities/MultiEmailInput";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -67,6 +68,8 @@ export function CreateProgramModal({
         endsAt: undefined,
       },
       budget: undefined,
+      adminEmails: [],
+      financeEmails: [],
     },
   });
 
@@ -93,6 +96,10 @@ export function CreateProgramModal({
         data as CreateProgramFormData,
         community
       );
+
+      // Add contact emails to metadata
+      metadata.adminEmails = data.adminEmails;
+      metadata.financeEmails = data.financeEmails;
 
       // Create program using service
       await ProgramRegistryService.createProgram(address, community.chainID, metadata);
@@ -317,6 +324,52 @@ export function CreateProgramModal({
               />
               {errors.budget && <p className="text-sm text-destructive">{errors.budget.message}</p>}
             </div>
+
+            {/* Admin Emails */}
+            <Controller
+              name="adminEmails"
+              control={control}
+              render={({ field, fieldState }) => (
+                <div className="flex w-full flex-col gap-1">
+                  <Label htmlFor="admin-emails">
+                    Admin Emails <span className="text-destructive">*</span>
+                  </Label>
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Applicants will reply to these email addresses when responding to notifications
+                  </p>
+                  <MultiEmailInput
+                    emails={field.value}
+                    onChange={field.onChange}
+                    placeholder="Enter admin email"
+                    disabled={isSubmitting}
+                    error={fieldState.error?.message}
+                  />
+                </div>
+              )}
+            />
+
+            {/* Finance Emails */}
+            <Controller
+              name="financeEmails"
+              control={control}
+              render={({ field, fieldState }) => (
+                <div className="flex w-full flex-col gap-1">
+                  <Label htmlFor="finance-emails">
+                    Finance Emails <span className="text-destructive">*</span>
+                  </Label>
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Finance team will be notified when milestones are verified
+                  </p>
+                  <MultiEmailInput
+                    emails={field.value}
+                    onChange={field.onChange}
+                    placeholder="Enter finance email"
+                    disabled={isSubmitting}
+                    error={fieldState.error?.message}
+                  />
+                </div>
+              )}
+            />
 
             {/* Actions */}
             <DialogFooter>

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/hooks/useAuth";
 import { useProgramConfig } from "@/hooks/useFundingPlatform";
-import { type CreateProgramFormSchema, createProgramSchema } from "@/schemas/programFormSchema";
+import { type UpdateProgramFormSchema, updateProgramSchema } from "@/schemas/programFormSchema";
 import { ProgramRegistryService } from "@/services/programRegistry.service";
 import fetchData from "@/utilities/fetchData";
 import { formatDate } from "@/utilities/formatDate";
@@ -74,7 +74,7 @@ function buildFormValuesFromMetadata(metadata: GrantProgram["metadata"]) {
  * Helper function to build metadata object for API update
  */
 function buildUpdateMetadata(
-  formData: CreateProgramFormSchema,
+  formData: UpdateProgramFormSchema,
   existingMetadata: GrantProgram["metadata"]
 ) {
   const updatedFields = {
@@ -120,8 +120,8 @@ export function ProgramDetailsTab({
     control,
     formState: { errors, isSubmitting, isDirty },
     reset,
-  } = useForm<CreateProgramFormSchema>({
-    resolver: zodResolver(createProgramSchema),
+  } = useForm<UpdateProgramFormSchema>({
+    resolver: zodResolver(updateProgramSchema),
     defaultValues: {
       name: "",
       description: "",
@@ -276,7 +276,7 @@ export function ProgramDetailsTab({
     [isDisabled, watch, setValue]
   );
 
-  const onSubmit = async (data: CreateProgramFormSchema) => {
+  const onSubmit = async (data: UpdateProgramFormSchema) => {
     const validationError = validateSubmissionPrerequisites();
     if (validationError) {
       toast.error(validationError);
@@ -530,14 +530,12 @@ export function ProgramDetailsTab({
             control={control}
             render={({ field, fieldState }) => (
               <div className="flex w-full flex-col gap-1">
-                <Label htmlFor="admin-emails">
-                  Admin Emails <span className="text-destructive">*</span>
-                </Label>
+                <Label htmlFor="admin-emails">Admin Emails (optional)</Label>
                 <p className="text-xs text-muted-foreground mb-1">
                   Applicants will reply to these email addresses when responding to notifications
                 </p>
                 <MultiEmailInput
-                  emails={field.value}
+                  emails={field.value || []}
                   onChange={field.onChange}
                   placeholder="Enter admin email"
                   disabled={isDisabled}
@@ -554,14 +552,12 @@ export function ProgramDetailsTab({
             control={control}
             render={({ field, fieldState }) => (
               <div className="flex w-full flex-col gap-1">
-                <Label htmlFor="finance-emails">
-                  Finance Emails <span className="text-destructive">*</span>
-                </Label>
+                <Label htmlFor="finance-emails">Finance Emails (optional)</Label>
                 <p className="text-xs text-muted-foreground mb-1">
                   Finance team will be notified when milestones are verified
                 </p>
                 <MultiEmailInput
-                  emails={field.value}
+                  emails={field.value || []}
                   onChange={field.onChange}
                   placeholder="Enter finance email"
                   disabled={isDisabled}

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -9,6 +9,7 @@ import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramLis
 import { DateTimePicker } from "@/components/Utilities/DateTimePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
+import { MultiEmailInput } from "@/components/Utilities/MultiEmailInput";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -64,6 +65,8 @@ function buildFormValuesFromMetadata(metadata: GrantProgram["metadata"]) {
       endsAt: metadata.endsAt ? new Date(metadata.endsAt) : undefined,
     },
     budget: metadata.programBudget ? parseFloat(metadata.programBudget.toString()) : undefined,
+    adminEmails: metadata.adminEmails || [],
+    financeEmails: metadata.financeEmails || [],
   };
 }
 
@@ -81,6 +84,8 @@ function buildUpdateMetadata(
     programBudget: formData.budget,
     startsAt: formData.dates.startsAt,
     endsAt: formData.dates.endsAt,
+    adminEmails: formData.adminEmails,
+    financeEmails: formData.financeEmails,
   };
 
   return sanitizeObject({
@@ -126,6 +131,8 @@ export function ProgramDetailsTab({
         endsAt: undefined,
       },
       budget: undefined,
+      adminEmails: [],
+      financeEmails: [],
     },
   });
 
@@ -516,6 +523,54 @@ export function ProgramDetailsTab({
             )}
             <AriaLiveError error={errors.budget} />
           </div>
+
+          {/* Admin Emails */}
+          <Controller
+            name="adminEmails"
+            control={control}
+            render={({ field, fieldState }) => (
+              <div className="flex w-full flex-col gap-1">
+                <Label htmlFor="admin-emails">
+                  Admin Emails <span className="text-destructive">*</span>
+                </Label>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Applicants will reply to these email addresses when responding to notifications
+                </p>
+                <MultiEmailInput
+                  emails={field.value}
+                  onChange={field.onChange}
+                  placeholder="Enter admin email"
+                  disabled={isDisabled}
+                  error={fieldState.error?.message}
+                />
+                <AriaLiveError error={fieldState.error} />
+              </div>
+            )}
+          />
+
+          {/* Finance Emails */}
+          <Controller
+            name="financeEmails"
+            control={control}
+            render={({ field, fieldState }) => (
+              <div className="flex w-full flex-col gap-1">
+                <Label htmlFor="finance-emails">
+                  Finance Emails <span className="text-destructive">*</span>
+                </Label>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Finance team will be notified when milestones are verified
+                </p>
+                <MultiEmailInput
+                  emails={field.value}
+                  onChange={field.onChange}
+                  placeholder="Enter finance email"
+                  disabled={isDisabled}
+                  error={fieldState.error?.message}
+                />
+                <AriaLiveError error={fieldState.error} />
+              </div>
+            )}
+          />
 
           {/* Actions */}
           {!readOnly && (

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -552,7 +552,9 @@ export function ProgramDetailsTab({
             control={control}
             render={({ field, fieldState }) => (
               <div className="flex w-full flex-col gap-1">
-                <Label htmlFor="finance-emails">Finance Emails (optional)</Label>
+                <Label htmlFor="finance-emails">
+                  Finance Emails <span className="text-destructive">*</span>
+                </Label>
                 <p className="text-xs text-muted-foreground mb-1">
                   Finance team will be notified when milestones are verified
                 </p>

--- a/components/Pages/ProgramRegistry/AddProgram.tsx
+++ b/components/Pages/ProgramRegistry/AddProgram.tsx
@@ -19,6 +19,7 @@ import { Twitter2Icon } from "@/components/Icons/Twitter2";
 import { Button } from "@/components/Utilities/Button";
 import { DateTimePicker } from "@/components/Utilities/DateTimePicker";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { MultiEmailInput } from "@/components/Utilities/MultiEmailInput";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useAuth } from "@/hooks/useAuth";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
@@ -147,6 +148,12 @@ const createProgramSchema = z.object({
   platformsUsed: z.array(z.string()),
   communityRef: z.array(z.string()),
   status: z.string().optional().or(z.literal("Active")),
+  adminEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one admin email is required" }),
+  financeEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one finance email is required" }),
 });
 
 type CreateProgramType = z.infer<typeof createProgramSchema>;
@@ -234,6 +241,8 @@ export default function AddProgram({
       platformsUsed: programToEdit?.metadata?.platformsUsed || [],
       communityRef: programToEdit?.metadata?.communityRef || [],
       status: programToEdit?.metadata?.status || "Active",
+      adminEmails: programToEdit?.metadata?.adminEmails || [],
+      financeEmails: programToEdit?.metadata?.financeEmails || [],
     },
   });
 
@@ -322,6 +331,8 @@ export default function AddProgram({
         type: "program",
         tags: ["karma-gap", "grant-program-registry"],
         communityRef: data.communityRef,
+        adminEmails: data.adminEmails,
+        financeEmails: data.financeEmails,
       };
 
       // Use V2 endpoint - owner comes from JWT session
@@ -433,6 +444,8 @@ export default function AddProgram({
         tags: ["karma-gap", "grant-program-registry"],
         status: data.status,
         communityRef: data.communityRef,
+        adminEmails: data.adminEmails,
+        financeEmails: data.financeEmails,
       });
 
       // Always use V2 update endpoint (off-chain)
@@ -633,6 +646,50 @@ export default function AddProgram({
                   placeholder="Please provide a description of this program"
                 />
                 <p className="text-base text-red-400">{errors.description?.message}</p>
+              </div>
+              <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-4">
+                <Controller
+                  name="adminEmails"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <div className="flex w-full flex-col gap-1">
+                      <label htmlFor="admin-emails" className={labelStyle}>
+                        Admin Emails *
+                      </label>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">
+                        Applicants will reply to these emails
+                      </p>
+                      <MultiEmailInput
+                        emails={field.value}
+                        onChange={field.onChange}
+                        placeholder="Enter admin email"
+                        disabled={isLoading}
+                        error={fieldState.error?.message}
+                      />
+                    </div>
+                  )}
+                />
+                <Controller
+                  name="financeEmails"
+                  control={control}
+                  render={({ field, fieldState }) => (
+                    <div className="flex w-full flex-col gap-1">
+                      <label htmlFor="finance-emails" className={labelStyle}>
+                        Finance Emails *
+                      </label>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">
+                        Notified when milestones are verified
+                      </p>
+                      <MultiEmailInput
+                        emails={field.value}
+                        onChange={field.onChange}
+                        placeholder="Enter finance email"
+                        disabled={isLoading}
+                        error={fieldState.error?.message}
+                      />
+                    </div>
+                  )}
+                />
               </div>
               <div className="grid grid-cols-4  max-sm:grid-cols-1 max-md:grid-cols-2 gap-4 justify-between">
                 <div className="flex w-full flex-col gap-1">

--- a/components/Utilities/MultiEmailInput.tsx
+++ b/components/Utilities/MultiEmailInput.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/utilities/tailwind";
+
+interface MultiEmailInputProps {
+  emails: string[];
+  onChange: (emails: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  error?: string;
+  className?: string;
+}
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function MultiEmailInput({
+  emails,
+  onChange,
+  placeholder = "Enter email address",
+  disabled = false,
+  error,
+  className,
+}: MultiEmailInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+
+  const handleAddEmail = () => {
+    const trimmedEmail = inputValue.trim().toLowerCase();
+
+    if (!trimmedEmail) {
+      return;
+    }
+
+    if (!emailRegex.test(trimmedEmail)) {
+      setInputError("Please enter a valid email address");
+      return;
+    }
+
+    if (emails.includes(trimmedEmail)) {
+      setInputError("This email is already added");
+      return;
+    }
+
+    onChange([...emails, trimmedEmail]);
+    setInputValue("");
+    setInputError(null);
+  };
+
+  const handleRemoveEmail = (emailToRemove: string) => {
+    onChange(emails.filter((email) => email !== emailToRemove));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddEmail();
+    }
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex gap-2">
+        <Input
+          type="email"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            setInputError(null);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="flex-1"
+        />
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={handleAddEmail}
+          disabled={disabled || !inputValue.trim()}
+        >
+          Add
+        </Button>
+      </div>
+
+      {inputError && <p className="text-sm text-destructive">{inputError}</p>}
+
+      {emails.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {emails.map((email) => (
+            <div
+              key={email}
+              className="flex items-center gap-1 rounded-full bg-muted px-3 py-1 text-sm"
+            >
+              <span>{email}</span>
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => handleRemoveEmail(email)}
+                  className="rounded-full p-0.5 hover:bg-muted-foreground/20"
+                  aria-label={`Remove ${email}`}
+                >
+                  <XMarkIcon className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/schemas/programFormSchema.ts
+++ b/schemas/programFormSchema.ts
@@ -32,8 +32,9 @@ const baseProgramFields = {
 };
 
 /**
- * Schema for creating new programs - emails are REQUIRED
- * Used in CreateProgramModal and AddProgram
+ * Schema for creating new programs
+ * - adminEmails: REQUIRED for new programs
+ * - financeEmails: OPTIONAL (used for milestone verification notifications)
  */
 export const createProgramSchema = z.object({
   ...baseProgramFields,
@@ -42,7 +43,8 @@ export const createProgramSchema = z.object({
     .min(1, { message: "At least one admin email is required" }),
   financeEmails: z
     .array(z.string().email({ message: "Invalid email address" }))
-    .min(1, { message: "At least one finance email is required" }),
+    .optional()
+    .default([]),
 });
 
 /**

--- a/schemas/programFormSchema.ts
+++ b/schemas/programFormSchema.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 
 /**
- * Shared Zod schema for program form validation
- * Used in both CreateProgramModal and ProgramDetailsTab
+ * Base schema fields shared between create and update
  */
-export const createProgramSchema = z.object({
+const baseProgramFields = {
   name: z
     .string()
     .min(3, { message: "Program name must be at least 3 characters" })
@@ -30,6 +29,14 @@ export const createProgramSchema = z.object({
       }
     ),
   budget: z.coerce.number().min(0, { message: "Budget must be a positive number" }).optional(),
+};
+
+/**
+ * Schema for creating new programs - emails are REQUIRED
+ * Used in CreateProgramModal and AddProgram
+ */
+export const createProgramSchema = z.object({
+  ...baseProgramFields,
   adminEmails: z
     .array(z.string().email({ message: "Invalid email address" }))
     .min(1, { message: "At least one admin email is required" }),
@@ -38,4 +45,16 @@ export const createProgramSchema = z.object({
     .min(1, { message: "At least one finance email is required" }),
 });
 
+/**
+ * Schema for updating existing programs - emails are OPTIONAL
+ * Used in ProgramDetailsTab (question-builder)
+ * Existing programs without emails can still be updated
+ */
+export const updateProgramSchema = z.object({
+  ...baseProgramFields,
+  adminEmails: z.array(z.string().email({ message: "Invalid email address" })).optional(),
+  financeEmails: z.array(z.string().email({ message: "Invalid email address" })).optional(),
+});
+
 export type CreateProgramFormSchema = z.infer<typeof createProgramSchema>;
+export type UpdateProgramFormSchema = z.infer<typeof updateProgramSchema>;

--- a/schemas/programFormSchema.ts
+++ b/schemas/programFormSchema.ts
@@ -30,6 +30,12 @@ export const createProgramSchema = z.object({
       }
     ),
   budget: z.coerce.number().min(0, { message: "Budget must be a positive number" }).optional(),
+  adminEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one admin email is required" }),
+  financeEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one finance email is required" }),
 });
 
 export type CreateProgramFormSchema = z.infer<typeof createProgramSchema>;

--- a/schemas/programFormSchema.ts
+++ b/schemas/programFormSchema.ts
@@ -32,30 +32,35 @@ const baseProgramFields = {
 };
 
 /**
- * Schema for creating new programs
- * - adminEmails: REQUIRED for new programs
- * - financeEmails: OPTIONAL (used for milestone verification notifications)
+ * Email fields shared between create and update schemas.
+ * Both adminEmails and financeEmails are required for all programs.
+ * Old programs without emails must add them when updating.
  */
-export const createProgramSchema = z.object({
-  ...baseProgramFields,
+const emailFields = {
   adminEmails: z
     .array(z.string().email({ message: "Invalid email address" }))
     .min(1, { message: "At least one admin email is required" }),
   financeEmails: z
     .array(z.string().email({ message: "Invalid email address" }))
-    .optional()
-    .default([]),
+    .min(1, { message: "At least one finance email is required" }),
+};
+
+/**
+ * Schema for creating new programs
+ */
+export const createProgramSchema = z.object({
+  ...baseProgramFields,
+  ...emailFields,
 });
 
 /**
- * Schema for updating existing programs - emails are OPTIONAL
+ * Schema for updating existing programs
+ * Both email fields are required - old programs must add them on update.
  * Used in ProgramDetailsTab (question-builder)
- * Existing programs without emails can still be updated
  */
 export const updateProgramSchema = z.object({
   ...baseProgramFields,
-  adminEmails: z.array(z.string().email({ message: "Invalid email address" })).optional(),
-  financeEmails: z.array(z.string().email({ message: "Invalid email address" })).optional(),
+  ...emailFields,
 });
 
 export type CreateProgramFormSchema = z.infer<typeof createProgramSchema>;

--- a/src/features/funding-map/types/funding-program.ts
+++ b/src/features/funding-map/types/funding-program.ts
@@ -40,6 +40,8 @@ export interface FundingProgramMetadata {
   platformsUsed?: string[];
   status: string;
   communityRef?: string[];
+  adminEmails?: string[];
+  financeEmails?: string[];
 }
 
 /**

--- a/types/program-registry.ts
+++ b/types/program-registry.ts
@@ -38,6 +38,8 @@ export interface ProgramMetadata {
   type: string;
   tags: string[];
   communityRef: string[];
+  adminEmails?: string[];
+  financeEmails?: string[];
 }
 
 export interface ProgramCreationRequest {
@@ -67,4 +69,6 @@ export interface CreateProgramFormData {
     endsAt?: Date;
   };
   budget?: number;
+  adminEmails?: string[];
+  financeEmails?: string[];
 }


### PR DESCRIPTION
## Summary

- Add admin and finance contact email fields to program creation and configuration
- Admin emails are required when creating new programs, optional for existing programs
- Finance emails are optional

## Changes

- Updated program creation modal to include admin/finance email fields
- Added email fields to question builder's program details tab
- Updated form validation schemas (required on create, optional on update)

## Test plan

- [ ] Create a new program - verify admin emails are required
- [ ] Update an existing program - verify emails are optional
- [ ] Verify email validation works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Admin Emails and Finance Emails to program create/edit flows with required validation and helper text.
  * New multi-email input control: add/remove chips, per-email validation, duplicate prevention, disabled state, and ARIA-friendly announcements.
  * Admin and finance emails persist in program metadata for create and update.

* **Tests**
  * Added schema and form tests for admin/finance email rules and multi-email interactions; tests include a test-friendly mock of the email input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->