### PR TITLE
feat: rename hasPayoutAddress URL param to raisingFunds

### DIFF
--- a/__tests__/navbar/unit/menu-items.test.tsx
+++ b/__tests__/navbar/unit/menu-items.test.tsx
@@ -152,10 +152,10 @@ describe("Menu Items Configuration", () => {
       expect(allProjectsItem?.href).toBe(PAGES.PROJECTS_EXPLORER);
     });
 
-    it('should contain "Raising Funds" item with hasPayoutAddress filter', () => {
+    it('should contain "Raising Funds" item with raisingFunds filter', () => {
       const raisingFundsItem = exploreItems.projects.find((item) => item.title === "Raising Funds");
       expect(raisingFundsItem).toBeDefined();
-      expect(raisingFundsItem?.href).toContain("hasPayoutAddress=true");
+      expect(raisingFundsItem?.href).toContain("raisingFunds=true");
     });
 
     it('should contain "Most Active" item with query parameters', () => {

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -52,8 +52,8 @@ export const ProjectsExplorer = () => {
     parse: (value) => (value as ExplorerSortOrder) || "desc",
   });
 
-  // URL state for hasPayoutAddress filter
-  const [hasPayoutAddress, setHasPayoutAddress] = useQueryState("hasPayoutAddress", {
+  // URL state for raisingFunds filter
+  const [hasPayoutAddress, setHasPayoutAddress] = useQueryState("raisingFunds", {
     defaultValue: "",
     serialize: (value) => value || "",
     parse: (value) => value || "",

--- a/src/components/navbar/menu-items.tsx
+++ b/src/components/navbar/menu-items.tsx
@@ -84,7 +84,7 @@ export const exploreItems: ExploreItems = {
       title: "All projects",
     },
     {
-      href: `${PAGES.PROJECTS_EXPLORER}?hasPayoutAddress=true`,
+      href: `${PAGES.PROJECTS_EXPLORER}?raisingFunds=true`,
       icon: BanknoteArrowDown,
       title: "Raising Funds",
     },


### PR DESCRIPTION
## Summary
- Renames the user-facing URL query parameter from `?hasPayoutAddress=true` to `?raisingFunds=true` on the projects explorer page
- Updates the navbar "Raising Funds" link to use the new param
- Internal variable names, service layer, and backend API param (`hasPayoutAddress`) remain unchanged

## Test plan
- [ ] Navigate to "Raising Funds" from the navbar dropdown — URL should show `?raisingFunds=true`
- [ ] Verify the projects list correctly filters to projects with payout addresses
- [ ] Verify `pnpm test` passes (menu-items test updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal query parameter naming conventions for project filtering to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->