### PR TITLE
fix: scope PR review bot to diff-only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -254,39 +254,50 @@ jobs:
             **STRUCTURE**: For each issue found, use this format:
             - **File**: `path/to/file.ts:LINE`
             - **Rule**: [rule identifier]
-            - **Severity**: CRITICAL | HIGH | MEDIUM
+            - **Severity**: 🔴 CRITICAL | 🟠 HIGH | 🟡 MEDIUM
             - **Problem**: One sentence describing what is wrong.
             - **Why**: Root cause or why this matters (one sentence).
             - **Fix**: Concrete code snippet or one-sentence fix.
 
             Only report MEDIUM severity and above. Skip nitpicks.
 
-            **AI SLOP DETECTION**: Flag AI-generated code smells: nonsensical comments that describe the obvious, copy-pasted boilerplate that does not fit the context, dead code left behind, overly verbose abstractions for trivial operations, hallucinated API usage.
+            **AI SLOP DETECTION** 🤖: Flag AI-generated code smells: nonsensical comments that describe the obvious, copy-pasted boilerplate that does not fit the context, dead code left behind, overly verbose abstractions for trivial operations, hallucinated API usage.
 
-            **END WITH**: A single line: "Recommendation: APPROVE" or "Recommendation: BLOCK (reason)". BLOCK only for CRITICAL issues. Nothing else after this line.
+            **END WITH** a verdict section in exactly this format:
+
+            ---
+            ### 📊 Score: [X]/100
+            Scoring guide: 100 = flawless, 90+ = excellent (minor nits only), 70-89 = good (some issues), 50-69 = needs work (significant issues), below 50 = major problems. Deduct points proportionally: -15 per CRITICAL, -7 per HIGH, -3 per MEDIUM.
+
+            ### 🏷️ Status: [one of the following]
+            - ✅ **APPROVE** — No CRITICAL or HIGH issues. Ship it.
+            - ⚠️ **APPROVE WITH SUGGESTIONS** — No CRITICAL issues, but has HIGH/MEDIUM issues worth addressing.
+            - 🔄 **REQUEST CHANGES** — Has CRITICAL issues that must be fixed before merge.
+
+            One sentence summary of why this status was chosen. Nothing else after this section.
 
             ---
 
-            ### 1. Waterfall and Async (CRITICAL)
+            ### 🔴 1. Waterfall and Async (CRITICAL)
             - Sequential await calls that could run in parallel: use Promise.all()
             - Awaiting values only used in one branch: move await into that branch
             - Missing Suspense boundaries for streaming async content
             - API routes that await early instead of starting promises early and awaiting late
 
-            ### 2. Bundle Size (CRITICAL)
+            ### 🔴 2. Bundle Size (CRITICAL)
             - Barrel file imports (import from index files): import from source file directly
             - Heavy components not using next/dynamic for lazy loading
             - Third-party scripts (analytics, logging) not deferred until after hydration
             - Modules loaded unconditionally that are only used behind feature flags: use dynamic import
 
-            ### 3. Server vs Client Components (HIGH)
+            ### 🟠 3. Server vs Client Components (HIGH)
             - "use client" on components that do not use hooks, event handlers, or browser APIs: make them Server Components
             - Data fetching in Client Components that should happen server-side
             - Large objects passed from Server to Client components: minimize serialization
             - Missing React.cache() for per-request deduplication in Server Components
             - Sequential server fetches that should be parallelized by restructuring component tree
 
-            ### 4. Component Architecture (HIGH)
+            ### 🟠 4. Component Architecture (HIGH)
             - Boolean prop proliferation (isX, showY, hasZ): use composition with compound components or explicit variants
             - Monolithic components with render props: prefer children-based compound components
             - State trapped inside components that siblings need: lift state into provider
@@ -295,13 +306,13 @@ jobs:
             - React 19: still using forwardRef when ref is now a regular prop
             - React 19: still using useContext() when use() is available
 
-            ### 5. TypeScript (HIGH)
+            ### 🟠 5. TypeScript (HIGH)
             - any type without explicit justification comment
             - Missing or incomplete prop type definitions
             - Type assertions (as) that could be replaced with type guards
             - Unused type imports or exports
 
-            ### 6. Re-render and Performance (MEDIUM)
+            ### 🟡 6. Re-render and Performance (MEDIUM)
             - Components subscribing to store state only used in callbacks: use useStore.getState() instead
             - Missing React.memo on expensive components that receive stable props from parent
             - Object/array dependencies in useEffect/useMemo: use primitive values or stable references
@@ -310,24 +321,24 @@ jobs:
             - Missing next/image for images
             - Using && for conditional rendering (can render 0 or empty string): use ternary
 
-            ### 7. State Management (MEDIUM)
+            ### 🟡 7. State Management (MEDIUM)
             - Zustand store with too many concerns: split stores by domain
             - React Query missing proper staleTime / gcTime configuration
             - Missing loading/error/empty states in data-dependent UI
             - Optimistic updates without rollback on error
 
-            ### 8. Web3 (MEDIUM)
+            ### 🟡 8. Web3 (MEDIUM)
             - Wagmi hooks used without proper error handling for rejected transactions
             - Missing wallet disconnection handling
             - Hardcoded chain IDs or contract addresses: use constants
 
-            ### 9. Accessibility (MEDIUM)
+            ### 🟡 9. Accessibility (MEDIUM)
             - Interactive elements missing ARIA labels or roles
             - Missing keyboard navigation for custom interactive components
             - Non-semantic HTML (div with onClick instead of button)
             - Missing focus management on modals/dialogs
 
-            ### 10. Testing (MEDIUM)
+            ### 🟡 10. Testing (MEDIUM)
             - New functionality without corresponding tests (target: 70% coverage)
             - Bug fixes without regression tests
             - Tests that test implementation details instead of behavior
@@ -342,7 +353,7 @@ jobs:
 
           # Conditional prompts based on triggers - enables automatic PR reviews
           direct_prompt: |
-            ${{ github.event_name == 'pull_request' && 'Review this PR against the rules in custom_instructions. Triage: security/bugs first, then performance, then architecture. Only report MEDIUM+ issues. For each: file:line, rule, severity, problem, root cause, fix. Flag any AI-generated slop. End with "Recommendation: APPROVE" or "Recommendation: BLOCK (reason)". No strengths, no praise. If clean, say "No issues found." then "Recommendation: APPROVE".' || '' }}
+            ${{ github.event_name == 'pull_request' && 'Review this PR against the rules in custom_instructions. Triage: security/bugs first, then performance, then architecture. Only report MEDIUM+ issues with emoji severity indicators. For each: file:line, rule, severity, problem, root cause, fix. Flag any AI slop. End with the verdict section: Score X/100, then Status (APPROVE / APPROVE WITH SUGGESTIONS / REQUEST CHANGES). No strengths, no praise.' || '' }}
 
           max_turns: '30'
           timeout_minutes: '45'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -245,6 +245,20 @@ jobs:
 
             Also read and enforce the CLAUDE.md in this repo for project-specific anti-patterns.
 
+            ## DIFF-ONLY REVIEW SCOPE (MANDATORY)
+
+            **CRITICAL CONSTRAINT**: You are reviewing a PULL REQUEST, not the entire codebase. You MUST only flag issues on lines that were ADDED or MODIFIED in this PR's diff. This is non-negotiable.
+
+            - Run `git diff origin/main...HEAD` to get the actual diff
+            - Only report issues on lines prefixed with `+` in the diff (new/changed lines)
+            - NEVER flag pre-existing code that was not touched by this PR, even if it has issues
+            - NEVER flag architectural patterns, imports, or component structure in files that were only touched to add a single prop or line
+            - If a file was modified but a specific component/hook/function was NOT changed, do NOT review that component/hook/function
+            - Pre-existing tech debt is OUT OF SCOPE — it should be tracked separately, not in PR reviews
+            - Context lines (unchanged lines shown for context in the diff) are NOT reviewable — they are only there to help you understand the change
+
+            **Why**: Reviewing pre-existing code in PR reviews creates an infinite fix-review loop where each fix triggers new findings in surrounding code, making PRs unmergeable. The purpose of a PR review is to evaluate the CHANGE, not audit the repository.
+
             ## Review Rules
 
             **OUTPUT FORMAT**: Only report problems. Do NOT list strengths, compliments, or "what looks good". If a file has no issues, skip it entirely. If the entire PR has no issues, say "No issues found." and nothing else.
@@ -347,13 +361,13 @@ jobs:
 
             ## Event-Specific Behavior
 
-            **New PRs**: Review all changed files against the rules above. Only output issues.
+            **New PRs**: Review ONLY the diff (added/modified lines) against the rules above. Do NOT review pre-existing code in touched files. Only output issues introduced by this PR.
             **@claude comments**: Answer the specific question or request directly.
             **Review comments**: Analyze the specific code referenced and respond.
 
           # Conditional prompts based on triggers - enables automatic PR reviews
           direct_prompt: |
-            ${{ github.event_name == 'pull_request' && 'Review this PR against the rules in custom_instructions. Triage: security/bugs first, then performance, then architecture. Only report MEDIUM+ issues with emoji severity indicators. For each: file:line, rule, severity, problem, root cause, fix. Flag any AI slop. End with the verdict section: Score X/100, then Status (APPROVE / APPROVE WITH SUGGESTIONS / REQUEST CHANGES). No strengths, no praise.' || '' }}
+            ${{ github.event_name == 'pull_request' && 'Review this PR against the rules in custom_instructions. IMPORTANT: First run `git diff origin/main...HEAD` and ONLY review lines that were added or modified in the diff. Never flag pre-existing code. Triage: security/bugs first, then performance, then architecture. Only report MEDIUM+ issues with emoji severity indicators. For each: file:line, rule, severity, problem, root cause, fix. Flag any AI slop. End with the verdict section: Score X/100, then Status (APPROVE / APPROVE WITH SUGGESTIONS / REQUEST CHANGES). No strengths, no praise.' || '' }}
 
           max_turns: '30'
           timeout_minutes: '45'


### PR DESCRIPTION
## Summary
- Add DIFF-ONLY REVIEW SCOPE constraint to `claude.yml` so the review bot only flags issues on lines added/modified in the PR diff
- Explicitly forbid flagging pre-existing code, architectural patterns, or component structure

## Problem
The review bot was reviewing entire changed files instead of just the diff hunks. This caused an infinite fix-review loop where each fix triggered new findings in surrounding untouched code, making PRs unmergeable despite all CI checks passing.

## Changes
- Added `DIFF-ONLY REVIEW SCOPE (MANDATORY)` section to `custom_instructions` with 7 explicit rules
- Updated `Event-Specific Behavior` from "Review all changed files" to "Review ONLY the diff"
- Updated `direct_prompt` to instruct the bot to run `git diff` first and only review added/modified lines

## Test plan
- [ ] Open a PR that touches an existing file
- [ ] Verify the bot only flags issues in the added/modified lines
- [ ] Verify the bot does NOT flag pre-existing patterns in the same file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review workflow automation with improved review scope guidance and structured verdict formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->