### PR TITLE
Implement API keys

### DIFF
--- a/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
+++ b/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
@@ -17,10 +17,10 @@ jest.mock("@/store/modals/apiKeyManagement", () => ({
   })),
 }));
 
-jest.mock("@/src/components/navbar/navbar-permissions-context", () => ({
-  useNavbarPermissions: jest.fn(() => ({
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: jest.fn(() => ({
     address: "0x1234567890123456789012345678901234567890",
-    isLoggedIn: true,
+    authenticated: true,
     ready: true,
   })),
 }));
@@ -30,15 +30,17 @@ const mockCreateKey = jest.fn();
 const mockRevokeKey = jest.fn();
 let mockApiKeyData: GetApiKeyResponse = { apiKey: null };
 let mockIsLoadingKey = false;
+let mockIsKeyError = false;
 let mockIsCreating = false;
 let mockIsRevoking = false;
+const mockRefetch = jest.fn();
 
 jest.mock("@/src/features/api-keys/hooks/use-api-key", () => ({
   useApiKey: jest.fn(() => ({
     data: mockApiKeyData,
     isLoading: mockIsLoadingKey,
-    isError: false,
-    refetch: jest.fn(),
+    isError: mockIsKeyError,
+    refetch: mockRefetch,
   })),
   useCreateApiKey: jest.fn((options?: any) => ({
     mutate: (name?: string) => {
@@ -106,6 +108,7 @@ describe("ApiKeyManagementModal", () => {
     mockIsModalOpen = true;
     mockApiKeyData = { apiKey: null };
     mockIsLoadingKey = false;
+    mockIsKeyError = false;
     mockIsCreating = false;
     mockIsRevoking = false;
   });
@@ -119,12 +122,29 @@ describe("ApiKeyManagementModal", () => {
     });
   });
 
+  describe("Error state", () => {
+    it("shows error UI and retry button when query fails", async () => {
+      const user = userEvent.setup();
+      mockIsKeyError = true;
+      renderModal();
+
+      expect(
+        screen.getByText("Failed to load API key data. Please try again.")
+      ).toBeInTheDocument();
+      expect(screen.getByText("Retry")).toBeInTheDocument();
+
+      await user.click(screen.getByText("Retry"));
+
+      expect(mockRefetch).toHaveBeenCalled();
+    });
+  });
+
   describe("No key state", () => {
     it("shows generate form when no key exists", () => {
       renderModal();
 
       expect(screen.getByText("Generate API Key")).toBeInTheDocument();
-      expect(screen.getByLabelText("Key name")).toBeInTheDocument();
+      expect(screen.getByLabelText(/Key name/)).toBeInTheDocument();
       expect(screen.getByText(/You don't have an API key yet/i)).toBeInTheDocument();
     });
 
@@ -132,7 +152,7 @@ describe("ApiKeyManagementModal", () => {
       const user = userEvent.setup();
       renderModal();
 
-      const input = screen.getByLabelText("Key name");
+      const input = screen.getByLabelText(/Key name/);
       await user.type(input, "My Agent");
 
       expect(input).toHaveValue("My Agent");
@@ -222,7 +242,7 @@ describe("ApiKeyManagementModal", () => {
       expect(screen.queryByText("Never")).not.toBeInTheDocument();
     });
 
-    it("calls regenerate on regenerate click", async () => {
+    it("shows confirmation dialog on regenerate click", async () => {
       const user = userEvent.setup();
       mockApiKeyData = {
         apiKey: {
@@ -237,7 +257,68 @@ describe("ApiKeyManagementModal", () => {
 
       await user.click(screen.getByText("Regenerate Key"));
 
-      expect(mockCreateKey).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(screen.getByText("Regenerate API Key?")).toBeInTheDocument();
+        expect(
+          screen.getByText(/immediately invalidate your current API key/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("cancels regenerate on cancel click", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Regenerate Key"));
+      await waitFor(() => {
+        expect(screen.getByText("Cancel")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      });
+    });
+
+    it("regenerates key and shows new key after confirmation", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Regenerate Key"));
+      await waitFor(() => {
+        expect(screen.getByText("Regenerate API Key?")).toBeInTheDocument();
+      });
+
+      const regenerateButtons = screen.getAllByRole("button", { name: /regenerate/i });
+      const confirmButton = regenerateButtons.find((btn) => btn.textContent === "Regenerate");
+      if (confirmButton) {
+        await user.click(confirmButton);
+      }
+
+      expect(mockCreateKey).toHaveBeenCalledWith("My Key");
+
+      await waitFor(() => {
+        expect(screen.getByText("API Key Created")).toBeInTheDocument();
+        expect(screen.getByText("karma_testkey123456789012345678")).toBeInTheDocument();
+      });
     });
   });
 

--- a/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
+++ b/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { ApiKeyManagementModal } from "@/src/features/api-keys/components/api-key-management-modal";
+import type { GetApiKeyResponse } from "@/src/features/api-keys/types/api-key";
 
 // Mock stores
 const mockCloseModal = jest.fn();
@@ -27,7 +28,7 @@ jest.mock("@/src/components/navbar/navbar-permissions-context", () => ({
 // Mock hooks
 const mockCreateKey = jest.fn();
 const mockRevokeKey = jest.fn();
-let mockApiKeyData: any = { apiKey: null };
+let mockApiKeyData: GetApiKeyResponse = { apiKey: null };
 let mockIsLoadingKey = false;
 let mockIsCreating = false;
 let mockIsRevoking = false;
@@ -36,6 +37,8 @@ jest.mock("@/src/features/api-keys/hooks/use-api-key", () => ({
   useApiKey: jest.fn(() => ({
     data: mockApiKeyData,
     isLoading: mockIsLoadingKey,
+    isError: false,
+    refetch: jest.fn(),
   })),
   useCreateApiKey: jest.fn((options?: any) => ({
     mutate: (name?: string) => {
@@ -65,6 +68,12 @@ jest.mock("@/src/features/api-keys/hooks/use-api-key", () => ({
 
 jest.mock("@/hooks/useCopyToClipboard", () => ({
   useCopyToClipboard: jest.fn(() => [null, jest.fn()]),
+}));
+
+jest.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://api.gap.karmahq.xyz",
+  },
 }));
 
 jest.mock("react-hot-toast", () => ({

--- a/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
+++ b/__tests__/features/api-keys/unit/api-key-management-modal.test.tsx
@@ -1,0 +1,318 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { ApiKeyManagementModal } from "@/src/features/api-keys/components/api-key-management-modal";
+
+// Mock stores
+const mockCloseModal = jest.fn();
+let mockIsModalOpen = true;
+
+jest.mock("@/store/modals/apiKeyManagement", () => ({
+  useApiKeyManagementModalStore: jest.fn(() => ({
+    isModalOpen: mockIsModalOpen,
+    openModal: jest.fn(),
+    closeModal: mockCloseModal,
+  })),
+}));
+
+jest.mock("@/src/components/navbar/navbar-permissions-context", () => ({
+  useNavbarPermissions: jest.fn(() => ({
+    address: "0x1234567890123456789012345678901234567890",
+    isLoggedIn: true,
+    ready: true,
+  })),
+}));
+
+// Mock hooks
+const mockCreateKey = jest.fn();
+const mockRevokeKey = jest.fn();
+let mockApiKeyData: any = { apiKey: null };
+let mockIsLoadingKey = false;
+let mockIsCreating = false;
+let mockIsRevoking = false;
+
+jest.mock("@/src/features/api-keys/hooks/use-api-key", () => ({
+  useApiKey: jest.fn(() => ({
+    data: mockApiKeyData,
+    isLoading: mockIsLoadingKey,
+  })),
+  useCreateApiKey: jest.fn((options?: any) => ({
+    mutate: (name?: string) => {
+      mockCreateKey(name);
+      // Simulate success callback
+      if (options?.onSuccess) {
+        options.onSuccess({
+          key: "karma_testkey123456789012345678",
+          keyHint: "...5678",
+          name: name || "Default",
+          createdAt: "2026-02-22T00:00:00.000Z",
+        });
+      }
+    },
+    isPending: mockIsCreating,
+  })),
+  useRevokeApiKey: jest.fn((options?: any) => ({
+    mutate: () => {
+      mockRevokeKey();
+      if (options?.onSuccess) {
+        options.onSuccess();
+      }
+    },
+    isPending: mockIsRevoking,
+  })),
+}));
+
+jest.mock("@/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: jest.fn(() => [null, jest.fn()]),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const renderModal = () => {
+  const Wrapper = createWrapper();
+  return render(React.createElement(Wrapper, null, React.createElement(ApiKeyManagementModal)));
+};
+
+describe("ApiKeyManagementModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsModalOpen = true;
+    mockApiKeyData = { apiKey: null };
+    mockIsLoadingKey = false;
+    mockIsCreating = false;
+    mockIsRevoking = false;
+  });
+
+  describe("Loading state", () => {
+    it("shows loading spinner when fetching key data", () => {
+      mockIsLoadingKey = true;
+      renderModal();
+
+      expect(screen.getByText("API Key")).toBeInTheDocument();
+    });
+  });
+
+  describe("No key state", () => {
+    it("shows generate form when no key exists", () => {
+      renderModal();
+
+      expect(screen.getByText("Generate API Key")).toBeInTheDocument();
+      expect(screen.getByLabelText("Key name")).toBeInTheDocument();
+      expect(screen.getByText(/You don't have an API key yet/i)).toBeInTheDocument();
+    });
+
+    it("allows entering key name", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      const input = screen.getByLabelText("Key name");
+      await user.type(input, "My Agent");
+
+      expect(input).toHaveValue("My Agent");
+    });
+
+    it("calls create mutation on generate click", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.click(screen.getByText("Generate API Key"));
+
+      expect(mockCreateKey).toHaveBeenCalled();
+    });
+  });
+
+  describe("Key created state", () => {
+    it("shows created key after generation", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.click(screen.getByText("Generate API Key"));
+
+      await waitFor(() => {
+        expect(screen.getByText("API Key Created")).toBeInTheDocument();
+      });
+      expect(screen.getByText("karma_testkey123456789012345678")).toBeInTheDocument();
+      expect(screen.getByText(/Copy your API key now/i)).toBeInTheDocument();
+    });
+
+    it("shows copy and done buttons", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.click(screen.getByText("Generate API Key"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Copy to Clipboard")).toBeInTheDocument();
+        expect(screen.getByText("I've Saved It")).toBeInTheDocument();
+      });
+    });
+
+    it("shows usage example with x-api-key header", async () => {
+      const user = userEvent.setup();
+      renderModal();
+
+      await user.click(screen.getByText("Generate API Key"));
+
+      await waitFor(() => {
+        expect(screen.getByText("x-api-key")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Active key state", () => {
+    it("shows existing key info", () => {
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      expect(screen.getByText("My Key")).toBeInTheDocument();
+      expect(screen.getByText("karma_...abcd")).toBeInTheDocument();
+      expect(screen.getByText("Never")).toBeInTheDocument();
+      expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      expect(screen.getByText("Revoke Key")).toBeInTheDocument();
+    });
+
+    it("shows last used date when available", () => {
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-01-15T00:00:00.000Z",
+          lastUsedAt: "2026-02-22T12:00:00.000Z",
+        },
+      };
+      renderModal();
+
+      expect(screen.getByText("Feb 22, 2026")).toBeInTheDocument();
+      expect(screen.queryByText("Never")).not.toBeInTheDocument();
+    });
+
+    it("calls regenerate on regenerate click", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Regenerate Key"));
+
+      expect(mockCreateKey).toHaveBeenCalled();
+    });
+  });
+
+  describe("Revoke confirmation", () => {
+    it("shows revoke confirmation dialog", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Revoke Key"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Revoke API Key?")).toBeInTheDocument();
+        expect(screen.getByText(/immediately invalidate/i)).toBeInTheDocument();
+      });
+    });
+
+    it("cancels revoke on cancel click", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Revoke Key"));
+      await waitFor(() => {
+        expect(screen.getByText("Cancel")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      });
+    });
+
+    it("calls revoke on confirm", async () => {
+      const user = userEvent.setup();
+      mockApiKeyData = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "My Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      renderModal();
+
+      await user.click(screen.getByText("Revoke Key"));
+      await waitFor(() => {
+        expect(screen.getByText("Revoke")).toBeInTheDocument();
+      });
+
+      // Click the "Revoke" button (not "Revoke Key" which is in the active state)
+      const revokeButtons = screen.getAllByRole("button", { name: /revoke/i });
+      const confirmButton = revokeButtons.find((btn) => btn.textContent === "Revoke");
+      if (confirmButton) {
+        await user.click(confirmButton);
+      }
+
+      expect(mockRevokeKey).toHaveBeenCalled();
+    });
+  });
+
+  describe("Modal closed state", () => {
+    it("does not render content when modal is closed", () => {
+      mockIsModalOpen = false;
+      renderModal();
+
+      expect(screen.queryByText("API Key")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/features/api-keys/unit/api-key-management-store.test.ts
+++ b/__tests__/features/api-keys/unit/api-key-management-store.test.ts
@@ -1,0 +1,34 @@
+import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
+
+// Need to unmock the store since the navbar setup.ts auto-mocks it
+jest.unmock("@/store/modals/apiKeyManagement");
+
+// Re-import the real module after unmocking
+const { useApiKeyManagementModalStore: realStore } = jest.requireActual(
+  "@/store/modals/apiKeyManagement"
+);
+
+describe("useApiKeyManagementModalStore", () => {
+  beforeEach(() => {
+    // Reset store state
+    realStore.setState({ isModalOpen: false });
+  });
+
+  it("should start with modal closed", () => {
+    const state = realStore.getState();
+    expect(state.isModalOpen).toBe(false);
+  });
+
+  it("should open modal", () => {
+    realStore.getState().openModal();
+    expect(realStore.getState().isModalOpen).toBe(true);
+  });
+
+  it("should close modal", () => {
+    realStore.getState().openModal();
+    expect(realStore.getState().isModalOpen).toBe(true);
+
+    realStore.getState().closeModal();
+    expect(realStore.getState().isModalOpen).toBe(false);
+  });
+});

--- a/__tests__/features/api-keys/unit/api-key-service.test.ts
+++ b/__tests__/features/api-keys/unit/api-key-service.test.ts
@@ -1,0 +1,95 @@
+import { apiKeyService } from "@/src/features/api-keys/services/api-key.service";
+
+jest.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockFetchData = jest.requireMock("@/utilities/fetchData").default;
+
+describe("apiKeyService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("get", () => {
+    it("should return API key response on success", async () => {
+      const mockResponse = {
+        apiKey: {
+          keyHint: "...abcd",
+          name: "Test Key",
+          isActive: true,
+          createdAt: "2026-02-22T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      };
+      mockFetchData.mockResolvedValue([mockResponse, null]);
+
+      const result = await apiKeyService.get();
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("api-keys"), "GET");
+    });
+
+    it("should throw on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Unauthorized"]);
+
+      await expect(apiKeyService.get()).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("create", () => {
+    it("should create API key with name", async () => {
+      const mockResponse = {
+        key: "karma_abc123",
+        keyHint: "...c123",
+        name: "My Key",
+        createdAt: "2026-02-22T00:00:00.000Z",
+      };
+      mockFetchData.mockResolvedValue([mockResponse, null]);
+
+      const result = await apiKeyService.create("My Key");
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("api-keys"), "POST", {
+        name: "My Key",
+      });
+    });
+
+    it("should create API key without name", async () => {
+      const mockResponse = {
+        key: "karma_abc123",
+        keyHint: "...c123",
+        name: "Default",
+        createdAt: "2026-02-22T00:00:00.000Z",
+      };
+      mockFetchData.mockResolvedValue([mockResponse, null]);
+
+      const result = await apiKeyService.create();
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("api-keys"), "POST", {});
+    });
+
+    it("should throw on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Failed to create"]);
+
+      await expect(apiKeyService.create("Test")).rejects.toThrow("Failed to create");
+    });
+  });
+
+  describe("revoke", () => {
+    it("should revoke API key successfully", async () => {
+      mockFetchData.mockResolvedValue([{}, null]);
+
+      await expect(apiKeyService.revoke()).resolves.toBeUndefined();
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("api-keys"), "DELETE");
+    });
+
+    it("should throw on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Not found"]);
+
+      await expect(apiKeyService.revoke()).rejects.toThrow("Not found");
+    });
+  });
+});

--- a/__tests__/features/api-keys/unit/use-api-key.test.ts
+++ b/__tests__/features/api-keys/unit/use-api-key.test.ts
@@ -1,0 +1,155 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import {
+  apiKeyKeys,
+  useApiKey,
+  useCreateApiKey,
+  useRevokeApiKey,
+} from "@/src/features/api-keys/hooks/use-api-key";
+
+jest.mock("@/src/features/api-keys/services/api-key.service", () => ({
+  apiKeyService: {
+    get: jest.fn(),
+    create: jest.fn(),
+    revoke: jest.fn(),
+  },
+}));
+
+const mockApiKeyService = jest.requireMock(
+  "@/src/features/api-keys/services/api-key.service"
+).apiKeyService;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe("apiKeyKeys", () => {
+  it("should produce correct query keys", () => {
+    expect(apiKeyKeys.all).toEqual(["apiKeys"]);
+    expect(apiKeyKeys.user("0xabc")).toEqual(["apiKeys", "0xabc"]);
+  });
+});
+
+describe("useApiKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch API key when address is provided", async () => {
+    const mockData = {
+      apiKey: {
+        keyHint: "...abcd",
+        name: "My Key",
+        isActive: true,
+        createdAt: "2026-02-22",
+        lastUsedAt: null,
+      },
+    };
+    mockApiKeyService.get.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useApiKey("0xabc"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockData);
+    expect(mockApiKeyService.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not fetch when address is undefined", () => {
+    const { result } = renderHook(() => useApiKey(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockApiKeyService.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCreateApiKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call create and invoke onSuccess", async () => {
+    const mockResponse = {
+      key: "karma_abc123",
+      keyHint: "...c123",
+      name: "Test",
+      createdAt: "2026-02-22",
+    };
+    mockApiKeyService.create.mockResolvedValue(mockResponse);
+    const onSuccess = jest.fn();
+
+    const { result } = renderHook(() => useCreateApiKey({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("Test");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(onSuccess).toHaveBeenCalledWith(mockResponse);
+    expect(mockApiKeyService.create).toHaveBeenCalledWith("Test");
+  });
+
+  it("should invoke onError on failure", async () => {
+    mockApiKeyService.create.mockRejectedValue(new Error("Failed"));
+    const onError = jest.fn();
+
+    const { result } = renderHook(() => useCreateApiKey({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("Test");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe("useRevokeApiKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call revoke and invoke onSuccess", async () => {
+    mockApiKeyService.revoke.mockResolvedValue(undefined);
+    const onSuccess = jest.fn();
+
+    const { result } = renderHook(() => useRevokeApiKey({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("should invoke onError on failure", async () => {
+    mockApiKeyService.revoke.mockRejectedValue(new Error("Failed"));
+    const onError = jest.fn();
+
+    const { result } = renderHook(() => useRevokeApiKey({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/__tests__/integration/pages/layout.test.tsx
+++ b/__tests__/integration/pages/layout.test.tsx
@@ -84,6 +84,7 @@ describe("RootLayout", () => {
     expect(screen.getByTestId("privy-provider")).toBeInTheDocument();
     expect(screen.getByTestId("theme-provider")).toBeInTheDocument();
     expect(screen.getByTestId("agent-chat-bubble")).toBeInTheDocument();
+    expect(screen.getByTestId("api-key-management-modal")).toBeInTheDocument();
   });
 
   it("renders children content", () => {

--- a/__tests__/integration/pages/layout.test.tsx
+++ b/__tests__/integration/pages/layout.test.tsx
@@ -64,6 +64,10 @@ jest.mock("@/components/AgentChat/AgentChatBubble", () => ({
   AgentChatBubble: () => <div data-testid="agent-chat-bubble" />,
 }));
 
+jest.mock("@/src/features/api-keys/components/api-key-management-modal", () => ({
+  ApiKeyManagementModal: () => <div data-testid="api-key-management-modal" />,
+}));
+
 describe("RootLayout", () => {
   it("renders all components correctly", () => {
     render(<RootLayout>Test Content</RootLayout>);

--- a/__tests__/navbar/setup.ts
+++ b/__tests__/navbar/setup.ts
@@ -330,6 +330,14 @@ jest.mock("@/store/modals/contributorProfile", () => ({
   })),
 }));
 
+jest.mock("@/store/modals/apiKeyManagement", () => ({
+  useApiKeyManagementModalStore: jest.fn(() => ({
+    isModalOpen: false,
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  })),
+}));
+
 // Mock the NavbarPermissionsContext - this is needed because NavbarDesktopNavigation
 // uses useNavbarPermissions() which reads from context, not from individual hooks directly
 export const mockNavbarPermissionsState = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,7 @@ import { PermissionsProvider } from "@/components/Utilities/PermissionsProvider"
 import PrivyProviderWrapper from "@/components/Utilities/PrivyProviderWrapper";
 import { Footer } from "@/src/components/footer/footer";
 import { Navbar } from "@/src/components/navbar/navbar";
+import { ApiKeyManagementModal } from "@/src/features/api-keys/components/api-key-management-modal";
 
 export const metadata = defaultMetadata;
 
@@ -72,6 +73,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             />
             <Suspense fallback={null}>
               <ContributorProfileDialog />
+            </Suspense>
+            <Suspense fallback={null}>
+              <ApiKeyManagementModal />
             </Suspense>
             <OnboardingDialog />
             <ProgressBarWrapper />

--- a/src/components/navbar/navbar-mobile-menu.tsx
+++ b/src/components/navbar/navbar-mobile-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/solid";
-import { CircleHelp, LogOutIcon, ToggleLeft, ToggleRight } from "lucide-react";
+import { CircleHelp, KeyRound, LogOutIcon, ToggleLeft, ToggleRight } from "lucide-react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
 import { useState } from "react";
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/drawer";
 import { useAuth } from "@/hooks/useAuth";
 import { useContributorProfile } from "@/hooks/useContributorProfile";
+import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 import { PAGES } from "@/utilities/pages";
 import { SOCIALS } from "@/utilities/socials";
@@ -76,6 +77,7 @@ export function NavbarMobileMenu() {
   };
 
   const { openModal: openProfileModal } = useContributorProfileModalStore();
+  const { openModal: openApiKeyModal } = useApiKeyManagementModalStore();
 
   // Get permissions from centralized context (prevents duplicate hook calls)
   const { isLoggedIn, address, isRegistryAllowed } = useNavbarPermissions();
@@ -244,6 +246,17 @@ export function NavbarMobileMenu() {
                     <CircleHelp className={menuStyles.itemIcon} />
                     <span className={menuStyles.itemText}>Docs</span>
                   </ExternalLink>
+                  <button
+                    type="button"
+                    className="w-full flex items-center gap-3 py-3 rounded-md hover:bg-accent text-left"
+                    onClick={() => {
+                      openApiKeyModal();
+                      setMobileMenuOpen(false);
+                    }}
+                  >
+                    <KeyRound className={menuStyles.itemIcon} />
+                    <span className={menuStyles.itemText}>API Keys</span>
+                  </button>
                   <hr className="h-[1px] w-full border-border" />
                   <button
                     type="button"

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   FolderKanban,
   Heart,
+  KeyRound,
   LogOutIcon,
   Settings,
   ToggleLeft,
@@ -28,6 +29,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useContributorProfile } from "@/hooks/useContributorProfile";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
 import { PAGES } from "@/utilities/pages";
 import { SOCIALS } from "@/utilities/socials";
@@ -87,6 +89,7 @@ export function NavbarUserMenu() {
   const { profile } = useContributorProfile(address);
 
   const { openModal: openProfileModal } = useContributorProfileModalStore();
+  const { openModal: openApiKeyModal } = useApiKeyManagementModalStore();
   const [, copyToClipboard] = useCopyToClipboard();
 
   if (!ready) {
@@ -194,6 +197,12 @@ export function NavbarUserMenu() {
                     <Heart className={menuStyles.itemIcon} />
                     <span className={menuStyles.itemText}>My donations</span>
                   </Link>
+                </MenubarItem>
+                <MenubarItem className="w-full cursor-pointer" onClick={openApiKeyModal}>
+                  <div className="flex items-center w-full flex-row gap-2">
+                    <KeyRound className={menuStyles.itemIcon} />
+                    <span className={menuStyles.itemText}>API Keys</span>
+                  </div>
                 </MenubarItem>
                 {isRegistryAllowed && (
                   <MenubarItem asChild className="w-full cursor-pointer">

--- a/src/features/api-keys/components/api-key-management-modal.tsx
+++ b/src/features/api-keys/components/api-key-management-modal.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { AlertTriangle, Check, Copy, KeyRound, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useNavbarPermissions } from "@/src/components/navbar/navbar-permissions-context";
+import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
+import { useApiKey, useCreateApiKey, useRevokeApiKey } from "../hooks/use-api-key";
+
+export function ApiKeyManagementModal() {
+  const { address } = useNavbarPermissions();
+  const { isModalOpen, closeModal } = useApiKeyManagementModalStore();
+  const { data, isLoading: isLoadingKey } = useApiKey(address);
+  const [justCreatedKey, setJustCreatedKey] = useState<string | null>(null);
+  const [keyName, setKeyName] = useState("");
+  const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+  const [, copyToClipboard] = useCopyToClipboard();
+
+  const { mutate: createKey, isPending: isCreating } = useCreateApiKey({
+    onSuccess: (result) => {
+      setJustCreatedKey(result.key);
+      setKeyName("");
+    },
+    onError: () => {
+      toast.error("Failed to generate API key");
+    },
+  });
+
+  const { mutate: revokeKey, isPending: isRevoking } = useRevokeApiKey({
+    onSuccess: () => {
+      setJustCreatedKey(null);
+      setShowRevokeConfirm(false);
+      toast.success("API key revoked");
+    },
+    onError: () => {
+      toast.error("Failed to revoke API key");
+    },
+  });
+
+  useEffect(() => {
+    if (!isModalOpen) {
+      setJustCreatedKey(null);
+      setKeyName("");
+      setShowRevokeConfirm(false);
+    }
+  }, [isModalOpen]);
+
+  const existingKey = data?.apiKey;
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={(open) => !open && closeModal()}>
+      <DialogContent className="w-full max-w-lg rounded-2xl dark:bg-zinc-800 bg-white p-6">
+        {showRevokeConfirm ? (
+          <RevokeConfirmation
+            onCancel={() => setShowRevokeConfirm(false)}
+            onConfirm={() => revokeKey()}
+            isRevoking={isRevoking}
+          />
+        ) : justCreatedKey ? (
+          <KeyCreatedState
+            apiKey={justCreatedKey}
+            onCopy={() => copyToClipboard(justCreatedKey, "API key copied to clipboard")}
+            onDone={closeModal}
+          />
+        ) : isLoadingKey ? (
+          <LoadingState />
+        ) : existingKey ? (
+          <ActiveKeyState
+            keyInfo={existingKey}
+            onRegenerate={() => createKey(keyName || undefined)}
+            onRevoke={() => setShowRevokeConfirm(true)}
+            isRegenerating={isCreating}
+          />
+        ) : (
+          <NoKeyState
+            keyName={keyName}
+            onKeyNameChange={setKeyName}
+            onGenerate={() => createKey(keyName || undefined)}
+            isGenerating={isCreating}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LoadingState() {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>API Key</DialogTitle>
+      </DialogHeader>
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    </>
+  );
+}
+
+function NoKeyState({
+  keyName,
+  onKeyNameChange,
+  onGenerate,
+  isGenerating,
+}: {
+  keyName: string;
+  onKeyNameChange: (name: string) => void;
+  onGenerate: () => void;
+  isGenerating: boolean;
+}) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <KeyRound className="h-5 w-5" />
+          API Key
+        </DialogTitle>
+        <DialogDescription>
+          You don&apos;t have an API key yet. API keys allow AI agents and scripts to authenticate
+          as your account.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-4 py-2">
+        <div>
+          <label htmlFor="key-name" className="text-sm font-medium text-foreground">
+            Key name
+          </label>
+          <input
+            id="key-name"
+            type="text"
+            value={keyName}
+            onChange={(e) => onKeyNameChange(e.target.value)}
+            placeholder="My AI Agent"
+            className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            maxLength={100}
+          />
+        </div>
+      </div>
+      <DialogFooter>
+        <Button onClick={onGenerate} disabled={isGenerating}>
+          {isGenerating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Generate API Key
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function KeyCreatedState({
+  apiKey,
+  onCopy,
+  onDone,
+}: {
+  apiKey: string;
+  onCopy: () => void;
+  onDone: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    onCopy();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <Check className="h-5 w-5 text-green-500" />
+          API Key Created
+        </DialogTitle>
+        <DialogDescription className="flex items-start gap-2 pt-2">
+          <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0 mt-0.5" />
+          <span>Copy your API key now. You won&apos;t be able to see it again.</span>
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-4 py-2">
+        <div className="rounded-md border border-border bg-muted p-3">
+          <code className="text-sm break-all text-foreground">{apiKey}</code>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Use this key in the <code className="text-foreground">x-api-key</code> header:
+          <pre className="mt-1 rounded bg-muted p-2 text-xs overflow-x-auto">
+            {`curl -H "x-api-key: ${apiKey.slice(0, 20)}..." \\
+  https://api.gap.karmahq.xyz/v2/user/me`}
+          </pre>
+        </div>
+      </div>
+      <DialogFooter className="flex gap-2 sm:gap-2">
+        <Button variant="outline" onClick={handleCopy}>
+          {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+          {copied ? "Copied" : "Copy to Clipboard"}
+        </Button>
+        <Button onClick={onDone}>I&apos;ve Saved It</Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function ActiveKeyState({
+  keyInfo,
+  onRegenerate,
+  onRevoke,
+  isRegenerating,
+}: {
+  keyInfo: {
+    keyHint: string;
+    name: string;
+    createdAt: string;
+    lastUsedAt: string | null;
+  };
+  onRegenerate: () => void;
+  onRevoke: () => void;
+  isRegenerating: boolean;
+}) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <KeyRound className="h-5 w-5" />
+          API Key
+        </DialogTitle>
+      </DialogHeader>
+      <div className="space-y-3 py-2">
+        <InfoRow label="Name" value={keyInfo.name} />
+        <InfoRow label="Key" value={`karma_${keyInfo.keyHint}`} />
+        <InfoRow
+          label="Created"
+          value={new Date(keyInfo.createdAt).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })}
+        />
+        <InfoRow
+          label="Last used"
+          value={
+            keyInfo.lastUsedAt
+              ? new Date(keyInfo.lastUsedAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })
+              : "Never"
+          }
+        />
+      </div>
+      <DialogFooter className="flex gap-2 sm:gap-2">
+        <Button variant="outline" onClick={onRegenerate} disabled={isRegenerating}>
+          {isRegenerating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Regenerate Key
+        </Button>
+        <Button variant="destructive" onClick={onRevoke}>
+          Revoke Key
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function RevokeConfirmation({
+  onCancel,
+  onConfirm,
+  isRevoking,
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+  isRevoking: boolean;
+}) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Revoke API Key?</DialogTitle>
+        <DialogDescription className="pt-2">
+          This will immediately invalidate your API key. Any agents or scripts using this key will
+          lose access. This action cannot be undone.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter className="flex gap-2 sm:gap-2">
+        <Button variant="outline" onClick={onCancel} disabled={isRevoking}>
+          Cancel
+        </Button>
+        <Button variant="destructive" onClick={onConfirm} disabled={isRevoking}>
+          {isRevoking && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Revoke
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between items-center">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium text-foreground">{value}</span>
+    </div>
+  );
+}

--- a/src/features/api-keys/components/api-key-management-modal.tsx
+++ b/src/features/api-keys/components/api-key-management-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, Check, Copy, KeyRound, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, Copy, KeyRound, Loader2, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
@@ -12,15 +12,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useNavbarPermissions } from "@/src/components/navbar/navbar-permissions-context";
 import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
+import { envVars } from "@/utilities/enviromentVars";
 import { useApiKey, useCreateApiKey, useRevokeApiKey } from "../hooks/use-api-key";
 
 export function ApiKeyManagementModal() {
   const { address } = useNavbarPermissions();
   const { isModalOpen, closeModal } = useApiKeyManagementModalStore();
-  const { data, isLoading: isLoadingKey } = useApiKey(address);
+  const { data, isLoading: isLoadingKey, isError: isKeyError, refetch } = useApiKey(address);
   const [justCreatedKey, setJustCreatedKey] = useState<string | null>(null);
   const [keyName, setKeyName] = useState("");
   const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
@@ -74,10 +76,12 @@ export function ApiKeyManagementModal() {
           />
         ) : isLoadingKey ? (
           <LoadingState />
+        ) : isKeyError ? (
+          <ErrorState onRetry={() => refetch()} />
         ) : existingKey ? (
           <ActiveKeyState
             keyInfo={existingKey}
-            onRegenerate={() => createKey(keyName || undefined)}
+            onRegenerate={() => createKey(existingKey.name || undefined)}
             onRevoke={() => setShowRevokeConfirm(true)}
             isRegenerating={isCreating}
           />
@@ -103,6 +107,26 @@ function LoadingState() {
       <div className="flex justify-center py-8">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
+    </>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-destructive" />
+          API Key
+        </DialogTitle>
+        <DialogDescription>Failed to load API key data. Please try again.</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button onClick={onRetry}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Retry
+        </Button>
+      </DialogFooter>
     </>
   );
 }
@@ -135,13 +159,12 @@ function NoKeyState({
           <label htmlFor="key-name" className="text-sm font-medium text-foreground">
             Key name
           </label>
-          <input
+          <Input
             id="key-name"
-            type="text"
             value={keyName}
             onChange={(e) => onKeyNameChange(e.target.value)}
             placeholder="My AI Agent"
-            className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            className="mt-1"
             maxLength={100}
           />
         </div>
@@ -192,8 +215,8 @@ function KeyCreatedState({
         <div className="text-xs text-muted-foreground">
           Use this key in the <code className="text-foreground">x-api-key</code> header:
           <pre className="mt-1 rounded bg-muted p-2 text-xs overflow-x-auto">
-            {`curl -H "x-api-key: ${apiKey.slice(0, 20)}..." \\
-  https://api.gap.karmahq.xyz/v2/user/me`}
+            {`curl -H "x-api-key: YOUR_API_KEY" \\
+  ${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/user/me`}
           </pre>
         </div>
       </div>

--- a/src/features/api-keys/components/api-key-management-modal.tsx
+++ b/src/features/api-keys/components/api-key-management-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle, Check, Copy, KeyRound, Loader2, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,25 +13,28 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { useAuth } from "@/hooks/useAuth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { useNavbarPermissions } from "@/src/components/navbar/navbar-permissions-context";
 import { useApiKeyManagementModalStore } from "@/store/modals/apiKeyManagement";
 import { envVars } from "@/utilities/enviromentVars";
 import { useApiKey, useCreateApiKey, useRevokeApiKey } from "../hooks/use-api-key";
+import type { ApiKeyInfo } from "../types/api-key";
 
 export function ApiKeyManagementModal() {
-  const { address } = useNavbarPermissions();
+  const { address } = useAuth();
   const { isModalOpen, closeModal } = useApiKeyManagementModalStore();
   const { data, isLoading: isLoadingKey, isError: isKeyError, refetch } = useApiKey(address);
   const [justCreatedKey, setJustCreatedKey] = useState<string | null>(null);
   const [keyName, setKeyName] = useState("");
   const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+  const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false);
   const [, copyToClipboard] = useCopyToClipboard();
 
   const { mutate: createKey, isPending: isCreating } = useCreateApiKey({
     onSuccess: (result) => {
       setJustCreatedKey(result.key);
       setKeyName("");
+      setShowRegenerateConfirm(false);
     },
     onError: () => {
       toast.error("Failed to generate API key");
@@ -54,19 +57,46 @@ export function ApiKeyManagementModal() {
       setJustCreatedKey(null);
       setKeyName("");
       setShowRevokeConfirm(false);
+      setShowRegenerateConfirm(false);
     }
   }, [isModalOpen]);
 
   const existingKey = data?.apiKey;
 
   return (
-    <Dialog open={isModalOpen} onOpenChange={(open) => !open && closeModal()}>
-      <DialogContent className="w-full max-w-lg rounded-2xl dark:bg-zinc-800 bg-white p-6">
-        {showRevokeConfirm ? (
-          <RevokeConfirmation
+    <Dialog
+      open={isModalOpen}
+      onOpenChange={(open) => {
+        if (!open && justCreatedKey) return;
+        if (!open) closeModal();
+      }}
+    >
+      <DialogContent
+        className="w-full max-w-lg max-h-[90dvh] overflow-y-auto rounded-2xl dark:bg-zinc-800 bg-white p-6"
+        onEscapeKeyDown={(e) => {
+          if (justCreatedKey) e.preventDefault();
+        }}
+        onPointerDownOutside={(e) => {
+          if (justCreatedKey) e.preventDefault();
+        }}
+      >
+        {showRegenerateConfirm ? (
+          <DestructiveConfirmation
+            title="Regenerate API Key?"
+            description="This will immediately invalidate your current API key and generate a new one. Any agents or scripts using the current key will lose access."
+            confirmLabel="Regenerate"
+            onCancel={() => setShowRegenerateConfirm(false)}
+            onConfirm={() => createKey(existingKey?.name || undefined)}
+            isPending={isCreating}
+          />
+        ) : showRevokeConfirm ? (
+          <DestructiveConfirmation
+            title="Revoke API Key?"
+            description="This will immediately invalidate your API key. Any agents or scripts using this key will lose access. This action cannot be undone."
+            confirmLabel="Revoke"
             onCancel={() => setShowRevokeConfirm(false)}
             onConfirm={() => revokeKey()}
-            isRevoking={isRevoking}
+            isPending={isRevoking}
           />
         ) : justCreatedKey ? (
           <KeyCreatedState
@@ -81,7 +111,7 @@ export function ApiKeyManagementModal() {
         ) : existingKey ? (
           <ActiveKeyState
             keyInfo={existingKey}
-            onRegenerate={() => createKey(existingKey.name || undefined)}
+            onRegenerate={() => setShowRegenerateConfirm(true)}
             onRevoke={() => setShowRevokeConfirm(true)}
             isRegenerating={isCreating}
           />
@@ -102,11 +132,24 @@ function LoadingState() {
   return (
     <>
       <DialogHeader>
-        <DialogTitle>API Key</DialogTitle>
+        <DialogTitle className="flex items-center gap-2">
+          <div className="h-5 w-5 rounded bg-muted animate-pulse" />
+          API Key
+        </DialogTitle>
+        <DialogDescription>Loading your API key information...</DialogDescription>
       </DialogHeader>
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      <div className="space-y-3 py-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex justify-between items-center">
+            <div className="h-4 w-16 rounded bg-muted animate-pulse" />
+            <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+          </div>
+        ))}
       </div>
+      <DialogFooter>
+        <div className="h-9 w-32 rounded-md bg-muted animate-pulse" />
+        <div className="h-9 w-24 rounded-md bg-muted animate-pulse" />
+      </DialogFooter>
     </>
   );
 }
@@ -122,7 +165,7 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
         <DialogDescription>Failed to load API key data. Please try again.</DialogDescription>
       </DialogHeader>
       <DialogFooter>
-        <Button onClick={onRetry}>
+        <Button onClick={onRetry} autoFocus>
           <RefreshCw className="mr-2 h-4 w-4" />
           Retry
         </Button>
@@ -157,7 +200,7 @@ function NoKeyState({
       <div className="space-y-4 py-2">
         <div>
           <label htmlFor="key-name" className="text-sm font-medium text-foreground">
-            Key name
+            Key name <span className="font-normal text-muted-foreground">(optional)</span>
           </label>
           <Input
             id="key-name"
@@ -170,7 +213,7 @@ function NoKeyState({
         </div>
       </div>
       <DialogFooter>
-        <Button onClick={onGenerate} disabled={isGenerating}>
+        <Button onClick={onGenerate} disabled={isGenerating} autoFocus>
           {isGenerating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Generate API Key
         </Button>
@@ -189,6 +232,11 @@ function KeyCreatedState({
   onDone: () => void;
 }) {
   const [copied, setCopied] = useState(false);
+  const copyRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    copyRef.current?.focus();
+  }, []);
 
   const handleCopy = () => {
     onCopy();
@@ -200,28 +248,28 @@ function KeyCreatedState({
     <>
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
-          <Check className="h-5 w-5 text-green-500" />
+          <Check className="h-5 w-5 text-green-600 dark:text-green-400" />
           API Key Created
         </DialogTitle>
         <DialogDescription className="flex items-start gap-2 pt-2">
-          <AlertTriangle className="h-4 w-4 text-yellow-500 shrink-0 mt-0.5" />
+          <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
           <span>Copy your API key now. You won&apos;t be able to see it again.</span>
         </DialogDescription>
       </DialogHeader>
       <div className="space-y-4 py-2">
         <div className="rounded-md border border-border bg-muted p-3">
-          <code className="text-sm break-all text-foreground">{apiKey}</code>
+          <code className="font-mono text-sm break-all text-foreground">{apiKey}</code>
         </div>
         <div className="text-xs text-muted-foreground">
-          Use this key in the <code className="text-foreground">x-api-key</code> header:
-          <pre className="mt-1 rounded bg-muted p-2 text-xs overflow-x-auto">
+          Use this key in the <code className="font-mono text-foreground">x-api-key</code> header:
+          <pre className="font-mono mt-1 rounded bg-muted p-2 text-xs overflow-x-auto">
             {`curl -H "x-api-key: YOUR_API_KEY" \\
   ${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/user/me`}
           </pre>
         </div>
       </div>
-      <DialogFooter className="flex gap-2 sm:gap-2">
-        <Button variant="outline" onClick={handleCopy}>
+      <DialogFooter>
+        <Button ref={copyRef} variant="outline" onClick={handleCopy}>
           {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
           {copied ? "Copied" : "Copy to Clipboard"}
         </Button>
@@ -237,12 +285,7 @@ function ActiveKeyState({
   onRevoke,
   isRegenerating,
 }: {
-  keyInfo: {
-    keyHint: string;
-    name: string;
-    createdAt: string;
-    lastUsedAt: string | null;
-  };
+  keyInfo: Pick<ApiKeyInfo, "keyHint" | "name" | "createdAt" | "lastUsedAt">;
   onRegenerate: () => void;
   onRevoke: () => void;
   isRegenerating: boolean;
@@ -254,10 +297,13 @@ function ActiveKeyState({
           <KeyRound className="h-5 w-5" />
           API Key
         </DialogTitle>
+        <DialogDescription>
+          Manage your API key for programmatic access to your account.
+        </DialogDescription>
       </DialogHeader>
       <div className="space-y-3 py-2">
         <InfoRow label="Name" value={keyInfo.name} />
-        <InfoRow label="Key" value={`karma_${keyInfo.keyHint}`} />
+        <InfoRow label="Key" value={`karma_${keyInfo.keyHint}`} mono />
         <InfoRow
           label="Created"
           value={new Date(keyInfo.createdAt).toLocaleDateString("en-US", {
@@ -278,8 +324,15 @@ function ActiveKeyState({
               : "Never"
           }
         />
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">Status</span>
+          <span className="flex items-center gap-1.5 text-sm font-medium text-green-600 dark:text-green-400">
+            <span className="h-2 w-2 rounded-full bg-green-500" />
+            Active
+          </span>
+        </div>
       </div>
-      <DialogFooter className="flex gap-2 sm:gap-2">
+      <DialogFooter>
         <Button variant="outline" onClick={onRegenerate} disabled={isRegenerating}>
           {isRegenerating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Regenerate Key
@@ -292,42 +345,47 @@ function ActiveKeyState({
   );
 }
 
-function RevokeConfirmation({
+function DestructiveConfirmation({
+  title,
+  description,
+  confirmLabel,
   onCancel,
   onConfirm,
-  isRevoking,
+  isPending,
 }: {
+  title: string;
+  description: string;
+  confirmLabel: string;
   onCancel: () => void;
   onConfirm: () => void;
-  isRevoking: boolean;
+  isPending: boolean;
 }) {
   return (
     <>
       <DialogHeader>
-        <DialogTitle>Revoke API Key?</DialogTitle>
-        <DialogDescription className="pt-2">
-          This will immediately invalidate your API key. Any agents or scripts using this key will
-          lose access. This action cannot be undone.
-        </DialogDescription>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription className="pt-2">{description}</DialogDescription>
       </DialogHeader>
-      <DialogFooter className="flex gap-2 sm:gap-2">
-        <Button variant="outline" onClick={onCancel} disabled={isRevoking}>
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel} disabled={isPending}>
           Cancel
         </Button>
-        <Button variant="destructive" onClick={onConfirm} disabled={isRevoking}>
-          {isRevoking && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          Revoke
+        <Button variant="destructive" onClick={onConfirm} disabled={isPending} autoFocus>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {confirmLabel}
         </Button>
       </DialogFooter>
     </>
   );
 }
 
-function InfoRow({ label, value }: { label: string; value: string }) {
+function InfoRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="flex justify-between items-center">
       <span className="text-sm text-muted-foreground">{label}</span>
-      <span className="text-sm font-medium text-foreground">{value}</span>
+      <span className={`text-sm font-medium text-foreground${mono ? " font-mono" : ""}`}>
+        {value}
+      </span>
     </div>
   );
 }

--- a/src/features/api-keys/hooks/use-api-key.ts
+++ b/src/features/api-keys/hooks/use-api-key.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiKeyService } from "../services/api-key.service";
+import type { CreateApiKeyResponse } from "../types/api-key";
+
+export const apiKeyKeys = {
+  all: ["apiKeys"] as const,
+  user: (address: string) => [...apiKeyKeys.all, address] as const,
+} as const;
+
+export function useApiKey(address: string | undefined) {
+  return useQuery({
+    queryKey: apiKeyKeys.user(address ?? ""),
+    queryFn: () => apiKeyService.get(),
+    enabled: !!address,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useCreateApiKey(options?: {
+  onSuccess?: (data: CreateApiKeyResponse) => void;
+  onError?: (error: Error) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name?: string) => apiKeyService.create(name),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: apiKeyKeys.all });
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}
+
+export function useRevokeApiKey(options?: {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiKeyService.revoke(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: apiKeyKeys.all });
+      options?.onSuccess?.();
+    },
+    onError: (error: Error) => {
+      options?.onError?.(error);
+    },
+  });
+}

--- a/src/features/api-keys/hooks/use-api-key.ts
+++ b/src/features/api-keys/hooks/use-api-key.ts
@@ -11,7 +11,7 @@ export const apiKeyKeys = {
 
 export function useApiKey(address: string | undefined) {
   return useQuery({
-    queryKey: apiKeyKeys.user(address ?? ""),
+    queryKey: address ? apiKeyKeys.user(address) : apiKeyKeys.all,
     queryFn: () => apiKeyService.get(),
     enabled: !!address,
     staleTime: 1000 * 60 * 5,

--- a/src/features/api-keys/services/api-key.service.ts
+++ b/src/features/api-keys/services/api-key.service.ts
@@ -5,8 +5,8 @@ import type { CreateApiKeyResponse, GetApiKeyResponse } from "../types/api-key";
 export const apiKeyService = {
   async get(): Promise<GetApiKeyResponse> {
     const [response, error] = await fetchData<GetApiKeyResponse>(INDEXER.API_KEYS.GET, "GET");
-    if (error) throw new Error(error);
-    return response!;
+    if (error || !response) throw new Error(error ?? "Unexpected empty response");
+    return response;
   },
 
   async create(name?: string): Promise<CreateApiKeyResponse> {
@@ -15,8 +15,8 @@ export const apiKeyService = {
       "POST",
       name ? { name } : {}
     );
-    if (error) throw new Error(error);
-    return response!;
+    if (error || !response) throw new Error(error ?? "Unexpected empty response");
+    return response;
   },
 
   async revoke(): Promise<void> {

--- a/src/features/api-keys/services/api-key.service.ts
+++ b/src/features/api-keys/services/api-key.service.ts
@@ -1,0 +1,26 @@
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type { CreateApiKeyResponse, GetApiKeyResponse } from "../types/api-key";
+
+export const apiKeyService = {
+  async get(): Promise<GetApiKeyResponse> {
+    const [response, error] = await fetchData<GetApiKeyResponse>(INDEXER.API_KEYS.GET, "GET");
+    if (error) throw new Error(error);
+    return response!;
+  },
+
+  async create(name?: string): Promise<CreateApiKeyResponse> {
+    const [response, error] = await fetchData<CreateApiKeyResponse>(
+      INDEXER.API_KEYS.CREATE,
+      "POST",
+      name ? { name } : {}
+    );
+    if (error) throw new Error(error);
+    return response!;
+  },
+
+  async revoke(): Promise<void> {
+    const [, error] = await fetchData(INDEXER.API_KEYS.REVOKE, "DELETE");
+    if (error) throw new Error(error);
+  },
+};

--- a/src/features/api-keys/types/api-key.ts
+++ b/src/features/api-keys/types/api-key.ts
@@ -1,0 +1,18 @@
+export interface ApiKeyInfo {
+  keyHint: string;
+  name: string;
+  isActive: boolean;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface CreateApiKeyResponse {
+  key: string;
+  keyHint: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface GetApiKeyResponse {
+  apiKey: ApiKeyInfo | null;
+}

--- a/store/modals/apiKeyManagement.ts
+++ b/store/modals/apiKeyManagement.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface ApiKeyManagementStore {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export const useApiKeyManagementModalStore = create<ApiKeyManagementStore>((set) => ({
+  isModalOpen: false,
+  openModal: () => set({ isModalOpen: true }),
+  closeModal: () => set({ isModalOpen: false }),
+}));

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -629,6 +629,11 @@ export const INDEXER = {
       `/projects/${idOrSlug}/update/contact/${contactId}`,
     DELETE: (idOrSlug: string) => `/projects/${idOrSlug}/delete/contact`,
   },
+  API_KEYS: {
+    GET: "/v2/user/api-keys",
+    CREATE: "/v2/user/api-keys",
+    REVOKE: "/v2/user/api-keys",
+  },
   KYC: {
     GET_STATUS: (projectUID: string, communityUID: string) =>
       `/v2/projects/${projectUID}/communities/${communityUID}/kyc-status`,


### PR DESCRIPTION
## Summary

Adds API key management UI, allowing users to create, view, regenerate, and revoke long-lived API keys for programmatic access (AI agents, scripts). Keys are mapped to wallet addresses and resolve through the existing authentication middleware.

## Changes

### Core Feature
- **API Key Management Modal** — Full lifecycle UI: create with optional name, view active key details, regenerate with confirmation, revoke with confirmation, and copy-to-clipboard flow
- **Service Layer** — `apiKeyService` with `get()`, `create(name?)`, and `revoke()` methods using `fetchData` utility
- **React Query Hooks** — `useApiKey`, `useCreateApiKey`, `useRevokeApiKey` with query key factory and automatic cache invalidation
- **Zustand Store** — `useApiKeyManagementModalStore` for modal open/close state
- **Navbar Integration** — "API Keys" menu entry in user dropdown

### Bug Fixes
- Fix modal always showing "no key" state — replaced `useNavbarPermissions()` (scoped to Navbar only) with `useAuth()` since the modal is rendered at layout level outside the NavbarPermissionsProvider
- Fix query key cache pollution — use conditional key (`address ? user(address) : all`) instead of `address ?? ""`
- Remove non-null assertions in service layer with proper error guards

### UX & Accessibility Improvements
- Two-step confirmation for destructive actions (regenerate, revoke) via shared `DestructiveConfirmation` component
- Close guard on key-created state — prevents accidental dismissal before copying the key (blocks Escape, outside click, and X button)
- Skeleton loading state matching ActiveKeyState shape instead of bare spinner
- Focus management — `autoFocus` on primary actions, `useRef` to auto-focus copy button
- Mobile viewport handling — `max-h-[90dvh] overflow-y-auto` for keyboard overlap
- WCAG contrast fixes — green check (`text-green-600 dark:text-green-400`), amber warning icon (`text-amber-600 dark:text-amber-400`)
- `font-mono` on code blocks and key hint display
- "Optional" label hint on key name input
- `DialogDescription` on ActiveKeyState for screen reader context
- Active status badge with green dot indicator

### Code Quality
- Extracted shared `DestructiveConfirmation` component (replaces separate Revoke/Regenerate components)
- `Pick<ApiKeyInfo, ...>` type instead of inline type duplication
- `InfoRow` component supports `mono` prop for monospace values

## Test Plan
- [x] 34 unit tests covering all modal states (loading skeleton, error/retry, no key, key created, active key, regenerate confirmation, revoke confirmation, modal closed)
- [x] Layout integration test verifies modal is present in root layout
- [x] All 71 related tests passing

Asana task: 1213380363621057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key management UI added (create, view, regenerate, copy, revoke keys), shows usage examples and last-used info; accessible from the navbar (desktop & mobile) and included in the app layout.
* **Tests**
  * Extensive unit and integration tests added for the API key UI, hooks, service, modal store, and related flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->