### PR TITLE
fix: correct milestone verification permissions for reviewers and community admins

### DIFF
--- a/__tests__/hooks/useCanVerifyMilestone.test.tsx
+++ b/__tests__/hooks/useCanVerifyMilestone.test.tsx
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react";
+import { useCanVerifyMilestone } from "@/hooks/useCanVerifyMilestone";
+import { useAuth } from "@/hooks/useAuth";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+import { useIsReviewer } from "@/hooks/usePermissions";
+import { useOwnerStore, useProjectStore } from "@/store";
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: jest.fn(),
+}));
+
+jest.mock("@/hooks/usePermissions", () => ({
+  useIsReviewer: jest.fn(),
+}));
+
+jest.mock("@/store", () => ({
+  useOwnerStore: jest.fn(),
+  useProjectStore: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as unknown as jest.Mock;
+const mockUseIsCommunityAdmin = useIsCommunityAdmin as unknown as jest.Mock;
+const mockUseIsReviewer = useIsReviewer as unknown as jest.Mock;
+const mockUseOwnerStore = useOwnerStore as unknown as jest.Mock;
+const mockUseProjectStore = useProjectStore as unknown as jest.Mock;
+
+function setupMocks(overrides: {
+  authenticated?: boolean;
+  isOwner?: boolean;
+  isProjectAdmin?: boolean;
+  isProjectOwner?: boolean;
+  isCommunityAdmin?: boolean;
+  isReviewer?: boolean;
+} = {}) {
+  const {
+    authenticated = true,
+    isOwner = false,
+    isProjectAdmin = false,
+    isProjectOwner = false,
+    isCommunityAdmin = false,
+    isReviewer = false,
+  } = overrides;
+
+  mockUseAuth.mockReturnValue({ authenticated });
+  mockUseOwnerStore.mockImplementation((selector: (s: any) => any) =>
+    selector({ isOwner })
+  );
+  mockUseProjectStore.mockImplementation((selector: (s: any) => any) =>
+    selector({ isProjectAdmin, isProjectOwner })
+  );
+  mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin });
+  mockUseIsReviewer.mockReturnValue({ isReviewer });
+}
+
+describe("useCanVerifyMilestone", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("allows contract owner to verify", () => {
+    setupMocks({ isOwner: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(true);
+  });
+
+  it("allows community admin to verify", () => {
+    setupMocks({ isCommunityAdmin: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(true);
+  });
+
+  it("allows program reviewer to verify", () => {
+    setupMocks({ isReviewer: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(true);
+  });
+
+  it("blocks project owner from verifying", () => {
+    setupMocks({ isProjectOwner: true, isCommunityAdmin: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(false);
+  });
+
+  it("blocks project admin from verifying", () => {
+    setupMocks({ isProjectAdmin: true, isReviewer: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(false);
+  });
+
+  it("blocks unauthenticated users", () => {
+    setupMocks({ authenticated: false, isOwner: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(false);
+  });
+
+  it("blocks authenticated users with no special role", () => {
+    setupMocks({});
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.canVerify).toBe(false);
+  });
+
+  it("passes programId to useIsReviewer", () => {
+    setupMocks({});
+    renderHook(() => useCanVerifyMilestone("my-program", "my-community"));
+    expect(mockUseIsReviewer).toHaveBeenCalledWith("my-program");
+  });
+
+  it("passes communityUID to useIsCommunityAdmin", () => {
+    setupMocks({});
+    renderHook(() => useCanVerifyMilestone("my-program", "my-community"));
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith("my-community");
+  });
+
+  it("works without programId or communityUID", () => {
+    setupMocks({ isOwner: true });
+    const { result } = renderHook(() => useCanVerifyMilestone());
+    expect(result.current.canVerify).toBe(true);
+    expect(mockUseIsReviewer).toHaveBeenCalledWith(undefined);
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith(undefined);
+  });
+
+  it("returns role flags for consumers", () => {
+    setupMocks({ isCommunityAdmin: true, isOwner: true });
+    const { result } = renderHook(() => useCanVerifyMilestone("prog1", "comm1"));
+    expect(result.current.isCommunityAdmin).toBe(true);
+    expect(result.current.isContractOwner).toBe(true);
+    expect(result.current.isReviewer).toBe(false);
+  });
+});

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/Updates.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/Updates.tsx
@@ -247,7 +247,7 @@ export const Updates: FC<UpdatesProps> = ({ milestone }) => {
               <img className="h-4 w-4" alt="Update" src="/icons/alert-message-white.svg" />
               <p className="text-xs font-bold text-white">UPDATE</p>
             </div>
-            {isVerified && !isAuthorized && (
+            {isVerified && (
               <VerifiedBadge
                 verifications={milestone.verified}
                 title={`${milestone.title} - Reviews`}
@@ -291,53 +291,57 @@ export const Updates: FC<UpdatesProps> = ({ milestone }) => {
               ) : null}
 
               <div className="flex flex-1 flex-row items-center justify-end">
-                {isAuthorized ? (
-                  <div className="flex w-max flex-row items-center gap-2">
-                    <MilestoneVerificationSection
-                      milestone={milestone}
-                      title={`${milestone.title} - Reviews`}
-                      isVerified={isVerified}
-                      verifications={milestone.verified}
-                      onVerified={markAsVerified}
-                    />
-                    <ExternalLink
-                      type="button"
-                      className="flex flex-row gap-2 bg-transparent text-sm font-semibold text-gray-600 dark:text-zinc-100 hover:bg-transparent"
-                      href={shareOnX(
-                        SHARE_TEXTS.MILESTONE_COMPLETED(
-                          grant?.details?.title as string,
-                          (project?.details?.slug || project?.uid) as string,
-                          grant?.uid as string
-                        )
-                      )}
-                    >
-                      <ShareIcon className="h-5 w-5" />
-                    </ExternalLink>
-                    <Button
-                      type="button"
-                      className="flex flex-row gap-2 bg-transparent text-sm font-semibold text-gray-600 dark:text-zinc-100 hover:bg-transparent"
-                      onClick={() => handleEditing(true)}
-                    >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </Button>
-                    <DeleteDialog
-                      deleteFunction={undoMilestoneCompletion}
-                      isLoading={isDeleting}
-                      title={
-                        <p className="font-normal">
-                          Are you sure you want to revoke the completion of <b>{milestone.title}</b>
-                          ?
-                        </p>
-                      }
-                      buttonElement={{
-                        text: "",
-                        icon: <TrashIcon className="h-5 w-5" />,
-                        styleClass:
-                          "bg-transparent p-0 w-max h-max text-gray-600 dark:text-zinc-100 hover:bg-transparent",
-                      }}
-                    />
-                  </div>
-                ) : null}
+                <div className="flex w-max flex-row items-center gap-2">
+                  <MilestoneVerificationSection
+                    milestone={milestone}
+                    title={`${milestone.title} - Reviews`}
+                    isVerified={isVerified}
+                    verifications={milestone.verified}
+                    onVerified={markAsVerified}
+                    programId={grant?.programId ?? grant?.details?.programId}
+                    communityUID={grant?.communityUID}
+                  />
+                  {isAuthorized ? (
+                    <>
+                      <ExternalLink
+                        type="button"
+                        className="flex flex-row gap-2 bg-transparent text-sm font-semibold text-gray-600 dark:text-zinc-100 hover:bg-transparent"
+                        href={shareOnX(
+                          SHARE_TEXTS.MILESTONE_COMPLETED(
+                            grant?.details?.title as string,
+                            (project?.details?.slug || project?.uid) as string,
+                            grant?.uid as string
+                          )
+                        )}
+                      >
+                        <ShareIcon className="h-5 w-5" />
+                      </ExternalLink>
+                      <Button
+                        type="button"
+                        className="flex flex-row gap-2 bg-transparent text-sm font-semibold text-gray-600 dark:text-zinc-100 hover:bg-transparent"
+                        onClick={() => handleEditing(true)}
+                      >
+                        <PencilSquareIcon className="h-5 w-5" />
+                      </Button>
+                      <DeleteDialog
+                        deleteFunction={undoMilestoneCompletion}
+                        isLoading={isDeleting}
+                        title={
+                          <p className="font-normal">
+                            Are you sure you want to revoke the completion of{" "}
+                            <b>{milestone.title}</b>?
+                          </p>
+                        }
+                        buttonElement={{
+                          text: "",
+                          icon: <TrashIcon className="h-5 w-5" />,
+                          styleClass:
+                            "bg-transparent p-0 w-max h-max text-gray-600 dark:text-zinc-100 hover:bg-transparent",
+                        }}
+                      />
+                    </>
+                  ) : null}
+                </div>
               </div>
             </div>
           </div>

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifyGrantUpdateDialog.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifyGrantUpdateDialog.tsx
@@ -10,12 +10,12 @@ import { z } from "zod";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
-import { useAuth } from "@/hooks/useAuth";
+import { useCanVerifyMilestone } from "@/hooks/useCanVerifyMilestone";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import { useProjectGrants } from "@/hooks/v2/useProjectGrants";
 import { getProjectGrants } from "@/services/project-grants.service";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import type { GrantUpdate } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
 import { getSDKGrantInstance } from "@/utilities/grant-helpers";
@@ -27,6 +27,8 @@ type VerifyGrantUpdateDialogProps = {
   grantUpdate: GrantUpdate;
   onVerified: () => void;
   isVerified: boolean;
+  programId?: string;
+  communityUID?: string;
 };
 
 const schema = z.object({
@@ -39,6 +41,8 @@ export const VerifyGrantUpdateDialog: FC<VerifyGrantUpdateDialogProps> = ({
   grantUpdate,
   onVerified,
   isVerified,
+  programId,
+  communityUID,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -174,17 +178,10 @@ export const VerifyGrantUpdateDialog: FC<VerifyGrantUpdateDialogProps> = ({
       setIsStepper(false);
     }
   };
-  const { authenticated: isAuth } = useAuth();
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const verifyPermission = () => {
-    if (!isAuth) return false;
-    return isContractOwner || !isProjectAdmin;
-  };
-  const ableToVerify = verifyPermission();
+  const { canVerify } = useCanVerifyMilestone(programId, communityUID);
 
   // Hide if already verified or user doesn't have permission
-  if (isVerified || !ableToVerify) return null;
+  if (isVerified || !canVerify) return null;
 
   return (
     <>

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifyMilestoneUpdateDialog.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifyMilestoneUpdateDialog.tsx
@@ -10,11 +10,11 @@ import { z } from "zod";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
-import { useAuth } from "@/hooks/useAuth";
+import { useCanVerifyMilestone } from "@/hooks/useCanVerifyMilestone";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import { useProjectGrants } from "@/hooks/v2/useProjectGrants";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import type { GrantMilestone } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
@@ -25,6 +25,8 @@ type VerifyMilestoneUpdateDialogProps = {
   milestone: GrantMilestone;
   onVerified: () => void;
   isVerified: boolean;
+  programId?: string;
+  communityUID?: string;
 };
 
 const schema = z.object({
@@ -37,6 +39,8 @@ export const VerifyMilestoneUpdateDialog: FC<VerifyMilestoneUpdateDialogProps> =
   milestone,
   onVerified,
   isVerified,
+  programId,
+  communityUID,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -163,15 +167,8 @@ export const VerifyMilestoneUpdateDialog: FC<VerifyMilestoneUpdateDialogProps> =
       setIsStepper(false);
     }
   };
-  const { authenticated: isAuth } = useAuth();
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const verifyPermission = () => {
-    if (!isAuth) return false;
-    return isContractOwner || !isProjectAdmin;
-  };
-  const ableToVerify = verifyPermission();
-  if (hasVerifiedThis || !ableToVerify) return null;
+  const { canVerify } = useCanVerifyMilestone(programId, communityUID);
+  if (hasVerifiedThis || !canVerify) return null;
 
   return (
     <>

--- a/components/Pages/Project/Impact/VerifyImpactDialog.tsx
+++ b/components/Pages/Project/Impact/VerifyImpactDialog.tsx
@@ -13,13 +13,13 @@ import { z } from "zod";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
-import { useAuth } from "@/hooks/useAuth";
+import { useCanVerifyMilestone } from "@/hooks/useCanVerifyMilestone";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import { useProjectImpacts } from "@/hooks/v2/useProjectImpacts";
 import type { ProjectImpactVerification } from "@/services/project-impacts.service";
 import { getProjectImpacts } from "@/services/project-impacts.service";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
@@ -29,6 +29,8 @@ import { getProjectById } from "@/utilities/sdk";
 type VerifyImpactDialogProps = {
   impact: IProjectImpact;
   addVerification: (newVerified: IProjectImpactStatus) => void;
+  programId?: string;
+  communityUID?: string;
 };
 
 const schema = z.object({
@@ -37,7 +39,12 @@ const schema = z.object({
 
 type SchemaType = z.infer<typeof schema>;
 
-export const VerifyImpactDialog: FC<VerifyImpactDialogProps> = ({ impact, addVerification }) => {
+export const VerifyImpactDialog: FC<VerifyImpactDialogProps> = ({
+  impact,
+  addVerification,
+  programId,
+  communityUID,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -150,27 +157,14 @@ export const VerifyImpactDialog: FC<VerifyImpactDialogProps> = ({ impact, addVer
       setIsStepper(false);
     }
   };
-  const { authenticated: isAuth, login } = useAuth();
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const verifyPermission = () => {
-    if (!isAuth) return false;
-    return isContractOwner || !isProjectAdmin;
-  };
-  const ableToVerify = verifyPermission();
+  const { canVerify } = useCanVerifyMilestone(programId, communityUID);
 
-  if (hasVerifiedThis || !ableToVerify) return null;
+  if (hasVerifiedThis || !canVerify) return null;
 
   return (
     <>
       <Button
-        onClick={() => {
-          if (!isAuth) {
-            login?.();
-          } else {
-            openModal();
-          }
-        }}
+        onClick={openModal}
         className={
           "flex justify-center items-center gap-x-2 rounded-md bg-transparent dark:bg-transparent px-3 py-2 text-sm font-semibold text-red-600 dark:text-red-300  hover:opacity-75 dark:hover:opacity-75 border border-red-200 dark:border-red-900 hover:bg-transparent"
         }

--- a/components/Shared/MilestoneVerification/MilestoneVerificationSection.tsx
+++ b/components/Shared/MilestoneVerification/MilestoneVerificationSection.tsx
@@ -13,6 +13,8 @@ interface MilestoneVerificationSectionProps {
   isVerified?: boolean;
   verifications?: VerificationRecord[];
   onVerified?: () => void;
+  programId?: string;
+  communityUID?: string;
 }
 
 export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps> = ({
@@ -21,6 +23,8 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
   isVerified: isVerifiedProp,
   verifications,
   onVerified,
+  programId,
+  communityUID,
 }) => {
   // V2: verified is an array of verifications
   const getInitialVerifiedState = (): boolean => {
@@ -75,6 +79,12 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
 
   const milestoneForDialog = getMilestoneForDialog();
 
+  // Extract grant context for permission checks
+  const grantContext =
+    "source" in milestone ? (milestone as UnifiedMilestone).source.grantMilestone?.grant : undefined;
+  const derivedProgramId = programId ?? grantContext?.details?.programId;
+  const derivedCommunityUID = communityUID ?? grantContext?.community?.uid;
+
   return (
     <div className="flex flex-row gap-4 items-center flex-wrap w-max max-w-full">
       {isVerified && (
@@ -89,6 +99,8 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
           milestone={milestoneForDialog}
           onVerified={markAsVerified}
           isVerified={isVerified}
+          programId={derivedProgramId}
+          communityUID={derivedCommunityUID}
         />
       )}
     </div>

--- a/hooks/useCanVerifyMilestone.ts
+++ b/hooks/useCanVerifyMilestone.ts
@@ -1,0 +1,31 @@
+import { useAuth } from "@/hooks/useAuth";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+import { useIsReviewer } from "@/hooks/usePermissions";
+import { useOwnerStore, useProjectStore } from "@/store";
+
+/**
+ * Consolidated hook for milestone/update/impact verification permissions.
+ *
+ * Separation of duties:
+ * - Project owners/admins can **complete** milestones but CANNOT **verify** them
+ * - Contract owners, community admins, and program reviewers CAN verify
+ *
+ * @param programId - Funding program ID (enables reviewer check)
+ * @param communityUID - Community UID or slug (enables community admin check)
+ */
+export function useCanVerifyMilestone(programId?: string, communityUID?: string) {
+  const { authenticated } = useAuth();
+  const isContractOwner = useOwnerStore((state) => state.isOwner);
+  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const { isCommunityAdmin } = useIsCommunityAdmin(communityUID);
+  const { isReviewer } = useIsReviewer(programId);
+
+  const canVerify =
+    authenticated &&
+    !isProjectOwner &&
+    !isProjectAdmin &&
+    (isContractOwner || isCommunityAdmin || isReviewer);
+
+  return { canVerify, isCommunityAdmin, isReviewer, isContractOwner };
+}


### PR DESCRIPTION
## Summary

- Fixed two bugs preventing milestone reviewers and community admins from seeing the "Verify" button on milestones
- Created shared `useCanVerifyMilestone` hook consolidating permission logic across 3 verify dialog components
- Extracted `MilestoneVerificationSection` from `isAuthorized` gate so it renders independently with proper role checks

## Problem

1. **Gate 1 (`isAuthorized`)**: The `Updates.tsx` component gated `MilestoneVerificationSection` behind `isAuthorized`, which excluded community admins and milestone reviewers
2. **Gate 2 (`verifyPermission()`)**: The inline logic `isContractOwner || !isProjectAdmin` was inverted — it blocked project admins (who should only be blocked from self-verifying) but allowed ANY authenticated non-admin

## Solution

- New `useCanVerifyMilestone(programId, communityUID)` hook enforces separation of duties: project owners/admins cannot verify their own milestones, while contract owners, community admins, and program reviewers can
- Uses standalone `useIsCommunityAdmin` from `hooks/communities/` (data-driven, works anywhere) and `useIsReviewer` from `hooks/usePermissions.ts`
- `MilestoneVerificationSection` now renders outside the `isAuthorized` gate and handles its own permissions internally
- Grant context (`programId`, `communityUID`) is threaded through the component chain

## Files Changed

| File | Change |
|------|--------|
| `hooks/useCanVerifyMilestone.ts` | **NEW** — shared permission hook |
| `VerifyMilestoneUpdateDialog.tsx` | Use `useCanVerifyMilestone` instead of buggy inline logic |
| `VerifyGrantUpdateDialog.tsx` | Same |
| `VerifyImpactDialog.tsx` | Same + removed dead login code |
| `MilestoneVerificationSection.tsx` | Added `programId`/`communityUID` props, extracts grant context |
| `Updates.tsx` | Extracted verification section from `isAuthorized` gate |
| `useCanVerifyMilestone.test.tsx` | **NEW** — 11 unit tests |

## Test plan

- [x] 11 unit tests for `useCanVerifyMilestone` covering all permission scenarios
- [ ] Manual: As community admin, visit project page and see verify button on completed milestones
- [ ] Manual: As milestone reviewer, visit grant milestones page and see verify button
- [ ] Manual: As project owner, should NOT see verify button on own milestones
- [ ] Manual: As random authenticated user, should NOT see verify button

🤖 Generated with [Claude Code](https://claude.ai/code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213197241605595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented centralized milestone verification permission system.

* **Bug Fixes**
  * Updated verified badge display logic to show badges correctly for verified milestones.
  * Refined verification access permissions across milestone and grant update dialogs.

* **Tests**
  * Added comprehensive test suite for milestone verification permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->