### PR TITLE
refactor: add MilestoneLifecycleStatus enum and UI polish

### DIFF
--- a/__tests__/control-center/fixtures.ts
+++ b/__tests__/control-center/fixtures.ts
@@ -12,6 +12,7 @@ import {
   type CommunityPayoutItem,
   type CommunityPayoutProjectInfo,
   type CommunityPayoutsResponse,
+  MilestoneLifecycleStatus,
   type PaginationInfo,
   type PayoutDisbursement,
   PayoutDisbursementStatus,

--- a/__tests__/control-center/unit/project-details-modal.test.tsx
+++ b/__tests__/control-center/unit/project-details-modal.test.tsx
@@ -52,10 +52,11 @@ import {
   ProjectDetailsModal,
   type ProjectDetailsModalGrant,
 } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsModal";
-import type {
-  CommunityPayoutAgreementInfo,
-  CommunityPayoutInvoiceInfo,
-  TokenTotal,
+import {
+  type CommunityPayoutAgreementInfo,
+  type CommunityPayoutInvoiceInfo,
+  MilestoneLifecycleStatus,
+  type TokenTotal,
 } from "@/src/features/payout-disbursement/types/payout-disbursement";
 import { createMockAgreement, createMockInvoice } from "../fixtures";
 
@@ -343,12 +344,12 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Completed",
             milestoneUID: "ms-c",
-            milestoneStatus: "completed",
+            milestoneStatus: MilestoneLifecycleStatus.COMPLETED,
           }),
           createMockInvoice({
             milestoneLabel: "MS Verified",
             milestoneUID: "ms-v",
-            milestoneStatus: "verified",
+            milestoneStatus: MilestoneLifecycleStatus.VERIFIED,
           }),
         ],
       });
@@ -378,7 +379,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Overdue",
             milestoneUID: "ms-overdue",
-            milestoneStatus: "pending",
+            milestoneStatus: MilestoneLifecycleStatus.PENDING,
             milestoneDueDate: "2020-01-01T00:00:00Z",
           }),
         ],
@@ -393,7 +394,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Done",
             milestoneUID: "ms-done",
-            milestoneStatus: "completed",
+            milestoneStatus: MilestoneLifecycleStatus.COMPLETED,
             milestoneDueDate: "2020-01-01T00:00:00Z",
           }),
         ],
@@ -403,18 +404,18 @@ describe("ProjectDetailsModal", () => {
       expect(screen.queryByText("Past due")).not.toBeInTheDocument();
     });
 
-    it("falls back to 'Pending' config for unknown milestone status", () => {
+    it("falls back to 'Pending' config when milestoneStatus is null", () => {
       renderModal({
         milestoneInvoices: [
           createMockInvoice({
-            milestoneLabel: "MS Unknown",
-            milestoneUID: "ms-unknown",
-            milestoneStatus: "some_unknown_status",
+            milestoneLabel: "MS Null Status",
+            milestoneUID: "ms-null-status",
+            milestoneStatus: null,
           }),
         ],
       });
 
-      // Unknown status falls back to pending config
+      // Null status falls back to pending config
       expect(screen.getByText("Pending")).toBeInTheDocument();
     });
 
@@ -425,7 +426,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Comp",
             milestoneUID: "ms-comp",
-            milestoneStatus: "completed",
+            milestoneStatus: MilestoneLifecycleStatus.COMPLETED,
             milestoneStatusUpdatedAt: "2024-07-10T00:00:00Z",
           }),
         ],
@@ -443,7 +444,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Ver",
             milestoneUID: "ms-ver",
-            milestoneStatus: "verified",
+            milestoneStatus: MilestoneLifecycleStatus.VERIFIED,
             milestoneStatusUpdatedAt: "2024-08-15T00:00:00Z",
           }),
         ],
@@ -461,7 +462,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Late",
             milestoneUID: "ms-late",
-            milestoneStatus: "pending",
+            milestoneStatus: MilestoneLifecycleStatus.PENDING,
             milestoneDueDate: "2020-06-01T00:00:00Z",
           }),
         ],
@@ -479,7 +480,7 @@ describe("ProjectDetailsModal", () => {
           createMockInvoice({
             milestoneLabel: "MS Pend",
             milestoneUID: "ms-pend",
-            milestoneStatus: "pending",
+            milestoneStatus: MilestoneLifecycleStatus.PENDING,
             milestoneStatusUpdatedAt: "2024-01-15T00:00:00Z",
             milestoneDueDate: "2030-12-31T00:00:00Z",
           }),
@@ -491,10 +492,63 @@ describe("ProjectDetailsModal", () => {
       expect(tooltip).toHaveTextContent(/Created.*Jan 15, 2024/);
       expect(tooltip).toHaveTextContent(/Due.*Dec 31, 2030/);
     });
+
+    it("shows alert icon with 'not verified yet' tooltip for completed milestone", async () => {
+      const user = userEvent.setup();
+      renderModal({
+        milestoneInvoices: [
+          createMockInvoice({
+            milestoneLabel: "MS Comp Alert",
+            milestoneUID: "ms-comp-alert",
+            milestoneStatus: MilestoneLifecycleStatus.COMPLETED,
+          }),
+        ],
+      });
+
+      // The alert icon should be present next to the completed badge
+      const alertIcon = document.querySelector("svg.text-amber-500");
+      expect(alertIcon).toBeInTheDocument();
+
+      // Hover on the alert icon to see the tooltip
+      await user.hover(alertIcon as Element);
+      const tooltip = await screen.findByRole("tooltip", {}, { timeout: 3000 });
+      expect(tooltip).toHaveTextContent("The milestone has not been verified yet");
+    });
+
+    it("does not show alert icon for verified milestone", () => {
+      renderModal({
+        milestoneInvoices: [
+          createMockInvoice({
+            milestoneLabel: "MS Ver No Alert",
+            milestoneUID: "ms-ver-no-alert",
+            milestoneStatus: MilestoneLifecycleStatus.VERIFIED,
+          }),
+        ],
+      });
+
+      // No amber alert icon should be present for verified milestones
+      const alertIcon = document.querySelector("svg.text-amber-500");
+      expect(alertIcon).not.toBeInTheDocument();
+    });
+
+    it("does not show alert icon for pending milestone", () => {
+      renderModal({
+        milestoneInvoices: [
+          createMockInvoice({
+            milestoneLabel: "MS Pend No Alert",
+            milestoneUID: "ms-pend-no-alert",
+            milestoneStatus: MilestoneLifecycleStatus.PENDING,
+          }),
+        ],
+      });
+
+      const alertIcon = document.querySelector("svg.text-amber-500");
+      expect(alertIcon).not.toBeInTheDocument();
+    });
   });
 
   describe("Invoice status column", () => {
-    it("shows 'Received' badge when invoice status is 'received'", () => {
+    it("shows 'Invoice received' badge when invoice status is 'received'", () => {
       renderModal({
         invoiceRequired: true,
         milestoneInvoices: [
@@ -506,12 +560,12 @@ describe("ProjectDetailsModal", () => {
         ],
       });
 
-      // "Received" appears both as column header and badge text
-      const receivedElements = screen.getAllByText("Received");
-      expect(receivedElements.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText("Invoice received")).toBeInTheDocument();
+      // "Received" column header is still present
+      expect(screen.getByText("Received")).toBeInTheDocument();
     });
 
-    it("shows 'Received' badge when invoice status is 'paid'", () => {
+    it("shows 'Invoice received' badge when invoice status is 'paid'", () => {
       renderModal({
         invoiceRequired: true,
         milestoneInvoices: [
@@ -523,9 +577,7 @@ describe("ProjectDetailsModal", () => {
         ],
       });
 
-      // "Received" appears both as column header and badge text
-      const receivedElements = screen.getAllByText("Received");
-      expect(receivedElements.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText("Invoice received")).toBeInTheDocument();
     });
 
     it("shows 'Not submitted' badge when invoice status is 'not_submitted'", () => {

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
@@ -31,6 +31,7 @@ import {
   formatDisplayAmount,
   fromSmallestUnit,
   type MilestoneAllocation,
+  MilestoneLifecycleStatus,
   type MilestonePaymentStatus,
   type PayoutDisbursement,
   PayoutDisbursementStatus,
@@ -112,28 +113,26 @@ const paymentStatusConfig: Record<
 
 // ─── Milestone lifecycle status display config ──────────────────────────────
 
-type MilestoneEffectiveStatus = "pending" | "completed" | "verified" | "past_due";
-
 const milestoneStatusConfig: Record<
-  MilestoneEffectiveStatus,
+  MilestoneLifecycleStatus,
   { label: string; dotColor: string; textColor: string }
 > = {
-  pending: {
+  [MilestoneLifecycleStatus.PENDING]: {
     label: "Pending",
     dotColor: "bg-gray-300 dark:bg-zinc-600",
     textColor: "text-gray-500 dark:text-zinc-500",
   },
-  completed: {
+  [MilestoneLifecycleStatus.COMPLETED]: {
     label: "Completed",
     dotColor: "bg-blue-400",
     textColor: "text-blue-600 dark:text-blue-400",
   },
-  verified: {
+  [MilestoneLifecycleStatus.VERIFIED]: {
     label: "Verified",
     dotColor: "bg-green-500",
     textColor: "text-green-600 dark:text-green-400",
   },
-  past_due: {
+  [MilestoneLifecycleStatus.PAST_DUE]: {
     label: "Past due",
     dotColor: "bg-amber-500",
     textColor: "text-amber-600 dark:text-amber-400",
@@ -148,7 +147,7 @@ const invoiceStatusConfig: Record<string, { label: string; className: string }> 
     className: "bg-gray-100 text-gray-600 dark:bg-zinc-800 dark:text-zinc-400",
   },
   received: {
-    label: "Received",
+    label: "Invoice received",
     className: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
   },
 };
@@ -157,14 +156,14 @@ const invoiceStatusConfig: Record<string, { label: string; className: string }> 
  * Compute effective milestone status: if pending and dueDate is in the past → past_due
  */
 function getEffectiveMilestoneStatus(
-  milestoneStatus: string | null,
+  milestoneStatus: MilestoneLifecycleStatus | null,
   milestoneDueDate: string | null
-): string {
-  const status = milestoneStatus || "pending";
-  if (status === "pending" && milestoneDueDate) {
+): MilestoneLifecycleStatus {
+  const status = milestoneStatus || MilestoneLifecycleStatus.PENDING;
+  if (status === MilestoneLifecycleStatus.PENDING && milestoneDueDate) {
     const due = new Date(milestoneDueDate);
     if (due.getTime() < Date.now()) {
-      return "past_due";
+      return MilestoneLifecycleStatus.PAST_DUE;
     }
   }
   return status;
@@ -179,19 +178,19 @@ function getInvoiceStatusKey(invoiceStatus: string): string {
 }
 
 function getMilestoneStatusTooltip(
-  effectiveStatus: string,
+  effectiveStatus: MilestoneLifecycleStatus,
   statusUpdatedAt: string | null,
   dueDate: string | null
 ): string {
   const fmtDate = (iso: string) => formatDate(iso, "UTC");
   switch (effectiveStatus) {
-    case "completed":
+    case MilestoneLifecycleStatus.COMPLETED:
       return statusUpdatedAt ? `Completed on ${fmtDate(statusUpdatedAt)}` : "Completed";
-    case "verified":
+    case MilestoneLifecycleStatus.VERIFIED:
       return statusUpdatedAt ? `Verified on ${fmtDate(statusUpdatedAt)}` : "Verified";
-    case "past_due":
+    case MilestoneLifecycleStatus.PAST_DUE:
       return dueDate ? `Due ${fmtDate(dueDate)}` : "Past due";
-    case "pending": {
+    case MilestoneLifecycleStatus.PENDING: {
       const parts: string[] = [];
       if (statusUpdatedAt) parts.push(`Created ${fmtDate(statusUpdatedAt)}`);
       if (dueDate) parts.push(`Due ${fmtDate(dueDate)}`);
@@ -755,8 +754,8 @@ export function ProjectDetailsModal({
                             invoice.milestoneDueDate
                           );
                           const msCfg =
-                            milestoneStatusConfig[effectiveMsStatus as MilestoneEffectiveStatus] ??
-                            milestoneStatusConfig.pending;
+                            milestoneStatusConfig[effectiveMsStatus] ??
+                            milestoneStatusConfig[MilestoneLifecycleStatus.PENDING];
                           const msTooltip = getMilestoneStatusTooltip(
                             effectiveMsStatus,
                             invoice.milestoneStatusUpdatedAt,
@@ -819,6 +818,16 @@ export function ProjectDetailsModal({
                                     <p>{msTooltip}</p>
                                   </TooltipContent>
                                 </Tooltip>
+                                {effectiveMsStatus === MilestoneLifecycleStatus.COMPLETED && (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <ExclamationTriangleIcon className="inline h-3.5 w-3.5 ml-1 text-amber-500 cursor-default" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>The milestone has not been verified yet</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
                               </td>
                               <td className="py-3 px-3 text-right">
                                 {(() => {

--- a/src/features/payout-disbursement/types/payout-disbursement.ts
+++ b/src/features/payout-disbursement/types/payout-disbursement.ts
@@ -207,10 +207,18 @@ export type InvoiceStatus = "not_submitted" | "submitted" | "received" | "paid";
 
 export type MilestonePaymentStatus = "unpaid" | "pending" | "awaiting_signatures" | "disbursed";
 
+export enum MilestoneLifecycleStatus {
+  PENDING = "pending",
+  COMPLETED = "completed",
+  VERIFIED = "verified",
+  /** Computed client-side when pending + past due date; never from API */
+  PAST_DUE = "past_due",
+}
+
 export interface CommunityPayoutInvoiceInfo {
   milestoneLabel: string;
   milestoneUID: string | null;
-  milestoneStatus: string | null;
+  milestoneStatus: MilestoneLifecycleStatus | null;
   milestoneDueDate: string | null;
   milestoneStatusUpdatedAt: string | null;
   invoiceStatus: InvoiceStatus;


### PR DESCRIPTION
## Summary

- Add `MilestoneLifecycleStatus` enum (`PENDING`, `COMPLETED`, `VERIFIED`, `PAST_DUE`) to payout-disbursement types
- Tighten `CommunityPayoutInvoiceInfo.milestoneStatus` from `string | null` to `MilestoneLifecycleStatus | null`
- Replace all string literals with enum members in `ProjectDetailsModal.tsx` (config keys, switch cases, conditionals)
- Add amber alert icon next to "Completed" milestone status with tooltip "The milestone has not been verified yet"
- Rename invoice status badge from "Received" to "Invoice received"
- Update test fixtures and assertions to use enum members (41 tests)

## Test plan

- [x] `pnpm test` — 41 tests pass
- [x] `pnpm lint:fix` — 0 errors
- [ ] Visual check: alert icon appears next to "Completed" milestones with correct tooltip
- [ ] Visual check: invoice status badge reads "Invoice received" instead of "Received"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning indicator to alert users when completed milestones are pending verification.

* **UI Improvements**
  * Updated invoice status label from "Received" to "Invoice received" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->