### PR TITLE
Rebrand product references from Karma GAP to Karma

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -4,7 +4,7 @@ This file provides specific guidance for working with the gap-app-v2 Next.js fro
 
 ## Project Overview
 
-gap-app-v2 is the main Next.js 15.3.3 frontend application for Karma GAP, built with:
+gap-app-v2 is the main Next.js 15.3.3 frontend application for Karma, built with:
 - React 19
 - TailwindCSS 3.x
 - shadcn/ui components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Purpose: give coding agents a concise, reliable operating guide for this reposit
 
 ## Project Context
 
-- `gap-app-v2` is the main frontend for GAP (Grantee Accountability Protocol).
+- `gap-app-v2` is the main frontend for Karma.
 - Core flows: programs create projects, manage milestones, and review community progress.
 - Web3 domain: EAS attestations, wallet interactions, and Privy-based authentication.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Route AI assistants to the correct code and patterns. Nothing else.
 
-**Project**: gap-app-v2 is the main frontend for the Grantee Accountability Protocol (GAP). It lets grant programs create projects, track milestones, and manage community reviews via EAS attestations on-chain. Part of a monorepo — see the parent repo's `CLAUDE.md` for cross-project guidance.
+**Project**: gap-app-v2 is the main frontend for Karma. It lets grant programs create projects, track milestones, and manage community reviews via EAS attestations on-chain. Part of a monorepo — see the parent repo's `CLAUDE.md` for cross-project guidance.
 
 ---
 

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 
 // Mock child components
 jest.mock("@/src/components/shared/logo", () => ({
-  Logo: () => <div data-testid="logo">Karma GAP</div>,
+  Logo: () => <div data-testid="logo">Karma</div>,
 }));
 
 jest.mock("@/src/components/footer/newsletter", () => ({

--- a/__tests__/navbar/integration/responsive-behavior.test.tsx
+++ b/__tests__/navbar/integration/responsive-behavior.test.tsx
@@ -563,7 +563,7 @@ describe("Responsive Behavior Integration Tests", () => {
         mockUsePrivy: createMockUsePrivy(authFixture.authState),
       });
 
-      // Logo should be present (Karma GAP or similar)
+      // Logo should be present (Karma or similar)
       // Logo is part of navbar structure
       const navElements = screen.getAllByRole("navigation");
       expect(navElements.length).toBeGreaterThan(0);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { defaultMetadata } from "@/utilities/meta";
 
 export const metadata = {
   ...defaultMetadata,
-  title: "Dashboard | Karma GAP",
+  title: "Dashboard | Karma",
 };
 
 export default function Page() {

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -10,7 +10,7 @@ import { customMetadata } from "@/utilities/meta";
 export const metadata = customMetadata({
   title: "Explore Projects",
   description:
-    "Thousands of projects utilize Karma GAP to track their grants, share project progress and build reputation. Explore projects making a difference.",
+    "Thousands of projects utilize Karma to track their grants, share project progress and build reputation. Explore projects making a difference.",
   path: "/projects",
 });
 

--- a/app/seeds/fund/page.tsx
+++ b/app/seeds/fund/page.tsx
@@ -7,7 +7,7 @@ import { SeedsHowItWorks } from "@/src/features/seeds/components/how-it-works";
 import { SeedsProjectsSection } from "@/src/features/seeds/components/projects-section";
 
 export const metadata: Metadata = {
-  title: "Fund Projects with Karma Seeds | Karma GAP",
+  title: "Fund Projects with Karma Seeds | Karma",
   description:
     "Support projects you believe in for just $1 per seed. Karma Seeds are ERC-20 tokens that give you on-chain proof of early backing.",
   keywords: [

--- a/app/seeds/page.tsx
+++ b/app/seeds/page.tsx
@@ -7,7 +7,7 @@ import { LaunchProblem } from "@/src/features/seeds/components/launch/launch-pro
 import { LaunchUseCases } from "@/src/features/seeds/components/launch/launch-use-cases";
 
 export const metadata: Metadata = {
-  title: "Karma Seeds - Raise Funds Without Launching a Token | Karma GAP",
+  title: "Karma Seeds - Raise Funds Without Launching a Token | Karma",
   description:
     "Raise funds from your community without launching a token. Karma Seeds let you build community and stay focused on building.",
   openGraph: {

--- a/components/Pages/Home/WhatIsSolving.tsx
+++ b/components/Pages/Home/WhatIsSolving.tsx
@@ -15,9 +15,9 @@ export function WhatIsSolving() {
           funding is crucial for ecosystem growth, it has also introduced a range of issues.
           <br />
           <br />
-          The Grantee Accountability Protocol (GAP) is designed to address these challenges by
-          aiding grantees in building their reputation, assisting communities in maintaining grantee
-          accountability, and enabling third parties to develop applications using this protocol.
+          Karma is designed to address these challenges by aiding grantees in building their
+          reputation, assisting communities in maintaining grantee accountability, and enabling
+          third parties to develop applications using this protocol.
         </p>
       </div>
       <div className="flex flex-1 flex-col gap-6">

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,6 +1,6 @@
 # E2E Tests - gap-app-v2
 
-End-to-end tests using Cypress for the GAP frontend application.
+End-to-end tests using Cypress for the Karma frontend application.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Replace all "Karma GAP", "GAP (Grantee Accountability Protocol)", and standalone "GAP" product name references with "Karma" across documentation, page metadata, and test files
- Part of a cross-repo rebrand effort to ensure the product is consistently referred to as "Karma"

## Changes
- **CLAUDE.md, AGENTS.md, .cursorrules**: Updated product name references in AI instruction files
- **Page metadata** (dashboard, projects, seeds): Changed "| Karma GAP" suffixes to "| Karma"
- **WhatIsSolving.tsx**: Updated homepage copy from "Grantee Accountability Protocol (GAP)" to "Karma"
- **Test files**: Updated mock logo text and comments to use "Karma"
- **cypress/README.md**: Updated product name reference

## Notes
- Repository names (gap-app-v2, etc.) are **not changed** as they are technical identifiers
- External field name patterns in gap-indexer test data (used for profile extraction from grant applications) are also preserved

## Test plan
- [x] Footer test suite passes (50 tests)
- [x] Navbar responsive behavior test suite passes (25 tests)
- [x] Biome lint-staged check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Product branding updated from "Karma GAP" to "Karma" across page titles, descriptions, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->