### PR TITLE
fix: convert invoice date to ISO datetime before sending to API

### DIFF
--- a/__tests__/control-center/unit/project-details-modal.test.tsx
+++ b/__tests__/control-center/unit/project-details-modal.test.tsx
@@ -445,6 +445,7 @@ describe("ProjectDetailsModal", () => {
             expect.objectContaining({
               milestoneLabel: "Milestone A",
               milestoneUID: "ms-a",
+              invoiceReceivedAt: "2024-06-15T00:00:00.000Z",
             }),
           ]),
         }),

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
@@ -351,10 +351,13 @@ export function ProjectDetailsModal({
       const matchedInvoice = milestoneInvoices.find(
         (inv, idx) => getMilestoneKey(inv, idx) === key
       );
+      const rawDate = edits.invoiceReceivedAt;
+      const isoDate =
+        rawDate && !rawDate.includes("T") ? `${rawDate}T00:00:00.000Z` : (rawDate ?? null);
       return {
         milestoneLabel: matchedInvoice?.milestoneLabel ?? key,
         milestoneUID: edits.milestoneUID ?? null,
-        invoiceReceivedAt: edits.invoiceReceivedAt ?? null,
+        invoiceReceivedAt: isoDate,
       };
     });
 


### PR DESCRIPTION
## Summary

- Fix `400 Bad Request` when saving invoice received dates — the HTML date input returns `YYYY-MM-DD` but the backend DTO expects ISO 8601 datetime format
- Appends `T00:00:00.000Z` (UTC midnight) when the time component is missing

## Test plan

- [ ] Open Control Center, edit an invoice received date, save — should succeed without 400 error
- [ ] `pnpm test -- project-details-modal` — 26 tests pass, including assertion that `invoiceReceivedAt` is sent as full ISO datetime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Invoice dates are now properly standardized to a consistent format when saving project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->