### PR TITLE
fix: replace SDK docs with Swagger API docs in footer

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -96,10 +96,10 @@ describe("Footer", () => {
       expect(screen.getByText("Guide")).toBeInTheDocument();
     });
 
-    it("should render SDK Docs link", () => {
+    it("should render API Docs link", () => {
       render(<Footer />);
 
-      expect(screen.getByText("SDK Docs")).toBeInTheDocument();
+      expect(screen.getByText("API Docs")).toBeInTheDocument();
     });
 
     it("should render Governance link", () => {
@@ -364,7 +364,7 @@ describe("Footer", () => {
     it("should render all navigation links as clickable", () => {
       render(<Footer />);
 
-      const navLinks = ["For Builders", "For Funders", "Blog", "Guide", "SDK Docs", "Governance"];
+      const navLinks = ["For Builders", "For Funders", "Blog", "Guide", "API Docs", "Governance"];
 
       navLinks.forEach((linkText) => {
         const link = screen.getByText(linkText);

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -17,7 +17,7 @@ const navigationLinks = [
   { label: "For Funders", href: PAGES.FUNDERS },
   { label: "Blog", href: SOCIALS.PARAGRAPH },
   { label: "Guide", href: SOCIALS.DOCS },
-  { label: "SDK Docs", href: karmaLinks.githubSDK },
+  { label: "API Docs", href: karmaLinks.apiDocs },
   { label: "Governance", href: karmaLinks.website },
 ];
 

--- a/utilities/karma/karma.ts
+++ b/utilities/karma/karma.ts
@@ -3,7 +3,7 @@ import { envVars } from "../enviromentVars";
 export const karmaLinks = {
   website: "https://gov.karmahq.xyz",
   githubSDK: "https://github.com/show-karma/karma-gap-sdk",
-  apiDocs: "https://documenter.getpostman.com/view/36647319/2sAXxQdrkZ",
+  apiDocs: "https://gapapi.karmahq.xyz/v2/docs",
 };
 
 export const karmaAPI = {


### PR DESCRIPTION
Update the footer navigation link from "SDK Docs" (pointing to the GitHub SDK repo) to "API Docs" (pointing to the Swagger documentation at gapapi.karmahq.xyz/v2/docs). Update tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated footer navigation link from "SDK Docs" to "API Docs" with a new documentation endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->