### PR TITLE
fix: harden community admin batch fetch under rate limits

### DIFF
--- a/__tests__/components/Pages/Admin/CommunityAdmin.test.tsx
+++ b/__tests__/components/Pages/Admin/CommunityAdmin.test.tsx
@@ -125,4 +125,35 @@ describe("CommunityAdmin", () => {
     expect(await screen.findByText("Optimism Builders")).toBeInTheDocument();
     expect(mockGetCommunities).not.toHaveBeenCalled();
   });
+
+  it("shows a clear message when admin batch data is rate limited", async () => {
+    const cachedCommunity = {
+      uid: "0x1111111111111111111111111111111111111111",
+      chainID: 10,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      details: {
+        name: "Optimism Builders",
+        slug: "optimism-builders",
+        imageURL: "",
+      },
+    };
+
+    mockUseQuery.mockReturnValue({
+      data: {
+        communities: [cachedCommunity],
+        admins: [{ id: cachedCommunity.uid, admins: [], status: "rate_limited" }],
+      },
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<CommunitiesToAdminPage />);
+
+    expect(await screen.findByText("Optimism Builders")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Admin data temporarily unavailable due to rate limiting. Please try again shortly."
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/__tests__/unit/services/communities.service.test.ts
+++ b/__tests__/unit/services/communities.service.test.ts
@@ -1,0 +1,274 @@
+import * as Sentry from "@sentry/nextjs";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { getCommunityAdminsBatch } from "@/services/communities.service";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+jest.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: jest.fn(),
+}));
+
+jest.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@sentry/nextjs", () => ({
+  captureMessage: jest.fn(),
+}));
+
+const mockFetchData = fetchData as jest.MockedFunction<typeof fetchData>;
+const mockErrorManager = errorManager as jest.MockedFunction<typeof errorManager>;
+const mockCaptureMessage = Sentry.captureMessage as jest.MockedFunction<
+  typeof Sentry.captureMessage
+>;
+
+describe("communities.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("getCommunityAdminsBatch", () => {
+    it("returns an empty array when no communities are requested", async () => {
+      const result = await getCommunityAdminsBatch([]);
+
+      expect(result).toEqual([]);
+      expect(mockFetchData).not.toHaveBeenCalled();
+    });
+
+    it("maps response data and marks missing communities as not found", async () => {
+      const communityUIDs = ["community-1", "community-2"];
+
+      mockFetchData.mockResolvedValueOnce([
+        {
+          data: [
+            {
+              communityUID: "community-1",
+              admins: [{ user: { id: "0xadmin" } }],
+              status: "ok",
+            },
+          ],
+          meta: {
+            requestedCount: 2,
+            uniqueRequestedCount: 2,
+            foundCommunityCount: 1,
+            notFoundCount: 1,
+            unavailableCount: 0,
+          },
+        },
+        null,
+        null,
+        200,
+      ] as any);
+
+      const result = await getCommunityAdminsBatch(communityUIDs);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        INDEXER.COMMUNITY.ADMINS_BATCH(),
+        "POST",
+        { communityUIDs },
+        {},
+        {}
+      );
+      expect(result).toEqual([
+        {
+          id: "community-1",
+          admins: [{ user: { id: "0xadmin" } }],
+          status: "ok",
+        },
+        {
+          id: "community-2",
+          admins: [],
+          status: "community_not_found",
+        },
+      ]);
+      expect(mockErrorManager).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it("retries on rate limits and recovers on a later successful attempt", async () => {
+      jest.useFakeTimers();
+      jest.spyOn(Math, "random").mockReturnValue(0);
+
+      const communityUIDs = ["community-1"];
+
+      mockFetchData
+        .mockResolvedValueOnce([null, "Rate limit exceeded. Try again later.", null, 429] as any)
+        .mockResolvedValueOnce([
+          {
+            data: [
+              {
+                communityUID: "community-1",
+                admins: [{ user: { id: "0xadmin" } }],
+                status: "ok",
+              },
+            ],
+            meta: {
+              requestedCount: 1,
+              uniqueRequestedCount: 1,
+              foundCommunityCount: 1,
+              notFoundCount: 0,
+              unavailableCount: 0,
+            },
+          },
+          null,
+          null,
+          200,
+        ] as any);
+
+      const promise = getCommunityAdminsBatch(communityUIDs);
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await promise;
+
+      expect(mockFetchData).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        {
+          id: "community-1",
+          admins: [{ user: { id: "0xadmin" } }],
+          status: "ok",
+        },
+      ]);
+      expect(mockErrorManager).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        "Rate limited while fetching batch community admins",
+        expect.objectContaining({
+          level: "warning",
+          tags: expect.objectContaining({
+            context: "admin.community.batch-admins",
+            outcome: "recovered",
+          }),
+          extra: expect.objectContaining({
+            rateLimitAttempts: 1,
+            communityCount: 1,
+            finalStatus: 200,
+          }),
+        })
+      );
+    });
+
+    it("returns rate_limited fallback after exhausting retries", async () => {
+      jest.useFakeTimers();
+      jest.spyOn(Math, "random").mockReturnValue(0);
+
+      const communityUIDs = ["community-1", "community-2"];
+
+      mockFetchData.mockResolvedValue([
+        null,
+        "Rate limit exceeded. Try again later.",
+        null,
+        429,
+      ] as any);
+
+      const promise = getCommunityAdminsBatch(communityUIDs);
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await promise;
+
+      expect(mockFetchData).toHaveBeenCalledTimes(3);
+      expect(result).toEqual([
+        {
+          id: "community-1",
+          admins: [],
+          status: "rate_limited",
+        },
+        {
+          id: "community-2",
+          admins: [],
+          status: "rate_limited",
+        },
+      ]);
+      expect(mockErrorManager).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        "Rate limited while fetching batch community admins",
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            outcome: "rate_limited_fallback",
+          }),
+          extra: expect.objectContaining({
+            rateLimitAttempts: 3,
+            communityCount: 2,
+            finalStatus: 429,
+          }),
+        })
+      );
+    });
+
+    it("reports non-rate-limit failures and returns subgraph_unavailable statuses", async () => {
+      const communityUIDs = ["community-1"];
+
+      mockFetchData.mockResolvedValueOnce([null, "Internal server error", null, 500] as any);
+
+      const result = await getCommunityAdminsBatch(communityUIDs);
+
+      expect(result).toEqual([
+        {
+          id: "community-1",
+          admins: [],
+          status: "subgraph_unavailable",
+        },
+      ]);
+      expect(mockErrorManager).toHaveBeenCalledWith(
+        "Error fetching batch community admins",
+        "Internal server error",
+        expect.objectContaining({
+          context: "admin.community.batch-admins",
+          status: 500,
+        })
+      );
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it("captures telemetry and reports error when a non-rate-limit error follows rate limiting", async () => {
+      jest.useFakeTimers();
+      jest.spyOn(Math, "random").mockReturnValue(0);
+
+      const communityUIDs = ["community-1"];
+
+      mockFetchData
+        .mockResolvedValueOnce([null, "Rate limit exceeded. Try again later.", null, 429] as any)
+        .mockResolvedValueOnce([null, "Internal server error", null, 500] as any);
+
+      const promise = getCommunityAdminsBatch(communityUIDs);
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await promise;
+
+      expect(mockFetchData).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        {
+          id: "community-1",
+          admins: [],
+          status: "subgraph_unavailable",
+        },
+      ]);
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        "Rate limited while fetching batch community admins",
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            outcome: "non_rate_limit_failure",
+          }),
+          extra: expect.objectContaining({
+            rateLimitAttempts: 1,
+            communityCount: 1,
+            finalStatus: 500,
+            error: "Internal server error",
+          }),
+        })
+      );
+      expect(mockErrorManager).toHaveBeenCalledWith(
+        "Error fetching batch community admins",
+        "Internal server error",
+        expect.objectContaining({
+          context: "admin.community.batch-admins",
+          status: 500,
+        })
+      );
+    });
+  });
+});

--- a/components/Pages/Admin/CommunityAdmin.tsx
+++ b/components/Pages/Admin/CommunityAdmin.tsx
@@ -60,6 +60,9 @@ const getAdminsBatchStatusMessage = (status: CommunityAdminsBatchStatus): string
   if (status === "subgraph_unavailable") {
     return "Admin data unavailable: subgraph is temporarily unavailable.";
   }
+  if (status === "rate_limited") {
+    return "Admin data temporarily unavailable due to rate limiting. Please try again shortly.";
+  }
   return "";
 };
 

--- a/services/communities.service.ts
+++ b/services/communities.service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { errorManager } from "@/components/Utilities/errorManager";
 import type { Community } from "@/types/v2/community";
 import fetchData from "@/utilities/fetchData";
@@ -23,7 +24,11 @@ export interface CommunityAdmin {
   status: CommunityAdminsBatchStatus;
 }
 
-export type CommunityAdminsBatchStatus = "ok" | "community_not_found" | "subgraph_unavailable";
+export type CommunityAdminsBatchStatus =
+  | "ok"
+  | "community_not_found"
+  | "subgraph_unavailable"
+  | "rate_limited";
 
 interface CommunityAdminsBatchResponse {
   data: Array<{
@@ -39,6 +44,64 @@ interface CommunityAdminsBatchResponse {
     unavailableCount: number;
   };
 }
+
+const MAX_RATE_LIMIT_RETRIES = 2;
+const RATE_LIMIT_RETRY_BASE_DELAY_MS = 300;
+const RATE_LIMIT_RETRY_MAX_DELAY_MS = 1200;
+const RATE_LIMIT_TELEMETRY_SAMPLE_RATE = 0.1;
+
+type RateLimitTelemetryOutcome = "recovered" | "rate_limited_fallback" | "non_rate_limit_failure";
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const getRateLimitRetryDelay = (attempt: number): number =>
+  Math.min(RATE_LIMIT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), RATE_LIMIT_RETRY_MAX_DELAY_MS);
+
+const shouldSampleRateLimitTelemetry = (): boolean =>
+  Math.random() < RATE_LIMIT_TELEMETRY_SAMPLE_RATE;
+
+const reportRateLimitTelemetry = ({
+  rateLimitAttempts,
+  communityCount,
+  outcome,
+  finalStatus,
+  error,
+}: {
+  rateLimitAttempts: number;
+  communityCount: number;
+  outcome: RateLimitTelemetryOutcome;
+  finalStatus: number;
+  error: string | null;
+}): void => {
+  if (rateLimitAttempts <= 0 || !shouldSampleRateLimitTelemetry()) return;
+
+  Sentry.captureMessage("Rate limited while fetching batch community admins", {
+    level: "warning",
+    tags: {
+      context: "admin.community.batch-admins",
+      outcome,
+    },
+    extra: {
+      rateLimitAttempts,
+      communityCount,
+      finalStatus,
+      error,
+    },
+  });
+};
+
+const buildUnavailableCommunityAdmins = (
+  communityUIDs: string[],
+  status: CommunityAdminsBatchStatus
+): CommunityAdmin[] =>
+  communityUIDs.map((uid) => ({
+    id: uid,
+    admins: [],
+    status,
+  }));
 
 /**
  * Fetches all communities using V2 API endpoint
@@ -78,38 +141,92 @@ export const getCommunityAdminsBatch = async (
 ): Promise<CommunityAdmin[]> => {
   if (!communityUIDs.length) return [];
 
-  const [adminsResponse, adminsError] = await fetchData<CommunityAdminsBatchResponse>(
-    INDEXER.COMMUNITY.ADMINS_BATCH(),
-    "POST",
-    { communityUIDs },
-    {},
-    {}
-  );
+  const maxAttempts = MAX_RATE_LIMIT_RETRIES + 1;
+  let rateLimitAttempts = 0;
+  let lastStatus = 500;
 
-  if (!adminsResponse?.data) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const [adminsResponse, adminsError, , adminsStatus] =
+      await fetchData<CommunityAdminsBatchResponse>(
+        INDEXER.COMMUNITY.ADMINS_BATCH(),
+        "POST",
+        { communityUIDs },
+        {},
+        {}
+      );
+
+    lastStatus = adminsStatus;
+
+    if (adminsResponse?.data) {
+      const adminsById = new Map(
+        adminsResponse.data.map((item) => [
+          item.communityUID,
+          { id: item.communityUID, admins: item.admins, status: item.status },
+        ])
+      );
+
+      if (rateLimitAttempts > 0) {
+        reportRateLimitTelemetry({
+          rateLimitAttempts,
+          communityCount: communityUIDs.length,
+          outcome: "recovered",
+          finalStatus: adminsStatus,
+          error: adminsError,
+        });
+      }
+
+      return communityUIDs.map(
+        (uid) =>
+          adminsById.get(uid) || {
+            id: uid,
+            admins: [],
+            status: "community_not_found",
+          }
+      );
+    }
+
+    if (adminsStatus === 429) {
+      rateLimitAttempts += 1;
+
+      if (attempt < maxAttempts) {
+        await wait(getRateLimitRetryDelay(attempt));
+        continue;
+      }
+
+      reportRateLimitTelemetry({
+        rateLimitAttempts,
+        communityCount: communityUIDs.length,
+        outcome: "rate_limited_fallback",
+        finalStatus: adminsStatus,
+        error: adminsError,
+      });
+
+      return buildUnavailableCommunityAdmins(communityUIDs, "rate_limited");
+    }
+
+    if (rateLimitAttempts > 0) {
+      reportRateLimitTelemetry({
+        rateLimitAttempts,
+        communityCount: communityUIDs.length,
+        outcome: "non_rate_limit_failure",
+        finalStatus: adminsStatus,
+        error: adminsError,
+      });
+    }
+
     errorManager(
       "Error fetching batch community admins",
       adminsError || "Empty batch admins response",
       {
         context: "admin.community.batch-admins",
+        status: adminsStatus,
       }
     );
-    throw new Error(adminsError || "Failed to fetch batch community admins");
+    return buildUnavailableCommunityAdmins(communityUIDs, "subgraph_unavailable");
   }
 
-  const adminsById = new Map(
-    adminsResponse.data.map((item) => [
-      item.communityUID,
-      { id: item.communityUID, admins: item.admins, status: item.status },
-    ])
-  );
-
-  return communityUIDs.map(
-    (uid) =>
-      adminsById.get(uid) || {
-        id: uid,
-        admins: [],
-        status: "community_not_found",
-      }
+  return buildUnavailableCommunityAdmins(
+    communityUIDs,
+    lastStatus === 429 ? "rate_limited" : "subgraph_unavailable"
   );
 };


### PR DESCRIPTION
## Summary
- add a dedicated `rate_limited` status for community admin batch fetch responses
- implement bounded exponential backoff retries for `429` responses before falling back
- keep observability with sampled Sentry warning telemetry for rate-limit outcomes (`recovered`, `rate_limited_fallback`, `non_rate_limit_failure`)
- preserve error reporting for non-rate-limit failures via `errorManager` while avoiding noisy exception capture on expected `429`s
- show a specific admin-page message when admin data is unavailable due to rate limiting
- add service and UI tests for retry, fallback, telemetry, and status rendering

## Sentry
- addresses issue `GAP-FRONTEND-1VW` (`/admin`, `admin.community.batch-admins`)

## Testing
- `pnpm test -- __tests__/unit/services/communities.service.test.ts __tests__/components/Pages/Admin/CommunityAdmin.test.tsx`
- `pnpm exec biome check services/communities.service.ts components/Pages/Admin/CommunityAdmin.tsx __tests__/unit/services/communities.service.test.ts __tests__/components/Pages/Admin/CommunityAdmin.test.tsx`