### PR TITLE
fix: remove duplicate Karma suffix from page titles

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { defaultMetadata } from "@/utilities/meta";
 
 export const metadata = {
   ...defaultMetadata,
-  title: "Dashboard | Karma",
+  title: "Dashboard",
 };
 
 export default function Page() {

--- a/app/seeds/fund/page.tsx
+++ b/app/seeds/fund/page.tsx
@@ -7,7 +7,7 @@ import { SeedsHowItWorks } from "@/src/features/seeds/components/how-it-works";
 import { SeedsProjectsSection } from "@/src/features/seeds/components/projects-section";
 
 export const metadata: Metadata = {
-  title: "Fund Projects with Karma Seeds | Karma",
+  title: "Fund Projects with Karma Seeds",
   description:
     "Support projects you believe in for just $1 per seed. Karma Seeds are ERC-20 tokens that give you on-chain proof of early backing.",
   keywords: [

--- a/app/seeds/page.tsx
+++ b/app/seeds/page.tsx
@@ -7,7 +7,7 @@ import { LaunchProblem } from "@/src/features/seeds/components/launch/launch-pro
 import { LaunchUseCases } from "@/src/features/seeds/components/launch/launch-use-cases";
 
 export const metadata: Metadata = {
-  title: "Karma Seeds - Raise Funds Without Launching a Token | Karma",
+  title: "Karma Seeds - Raise Funds Without Launching a Token",
   description:
     "Raise funds from your community without launching a token. Karma Seeds let you build community and stay focused on building.",
   openGraph: {


### PR DESCRIPTION
## Summary
- Removed hardcoded `| Karma` suffix from page titles that were duplicating the layout metadata template (`%s | Karma`), causing titles like "Dashboard | Karma | Karma"
- Affected pages: `/dashboard`, `/seeds`, `/seeds/fund`

## Test plan
- [ ] Visit `/dashboard` and verify browser tab shows "Dashboard | Karma" (not "Dashboard | Karma | Karma")
- [ ] Visit `/seeds` and verify title shows "Karma Seeds - Raise Funds Without Launching a Token | Karma"
- [ ] Visit `/seeds/fund` and verify title shows "Fund Projects with Karma Seeds | Karma"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated page titles on the dashboard and seeds pages to provide cleaner, more concise titles throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->