### PR TITLE
fix(auth): harden auth state management and wagmi cleanup

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -161,9 +161,13 @@ export const useAuth = () => {
   useEffect(() => {
     if (!ready || !authenticated) return;
 
-    const handleAuthFailure = () => {
+    const handleAuthFailure = (reason: string) => {
       authFailureCount.current += 1;
+      console.debug(
+        `[useAuth] Auth failure #${authFailureCount.current}/${AUTH_FAILURE_THRESHOLD}: ${reason}`
+      );
       if (authFailureCount.current >= AUTH_FAILURE_THRESHOLD) {
+        console.debug("[useAuth] Failure threshold reached, logging out");
         authFailureCount.current = 0;
         logout();
       }
@@ -185,10 +189,10 @@ export const useAuth = () => {
         // - Slow network during token refresh
         // - Temporary network hiccups
         // - Privy initialization timing
-        handleAuthFailure();
+        handleAuthFailure("no token and no session");
       } catch {
         // Token check failed (network error, etc.) - treat as a failure
-        handleAuthFailure();
+        handleAuthFailure("token check threw an error");
       }
     };
 


### PR DESCRIPTION
## Summary
- **Token cache invalidation**: `TokenManager.setPrivyInstance()` now clears cached token when the Privy instance changes, preventing stale tokens after re-login
- **User identity change detection**: Detects when Privy shared auth switches users (different `user.id` while still authenticated) and forces logout + full cache clear
- **Wagmi state cleanup**: Clears all `wagmi`-prefixed localStorage keys on logout and user switch to prevent stale wallet address persisting across sessions
- **Broadened cross-tab sync**: Storage event handler now detects `privy:token` replacement (not just removal) and `privy:user` changes for shared auth scenarios
- **Cache strategy upgrade**: Replaced selective `removeQueries()` with `queryClient.clear()` on logout for complete cache purge
- **Dead code removal**: Removed unused V1 programs endpoint, orphaned `langfusePromptId` fallback

## Test plan
- [x] `TokenManager` cache invalidation on instance change (3 tests)
- [x] Token caching with TTL and request deduplication (7 tests)
- [x] User identity change detection and forced logout (2 tests)
- [x] Wagmi localStorage clearance on logout (1 test)
- [x] Wagmi localStorage clearance on user identity change (1 test)
- [x] Non-wagmi keys preserved during cleanup (1 test)
- [x] Cross-tab sync: token replacement, privy:user change, error-as-failure (3 tests)
- [x] All 26 useAuth tests passing
- [x] All 44 token-manager tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet session management by clearing wallet-related cached data when users log out or switch accounts. This prevents wallet data from persisting across different user sessions, enhancing privacy and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->