### PR TITLE
feat(indicators): migrate datapoint reads from MongoDB to V2 PostgreSQL

### DIFF
--- a/hooks/useProjectImpactIndicators.ts
+++ b/hooks/useProjectImpactIndicators.ts
@@ -44,7 +44,7 @@ export const useProjectImpactIndicators = (projectId: string, range: number = 30
   const period = mapRangeToPeriod(range);
 
   return useQuery({
-    queryKey: ["project-impact-indicators", projectId, range],
+    queryKey: ["project-impact-indicators", projectId, period],
     queryFn: async () => {
       const [data, error] = await fetchData(
         INDEXER.INDICATORS.V2.DASHBOARD_METRICS(projectId, { period })

--- a/hooks/useProjectImpactIndicators.ts
+++ b/hooks/useProjectImpactIndicators.ts
@@ -3,34 +3,52 @@ import { useQuery } from "@tanstack/react-query";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
-// New type definitions for the updated API response
 export interface MetricData {
   lastUpdated: string;
   source: string;
   unit: string;
   value: number;
+  breakdown?: Record<string, number>;
 }
 
 export interface ProjectImpactResponse {
   metrics: {
-    gitCommits: MetricData;
-    mergedPRs: MetricData;
-    transactions: MetricData;
-    uniqueUsers: MetricData;
+    gitCommits: MetricData | null;
+    mergedPRs: MetricData | null;
+    transactions: MetricData | null;
+    uniqueUsers: MetricData | null;
   };
-  projectTitle: string;
+  projectTitle?: string;
   projectUID: string;
+  period: string;
   timeRange: {
     endDate: string;
     startDate: string;
   };
 }
 
+function mapRangeToPeriod(range: number): "30d" | "90d" | "180d" | "1y" {
+  switch (range) {
+    case 90:
+      return "90d";
+    case 180:
+      return "180d";
+    case 360:
+      return "1y";
+    default:
+      return "30d";
+  }
+}
+
 export const useProjectImpactIndicators = (projectId: string, range: number = 30) => {
+  const period = mapRangeToPeriod(range);
+
   return useQuery({
     queryKey: ["project-impact-indicators", projectId, range],
     queryFn: async () => {
-      const [data, error] = await fetchData(INDEXER.INDICATORS.BY_TIMERANGE(projectId, { range }));
+      const [data, error] = await fetchData(
+        INDEXER.INDICATORS.V2.DASHBOARD_METRICS(projectId, { period })
+      );
       if (error) throw error;
       return data as ProjectImpactResponse;
     },

--- a/services/impactService.ts
+++ b/services/impactService.ts
@@ -39,15 +39,15 @@ function transformProjectIndicators(
 export const getImpactAnswers = async (
   projectIdentifier: string
 ): Promise<ImpactIndicatorWithData[]> => {
-  // Use the original endpoint which has the full data
-  const [data, error] = await fetchData(INDEXER.PROJECT.IMPACT_INDICATORS.GET(projectIdentifier));
+  const [data, error] = await fetchData(
+    INDEXER.INDICATORS.V2.PROJECT_INDICATORS(projectIdentifier)
+  );
 
   if (error) {
     throw new Error(error);
   }
 
-  // The old endpoint returns data in the ImpactIndicatorWithData format directly
-  return data as ImpactIndicatorWithData[];
+  return transformProjectIndicators(data as ProjectIndicatorsResponse);
 };
 
 /**

--- a/utilities/impact/milestoneImpactAnswers.ts
+++ b/utilities/impact/milestoneImpactAnswers.ts
@@ -1,5 +1,6 @@
 import toast from "react-hot-toast";
 import type { ImpactIndicatorWithData } from "@/types/impactMeasurement";
+import type { ProjectIndicatorResponse } from "@/types/indicator";
 import fetchData from "../fetchData";
 import { INDEXER } from "../indexer";
 import { MESSAGES } from "../messages";
@@ -74,6 +75,33 @@ export const sendMilestoneImpactAnswers = async (
 };
 
 /**
+ * Transform V2 milestone indicators response to ImpactIndicatorWithData[]
+ */
+function transformMilestoneIndicators(
+  response: { milestoneUID: string; indicators: ProjectIndicatorResponse[] }
+): ImpactIndicatorWithData[] {
+  return response.indicators.map((indicator) => ({
+    id: indicator.id,
+    name: indicator.name,
+    description: indicator.description,
+    unitOfMeasure: indicator.unitOfMeasure,
+    programs: [],
+    datapoints: indicator.datapoints.map((dp) => ({
+      value: dp.value,
+      proof: dp.proof || "",
+      startDate: dp.startDate,
+      endDate: dp.endDate,
+      outputTimestamp: dp.startDate,
+      breakdown: dp.breakdown || undefined,
+      period: dp.period || undefined,
+    })),
+    hasData: indicator.hasData,
+    isAssociatedWithPrograms: false,
+    aggregatedData: indicator.aggregatedData,
+  }));
+}
+
+/**
  * Retrieves impact indicator data for a milestone
  *
  * @param milestoneUID - The milestone UID
@@ -84,7 +112,7 @@ export const getMilestoneImpactAnswers = async (
 ): Promise<ImpactIndicatorWithData[]> => {
   try {
     const [data, error] = await fetchData(
-      INDEXER.MILESTONE.IMPACT_INDICATORS.GET(milestoneUID),
+      INDEXER.INDICATORS.V2.MILESTONE_INDICATORS(milestoneUID),
       "GET"
     );
 
@@ -93,7 +121,7 @@ export const getMilestoneImpactAnswers = async (
       return [];
     }
 
-    return data || [];
+    return transformMilestoneIndicators(data);
   } catch (error) {
     console.error("Error fetching milestone impact data:", error);
     return [];

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -445,6 +445,17 @@ export const INDEXER = {
         const query = queryParams.toString();
         return `/v2/indicators/projects/${projectUID}${query ? `?${query}` : ""}`;
       },
+      DASHBOARD_METRICS: (
+        projectUID: string,
+        params?: { period?: "30d" | "90d" | "180d" | "1y" }
+      ) => {
+        const queryParams = new URLSearchParams();
+        if (params?.period) queryParams.set("period", params.period);
+        const query = queryParams.toString();
+        return `/v2/indicators/projects/${projectUID}/dashboard-metrics${query ? `?${query}` : ""}`;
+      },
+      MILESTONE_INDICATORS: (milestoneUID: string) =>
+        `/v2/indicators/milestones/${milestoneUID}`,
       COMMUNITY_AGGREGATE: (
         communityUID: string,
         params?: {

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -341,7 +341,6 @@ export const INDEXER = {
       GET: (projectUID: string) => `/projects/${projectUID}/regions`,
     },
     IMPACT_INDICATORS: {
-      GET: (projectUID: string) => `/projects/${projectUID}/indicators/data/all`,
       SEND: (projectUID: string) => `/projects/${projectUID}/indicators/data`,
     },
     PAYOUT_ADDRESS: {
@@ -358,7 +357,6 @@ export const INDEXER = {
   },
   MILESTONE: {
     IMPACT_INDICATORS: {
-      GET: (milestoneUID: string) => `/grants/milestones/${milestoneUID}/indicators/data`,
       SEND: (milestoneUID: string) => `/grants/milestones/${milestoneUID}/indicators/data`,
     },
   },
@@ -381,10 +379,6 @@ export const INDEXER = {
     CREATE_OR_UPDATE: () => `/indicators`,
     DELETE: (indicatorId: string) => `/indicators/${indicatorId}`,
     UNLINKED: () => `/indicators/unlinked`,
-    BY_TIMERANGE: (projectUID: string, params: Record<string, number>) =>
-      `/projects/${projectUID}/indicator-dashboard-metrics?${Object.entries(params)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&")}`,
     V2: {
       LIST: (params?: {
         communityUID?: string;


### PR DESCRIPTION
## Summary
- Switch `getImpactAnswers()` from legacy `/projects/:id/indicators/data/all` (MongoDB) to `/v2/indicators/projects/:projectUID` (PostgreSQL)
- Switch `useProjectImpactIndicators` from `/indicator-dashboard-metrics?range=30` to `/v2/indicators/projects/:projectUID/dashboard-metrics?period=30d` with range-to-period mapping
- Switch `getMilestoneImpactAnswers()` from `/grants/milestones/:id/indicators/data` (MongoDB) to `/v2/indicators/milestones/:milestoneUID` (PostgreSQL)
- Add `DASHBOARD_METRICS` and `MILESTONE_INDICATORS` V2 URL builders to indexer.ts

## Context
Prepares for dropping MongoDB datapoints. All 3 impact page data fetches now read from PostgreSQL via V2 endpoints. Depends on [gap-indexer#902](https://github.com/show-karma/gap-indexer/pull/902) for the new backend endpoints.

## Test plan
- [ ] Navigate to `project/{id}/impact` — verify stats cards show transaction/commit/PR/user counts
- [ ] Verify OutputsAndOutcomes section shows indicator datapoints with charts
- [ ] Verify milestone indicator data loads correctly
- [ ] Confirm no requests to legacy endpoints in network tab (`/indicators/data/all`, `/indicator-dashboard-metrics`, `/milestones/*/indicators/data`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for period-based filtering of project impact metrics (30 days, 90 days, 180 days, 1 year).
  * Enabled impact indicator tracking at the milestone level.

* **Refactor**
  * Updated internal data transformation processes for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->