### PR TITLE
fix: improve empty state CTA on manage and funding platform pages

### DIFF
--- a/app/community/[communityId]/manage/funding-platform/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/page.tsx
@@ -86,6 +86,14 @@ function FundingPlatformContent() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [togglingPrograms, setTogglingPrograms] = useState<Set<string>>(new Set());
 
+  // Auto-open create modal when navigated with ?create=true
+  const createParam = searchParams.get("create");
+  useEffect(() => {
+    if (createParam === "true" && isAdmin) {
+      setShowCreateModal(true);
+    }
+  }, [createParam, isAdmin]);
+
   const [searchTerm, setSearchTerm] = useState(searchParams.get("search") || "");
   const [enabledFilter, setEnabledFilter] = useState<"all" | "enabled" | "disabled">(
     (searchParams.get("status") as "all" | "enabled" | "disabled") || "all"
@@ -682,18 +690,13 @@ function FundingPlatformContent() {
         <div className="text-center py-12">
           <div className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-8">
             <PlusIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-              No Funding Programs Yet
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+              {isAdmin ? "Create your first program" : "No programs yet"}
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {isAdmin
-                ? "Create your first funding program to start accepting applications from your community."
-                : "There are no funding programs available in this community yet."}
-            </p>
             <AdminOnly>
               <Button onClick={() => setShowCreateModal(true)} className="inline-flex items-center">
                 <PlusIcon className="w-4 h-4 mr-2" />
-                Create Your First Program
+                Create your first program
               </Button>
             </AdminOnly>
           </div>
@@ -704,7 +707,19 @@ function FundingPlatformContent() {
       <AdminOnly>
         <CreateProgramModal
           isOpen={showCreateModal}
-          onClose={() => setShowCreateModal(false)}
+          onClose={() => {
+            setShowCreateModal(false);
+            if (searchParams.get("create")) {
+              const params = new URLSearchParams(searchParams.toString());
+              params.delete("create");
+              const queryString = params.toString();
+              router.replace(
+                queryString
+                  ? `${PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId)}?${queryString}`
+                  : PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId)
+              );
+            }
+          }}
           communityId={communityId}
           onSuccess={async () => {
             await refetch();

--- a/components/Manage/DashboardOverview.tsx
+++ b/components/Manage/DashboardOverview.tsx
@@ -346,18 +346,14 @@ export function DashboardOverview({ community }: { community: Community }) {
       {(!programs || programs.length === 0) && (
         <div className="text-center py-12 bg-white dark:bg-zinc-900 rounded-xl border border-gray-200 dark:border-zinc-700">
           <FolderOpenIcon className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-            No programs yet
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+            Create your first program
           </h3>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-            Create your first funding program to get started.
-          </p>
           <Link
-            href={PAGES.ADMIN.FUNDING_PLATFORM(slug)}
+            href={`${PAGES.ADMIN.FUNDING_PLATFORM(slug)}?create=true`}
             className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors"
           >
-            Go to Funding Platform
-            <ArrowRightIcon className="w-4 h-4" />
+            Create your first program
           </Link>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replace verbose empty state messaging with concise "Create your first program" heading and action button on both the dashboard overview and funding platform pages
- Dashboard overview button navigates to funding platform with `?create=true` to auto-open the create program modal
- Modal close handler cleans up the `create` query param to prevent unwanted reopens on page refresh
- Reviewers (non-admins) see a neutral "No programs yet" heading without the create button

## Test plan
- [ ] Navigate to `/community/{slug}/manage` with no programs — verify "Create your first program" heading and button appear
- [ ] Click the button — verify it navigates to funding platform and the create modal opens automatically
- [ ] Close the modal — verify `?create=true` is removed from the URL
- [ ] Refresh after closing — verify the modal does not reopen
- [ ] Navigate to `/community/{slug}/manage/funding-platform` with no programs as admin — verify "Create your first program" heading and button
- [ ] Access funding platform as a reviewer with no programs — verify "No programs yet" heading with no create button

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213380363621052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-opens the Create Program dialog for admins via link, with role-specific empty-state messaging and streamlined create CTA.

* **Bug Fixes / Improvements**
  * Prevents closing dialogs while create/submit/delete/transfer operations are in progress to avoid accidental interruptions.
  * Keeps progress-submission state synchronized so the UI reflects ongoing submissions and disables interactions until complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->