### PR TITLE
feat(projects): add raising funds filter and auto-scroll

### DIFF
--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -4,7 +4,7 @@ import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/24/solid";
 import debounce from "lodash.debounce";
 import { useQueryState } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Select,
   SelectContent,
@@ -29,6 +29,9 @@ const sortOptions: Record<ExplorerSortByOptions, string> = {
 };
 
 export const ProjectsExplorer = () => {
+  const sectionRef = useRef<HTMLElement>(null);
+  const hasScrolledRef = useRef(false);
+
   // URL state for search
   const [searchQuery, setSearchQuery] = useQueryState("q", {
     defaultValue: "",
@@ -48,6 +51,15 @@ export const ProjectsExplorer = () => {
     serialize: (value) => value,
     parse: (value) => (value as ExplorerSortOrder) || "desc",
   });
+
+  // URL state for "Raising funds" filter
+  const [hasPayoutAddress, setHasPayoutAddress] = useQueryState("hasPayoutAddress", {
+    defaultValue: "",
+    serialize: (value) => value || "",
+    parse: (value) => value || "",
+  });
+
+  const isRaisingFunds = hasPayoutAddress === "true";
 
   // Internal search state for debouncing
   const [inputValue, setInputValue] = useState(searchQuery || "");
@@ -73,11 +85,37 @@ export const ProjectsExplorer = () => {
     setInputValue(searchQuery || "");
   }, [searchQuery]);
 
+  // Auto-scroll to this section when navigating with filter params from the navbar
+  useEffect(() => {
+    if (hasScrolledRef.current) return;
+
+    const hasFilterParams =
+      selectedSort !== "updatedAt" || selectedSortOrder !== "desc" || isRaisingFunds;
+
+    if (hasFilterParams) {
+      hasScrolledRef.current = true;
+      // Small delay to let the section render
+      requestAnimationFrame(() => {
+        sectionRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      });
+    }
+  }, [selectedSort, selectedSortOrder, isRaisingFunds]);
+
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputValue(value);
     debouncedSetSearch(value);
   };
+
+  const toggleRaisingFunds = useCallback(() => {
+    setHasPayoutAddress(isRaisingFunds ? null : "true");
+    queryClient.removeQueries({
+      predicate: (query) => query.queryKey[0] === "projects-explorer-infinite",
+    });
+  }, [isRaisingFunds, setHasPayoutAddress]);
 
   // Infinite query
   const {
@@ -93,6 +131,7 @@ export const ProjectsExplorer = () => {
     search: searchQuery,
     sortBy: selectedSort as ExplorerSortByOptions,
     sortOrder: selectedSortOrder as ExplorerSortOrder,
+    hasPayoutAddress: isRaisingFunds || undefined,
   });
 
   // Handle sort change
@@ -109,7 +148,11 @@ export const ProjectsExplorer = () => {
   };
 
   return (
-    <section id="browse-projects" className="w-full max-w-7xl mx-auto px-4 py-8 mt-8">
+    <section
+      ref={sectionRef}
+      id="browse-projects"
+      className="w-full max-w-7xl mx-auto px-4 py-8 mt-8"
+    >
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <div>
@@ -135,6 +178,20 @@ export const ProjectsExplorer = () => {
               className="w-full sm:w-64 pl-10 pr-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
             />
           </div>
+
+          {/* Raising Funds Filter */}
+          <button
+            type="button"
+            onClick={toggleRaisingFunds}
+            aria-pressed={isRaisingFunds}
+            className={`px-4 py-2 rounded-md border text-sm font-medium transition-colors ${
+              isRaisingFunds
+                ? "bg-blue-600 text-white border-blue-600 hover:bg-blue-700"
+                : "bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border-gray-300 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700"
+            }`}
+          >
+            Raising funds
+          </button>
 
           {/* Sort Dropdown */}
           <div className="flex items-center gap-x-2">
@@ -196,7 +253,11 @@ export const ProjectsExplorer = () => {
         </div>
       ) : projects.length === 0 ? (
         <div className="text-center py-12 text-gray-500">
-          {searchQuery ? `No projects found for "${searchQuery}"` : "No projects available"}
+          {searchQuery
+            ? `No projects found for "${searchQuery}"`
+            : isRaisingFunds
+              ? "No projects raising funds at this time"
+              : "No projects available"}
         </div>
       ) : (
         <>

--- a/hooks/useProjectsExplorerInfinite.ts
+++ b/hooks/useProjectsExplorerInfinite.ts
@@ -13,6 +13,7 @@ interface UseProjectsExplorerInfiniteOptions {
   sortOrder?: ExplorerSortOrder;
   limit?: number;
   enabled?: boolean;
+  hasPayoutAddress?: boolean;
 }
 
 /**
@@ -44,10 +45,17 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
     sortOrder = "desc",
     limit = PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
     enabled = true,
+    hasPayoutAddress,
   } = options;
 
   const query = useInfiniteQuery<PaginatedProjectsResponse, Error>({
-    queryKey: QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ search, sortBy, sortOrder, limit }),
+    queryKey: QUERY_KEYS.PROJECT.EXPLORER_INFINITE({
+      search,
+      sortBy,
+      sortOrder,
+      limit,
+      hasPayoutAddress,
+    }),
     queryFn: async ({ pageParam = 1 }) => {
       return getExplorerProjectsPaginated({
         search,
@@ -56,6 +64,7 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
         sortBy,
         sortOrder,
         includeStats: true, // Always include stats for explorer cards
+        hasPayoutAddress,
       });
     },
     getNextPageParam: (lastPage) => {

--- a/services/projects-explorer.service.ts
+++ b/services/projects-explorer.service.ts
@@ -18,6 +18,8 @@ export interface ExplorerProjectsPaginatedParams {
   sortOrder?: ExplorerSortOrder;
   /** When true, includes stats for each project (grantsCount, grantMilestonesCount, roadmapItemsCount) */
   includeStats?: boolean;
+  /** When true, only returns projects that have at least one payout address configured */
+  hasPayoutAddress?: boolean;
 }
 
 /**
@@ -78,6 +80,7 @@ export const getExplorerProjectsPaginated = async (
     sortBy = "updatedAt",
     sortOrder = "desc",
     includeStats = false,
+    hasPayoutAddress,
   } = params;
 
   // Validate search length if provided
@@ -92,6 +95,7 @@ export const getExplorerProjectsPaginated = async (
     sortOrder,
     includeStats,
     excludeTestProjects: true, // Filter test projects on backend for accurate pagination
+    hasPayoutAddress,
   });
 
   const [data, error] = await fetchData<PaginatedProjectsResponse>(endpoint);

--- a/src/components/navbar/menu-items.tsx
+++ b/src/components/navbar/menu-items.tsx
@@ -1,9 +1,9 @@
 import {
   BanknoteArrowDown,
   BellDot,
-  Flame,
   GalleryThumbnails,
   GoalIcon,
+  HandCoins,
   LayoutGrid,
   LayoutList,
   LifeBuoy,
@@ -85,9 +85,9 @@ export const exploreItems: ExploreItems = {
       title: "All projects",
     },
     {
-      href: `${PAGES.PROJECTS_EXPLORER}?sortBy=noOfGrants&sortOrder=desc`,
-      icon: Flame,
-      title: "Most Grants",
+      href: `${PAGES.PROJECTS_EXPLORER}?hasPayoutAddress=true`,
+      icon: HandCoins,
+      title: "Raising funds",
     },
     {
       href: `${PAGES.PROJECTS_EXPLORER}?sortBy=noOfGrantMilestones&sortOrder=desc`,

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -94,6 +94,7 @@ export const INDEXER = {
         sortOrder?: "asc" | "desc";
         includeStats?: boolean;
         excludeTestProjects?: boolean;
+        hasPayoutAddress?: boolean;
       }) => {
         const queryParams = new URLSearchParams();
         if (params?.q) queryParams.set("q", params.q);
@@ -103,6 +104,7 @@ export const INDEXER = {
         if (params?.sortOrder) queryParams.set("sortOrder", params.sortOrder);
         if (params?.includeStats) queryParams.set("includeStats", "true");
         if (params?.excludeTestProjects) queryParams.set("excludeTestProjects", "true");
+        if (params?.hasPayoutAddress) queryParams.set("hasPayoutAddress", "true");
         const query = queryParams.toString();
         return `/v2/projects${query ? `?${query}` : ""}`;
       },

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -181,6 +181,7 @@ export const QUERY_KEYS = {
       sortBy?: string;
       sortOrder?: string;
       limit?: number;
+      hasPayoutAddress?: boolean;
     }) =>
       [
         "projects-explorer-infinite",
@@ -188,6 +189,7 @@ export const QUERY_KEYS = {
         params.sortBy || "updatedAt",
         params.sortOrder || "desc",
         params.limit ?? 50,
+        params.hasPayoutAddress ?? false,
       ] as const,
   },
   INDICATORS: {


### PR DESCRIPTION
## Summary

- Add "Raising funds" toggle filter on the Projects Explorer page that shows only projects with payout addresses
- Auto-scroll to the project list when navigating from the Explore menu with filter parameters
- Replace "Most Grants" nav menu item with "Raising funds" (HandCoins icon)

## Changes

- **ProjectsExplorer.tsx**: Add `hasPayoutAddress` URL state, "Raising funds" toggle button, auto-scroll via `useRef` + `scrollIntoView`, empty state message for raising funds filter
- **useProjectsExplorerInfinite.ts**: Thread `hasPayoutAddress` option through to service and query keys
- **projects-explorer.service.ts**: Add `hasPayoutAddress` parameter to API call
- **menu-items.tsx**: Replace "Most Grants" (Flame icon) with "Raising funds" (HandCoins icon), update href to `?hasPayoutAddress=true`
- **indexer.ts**: Add `hasPayoutAddress` query parameter to URL builder
- **queryKeys.ts**: Include `hasPayoutAddress` in cache key for proper query invalidation

## Dependencies

- Requires backend PR: gap-indexer `hasPayoutAddress` filter support

## Test plan

- [ ] Click "Raising funds" in Explore → Projects menu, verify page scrolls to project list
- [ ] Verify "Raising funds" filter button toggles on/off and filters projects correctly
- [ ] Verify filter state persists in URL (`?hasPayoutAddress=true`)
- [ ] Verify "Most Active" and other sort options still work with raising funds filter
- [ ] Verify search + raising funds filter combination works
- [ ] Verify empty state message when no projects are raising funds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Raising funds" filter to help discover projects actively seeking funding.
  * Replaced "Most Grants" navigation option with "Raising funds" for streamlined project discovery.
  * Implemented automatic scroll-to-filters when filters are applied.
  * Updated empty state messaging to reflect current fundraising filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->