### PR TITLE
fix: remove hardcoded assetAndChainId causing 0x0 currency display

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
@@ -160,7 +160,6 @@ export const MilestonesScreen: React.FC = () => {
         programId: normalizedProgramId, // Use normalized programId (no chainId)
         amount: newGrantData.amount || "",
         proposalURL: newGrantData.linkToProposal,
-        assetAndChainId: ["0x0", 1],
         payoutAddress: smartWalletAddress || address,
         questions: newGrantData.questions,
         description:


### PR DESCRIPTION
## Summary

- Removes the hardcoded `assetAndChainId: ["0x0", 1]` from grant creation in `MilestonesScreen.tsx`
- The field is optional in the SDK (`IGrantDetails.assetAndChainId?: [Hex, number]`), so omitting it is safe
- The indexer's attestation processor (`attestation-processor.service.ts:575`) uses optional chaining with a `|| ''` fallback, so `undefined` gracefully becomes `currency: ""`

## Problem

Every new grant was being created with `assetAndChainId: ["0x0", 1]`, a placeholder value. The indexer reads `assetAndChainId[0]` as the grant's currency, causing `"0x0"` to be displayed in the UI (e.g., on Celo grants).

## Solution

Remove the hardcoded line. The `assetAndChainId` field is optional — when absent, the indexer falls back to an empty string, which is the correct representation of "no currency specified."

## Test plan

- [ ] Create a new grant and verify it no longer shows `0x0` as currency
- [ ] Verify existing grants with real currency values are unaffected
- [ ] Confirm the indexer processes the grant without errors when `assetAndChainId` is missing

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213119932341546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grant milestone details handling by removing unnecessary asset and chain identifier information that was being incorrectly included during grant detail construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->