### PR TITLE
ci: rollback from Blacksmith to GitHub Actions runners

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -371,5 +371,4 @@ jobs:
 
           max_turns: '30'
           timeout_minutes: '45'
-          # Allow the Blacksmith bot account to trigger Claude on automation PRs.
-          allowed_bots: blacksmith-sh,blacksmith-sh[bot]
+

--- a/.github/workflows/comment-on-task.yaml
+++ b/.github/workflows/comment-on-task.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   create-comment-in-asana-task-job:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     name: Create a comment in Asana Task
     steps:
       - name: Create a comment

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   detect-flaky-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:
@@ -51,7 +51,7 @@ jobs:
 
   analyze-results:
     needs: detect-flaky-tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: always()
 
     steps:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   deploy:
     name: Deploy to Production
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout (tag push)
         if: github.event_name == 'push'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   deploy:
     name: Deploy to Staging
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Reverts all workflow runners from `blacksmith-4vcpu-ubuntu-2404` back to `ubuntu-latest`
- Removes Blacksmith bot `allowed_bots` configuration from `claude.yml`

## Changed files
- `.github/workflows/claude.yml`
- `.github/workflows/comment-on-task.yaml`
- `.github/workflows/e2e-tests.yml`
- `.github/workflows/flaky-tests.yml`
- `.github/workflows/pr-tests.yml`
- `.github/workflows/production.yml`
- `.github/workflows/staging.yml`

## Test plan
- [ ] Verify CI workflows trigger correctly on PRs
- [ ] Verify staging deployment works on merge to main
- [ ] Verify production deployment works on tag push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration runner environments across multiple workflows for enhanced consistency and standardization.
  * Removed outdated automation configuration from CI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->