### PR TITLE
refactor(indicators): migrate write endpoints to V2 and remove dead constants

### DIFF
--- a/__tests__/components/Forms/IndicatorForm.test.tsx
+++ b/__tests__/components/Forms/IndicatorForm.test.tsx
@@ -175,7 +175,7 @@ describe("IndicatorForm", () => {
 
       await waitFor(() => {
         expect(mockFetchData).toHaveBeenCalledWith(
-          INDEXER.INDICATORS.CREATE_OR_UPDATE(),
+          INDEXER.INDICATORS.V2.CREATE_OR_UPDATE(),
           "POST",
           expect.objectContaining({
             name: "Test Indicator",
@@ -266,7 +266,7 @@ describe("IndicatorForm", () => {
 
       await waitFor(() => {
         expect(mockFetchData).toHaveBeenCalledWith(
-          INDEXER.INDICATORS.CREATE_OR_UPDATE(),
+          INDEXER.INDICATORS.V2.CREATE_OR_UPDATE(),
           "POST",
           expect.objectContaining({
             indicatorId: "indicator-123",
@@ -498,7 +498,7 @@ describe("IndicatorForm", () => {
 
       await waitFor(() => {
         expect(mockFetchData).toHaveBeenCalledWith(
-          INDEXER.INDICATORS.CREATE_OR_UPDATE(),
+          INDEXER.INDICATORS.V2.CREATE_OR_UPDATE(),
           "POST",
           expect.objectContaining({
             programs: [{ programId: "program-1", chainID: 1 }],
@@ -647,7 +647,7 @@ describe("IndicatorForm", () => {
 
       await waitFor(() => {
         expect(mockFetchData).toHaveBeenCalledWith(
-          INDEXER.INDICATORS.CREATE_OR_UPDATE(),
+          INDEXER.INDICATORS.V2.CREATE_OR_UPDATE(),
           "POST",
           expect.objectContaining({
             communityUID: "community-123",

--- a/components/Forms/IndicatorForm.tsx
+++ b/components/Forms/IndicatorForm.tsx
@@ -125,7 +125,7 @@ export const IndicatorForm: React.FC<IndicatorFormProps> = ({
 
     setIsLoading(true);
     try {
-      const [response, error] = await fetchData(INDEXER.INDICATORS.CREATE_OR_UPDATE(), "POST", {
+      const [response, error] = await fetchData(INDEXER.INDICATORS.V2.CREATE_OR_UPDATE(), "POST", {
         indicatorId: indicatorId,
         name: data.name,
         description: data.description,

--- a/components/Pages/Admin/IndicatorsHub.tsx
+++ b/components/Pages/Admin/IndicatorsHub.tsx
@@ -90,7 +90,7 @@ export const IndicatorsHub = ({ communitySlug, communityId }: IndicatorsHubProps
   const handleDelete = async (id: string) => {
     try {
       setDeletingId(id);
-      const [, error] = await fetchData(INDEXER.INDICATORS.DELETE(id), "DELETE");
+      const [, error] = await fetchData(INDEXER.INDICATORS.V2.DELETE(id), "DELETE");
       if (error) throw error;
 
       refetch();

--- a/components/Pages/Admin/IndicatorsView.tsx
+++ b/components/Pages/Admin/IndicatorsView.tsx
@@ -69,7 +69,7 @@ export const IndicatorsView = ({ categories, onRefresh, communityId }: Indicator
   const handleDeleteIndicator = async (id: string) => {
     try {
       setIsDeletingId(id);
-      const [, error] = await fetchData(INDEXER.INDICATORS.DELETE(id), "DELETE");
+      const [, error] = await fetchData(INDEXER.INDICATORS.V2.DELETE(id), "DELETE");
       if (error) throw error;
 
       // Refresh indicators using the hook's refetch method

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -343,10 +343,6 @@ export const INDEXER = {
     IMPACT_INDICATORS: {
       SEND: (projectUID: string) => `/projects/${projectUID}/indicators/data`,
     },
-    PAYOUT_ADDRESS: {
-      UPDATE: (projectUID: string) => `/projects/${projectUID}/payout-address`,
-      GET: (projectUID: string) => `/projects/${projectUID}/payout-address`,
-    },
     CHAIN_PAYOUT_ADDRESS: {
       UPDATE: (projectId: string) => `/v2/projects/${projectId}/chain-payout-address`,
     },
@@ -376,19 +372,15 @@ export const INDEXER = {
     GET_BY_ID: (regionId: string) => `/v2/regions/${regionId}`,
   },
   INDICATORS: {
-    CREATE_OR_UPDATE: () => `/indicators`,
-    DELETE: (indicatorId: string) => `/indicators/${indicatorId}`,
     UNLINKED: (search?: string) => {
       const params = new URLSearchParams();
       if (search) params.set("search", search);
       const query = params.toString();
       return `/v2/indicators/unlinked${query ? `?${query}` : ""}`;
     },
-    BY_TIMERANGE: (projectUID: string, params: Record<string, number>) =>
-      `/projects/${projectUID}/indicator-dashboard-metrics?${Object.entries(params)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&")}`,
     V2: {
+      CREATE_OR_UPDATE: () => `/v2/indicators`,
+      DELETE: (indicatorId: string) => `/v2/indicators/${indicatorId}`,
       LIST: (params?: {
         communityUID?: string;
         programId?: number;
@@ -611,14 +603,6 @@ export const INDEXER = {
     GLOBAL_STATS: () => `/v2/communities/stats`,
     ADMINS: (communityIdOrSlug: string) => `/communities/${communityIdOrSlug}/admins`,
     BATCH_UPDATE: (idOrSlug: string) => `/communities/${idOrSlug}/batch-update`,
-    INDICATORS: {
-      COMMUNITY: {
-        LIST: (communityId: string) => `/communities/${communityId}/impact-indicators`,
-      },
-      CATEGORY: {
-        LIST: (categoryId: string) => `/category/${categoryId}/impact-indicators`,
-      },
-    },
     PROJECT_UPDATES: (communityIdOrSlug: string) =>
       `/v2/communities/${communityIdOrSlug}/project-updates`,
     CONFIG: {


### PR DESCRIPTION
## Summary

- Migrate `INDICATORS.CREATE_OR_UPDATE` from `/indicators` → `/v2/indicators`
- Migrate `INDICATORS.DELETE` from `/indicators/${id}` → `/v2/indicators/${id}`
- Remove dead constants that are never called anywhere in the codebase:
  - `PROJECT.PAYOUT_ADDRESS.UPDATE` and `PROJECT.PAYOUT_ADDRESS.GET`
  - `INDICATORS.BY_TIMERANGE`
  - `COMMUNITY.INDICATORS.COMMUNITY.LIST`
  - `COMMUNITY.INDICATORS.CATEGORY.LIST`

## Test plan

- [x] All 32 existing IndicatorForm tests pass
- [x] TypeScript compiles cleanly
- [x] Grep verified removed constants are unused across entire codebase
- [ ] Smoke test: create an indicator in the UI
- [ ] Smoke test: delete an indicator in the UI

## Related

- Backend PR: https://github.com/show-karma/gap-indexer/pull/911 (adds the V2 write endpoints this PR consumes)

> **Deploy order**: Backend PR must be deployed first, then this frontend PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Indicator management endpoints migrated to v2 paths (create/update and delete)
  * Removed payout address access from impact indicators
  * Removed timerange-based indicator query
  * Removed community indicator list and category endpoints
  * Removed all project indicator endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->