### PR TITLE
fix: guard against null chainID in composite programId construction

### DIFF
--- a/components/Pages/Admin/ProgramScoresUpload.tsx
+++ b/components/Pages/Admin/ProgramScoresUpload.tsx
@@ -211,7 +211,8 @@ export function ProgramScoresUpload({
                 key={buildCompositeProgramId(program.programId, program.chainID)}
                 value={buildCompositeProgramId(program.programId, program.chainID)}
               >
-                {program.metadata?.title || program.programId} (Chain: {program.chainID})
+                {program.metadata?.title || program.programId}
+                {program.chainID != null ? ` (Chain: ${program.chainID})` : " (Off-chain)"}
               </option>
             ))}
           </select>

--- a/components/Pages/Admin/ProgramScoresUpload.tsx
+++ b/components/Pages/Admin/ProgramScoresUpload.tsx
@@ -177,12 +177,22 @@ export function ProgramScoresUpload({
           </label>
           <select
             id="program-scores-program"
-            value={selectedProgram ? `${selectedProgram.programId}_${selectedProgram.chainID}` : ""}
+            value={
+              selectedProgram
+                ? selectedProgram.chainID != null
+                  ? `${selectedProgram.programId}_${selectedProgram.chainID}`
+                  : selectedProgram.programId
+                : ""
+            }
             onChange={(e) => {
               if (e.target.value) {
-                const [progId, chain] = e.target.value.split("_");
+                const parts = e.target.value.split("_");
+                const progId = parts[0];
+                const chain = parts.length > 1 ? parseInt(parts[1], 10) : NaN;
                 const program = programs.find(
-                  (p) => p.programId === progId && p.chainID === parseInt(chain, 10)
+                  (p) =>
+                    p.programId === progId &&
+                    (isNaN(chain) ? p.chainID == null : p.chainID === chain)
                 );
                 setSelectedProgram(program || null);
                 if (program?.chainID) {
@@ -198,8 +208,16 @@ export function ProgramScoresUpload({
             <option value="">Choose a program...</option>
             {programs.map((program) => (
               <option
-                key={`${program.programId}_${program.chainID}`}
-                value={`${program.programId}_${program.chainID}`}
+                key={
+                  program.chainID != null
+                    ? `${program.programId}_${program.chainID}`
+                    : program.programId
+                }
+                value={
+                  program.chainID != null
+                    ? `${program.programId}_${program.chainID}`
+                    : program.programId
+                }
               >
                 {program.metadata?.title || program.programId} (Chain: {program.chainID})
               </option>

--- a/components/Pages/Admin/ProgramScoresUpload.tsx
+++ b/components/Pages/Admin/ProgramScoresUpload.tsx
@@ -10,6 +10,10 @@ import Papa from "papaparse";
 import { useCallback, useState } from "react";
 import toast from "react-hot-toast";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
+import {
+  buildCompositeProgramId,
+  parseCompositeProgramKey,
+} from "@/components/Pages/ProgramRegistry/programUtils";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { FileUpload } from "@/components/Utilities/FileUpload";
 import { Button } from "@/components/ui/button";
@@ -179,20 +183,16 @@ export function ProgramScoresUpload({
             id="program-scores-program"
             value={
               selectedProgram
-                ? selectedProgram.chainID != null
-                  ? `${selectedProgram.programId}_${selectedProgram.chainID}`
-                  : selectedProgram.programId
+                ? buildCompositeProgramId(selectedProgram.programId, selectedProgram.chainID)
                 : ""
             }
             onChange={(e) => {
               if (e.target.value) {
-                const parts = e.target.value.split("_");
-                const progId = parts[0];
-                const chain = parts.length > 1 ? parseInt(parts[1], 10) : NaN;
+                const { programId: progId, chainID: chain } = parseCompositeProgramKey(
+                  e.target.value
+                );
                 const program = programs.find(
-                  (p) =>
-                    p.programId === progId &&
-                    (isNaN(chain) ? p.chainID == null : p.chainID === chain)
+                  (p) => p.programId === progId && (p.chainID ?? null) === chain
                 );
                 setSelectedProgram(program || null);
                 if (program?.chainID) {
@@ -208,16 +208,8 @@ export function ProgramScoresUpload({
             <option value="">Choose a program...</option>
             {programs.map((program) => (
               <option
-                key={
-                  program.chainID != null
-                    ? `${program.programId}_${program.chainID}`
-                    : program.programId
-                }
-                value={
-                  program.chainID != null
-                    ? `${program.programId}_${program.chainID}`
-                    : program.programId
-                }
+                key={buildCompositeProgramId(program.programId, program.chainID)}
+                value={buildCompositeProgramId(program.programId, program.chainID)}
               >
                 {program.metadata?.title || program.programId} (Chain: {program.chainID})
               </option>

--- a/components/Pages/Communities/TracksAdminPage.tsx
+++ b/components/Pages/Communities/TracksAdminPage.tsx
@@ -300,8 +300,16 @@ export const TracksAdminPage = ({
                   .filter((program) => program.programId)
                   .map((program) => (
                     <option
-                      key={`${program.programId}_${program.chainID}`}
-                      value={`${program.programId}_${program.chainID}`}
+                      key={
+                        program.chainID != null
+                          ? `${program.programId}_${program.chainID}`
+                          : program.programId
+                      }
+                      value={
+                        program.chainID != null
+                          ? `${program.programId}_${program.chainID}`
+                          : program.programId
+                      }
                     >
                       {program.metadata?.title}
                     </option>

--- a/components/Pages/Communities/TracksAdminPage.tsx
+++ b/components/Pages/Communities/TracksAdminPage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { CreateTrackModal } from "@/components/Pages/Communities/Tracks/CreateTrackModal";
+import { buildCompositeProgramId } from "@/components/Pages/ProgramRegistry/programUtils";
 import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
@@ -300,16 +301,8 @@ export const TracksAdminPage = ({
                   .filter((program) => program.programId)
                   .map((program) => (
                     <option
-                      key={
-                        program.chainID != null
-                          ? `${program.programId}_${program.chainID}`
-                          : program.programId
-                      }
-                      value={
-                        program.chainID != null
-                          ? `${program.programId}_${program.chainID}`
-                          : program.programId
-                      }
+                      key={buildCompositeProgramId(program.programId, program.chainID)}
+                      value={buildCompositeProgramId(program.programId, program.chainID)}
                     >
                       {program.metadata?.title}
                     </option>

--- a/components/Pages/ProgramRegistry/programUtils.ts
+++ b/components/Pages/ProgramRegistry/programUtils.ts
@@ -50,6 +50,35 @@ export const parseProgramIdAndChainId = (
 };
 
 /**
+ * Build a composite key from programId and chainID for use in dropdowns/selectors.
+ * Returns "programId_chainID" for on-chain programs or just "programId" for off-chain (null chainID).
+ */
+export const buildCompositeProgramId = (
+  programId: string | undefined,
+  chainID: number | null | undefined
+): string => {
+  const id = programId ?? "";
+  return chainID != null ? `${id}_${chainID}` : id;
+};
+
+/**
+ * Parse a composite key back into programId and chainID.
+ * Inverse of buildCompositeProgramId — returns null chainID for off-chain programs.
+ */
+export const parseCompositeProgramKey = (
+  value: string
+): { programId: string; chainID: number | null } => {
+  const parts = value.split("_");
+  if (parts.length === 2) {
+    const chainID = parseInt(parts[1], 10);
+    if (!Number.isNaN(chainID)) {
+      return { programId: parts[0], chainID };
+    }
+  }
+  return { programId: value, chainID: null };
+};
+
+/**
  * Get the URL-friendly program ID for a GrantProgram
  * Priority: refToGrant > programId > _id.$oid
  * Note: No longer appends chainId - URLs should use just programId

--- a/components/Pages/ProgramRegistry/programUtils.ts
+++ b/components/Pages/ProgramRegistry/programUtils.ts
@@ -68,11 +68,11 @@ export const buildCompositeProgramId = (
 export const parseCompositeProgramKey = (
   value: string
 ): { programId: string; chainID: number | null } => {
-  const parts = value.split("_");
-  if (parts.length === 2) {
-    const chainID = parseInt(parts[1], 10);
+  const lastUnderscore = value.lastIndexOf("_");
+  if (lastUnderscore > 0) {
+    const chainID = parseInt(value.substring(lastUnderscore + 1), 10);
     if (!Number.isNaN(chainID)) {
-      return { programId: parts[0], chainID };
+      return { programId: value.substring(0, lastUnderscore), chainID };
     }
   }
   return { programId: value, chainID: null };


### PR DESCRIPTION
## Summary

- Adds `buildCompositeProgramId` and `parseCompositeProgramKey` utilities to `programUtils.ts` for safe composite ID construction/parsing
- Fixes `ProgramScoresUpload` and `TracksAdminPage` dropdowns that produced malformed IDs like `"1045_null"` for off-chain programs (where `chainID` is `null`)
- `parseCompositeProgramKey` uses `lastIndexOf("_")` to correctly handle programIds containing underscores (e.g. `"abc_123_10"`)
- Off-chain programs now display "(Off-chain)" instead of "(Chain: null)" in dropdown labels

## Changes

**`components/Pages/ProgramRegistry/programUtils.ts`**
- `buildCompositeProgramId(programId, chainID)` — returns `"id_chain"` or just `"id"` when chainID is null
- `parseCompositeProgramKey(value)` — inverse of build, splits on last underscore

**`components/Pages/Admin/ProgramScoresUpload.tsx`**
- Dropdown value/key use `buildCompositeProgramId` instead of inline interpolation
- `onChange` uses `parseCompositeProgramKey` instead of manual split
- Off-chain programs show "(Off-chain)" label

**`components/Pages/Communities/TracksAdminPage.tsx`**
- Dropdown key/value use `buildCompositeProgramId`

## Test plan

- [ ] Open ProgramScoresUpload with a community that has off-chain programs — verify dropdown values don't contain `_null` and label shows "(Off-chain)"
- [ ] Open TracksAdminPage with off-chain programs — verify dropdown values don't contain `_null`
- [ ] Select an off-chain program — verify no API errors (no `ProgramRegistryNotFoundException`)
- [ ] Select an on-chain program — verify existing composite format still works
- [ ] Programs with underscores in their ID (e.g. `"abc_123"` on chain 10) parse correctly as `{ programId: "abc_123", chainID: 10 }`