### PR TITLE
fix: align RBAC permission matrix with layered inheritance model

### DIFF
--- a/src/core/rbac/__tests__/cross-project-alignment.test.ts
+++ b/src/core/rbac/__tests__/cross-project-alignment.test.ts
@@ -36,20 +36,24 @@ describe("Cross-Project RBAC Alignment", () => {
       expect(ROLE_HIERARCHY[Role.GUEST]).toBe(0);
       expect(ROLE_HIERARCHY[Role.APPLICANT]).toBe(1);
       expect(ROLE_HIERARCHY[Role.PROGRAM_REVIEWER]).toBe(2);
-      expect(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]).toBe(2);
-      expect(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]).toBe(3);
-      expect(ROLE_HIERARCHY[Role.PROGRAM_ADMIN]).toBe(3);
-      expect(ROLE_HIERARCHY[Role.COMMUNITY_ADMIN]).toBe(4);
-      expect(ROLE_HIERARCHY[Role.REGISTRY_ADMIN]).toBe(5);
-      expect(ROLE_HIERARCHY[Role.SUPER_ADMIN]).toBe(6);
+      expect(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]).toBe(3);
+      expect(ROLE_HIERARCHY[Role.PROGRAM_ADMIN]).toBe(4);
+      expect(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]).toBe(5);
+      expect(ROLE_HIERARCHY[Role.COMMUNITY_ADMIN]).toBe(6);
+      expect(ROLE_HIERARCHY[Role.REGISTRY_ADMIN]).toBe(7);
+      expect(ROLE_HIERARCHY[Role.SUPER_ADMIN]).toBe(8);
     });
 
-    it("should have reviewers at the same hierarchy level", () => {
-      expect(ROLE_HIERARCHY[Role.PROGRAM_REVIEWER]).toBe(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]);
+    it("should have MILESTONE_REVIEWER above PROGRAM_REVIEWER", () => {
+      expect(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]).toBeGreaterThan(
+        ROLE_HIERARCHY[Role.PROGRAM_REVIEWER]
+      );
     });
 
-    it("should have program admin and program creator at the same hierarchy level", () => {
-      expect(ROLE_HIERARCHY[Role.PROGRAM_ADMIN]).toBe(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]);
+    it("should have PROGRAM_CREATOR above PROGRAM_ADMIN", () => {
+      expect(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]).toBeGreaterThan(
+        ROLE_HIERARCHY[Role.PROGRAM_ADMIN]
+      );
     });
   });
 

--- a/src/core/rbac/__tests__/permission-boundary.test.ts
+++ b/src/core/rbac/__tests__/permission-boundary.test.ts
@@ -50,7 +50,8 @@ describe("Permission Boundary Tests", () => {
       expect(perms).toContain(Permission.REVIEW_CREATE);
       expect(perms).toContain(Permission.COMMENT_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_DELETE_OWN);
-      expect(perms).toHaveLength(18);
+      // Layered: GUEST(4) + APPLICANT(6) + PROGRAM_REVIEWER(5) + MILESTONE_REVIEWER(4) + PROGRAM_ADMIN(8) + PROGRAM_CREATOR(1) = 28
+      expect(perms).toHaveLength(28);
     });
 
     it("should match the expected PROGRAM_ADMIN permissions", () => {
@@ -72,7 +73,8 @@ describe("Permission Boundary Tests", () => {
       expect(perms).toContain(Permission.REVIEW_CREATE);
       expect(perms).toContain(Permission.COMMENT_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_DELETE_OWN);
-      expect(perms).toHaveLength(17);
+      // Layered: GUEST(4) + APPLICANT(6) + PROGRAM_REVIEWER(5) + MILESTONE_REVIEWER(4) + PROGRAM_ADMIN(8) = 27
+      expect(perms).toHaveLength(27);
     });
 
     it("should match the expected PROGRAM_REVIEWER permissions", () => {
@@ -87,22 +89,30 @@ describe("Permission Boundary Tests", () => {
       expect(perms).toContain(Permission.REVIEW_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_DELETE_OWN);
-      expect(perms).toHaveLength(10);
+      // Layered: GUEST(4) + APPLICANT(6) + PROGRAM_REVIEWER(5) = 15
+      expect(perms).toHaveLength(15);
     });
 
     it("should match the expected MILESTONE_REVIEWER permissions", () => {
       const perms = PERMISSION_MATRIX[Role.MILESTONE_REVIEWER];
+      // Inherits all PROGRAM_REVIEWER permissions
       expect(perms).toContain(Permission.PROGRAM_VIEW);
+      expect(perms).toContain(Permission.APPLICATION_VIEW_ASSIGNED);
+      expect(perms).toContain(Permission.APPLICATION_READ);
+      expect(perms).toContain(Permission.APPLICATION_COMMENT);
+      expect(perms).toContain(Permission.APPLICATION_REVIEW);
+      expect(perms).toContain(Permission.APPLICATION_CHANGE_STATUS);
+      expect(perms).toContain(Permission.REVIEW_CREATE);
+      expect(perms).toContain(Permission.REVIEW_EDIT_OWN);
+      // Milestone-specific additions
       expect(perms).toContain(Permission.MILESTONE_VIEW_ASSIGNED);
       expect(perms).toContain(Permission.MILESTONE_REVIEW);
       expect(perms).toContain(Permission.MILESTONE_APPROVE);
       expect(perms).toContain(Permission.MILESTONE_REJECT);
-      expect(perms).toContain(Permission.APPLICATION_CHANGE_STATUS);
-      expect(perms).toContain(Permission.REVIEW_CREATE);
-      expect(perms).toContain(Permission.REVIEW_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_EDIT_OWN);
       expect(perms).toContain(Permission.COMMENT_DELETE_OWN);
-      expect(perms).toHaveLength(10);
+      // Layered: GUEST(4) + APPLICANT(6) + PROGRAM_REVIEWER(5) + MILESTONE_REVIEWER(4) = 19
+      expect(perms).toHaveLength(19);
     });
 
     it("should match the expected APPLICANT permissions", () => {
@@ -253,10 +263,12 @@ describe("Permission Boundary Tests", () => {
       expect(permissions).not.toContain(Permission.APPLICATION_REJECT);
     });
 
-    it("MILESTONE_REVIEWER should NOT have program review permissions", () => {
+    it("MILESTONE_REVIEWER inherits review but NOT admin permissions", () => {
       const permissions = getPermissionsForRoles([Role.MILESTONE_REVIEWER]);
-      expect(permissions).not.toContain(Permission.APPLICATION_REVIEW);
-      expect(permissions).not.toContain(Permission.APPLICATION_VIEW_ASSIGNED);
+      // Inherits from PROGRAM_REVIEWER layer
+      expect(permissions).toContain(Permission.APPLICATION_REVIEW);
+      expect(permissions).toContain(Permission.APPLICATION_VIEW_ASSIGNED);
+      // Admin-only permissions remain restricted
       expect(permissions).not.toContain(Permission.APPLICATION_APPROVE);
       expect(permissions).not.toContain(Permission.APPLICATION_REJECT);
     });

--- a/src/core/rbac/__tests__/rbac-comprehensive.test.ts
+++ b/src/core/rbac/__tests__/rbac-comprehensive.test.ts
@@ -97,24 +97,24 @@ describe("Permission Boundary Tests - Role Isolation", () => {
     });
   });
 
-  describe("MILESTONE_REVIEWER cannot review or approve applications", () => {
+  describe("MILESTONE_REVIEWER inherits PROGRAM_REVIEWER and adds milestone management", () => {
     const milestoneReviewerPerms = getPermissionsForRoles([Role.MILESTONE_REVIEWER]);
 
-    it("should NOT have APPLICATION_REVIEW", () => {
-      expect(milestoneReviewerPerms).not.toContain(Permission.APPLICATION_REVIEW);
+    it("should inherit APPLICATION_REVIEW from PROGRAM_REVIEWER layer", () => {
+      expect(milestoneReviewerPerms).toContain(Permission.APPLICATION_REVIEW);
     });
 
-    it("should NOT have APPLICATION_APPROVE", () => {
+    it("should NOT have APPLICATION_APPROVE (admin-only)", () => {
       expect(milestoneReviewerPerms).not.toContain(Permission.APPLICATION_APPROVE);
     });
 
-    it("should NOT have APPLICATION_REJECT", () => {
+    it("should NOT have APPLICATION_REJECT (admin-only)", () => {
       expect(milestoneReviewerPerms).not.toContain(Permission.APPLICATION_REJECT);
     });
 
-    it("should NOT see all applications (only milestones)", () => {
+    it("should inherit APPLICATION_VIEW_ASSIGNED from PROGRAM_REVIEWER layer", () => {
       expect(milestoneReviewerPerms).not.toContain(Permission.APPLICATION_VIEW_ALL);
-      expect(milestoneReviewerPerms).not.toContain(Permission.APPLICATION_VIEW_ASSIGNED);
+      expect(milestoneReviewerPerms).toContain(Permission.APPLICATION_VIEW_ASSIGNED);
     });
 
     it("should have milestone-specific permissions", () => {
@@ -122,6 +122,14 @@ describe("Permission Boundary Tests - Role Isolation", () => {
       expect(milestoneReviewerPerms).toContain(Permission.MILESTONE_REVIEW);
       expect(milestoneReviewerPerms).toContain(Permission.MILESTONE_APPROVE);
       expect(milestoneReviewerPerms).toContain(Permission.MILESTONE_REJECT);
+    });
+
+    it("should be a strict superset of PROGRAM_REVIEWER", () => {
+      const programReviewerPerms = getPermissionsForRoles([Role.PROGRAM_REVIEWER]);
+      for (const perm of programReviewerPerms) {
+        expect(milestoneReviewerPerms).toContain(perm);
+      }
+      expect(milestoneReviewerPerms.length).toBeGreaterThan(programReviewerPerms.length);
     });
   });
 

--- a/src/core/rbac/__tests__/role.test.ts
+++ b/src/core/rbac/__tests__/role.test.ts
@@ -42,26 +42,26 @@ describe("Role Types", () => {
       expect(ROLE_HIERARCHY[Role.APPLICANT]).toBe(1);
     });
 
-    it("should assign reviewers level 2", () => {
+    it("should assign PROGRAM_REVIEWER level 2 and MILESTONE_REVIEWER level 3", () => {
       expect(ROLE_HIERARCHY[Role.PROGRAM_REVIEWER]).toBe(2);
-      expect(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]).toBe(2);
+      expect(ROLE_HIERARCHY[Role.MILESTONE_REVIEWER]).toBe(3);
     });
 
-    it("should assign PROGRAM_ADMIN and PROGRAM_CREATOR level 3", () => {
-      expect(ROLE_HIERARCHY[Role.PROGRAM_ADMIN]).toBe(3);
-      expect(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]).toBe(3);
+    it("should assign PROGRAM_ADMIN level 4 and PROGRAM_CREATOR level 5", () => {
+      expect(ROLE_HIERARCHY[Role.PROGRAM_ADMIN]).toBe(4);
+      expect(ROLE_HIERARCHY[Role.PROGRAM_CREATOR]).toBe(5);
     });
 
-    it("should assign COMMUNITY_ADMIN level 4", () => {
-      expect(ROLE_HIERARCHY[Role.COMMUNITY_ADMIN]).toBe(4);
+    it("should assign COMMUNITY_ADMIN level 6", () => {
+      expect(ROLE_HIERARCHY[Role.COMMUNITY_ADMIN]).toBe(6);
     });
 
-    it("should assign REGISTRY_ADMIN level 5", () => {
-      expect(ROLE_HIERARCHY[Role.REGISTRY_ADMIN]).toBe(5);
+    it("should assign REGISTRY_ADMIN level 7", () => {
+      expect(ROLE_HIERARCHY[Role.REGISTRY_ADMIN]).toBe(7);
     });
 
-    it("should assign SUPER_ADMIN level 6", () => {
-      expect(ROLE_HIERARCHY[Role.SUPER_ADMIN]).toBe(6);
+    it("should assign SUPER_ADMIN level 8", () => {
+      expect(ROLE_HIERARCHY[Role.SUPER_ADMIN]).toBe(8);
     });
   });
 
@@ -78,12 +78,12 @@ describe("Role Types", () => {
       expect(getRoleLevel(Role.GUEST)).toBe(0);
       expect(getRoleLevel(Role.APPLICANT)).toBe(1);
       expect(getRoleLevel(Role.PROGRAM_REVIEWER)).toBe(2);
-      expect(getRoleLevel(Role.MILESTONE_REVIEWER)).toBe(2);
-      expect(getRoleLevel(Role.PROGRAM_ADMIN)).toBe(3);
-      expect(getRoleLevel(Role.PROGRAM_CREATOR)).toBe(3);
-      expect(getRoleLevel(Role.COMMUNITY_ADMIN)).toBe(4);
-      expect(getRoleLevel(Role.REGISTRY_ADMIN)).toBe(5);
-      expect(getRoleLevel(Role.SUPER_ADMIN)).toBe(6);
+      expect(getRoleLevel(Role.MILESTONE_REVIEWER)).toBe(3);
+      expect(getRoleLevel(Role.PROGRAM_ADMIN)).toBe(4);
+      expect(getRoleLevel(Role.PROGRAM_CREATOR)).toBe(5);
+      expect(getRoleLevel(Role.COMMUNITY_ADMIN)).toBe(6);
+      expect(getRoleLevel(Role.REGISTRY_ADMIN)).toBe(7);
+      expect(getRoleLevel(Role.SUPER_ADMIN)).toBe(8);
     });
 
     it("should return 0 for unknown role", () => {
@@ -106,9 +106,9 @@ describe("Role Types", () => {
       expect(isRoleAtLeast(Role.APPLICANT, Role.PROGRAM_REVIEWER)).toBe(false);
     });
 
-    it("should handle same-level reviewers", () => {
-      expect(isRoleAtLeast(Role.PROGRAM_REVIEWER, Role.MILESTONE_REVIEWER)).toBe(true);
+    it("should have MILESTONE_REVIEWER above PROGRAM_REVIEWER", () => {
       expect(isRoleAtLeast(Role.MILESTONE_REVIEWER, Role.PROGRAM_REVIEWER)).toBe(true);
+      expect(isRoleAtLeast(Role.PROGRAM_REVIEWER, Role.MILESTONE_REVIEWER)).toBe(false);
     });
   });
 

--- a/src/core/rbac/types/role.ts
+++ b/src/core/rbac/types/role.ts
@@ -22,12 +22,12 @@ export const ROLE_HIERARCHY: Record<Role, number> = {
   [Role.GUEST]: 0,
   [Role.APPLICANT]: 1,
   [Role.PROGRAM_REVIEWER]: 2,
-  [Role.MILESTONE_REVIEWER]: 2,
-  [Role.PROGRAM_CREATOR]: 3,
-  [Role.PROGRAM_ADMIN]: 3,
-  [Role.COMMUNITY_ADMIN]: 4,
-  [Role.REGISTRY_ADMIN]: 5,
-  [Role.SUPER_ADMIN]: 6,
+  [Role.MILESTONE_REVIEWER]: 3,
+  [Role.PROGRAM_ADMIN]: 4,
+  [Role.PROGRAM_CREATOR]: 5,
+  [Role.COMMUNITY_ADMIN]: 6,
+  [Role.REGISTRY_ADMIN]: 7,
+  [Role.SUPER_ADMIN]: 8,
 };
 
 export enum ReviewerType {


### PR DESCRIPTION
## Summary
- Replace flat permission lists with layered composition model where each role inherits all permissions from lower roles (GUEST → APPLICANT → PROGRAM_REVIEWER → MILESTONE_REVIEWER → PROGRAM_ADMIN → PROGRAM_CREATOR)
- Update ROLE_HIERARCHY levels to match gap-indexer backend (MILESTONE_REVIEWER=3, PROGRAM_ADMIN=4, PROGRAM_CREATOR=5, etc.)
- Fix MILESTONE_REVIEWER missing APPLICATION_READ and APPLICATION_VIEW_ASSIGNED permissions

## Context
A MILESTONE_REVIEWER at app.filpgf.io could post comments on applications but couldn't see them when logged in. Root cause: the frontend permission matrix didn't give MILESTONE_REVIEWER inherited read permissions from PROGRAM_REVIEWER.

Related PRs:
- gap-indexer: https://github.com/show-karma/gap-indexer/pull/901
- gap-whitelabel-app: https://github.com/show-karma/gap-whitelabel-app/pull/151

## Permission scope change

The layered inheritance model intentionally broadens the permission sets for higher roles to match the backend:

| Role | Before | After | New inherited permissions |
|------|--------|-------|--------------------------|
| PROGRAM_ADMIN | 17 | 27 | +APPLICANT layer (APPLICATION_CREATE, APPLICATION_EDIT_OWN, APPLICATION_VIEW_OWN, MILESTONE_VIEW_OWN, MILESTONE_SUBMIT) +PROGRAM_REVIEWER layer (APPLICATION_VIEW_ASSIGNED, APPLICATION_REVIEW, REVIEW_EDIT_OWN) +MILESTONE_REVIEWER layer |
| PROGRAM_CREATOR | 18 | 28 | Same as PROGRAM_ADMIN + PROGRAM_MANAGE_ADMINS |

This aligns the frontend with the backend (gap-indexer), where these roles already inherit everything from lower tiers. In practice, admins/creators won't exercise these inherited permissions (e.g., submitting milestones as an applicant), but having them prevents edge-case permission denials.

## Test plan
- [x] Verify all RBAC tests pass
- [ ] Verify MILESTONE_REVIEWER can see comments on applications
- [ ] Verify MILESTONE_REVIEWER inherits all PROGRAM_REVIEWER permissions
- [ ] Verify no role can write comments but not read them