### PR TITLE
fix: resolve permissions flash and harden manage route access control

### DIFF
--- a/app/community/[communityId]/manage/edit-categories/loading.tsx
+++ b/app/community/[communityId]/manage/edit-categories/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/edit-categories/loading.tsx
+++ b/app/community/[communityId]/manage/edit-categories/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/edit-projects/loading.tsx
+++ b/app/community/[communityId]/manage/edit-projects/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/edit-projects/loading.tsx
+++ b/app/community/[communityId]/manage/edit-projects/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/setup/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/setup/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/[programId]/setup/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/setup/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/funding-platform/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/funding-platform/loading.tsx
+++ b/app/community/[communityId]/manage/funding-platform/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/impact/loading.tsx
+++ b/app/community/[communityId]/manage/impact/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/impact/loading.tsx
+++ b/app/community/[communityId]/manage/impact/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/kyc-settings/loading.tsx
+++ b/app/community/[communityId]/manage/kyc-settings/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/kyc-settings/loading.tsx
+++ b/app/community/[communityId]/manage/kyc-settings/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/loading.tsx
+++ b/app/community/[communityId]/manage/loading.tsx
@@ -2,8 +2,11 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-screen h-full justify-center">
+    <output
+      aria-label="Loading"
+      className="flex w-full items-center min-h-screen h-full justify-center"
+    >
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/manage-indicators/loading.tsx
+++ b/app/community/[communityId]/manage/manage-indicators/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/manage-indicators/loading.tsx
+++ b/app/community/[communityId]/manage/manage-indicators/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/milestones-report/loading.tsx
+++ b/app/community/[communityId]/manage/milestones-report/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/Utilities/Skeleton";
 
 export default function Loading() {
   return (
-    <div className="space-y-6">
+    <output aria-label="Loading" className="block space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="space-y-2">
@@ -73,6 +73,6 @@ export default function Loading() {
           </div>
         </div>
       </div>
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/payouts/loading.tsx
+++ b/app/community/[communityId]/manage/payouts/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/payouts/loading.tsx
+++ b/app/community/[communityId]/manage/payouts/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/program-scores/loading.tsx
+++ b/app/community/[communityId]/manage/program-scores/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <output aria-label="Loading" className="flex items-center justify-center min-h-screen">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/tracks/loading.tsx
+++ b/app/community/[communityId]/manage/tracks/loading.tsx
@@ -2,8 +2,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 
 export default function Loading() {
   return (
-    <div className="flex w-full items-center min-h-[400px] justify-center">
+    <output aria-label="Loading" className="flex w-full items-center min-h-[400px] justify-center">
       <Spinner />
-    </div>
+    </output>
   );
 }

--- a/app/community/[communityId]/manage/tracks/loading.tsx
+++ b/app/community/[communityId]/manage/tracks/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <div className="flex w-full items-center min-h-[400px] justify-center">
+      <Spinner />
+    </div>
+  );
+}

--- a/components/Manage/DashboardOverview.tsx
+++ b/components/Manage/DashboardOverview.tsx
@@ -14,7 +14,6 @@ import { useParams } from "next/navigation";
 import { useMemo } from "react";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
-import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
@@ -143,15 +142,7 @@ function ProgramRow({
 
 export function DashboardOverview({ community }: { community: Community }) {
   const { communityId } = useParams() as { communityId: string };
-  const {
-    permissions,
-    isCommunityAdmin,
-    isProgramAdmin,
-    isLoading: permissionsLoading,
-  } = usePermissionContext();
   const slug = community?.details?.slug || communityId;
-
-  const hasAdminAccess = isCommunityAdmin || isProgramAdmin || permissions.length > 0;
 
   const {
     programs,
@@ -233,20 +224,10 @@ export function DashboardOverview({ community }: { community: Community }) {
     return items;
   }, [stats, programs, slug]);
 
-  if (permissionsLoading || programsLoading) {
+  if (programsLoading) {
     return (
       <div className="flex items-center justify-center min-h-[300px]">
         <Spinner />
-      </div>
-    );
-  }
-
-  if (!hasAdminAccess) {
-    return (
-      <div className="flex items-center justify-center min-h-[300px]">
-        <p className="text-sm text-gray-500 dark:text-gray-400">
-          You don&apos;t have permission to view this dashboard.
-        </p>
       </div>
     );
   }

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { useOwnerStore } from "@/store/owner";
 import { PAGES } from "@/utilities/pages";
 import { ManageBreadcrumbs } from "./ManageBreadcrumbs";
 import { ManageSidebar } from "./ManageSidebar";
@@ -17,12 +18,15 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
     isCommunityAdmin,
     isProgramAdmin,
     isReviewer,
+    isRegistryAdmin,
     isLoading: permissionsLoading,
   } = usePermissionContext();
+  const { isOwner, isOwnerLoading } = useOwnerStore();
 
-  const hasManageAccess = isCommunityAdmin || isProgramAdmin || isReviewer;
+  const hasManageAccess =
+    isCommunityAdmin || isProgramAdmin || isReviewer || isRegistryAdmin || isOwner;
 
-  if (isLoading || permissionsLoading) {
+  if (isLoading || permissionsLoading || isOwnerLoading) {
     return (
       <div className="flex w-full min-h-[60vh]">
         {/* Sidebar skeleton */}
@@ -46,6 +50,23 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
     );
   }
 
+  if (isError) {
+    return (
+      <div className="flex w-full min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <p className="text-gray-500 dark:text-gray-400 mb-2">Failed to load community data</p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   if (!hasManageAccess) {
     return (
       <div className="flex w-full min-h-[60vh] items-center justify-center">
@@ -60,23 +81,6 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
           >
             Go to Community
           </Link>
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="flex w-full min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <p className="text-gray-500 dark:text-gray-400 mb-2">Failed to load community data</p>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-          >
-            Retry
-          </button>
         </div>
       </div>
     );

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
+import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { PAGES } from "@/utilities/pages";
 import { ManageBreadcrumbs } from "./ManageBreadcrumbs";
 import { ManageSidebar } from "./ManageSidebar";
 
@@ -10,8 +13,16 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
   const params = useParams();
   const communityId = params.communityId as string;
   const { data: community, isLoading, isError } = useCommunityDetails(communityId);
+  const {
+    isCommunityAdmin,
+    isProgramAdmin,
+    isReviewer,
+    isLoading: permissionsLoading,
+  } = usePermissionContext();
 
-  if (isLoading) {
+  const hasManageAccess = isCommunityAdmin || isProgramAdmin || isReviewer;
+
+  if (isLoading || permissionsLoading) {
     return (
       <div className="flex w-full min-h-[60vh]">
         {/* Sidebar skeleton */}
@@ -30,6 +41,25 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
               <Skeleton key={i} className="h-24 w-full rounded-xl" />
             ))}
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasManageAccess) {
+    return (
+      <div className="flex w-full min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">Access Denied</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            You don&apos;t have permission to access this area.
+          </p>
+          <Link
+            href={PAGES.COMMUNITY.ALL_GRANTS(communityId)}
+            className="text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          >
+            Go to Community
+          </Link>
         </div>
       </div>
     );

--- a/components/Manage/ManageSidebar.tsx
+++ b/components/Manage/ManageSidebar.tsx
@@ -19,9 +19,20 @@ import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { Role } from "@/src/core/rbac/types";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
+
+const ROLE_LABELS: Partial<Record<Role, string>> = {
+  [Role.SUPER_ADMIN]: "Super Admin",
+  [Role.REGISTRY_ADMIN]: "Registry Admin",
+  [Role.COMMUNITY_ADMIN]: "Community Admin",
+  [Role.PROGRAM_ADMIN]: "Program Admin",
+  [Role.PROGRAM_CREATOR]: "Program Creator",
+  [Role.PROGRAM_REVIEWER]: "Reviewer",
+  [Role.MILESTONE_REVIEWER]: "Reviewer",
+};
 
 interface NavItem {
   href: (slug: string) => string;
@@ -108,6 +119,9 @@ const NAV_GROUPS: NavGroup[] = [
   },
 ];
 
+/** Sidebar items visible to reviewers (program + milestone reviewers). */
+const REVIEWER_SEGMENTS = new Set(["funding-platform", "milestones-report"]);
+
 function isActiveRoute(pathname: string, matchSegment: string, slug: string): boolean {
   const managePath = PAGES.ADMIN.ROOT(slug);
   const itemPath = `${managePath}/${matchSegment}`;
@@ -147,16 +161,25 @@ function useSidebarCounts(communityId: string) {
 
 export function ManageSidebar({ communityId, community }: ManageSidebarProps) {
   const pathname = usePathname();
-  const { permissions, isCommunityAdmin, isProgramAdmin, isLoading } = usePermissionContext();
+  const { roles, isCommunityAdmin, isProgramAdmin, isReviewer, isLoading } = usePermissionContext();
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const badgeCounts = useSidebarCounts(communityId);
 
   const slug = community?.details?.slug || communityId;
 
-  // Gate: user must have any admin-level access to see nav items.
-  // Once gated, show ALL items (no per-item filtering) — matches original behavior.
-  const hasAdminAccess = isCommunityAdmin || isProgramAdmin || permissions.length > 0;
-  const visibleGroups = isLoading || !hasAdminAccess ? [] : NAV_GROUPS;
+  const hasAdminAccess = isCommunityAdmin || isProgramAdmin;
+  const hasReviewerAccess = isReviewer;
+  const roleLabel = ROLE_LABELS[roles.primaryRole] ?? "";
+
+  const visibleGroups = useMemo(() => {
+    if (isLoading || (!hasAdminAccess && !hasReviewerAccess)) return [];
+    if (hasAdminAccess) return NAV_GROUPS;
+    // Reviewer-only: filter to allowed items
+    return NAV_GROUPS.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => REVIEWER_SEGMENTS.has(item.matchSegment)),
+    })).filter((group) => group.items.length > 0);
+  }, [isLoading, hasAdminAccess, hasReviewerAccess]);
 
   const sidebarContent = (
     <div className="flex flex-col h-full">
@@ -180,7 +203,7 @@ export function ManageSidebar({ communityId, community }: ManageSidebarProps) {
             <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
               {community?.details?.name || communityId}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Admin</p>
+            {roleLabel && <p className="text-xs text-gray-500 dark:text-gray-400">{roleLabel}</p>}
           </div>
         </div>
       </div>

--- a/hooks/communities/useCommunityAdminAccess.ts
+++ b/hooks/communities/useCommunityAdminAccess.ts
@@ -37,7 +37,7 @@ interface UseCommunityAdminAccessResult {
 export const useCommunityAdminAccess = (communityId?: string): UseCommunityAdminAccessResult => {
   const { isCommunityAdmin, isLoading: isCheckingAdmin } = useIsCommunityAdmin(communityId);
   const { isOwner, isOwnerLoading } = useOwnerStore();
-  const { authenticated } = useAuth();
+  const { authenticated, ready } = useAuth();
   const { data: permissions, isLoading: isPermissionsLoading } = usePermissionsQuery(
     {},
     { enabled: authenticated }
@@ -50,9 +50,13 @@ export const useCommunityAdminAccess = (communityId?: string): UseCommunityAdmin
     [isCommunityAdmin, isOwner, isSuperAdmin]
   );
 
+  // Auth-state-aware loading: when Privy hasn't initialized or the user is authenticated
+  // but queries haven't started yet (RQ v5 disabled queries return isLoading=false),
+  // we must report loading=true to prevent a flash of "Access Denied".
+  const isAuthSettling = !ready || (ready && authenticated && !permissions);
   const isLoading = useMemo(
-    () => isCheckingAdmin || isPermissionsLoading || isOwnerLoading,
-    [isCheckingAdmin, isPermissionsLoading, isOwnerLoading]
+    () => isAuthSettling || isCheckingAdmin || isPermissionsLoading || isOwnerLoading,
+    [isAuthSettling, isCheckingAdmin, isPermissionsLoading, isOwnerLoading]
   );
 
   const checks = useMemo(

--- a/hooks/useContractOwner.ts
+++ b/hooks/useContractOwner.ts
@@ -55,10 +55,14 @@ export const useContractOwner = (chainOverride?: Chain) => {
 
   const { data, isLoading, error, refetch } = queryResult;
 
-  // Sync with Zustand store
+  // Sync with Zustand store — only when auth is ready and the query is active.
+  // When auth isn't ready, the query is disabled and RQ v5 reports isLoading=false,
+  // which would overwrite the safe default of isOwnerLoading=true in the store.
   useEffect(() => {
-    setIsOwnerLoading(isLoading);
-  }, [isLoading, setIsOwnerLoading]);
+    if (isAuth) {
+      setIsOwnerLoading(isLoading);
+    }
+  }, [isLoading, isAuth, setIsOwnerLoading]);
 
   useEffect(() => {
     if (!isAuth) {

--- a/hooks/useContractOwner.ts
+++ b/hooks/useContractOwner.ts
@@ -67,6 +67,7 @@ export const useContractOwner = (chainOverride?: Chain) => {
   useEffect(() => {
     if (!isAuth) {
       setIsOwner(false);
+      setIsOwnerLoading(false);
       return;
     }
     if (typeof data === "boolean") {

--- a/src/core/rbac/__tests__/authorization.service.test.ts
+++ b/src/core/rbac/__tests__/authorization.service.test.ts
@@ -12,15 +12,18 @@ describe("authorizationService", () => {
   });
 
   describe("getPermissions", () => {
-    it("should return default GUEST permissions on error", async () => {
+    it("should throw on API error so React Query can retry", async () => {
       mockFetchData.mockResolvedValue([null, "Error", null, 500]);
 
-      const result = await authorizationService.getPermissions();
+      await expect(authorizationService.getPermissions()).rejects.toBe("Error");
+    });
 
-      expect(result.roles.primaryRole).toBe("GUEST");
-      expect(result.roles.roles).toContain("GUEST");
-      expect(result.permissions).toEqual([]);
-      expect(result.resourceContext).toEqual({});
+    it("should throw on empty response", async () => {
+      mockFetchData.mockResolvedValue([null, null, null, 200]);
+
+      await expect(authorizationService.getPermissions()).rejects.toThrow(
+        "Failed to fetch permissions: empty response"
+      );
     });
 
     it("should return parsed permissions from API response", async () => {

--- a/src/core/rbac/__tests__/permission-context.test.tsx
+++ b/src/core/rbac/__tests__/permission-context.test.tsx
@@ -42,6 +42,8 @@ describe("PermissionProvider", () => {
 
     mockUseAccount.mockReturnValue({
       isConnected: false,
+      isConnecting: false,
+      isReconnecting: false,
     });
 
     mockUsePermissionsQuery.mockReturnValue({
@@ -113,5 +115,116 @@ describe("PermissionProvider", () => {
     expect(mockUsePermissionsQuery).toHaveBeenCalledWith({}, { enabled: false });
     expect(result.current.isLoading).toBe(true);
     expect(result.current.isGuestDueToError).toBe(false);
+  });
+
+  describe("Wagmi initialization race condition", () => {
+    it("reports isLoading=true when Privy is ready+authenticated but Wagmi is still connecting", () => {
+      mockUsePrivy.mockReturnValue({
+        ready: true,
+        authenticated: true,
+      });
+
+      mockUseAccount.mockReturnValue({
+        isConnected: false,
+        isConnecting: true,
+        isReconnecting: false,
+      });
+
+      const { result } = renderHook(() => usePermissionContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isGuestDueToError).toBe(false);
+    });
+
+    it("reports isLoading=true when Privy is ready+authenticated but Wagmi is reconnecting", () => {
+      mockUsePrivy.mockReturnValue({
+        ready: true,
+        authenticated: true,
+      });
+
+      mockUseAccount.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isReconnecting: true,
+      });
+
+      const { result } = renderHook(() => usePermissionContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isGuestDueToError).toBe(false);
+    });
+
+    it("reports isLoading=false once Wagmi connects and permissions load", () => {
+      mockUsePrivy.mockReturnValue({
+        ready: true,
+        authenticated: true,
+      });
+
+      mockUseAccount.mockReturnValue({
+        isConnected: true,
+        isConnecting: false,
+        isReconnecting: false,
+      });
+
+      mockUsePermissionsQuery.mockReturnValue({
+        data: {
+          roles: {
+            primaryRole: Role.COMMUNITY_ADMIN,
+            roles: [Role.COMMUNITY_ADMIN],
+            reviewerTypes: [],
+          },
+          permissions: [Permission.PROGRAM_VIEW],
+          resourceContext: {},
+          isCommunityAdmin: true,
+          isProgramAdmin: false,
+          isReviewer: false,
+          isRegistryAdmin: false,
+          isProgramCreator: false,
+        },
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => usePermissionContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isCommunityAdmin).toBe(true);
+    });
+
+    it("reports isLoading=true when Privy is authenticated but Wagmi hasn't started yet", () => {
+      mockUsePrivy.mockReturnValue({
+        ready: true,
+        authenticated: true,
+      });
+
+      mockUseAccount.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isReconnecting: false,
+      });
+
+      const { result } = renderHook(() => usePermissionContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isGuestDueToError).toBe(false);
+    });
+
+    it("does not report loading for genuinely unauthenticated users", () => {
+      mockUsePrivy.mockReturnValue({
+        ready: true,
+        authenticated: false,
+      });
+
+      mockUseAccount.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isReconnecting: false,
+      });
+
+      const { result } = renderHook(() => usePermissionContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.roles.primaryRole).toBe(Role.GUEST);
+    });
   });
 });

--- a/src/core/rbac/context/permission-context.tsx
+++ b/src/core/rbac/context/permission-context.tsx
@@ -29,8 +29,8 @@ const defaultResourceContext: ResourceContext = {};
 const defaultContextValue: PermissionContextValue = {
   roles: defaultUserRoles,
   permissions: [],
-  isLoading: false,
-  isGuestDueToError: true,
+  isLoading: true,
+  isGuestDueToError: false,
   resourceContext: defaultResourceContext,
   isCommunityAdmin: false,
   isProgramAdmin: false,
@@ -69,7 +69,14 @@ export function PermissionProvider({ children, resourceContext = {} }: Permissio
     const permissions = data?.permissions ?? [];
     const context = data?.resourceContext ?? defaultResourceContext;
 
-    const effectiveIsLoading = (isCypressMockAuthenticated ? false : !ready) || isLoading;
+    // Keep loading while Privy initializes
+    const privyNotReady = isCypressMockAuthenticated ? false : !ready;
+    // If we believe the user is authenticated (Privy says so) but we don't
+    // have permission data yet, stay in loading state. This covers ALL race
+    // conditions: Wagmi not connected yet, query disabled, query in-flight, etc.
+    const believedAuthenticated = isCypressMockAuthenticated || (ready && authenticated);
+    const awaitingPermissions = believedAuthenticated && !data && !isError;
+    const effectiveIsLoading = privyNotReady || awaitingPermissions || isLoading;
     const isGuestDueToError = isError || (!effectiveIsLoading && isAuthenticated && !data);
 
     return {
@@ -91,7 +98,7 @@ export function PermissionProvider({ children, resourceContext = {} }: Permissio
         isValidRole(role) && isRoleAtLeast(roles.primaryRole, role),
       isReviewerType: (type: ReviewerType) => roles.reviewerTypes?.includes(type) ?? false,
     };
-  }, [data, isLoading, isError, ready, isAuthenticated, isCypressMockAuthenticated]);
+  }, [data, isLoading, isError, ready, authenticated, isAuthenticated, isCypressMockAuthenticated]);
 
   return <PermissionContext.Provider value={contextValue}>{children}</PermissionContext.Provider>;
 }

--- a/src/core/rbac/hooks/use-permissions.ts
+++ b/src/core/rbac/hooks/use-permissions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { authorizationService, type GetPermissionsParams } from "../services/authorization.service";
 
 export const permissionsKeys = {
@@ -35,6 +35,9 @@ export function usePermissionsQuery(
     staleTime: 5 * 60 * 1000, // 5 minutes - permissions don't change frequently
     gcTime: 10 * 60 * 1000, // 10 minutes garbage collection
     refetchOnWindowFocus: false, // Avoid excessive refetches on tab switch
+    // Keep previous permissions visible while fetching new context (e.g., navigating
+    // between programs). Prevents flash of "Access Denied" during query key transitions.
+    placeholderData: keepPreviousData,
     // Avoid retry storms on rate limiting; retry other transient failures up to 2 times.
     retry: (failureCount, error) => !isRateLimitError(error) && failureCount < 2,
     enabled, // Only fetch when user is authenticated

--- a/src/core/rbac/services/authorization.service.ts
+++ b/src/core/rbac/services/authorization.service.ts
@@ -54,13 +54,14 @@ export const authorizationService = {
     );
 
     if (error || !response) {
-      if (error) {
-        errorManager("Failed to fetch user permissions", error, {
-          context: "authorization.service.getPermissions",
-          params,
-        });
-      }
-      return DEFAULT_GUEST_PERMISSIONS;
+      errorManager("Failed to fetch user permissions", error || new Error("Empty response"), {
+        context: "authorization.service.getPermissions",
+        params,
+      });
+      // Throw so React Query retries (up to 2x) and keeps isLoading=true during retries.
+      // Previously returned DEFAULT_GUEST_PERMISSIONS, which React Query cached as "success"
+      // for 5 minutes — causing persistent "Access Denied" even after the API recovered.
+      throw error || new Error("Failed to fetch permissions: empty response");
     }
 
     const primaryRole = isValidRole(response.roles.primaryRole)

--- a/store/owner.ts
+++ b/store/owner.ts
@@ -10,6 +10,8 @@ interface OwnerStore {
 export const useOwnerStore = create<OwnerStore>((set, _get) => ({
   isOwner: false,
   setIsOwner: (isOwner: boolean) => set({ isOwner }),
-  isOwnerLoading: false,
+  // Default to true: prevents flash of "not authorized" before useContractOwner
+  // completes its first check. The hook sets this to false once loading finishes.
+  isOwnerLoading: true,
   setIsOwnerLoading: (isOwnerLoading: boolean) => set({ isOwnerLoading }),
 }));


### PR DESCRIPTION
## Summary

- Fix "Access Denied" flash on manage pages caused by Privy/Wagmi initialization race conditions
- Add route-level permission gate in `ManageLayoutShell` to protect all manage routes uniformly
- Remove broken `permissions.length > 0` access check (guests have permissions too)
- Show actual RBAC role label in sidebar instead of hardcoded "Admin"
- Add Suspense loading boundaries for all manage sub-routes

## Problem

Multiple independent issues caused permission flashes and guest access leaks:

1. **Wagmi initialization gap**: Privy reports `authenticated=true` before Wagmi connects. During this gap, the permissions query is disabled (RQ v5 returns `isLoading=false`), causing a render where all role flags are `false` → brief "Access Denied" flash
2. **No route-level guard**: Each manage page handled its own permission check (inconsistently), so some pages had no access control at all
3. **Broken access gate**: `permissions.length > 0` was used to gate access, but guests have 4 default permissions (PROGRAM_VIEW, APPLICATION_READ, etc.), so this check passes for everyone
4. **Error swallowing**: `authorization.service` returned guest defaults on API error, which React Query cached as "success" for 5 minutes

## Solution

**Permission loading** — replaced fragile Wagmi flag checks (`isConnecting || isReconnecting`) with a simple, robust rule: if Privy says the user is authenticated but we don't have permission data yet, stay in loading state. This covers all race conditions in one check.

**Route-level guard** — `ManageLayoutShell` now checks permissions before rendering any children. Shows skeleton while loading, "Access Denied" for unauthorized users. Individual page-level checks are no longer needed.

**Sidebar role mapping** — uses `roles.primaryRole` from RBAC context with a `ROLE_LABELS` map to display the correct role (Super Admin, Community Admin, Reviewer, etc.).

## Changed files

| File | Change |
|------|--------|
| `permission-context.tsx` | Replace Wagmi flag checks with `awaitingPermissions` pattern; default `isLoading: true` |
| `ManageLayoutShell.tsx` | Add route-level permission gate (skeleton → Access Denied → content) |
| `ManageSidebar.tsx` | Role label from RBAC, reviewer nav filtering, remove `permissions.length > 0` |
| `DashboardOverview.tsx` | Remove redundant permission check (shell handles it now) |
| `useCommunityAdminAccess.ts` | Add `isAuthSettling` for same race condition |
| `useContractOwner.ts` | Guard Zustand sync when auth not ready |
| `authorization.service.ts` | Throw on error instead of returning guest defaults |
| `use-permissions.ts` | Add `keepPreviousData` for smoother context transitions |
| `store/owner.ts` | Default `isOwnerLoading: true` |
| `permission-context.test.tsx` | Add regression tests for Wagmi race conditions |
| 14x `loading.tsx` | Suspense boundaries for all manage sub-routes |

## Test plan

- [ ] Navigate to `/community/optimism/manage` as admin — no "Access Denied" flash, see full dashboard
- [ ] Navigate as reviewer — see only Funding Platform and Milestones in sidebar, role shows "Reviewer"
- [ ] Navigate as guest (random wallet) — see "Access Denied" with link back to community
- [ ] Navigate to `/community/optimism/manage/funding-platform` directly as guest — blocked by shell
- [ ] Hard refresh manage page as admin — skeleton shows during load, no flash
- [ ] `npx jest --testPathPattern="permission-context"` — all 8 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent loading indicators across community management pages and flows.
  * Role labels shown in the community management header; reviewer users see a filtered set of nav items.

* **Bug Fixes**
  * Prevented brief "access denied" flashes during auth/permission transitions.
  * Improved permission data persistence while navigating and refined ownership/loading behavior.

* **Tests**
  * Expanded permission-related tests to cover authentication/load race conditions and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->