### PR TITLE
feat(grants): add approvedAmount from payout_grant_config to API response

### DIFF
--- a/__tests__/utilities/getGrantDisplayAmount.test.ts
+++ b/__tests__/utilities/getGrantDisplayAmount.test.ts
@@ -1,0 +1,272 @@
+import type { Grant } from "@/types/v2/grant";
+import { getGrantAmountDisplay, getGrantDisplayAmount } from "@/utilities/getGrantDisplayAmount";
+
+describe("getGrantDisplayAmount", () => {
+  describe("when grant is null or undefined", () => {
+    it("should return empty result for null grant", () => {
+      const result = getGrantDisplayAmount(null);
+
+      expect(result.hasAmount).toBe(false);
+      expect(result.displayAmount).toBeUndefined();
+      expect(result.rawAmount).toBeUndefined();
+      expect(result.currency).toBe("");
+      expect(result.isFromFinancialConfig).toBe(false);
+    });
+
+    it("should return empty result for undefined grant", () => {
+      const result = getGrantDisplayAmount(undefined);
+
+      expect(result.hasAmount).toBe(false);
+      expect(result.displayAmount).toBeUndefined();
+    });
+  });
+
+  describe("when approvedAmount is present (financial config)", () => {
+    it("should prioritize approvedAmount over details.amount", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "80000",
+        details: {
+          title: "Test Grant",
+          amount: "190000", // This should be ignored
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.isFromFinancialConfig).toBe(true);
+      expect(result.rawAmount).toBe("80000");
+      expect(result.displayAmount).toBe("80K");
+    });
+
+    it("should extract currency from approvedAmount string", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "50000 USDC",
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.currency).toBe("USDC");
+      expect(result.displayAmount).toBe("50K");
+    });
+
+    it("should use details.currency if not in approvedAmount", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "25000",
+        details: {
+          title: "Test Grant",
+          currency: "ARB",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.currency).toBe("ARB");
+    });
+
+    it("should handle already formatted amounts like 40K", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "40K USDC",
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.displayAmount).toBe("40K");
+      expect(result.currency).toBe("USDC");
+    });
+  });
+
+  describe("when only details.amount is present (attestation data)", () => {
+    it("should use details.amount when approvedAmount is not set", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        details: {
+          title: "Test Grant",
+          amount: "100000",
+          currency: "USDC",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.isFromFinancialConfig).toBe(false);
+      expect(result.rawAmount).toBe("100000");
+      expect(result.displayAmount).toBe("100K");
+      expect(result.currency).toBe("USDC");
+    });
+
+    it("should handle amount with embedded currency", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        details: {
+          title: "Test Grant",
+          amount: "5686.59 USD",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.currency).toBe("USD");
+    });
+
+    it("should handle decimal amounts", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        details: {
+          title: "Test Grant",
+          amount: "2500.50",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+    });
+  });
+
+  describe("when root-level amount is present (legacy format)", () => {
+    it("should use root-level amount when approvedAmount is not set", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        amount: "50000",
+        details: {
+          title: "Test Grant",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.isFromFinancialConfig).toBe(false);
+      expect(result.rawAmount).toBe("50000");
+    });
+
+    it("should prioritize approvedAmount over root-level amount", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "30000",
+        amount: "50000",
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.rawAmount).toBe("30000");
+      expect(result.isFromFinancialConfig).toBe(true);
+    });
+  });
+
+  describe("when no amount is present", () => {
+    it("should return hasAmount false when no amounts exist", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        details: {
+          title: "Test Grant",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(false);
+      expect(result.displayAmount).toBeUndefined();
+    });
+
+    it("should return hasAmount false when amount is zero", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        details: {
+          title: "Test Grant",
+          amount: "0",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle amounts with commas", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: "1,000,000",
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.hasAmount).toBe(true);
+      expect(result.displayAmount).toBe("1M");
+    });
+
+    it("should handle null approvedAmount", () => {
+      const grant: Grant = {
+        uid: "test-uid",
+        chainID: 1,
+        approvedAmount: null,
+        details: {
+          title: "Test Grant",
+          amount: "50000",
+        },
+      };
+
+      const result = getGrantDisplayAmount(grant);
+
+      expect(result.isFromFinancialConfig).toBe(false);
+      expect(result.rawAmount).toBe("50000");
+    });
+  });
+});
+
+describe("getGrantAmountDisplay", () => {
+  it("should return formatted amount for valid grant", () => {
+    const grant: Grant = {
+      uid: "test-uid",
+      chainID: 1,
+      approvedAmount: "80000",
+    };
+
+    const result = getGrantAmountDisplay(grant);
+
+    expect(result).toBe("80K");
+  });
+
+  it("should return undefined when no valid amount exists", () => {
+    const grant: Grant = {
+      uid: "test-uid",
+      chainID: 1,
+      details: {
+        title: "Test Grant",
+      },
+    };
+
+    const result = getGrantAmountDisplay(grant);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for null grant", () => {
+    const result = getGrantAmountDisplay(null);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/types/v2/grant.ts
+++ b/types/v2/grant.ts
@@ -178,4 +178,10 @@ export interface Grant {
   amount?: string;
   createdAt?: string;
   updatedAt?: string;
+  /**
+   * Approved amount from payout_grant_config (admin-configured).
+   * This takes priority over details.amount for financial display.
+   * Human-readable format (e.g., "80000" for 80,000 USDC).
+   */
+  approvedAmount?: string | null;
 }

--- a/utilities/getGrantDisplayAmount.ts
+++ b/utilities/getGrantDisplayAmount.ts
@@ -1,0 +1,169 @@
+import type { Grant } from "@/types/v2/grant";
+import formatCurrency from "./formatCurrency";
+
+interface GrantAmountInfo {
+  /** The raw amount string (e.g., "80000", "50000 USDC") */
+  rawAmount: string | undefined;
+  /** The formatted display amount (e.g., "80K", "50,000") */
+  displayAmount: string | undefined;
+  /** The currency extracted from the amount string or grant details */
+  currency: string;
+  /** Whether the amount comes from financial config (approvedAmount) vs attestation (details.amount) */
+  isFromFinancialConfig: boolean;
+  /** Whether there's a valid amount to display */
+  hasAmount: boolean;
+}
+
+/**
+ * Parses an amount string that may contain currency (e.g., "50000 USDC", "40K", "5686.59 USD")
+ * Returns the numeric value and extracted currency
+ */
+function parseAmountString(amount: string): {
+  numericPart: string;
+  currencyInAmount: string;
+  parsedValue: number;
+  isAlreadyFormatted: boolean;
+} {
+  const trimmed = amount.trim();
+
+  // Match patterns like: "5686.59 USD", "40K USDC", "2500 ARB", "80000", "40K"
+  const amountMatch = trimmed.match(/^([\d,.]+[KMBTkmbt]?)\s*([a-zA-Z]{2,})?$/);
+  const numericPart = amountMatch?.[1] || trimmed;
+  const currencyInAmount = amountMatch?.[2] || "";
+
+  // Check if numeric part is already formatted (like "40K", "5M")
+  const isAlreadyFormatted = /[KMBTkmbt]$/.test(numericPart);
+
+  // Parse the numeric value (remove commas for parsing)
+  const cleanNumber = numericPart.replace(/,/g, "").replace(/[KMBTkmbt]$/, "");
+  const multiplier = /[Kk]$/.test(numericPart)
+    ? 1000
+    : /[Mm]$/.test(numericPart)
+      ? 1e6
+      : /[Bb]$/.test(numericPart)
+        ? 1e9
+        : /[Tt]$/.test(numericPart)
+          ? 1e12
+          : 1;
+
+  const parsedValue = Number(cleanNumber) * multiplier;
+
+  return {
+    numericPart,
+    currencyInAmount,
+    parsedValue,
+    isAlreadyFormatted,
+  };
+}
+
+/**
+ * Formats an amount for display, handling various input formats
+ */
+function formatAmount(rawAmount: string): string {
+  const { numericPart, parsedValue, isAlreadyFormatted } = parseAmountString(rawAmount);
+
+  if (isAlreadyFormatted) {
+    return numericPart;
+  }
+
+  if (!Number.isNaN(parsedValue) && parsedValue !== 0) {
+    return formatCurrency(parsedValue);
+  }
+
+  return numericPart;
+}
+
+/**
+ * Gets the display amount for a grant, prioritizing financial config (approvedAmount)
+ * over attestation data (details.amount).
+ *
+ * Priority:
+ * 1. grant.approvedAmount - Admin-configured amount from payout_grant_config
+ * 2. grant.amount - Root-level amount (legacy Hex format)
+ * 3. grant.details.amount - Attestation amount from on-chain data
+ *
+ * @param grant - The grant object
+ * @returns Information about the amount to display
+ *
+ * @example
+ * ```tsx
+ * const { displayAmount, currency, hasAmount } = getGrantDisplayAmount(grant);
+ * if (hasAmount) {
+ *   return <span>${displayAmount} {currency}</span>;
+ * }
+ * ```
+ */
+export function getGrantDisplayAmount(grant: Grant | undefined | null): GrantAmountInfo {
+  if (!grant) {
+    return {
+      rawAmount: undefined,
+      displayAmount: undefined,
+      currency: "",
+      isFromFinancialConfig: false,
+      hasAmount: false,
+    };
+  }
+
+  // Priority 1: Use approvedAmount from financial config if available
+  if (grant.approvedAmount) {
+    const { currencyInAmount, parsedValue } = parseAmountString(grant.approvedAmount);
+    const currency = currencyInAmount || grant.details?.currency || "";
+
+    return {
+      rawAmount: grant.approvedAmount,
+      displayAmount: formatAmount(grant.approvedAmount),
+      currency,
+      isFromFinancialConfig: true,
+      hasAmount: !Number.isNaN(parsedValue) && parsedValue > 0,
+    };
+  }
+
+  // Priority 2: Check root-level amount (legacy Hex format)
+  if (grant.amount) {
+    const numericValue = Number(grant.amount);
+    const isValidNumber = !Number.isNaN(numericValue) && numericValue > 0;
+    const formattedAmount = isValidNumber ? formatCurrency(numericValue) : grant.amount;
+
+    return {
+      rawAmount: grant.amount,
+      displayAmount: formattedAmount,
+      currency: grant.details?.currency || "",
+      isFromFinancialConfig: false,
+      hasAmount: isValidNumber,
+    };
+  }
+
+  // Priority 3: Fallback to details.amount (attestation data)
+  const detailsAmount = grant.details?.amount;
+  if (!detailsAmount) {
+    return {
+      rawAmount: undefined,
+      displayAmount: undefined,
+      currency: grant.details?.currency || "",
+      isFromFinancialConfig: false,
+      hasAmount: false,
+    };
+  }
+
+  const { currencyInAmount, parsedValue } = parseAmountString(detailsAmount);
+  const currency = currencyInAmount || grant.details?.currency || "";
+
+  return {
+    rawAmount: detailsAmount,
+    displayAmount: formatAmount(detailsAmount),
+    currency,
+    isFromFinancialConfig: false,
+    hasAmount: !Number.isNaN(parsedValue) && parsedValue > 0,
+  };
+}
+
+/**
+ * Simple helper to get just the formatted amount string
+ * Returns undefined if no valid amount exists
+ */
+export function getGrantAmountDisplay(grant: Grant | undefined | null): string | undefined {
+  const { displayAmount, hasAmount } = getGrantDisplayAmount(grant);
+  return hasAmount ? displayAmount : undefined;
+}
+
+export default getGrantDisplayAmount;


### PR DESCRIPTION
## Summary
- Add support for `approvedAmount` field from backend API
- Create `getGrantDisplayAmount` utility to determine correct amount to display
- Update grant display components to use the new utility

## Changes
- Add `approvedAmount?: string | null` to `Grant` type
- Create `utilities/getGrantDisplayAmount.ts` with amount parsing/formatting
- Update `Overview.tsx` to use new utility
- Update `FundingContent.tsx` to use new utility
- Add 18 comprehensive tests for `getGrantDisplayAmount`

## Amount Priority
1. `approvedAmount` - from `payout_grant_config` (admin configured)
2. `amount` - legacy root-level field
3. `details.amount` - from attestation (user submitted)

## Context
Resolves inconsistency where financials page shows 80k but grant detail page shows 190k for the same grant. The `approvedAmount` from financial config should take priority.

## Test plan
- [x] Unit tests pass for `getGrantDisplayAmount` utility (18 tests)
- [ ] Verify grant cards show correct amount from `approvedAmount` when available
- [ ] Verify grant overview shows correct amount from `approvedAmount` when available
- [ ] Verify fallback to `details.amount` when `approvedAmount` is not set

## Related
- Backend PR: https://github.com/show-karma/gap-indexer/pull/869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now configure approved amounts for grants that take priority in all displays

* **Improvements**
  * Standardized grant amount display across all pages for improved consistency and clarity
  * Enhanced handling of various amount formats including currency symbols and decimal values

* **Tests**
  * Added comprehensive test coverage for grant amount formatting scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->