### PR TITLE
fix: remove newest/oldest dropdown from updates milestones

### DIFF
--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -5,11 +5,7 @@ import { Suspense, useCallback, useMemo } from "react";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { ActivityFeed } from "../MainContent/ActivityFeed";
-import {
-  ActivityFilters,
-  type ActivityFilterType,
-  type SortOption,
-} from "../MainContent/ActivityFilters";
+import { ActivityFilters, type ActivityFilterType } from "../MainContent/ActivityFilters";
 import { ActivityFeedSkeleton } from "../Skeletons";
 
 interface UpdatesContentProps {
@@ -37,14 +33,9 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
     return filterParam.split(",") as ActivityFilterType[];
   }, [searchParams]);
 
-  const sortBy = useMemo(() => {
-    const sortParam = searchParams.get("sort");
-    return (sortParam === "oldest" ? "oldest" : "newest") as SortOption;
-  }, [searchParams]);
-
   // Update URL when filters change
   const updateURL = useCallback(
-    (newFilters: ActivityFilterType[], newSort: SortOption) => {
+    (newFilters: ActivityFilterType[]) => {
       const params = new URLSearchParams(searchParams.toString());
 
       // Update filter param
@@ -53,13 +44,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       } else {
         params.delete("filter");
       }
-
-      // Update sort param (only if not default)
-      if (newSort !== "newest") {
-        params.set("sort", newSort);
-      } else {
-        params.delete("sort");
-      }
+      params.delete("sort");
 
       const newURL = params.toString() ? `?${params.toString()}` : window.location.pathname;
       router.replace(newURL, { scroll: false });
@@ -72,14 +57,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       const newFilters = activeFilters.includes(filter)
         ? activeFilters.filter((f) => f !== filter)
         : [...activeFilters, filter];
-      updateURL(newFilters, sortBy);
-    },
-    [activeFilters, sortBy, updateURL]
-  );
-
-  const handleSortChange = useCallback(
-    (newSort: SortOption) => {
-      updateURL(activeFilters, newSort);
+      updateURL(newFilters);
     },
     [activeFilters, updateURL]
   );
@@ -91,8 +69,6 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
     <div className={className} data-testid="updates-content">
       {/* Filters */}
       <ActivityFilters
-        sortBy={sortBy}
-        onSortChange={handleSortChange}
         activeFilters={activeFilters}
         onFilterToggle={handleFilterToggle}
         milestonesCount={milestonesCount}
@@ -108,7 +84,6 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
             <ActivityFeed
               milestones={allUpdates}
               isAuthorized={isAuthorized}
-              sortBy={sortBy}
               activeFilters={activeFilters}
             />
           </Suspense>

--- a/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import type { ActivityFilterType, SortOption } from "@/types/v2/project-profile.types";
+import type { ActivityFilterType } from "@/types/v2/project-profile.types";
 import { ACTIVITY_FILTER_OPTIONS } from "@/types/v2/project-profile.types";
 import { cn } from "@/utilities/tailwind";
 
@@ -16,8 +9,6 @@ import { cn } from "@/utilities/tailwind";
 export type { ActivityFilterType, SortOption } from "@/types/v2/project-profile.types";
 
 interface ActivityFiltersProps {
-  sortBy: SortOption;
-  onSortChange: (sort: SortOption) => void;
   activeFilters: ActivityFilterType[];
   onFilterToggle: (filter: ActivityFilterType) => void;
   milestonesCount?: number;
@@ -31,15 +22,12 @@ const filterOptions = ACTIVITY_FILTER_OPTIONS.filter(
 );
 
 /**
- * ActivityFilters provides sorting and filtering controls for the activity feed.
+ * ActivityFilters provides filtering controls for the activity feed.
  * Includes:
- * - Sort dropdown (Newest/Oldest)
  * - Milestone count display
  * - Filter badges (toggleable)
  */
 export function ActivityFilters({
-  sortBy,
-  onSortChange,
   activeFilters,
   onFilterToggle,
   milestonesCount = 0,
@@ -48,34 +36,16 @@ export function ActivityFilters({
 }: ActivityFiltersProps) {
   return (
     <div className={cn("flex flex-col gap-4", className)} data-testid="activity-filters">
-      {/* Top row: Sort and milestone count */}
-      <div className="flex flex-row items-center justify-between flex-wrap gap-4">
-        {/* Sort Dropdown */}
-        <Select value={sortBy} onValueChange={(value) => onSortChange(value as SortOption)}>
-          <SelectTrigger className="w-[140px]" data-testid="sort-select">
-            <SelectValue placeholder="Sort by" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="newest" data-testid="sort-newest">
-              Newest first
-            </SelectItem>
-            <SelectItem value="oldest" data-testid="sort-oldest">
-              Oldest first
-            </SelectItem>
-          </SelectContent>
-        </Select>
-
-        {/* Milestone Count */}
-        {milestonesCount > 0 && (
-          <span
-            className="text-xl font-semibold leading-tight tracking-tight text-foreground"
-            data-testid="milestones-count"
-          >
-            {milestonesCount} {milestonesCount === 1 ? "Milestone" : "Milestones"}, {completedCount}{" "}
-            Completed
-          </span>
-        )}
-      </div>
+      {/* Milestone Count */}
+      {milestonesCount > 0 && (
+        <span
+          className="text-xl font-semibold leading-tight tracking-tight text-foreground"
+          data-testid="milestones-count"
+        >
+          {milestonesCount} {milestonesCount === 1 ? "Milestone" : "Milestones"}, {completedCount}{" "}
+          Completed
+        </span>
+      )}
 
       {/* Filter Badges */}
       <div className="flex flex-row flex-wrap gap-2" data-testid="filter-badges">

--- a/components/Pages/Project/v2/MainContent/ProjectMainContent.tsx
+++ b/components/Pages/Project/v2/MainContent/ProjectMainContent.tsx
@@ -6,7 +6,7 @@ import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { cn } from "@/utilities/tailwind";
 import { AboutContent } from "./AboutContent";
 import { ActivityFeed } from "./ActivityFeed";
-import { ActivityFilters, type ActivityFilterType, type SortOption } from "./ActivityFilters";
+import { ActivityFilters, type ActivityFilterType } from "./ActivityFilters";
 import { type ContentTab, ContentTabs } from "./ContentTabs";
 import { ImpactContent } from "./ImpactContent";
 
@@ -26,7 +26,7 @@ interface ProjectMainContentProps {
 /**
  * ProjectMainContent is the main content area containing:
  * - Content tabs (Profile, Updates, About, Funding, Impact)
- * - Activity filters (Sort, filter badges)
+ * - Activity filters (filter badges)
  * - Activity feed (Timeline of project activities)
  */
 export function ProjectMainContent({
@@ -42,7 +42,6 @@ export function ProjectMainContent({
   className,
 }: ProjectMainContentProps) {
   const [activeTab, setActiveTab] = useState<ContentTab>(initialTab);
-  const [sortBy, setSortBy] = useState<SortOption>("newest");
   const [activeFilters, setActiveFilters] = useState<ActivityFilterType[]>([]);
 
   const handleTabChange = useCallback(
@@ -75,8 +74,6 @@ export function ProjectMainContent({
       {/* Filters - only show on Updates tab */}
       {activeTab === "updates" && (
         <ActivityFilters
-          sortBy={sortBy}
-          onSortChange={setSortBy}
           activeFilters={activeFilters}
           onFilterToggle={handleFilterToggle}
           milestonesCount={milestonesCount}
@@ -90,7 +87,6 @@ export function ProjectMainContent({
           <ActivityFeed
             milestones={milestones}
             isAuthorized={isAuthorized}
-            sortBy={sortBy}
             activeFilters={activeFilters}
           />
         )}

--- a/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
+++ b/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
@@ -128,8 +128,6 @@ describe("ContentTabs", () => {
 
 describe("ActivityFilters", () => {
   const defaultProps = {
-    sortBy: "newest" as const,
-    onSortChange: jest.fn(),
     activeFilters: [] as ("funding" | "updates" | "blog" | "socials" | "other")[],
     onFilterToggle: jest.fn(),
   };
@@ -145,10 +143,10 @@ describe("ActivityFilters", () => {
       expect(screen.getByTestId("activity-filters")).toBeInTheDocument();
     });
 
-    it("should render sort select", () => {
+    it("should not render sort select", () => {
       render(<ActivityFilters {...defaultProps} />);
 
-      expect(screen.getByTestId("sort-select")).toBeInTheDocument();
+      expect(screen.queryByTestId("sort-select")).not.toBeInTheDocument();
     });
 
     it("should render filter badges", () => {


### PR DESCRIPTION
## Summary
- remove the Newest/Oldest sort dropdown from the project profile Updates tab filters
- simplify updates-tab state by removing sort URL/query handling and keeping timeline order fixed to existing newest-first behavior
- update Project v2 tests to reflect the removed sort control

## Testing
- pnpm test -- components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx components/Pages/Project/v2/Content/__tests__/UpdatesContent.test.tsx

## Manual QA
- Playwright MCP transport was unstable in-session (`Transport closed`), so manual browser validation was run via a standalone Playwright process
- app was run on isolated random port `http://localhost:4717` to avoid interference from other sessions
- validated on `/project/zcash-wallet-community-developer`:
  - `activity-filters` renders
  - `sort-select` is not present
  - `Funding`, `Product updates`, and `Everything` filters render
  - selecting `Product updates` sets URL to `?filter=updates` (no `sort` param)
  - selecting `Everything` clears filter query (no `sort` param)
  - starting from `?sort=oldest`, interacting with filters removes `sort`