### PR TITLE
feat: allow staff (SUPER_ADMIN) access to manage programs

### DIFF
--- a/components/Pages/ProgramRegistry/ManagePrograms.tsx
+++ b/components/Pages/ProgramRegistry/ManagePrograms.tsx
@@ -25,6 +25,7 @@ import Pagination from "@/components/Utilities/Pagination";
 import { useAuth } from "@/hooks/useAuth";
 import { ProgramRegistryService } from "@/services/programRegistry.service";
 import { usePermissionsQuery } from "@/src/core/rbac/hooks/use-permissions";
+import { Role } from "@/src/core/rbac/types/role";
 import { useSigner } from "@/utilities/eas-wagmi-utils";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
@@ -85,7 +86,8 @@ export const ManagePrograms = () => {
 
   const isRegistryAdmin = permissions?.isRegistryAdmin ?? false;
   const isProgramCreator = permissions?.isProgramCreator ?? false;
-  const isAllowed = Boolean(address) && (isRegistryAdmin || isProgramCreator) && isAuth;
+  const isStaff = permissions?.roles?.roles.includes(Role.SUPER_ADMIN) ?? false;
+  const isAllowed = Boolean(address) && (isRegistryAdmin || isProgramCreator || isStaff) && isAuth;
 
   const [tab, setTab] = useQueryState("tab", {
     defaultValue: defaultTab || "pending",
@@ -161,7 +163,7 @@ export const ManagePrograms = () => {
         grantTypes: selectedGrantTypes.length ? selectedGrantTypes.join(",") : undefined,
         sortField: sortField as "createdAt" | "updatedAt" | "name" | "programId",
         sortOrder: sortOrder as "asc" | "desc",
-        owners: address && !isRegistryAdmin ? address : undefined,
+        owners: address && !(isRegistryAdmin || isStaff) ? address : undefined,
       });
 
       const [res, error] = await fetchData(url);
@@ -195,6 +197,7 @@ export const ManagePrograms = () => {
       isPermissionsLoading,
       isRegistryAdmin,
       isProgramCreator,
+      isStaff,
       selectedEcosystems,
       selectedGrantTypes,
       selectedNetworks,
@@ -341,7 +344,7 @@ export const ManagePrograms = () => {
                       color: tab === "pending" ? "black" : "gray",
                     }}
                   >
-                    {isRegistryAdmin ? "Pending" : "Waiting for approval"}
+                    {isRegistryAdmin || isStaff ? "Pending" : "Waiting for approval"}
                   </Button>
                   <Button
                     className="bg-transparent text-black"
@@ -438,7 +441,7 @@ export const ManagePrograms = () => {
                     <div className="mt-8 flow-root">
                       <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                         <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                          {isRegistryAdmin ? (
+                          {isRegistryAdmin || isStaff ? (
                             <ManageProgramList
                               approveOrReject={approveOrReject}
                               grantPrograms={grantPrograms}


### PR DESCRIPTION
## Summary

- Staff users with `SUPER_ADMIN` role can now access `/funding-map/manage-programs`
- They see the admin view (approve/reject) and all programs (not filtered by owner)
- No backend changes needed — the permissions API already returns role data

## Changes

Single file: `components/Pages/ProgramRegistry/ManagePrograms.tsx`

1. **Access gate**: Added `isStaff` check (derived from `permissions.roles.roles`) to `isAllowed`
2. **Owner filter bypass**: Staff see all programs, not just their own
3. **Admin UI**: Staff see "Pending" tab label and `ManageProgramList` with approve/reject
4. **Query key**: Added `isStaff` to ensure proper cache invalidation

## Test plan

- [x] `pnpm lint:fix` — no new errors
- [x] `pnpm test` — all 345 suites, 7264 tests pass
- [ ] Manual: log in as SUPER_ADMIN → navigate to `/funding-map/manage-programs` → confirm admin view with approve/reject
- [ ] Manual: log in as registry admin → confirm existing behavior unchanged
- [ ] Manual: log in as program creator → confirm existing behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Staff members can now access program management capabilities.

* **Refactor**
  * Expanded access control to include staff role alongside registry administrators.
  * Updated UI labels and conditional rendering to reflect user roles and permissions.
  * Optimized data fetching to include staff status in program queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->