### PR TITLE
fix: AI Score column not showing for programs using new prompt system

### DIFF
--- a/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIColumnVisibility.test.ts
@@ -1,13 +1,83 @@
 import { getAIColumnVisibility } from "@/components/FundingPlatform/helper/getAIColumnVisibility";
+import type { IFundingApplication } from "@/types/funding-platform";
+import type { ProgramPromptsResponse } from "@/src/features/prompt-management/types/program-prompt";
+
+/**
+ * Helper to create a minimal mock application with AI evaluation data
+ */
+function mockApplication(
+  overrides: Partial<IFundingApplication> = {}
+): IFundingApplication {
+  return {
+    referenceNumber: "APP-TEST-001",
+    ...overrides,
+  } as IFundingApplication;
+}
+
+function mockAppWithAIScore(score: number): IFundingApplication {
+  return mockApplication({
+    aiEvaluation: {
+      evaluation: JSON.stringify({ final_score: score, feedback: "test" }),
+    },
+  });
+}
+
+function mockAppWithInternalAIScore(score: number): IFundingApplication {
+  return mockApplication({
+    internalAIEvaluation: {
+      evaluation: JSON.stringify({ final_score: score, feedback: "test" }),
+    },
+  });
+}
+
+function mockAppWithoutScore(): IFundingApplication {
+  return mockApplication({
+    aiEvaluation: {
+      evaluation: JSON.stringify({ Applicant_Guidance: "some guidance" }),
+    },
+  });
+}
+
+function mockPromptsResponse(
+  overrides: Partial<ProgramPromptsResponse> = {}
+): ProgramPromptsResponse {
+  return {
+    external: null,
+    internal: null,
+    migrationRequired: false,
+    legacyPromptIds: { external: null, internal: null },
+    ...overrides,
+  };
+}
+
+const mockExternalPrompt = {
+  id: "1",
+  programId: "1045",
+  promptType: "external" as const,
+  name: "test-prompt",
+  systemMessage: "You are a reviewer",
+  content: "Evaluate this application",
+  modelId: "gpt-4o",
+  langfusePromptId: "test-prompt",
+  langfuseVersion: 1,
+  createdAt: "2026-01-01",
+  updatedAt: "2026-01-01",
+  createdBy: "0x123",
+  updatedBy: "0x123",
+};
+
+const mockInternalPrompt = {
+  ...mockExternalPrompt,
+  id: "2",
+  promptType: "internal" as const,
+  name: "internal-prompt",
+  langfusePromptId: "internal-prompt",
+};
 
 describe("getAIColumnVisibility", () => {
-  describe("When formSchema has aiConfig", () => {
-    it("should show AI score column when langfusePromptId is present in aiConfig", () => {
-      const formSchema = {
-        aiConfig: {
-          langfusePromptId: "prompt-123",
-        },
-      };
+  describe("Legacy config (formSchema.aiConfig)", () => {
+    it("should show AI score column when langfusePromptId is present", () => {
+      const formSchema = { aiConfig: { langfusePromptId: "prompt-123" } };
 
       const result = getAIColumnVisibility(formSchema);
       expect(result.showAIScoreColumn).toBe(true);
@@ -15,11 +85,7 @@ describe("getAIColumnVisibility", () => {
     });
 
     it("should show internal AI score column when internalLangfusePromptId is present", () => {
-      const formSchema = {
-        aiConfig: {
-          internalLangfusePromptId: "internal-prompt-456",
-        },
-      };
+      const formSchema = { aiConfig: { internalLangfusePromptId: "internal-456" } };
 
       const result = getAIColumnVisibility(formSchema);
       expect(result.showAIScoreColumn).toBe(false);
@@ -28,10 +94,7 @@ describe("getAIColumnVisibility", () => {
 
     it("should show both columns when both prompt IDs are present", () => {
       const formSchema = {
-        aiConfig: {
-          langfusePromptId: "prompt-123",
-          internalLangfusePromptId: "internal-prompt-456",
-        },
+        aiConfig: { langfusePromptId: "prompt-123", internalLangfusePromptId: "internal-456" },
       };
 
       const result = getAIColumnVisibility(formSchema);
@@ -40,13 +103,127 @@ describe("getAIColumnVisibility", () => {
     });
 
     it("should not show columns when aiConfig is empty", () => {
-      const formSchema = {
-        aiConfig: {},
-      };
-
-      const result = getAIColumnVisibility(formSchema);
+      const result = getAIColumnVisibility({ aiConfig: {} });
       expect(result.showAIScoreColumn).toBe(false);
       expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("New prompt system (program_prompts collection)", () => {
+    it("should show AI score column when external prompt exists", () => {
+      const formSchema = { aiConfig: { langfusePromptId: "" } };
+      const promptsData = mockPromptsResponse({ external: mockExternalPrompt });
+
+      const result = getAIColumnVisibility(formSchema, promptsData);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should show internal AI score column when internal prompt exists", () => {
+      const formSchema = { aiConfig: { internalLangfusePromptId: "" } };
+      const promptsData = mockPromptsResponse({ internal: mockInternalPrompt });
+
+      const result = getAIColumnVisibility(formSchema, promptsData);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should show both columns when both prompts exist", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse({
+        external: mockExternalPrompt,
+        internal: mockInternalPrompt,
+      });
+
+      const result = getAIColumnVisibility(formSchema, promptsData);
+      expect(result.showAIScoreColumn).toBe(true);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should not show columns when prompts are null", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse();
+
+      const result = getAIColumnVisibility(formSchema, promptsData);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("Application data fallback", () => {
+    it("should show AI score column when any application has a score", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse();
+      const applications = [mockAppWithAIScore(7.0), mockAppWithoutScore()];
+
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should show internal AI score column when any application has an internal score", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse();
+      const applications = [mockAppWithInternalAIScore(8.5)];
+
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
+      expect(result.showInternalAIScoreColumn).toBe(true);
+    });
+
+    it("should not show column when no application has a parseable score", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse();
+      const applications = [mockAppWithoutScore(), mockApplication()];
+
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
+      expect(result.showAIScoreColumn).toBe(false);
+    });
+
+    it("should not scan applications when prompt already configured via new system", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse({ external: mockExternalPrompt });
+      // Even with no scored applications, column shows because prompt exists
+      const applications = [mockAppWithoutScore()];
+
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should show column with score of 0 (valid score)", () => {
+      const formSchema = { aiConfig: {} };
+      const applications = [mockAppWithAIScore(0)];
+
+      const result = getAIColumnVisibility(formSchema, null, applications);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should not show columns when applications array is empty", () => {
+      const result = getAIColumnVisibility({ aiConfig: {} }, null, []);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+  });
+
+  describe("Priority: legacy > new prompts > application data", () => {
+    it("should show column from legacy config even without prompts or scores", () => {
+      const formSchema = { aiConfig: { langfusePromptId: "prompt-123" } };
+
+      const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should show column from new prompts even without legacy config or scores", () => {
+      const formSchema = { aiConfig: { langfusePromptId: "" } };
+      const promptsData = mockPromptsResponse({ external: mockExternalPrompt });
+
+      const result = getAIColumnVisibility(formSchema, promptsData, []);
+      expect(result.showAIScoreColumn).toBe(true);
+    });
+
+    it("should show column from application data when no config exists", () => {
+      const formSchema = { aiConfig: {} };
+      const promptsData = mockPromptsResponse();
+      const applications = [mockAppWithAIScore(5)];
+
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
+      expect(result.showAIScoreColumn).toBe(true);
     });
   });
 
@@ -64,39 +241,41 @@ describe("getAIColumnVisibility", () => {
     });
 
     it("should handle formSchema without aiConfig", () => {
-      const formSchema = {
-        fields: [],
-      };
-
-      const result = getAIColumnVisibility(formSchema);
+      const result = getAIColumnVisibility({ fields: [] });
       expect(result.showAIScoreColumn).toBe(false);
       expect(result.showInternalAIScoreColumn).toBe(false);
     });
 
     it("should handle empty string prompt IDs as falsy", () => {
       const formSchema = {
-        aiConfig: {
-          langfusePromptId: "",
-          internalLangfusePromptId: "",
-        },
+        aiConfig: { langfusePromptId: "", internalLangfusePromptId: "" },
       };
 
       const result = getAIColumnVisibility(formSchema);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle null promptsData", () => {
+      const result = getAIColumnVisibility({ aiConfig: {} }, null);
+      expect(result.showAIScoreColumn).toBe(false);
+      expect(result.showInternalAIScoreColumn).toBe(false);
+    });
+
+    it("should handle undefined promptsData and applications", () => {
+      const result = getAIColumnVisibility({ aiConfig: {} }, undefined, undefined);
       expect(result.showAIScoreColumn).toBe(false);
       expect(result.showInternalAIScoreColumn).toBe(false);
     });
   });
 
   describe("Real-world scenarios", () => {
-    it("should handle typical program config structure", () => {
+    it("should handle typical legacy program config", () => {
       const formSchema = {
-        fields: [
-          { name: "projectTitle", type: "text" },
-          { name: "description", type: "textarea" },
-        ],
+        fields: [{ name: "projectTitle", type: "text" }],
         aiConfig: {
           langfusePromptId: "prompt-abc-123",
-          internalLangfusePromptId: "internal-prompt-xyz-789",
+          internalLangfusePromptId: "internal-prompt-xyz",
         },
       };
 
@@ -105,28 +284,29 @@ describe("getAIColumnVisibility", () => {
       expect(result.showInternalAIScoreColumn).toBe(true);
     });
 
-    it("should handle program with only external AI evaluation", () => {
+    it("should handle program 1045 scenario: new prompt system with empty legacy fields and scored apps", () => {
       const formSchema = {
         aiConfig: {
-          langfusePromptId: "external-prompt",
+          aiModel: "gpt-5.2",
+          enableRealTimeEvaluation: true,
+          langfusePromptId: "",
+          internalLangfusePromptId: "",
         },
       };
+      const promptsData = mockPromptsResponse({ external: mockExternalPrompt });
+      const applications = [mockAppWithAIScore(7.0), mockAppWithoutScore()];
 
-      const result = getAIColumnVisibility(formSchema);
+      const result = getAIColumnVisibility(formSchema, promptsData, applications);
       expect(result.showAIScoreColumn).toBe(true);
       expect(result.showInternalAIScoreColumn).toBe(false);
     });
 
-    it("should handle program with only internal AI evaluation", () => {
-      const formSchema = {
-        aiConfig: {
-          internalLangfusePromptId: "internal-only-prompt",
-        },
-      };
+    it("should handle program with new prompt but no scores yet", () => {
+      const formSchema = { aiConfig: { langfusePromptId: "" } };
+      const promptsData = mockPromptsResponse({ external: mockExternalPrompt });
 
-      const result = getAIColumnVisibility(formSchema);
-      expect(result.showAIScoreColumn).toBe(false);
-      expect(result.showInternalAIScoreColumn).toBe(true);
+      const result = getAIColumnVisibility(formSchema, promptsData, []);
+      expect(result.showAIScoreColumn).toBe(true);
     });
   });
 });

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -17,6 +17,7 @@ import { useKycBatchStatusesByAppRef, useKycConfig } from "@/hooks/useKycStatus"
 import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import type { IApplicationFilters } from "@/services/fundingPlatformService";
+import { useProgramPrompts } from "@/src/features/prompt-management";
 import type { IFundingApplication } from "@/types/funding-platform";
 import formatCurrency from "@/utilities/formatCurrency";
 import { getAIColumnVisibility } from "../helper/getAIColumnVisibility";
@@ -105,8 +106,9 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
 
   const { exportApplications, isExporting } = useApplicationExport(programId, isAdmin);
 
-  // Fetch program config to determine AI column visibility
+  // Fetch program config and prompts to determine AI column visibility
   const { config } = useProgramConfig(programId);
+  const { data: promptsData } = useProgramPrompts(programId);
 
   // Fetch reviewers for the program
   const {
@@ -120,10 +122,10 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     isError: isMilestoneReviewersError,
   } = useMilestoneReviewers(programId);
 
-  // Determine column visibility based on configured prompts
+  // Determine column visibility based on config, prompts, or application data
   const { showAIScoreColumn, showInternalAIScoreColumn } = useMemo(
-    () => getAIColumnVisibility(config?.formSchema),
-    [config?.formSchema]
+    () => getAIColumnVisibility(config?.formSchema, promptsData, applications),
+    [config?.formSchema, promptsData, applications]
   );
 
   // KYC: Collect unique reference numbers from loaded applications

--- a/components/FundingPlatform/helper/getAIColumnVisibility.ts
+++ b/components/FundingPlatform/helper/getAIColumnVisibility.ts
@@ -1,3 +1,8 @@
+import type { IFundingApplication } from "@/types/funding-platform";
+import type { ProgramPromptsResponse } from "@/src/features/prompt-management/types/program-prompt";
+import { getAIScore } from "./getAIScore";
+import { getInternalAIScore } from "./getInternalAIScore";
+
 /**
  * Type for form schema with AI configuration
  */
@@ -9,19 +14,51 @@ type FormSchemaWithAiConfig = {
 };
 
 /**
- * Determines AI column visibility based on configured prompts
+ * Determines AI column visibility based on three sources (checked in order):
+ *
+ * 1. Legacy config: formSchema.aiConfig.langfusePromptId is set
+ * 2. New prompt system: program_prompts collection has an external/internal prompt
+ * 3. Application data: any application has a parseable AI evaluation score
+ *
  * @param formSchema - The form schema from program config (may have aiConfig)
+ * @param promptsData - The program prompts from the new prompt management system
+ * @param applications - The list of funding applications to check for scores
  * @returns Object with column visibility flags
  */
-export function getAIColumnVisibility(formSchema: unknown): {
+export function getAIColumnVisibility(
+  formSchema: unknown,
+  promptsData?: ProgramPromptsResponse | null,
+  applications?: IFundingApplication[]
+): {
   showAIScoreColumn: boolean;
   showInternalAIScoreColumn: boolean;
 } {
   const formSchemaWithAiConfig = formSchema as FormSchemaWithAiConfig | undefined;
   const aiConfig = formSchemaWithAiConfig?.aiConfig;
 
+  // 1. Legacy config check
+  const hasLegacyExternalPrompt = !!aiConfig?.langfusePromptId;
+  const hasLegacyInternalPrompt = !!aiConfig?.internalLangfusePromptId;
+
+  // 2. New prompt system check
+  const hasNewExternalPrompt = !!promptsData?.external;
+  const hasNewInternalPrompt = !!promptsData?.internal;
+
+  // 3. Application data check (only if neither config source matched)
+  const hasApplicationWithAIScore =
+    !hasLegacyExternalPrompt &&
+    !hasNewExternalPrompt &&
+    !!applications?.some((app) => getAIScore(app) !== null);
+
+  const hasApplicationWithInternalAIScore =
+    !hasLegacyInternalPrompt &&
+    !hasNewInternalPrompt &&
+    !!applications?.some((app) => getInternalAIScore(app) !== null);
+
   return {
-    showAIScoreColumn: !!aiConfig?.langfusePromptId,
-    showInternalAIScoreColumn: !!aiConfig?.internalLangfusePromptId,
+    showAIScoreColumn:
+      hasLegacyExternalPrompt || hasNewExternalPrompt || hasApplicationWithAIScore,
+    showInternalAIScoreColumn:
+      hasLegacyInternalPrompt || hasNewInternalPrompt || hasApplicationWithInternalAIScore,
   };
 }


### PR DESCRIPTION
## Summary
- The AI Score column visibility only checked the legacy `formSchema.aiConfig.langfusePromptId` field, which is not populated by the new prompt management system (`program_prompts` collection)
- Updated `getAIColumnVisibility` to check three sources in priority order: legacy config, new prompt system (`/prompts` endpoint), and application data fallback (any app has a parseable AI score)
- Added `useProgramPrompts` hook to `ApplicationListWithAPI` to fetch prompt data for the visibility check

## Test plan
- [x] All 26 unit tests pass for `getAIColumnVisibility`
- [x] All 99 AI-related tests pass (getAIScore, getAIScoreBase, getInternalAIScore, getAIColumnVisibility)
- [ ] Verify on program 1045 (Optimism) that AI Score column now appears when prompts are configured via new system
- [ ] Verify on program 959 (Optimism) that AI Score column still works with legacy config
- [ ] Verify programs with no AI config still hide the column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI column visibility now determines appearance based on multiple data sources: legacy configuration, program prompts, and application scoring data.

* **Tests**
  * Extended test coverage for AI column visibility across various configuration scenarios and data combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->