### PR TITLE
Add /foundations landing page for lean foundations

### DIFF
--- a/app/community/[communityId]/manage/funding-platform/[programId]/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/page.tsx
@@ -1,10 +1,11 @@
 import { redirect } from "next/navigation";
 import { PAGES } from "@/utilities/pages";
 
-export default function ProgramIdPage({
+export default async function ProgramIdPage({
   params,
 }: {
-  params: { communityId: string; programId: string };
+  params: Promise<{ communityId: string; programId: string }>;
 }) {
-  redirect(PAGES.MANAGE.FUNDING_PLATFORM.QUESTION_BUILDER(params.communityId, params.programId));
+  const { communityId, programId } = await params;
+  redirect(PAGES.MANAGE.FUNDING_PLATFORM.QUESTION_BUILDER(communityId, programId));
 }

--- a/app/foundations/page.tsx
+++ b/app/foundations/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import { CTASection } from "@/src/features/foundations/components/cta-section";
+import { Hero } from "@/src/features/foundations/components/hero";
+import { HowItWorksSection } from "@/src/features/foundations/components/how-it-works-section";
+import { ObjectionsSection } from "@/src/features/foundations/components/objections-section";
+import { PainPointsSection } from "@/src/features/foundations/components/pain-points-section";
+import { PlatformSection } from "@/src/features/foundations/components/platform-section";
+import { WhyKarmaSection } from "@/src/features/foundations/components/why-karma-section";
+import { customMetadata } from "@/utilities/meta";
+import { cn } from "@/utilities/tailwind";
+
+export const metadata: Metadata = customMetadata({
+  title: "For Foundations - Professional Grant Programs Without the Overhead",
+  description:
+    "Karma helps lean foundations run structured, professional grant programs with AI-powered evaluation, milestone tracking, and live portfolio dashboards — without hiring more staff.",
+  path: "/foundations",
+});
+
+const HorizontalLine = ({ className }: { className?: string }) => {
+  return <hr className={cn("w-full h-[1px] bg-border max-w-[75%]", className)} />;
+};
+
+export default function FoundationsPage() {
+  return (
+    <main className="flex w-full flex-col flex-1 items-center bg-background">
+      <div className="flex w-full max-w-[1920px] justify-center items-center flex-1 flex-col gap-16 lg:gap-24">
+        <Hero />
+        <HorizontalLine className="max-w-full" />
+        <PainPointsSection />
+        <HorizontalLine />
+        <PlatformSection />
+        <HorizontalLine />
+        <WhyKarmaSection />
+        <HorizontalLine />
+        <HowItWorksSection />
+        <HorizontalLine />
+        <ObjectionsSection />
+        <CTASection />
+      </div>
+    </main>
+  );
+}

--- a/src/features/foundations/components/cta-section.tsx
+++ b/src/features/foundations/components/cta-section.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { SOCIALS } from "@/utilities/socials";
+import { cn } from "@/utilities/tailwind";
+
+export function CTASection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "pb-16 md:pb-24")}>
+      <SectionContainer>
+        <div className="flex flex-col items-center gap-6">
+          <h2 className="section-title text-foreground text-center">
+            Ready to upgrade your next grant cycle?
+          </h2>
+          <p className="text-base md:text-xl font-normal text-muted-foreground text-center leading-[30px] tracking-normal max-w-lg">
+            30-minute call. No commitment. We&apos;ll show you exactly how Karma works for
+            foundations your size.
+          </p>
+          <div className="flex flex-col md:flex-row items-center gap-4 w-full md:w-auto px-4 md:px-0">
+            <Button
+              asChild
+              className="bg-foreground text-background hover:bg-foreground/90 rounded-md font-medium px-6 py-2.5"
+            >
+              <Link href={SOCIALS.PARTNER_FORM} target="_blank" rel="noopener noreferrer">
+                Schedule a Demo
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/hero.tsx
+++ b/src/features/foundations/components/hero.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { SOCIALS } from "@/utilities/socials";
+import { cn } from "@/utilities/tailwind";
+
+export function Hero() {
+  return (
+    <section
+      className={cn(
+        marketingLayoutTheme.padding,
+        "flex flex-col items-center w-full pt-16 md:pt-24"
+      )}
+    >
+      <SectionContainer className="flex flex-col items-center gap-6">
+        {/* Badge */}
+        <div className="w-full flex justify-start md:justify-center">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            For Foundations
+          </Badge>
+        </div>
+
+        {/* Main Heading */}
+        <h1
+          className={cn(
+            "text-foreground font-semibold text-[40px] md:text-5xl lg:text-[48px]",
+            "leading-[110%] tracking-[-0.02em]",
+            "text-left md:text-center max-w-[768px] w-full md:mx-auto"
+          )}
+        >
+          Run professional grant programs without hiring more staff
+        </h1>
+
+        {/* Description */}
+        <p
+          className={cn(
+            "text-muted-foreground font-medium text-base md:text-lg",
+            "text-left md:text-center",
+            "max-w-[640px] w-full md:mx-auto"
+          )}
+        >
+          Structured intake, standardized evaluation, milestone tracking, and a live portfolio
+          dashboard — purpose-built for lean foundations giving $500K to $2M per year.
+        </p>
+
+        {/* CTA Buttons */}
+        <div className="w-full flex flex-col sm:flex-row justify-start md:justify-center gap-3 max-w-[768px] md:mx-auto">
+          <Button
+            asChild
+            className="bg-foreground text-background hover:bg-foreground/90 rounded-md font-medium px-6 py-2.5"
+          >
+            <Link href={SOCIALS.PARTNER_FORM} target="_blank" rel="noopener noreferrer">
+              Schedule a Demo
+            </Link>
+          </Button>
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/how-it-works-section.tsx
+++ b/src/features/foundations/components/how-it-works-section.tsx
@@ -1,0 +1,131 @@
+import { BarChart2, Mail, Zap } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { SOCIALS } from "@/utilities/socials";
+import { cn } from "@/utilities/tailwind";
+
+interface StepCard {
+  icon: React.ComponentType<{ className?: string }>;
+  stepLabel: string;
+  title: string;
+  description: string;
+  hasButton?: boolean;
+}
+
+const steps: StepCard[] = [
+  {
+    icon: Mail,
+    stepLabel: "Step 1",
+    title: "Tell us about your program",
+    description:
+      "A 30-minute call to understand your grant cycle, evaluation criteria, and reporting needs. No sales pitch — just discovery.",
+    hasButton: true,
+  },
+  {
+    icon: Zap,
+    stepLabel: "Step 2",
+    title: "We configure everything",
+    description:
+      "We set up your intake forms, evaluation rubrics, milestone templates, and dashboard. Implementation is done for you — typically within a week.",
+  },
+  {
+    icon: BarChart2,
+    stepLabel: "Step 3",
+    title: "Launch your next cycle",
+    description:
+      "Run your next grant cycle on Karma. Compare the experience against your current workflow. Most teams never look back.",
+  },
+];
+
+export function HowItWorksSection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "flex flex-col items-start w-full")}>
+      <SectionContainer className="flex flex-col items-start gap-16">
+        {/* Header */}
+        <div className="flex flex-col items-start gap-4 w-full">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            How It Works
+          </Badge>
+
+          <h2 className={cn("section-title", "w-full")}>
+            <span className="text-foreground">Go live in one week.</span>{" "}
+            <br className="hidden md:block" />
+            <span className="text-muted-foreground">No IT required.</span>
+          </h2>
+        </div>
+
+        {/* Steps Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full items-stretch">
+          {steps.map((step, index) => {
+            const IconComponent = step.icon;
+            return (
+              <div key={index} className="flex flex-col items-center gap-4 h-full">
+                <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center flex-shrink-0">
+                  <IconComponent className="w-6 h-6 text-foreground" />
+                </div>
+
+                <Badge
+                  variant="secondary"
+                  className={cn(
+                    "text-secondary-foreground font-medium text-xs",
+                    "leading-[150%] tracking-[0.015em]",
+                    "rounded-full py-[3px] px-2",
+                    "bg-secondary border-0 w-fit"
+                  )}
+                >
+                  {step.stepLabel}
+                </Badge>
+
+                <div className={cn("flex flex-col w-full h-full rounded-2xl bg-secondary p-8")}>
+                  <div
+                    className={cn(
+                      "flex flex-col items-start gap-2",
+                      step.hasButton ? "justify-between h-full" : ""
+                    )}
+                  >
+                    <div className="flex flex-col gap-2">
+                      <h3 className="text-foreground font-semibold text-[20px] leading-[120%] tracking-[-0.02em]">
+                        {step.title}
+                      </h3>
+                      <p className="text-muted-foreground font-medium text-sm leading-[20px]">
+                        {step.description}
+                      </p>
+                    </div>
+
+                    {step.hasButton && (
+                      <div className="mt-4">
+                        <Button
+                          asChild
+                          className="bg-foreground text-background hover:bg-foreground/90 rounded-md font-medium"
+                        >
+                          <Link
+                            href={SOCIALS.PARTNER_FORM}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Schedule a Call
+                          </Link>
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/objections-section.tsx
+++ b/src/features/foundations/components/objections-section.tsx
@@ -1,0 +1,75 @@
+import { Badge } from "@/components/ui/badge";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { cn } from "@/utilities/tailwind";
+
+interface Objection {
+  question: string;
+  answer: string;
+}
+
+const objections: Objection[] = [
+  {
+    question: '"We\'re too small for this."',
+    answer:
+      "That's exactly who we built this for. Karma replaces the patchwork of tools small teams cobble together. No large team or IT department required.",
+  },
+  {
+    question: '"We already use spreadsheets and they work fine."',
+    answer:
+      "Spreadsheets work until they don't — fragmented review, no audit trail, manual board reporting. Karma gives you governance-grade structure with the same simplicity.",
+  },
+  {
+    question: '"We don\'t need AI."',
+    answer:
+      "The AI runs in the background. You don't configure it, train it, or think about it. You just get pre-scored applications and save hours of review time per cycle.",
+  },
+  {
+    question: '"Switching tools sounds painful."',
+    answer:
+      "Implementation is done for you. We configure your intake, evaluation, and dashboards. Most foundations are live within a week with zero disruption to current cycles.",
+  },
+];
+
+export function ObjectionsSection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "flex flex-col items-start w-full")}>
+      <SectionContainer className="flex flex-col items-start gap-16">
+        {/* Header */}
+        <div className="flex flex-col items-start gap-4 w-full max-w-xl">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            Common Questions
+          </Badge>
+
+          <h2 className={cn("section-title", "text-left", "w-full")}>
+            <span className="text-foreground">We get it.</span>
+            <br />
+            <span className="text-muted-foreground">Here&apos;s the honest answer.</span>
+          </h2>
+        </div>
+
+        {/* Objections Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+          {objections.map((objection, index) => (
+            <div key={index} className="flex flex-col gap-3 rounded-2xl border border-border p-8">
+              <h3 className="text-foreground font-semibold text-lg leading-[120%] tracking-[-0.02em]">
+                {objection.question}
+              </h3>
+              <p className="text-muted-foreground font-medium text-sm leading-[20px]">
+                {objection.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/pain-points-section.tsx
+++ b/src/features/foundations/components/pain-points-section.tsx
@@ -1,0 +1,87 @@
+import { Eye, FileSpreadsheet, Repeat, ShieldAlert } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { cn } from "@/utilities/tailwind";
+
+interface PainPoint {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}
+
+const painPoints: PainPoint[] = [
+  {
+    icon: FileSpreadsheet,
+    title: "Fragmented tools",
+    description:
+      "Google Forms for intake, spreadsheets for tracking, email for updates. Each grant cycle means rebuilding the same workflows from scratch.",
+  },
+  {
+    icon: Eye,
+    title: "No portfolio visibility",
+    description:
+      "No single view of all the projects you have funded, their progress, or their outcomes. Board reporting is a manual scramble every quarter.",
+  },
+  {
+    icon: Repeat,
+    title: "Inconsistent evaluation",
+    description:
+      "Without standardized scoring, every reviewer applies different criteria. Decisions feel subjective and hard to defend.",
+  },
+  {
+    icon: ShieldAlert,
+    title: "Accountability gaps",
+    description:
+      "Once the check is written, tracking whether grantees hit their milestones depends on chasing emails and hope.",
+  },
+];
+
+export function PainPointsSection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "flex flex-col items-start w-full")}>
+      <SectionContainer className="flex flex-col items-start gap-16">
+        {/* Header */}
+        <div className="flex flex-col items-start gap-4 w-full max-w-xl">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            Sound Familiar?
+          </Badge>
+
+          <h2 className={cn("section-title", "text-left", "w-full")}>
+            <span className="text-foreground">Spreadsheets collect applications.</span>
+            <br />
+            <span className="text-muted-foreground">They don&apos;t run grant programs.</span>
+          </h2>
+        </div>
+
+        {/* Cards Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+          {painPoints.map((point, index) => {
+            const IconComponent = point.icon;
+            return (
+              <div key={index} className="flex flex-col gap-4 bg-secondary rounded-2xl p-8">
+                <div className="w-10 h-10 rounded-full bg-background flex items-center justify-center">
+                  <IconComponent className="w-5 h-5 text-foreground" />
+                </div>
+                <h3 className="text-foreground font-semibold text-[20px] leading-[120%] tracking-[-0.02em]">
+                  {point.title}
+                </h3>
+                <p className="text-muted-foreground font-medium text-sm leading-[20px]">
+                  {point.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/platform-section.tsx
+++ b/src/features/foundations/components/platform-section.tsx
@@ -1,0 +1,127 @@
+import { Badge } from "@/components/ui/badge";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { cn } from "@/utilities/tailwind";
+
+interface PlatformFeature {
+  subtitle: string;
+  title: string;
+  description: string;
+  highlights: string[];
+}
+
+const features: PlatformFeature[] = [
+  {
+    subtitle: "Structured Intake",
+    title: "Professional applications in minutes",
+    description:
+      "Launch a branded application portal with custom questions, eligibility criteria, and automatic validation. Applicants get a professional experience. You get structured, comparable data.",
+    highlights: [
+      "Custom application forms with conditional logic",
+      "Automatic eligibility screening",
+      "Branded applicant portal",
+    ],
+  },
+  {
+    subtitle: "AI-Powered Review",
+    title: "Cut review time by 70%",
+    description:
+      "AI pre-scores every application against your criteria, flags risks, and surfaces the strongest proposals. Your team focuses on final decisions, not reading hundreds of pages.",
+    highlights: [
+      "Automated scoring against your rubric",
+      "Risk and quality flags",
+      "Side-by-side comparison views",
+    ],
+  },
+  {
+    subtitle: "Milestone Tracking",
+    title: "Accountability that runs itself",
+    description:
+      "Grantees submit milestone updates with proof of work. You see progress in real time without chasing emails. Set automatic check-ins and reminders on a schedule.",
+    highlights: [
+      "Milestone-based progress tracking",
+      "Automated grantee reminders",
+      "Proof-of-work submissions",
+    ],
+  },
+  {
+    subtitle: "Portfolio Dashboard",
+    title: "Every funded project in one place",
+    description:
+      "A live, always-current view of your entire portfolio. See which projects are on track, which need attention, and generate board-ready reports instantly.",
+    highlights: [
+      "Real-time project status overview",
+      "Exportable board reports",
+      "Historical grant cycle data",
+    ],
+  },
+];
+
+export function PlatformSection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "flex flex-col items-start w-full")}>
+      <SectionContainer className="flex flex-col items-start gap-16">
+        <div className="flex flex-col items-start gap-4 w-full max-w-[768px]">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            The Platform
+          </Badge>
+
+          <h2 className={cn("section-title", "text-left", "w-full")}>
+            <span className="text-foreground">Structured control</span>
+            <br />
+            <span className="text-muted-foreground">over your entire grant lifecycle</span>
+          </h2>
+
+          <p
+            className={cn(
+              "text-muted-foreground font-normal text-left",
+              "text-[20px] leading-[30px] tracking-[0%]",
+              "w-full"
+            )}
+          >
+            From intake to impact measurement, every step is structured, visible, and under your
+            control.
+          </p>
+        </div>
+
+        {/* Features Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+          {features.map((feature, index) => (
+            <div key={index} className="flex flex-col gap-4 bg-secondary rounded-2xl p-8 md:p-10">
+              <span className="text-muted-foreground font-medium text-xs leading-[150%] tracking-[0.015em]">
+                {feature.subtitle}
+              </span>
+
+              <h3 className="text-foreground font-semibold text-[20px] leading-[120%] tracking-[-0.02em]">
+                {feature.title}
+              </h3>
+
+              <p className="text-muted-foreground font-medium text-sm leading-[20px]">
+                {feature.description}
+              </p>
+
+              <ul className="flex flex-col gap-2 mt-2">
+                {feature.highlights.map((highlight, hIndex) => (
+                  <li key={hIndex} className="flex items-start gap-2">
+                    <span className="w-1.5 h-1.5 rounded-full bg-foreground flex-shrink-0 mt-1.5" />
+                    <span className="text-foreground font-normal text-sm leading-[150%]">
+                      {highlight}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/src/features/foundations/components/why-karma-section.tsx
+++ b/src/features/foundations/components/why-karma-section.tsx
@@ -1,0 +1,93 @@
+import { LayoutDashboard, MousePointerClick, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { SectionContainer } from "@/src/components/shared/section-container";
+import { marketingLayoutTheme } from "@/src/helper/theme";
+import { cn } from "@/utilities/tailwind";
+
+interface Advantage {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  tagline: string;
+  description: string;
+}
+
+const advantages: Advantage[] = [
+  {
+    icon: MousePointerClick,
+    title: "No training required",
+    tagline: "Intuitive by design",
+    description:
+      "Most grant software is built for large institutions with IT teams. Karma is built for lean teams. If you can use a spreadsheet, you can run Karma. Zero onboarding burden, no 3-week implementations.",
+  },
+  {
+    icon: Sparkles,
+    title: "AI that saves hours, not adds complexity",
+    tagline: "Time compression engine",
+    description:
+      "AI reviews, summarizes, and scores applications in the background. You don't need to learn prompt engineering or configure models. You just save time — typically 70% less on application review.",
+  },
+  {
+    icon: LayoutDashboard,
+    title: "Full visibility for your board",
+    tagline: "Live portfolio dashboard",
+    description:
+      "See every project you've funded, their milestones, and their outcomes in one place. Generate board-ready reports instantly instead of spending days compiling spreadsheets every quarter.",
+  },
+];
+
+export function WhyKarmaSection() {
+  return (
+    <section className={cn(marketingLayoutTheme.padding, "flex flex-col items-start w-full")}>
+      <SectionContainer className="flex flex-col items-start gap-16">
+        {/* Header */}
+        <div className="flex flex-col items-start gap-4 w-full max-w-xl">
+          <Badge
+            variant="secondary"
+            className={cn(
+              "text-secondary-foreground font-medium text-xs",
+              "leading-[150%] tracking-[0.015em]",
+              "rounded-full py-[3px] px-2",
+              "bg-secondary border-0 w-fit"
+            )}
+          >
+            Why Karma
+          </Badge>
+
+          <h2 className={cn("section-title", "text-left", "w-full")}>
+            <span className="text-foreground">Built for foundations</span>
+            <br />
+            <span className="text-muted-foreground">that run lean and move fast</span>
+          </h2>
+        </div>
+
+        {/* Advantages Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full items-stretch">
+          {advantages.map((advantage, index) => {
+            const IconComponent = advantage.icon;
+            return (
+              <div key={index} className="flex flex-col items-center gap-4 h-full">
+                <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center">
+                  <IconComponent className="w-6 h-6 text-foreground" />
+                </div>
+
+                <div className="flex flex-col w-full h-full rounded-2xl bg-secondary p-8">
+                  <div className="flex flex-col items-start gap-3">
+                    <span className="text-muted-foreground font-medium text-xs leading-[150%] tracking-[0.015em]">
+                      {advantage.tagline}
+                    </span>
+                    <h3 className="text-foreground font-semibold text-[20px] leading-[120%] tracking-[-0.02em]">
+                      {advantage.title}
+                    </h3>
+                    <p className="text-muted-foreground font-medium text-sm leading-[20px]">
+                      {advantage.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </SectionContainer>
+    </section>
+  );
+}

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -108,6 +108,7 @@ export const PAGES = {
   },
   STATS: `/stats`,
   SUMUP_CONFIG: `/admin/sumup`,
+  FOUNDATIONS: `/foundations`,
   FUNDERS: `/funders`,
   SEEDS: `/seeds`,
   SEEDS_FUND: `/seeds/fund`,


### PR DESCRIPTION
## Summary
- Add new `/foundations` marketing landing page targeting lean foundations giving $500K-$2M/year
- Page includes hero, pain points, platform features, why Karma, how it works, objections, and CTA sections
- Content focused on operational simplification: structured intake, AI-powered review, milestone tracking, portfolio dashboard
- Fix pre-existing async params type error in funding-platform program redirect page (Next.js 15 PageProps)

## Test plan
- [ ] Visit `/foundations` and verify all sections render correctly
- [ ] Check responsive layout on mobile, tablet, and desktop
- [ ] Verify "Schedule a Demo" / "Schedule a Call" buttons link to Tally partner form
- [ ] Test dark mode appearance
- [ ] Verify page metadata (title, description) in browser tab and view source


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Foundations page with comprehensive information about grant program management and platform capabilities.
  * Includes sections highlighting platform benefits, core features, step-by-step workflows, frequently asked questions, and answers.
  * Added prominent call-to-action elements for scheduling demos and partnership inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->