### PR TITLE
fix: remove dead V1 /programs/:id code path

### DIFF
--- a/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
@@ -50,41 +50,6 @@ describe("getAIColumnVisibility", () => {
     });
   });
 
-  describe("When using fallback langfusePromptId", () => {
-    it("should show AI score column when fallback langfusePromptId is provided", () => {
-      const formSchema = undefined;
-      const langfusePromptId = "fallback-prompt-789";
-
-      const result = getAIColumnVisibility(formSchema, langfusePromptId);
-      expect(result.showAIScoreColumn).toBe(true);
-      expect(result.showInternalAIScoreColumn).toBe(false);
-    });
-
-    it("should prefer aiConfig langfusePromptId over fallback", () => {
-      const formSchema = {
-        aiConfig: {
-          langfusePromptId: "config-prompt",
-        },
-      };
-      const langfusePromptId = "fallback-prompt";
-
-      const result = getAIColumnVisibility(formSchema, langfusePromptId);
-      expect(result.showAIScoreColumn).toBe(true);
-      expect(result.showInternalAIScoreColumn).toBe(false);
-    });
-
-    it("should use fallback when aiConfig langfusePromptId is missing", () => {
-      const formSchema = {
-        aiConfig: {},
-      };
-      const langfusePromptId = "fallback-prompt";
-
-      const result = getAIColumnVisibility(formSchema, langfusePromptId);
-      expect(result.showAIScoreColumn).toBe(true);
-      expect(result.showInternalAIScoreColumn).toBe(false);
-    });
-  });
-
   describe("Edge cases", () => {
     it("should handle undefined formSchema", () => {
       const result = getAIColumnVisibility(undefined);
@@ -117,15 +82,6 @@ describe("getAIColumnVisibility", () => {
       };
 
       const result = getAIColumnVisibility(formSchema);
-      expect(result.showAIScoreColumn).toBe(false);
-      expect(result.showInternalAIScoreColumn).toBe(false);
-    });
-
-    it("should handle empty string fallback prompt ID as falsy", () => {
-      const formSchema = undefined;
-      const langfusePromptId = "";
-
-      const result = getAIColumnVisibility(formSchema, langfusePromptId);
       expect(result.showAIScoreColumn).toBe(false);
       expect(result.showInternalAIScoreColumn).toBe(false);
     });
@@ -171,15 +127,6 @@ describe("getAIColumnVisibility", () => {
       const result = getAIColumnVisibility(formSchema);
       expect(result.showAIScoreColumn).toBe(false);
       expect(result.showInternalAIScoreColumn).toBe(true);
-    });
-
-    it("should handle legacy program with fallback prompt ID", () => {
-      const formSchema = undefined;
-      const langfusePromptId = "legacy-prompt-id";
-
-      const result = getAIColumnVisibility(formSchema, langfusePromptId);
-      expect(result.showAIScoreColumn).toBe(true);
-      expect(result.showInternalAIScoreColumn).toBe(false);
     });
   });
 });

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/hooks/useFundingPlatform";
 import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
-import { useProgram } from "@/hooks/usePrograms";
 import type { IApplicationFilters } from "@/services/fundingPlatformService";
 import type { IFundingApplication } from "@/types/funding-platform";
 import formatCurrency from "@/utilities/formatCurrency";
@@ -103,9 +102,8 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
 
   const { exportApplications, isExporting } = useApplicationExport(programId, isAdmin);
 
-  // Fetch program config and program data to determine AI column visibility
+  // Fetch program config to determine AI column visibility
   const { config } = useProgramConfig(programId);
-  const { data: program } = useProgram(programId);
 
   // Fetch reviewers for the program
   const {
@@ -121,8 +119,8 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
 
   // Determine column visibility based on configured prompts
   const { showAIScoreColumn, showInternalAIScoreColumn } = useMemo(
-    () => getAIColumnVisibility(config?.formSchema, program?.langfusePromptId),
-    [config?.formSchema, program?.langfusePromptId]
+    () => getAIColumnVisibility(config?.formSchema),
+    [config?.formSchema]
   );
 
   // Sync filters and sorting with URL

--- a/components/FundingPlatform/helper/getAIColumnVisibility.ts
+++ b/components/FundingPlatform/helper/getAIColumnVisibility.ts
@@ -11,13 +11,9 @@ type FormSchemaWithAiConfig = {
 /**
  * Determines AI column visibility based on configured prompts
  * @param formSchema - The form schema from program config (may have aiConfig)
- * @param langfusePromptId - Fallback langfusePromptId from program registry
  * @returns Object with column visibility flags
  */
-export function getAIColumnVisibility(
-  formSchema: unknown,
-  langfusePromptId?: string
-): {
+export function getAIColumnVisibility(formSchema: unknown): {
   showAIScoreColumn: boolean;
   showInternalAIScoreColumn: boolean;
 } {
@@ -25,7 +21,7 @@ export function getAIColumnVisibility(
   const aiConfig = formSchemaWithAiConfig?.aiConfig;
 
   return {
-    showAIScoreColumn: !!(aiConfig?.langfusePromptId || langfusePromptId),
+    showAIScoreColumn: !!aiConfig?.langfusePromptId,
     showInternalAIScoreColumn: !!aiConfig?.internalLangfusePromptId,
   };
 }

--- a/components/QuestionBuilder/AIPromptConfiguration.tsx
+++ b/components/QuestionBuilder/AIPromptConfiguration.tsx
@@ -7,7 +7,6 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { PAGE_HEADER_CONTENT, PageHeader } from "@/components/FundingPlatform/PageHeader";
 import { useAvailableAIModels } from "@/hooks/useAvailableAIModels";
-import { useProgram } from "@/hooks/usePrograms";
 import { MigrationBanner, PromptEditor, useProgramPrompts } from "@/src/features/prompt-management";
 import type { FormSchema } from "@/types/question-builder";
 import { TabContent } from "../Utilities/Tabs/TabContent";
@@ -118,16 +117,11 @@ export function AIPromptConfiguration({
   chainId,
   readOnly = false,
 }: AIPromptConfigurationProps) {
-  // Fetch program data for default langfusePromptId
-  const { data: program } = useProgram(programId || "");
-
   // Fetch available AI models from backend
   const { data: availableModels = [DEFAULT_AI_MODEL], isLoading: isLoadingModels } =
     useAvailableAIModels();
 
-  // Get default langfusePromptId from program registry if not set in schema
-  const defaultLangfusePromptId =
-    schema.aiConfig?.langfusePromptId || program?.langfusePromptId || "";
+  const defaultLangfusePromptId = schema.aiConfig?.langfusePromptId || "";
 
   // Get default model - use schema value if valid, otherwise use first available model
   const defaultModel = useMemo(() => {
@@ -165,13 +159,6 @@ export function AIPromptConfiguration({
       }
     }
   }, [availableModels, isLoadingModels, defaultModel, getValues, setValue]);
-
-  // Update form value when program data loads and no langfusePromptId is set
-  useEffect(() => {
-    if (program?.langfusePromptId && !schema.aiConfig?.langfusePromptId) {
-      setValue("langfusePromptId", program.langfusePromptId);
-    }
-  }, [program?.langfusePromptId, schema.aiConfig?.langfusePromptId, setValue]);
 
   // Refs to hold latest values without causing stale closures in watch subscription
   const schemaRef = useRef(schema);

--- a/hooks/usePrograms.ts
+++ b/hooks/usePrograms.ts
@@ -6,7 +6,6 @@ export const PROGRAM_QUERY_KEYS = {
   all: ["programs"] as const,
   community: (communityId: string) =>
     [...PROGRAM_QUERY_KEYS.all, "community", communityId] as const,
-  program: (programId: string) => [...PROGRAM_QUERY_KEYS.all, "details", programId] as const,
 };
 
 /**
@@ -17,18 +16,6 @@ export const useCommunityPrograms = (communityId: string) => {
     queryKey: PROGRAM_QUERY_KEYS.community(communityId),
     queryFn: () => programService.getCommunityPrograms(communityId),
     enabled: !!communityId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-  });
-};
-
-/**
- * Hook to fetch a specific program by ID
- */
-export const useProgram = (programId: string) => {
-  return useQuery({
-    queryKey: PROGRAM_QUERY_KEYS.program(programId),
-    queryFn: () => programService.getProgram(programId),
-    enabled: !!programId,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 };

--- a/services/programs.ts
+++ b/services/programs.ts
@@ -19,19 +19,4 @@ export const programService = {
       throw error;
     }
   },
-
-  // Get a specific program by ID
-  getProgram: async (programId: string): Promise<GrantProgram> => {
-    try {
-      const [data, error] = await fetchData(INDEXER.PROGRAMS.GET(programId));
-      if (error) {
-        throw new Error(error);
-      }
-
-      return data as GrantProgram;
-    } catch (error: any) {
-      errorManager(`Error fetching program ${programId}`, error);
-      throw error;
-    }
-  },
 };

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -274,7 +274,6 @@ export const INDEXER = {
     },
   },
   PROGRAMS: {
-    GET: (programId: string) => `/programs/${programId}`,
     COMMUNITY: (communityId: string) => `/communities/${communityId}/programs`,
     FINANCIALS: (programId: string, page?: number, limit?: number) => {
       const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- Removed the `useProgram` hook, `getProgram` service method, and `INDEXER.PROGRAMS.GET` URL builder that targeted a non-existent `GET /programs/{programId}` endpoint
- Cleaned up `ApplicationListWithAPI.tsx` and `AIPromptConfiguration.tsx` which were the only two consumers
- Net removal of 44 lines of dead code that was silently 404ing on every funding-platform admin page load

## Test plan
- [ ] Load `/community/{id}/admin/funding-platform/{programId}/applications` — verify table renders, infinite scroll works, AI Score column visibility unchanged
- [ ] Load `/community/{id}/admin/funding-platform/{programId}/question-builder` — verify AI config section loads, prompt tabs render, legacy settings work
- [ ] Confirm `GET /programs/{programId}` no longer fires in the Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * AI-related UI now derives behavior solely from form/schema settings rather than external program data, simplifying configuration and reducing unexpected variability.
  * AI column visibility and prompt configuration consistently follow schema-provided values.
* **Tests**
  * Adjusted test coverage to reflect the new schema-only behavior, removing legacy fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->