### PR TITLE
feat(kyc): add KYC/KYB status column to funding applications list

### DIFF
--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
@@ -145,6 +145,7 @@ export default function ApplicationsPage() {
         <div className="sm:px-3 md:px-4 px-6 py-2 flex-1">
           <ApplicationListWithAPI
             programId={programId}
+            communityId={communityId}
             showStatusActions={isAdmin}
             onApplicationSelect={handleApplicationSelect}
             onApplicationHover={handleApplicationHover}

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -10,6 +10,8 @@ import type { KycStatusResponse } from "@/types/kyc";
 import StatusChangeModal from "../ApplicationView/StatusChangeModal";
 import { ApplicationTable } from "./ApplicationTable";
 
+const EMPTY_KYC_MAP = new Map<string, KycStatusResponse | null>();
+
 interface IApplicationListComponentProps extends IApplicationListProps {
   applications: IFundingApplication[];
   isLoading?: boolean;
@@ -59,7 +61,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   isMilestoneReviewersError = false,
   onReviewerAssignmentChange,
   isKycEnabled = false,
-  kycStatuses = new Map(),
+  kycStatuses = EMPTY_KYC_MAP,
   isLoadingKycStatuses = false,
 }) => {
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);

--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -6,6 +6,7 @@ import type { IApplicationFilters } from "@/services/fundingPlatformService";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { IApplicationListProps, IFundingApplication } from "@/types/funding-platform";
+import type { KycStatusResponse } from "@/types/kyc";
 import StatusChangeModal from "../ApplicationView/StatusChangeModal";
 import { ApplicationTable } from "./ApplicationTable";
 
@@ -33,6 +34,9 @@ interface IApplicationListComponentProps extends IApplicationListProps {
   isLoadingMilestoneReviewers?: boolean;
   isMilestoneReviewersError?: boolean;
   onReviewerAssignmentChange?: () => void;
+  isKycEnabled?: boolean;
+  kycStatuses?: Map<string, KycStatusResponse | null>;
+  isLoadingKycStatuses?: boolean;
 }
 
 const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
@@ -54,6 +58,9 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   isLoadingMilestoneReviewers = false,
   isMilestoneReviewersError = false,
   onReviewerAssignmentChange,
+  isKycEnabled = false,
+  kycStatuses = new Map(),
+  isLoadingKycStatuses = false,
 }) => {
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
   const [statusModalOpen, setStatusModalOpen] = useState(false);
@@ -166,6 +173,9 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
             onStatusChange={handleStatusChangeClick}
             onReviewerAssignmentChange={onReviewerAssignmentChange}
             isUpdatingStatus={isUpdatingStatus}
+            isKycEnabled={isKycEnabled}
+            kycStatuses={kycStatuses}
+            isLoadingKycStatuses={isLoadingKycStatuses}
           />
         )}
       </div>

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -132,17 +132,16 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     [applications]
   );
 
-  // KYC: Check if KYC is enabled for this community
+  // KYC: Fetch config and batch statuses in parallel (no waterfall)
   const { isEnabled: isKycEnabled } = useKycConfig(communityId, {
     enabled: !!communityId,
   });
 
-  // KYC: Fetch batch statuses by application reference
   const { statuses: kycStatuses, isLoading: isLoadingKycStatuses } = useKycBatchStatusesByAppRef(
     communityId,
     referenceNumbers,
     {
-      enabled: !!communityId && referenceNumbers.length > 0 && isKycEnabled,
+      enabled: !!communityId && referenceNumbers.length > 0,
     }
   );
 

--- a/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
@@ -7,6 +7,7 @@ import type { IApplicationFilters } from "@/services/fundingPlatformService";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { IFundingApplication } from "@/types/funding-platform";
+import type { KycStatusResponse } from "@/types/kyc";
 import { ApplicationTableRow } from "./ApplicationTableRow";
 
 interface ApplicationTableProps {
@@ -30,6 +31,9 @@ interface ApplicationTableProps {
   onStatusChange?: (applicationId: string, status: string, e: React.MouseEvent) => void;
   onReviewerAssignmentChange?: () => void;
   isUpdatingStatus?: boolean;
+  isKycEnabled?: boolean;
+  kycStatuses?: Map<string, KycStatusResponse | null>;
+  isLoadingKycStatuses?: boolean;
 }
 
 const ApplicationTableComponent: FC<ApplicationTableProps> = ({
@@ -53,6 +57,9 @@ const ApplicationTableComponent: FC<ApplicationTableProps> = ({
   onStatusChange,
   onReviewerAssignmentChange,
   isUpdatingStatus = false,
+  isKycEnabled = false,
+  kycStatuses = new Map(),
+  isLoadingKycStatuses = false,
 }) => {
   return (
     <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -86,6 +93,14 @@ const ApplicationTableComponent: FC<ApplicationTableProps> = ({
             currentSortDirection={sortOrder}
             onSort={onSortChange}
           />
+          {isKycEnabled && (
+            <th
+              scope="col"
+              className="px-4 py-3 text-left text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider"
+            >
+              KYC/KYB
+            </th>
+          )}
           {showAIScoreColumn && (
             <SortableTableHeader
               label="AI Score"
@@ -188,6 +203,9 @@ const ApplicationTableComponent: FC<ApplicationTableProps> = ({
             onStatusChange={onStatusChange}
             onReviewerAssignmentChange={onReviewerAssignmentChange}
             isUpdatingStatus={isUpdatingStatus}
+            isKycEnabled={isKycEnabled}
+            kycStatus={kycStatuses.get(application.referenceNumber) ?? null}
+            isLoadingKycStatus={isLoadingKycStatuses}
           />
         ))}
       </tbody>

--- a/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
@@ -10,6 +10,8 @@ import type { IFundingApplication } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
 import { ApplicationTableRow } from "./ApplicationTableRow";
 
+const EMPTY_KYC_MAP = new Map<string, KycStatusResponse | null>();
+
 interface ApplicationTableProps {
   applications: IFundingApplication[];
   sortBy?: IApplicationFilters["sortBy"];
@@ -58,7 +60,7 @@ const ApplicationTableComponent: FC<ApplicationTableProps> = ({
   onReviewerAssignmentChange,
   isUpdatingStatus = false,
   isKycEnabled = false,
-  kycStatuses = new Map(),
+  kycStatuses = EMPTY_KYC_MAP,
   isLoadingKycStatuses = false,
 }) => {
   return (

--- a/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
@@ -2,10 +2,13 @@
 
 import { ClipboardDocumentCheckIcon } from "@heroicons/react/24/solid";
 import React, { type FC, useState } from "react";
+import { KycStatusBadge } from "@/components/KycStatusIcon";
+import { Spinner } from "@/components/Utilities/Spinner";
 import { ReviewerType } from "@/hooks/useReviewerAssignment";
 import type { MilestoneReviewer } from "@/services/milestone-reviewers.service";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import type { FundingApplicationStatusV2, IFundingApplication } from "@/types/funding-platform";
+import type { KycStatusResponse } from "@/types/kyc";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { formatAIScore } from "../helper/getAIScore";
@@ -45,6 +48,9 @@ interface ApplicationTableRowProps {
   onStatusChange?: (applicationId: string, status: string, e: React.MouseEvent) => void;
   onReviewerAssignmentChange?: () => void;
   isUpdatingStatus?: boolean;
+  isKycEnabled?: boolean;
+  kycStatus?: KycStatusResponse | null;
+  isLoadingKycStatus?: boolean;
 }
 
 const getStatusBadge = (status: string) => (
@@ -72,6 +78,9 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
   onStatusChange,
   onReviewerAssignmentChange,
   isUpdatingStatus = false,
+  isKycEnabled = false,
+  kycStatus = null,
+  isLoadingKycStatus = false,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [evaluationType, setEvaluationType] = useState<EvaluationType>("external");
@@ -130,6 +139,15 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
             )}
           </div>
         </td>
+        {isKycEnabled && (
+          <td className="px-4 py-4 whitespace-nowrap">
+            {isLoadingKycStatus ? (
+              <Spinner className="w-4 h-4" />
+            ) : (
+              <KycStatusBadge status={kycStatus ?? null} showValidityInLabel={false} />
+            )}
+          </td>
+        )}
         {showAIScoreColumn && (
           <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 text-center">
             {application.aiEvaluation?.evaluation ? (

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -649,8 +649,10 @@ export const INDEXER = {
     GET_STATUS_BY_APP_REF: (referenceNumber: string) =>
       `/v2/funding-applications/${referenceNumber}/kyc-status`,
     GET_CONFIG: (communityIdOrSlug: string) => `/v2/communities/${communityIdOrSlug}/kyc-config`,
-    GET_BATCH_STATUSES: (communityUID: string) =>
-      `/v2/communities/${communityUID}/kyc-batch-status`,
+    GET_BATCH_STATUSES: (communityIdOrSlug: string) =>
+      `/v2/communities/${communityIdOrSlug}/kyc/batch-status/by-project-uid`,
+    GET_BATCH_STATUSES_BY_APP_REF: (communityIdOrSlug: string) =>
+      `/v2/communities/${communityIdOrSlug}/kyc/batch-status/by-application-reference`,
     GET_FORM_URL: (communityIdOrSlug: string) =>
       `/v2/communities/${communityIdOrSlug}/kyc-form-url`,
   },


### PR DESCRIPTION
## Summary

- Add KYC/KYB verification status column to the funding applications table at `/community/:communityId/manage/funding-platform/:programId/applications`
- Reuse existing `KycStatusBadge` component and follow the same pattern as the `/payouts` page
- Column only renders when KYC is enabled for the community

## Changes

- Add `useKycBatchStatusesByAppRef` hook and query key for batch status fetching by application reference
- Update `GET_BATCH_STATUSES` endpoint URL to new nested pattern (`/kyc/batch-status/by-project-uid`)
- Add `GET_BATCH_STATUSES_BY_APP_REF` endpoint constant
- Pass `communityId` from page to `ApplicationListWithAPI`
- Wire `useKycConfig` + `useKycBatchStatusesByAppRef` hooks into `ApplicationListWithAPI`
- Pass KYC props through `ApplicationList` → `ApplicationTable` → `ApplicationTableRow`
- Add conditional `KYC/KYB` column header (after Status, before AI Score)
- Render `KycStatusBadge` with `showValidityInLabel={false}` per row, with `Spinner` loading state

## Dependencies

- Requires [show-karma/gap-indexer#913](https://github.com/show-karma/gap-indexer/pull/913) to be deployed first

## Test plan

- [x] `pnpm run build` — no type errors
- [x] `pnpm lint:fix` — no new lint errors
- [ ] Navigate to a community's funding applications list with KYC enabled — verify KYC/KYB column appears with correct badges
- [ ] Navigate to a community without KYC — verify no KYC column shown
- [ ] Verify `/payouts` page still works with refactored endpoint URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KYC status badges now appear in the applications table.
  * A KYC/KYB column shows when community KYC is enabled.
  * Loading spinners display while KYC status data is retrieved.
  * Batch retrieval now fetches statuses by application reference for multiple apps at once.
  * KYC status lookup is scoped to the community, improving per-application accuracy and context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->