### PR TITLE
fix(csp): allow Privy shared auth iframe in frame-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value:
-      "frame-src 'self' https://auth.privy.io https://*.privy.io https://paragraph.com https://*.paragraph.com https://js.stripe.com https://crypto-js.stripe.com; frame-ancestors 'self';",
+      "frame-src 'self' https://auth.privy.io https://*.privy.io https://privy.karmahq.xyz https://paragraph.com https://*.paragraph.com https://js.stripe.com https://crypto-js.stripe.com; frame-ancestors 'self';",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Add `https://privy.karmahq.xyz` to the CSP `frame-src` directive to allow Privy's shared auth iframe

## Problem

When HttpOnly cookies are enabled for Privy shared auth, Privy uses a custom domain iframe (`privy.karmahq.xyz`) instead of `auth.privy.io` to manage session cookies scoped to `.karmahq.xyz`.

The existing CSP only allowed `https://auth.privy.io` and `https://*.privy.io`, which blocked the `privy.karmahq.xyz` iframe entirely:

```
Framing 'https://privy.karmahq.xyz/' violates the following Content Security Policy directive:
"frame-src 'self' https://auth.privy.io https://*.privy.io ..."
```

This caused:
1. Privy iframe fails to load
2. No session cookies are set
3. Session is lost on every page reload

The whitelabel app (`testapp.karmahq.xyz`) was unaffected because it has no CSP headers.

## Solution

Add `https://privy.karmahq.xyz` to the `frame-src` CSP directive.

## Test plan

- [ ] Deploy to staging (`staging.karmahq.xyz`)
- [ ] Enable HttpOnly cookies in Privy dashboard
- [ ] Login → verify `privy-session` cookie appears in Application > Cookies
- [ ] Reload page → should stay logged in
- [ ] Open `testapp.karmahq.xyz` → should share the session

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policy configuration to support additional domain access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->