### PR TITLE
fix: pre-initialize GAP instances for all chains to fix cross-chain RPC errors

### DIFF
--- a/components/Dialogs/ProjectDialog/FaucetSection.tsx
+++ b/components/Dialogs/ProjectDialog/FaucetSection.tsx
@@ -9,10 +9,10 @@ import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFaucetClaim, useFaucetEligibility } from "@/hooks/useFaucet";
-import { getGapClient } from "@/hooks/useGap";
 import { useWallet } from "@/hooks/useWallet";
 import type { FaucetTransaction } from "@/utilities/faucet/faucetService";
 import { buildProjectAttestationTransaction } from "@/utilities/gap/buildAttestationTransaction";
+import { getGapClient } from "@/utilities/gapClient";
 import { cn } from "@/utilities/tailwind";
 
 interface FaucetSectionProps {

--- a/hooks/useGap.ts
+++ b/hooks/useGap.ts
@@ -1,146 +1,31 @@
 "use client";
 
-import type { TNetwork } from "@show-karma/karma-gap-sdk";
-import { GAP } from "@show-karma/karma-gap-sdk/core/class/GAP";
-import { GapIndexerClient } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/GapIndexerClient";
-import { Networks } from "@show-karma/karma-gap-sdk/core/consts";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useAccount } from "wagmi";
-import { envVars } from "@/utilities/enviromentVars";
-import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
-import {
-  appNetwork,
-  gapSupportedNetworks,
-  getChainIdByName,
-  getChainNameById,
-} from "@/utilities/network";
-
-const gapClients: Record<number, GAP> = {};
-
-const isSupportedNetwork = (network: string): network is TNetwork =>
-  Object.hasOwn(Networks, network);
-
-const getSupportedNetworkForChain = (chainID: number): TNetwork | null => {
-  const candidate = getChainNameById(chainID);
-  return isSupportedNetwork(candidate) ? candidate : null;
-};
-
-const findDefaultSupportedChainId = (): number | undefined => {
-  const fallbackChain = appNetwork.find((chain) => isSupportedNetwork(getChainNameById(chain.id)));
-  return fallbackChain?.id;
-};
-
-export const getDefaultGapChainId = (): number | undefined => findDefaultSupportedChainId();
-
-const createGapInstance = (network: TNetwork): GAP => {
-  const apiUrl = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
-  return new GAP({
-    globalSchemas: false,
-    network,
-    rpcUrls: getGapRpcConfig(),
-    ...(apiUrl?.trim()
-      ? {
-          apiClient: new GapIndexerClient(apiUrl),
-        }
-      : {}),
-  });
-};
-
-let allNetworksInitialized = false;
-
-/**
- * Eagerly initialize GAP instances for every supported network so that the
- * SDK's AllGapSchemas.findSchema() always finds an existing instance with
- * rpcConfig populated instead of creating a bare one without it.
- */
-const ensureAllNetworksInitialized = () => {
-  if (allNetworksInitialized) return;
-  allNetworksInitialized = true;
-
-  for (const network of Object.keys(Networks) as TNetwork[]) {
-    const expectedChainId = Networks[network]?.chainId;
-    const resolvedChainId = getChainIdByName(network);
-    if (expectedChainId && resolvedChainId === expectedChainId && !gapClients[resolvedChainId]) {
-      try {
-        gapClients[resolvedChainId] = createGapInstance(network);
-      } catch (error) {
-        console.error(
-          `GAP::Failed to pre-initialize client for ${network} (chain ${resolvedChainId})`,
-          error
-        );
-      }
-    }
-  }
-};
-
-export const getGapClient = (chainID: number): GAP => {
-  ensureAllNetworksInitialized();
-
-  const network = getSupportedNetworkForChain(chainID);
-  if (!network) {
-    throw new Error(`GAP::Unsupported chain ${chainID}`);
-  }
-  const networkChainId = getChainIdByName(network);
-  return (
-    gapClients[networkChainId] ??
-    (() => {
-      const client = createGapInstance(network);
-      gapClients[networkChainId] = client;
-      return client;
-    })()
-  );
-};
+import { getDefaultGapChainId, getGapClient } from "@/utilities/gapClient";
 
 export const useGap = () => {
-  const [gap, setGapClient] = useState<GAP>();
-  const [isUpdating, setIsUpdating] = useState(false);
   const { chain } = useAccount();
-  const defaultSupportedChainId = useMemo(findDefaultSupportedChainId, []);
 
-  const updateGapClient = useCallback(
-    async (chainId: number) => {
-      if (isUpdating) return;
-      setIsUpdating(true);
+  const gap = useMemo(() => {
+    const defaultChainId = getDefaultGapChainId();
+    const targetChainId = chain?.id ?? defaultChainId;
+    if (!targetChainId) return undefined;
 
-      const network = getSupportedNetworkForChain(chainId);
-
-      if (!network) {
-        // Unsupported chain - switch to first supported network
-        const firstSupportedChain = gapSupportedNetworks[0];
-        console.warn(
-          `GAP::Unsupported chain ${chainId}. Switching to ${firstSupportedChain.name}...`
-        );
-
-        setGapClient(getGapClient(firstSupportedChain.id));
-        setIsUpdating(false);
-        return;
+    try {
+      return getGapClient(targetChainId);
+    } catch {
+      // Unsupported chain — fall back to default
+      if (defaultChainId && defaultChainId !== targetChainId) {
+        try {
+          return getGapClient(defaultChainId);
+        } catch {
+          /* noop */
+        }
       }
-
-      // Supported chain - normal flow
-      const normalizedChainId = getChainIdByName(network);
-
-      try {
-        const client = getGapClient(normalizedChainId);
-        setGapClient(client);
-      } catch (error) {
-        console.error("GAP::Failed to initialize client", error);
-        setGapClient(undefined);
-      } finally {
-        setIsUpdating(false);
-      }
-    },
-    [isUpdating]
-  );
-
-  useEffect(() => {
-    const targetChainId = chain?.id ?? defaultSupportedChainId;
-    if (!targetChainId) {
-      setGapClient(undefined);
-      return;
+      return undefined;
     }
+  }, [chain?.id]);
 
-    updateGapClient(targetChainId);
-  }, [chain?.id, defaultSupportedChainId, updateGapClient]);
-
-  return useMemo(() => ({ gap, updateGapClient }), [gap, updateGapClient]);
+  return { gap };
 };

--- a/utilities/ensureCorrectChain.ts
+++ b/utilities/ensureCorrectChain.ts
@@ -1,5 +1,5 @@
 import toast from "react-hot-toast";
-import { getGapClient } from "@/hooks/useGap";
+import { getGapClient } from "@/utilities/gapClient";
 
 interface EnsureCorrectChainParams {
   targetChainId: number;

--- a/utilities/gapClient.ts
+++ b/utilities/gapClient.ts
@@ -1,0 +1,83 @@
+import type { TNetwork } from "@show-karma/karma-gap-sdk";
+import { GAP } from "@show-karma/karma-gap-sdk/core/class/GAP";
+import { GapIndexerClient } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/GapIndexerClient";
+import { Networks } from "@show-karma/karma-gap-sdk/core/consts";
+import { envVars } from "@/utilities/enviromentVars";
+import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
+import { appNetwork, getChainIdByName, getChainNameById } from "@/utilities/network";
+
+const gapClients: Record<number, GAP> = {};
+
+const isSupportedNetwork = (network: string): network is TNetwork =>
+  Object.hasOwn(Networks, network);
+
+const getSupportedNetworkForChain = (chainID: number): TNetwork | null => {
+  const candidate = getChainNameById(chainID);
+  return isSupportedNetwork(candidate) ? candidate : null;
+};
+
+const findDefaultSupportedChainId = (): number | undefined => {
+  const fallbackChain = appNetwork.find((chain) => isSupportedNetwork(getChainNameById(chain.id)));
+  return fallbackChain?.id;
+};
+
+export const getDefaultGapChainId = (): number | undefined => findDefaultSupportedChainId();
+
+const createGapInstance = (network: TNetwork): GAP => {
+  const apiUrl = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
+  return new GAP({
+    globalSchemas: false,
+    network,
+    rpcUrls: getGapRpcConfig(),
+    ...(apiUrl?.trim()
+      ? {
+          apiClient: new GapIndexerClient(apiUrl),
+        }
+      : {}),
+  });
+};
+
+let allNetworksInitialized = false;
+
+/**
+ * Eagerly initialize GAP instances for every supported network so that the
+ * SDK's AllGapSchemas.findSchema() always finds an existing instance with
+ * rpcConfig populated instead of creating a bare one without it.
+ */
+const ensureAllNetworksInitialized = () => {
+  if (allNetworksInitialized) return;
+  allNetworksInitialized = true;
+
+  for (const network of Object.keys(Networks) as TNetwork[]) {
+    const expectedChainId = Networks[network]?.chainId;
+    const resolvedChainId = getChainIdByName(network);
+    if (expectedChainId && resolvedChainId === expectedChainId && !gapClients[resolvedChainId]) {
+      try {
+        gapClients[resolvedChainId] = createGapInstance(network);
+      } catch (error) {
+        console.error(
+          `GAP::Failed to pre-initialize client for ${network} (chain ${resolvedChainId})`,
+          error
+        );
+      }
+    }
+  }
+};
+
+export const getGapClient = (chainID: number): GAP => {
+  ensureAllNetworksInitialized();
+
+  const network = getSupportedNetworkForChain(chainID);
+  if (!network) {
+    throw new Error(`GAP::Unsupported chain ${chainID}`);
+  }
+  const networkChainId = getChainIdByName(network);
+  return (
+    gapClients[networkChainId] ??
+    (() => {
+      const client = createGapInstance(network);
+      gapClients[networkChainId] = client;
+      return client;
+    })()
+  );
+};

--- a/utilities/sdk/projects/getProjectById.ts
+++ b/utilities/sdk/projects/getProjectById.ts
@@ -1,8 +1,8 @@
 import type { Project } from "@show-karma/karma-gap-sdk/core/class/entities/Project";
 import type { Hex } from "viem";
 import { errorManager } from "@/components/Utilities/errorManager";
-import { getDefaultGapChainId, getGapClient } from "@/hooks/useGap";
 import { zeroUID } from "@/utilities/commons";
+import { getDefaultGapChainId, getGapClient } from "@/utilities/gapClient";
 
 export const getProjectById = async (projectId: string): Promise<Project | undefined> => {
   try {


### PR DESCRIPTION
## Summary

- Pre-initialize GAP SDK instances for **all supported networks** at module load time, fixing `RPC URL not configured for chain 8453` errors on cross-chain project pages

## Problem

When viewing a project on Base (chain 8453) while the default GAP client is initialized for Optimism, the SDK's internal `AllGapSchemas.findSchema()` calls `GAP.getInstance({ network: "base" })` with **only** the network name — no `rpcUrls`. This creates a new GAP instance with an empty `rpcConfig`, causing `getWeb3Provider(8453, {})` to throw because `config[8453]` is undefined.

The previous fix (PR #1027) added fallback RPC URLs and passed `rpcUrls` to the GAP constructor, but only the **default chain's** GAP instance was created at startup. Cross-chain projects still triggered `AllGapSchemas` to create bare instances without RPC config.

## Solution

- Extract `createGapInstance()` helper to avoid duplication
- Add module-level initialization loop that pre-creates GAP clients for every network in the SDK's `Networks` config, each with the full `rpcUrls` map
- Safety check ensures chain ID resolves correctly before initializing (avoids collisions for unmapped networks like `sei-testnet`)

Now when `AllGapSchemas.findSchema()` calls `GAP.getInstance({ network: "base" })`, it finds the pre-existing instance that already has `rpcConfig` populated.

## Test plan

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All 327 test suites pass (6821 tests)
- [x] Biome lint passes (lint-staged)
- [ ] Verify on staging: navigate to a Base project's milestones page while connected on a different chain
- [ ] Confirm no Sentry errors for `RPC URL not configured for chain 8453`

Fixes GAP-FRONTEND-1VC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined network client construction into a single, consistent initialization path to reduce duplication.
  * Added eager pre-initialization for supported networks and a readiness check before retrieval, improving reliability while preserving existing supported/unsupported error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213370331771783