### PR TITLE
fix: make admin emails required in program dashboard

### DIFF
--- a/__tests__/schemas/programFormSchema.test.ts
+++ b/__tests__/schemas/programFormSchema.test.ts
@@ -514,7 +514,7 @@ describe("createProgramSchema", () => {
 });
 
 describe("updateProgramSchema", () => {
-  it("should allow empty admin emails when finance emails are provided", () => {
+  it("should require at least one admin email", () => {
     const result = updateProgramSchema.safeParse({
       name: "Test Program",
       description: "Test description",
@@ -525,16 +525,34 @@ describe("updateProgramSchema", () => {
       financeEmails: ["finance@example.com"],
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const adminError = result.error.errors.find((err) => err.path.includes("adminEmails"));
+      expect(adminError?.message).toBe("At least one admin email is required");
+    }
   });
 
-  it("should allow omitting admin emails", () => {
+  it("should reject omitting admin emails", () => {
     const result = updateProgramSchema.safeParse({
       name: "Test Program",
       description: "Test description",
       shortDescription: "Short desc",
       invoiceRequired: false,
       dates: {},
+      financeEmails: ["finance@example.com"],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid admin emails when provided", () => {
+    const result = updateProgramSchema.safeParse({
+      name: "Test Program",
+      description: "Test description",
+      shortDescription: "Short desc",
+      invoiceRequired: false,
+      dates: {},
+      adminEmails: ["admin@example.com"],
       financeEmails: ["finance@example.com"],
     });
 
@@ -560,7 +578,7 @@ describe("updateProgramSchema", () => {
       description: "Test description",
       shortDescription: "Short desc",
       dates: {},
-      adminEmails: [],
+      adminEmails: ["admin@example.com"],
       financeEmails: [],
     });
 

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -518,7 +518,9 @@ export function ProgramDetailsTab({
             control={control}
             render={({ field, fieldState }) => (
               <div className="flex w-full flex-col gap-1">
-                <Label htmlFor="admin-emails">Admin Emails (optional)</Label>
+                <Label htmlFor="admin-emails">
+                  Admin Emails <span className="text-destructive">*</span>
+                </Label>
                 <p className="text-xs text-muted-foreground mb-1">
                   Applicants will reply to these email addresses when responding to notifications
                 </p>

--- a/schemas/programFormSchema.ts
+++ b/schemas/programFormSchema.ts
@@ -33,11 +33,24 @@ const baseProgramFields = {
 };
 
 /**
- * Shared email fields for create and update program forms.
+ * Shared email fields for create program forms.
  * Admin emails are optional; finance emails are required.
  */
-const emailFields = {
+const createEmailFields = {
   adminEmails: z.array(z.string().email({ message: "Invalid email address" })).optional(),
+  financeEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one finance email is required" }),
+};
+
+/**
+ * Email fields for update program forms (admin dashboard).
+ * Admin emails are required; finance emails are required.
+ */
+const updateEmailFields = {
+  adminEmails: z
+    .array(z.string().email({ message: "Invalid email address" }))
+    .min(1, { message: "At least one admin email is required" }),
   financeEmails: z
     .array(z.string().email({ message: "Invalid email address" }))
     .min(1, { message: "At least one finance email is required" }),
@@ -48,7 +61,7 @@ const emailFields = {
  */
 export const createProgramSchema = z.object({
   ...baseProgramFields,
-  ...emailFields,
+  ...createEmailFields,
 });
 
 /**
@@ -57,7 +70,7 @@ export const createProgramSchema = z.object({
  */
 export const updateProgramSchema = z.object({
   ...baseProgramFields,
-  ...emailFields,
+  ...updateEmailFields,
 });
 
 export type CreateProgramFormSchema = z.infer<typeof createProgramSchema>;


### PR DESCRIPTION
## Summary
- Admin Emails input is now **required** when editing a funding program from the admin dashboard
- Remains **optional** in the public program creation form and the admin create modal
- Split shared `emailFields` into `createEmailFields` (optional) and `updateEmailFields` (required with `.min(1)` validation)
- Updated the label from "Admin Emails (optional)" to "Admin Emails *" with required asterisk styling

## Test plan
- [ ] Edit a program in the admin dashboard — verify Admin Emails shows as required with asterisk
- [ ] Try to save without any admin emails — verify validation error "At least one admin email is required"
- [ ] Create a new program via the public form — verify Admin Emails remains optional
- [ ] Create a new program via the admin modal — verify Admin Emails remains optional
- [ ] Run `pnpm test` — all 39 schema tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin Emails field now marked as required in the program details form UI.
  * Form validation updated to enforce at least one admin email when finance emails are provided.
  * Stricter admin email validation requirements applied for program updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->