### PR TITLE
feat(indicators): searchable dropdown + V2 endpoint migration

### DIFF
--- a/components/Forms/Outputs/MetricsTable.tsx
+++ b/components/Forms/Outputs/MetricsTable.tsx
@@ -243,19 +243,19 @@ const CategorizedIndicatorDropdown = ({
             />
           </div>
 
-          <div className="max-h-60 overflow-y-auto py-1" role="listbox">
-            <button
-              type="button"
-              onClick={() => {
-                onCreateNew();
-                setIsOpen(false);
-                setSearchTerm("");
-              }}
-              className="w-full px-3 py-2 text-left text-sm font-semibold text-brand-blue hover:bg-gray-100 dark:hover:bg-zinc-700"
-            >
-              + Create New Metric
-            </button>
+          <button
+            type="button"
+            onClick={() => {
+              onCreateNew();
+              setIsOpen(false);
+              setSearchTerm("");
+            }}
+            className="w-full px-3 py-2 text-left text-sm font-semibold text-brand-blue hover:bg-gray-100 dark:hover:bg-zinc-700 border-b border-gray-100 dark:border-zinc-700"
+          >
+            + Create New Metric
+          </button>
 
+          <div className="max-h-60 overflow-y-auto py-1" role="listbox">
             {isFetching && allItems.length === 0 ? (
               <div className="px-3 py-2 text-sm text-gray-500 dark:text-zinc-400">Searching...</div>
             ) : allItems.length === 0 ? (

--- a/components/Forms/Outputs/MetricsTable.tsx
+++ b/components/Forms/Outputs/MetricsTable.tsx
@@ -111,16 +111,19 @@ const CategorizedIndicatorDropdown = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
-  // Close on scroll/resize so panel doesn't float detached
+  // Close on resize; close on scroll only if outside the panel
   useEffect(() => {
     if (!isOpen) return;
     const close = () => setIsOpen(false);
+    const handleScroll = (e: Event) => {
+      if (panelRef.current?.contains(e.target as Node)) return;
+      setIsOpen(false);
+    };
     window.addEventListener("resize", close);
-    // Capture scroll on any ancestor
-    document.addEventListener("scroll", close, true);
+    document.addEventListener("scroll", handleScroll, true);
     return () => {
       window.removeEventListener("resize", close);
-      document.removeEventListener("scroll", close, true);
+      document.removeEventListener("scroll", handleScroll, true);
     };
   }, [isOpen]);
 

--- a/components/Forms/Outputs/MetricsTable.tsx
+++ b/components/Forms/Outputs/MetricsTable.tsx
@@ -97,18 +97,24 @@ const CategorizedIndicatorDropdown = ({
   const selectedLabel = dropdownList.find((item) => item.value === selected)?.title;
 
   return (
-    <div ref={containerRef} className="relative w-full">
+    <div ref={containerRef} className="relative min-w-[200px]">
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
-        className="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-left text-gray-900 dark:bg-zinc-800 dark:border-zinc-700 dark:text-white truncate"
+        className={cn(
+          "w-full rounded-lg border bg-white px-3 py-1.5 text-left text-sm dark:bg-zinc-800 dark:text-white truncate",
+          isOpen
+            ? "border-blue-500 ring-1 ring-blue-500"
+            : "border-gray-200 dark:border-zinc-700",
+          selected ? "text-gray-900" : "text-gray-400 dark:text-zinc-500"
+        )}
       >
-        {selectedLabel || "Select"}
+        {selectedLabel || "Select indicator..."}
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg dark:bg-zinc-800 dark:border-zinc-700">
-          <div className="p-2">
+        <div className="absolute left-0 z-50 mt-1 min-w-[340px] w-max max-w-[480px] rounded-lg border border-gray-200 bg-white shadow-lg dark:bg-zinc-800 dark:border-zinc-700">
+          <div className="p-2 border-b border-gray-100 dark:border-zinc-700">
             <input
               type="text"
               value={searchTerm}
@@ -119,7 +125,7 @@ const CategorizedIndicatorDropdown = ({
             />
           </div>
 
-          <div className="max-h-60 overflow-y-auto">
+          <div className="max-h-60 overflow-y-auto py-1">
             <button
               type="button"
               onClick={() => {
@@ -256,7 +262,7 @@ export const MetricsTable = ({
           <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-700">
             <thead>
               <tr>
-                <th className="px-4 py-3 text-left text-sm font-bold text-gray-700 dark:text-zinc-300">
+                <th className="px-4 py-3 text-left text-sm font-bold text-gray-700 dark:text-zinc-300 min-w-[200px]">
                   Output
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-bold text-gray-700 dark:text-zinc-300">

--- a/components/Pages/Admin/IndicatorsDropdown.tsx
+++ b/components/Pages/Admin/IndicatorsDropdown.tsx
@@ -391,6 +391,9 @@ export const IndicatorsDropdown: FC<IndicatorsDropdownProps> = ({
                       // Add the new indicator to local state
                       setNewIndicators((prev) => [...prev, indicator]);
 
+                      // Auto-select the newly created indicator
+                      handleIndicatorChange(indicator.id);
+
                       // Notify parent callback
                       onIndicatorCreated?.(indicator);
 

--- a/hooks/useUnlinkedIndicators.ts
+++ b/hooks/useUnlinkedIndicators.ts
@@ -7,7 +7,7 @@ import {
 export const useUnlinkedIndicators = () => {
   return useQuery<UnlinkedIndicator[]>({
     queryKey: ["unlinkedIndicators"],
-    queryFn: getUnlinkedIndicators,
+    queryFn: () => getUnlinkedIndicators(),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/services/impactService.ts
+++ b/services/impactService.ts
@@ -31,23 +31,23 @@ function transformProjectIndicators(
 }
 
 /**
- * Fetches impact indicator data for a project
+ * Fetches impact indicator data for a project using V2 PostgreSQL endpoint
  *
- * @param projectIdentifier - The project slug or UID
+ * @param projectIdentifier - The project UID
  * @returns Promise with the impact indicators data
  */
 export const getImpactAnswers = async (
   projectIdentifier: string
 ): Promise<ImpactIndicatorWithData[]> => {
-  // Use the original endpoint which has the full data
-  const [data, error] = await fetchData(INDEXER.PROJECT.IMPACT_INDICATORS.GET(projectIdentifier));
+  const [data, error] = await fetchData(
+    INDEXER.INDICATORS.V2.PROJECT_INDICATORS(projectIdentifier)
+  );
 
   if (error) {
     throw new Error(error);
   }
 
-  // The old endpoint returns data in the ImpactIndicatorWithData format directly
-  return data as ImpactIndicatorWithData[];
+  return transformProjectIndicators(data as ProjectIndicatorsResponse);
 };
 
 /**

--- a/services/impactService.ts
+++ b/services/impactService.ts
@@ -1,3 +1,4 @@
+import { errorManager } from "@/components/Utilities/errorManager";
 import type { ImpactIndicatorWithData } from "@/types/impactMeasurement";
 import type { ProjectIndicatorsResponse } from "@/types/indicator";
 import fetchData from "@/utilities/fetchData";
@@ -39,15 +40,20 @@ function transformProjectIndicators(
 export const getImpactAnswers = async (
   projectIdentifier: string
 ): Promise<ImpactIndicatorWithData[]> => {
-  const [data, error] = await fetchData(
-    INDEXER.INDICATORS.V2.PROJECT_INDICATORS(projectIdentifier)
-  );
+  try {
+    const [data, error] = await fetchData(
+      INDEXER.INDICATORS.V2.PROJECT_INDICATORS(projectIdentifier)
+    );
 
-  if (error) {
-    throw new Error(error);
+    if (error) {
+      throw new Error(error);
+    }
+
+    return transformProjectIndicators(data as ProjectIndicatorsResponse);
+  } catch (error: unknown) {
+    errorManager(`Error fetching impact answers for project ${projectIdentifier}`, error);
+    throw error;
   }
-
-  return transformProjectIndicators(data as ProjectIndicatorsResponse);
 };
 
 /**

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -380,7 +380,7 @@ export const INDEXER = {
   INDICATORS: {
     CREATE_OR_UPDATE: () => `/indicators`,
     DELETE: (indicatorId: string) => `/indicators/${indicatorId}`,
-    UNLINKED: () => `/indicators/unlinked`,
+    UNLINKED: () => `/v2/indicators/unlinked`,
     BY_TIMERANGE: (projectUID: string, params: Record<string, number>) =>
       `/projects/${projectUID}/indicator-dashboard-metrics?${Object.entries(params)
         .map(([key, value]) => `${key}=${value}`)

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -380,7 +380,12 @@ export const INDEXER = {
   INDICATORS: {
     CREATE_OR_UPDATE: () => `/indicators`,
     DELETE: (indicatorId: string) => `/indicators/${indicatorId}`,
-    UNLINKED: () => `/v2/indicators/unlinked`,
+    UNLINKED: (search?: string) => {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      const query = params.toString();
+      return `/v2/indicators/unlinked${query ? `?${query}` : ""}`;
+    },
     BY_TIMERANGE: (projectUID: string, params: Record<string, number>) =>
       `/projects/${projectUID}/indicator-dashboard-metrics?${Object.entries(params)
         .map(([key, value]) => `${key}=${value}`)

--- a/utilities/queries/getUnlinkedIndicators.ts
+++ b/utilities/queries/getUnlinkedIndicators.ts
@@ -11,9 +11,11 @@ export interface UnlinkedIndicator {
   updatedAt: string;
 }
 
-export const getUnlinkedIndicators = async (): Promise<UnlinkedIndicator[]> => {
+export const getUnlinkedIndicators = async (
+  search?: string
+): Promise<UnlinkedIndicator[]> => {
   try {
-    const [data, error] = await fetchData(INDEXER.INDICATORS.UNLINKED());
+    const [data, error] = await fetchData(INDEXER.INDICATORS.UNLINKED(search));
     if (error) {
       throw error;
     }


### PR DESCRIPTION
## Summary
- Replace plain `<select>` with searchable dropdown for indicator selection in MetricsTable
- Migrate all indicator reads to V2 PostgreSQL endpoints (unlinked + impact page)
- Dropdown uses debounced API search (300ms) so newly created indicators appear immediately

## Changes
- **`utilities/indexer.ts`**: `INDICATORS.UNLINKED` now points to `/v2/indicators/unlinked` with optional `?search=` param
- **`utilities/queries/getUnlinkedIndicators.ts`**: Accepts optional `search` param
- **`services/impactService.ts`**: `getImpactAnswers` now uses `GET /v2/indicators/projects/:projectUID` instead of legacy MongoDB endpoint
- **`components/Forms/Outputs/MetricsTable.tsx`**: Searchable dropdown with:
  - Debounced API search (300ms) for global indicators
  - Client-side filtering for community indicators
  - Portal rendering (`createPortal`) to escape overflow clipping
  - Section headers (Community / Global)
  - "Create New Metric" always visible at top
  - Click-outside-to-close, scroll/resize aware

## Depends on
- show-karma/gap-indexer#906 (V2 unlinked endpoint)

## Test plan
- [ ] Open MetricsTable → dropdown shows search input + indicator list
- [ ] Type in search → debounced API call filters results
- [ ] Create new indicator → search for it immediately → appears in list
- [ ] Select an indicator → form still works (value, proof, submit)
- [ ] "Create New Metric" option always visible
- [ ] Scrolling inside dropdown works without closing
- [ ] Clicking outside closes dropdown
- [ ] Impact page (`/project/.../impact`) loads indicators from PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced metrics dropdown with debounced async search, keyboard focus, portal-rendered panel, dynamic sizing, and loading/empty states
  * Results grouped into "Community" and "Global" with a "+ Create New Metric" option; newly created indicators are auto-selected

* **Refactor**
  * Backend integrations moved to V2 endpoints for indicator queries and project answers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->