### PR TITLE
feat: expose open enrollment toggle in program settings tab

### DIFF
--- a/__tests__/services/programRegistry.service.test.ts
+++ b/__tests__/services/programRegistry.service.test.ts
@@ -84,15 +84,15 @@ describe("ProgramRegistryService", () => {
         type: "program",
         tags: ["karma-gap", "grant-program-registry"],
         communityRef: [mockCommunity.uid],
-        anyoneCanJoin: false,
+        anyoneCanJoin: true,
       });
     });
 
     describe("anyoneCanJoin option", () => {
-      it("should default anyoneCanJoin to false when no options provided", () => {
+      it("should default anyoneCanJoin to true when no options provided", () => {
         const metadata = ProgramRegistryService.buildProgramMetadata(mockFormData, mockCommunity);
 
-        expect(metadata.anyoneCanJoin).toBe(false);
+        expect(metadata.anyoneCanJoin).toBe(true);
       });
 
       it("should set anyoneCanJoin to false when explicitly passed as false", () => {
@@ -111,22 +111,22 @@ describe("ProgramRegistryService", () => {
         expect(metadata.anyoneCanJoin).toBe(true);
       });
 
-      it("should default anyoneCanJoin to false when options object is empty", () => {
+      it("should default anyoneCanJoin to true when options object is empty", () => {
         const metadata = ProgramRegistryService.buildProgramMetadata(
           mockFormData,
           mockCommunity,
           {}
         );
 
-        expect(metadata.anyoneCanJoin).toBe(false);
+        expect(metadata.anyoneCanJoin).toBe(true);
       });
 
-      it("should default anyoneCanJoin to false when options.anyoneCanJoin is undefined", () => {
+      it("should default anyoneCanJoin to true when options.anyoneCanJoin is undefined", () => {
         const metadata = ProgramRegistryService.buildProgramMetadata(mockFormData, mockCommunity, {
           anyoneCanJoin: undefined,
         });
 
-        expect(metadata.anyoneCanJoin).toBe(false);
+        expect(metadata.anyoneCanJoin).toBe(true);
       });
     });
 

--- a/components/FundingPlatform/CreateProgramModal.tsx
+++ b/components/FundingPlatform/CreateProgramModal.tsx
@@ -94,7 +94,7 @@ export function CreateProgramModal({
 
     setIsSubmitting(true);
     try {
-      // Build metadata using service (defaults to anyoneCanJoin: false for admin-created programs)
+      // Build metadata using service (defaults to anyoneCanJoin: true)
       const metadata = ProgramRegistryService.buildProgramMetadata(
         data as CreateProgramFormData,
         community

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -894,7 +894,7 @@ export function QuestionBuilder({
                 programId={programId}
                 readOnly={readOnly}
                 anyoneCanJoin={anyoneCanJoin}
-                onAnyoneCanJoinChange={readOnly ? undefined : updateEnrollment}
+                onAnyoneCanJoinChange={!readOnly && program ? updateEnrollment : undefined}
                 isEnrollmentPending={isEnrollmentPending}
               />
               {/* Save Button at bottom of Settings tab */}

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -40,8 +40,7 @@ import { ReviewerManagementTab } from "@/components/FundingPlatform/QuestionBuil
 import { SettingsSidebar, type SidebarTabKey } from "@/components/FundingPlatform/Sidebar";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
-import { ProgramRegistryService } from "@/services/programRegistry.service";
-import type { ProgramMetadata } from "@/types/program-registry";
+import { useUpdateProgramEnrollment } from "@/hooks/useFundingPlatform";
 import type { FormField, FormSchema } from "@/types/question-builder";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
 import { MarkdownPreview } from "../Utilities/MarkdownPreview";
@@ -138,17 +137,14 @@ export function QuestionBuilder({
     }
   );
 
-  // Track anyoneCanJoin from program metadata
-  const [anyoneCanJoin, setAnyoneCanJoin] = useState<boolean>(
-    program?.metadata?.anyoneCanJoin ?? true
+  // Mutation for toggling open enrollment (anyoneCanJoin)
+  const { updateEnrollment, isPending: isEnrollmentPending } = useUpdateProgramEnrollment(
+    programId,
+    communityId,
+    program
   );
 
-  // Sync anyoneCanJoin when program data loads/changes
-  useEffect(() => {
-    if (program?.metadata?.anyoneCanJoin !== undefined) {
-      setAnyoneCanJoin(program.metadata.anyoneCanJoin);
-    }
-  }, [program?.metadata?.anyoneCanJoin]);
+  const anyoneCanJoin = program?.metadata?.anyoneCanJoin ?? true;
 
   const [activeTab, setActiveTab] = useState<SidebarTabKey>(() =>
     getValidTab(searchParams.get("tab"))
@@ -416,37 +412,6 @@ export function QuestionBuilder({
       onSave?.(updatedSchema);
     },
     [readOnly, schema, onSave]
-  );
-
-  // Handle anyoneCanJoin toggle - updates program metadata directly
-  const handleAnyoneCanJoinChange = useCallback(
-    async (value: boolean) => {
-      if (readOnly || !programId) return;
-
-      if (!program?.metadata) {
-        toast.error("Program data is not loaded. Please refresh and try again.");
-        return;
-      }
-
-      try {
-        setAnyoneCanJoin(value);
-        const updatedMetadata = {
-          ...program.metadata,
-          anyoneCanJoin: value,
-        } as ProgramMetadata;
-        await ProgramRegistryService.updateProgram(programId, updatedMetadata);
-        toast.success(`Open enrollment ${value ? "enabled" : "disabled"}`);
-      } catch (error) {
-        // Revert on failure
-        setAnyoneCanJoin(!value);
-        errorManager("Failed to update open enrollment setting", error, {
-          programId,
-          anyoneCanJoin: value,
-        });
-        toast.error("Failed to update enrollment setting. Please try again.");
-      }
-    },
-    [readOnly, programId, program?.metadata]
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -929,7 +894,8 @@ export function QuestionBuilder({
                 programId={programId}
                 readOnly={readOnly}
                 anyoneCanJoin={anyoneCanJoin}
-                onAnyoneCanJoinChange={readOnly ? undefined : handleAnyoneCanJoinChange}
+                onAnyoneCanJoinChange={readOnly ? undefined : updateEnrollment}
+                isEnrollmentPending={isEnrollmentPending}
               />
               {/* Save Button at bottom of Settings tab */}
               {renderSaveButton()}

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -40,6 +40,8 @@ import { ReviewerManagementTab } from "@/components/FundingPlatform/QuestionBuil
 import { SettingsSidebar, type SidebarTabKey } from "@/components/FundingPlatform/Sidebar";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { ProgramRegistryService } from "@/services/programRegistry.service";
+import type { ProgramMetadata } from "@/types/program-registry";
 import type { FormField, FormSchema } from "@/types/question-builder";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
 import { MarkdownPreview } from "../Utilities/MarkdownPreview";
@@ -135,6 +137,18 @@ export function QuestionBuilder({
       },
     }
   );
+
+  // Track anyoneCanJoin from program metadata
+  const [anyoneCanJoin, setAnyoneCanJoin] = useState<boolean>(
+    program?.metadata?.anyoneCanJoin ?? true
+  );
+
+  // Sync anyoneCanJoin when program data loads/changes
+  useEffect(() => {
+    if (program?.metadata?.anyoneCanJoin !== undefined) {
+      setAnyoneCanJoin(program.metadata.anyoneCanJoin);
+    }
+  }, [program?.metadata?.anyoneCanJoin]);
 
   const [activeTab, setActiveTab] = useState<SidebarTabKey>(() =>
     getValidTab(searchParams.get("tab"))
@@ -402,6 +416,37 @@ export function QuestionBuilder({
       onSave?.(updatedSchema);
     },
     [readOnly, schema, onSave]
+  );
+
+  // Handle anyoneCanJoin toggle - updates program metadata directly
+  const handleAnyoneCanJoinChange = useCallback(
+    async (value: boolean) => {
+      if (readOnly || !programId) return;
+
+      if (!program?.metadata) {
+        toast.error("Program data is not loaded. Please refresh and try again.");
+        return;
+      }
+
+      try {
+        setAnyoneCanJoin(value);
+        const updatedMetadata = {
+          ...program.metadata,
+          anyoneCanJoin: value,
+        } as ProgramMetadata;
+        await ProgramRegistryService.updateProgram(programId, updatedMetadata);
+        toast.success(`Open enrollment ${value ? "enabled" : "disabled"}`);
+      } catch (error) {
+        // Revert on failure
+        setAnyoneCanJoin(!value);
+        errorManager("Failed to update open enrollment setting", error, {
+          programId,
+          anyoneCanJoin: value,
+        });
+        toast.error("Failed to update enrollment setting. Please try again.");
+      }
+    },
+    [readOnly, programId, program?.metadata]
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -883,6 +928,8 @@ export function QuestionBuilder({
                 schema={currentSchema}
                 programId={programId}
                 readOnly={readOnly}
+                anyoneCanJoin={anyoneCanJoin}
+                onAnyoneCanJoinChange={readOnly ? undefined : handleAnyoneCanJoinChange}
               />
               {/* Save Button at bottom of Settings tab */}
               {renderSaveButton()}

--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -29,6 +29,10 @@ interface SettingsConfigurationProps {
   className?: string;
   programId?: string;
   readOnly?: boolean;
+  /** Current value of anyoneCanJoin from program metadata */
+  anyoneCanJoin?: boolean;
+  /** Callback to update anyoneCanJoin in program metadata */
+  onAnyoneCanJoinChange?: (value: boolean) => void;
 }
 
 // Convert local datetime-local value to UTC ISO string
@@ -57,6 +61,8 @@ export function SettingsConfiguration({
   className = "",
   programId,
   readOnly = false,
+  anyoneCanJoin,
+  onAnyoneCanJoinChange,
 }: SettingsConfigurationProps) {
   const { communityId } = useParams() as { communityId: string };
   const [copied, setCopied] = useState(false);
@@ -205,6 +211,30 @@ export function SettingsConfiguration({
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                       Enable this if this program is a donation round where users can contribute
                       funds.
+                    </p>
+                  </div>
+                </div>
+
+                {/* Open Enrollment */}
+                <div className="flex items-start space-x-3">
+                  <input
+                    type="checkbox"
+                    id="anyoneCanJoin"
+                    checked={anyoneCanJoin ?? true}
+                    onChange={(e) => onAnyoneCanJoinChange?.(e.target.checked)}
+                    disabled={readOnly || !onAnyoneCanJoinChange}
+                    className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+                  />
+                  <div className="flex-1">
+                    <label
+                      htmlFor="anyoneCanJoin"
+                      className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Open Enrollment
+                    </label>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      Any project can self attest their participation in this program. When
+                      disabled, projects must contact the program manager to join.
                     </p>
                   </div>
                 </div>

--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -33,6 +33,8 @@ interface SettingsConfigurationProps {
   anyoneCanJoin?: boolean;
   /** Callback to update anyoneCanJoin in program metadata */
   onAnyoneCanJoinChange?: (value: boolean) => void;
+  /** Whether an enrollment update is in flight */
+  isEnrollmentPending?: boolean;
 }
 
 // Convert local datetime-local value to UTC ISO string
@@ -63,6 +65,7 @@ export function SettingsConfiguration({
   readOnly = false,
   anyoneCanJoin,
   onAnyoneCanJoinChange,
+  isEnrollmentPending = false,
 }: SettingsConfigurationProps) {
   const { communityId } = useParams() as { communityId: string };
   const [copied, setCopied] = useState(false);
@@ -222,8 +225,8 @@ export function SettingsConfiguration({
                     id="anyoneCanJoin"
                     checked={anyoneCanJoin ?? true}
                     onChange={(e) => onAnyoneCanJoinChange?.(e.target.checked)}
-                    disabled={readOnly || !onAnyoneCanJoinChange}
-                    className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+                    disabled={readOnly || !onAnyoneCanJoinChange || isEnrollmentPending}
+                    className={`mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${readOnly || !onAnyoneCanJoinChange || isEnrollmentPending ? "opacity-50 cursor-not-allowed" : ""}`}
                   />
                   <div className="flex-1">
                     <label

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -21,6 +21,7 @@ import type {
   IFundingApplication,
   IFundingProgramConfig,
 } from "@/types/funding-platform";
+import type { ProgramMetadata } from "@/types/program-registry";
 import { useAuth } from "./useAuth";
 
 // Query keys for caching
@@ -118,7 +119,7 @@ export const useUpdateProgramEnrollment = (
         ...program.metadata,
         anyoneCanJoin,
       };
-      await ProgramRegistryService.updateProgram(programId, updatedMetadata as any);
+      await ProgramRegistryService.updateProgram(programId, updatedMetadata as ProgramMetadata);
       return anyoneCanJoin;
     },
     onMutate: async (anyoneCanJoin: boolean) => {

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -5,10 +5,12 @@ import { errorManager } from "@/components/Utilities/errorManager";
 import { applicationCommentsService } from "@/services/application-comments.service";
 import { deleteApplication } from "@/services/funding-applications";
 import {
+  type FundingProgram,
   fundingApplicationsAPI,
   fundingPlatformService,
   type IApplicationFilters,
 } from "@/services/fundingPlatformService";
+import { ProgramRegistryService } from "@/services/programRegistry.service";
 import type {
   ExportFormat,
   FundingApplicationStatusV2,
@@ -92,6 +94,69 @@ export const useFundingPrograms = (communityId: string) => {
     refetch: () => {
       programsQuery.refetch();
     },
+  };
+};
+
+/**
+ * Hook for toggling anyoneCanJoin (open enrollment) on a program.
+ * Uses optimistic updates with rollback on failure and invalidates
+ * the programs cache on settle.
+ */
+export const useUpdateProgramEnrollment = (
+  programId: string,
+  communityId: string,
+  program: { metadata: Record<string, any> } | null | undefined
+) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (anyoneCanJoin: boolean) => {
+      if (!program?.metadata) {
+        throw new Error("Program data is not loaded");
+      }
+      const updatedMetadata = {
+        ...program.metadata,
+        anyoneCanJoin,
+      };
+      await ProgramRegistryService.updateProgram(programId, updatedMetadata as any);
+      return anyoneCanJoin;
+    },
+    onMutate: async (anyoneCanJoin: boolean) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.programs(communityId) });
+
+      const previous = queryClient.getQueryData<FundingProgram[]>(QUERY_KEYS.programs(communityId));
+
+      if (previous) {
+        queryClient.setQueryData<FundingProgram[]>(
+          QUERY_KEYS.programs(communityId),
+          previous.map((p) =>
+            p.programId === programId ? { ...p, metadata: { ...p.metadata, anyoneCanJoin } } : p
+          )
+        );
+      }
+
+      return { previous };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(QUERY_KEYS.programs(communityId), context.previous);
+      }
+      errorManager("Failed to update open enrollment setting", error, {
+        programId,
+      });
+      toast.error("Failed to update enrollment setting. Please try again.");
+    },
+    onSuccess: (_data, anyoneCanJoin) => {
+      toast.success(`Open enrollment ${anyoneCanJoin ? "enabled" : "disabled"}`);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.programs(communityId) });
+    },
+  });
+
+  return {
+    updateEnrollment: mutation.mutate,
+    isPending: mutation.isPending,
   };
 };
 

--- a/services/programRegistry.service.ts
+++ b/services/programRegistry.service.ts
@@ -15,9 +15,8 @@ import { INDEXER } from "@/utilities/indexer";
 export class ProgramRegistryService {
   /**
    * Build program metadata from form data and community.
-   * Default: anyoneCanJoin = false (admin/funding-platform form creates restricted programs).
-   * The public AddProgram form uses inline metadata with anyoneCanJoin = true (open enrollment).
-   * See AddProgram.tsx for the divergent default.
+   * Default: anyoneCanJoin = true (open enrollment).
+   * Both admin (CreateProgramModal) and public (AddProgram) forms now explicitly pass the value.
    */
   static buildProgramMetadata(
     formData: CreateProgramFormData,
@@ -59,7 +58,7 @@ export class ProgramRegistryService {
       type: "program",
       tags: ["karma-gap", "grant-program-registry"],
       communityRef: [community.uid], // Use community UID (hex address), not slug
-      anyoneCanJoin: options?.anyoneCanJoin ?? false, // Default to restricted for admin-created programs
+      anyoneCanJoin: options?.anyoneCanJoin ?? true, // Default to open enrollment
     };
   }
 


### PR DESCRIPTION
## Summary

- Moved the `anyoneCanJoin` program setting from a hidden default to a visible **Open Enrollment** checkbox in the question-builder Settings tab (Application Settings section)
- Changed the default from `false` to `true` so new programs use open enrollment by default
- The toggle saves immediately to program metadata via optimistic UI with rollback on API failure

## Changes

- **`SettingsConfiguration.tsx`** — Added Open Enrollment checkbox under Application Settings, consistent with existing checkbox patterns (e.g., Donation Round)
- **`QuestionBuilder.tsx`** — Added state tracking, async sync via `useEffect`, and `handleAnyoneCanJoinChange` handler with optimistic update + error revert + null-metadata guard
- **`programRegistry.service.ts`** — Changed `anyoneCanJoin` default from `false` to `true`, updated JSDoc
- **`CreateProgramModal.tsx`** — Updated comment to reflect new default
- **`programRegistry.service.test.ts`** — Updated 4 test expectations to match new `true` default

## Test plan

- [ ] Navigate to a program's question-builder Settings tab and verify the Open Enrollment checkbox appears under Application Settings
- [ ] Toggle the checkbox and verify success toast appears
- [ ] Refresh the page and verify the checkbox reflects the saved state
- [ ] Verify the checkbox is disabled for read-only (reviewer) users
- [ ] Create a new program and verify it defaults to open enrollment
- [ ] Verify `pnpm test` passes (22/22 programRegistry tests green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open Enrollment toggle added to Application Settings so admins can enable/disable public registrations.
  * Enrollment update capability with optimistic UI, pending state, and success/error feedback during saves.

* **Behavior Changes**
  * Programs now default to open enrollment (anyone can register) unless explicitly set otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213346989612812