### PR TITLE
fix: reset control center pagination when filters change

### DIFF
--- a/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
+++ b/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
@@ -2,7 +2,7 @@
 
 import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { Button } from "@/components/ui/button";
@@ -56,6 +56,14 @@ export function ControlCenterPage() {
     | "COMPLETED"
     | undefined;
   const kycFilter = searchParams.get("kycStatus") || undefined;
+  const filterSignature = JSON.stringify({
+    selectedProgramId,
+    agreementFilter,
+    invoiceFilter,
+    disbursementFilter,
+    kycFilter,
+    searchQuery,
+  });
 
   // Local state
   const [localSearch, setLocalSearch] = useState(searchQuery);
@@ -118,6 +126,25 @@ export function ControlCenterPage() {
     },
     [searchParams]
   );
+
+  const previousFilterSignature = useRef(filterSignature);
+
+  // Safety net: whenever any filter changes, force page back to 1.
+  // This covers cases where a child component updates query params directly.
+  useEffect(() => {
+    if (previousFilterSignature.current === filterSignature) {
+      return;
+    }
+
+    previousFilterSignature.current = filterSignature;
+
+    if (currentPage === 1) {
+      return;
+    }
+
+    const query = createQueryString({ page: "1" });
+    router.replace(`${pathname}?${query}`);
+  }, [createQueryString, currentPage, filterSignature, pathname, router]);
 
   // ─── Data fetching (extracted hook) ───────────────────────────────────────
 
@@ -613,6 +640,7 @@ export function ControlCenterPage() {
       {selectedGrants.size > 0 && (
         <div className="fixed bottom-6 right-6 z-40 animate-in slide-in-from-bottom-4 fade-in duration-300">
           <button
+            type="button"
             onClick={handleOpenDisbursementModal}
             className="flex items-center gap-3 px-6 py-4 bg-brand-blue hover:bg-brand-blue/80 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-200 text-base font-semibold"
           >

--- a/components/Pages/Communities/Impact/ProgramFilter.tsx
+++ b/components/Pages/Communities/Impact/ProgramFilter.tsx
@@ -13,7 +13,7 @@ interface ProgramFilterProps {
 export const ProgramFilter = ({ defaultProgramSelected, onChange }: ProgramFilterProps) => {
   const { communityId } = useParams();
 
-  const { data, isLoading } = useCommunityPrograms(communityId as string);
+  const { data } = useCommunityPrograms(communityId as string);
   const programs = data?.map((program) => ({
     title: program.metadata?.title || "",
     value: program.programId || "", // Use programId only (backend handles composite format internally)
@@ -57,14 +57,24 @@ export const ProgramFilter = ({ defaultProgramSelected, onChange }: ProgramFilte
         id="filter-by-programs"
         list={programs || []}
         onSelectFunction={(value: string) => {
-          onChange?.(value) || changeSelectedProgramIdQuery(value);
+          if (onChange) {
+            onChange(value);
+            return;
+          }
+          changeSelectedProgramIdQuery(value);
         }}
         type={"Programs"}
         selected={selectedProgram ? [selectedProgram.title as string] : []}
         prefixUnselected="All"
         buttonClassname="w-full max-w-full"
         isMultiple={false}
-        cleanFunction={() => onChange?.(null) || changeSelectedProgramIdQuery(null)}
+        cleanFunction={() => {
+          if (onChange) {
+            onChange(null);
+            return;
+          }
+          changeSelectedProgramIdQuery(null);
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## Problem
In Community Admin Control Center, when users changed filters (program/agreement/status), the table sometimes stayed on the previous page instead of resetting to page 1.

## Root Cause
`ProgramFilter` could trigger two query updates when `onChange` was provided:
- parent handler update
- internal `useQueryState` update

That second update could overwrite the `page=1` reset from the parent.

## Solution
- Updated `ProgramFilter` to use a single update path:
  - If `onChange` exists, use only `onChange`
  - Otherwise use internal `changeSelectedProgramIdQuery`
- Added a defensive page reset effect in `ControlCenterPage`:
  - On any filter signature change (`programId`, `agreementStatus`, `invoiceStatus`, `status`, `kycStatus`, `search`), force `page=1` via URL replace when needed.
- Added explicit `type="button"` on the floating disbursement button (small a11y/lint fix).

## Files Changed
- `components/Pages/Communities/Impact/ProgramFilter.tsx`
- `components/Pages/Admin/ControlCenter/ControlCenterPage.tsx`

## Validation
- `pnpm biome check components/Pages/Communities/Impact/ProgramFilter.tsx components/Pages/Admin/ControlCenter/ControlCenterPage.tsx`

## Manual QA
1. Go to Control Center and navigate to page > 1.
2. Change Program filter.
3. Change Agreement filter.
4. Change Status filter.
5. Confirm the URL/page resets to page 1 after each filter change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filters now automatically reset pagination to the first page when modified, preventing empty result confusion

* **Bug Fixes**
  * Fixed button behavior to prevent unintended form submissions
  * Enhanced filter selection handling for more consistent behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->