### PR TITLE
fix(kyc): restore KYC/KYB settings tab in program settings sidebar

### DIFF
--- a/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useBackNavigation } from "@/hooks/useBackNavigation";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
+import { useKycConfig } from "@/hooks/useKycStatus";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import { usePostApprovalSchema, useQuestionBuilderSchema } from "@/hooks/useQuestionBuilder";
 import { FundingPlatformGuard, useIsFundingPlatformAdmin } from "@/src/core/rbac";
@@ -60,6 +61,9 @@ export default function QuestionBuilderPage() {
   // Fetch reviewers to check if any are configured
   const { data: reviewers, isLoading: isLoadingReviewers } = useProgramReviewers(programId);
 
+  // Fetch KYC config to check if KYC is enabled for the community
+  const { isEnabled: kycEnabled, isLoading: isLoadingKycConfig } = useKycConfig(communityId);
+
   // Derive computed values for sidebar completion status
   const hasReviewers = reviewers && reviewers.length > 0;
   const hasAIConfig = Boolean(existingConfig?.systemPrompt);
@@ -82,7 +86,8 @@ export default function QuestionBuilderPage() {
     isLoadingPrograms ||
     isLoadingSchema ||
     isLoadingPostApprovalSchema ||
-    isLoadingReviewers
+    isLoadingReviewers ||
+    isLoadingKycConfig
   ) {
     return (
       <div className="flex w-full items-center justify-center min-h-[600px]">
@@ -159,6 +164,7 @@ export default function QuestionBuilderPage() {
             hasReviewers={hasReviewers}
             hasAIConfig={hasAIConfig}
             program={program}
+            kycEnabled={kycEnabled}
           />
         </FormBuilderErrorBoundary>
       </div>


### PR DESCRIPTION
## Summary
- Restores the KYC/KYB Settings tab in the funding platform program settings sidebar
- The tab was accidentally dropped during PR #956 (RBAC migration) conflict resolution, which deleted the `/admin/` question-builder page (that had the KYC wiring from PR #948) and replaced it with a `/manage/` version created before the KYC feature existed

## Changes
Re-adds 4 lines to `app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page.tsx`:
1. `useKycConfig` hook import
2. `kycEnabled` / `isLoadingKycConfig` destructuring from the hook
3. `isLoadingKycConfig` in the loading guard
4. `kycEnabled={kycEnabled}` prop passed to `<QuestionBuilder>`

## Test plan
- [ ] Navigate to a community with KYC enabled → Program Settings → verify "KYC/KYB Settings" tab appears in the sidebar under Configuration
- [ ] Navigate to a community without KYC → verify the tab does NOT appear
- [ ] Click the KYC/KYB Settings tab → verify the settings form loads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Community funding platform question builder now properly waits for KYC configuration to load before rendering, ensuring correct setup based on community settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->