### PR TITLE
ci: add merge gate to block PRs when tests fail

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,6 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: ['**']
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'  # Nightly at 4 AM UTC

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -149,3 +149,136 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  e2e_tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '!node_modules/**') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
+
+      - name: Build application
+        run: pnpm run build
+        env:
+          NODE_ENV: production
+          NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
+          NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
+          NEXT_PUBLIC_GAP_INDEXER_URL: https://gapstagapi.karmahq.xyz
+
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-
+
+      - name: Install Cypress binary
+        run: pnpm exec cypress install
+
+      - name: Run E2E tests
+        run: pnpm run e2e:ci
+        env:
+          NODE_ENV: production
+          CYPRESS_BASE_URL: http://localhost:3000
+          CYPRESS_VIDEO: false
+          CYPRESS_CI: true
+          NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
+          NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
+          NEXT_PUBLIC_GAP_INDEXER_URL: https://gapstagapi.karmahq.xyz
+
+      - name: Upload Cypress screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Cypress videos
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Comment PR with E2E test results
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = '${{ job.status }}' === 'success'
+              ? `## ✅ E2E Tests Passed!\n\nAll end-to-end tests completed successfully.`
+              : `## ❌ E2E Tests Failed\n\nSome E2E tests failed. Please check the workflow logs and artifacts for details.\n\n**Artifacts available:**\n- Screenshots (on failure)\n- Videos (on failure)`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const e2eComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('E2E Tests')
+            );
+
+            if (e2eComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: e2eComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  merge_gate:
+    name: Merge Gate
+    needs: [test, e2e_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required checks passed
+        run: |
+          echo "PR Tests: ${{ needs.test.result }}"
+          echo "E2E Tests: ${{ needs.e2e_tests.result }}"
+          if [[ "${{ needs.test.result }}" != "success" || "${{ needs.e2e_tests.result }}" != "success" ]]; then
+            echo "::error::One or more required checks failed. Merge blocked."
+            exit 1
+          fi
+          echo "All required checks passed. Safe to merge."
+


### PR DESCRIPTION
## Summary
- Adds a **Merge Gate** job that depends on both **PR Tests** and **E2E Tests** — fails if either fails, blocking the merge
- Moves E2E tests into the PR workflow so a single gate can enforce both
- Removes PR trigger from standalone `e2e-tests.yml` (keeps nightly schedule + manual dispatch)

## Setup required after merge
In **Settings > Branches > Branch protection rules** for `main`:
1. Enable "Require status checks to pass before merging"
2. Add **"Merge Gate"** as a required status check

## Test plan
- [ ] Open a PR and verify the Merge Gate job appears in the checks list
- [ ] Confirm it passes when both PR tests and E2E tests pass
- [ ] Confirm it fails (and blocks merge) when either test suite fails
- [ ] Confirm nightly E2E runs still work via schedule/dispatch