### PR TITLE
fix: make AI score field matching case-insensitive

### DIFF
--- a/__tests__/integration/components/FundingPlatform/helper/getAIScore.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIScore.test.ts
@@ -151,7 +151,7 @@ describe("getAIScore", () => {
 
     it("should handle JSON with wrong field name", () => {
       const application = createMockApplication({
-        evaluation: JSON.stringify({ score: 4.5 }), // Wrong field name
+        evaluation: JSON.stringify({ rating: 4.5 }), // Wrong field name
         promptId: "test-prompt",
       });
 
@@ -159,7 +159,7 @@ describe("getAIScore", () => {
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining("aiEvaluation evaluation missing valid score field"),
-        { score: 4.5 }
+        { rating: 4.5 }
       );
     });
   });

--- a/__tests__/integration/components/FundingPlatform/helper/getAIScoreBase.test.ts
+++ b/__tests__/integration/components/FundingPlatform/helper/getAIScoreBase.test.ts
@@ -178,7 +178,7 @@ describe("getAIScoreBase", () => {
 
     it("should handle JSON with wrong field name", () => {
       const application = createMockApplication({
-        evaluation: JSON.stringify({ score: 4.5 }), // Wrong field name
+        evaluation: JSON.stringify({ rating: 4.5 }), // Wrong field name
         promptId: "test-prompt",
       });
 
@@ -186,7 +186,7 @@ describe("getAIScoreBase", () => {
       expect(score).toBeNull();
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining("aiEvaluation evaluation missing valid score field"),
-        { score: 4.5 }
+        { rating: 4.5 }
       );
     });
   });

--- a/components/FundingPlatform/helper/getAIScoreBase.ts
+++ b/components/FundingPlatform/helper/getAIScoreBase.ts
@@ -6,14 +6,16 @@ import type { IFundingApplication } from "@/types/funding-platform";
 export type EvaluationSource = "aiEvaluation" | "internalAIEvaluation";
 
 /**
- * Supported score field names in evaluation objects
+ * Supported score field names in evaluation objects (lowercase for case-insensitive matching)
  * Different AI prompts may use different field names for the score
+ * e.g. "final_score", "Score", "total_score", "SCORE"
  */
-const SCORE_FIELDS = ["final_score", "total_score"] as const;
+const SCORE_FIELDS = ["final_score", "total_score", "score"] as const;
 
 /**
- * Extracts score from evaluation object, checking multiple possible field names
- * @returns The score value and field name, or null if no valid score found
+ * Extracts score from evaluation object, checking multiple possible field names.
+ * Matching is case-insensitive to handle varied AI prompt output formats.
+ * @returns The score value and matched field name, or null if no valid score found
  */
 function extractScore(evaluation: unknown): { score: number; field: string } | null {
   if (evaluation === null || typeof evaluation !== "object") {
@@ -21,10 +23,12 @@ function extractScore(evaluation: unknown): { score: number; field: string } | n
   }
 
   const evalObj = evaluation as Record<string, unknown>;
+  const keys = Object.keys(evalObj);
 
-  for (const field of SCORE_FIELDS) {
-    if (field in evalObj && typeof evalObj[field] === "number" && !Number.isNaN(evalObj[field])) {
-      return { score: evalObj[field] as number, field };
+  for (const targetField of SCORE_FIELDS) {
+    const matchedKey = keys.find((k) => k.toLowerCase() === targetField);
+    if (matchedKey && typeof evalObj[matchedKey] === "number" && !Number.isNaN(evalObj[matchedKey])) {
+      return { score: evalObj[matchedKey] as number, field: matchedKey };
     }
   }
 


### PR DESCRIPTION
## Summary
- The score parser in `getAIScoreBase.ts` only checked for `final_score` and `total_score`, but AI prompts can output `Score` (capital S) or other casing variants
- Added `score` to recognized fields and made matching case-insensitive so any casing (`Score`, `SCORE`, `Final_Score`, etc.) is correctly parsed
- This is a follow-up to #1007 — without this fix, programs like 1045 where the AI returns `"Score": 4` instead of `"final_score": 4` would show the column but with empty cells

## Test plan
- [x] All 99 AI-related tests pass
- [ ] Verify program 1045 applications with `"Score"` field now display the value in the AI Score column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AI score field extraction to handle case-insensitive field names and varied naming conventions, improving compatibility with different AI model output formats.

* **Tests**
  * Updated test cases to validate the improved field matching behavior for AI score extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->