### PR TITLE
fix: verify button hidden for milestones with empty completion description

### DIFF
--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -42,8 +42,8 @@ export function MilestoneCard({
   isDeleting = false,
 }: MilestoneCardProps) {
   const useOnChainData = useMemo(
-    () => !!milestone.completionDetails?.description,
-    [milestone.completionDetails?.description]
+    () => milestone.completionDetails !== null,
+    [milestone.completionDetails]
   );
 
   const completionData = useMemo(


### PR DESCRIPTION
## Summary

- Milestones completed on-chain with an empty description (`""`) were not showing the "Verify Milestone" button
- `useOnChainData` checked `!!completionDetails?.description` — falsy for empty strings, causing fallback to `fundingApplicationCompletion` (null) and hiding the verify UI
- Changed to `completionDetails !== null` to correctly detect on-chain completion data regardless of description content

## Test plan

- [ ] Navigate to a grant with milestones that have empty completion descriptions (e.g. [staging link](https://staging.karmahq.xyz/community/filecoin/manage/funding-platform/184/milestones/0x75fea20a07582b9a557760088b85a6e966f67b2d3d90c96b886c6a646bfa01d3))
- [ ] Verify all 4 milestones show the "Verify Milestone" button
- [ ] Verify milestones with non-empty descriptions still display completion details correctly
- [ ] Verify already-verified milestones still show the green verification box instead of the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213543410367522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of milestone completion data detection to enhance system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->