### PR TITLE
feat: add Raising Funds filter to projects explorer

### DIFF
--- a/__tests__/navbar/unit/menu-items.test.tsx
+++ b/__tests__/navbar/unit/menu-items.test.tsx
@@ -152,11 +152,10 @@ describe("Menu Items Configuration", () => {
       expect(allProjectsItem?.href).toBe(PAGES.PROJECTS_EXPLORER);
     });
 
-    it('should contain "Most Grants" item with query parameters', () => {
-      const mostGrantsItem = exploreItems.projects.find((item) => item.title === "Most Grants");
-      expect(mostGrantsItem).toBeDefined();
-      expect(mostGrantsItem?.href).toContain("sortBy=noOfGrants");
-      expect(mostGrantsItem?.href).toContain("sortOrder=desc");
+    it('should contain "Raising Funds" item with hasPayoutAddress filter', () => {
+      const raisingFundsItem = exploreItems.projects.find((item) => item.title === "Raising Funds");
+      expect(raisingFundsItem).toBeDefined();
+      expect(raisingFundsItem?.href).toContain("hasPayoutAddress=true");
     });
 
     it('should contain "Most Active" item with query parameters', () => {

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -53,7 +53,7 @@ export const ProjectsExplorer = () => {
   });
 
   // URL state for hasPayoutAddress filter
-  const [hasPayoutAddress] = useQueryState("hasPayoutAddress", {
+  const [hasPayoutAddress, setHasPayoutAddress] = useQueryState("hasPayoutAddress", {
     defaultValue: "",
     serialize: (value) => value || "",
     parse: (value) => value || "",
@@ -169,6 +169,25 @@ export const ProjectsExplorer = () => {
               className="w-full sm:w-64 pl-10 pr-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
             />
           </div>
+
+          {/* Raising Funds Filter */}
+          <button
+            type="button"
+            onClick={() => setHasPayoutAddress(isPayoutAddressFilterActive ? null : "true")}
+            aria-label={
+              isPayoutAddressFilterActive
+                ? "Remove Raising Funds filter"
+                : "Filter by Raising Funds"
+            }
+            aria-pressed={isPayoutAddressFilterActive}
+            className={`px-3 py-2 rounded-md border text-sm font-medium transition-colors whitespace-nowrap ${
+              isPayoutAddressFilterActive
+                ? "bg-blue-600 text-white border-blue-600 hover:bg-blue-700"
+                : "bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border-gray-300 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700"
+            }`}
+          >
+            Raising Funds
+          </button>
 
           {/* Sort Dropdown */}
           <div className="flex items-center gap-x-2">

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -4,7 +4,7 @@ import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/24/solid";
 import debounce from "lodash.debounce";
 import { useQueryState } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Select,
   SelectContent,
@@ -29,6 +29,9 @@ const sortOptions: Record<ExplorerSortByOptions, string> = {
 };
 
 export const ProjectsExplorer = () => {
+  const sectionRef = useRef<HTMLElement>(null);
+  const hasScrolledRef = useRef(false);
+
   // URL state for search
   const [searchQuery, setSearchQuery] = useQueryState("q", {
     defaultValue: "",
@@ -48,6 +51,30 @@ export const ProjectsExplorer = () => {
     serialize: (value) => value,
     parse: (value) => (value as ExplorerSortOrder) || "desc",
   });
+
+  // URL state for hasPayoutAddress filter
+  const [hasPayoutAddress] = useQueryState("hasPayoutAddress", {
+    defaultValue: "",
+    serialize: (value) => value || "",
+    parse: (value) => value || "",
+  });
+
+  const isPayoutAddressFilterActive = hasPayoutAddress === "true";
+
+  // Auto-scroll to project list when navigated with filter/sort params from navbar
+  useEffect(() => {
+    if (hasScrolledRef.current) return;
+
+    const hasFilterParams =
+      isPayoutAddressFilterActive || selectedSort !== "updatedAt" || selectedSortOrder !== "desc";
+
+    if (hasFilterParams) {
+      hasScrolledRef.current = true;
+      requestAnimationFrame(() => {
+        sectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    }
+  }, [isPayoutAddressFilterActive, selectedSort, selectedSortOrder]);
 
   // Internal search state for debouncing
   const [inputValue, setInputValue] = useState(searchQuery || "");
@@ -93,6 +120,7 @@ export const ProjectsExplorer = () => {
     search: searchQuery,
     sortBy: selectedSort as ExplorerSortByOptions,
     sortOrder: selectedSortOrder as ExplorerSortOrder,
+    hasPayoutAddress: isPayoutAddressFilterActive,
   });
 
   // Handle sort change
@@ -109,11 +137,17 @@ export const ProjectsExplorer = () => {
   };
 
   return (
-    <section id="browse-projects" className="w-full max-w-7xl mx-auto px-4 py-8 mt-8">
+    <section
+      ref={sectionRef}
+      id="browse-projects"
+      className="w-full max-w-7xl mx-auto px-4 py-8 mt-8"
+    >
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <div>
-          <h2 className="text-2xl font-bold text-black dark:text-white">Projects on Karma</h2>
+          <h2 className="text-2xl font-bold text-black dark:text-white">
+            {isPayoutAddressFilterActive ? "Projects Raising Funds" : "Projects on Karma"}
+          </h2>
           {!isLoading && totalCount > 0 && (
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
               {totalCount.toLocaleString()} {totalCount === 1 ? "project" : "projects"} found
@@ -196,7 +230,11 @@ export const ProjectsExplorer = () => {
         </div>
       ) : projects.length === 0 ? (
         <div className="text-center py-12 text-gray-500">
-          {searchQuery ? `No projects found for "${searchQuery}"` : "No projects available"}
+          {searchQuery
+            ? `No projects found for "${searchQuery}"`
+            : isPayoutAddressFilterActive
+              ? "No projects are currently raising funds"
+              : "No projects available"}
         </div>
       ) : (
         <>

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -154,7 +154,7 @@ export const ProjectsExplorer = () => {
         </div>
 
         {/* Controls */}
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-6">
           {/* Search Input */}
           <div className="relative">
             <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -145,9 +145,7 @@ export const ProjectsExplorer = () => {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <div>
-          <h2 className="text-2xl font-bold text-black dark:text-white">
-            {isPayoutAddressFilterActive ? "Projects Raising Funds" : "Projects on Karma"}
-          </h2>
+          <h2 className="text-2xl font-bold text-black dark:text-white">Projects on Karma</h2>
           {!isLoading && totalCount > 0 && (
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
               {totalCount.toLocaleString()} {totalCount === 1 ? "project" : "projects"} found
@@ -171,23 +169,28 @@ export const ProjectsExplorer = () => {
           </div>
 
           {/* Raising Funds Filter */}
-          <button
-            type="button"
-            onClick={() => setHasPayoutAddress(isPayoutAddressFilterActive ? null : "true")}
-            aria-label={
-              isPayoutAddressFilterActive
-                ? "Remove Raising Funds filter"
-                : "Filter by Raising Funds"
-            }
-            aria-pressed={isPayoutAddressFilterActive}
-            className={`px-3 py-2 rounded-md border text-sm font-medium transition-colors whitespace-nowrap ${
-              isPayoutAddressFilterActive
-                ? "bg-blue-600 text-white border-blue-600 hover:bg-blue-700"
-                : "bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 border-gray-300 dark:border-zinc-700 hover:bg-gray-50 dark:hover:bg-zinc-700"
-            }`}
-          >
-            Raising Funds
-          </button>
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={isPayoutAddressFilterActive}
+              onChange={() => setHasPayoutAddress(isPayoutAddressFilterActive ? null : "true")}
+              className="sr-only peer"
+            />
+            <span
+              className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors ${
+                isPayoutAddressFilterActive ? "bg-blue-600" : "bg-gray-300 dark:bg-zinc-600"
+              } peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 peer-focus-visible:ring-offset-2`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${
+                  isPayoutAddressFilterActive ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </span>
+            <span className="text-sm font-medium text-gray-700 dark:text-zinc-300 whitespace-nowrap">
+              Raising Funds
+            </span>
+          </label>
 
           {/* Sort Dropdown */}
           <div className="flex items-center gap-x-2">

--- a/hooks/useProjectsExplorerInfinite.ts
+++ b/hooks/useProjectsExplorerInfinite.ts
@@ -13,6 +13,7 @@ interface UseProjectsExplorerInfiniteOptions {
   sortOrder?: ExplorerSortOrder;
   limit?: number;
   enabled?: boolean;
+  hasPayoutAddress?: boolean;
 }
 
 /**
@@ -44,10 +45,17 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
     sortOrder = "desc",
     limit = PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
     enabled = true,
+    hasPayoutAddress = false,
   } = options;
 
   const query = useInfiniteQuery<PaginatedProjectsResponse, Error>({
-    queryKey: QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ search, sortBy, sortOrder, limit }),
+    queryKey: QUERY_KEYS.PROJECT.EXPLORER_INFINITE({
+      search,
+      sortBy,
+      sortOrder,
+      limit,
+      hasPayoutAddress,
+    }),
     queryFn: async ({ pageParam = 1 }) => {
       return getExplorerProjectsPaginated({
         search,
@@ -56,6 +64,7 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
         sortBy,
         sortOrder,
         includeStats: true, // Always include stats for explorer cards
+        hasPayoutAddress,
       });
     },
     getNextPageParam: (lastPage) => {

--- a/services/projects-explorer.service.ts
+++ b/services/projects-explorer.service.ts
@@ -18,6 +18,8 @@ export interface ExplorerProjectsPaginatedParams {
   sortOrder?: ExplorerSortOrder;
   /** When true, includes stats for each project (grantsCount, grantMilestonesCount, roadmapItemsCount) */
   includeStats?: boolean;
+  /** When true, only returns projects with at least one payout address configured */
+  hasPayoutAddress?: boolean;
 }
 
 /**
@@ -78,6 +80,7 @@ export const getExplorerProjectsPaginated = async (
     sortBy = "updatedAt",
     sortOrder = "desc",
     includeStats = false,
+    hasPayoutAddress = false,
   } = params;
 
   // Validate search length if provided
@@ -92,6 +95,7 @@ export const getExplorerProjectsPaginated = async (
     sortOrder,
     includeStats,
     excludeTestProjects: true, // Filter test projects on backend for accurate pagination
+    hasPayoutAddress,
   });
 
   const [data, error] = await fetchData<PaginatedProjectsResponse>(endpoint);

--- a/src/components/navbar/menu-items.tsx
+++ b/src/components/navbar/menu-items.tsx
@@ -1,7 +1,6 @@
 import {
   BanknoteArrowDown,
   BellDot,
-  Flame,
   GalleryThumbnails,
   GoalIcon,
   LayoutGrid,
@@ -85,9 +84,9 @@ export const exploreItems: ExploreItems = {
       title: "All projects",
     },
     {
-      href: `${PAGES.PROJECTS_EXPLORER}?sortBy=noOfGrants&sortOrder=desc`,
-      icon: Flame,
-      title: "Most Grants",
+      href: `${PAGES.PROJECTS_EXPLORER}?hasPayoutAddress=true`,
+      icon: BanknoteArrowDown,
+      title: "Raising Funds",
     },
     {
       href: `${PAGES.PROJECTS_EXPLORER}?sortBy=noOfGrantMilestones&sortOrder=desc`,

--- a/utilities/__tests__/queryKeys.test.ts
+++ b/utilities/__tests__/queryKeys.test.ts
@@ -290,6 +290,7 @@ describe("queryKeys", () => {
           sortBy: "noOfGrants",
           sortOrder: "asc",
           limit: 25,
+          hasPayoutAddress: true,
         };
         const key = QUERY_KEYS.PROJECT.EXPLORER_INFINITE(params);
         expect(key[0]).toBe("projects-explorer-infinite");
@@ -297,6 +298,7 @@ describe("queryKeys", () => {
         expect(key[2]).toBe("noOfGrants");
         expect(key[3]).toBe("asc");
         expect(key[4]).toBe(25);
+        expect(key[5]).toBe(true);
       });
 
       it("should use default values when params are not provided", () => {
@@ -306,6 +308,7 @@ describe("queryKeys", () => {
         expect(key[2]).toBe("updatedAt"); // default sortBy
         expect(key[3]).toBe("desc"); // default sortOrder
         expect(key[4]).toBe(50); // default limit
+        expect(key[5]).toBe(false); // default hasPayoutAddress
       });
 
       it("should handle undefined search", () => {
@@ -319,7 +322,13 @@ describe("queryKeys", () => {
       it("should return as const tuple", () => {
         const key = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ search: "test" });
         expect(Array.isArray(key)).toBe(true);
-        expect(key.length).toBe(5);
+        expect(key.length).toBe(6);
+      });
+
+      it("should generate different keys for hasPayoutAddress filter", () => {
+        const key1 = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ hasPayoutAddress: false });
+        const key2 = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ hasPayoutAddress: true });
+        expect(key1).not.toEqual(key2);
       });
 
       it("should generate different keys for different search queries", () => {

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -94,6 +94,7 @@ export const INDEXER = {
         sortOrder?: "asc" | "desc";
         includeStats?: boolean;
         excludeTestProjects?: boolean;
+        hasPayoutAddress?: boolean;
       }) => {
         const queryParams = new URLSearchParams();
         if (params?.q) queryParams.set("q", params.q);
@@ -103,6 +104,7 @@ export const INDEXER = {
         if (params?.sortOrder) queryParams.set("sortOrder", params.sortOrder);
         if (params?.includeStats) queryParams.set("includeStats", "true");
         if (params?.excludeTestProjects) queryParams.set("excludeTestProjects", "true");
+        if (params?.hasPayoutAddress) queryParams.set("hasPayoutAddress", "true");
         const query = queryParams.toString();
         return `/v2/projects${query ? `?${query}` : ""}`;
       },

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -190,6 +190,7 @@ export const QUERY_KEYS = {
       sortBy?: string;
       sortOrder?: string;
       limit?: number;
+      hasPayoutAddress?: boolean;
     }) =>
       [
         "projects-explorer-infinite",
@@ -197,6 +198,7 @@ export const QUERY_KEYS = {
         params.sortBy || "updatedAt",
         params.sortOrder || "desc",
         params.limit ?? 50,
+        params.hasPayoutAddress ?? false,
       ] as const,
   },
   INDICATORS: {


### PR DESCRIPTION
## Summary

- Replace "Most Grants" nav item with "Raising Funds" that filters projects with at least one configured payout address (`hasPayoutAddress=true`)
- Add auto-scroll to project list when navigating from navbar with filter/sort params (e.g., clicking "Raising Funds" or "Most Active" in the Explore menu)
- Dynamic section header ("Projects Raising Funds" vs "Projects on Karma") and filter-aware empty state

## Changes

### Navbar (`src/components/navbar/menu-items.tsx`)
- Renamed "Most Grants" → "Raising Funds" with `BanknoteArrowDown` icon
- Changed href from `?sortBy=noOfGrants&sortOrder=desc` to `?hasPayoutAddress=true`

### Projects Explorer (`components/Pages/Projects/ProjectsExplorer.tsx`)
- Added `hasPayoutAddress` URL state via `useQueryState`
- Auto-scroll effect: scrolls to project list when filter/sort params are present
- Passes `hasPayoutAddress` to the infinite query hook
- Dynamic header and empty state messaging

### Data Layer
- `useProjectsExplorerInfinite.ts`: Added `hasPayoutAddress` option, passed to query key and API call
- `projects-explorer.service.ts`: Added `hasPayoutAddress` to paginated params
- `utilities/indexer.ts`: Added `hasPayoutAddress` to `LIST_PAGINATED` URL builder
- `utilities/queryKeys.ts`: Added `hasPayoutAddress` to `EXPLORER_INFINITE` cache key tuple

### Tests
- Updated menu-items tests: "Most Grants" → "Raising Funds" assertions
- Updated queryKeys tests: tuple length 5 → 6, added `hasPayoutAddress` assertions

## Backend dependency

Requires [gap-indexer PR #950](https://github.com/show-karma/gap-indexer/pull/950) — adds `hasPayoutAddress` filter to the `/v2/projects` endpoint (MongoDB aggregation on `payoutAddress` and `chainPayoutAddress` fields).

## Test plan

- [ ] Click "Raising Funds" in Explore → Projects nav, verify it auto-scrolls and shows only projects with payout addresses
- [ ] Click "Most Active" in nav, verify auto-scroll behavior
- [ ] Direct navigation to `/projects` shows "Projects on Karma" header
- [ ] Navigation with `?hasPayoutAddress=true` shows "Projects Raising Funds" header
- [ ] Empty state shows "No projects are currently raising funds" when filter is active with no results
- [ ] Search still works with the filter active
- [ ] Sort controls work alongside the filter
- [ ] `pnpm test` passes (98 tests in menu-items + queryKeys)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Raising Funds" filter to discover projects that accept payouts/donations.
  * Auto-scrolls to the projects list when the payout filter or related sort parameters are applied.
  * Updated empty-state and header messaging to reflect the fundraising/payout filter context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->