### PR TITLE
fix(payouts): remove incorrect unit conversion on milestone allocation amounts

### DIFF
--- a/components/Pages/Admin/PayoutsAdminPage.tsx
+++ b/components/Pages/Admin/PayoutsAdminPage.tsx
@@ -21,7 +21,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getTokenDecimals } from "@/config/tokens";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { useAuth } from "@/hooks/useAuth";
@@ -693,24 +692,11 @@ export default function PayoutsAdminPage() {
         ? editedFields[item.uid].amount || "0"
         : item.currentAmount || "0";
 
-      // Get milestone allocations from payout config and convert to human-readable
+      // Get milestone allocations from payout config
+      // Note: Allocation amounts are already stored in human-readable format (e.g., "50000" for 50000 USDC)
+      // by PayoutConfigurationModal, so no unit conversion is needed here.
       const payoutConfig = payoutConfigMap[item.uid];
-      const tokenDecimals = getTokenDecimals(
-        payoutConfig?.tokenAddress || null,
-        payoutConfig?.chainId || undefined
-      );
-
-      // Convert allocation amounts from smallest units to human-readable
-      const milestoneAllocations = (payoutConfig?.milestoneAllocations || []).map((alloc) => {
-        if (!alloc.amount || alloc.amount === "0") return alloc;
-        try {
-          const humanReadable = formatUnits(BigInt(alloc.amount), tokenDecimals);
-          return { ...alloc, amount: humanReadable };
-        } catch {
-          // If conversion fails (e.g., already human-readable), use as-is
-          return alloc;
-        }
-      });
+      const milestoneAllocations = payoutConfig?.milestoneAllocations || [];
 
       // Get paid allocation IDs from disbursement history (excluding failed/cancelled)
       const disbursementHistory = disbursementMap[item.uid]?.history || [];

--- a/src/features/payout-disbursement/components/MilestoneSelectionStep.tsx
+++ b/src/features/payout-disbursement/components/MilestoneSelectionStep.tsx
@@ -66,7 +66,7 @@ export function MilestoneSelectionStep({
   }, [allocations, paidIds]);
 
   // Calculate totals
-  // Note: Allocation amounts are passed as human-readable values (converted from smallest units by parent)
+  // Note: Allocation amounts are stored in human-readable format (e.g., "50000" for 50000 USDC)
   const { totalUnpaid, selectedTotal } = useMemo(() => {
     let unpaidSum = 0;
     let selectedSum = 0;
@@ -86,7 +86,7 @@ export function MilestoneSelectionStep({
   }, [unpaidAllocations, selectedAllocationIds]);
 
   // Format amount for display
-  // Note: Allocation amounts are passed as human-readable values (converted from smallest units by parent),
+  // Note: Allocation amounts are stored in human-readable format,
   // so we just format them nicely without additional conversion.
   const formatAmount = (amount: string): string => {
     const num = parseFloat(amount);
@@ -354,7 +354,7 @@ export function getPaidAllocationIds(disbursements: PayoutDisbursement[]): strin
 
 /**
  * Helper function to calculate the total amount from selected allocations.
- * Note: Allocation amounts should be passed as human-readable values (converted from smallest units).
+ * Note: Allocation amounts are stored in human-readable format (e.g., "50000" for 50000 USDC).
  * Returns the sum as a number (not bigint) since amounts can have decimals.
  */
 export function calculateSelectedTotal(

--- a/src/features/payout-disbursement/types/payout-disbursement.ts
+++ b/src/features/payout-disbursement/types/payout-disbursement.ts
@@ -241,7 +241,7 @@ export interface MilestoneAllocation {
   milestoneUID?: string;
   /** Human-readable label for this allocation */
   label: string;
-  /** Amount allocated in smallest token unit (wei-like) */
+  /** Amount allocated in human-readable format (e.g., "50000" for 50000 USDC) */
   amount: string;
 }
 


### PR DESCRIPTION
## Summary

- **Bug fix**: Milestone allocation amounts (e.g., 50000 USDC) were displaying as tiny values (e.g., 0.05 USDC) in the disbursement creation view because `PayoutsAdminPage` incorrectly applied `formatUnits()` to values already stored in human-readable format
- **Root cause**: `PayoutConfigurationModal` saves amounts as human-readable strings (e.g., `"50000"`), but the disbursement flow treated them as smallest token units and divided by `10^decimals`
- **Cleanup**: Fixed misleading comments across `MilestoneSelectionStep` and the `MilestoneAllocation` type that referenced "smallest token unit" or "converted from smallest units"

## Test plan

- [x] All 64 existing payout-disbursement tests pass (MilestoneSelectionStep, PayoutConfigurationModal, use-payout-disbursement)
- [ ] Manually verify: configure payout with 50000 USDC for a milestone, then open disbursement modal — should show 50000 USDC, not 0.05
- [ ] Verify decimal amounts (e.g., 0.5 ETH) still display correctly in disbursement view

🤖 Generated with [Claude Code](https://claude.com/claude-code)