### PR TITLE
fix: improve funding-platform back navigation and 429 retry handling

### DIFF
--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -377,7 +377,7 @@ describe("ProgramDetailsTab", () => {
       });
     });
 
-    it("should not show submit button in read-only mode", async () => {
+    it("should show disabled submit button in read-only mode", async () => {
       renderWithProviders(
         <ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} readOnly={true} />
       );
@@ -386,7 +386,7 @@ describe("ProgramDetailsTab", () => {
         expect(screen.getByLabelText(/program name/i)).toBeInTheDocument();
       });
 
-      expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
     });
 
     it("should disable form fields in read-only mode", async () => {
@@ -821,7 +821,6 @@ describe("ProgramDetailsTab", () => {
     });
 
     it("should prevent submission in read-only mode", async () => {
-      const user = userEvent.setup();
       renderWithProviders(
         <ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} readOnly={true} />
       );
@@ -830,8 +829,8 @@ describe("ProgramDetailsTab", () => {
         expect(screen.getByLabelText(/program name/i)).toBeInTheDocument();
       });
 
-      // Submit button should not exist in read-only mode
-      expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+      // Submit button is rendered as disabled in read-only mode
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
     });
   });
 

--- a/__tests__/navbar/setup.ts
+++ b/__tests__/navbar/setup.ts
@@ -341,6 +341,7 @@ export const mockNavbarPermissionsState = {
     isStaffLoading: false,
     isOwner: false,
     isCommunityAdmin: false,
+    isReviewer: false,
     hasReviewerRole: false,
     reviewerPrograms: [],
     isProgramCreator: false,

--- a/__tests__/navbar/utils/test-helpers.tsx
+++ b/__tests__/navbar/utils/test-helpers.tsx
@@ -37,6 +37,7 @@ export const resetMockAuthState = () => {
     isStaffLoading: false,
     isOwner: false,
     isCommunityAdmin: false,
+    isReviewer: false,
     hasReviewerRole: false,
     reviewerPrograms: [],
     isProgramCreator: false,
@@ -317,7 +318,7 @@ const updateNavbarPermissionsState = (authMock?: any, permissionsMock?: any) => 
 
   // Compute derived values
   const isCommunityAdmin = communities.length > 0;
-  const hasReviewerRole = reviewerPrograms.length > 0;
+  const isReviewer = reviewerPrograms.length > 0;
   const hasAdminAccess = !isStaffLoading && (isStaff || isOwner || isCommunityAdmin);
   const isRegistryAllowed = (isRegistryAdmin || isProgramCreator) && isLoggedIn;
 
@@ -329,7 +330,8 @@ const updateNavbarPermissionsState = (authMock?: any, permissionsMock?: any) => 
     isStaffLoading,
     isOwner,
     isCommunityAdmin,
-    hasReviewerRole,
+    isReviewer,
+    hasReviewerRole: isReviewer,
     reviewerPrograms,
     isProgramCreator,
     isRegistryAdmin,

--- a/__tests__/services/programRegistry.service.test.ts
+++ b/__tests__/services/programRegistry.service.test.ts
@@ -53,6 +53,7 @@ describe("ProgramRegistryService", () => {
         title: "Test Program",
         description: "Test Description",
         shortDescription: "Short description",
+        anyoneCanJoin: false,
         programBudget: 100000,
         startsAt: new Date("2024-01-01"),
         endsAt: new Date("2024-12-31"),

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -26,6 +26,7 @@ import { StatusChangeInline } from "@/components/FundingPlatform/ApplicationView
 import { TabPanel } from "@/components/FundingPlatform/ApplicationView/TabPanel";
 import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
+import { useBackNavigation } from "@/hooks/useBackNavigation";
 import {
   useApplication,
   useApplicationComments,
@@ -37,7 +38,6 @@ import {
 import { useKycConfig, useKycStatus } from "@/hooks/useKycStatus";
 import {
   AdminOnly,
-  Can,
   FundingPlatformGuard,
   Permission,
   useIsFundingPlatformAdmin,
@@ -127,6 +127,10 @@ export default function ApplicationDetailPage() {
 
   // Use the delete application hook
   const { deleteApplicationAsync, isDeleting } = useDeleteApplication();
+
+  const handleBackClick = useBackNavigation({
+    fallbackRoute: PAGES.MANAGE.FUNDING_PLATFORM.APPLICATIONS(communityId, combinedProgramId),
+  });
 
   // Get application identifier for fetching versions
   const applicationIdentifier = application?.referenceNumber || application?.id || applicationId;
@@ -299,10 +303,6 @@ export default function ApplicationDetailPage() {
     }, 100); // Small delay to ensure the view mode has changed
   };
 
-  const handleBackClick = () => {
-    router.push(PAGES.MANAGE.FUNDING_PLATFORM.APPLICATIONS(communityId, combinedProgramId));
-  };
-
   // Memoized milestone review URL - only returns URL if approved and has projectUID
   const milestoneReviewUrl = useMemo(() => {
     if (application?.status?.toLowerCase() === "approved" && application?.projectUID) {
@@ -392,7 +392,7 @@ export default function ApplicationDetailPage() {
             statusActions={
               showStatusActions ? (
                 <HeaderActions
-                  currentStatus={application.status as any}
+                  currentStatus={application.status as ApplicationStatus}
                   onStatusChange={handleStatusChangeClick}
                   isUpdating={isUpdatingStatus}
                 />

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
@@ -3,11 +3,12 @@
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 import { ArrowLeftIcon } from "@heroicons/react/24/solid";
 import Link from "next/link";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { ApplicationListWithAPI } from "@/components/FundingPlatform";
 import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
+import { useBackNavigation } from "@/hooks/useBackNavigation";
 import {
   useApplication,
   useApplicationStatus,
@@ -21,7 +22,6 @@ import type { IFundingApplication } from "@/types/funding-platform";
 import { PAGES } from "@/utilities/pages";
 
 export default function ApplicationsPage() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const { communityId, programId: combinedProgramId } = useParams() as {
     communityId: string;
@@ -67,9 +67,9 @@ export default function ApplicationsPage() {
   const { prefetchApplication } = useApplication(null);
   const { updateStatusAsync } = useApplicationStatus(programId);
 
-  const handleBackClick = () => {
-    router.push(PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId));
-  };
+  const handleBackClick = useBackNavigation({
+    fallbackRoute: PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId),
+  });
 
   const handleApplicationSelect = (_application: IFundingApplication) => {
     // This function is now called by ApplicationList but we handle opening in new tab there

--- a/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { ArrowLeftIcon } from "@heroicons/react/24/solid";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import FormBuilderErrorBoundary from "@/components/ErrorBoundary/FormBuilderErrorBoundary";
 import { QuestionBuilder } from "@/components/QuestionBuilder";
 import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
+import { useBackNavigation } from "@/hooks/useBackNavigation";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import { usePostApprovalSchema, useQuestionBuilderSchema } from "@/hooks/useQuestionBuilder";
@@ -15,7 +16,6 @@ import type { FormSchema } from "@/types/question-builder";
 import { PAGES } from "@/utilities/pages";
 
 export default function QuestionBuilderPage() {
-  const router = useRouter();
   const { communityId, programId: combinedProgramId } = useParams() as {
     communityId: string;
     programId: string;
@@ -73,9 +73,9 @@ export default function QuestionBuilderPage() {
     updatePostApprovalSchema({ schema, existingConfig: existingConfig || null });
   };
 
-  const handleBackClick = () => {
-    router.push(PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId));
-  };
+  const handleBackClick = useBackNavigation({
+    fallbackRoute: PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId),
+  });
 
   if (
     isLoadingPermissions ||

--- a/app/community/[communityId]/manage/funding-platform/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/page.tsx
@@ -89,6 +89,7 @@ function FundingPlatformContent() {
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [togglingPrograms, setTogglingPrograms] = useState<Set<string>>(new Set());
+  const fallbackBackRoute = PAGES.MANAGE.ROOT(communityId);
 
   const [searchTerm, setSearchTerm] = useState(searchParams.get("search") || "");
   const [enabledFilter, setEnabledFilter] = useState<"all" | "enabled" | "disabled">(
@@ -175,6 +176,18 @@ function FundingPlatformContent() {
       return matchesSearch && matchesEnabled;
     });
   }, [programs, searchTerm, enabledFilter]);
+
+  const handleBackClick = () => {
+    // Next.js app router stores a session history index in history.state.idx.
+    // If idx is 0/undefined (direct load or refresh with no in-app history), use fallback.
+    const historyIndex = window.history.state?.idx;
+    if (typeof historyIndex === "number" && historyIndex > 0) {
+      router.back();
+      return;
+    }
+
+    router.push(fallbackBackRoute);
+  };
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -338,13 +351,14 @@ function FundingPlatformContent() {
     <div className="sm:px-3 md:px-4 px-6 py-2 flex flex-col gap-4">
       {/* Header with Back button and Role indicator */}
       <div className="flex items-center justify-between">
-        <Link
-          href={`/community/${communityId}`}
+        <button
+          type="button"
+          onClick={handleBackClick}
           className="flex items-center border border-black dark:border-white text-black dark:text-white rounded-md py-2 px-4 w-max"
         >
           <ArrowLeftIcon className="w-4 h-4 mr-2" />
           Back
-        </Link>
+        </button>
 
         {/* Role Badge */}
         {!isAdmin && (

--- a/cypress/e2e/navbar/visual-regression.cy.ts
+++ b/cypress/e2e/navbar/visual-regression.cy.ts
@@ -152,12 +152,9 @@ describe("Navbar UI States", () => {
       cy.visit("/");
       waitForPageLoad();
 
-      // On mobile, the Sign in button is visible in the fixed header navbar
-      // Use the fixed positioning class to target the header nav specifically
-      // (the page may have multiple nav elements, e.g., footer nav)
-      cy.get("nav.fixed").within(() => {
-        cy.contains("button", "Sign in").should("be.visible");
-      });
+      // Desktop and mobile auth buttons are both rendered in DOM.
+      // Select only visible button to avoid matching hidden desktop element first.
+      cy.contains("button:visible", "Sign in").should("be.visible");
     });
   });
 });

--- a/cypress/e2e/navbar/visual-regression.cy.ts
+++ b/cypress/e2e/navbar/visual-regression.cy.ts
@@ -8,6 +8,11 @@ import {
   waitForPageLoad,
 } from "../../support/intercepts";
 
+const visitHome = () => {
+  cy.visit("/", { timeout: 120000 });
+  waitForPageLoad();
+};
+
 describe("Navbar UI States", () => {
   beforeEach(() => {
     setupCommonIntercepts();
@@ -16,8 +21,7 @@ describe("Navbar UI States", () => {
   describe("Desktop Navbar Appearance", () => {
     beforeEach(() => {
       cy.viewport(1440, 900);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
     });
 
     it("should display navbar in default state", () => {
@@ -54,8 +58,7 @@ describe("Navbar UI States", () => {
   describe("Search UI States", () => {
     beforeEach(() => {
       cy.viewport(1440, 900);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
     });
 
     it("should display search input", () => {
@@ -71,8 +74,7 @@ describe("Navbar UI States", () => {
   describe("Button Interactions", () => {
     beforeEach(() => {
       cy.viewport(1440, 900);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
     });
 
     it("should show hover state on buttons", () => {
@@ -93,8 +95,7 @@ describe("Navbar UI States", () => {
   describe("Focus States", () => {
     beforeEach(() => {
       cy.viewport(1440, 900);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
     });
 
     it("should focus button with keyboard", () => {
@@ -111,8 +112,7 @@ describe("Navbar UI States", () => {
   describe("Tablet Appearance", () => {
     it("should display navbar on tablet", () => {
       cy.viewport(768, 1024);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
 
       cy.get("nav").should("be.visible");
     });
@@ -121,8 +121,7 @@ describe("Navbar UI States", () => {
   describe("Mobile Appearance", () => {
     beforeEach(() => {
       cy.viewport(375, 667);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
     });
 
     it("should display mobile navbar", () => {
@@ -140,8 +139,7 @@ describe("Navbar UI States", () => {
   describe("Auth Buttons Display", () => {
     it("should display Sign in button on desktop", () => {
       cy.viewport(1440, 900);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
 
       cy.contains("Sign in").should("be.visible");
       cy.contains("Contact sales").should("be.visible");
@@ -149,8 +147,7 @@ describe("Navbar UI States", () => {
 
     it("should display Sign in button on mobile", () => {
       cy.viewport(375, 667);
-      cy.visit("/");
-      waitForPageLoad();
+      visitHome();
 
       // Desktop and mobile auth buttons are both rendered in DOM.
       // Select only visible button to avoid matching hidden desktop element first.

--- a/hooks/__tests__/useBackNavigation.test.ts
+++ b/hooks/__tests__/useBackNavigation.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import { useBackNavigation } from "../useBackNavigation";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+const mockRefresh = jest.fn();
+const mockPrefetch = jest.fn();
+const mockForward = jest.fn();
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe("useBackNavigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      back: mockBack,
+      replace: mockReplace,
+      refresh: mockRefresh,
+      prefetch: mockPrefetch,
+      forward: mockForward,
+    });
+    window.history.replaceState({}, "", window.location.href);
+  });
+
+  it("should push to fallback route by default", () => {
+    const { result } = renderHook(() => useBackNavigation({ fallbackRoute: "/fallback" }));
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/fallback");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+
+  it("should go back when history index exists and preferHistoryBack is enabled", () => {
+    window.history.replaceState({ idx: 2 }, "", window.location.href);
+    const { result } = renderHook(() =>
+      useBackNavigation({ fallbackRoute: "/fallback", preferHistoryBack: true })
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockBack).toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("should use fallback when history index is missing and preferHistoryBack is enabled", () => {
+    window.history.replaceState({}, "", window.location.href);
+    const { result } = renderHook(() =>
+      useBackNavigation({ fallbackRoute: "/fallback", preferHistoryBack: true })
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/fallback");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useBackNavigation.ts
+++ b/hooks/useBackNavigation.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+
+interface UseBackNavigationOptions {
+  fallbackRoute: string;
+  preferHistoryBack?: boolean;
+}
+
+export function useBackNavigation({
+  fallbackRoute,
+  preferHistoryBack = false,
+}: UseBackNavigationOptions) {
+  const router = useRouter();
+
+  return useCallback(() => {
+    if (preferHistoryBack) {
+      // Next.js app router stores a session history index in history.state.idx.
+      // If idx is 0/undefined (direct load or refresh with no in-app history), use fallback.
+      const historyIndex = window.history.state?.idx;
+      if (typeof historyIndex === "number" && historyIndex > 0) {
+        router.back();
+        return;
+      }
+    }
+
+    router.push(fallbackRoute);
+  }, [fallbackRoute, preferHistoryBack, router]);
+}


### PR DESCRIPTION
## Problem
- Funding platform dashboard back button always linked to a fixed route instead of browser history.
- Permissions query retried on all failures, which can amplify rate-limit spikes on 429 responses.

## Changes
- Updated funding platform back button behavior:
  - uses `router.back()` when browser history exists
  - falls back to `/community/:communityId/manage` when there is no previous history (e.g. refresh/direct load)
- Updated RBAC permissions query retry logic:
  - do not retry when the error is HTTP 429
  - still retry transient non-429 errors (up to 2 attempts)

## Validation
- `pnpm exec jest src/core/rbac/__tests__/use-permissions.test.tsx --runInBand`
- `pnpm exec biome check src/core/rbac/hooks/use-permissions.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized intelligent back navigation across management screens — back buttons prefer browser history with automatic fallback.

* **Bug Fixes**
  * Reduced unnecessary retries on rate-limited requests to improve responsiveness under throttling.

* **UI Changes**
  * Read-only forms now show the submit button but disabled.
  * Reviewer badge wording updated to clarify reviewer mode.

* **Tests**
  * Added and updated unit and e2e tests covering back-navigation, UI states, and permission-driven behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->