### PR TITLE
feat: reuse FundingPlatformContent in dashboard empty state

### DIFF
--- a/app/community/[communityId]/manage/funding-platform/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/page.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { CreateProgramModal } from "@/components/FundingPlatform/CreateProgramModal";
 import { FundingPlatformStatsCard } from "@/components/FundingPlatform/Dashboard/card";
+import { NoProgramsEmptyState } from "@/components/FundingPlatform/NoProgramsEmptyState";
 import {
   hasFormConfigured,
   ProgramSetupStatus,
@@ -42,7 +43,7 @@ import { getProgramApplyUrl } from "@/utilities/fundingPlatformUrls";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 
-export function FundingPlatformContent() {
+function FundingPlatformContent() {
   const { communityId } = useParams() as { communityId: string };
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -687,20 +688,18 @@ export function FundingPlatformContent() {
           </div>
         )
       ) : (
-        <div className="text-center py-12">
-          <div className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-8">
-            <PlusIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              {isAdmin ? "Create your first program" : "No programs yet"}
-            </h3>
+        <NoProgramsEmptyState
+          title={isAdmin ? "Create your first program" : "No programs yet"}
+          className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-8"
+          action={
             <AdminOnly>
               <Button onClick={() => setShowCreateModal(true)} className="inline-flex items-center">
                 <PlusIcon className="w-4 h-4 mr-2" />
                 Create your first program
               </Button>
             </AdminOnly>
-          </div>
-        </div>
+          }
+        />
       )}
 
       {/* Create Program Modal - Admin Only */}

--- a/components/FundingPlatform/NoProgramsEmptyState.tsx
+++ b/components/FundingPlatform/NoProgramsEmptyState.tsx
@@ -1,0 +1,22 @@
+import { FolderOpenIcon } from "@heroicons/react/24/outline";
+import { cn } from "@/utilities/tailwind";
+
+interface NoProgramsEmptyStateProps {
+  title?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function NoProgramsEmptyState({
+  title = "No programs yet",
+  action,
+  className,
+}: NoProgramsEmptyStateProps) {
+  return (
+    <div className={cn("text-center py-12", className)}>
+      <FolderOpenIcon className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+      <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">{title}</h3>
+      {action}
+    </div>
+  );
+}

--- a/components/Manage/DashboardOverview.tsx
+++ b/components/Manage/DashboardOverview.tsx
@@ -11,7 +11,7 @@ import {
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useMemo } from "react";
-import { FundingPlatformContent } from "@/app/community/[communityId]/manage/funding-platform/page";
+import { NoProgramsEmptyState } from "@/components/FundingPlatform/NoProgramsEmptyState";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import type { Community } from "@/types/v2/community";
@@ -342,8 +342,21 @@ export function DashboardOverview({ community }: { community: Community }) {
         </div>
       )}
 
-      {/* When no programs, show the full funding platform view */}
-      {(!programs || programs.length === 0) && <FundingPlatformContent />}
+      {/* Empty state */}
+      {(!programs || programs.length === 0) && (
+        <NoProgramsEmptyState
+          title="Create your first program"
+          className="bg-white dark:bg-zinc-900 rounded-xl border border-gray-200 dark:border-zinc-700"
+          action={
+            <Link
+              href={`${PAGES.ADMIN.FUNDING_PLATFORM(slug)}?create=true`}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg transition-colors"
+            >
+              Create your first program
+            </Link>
+          }
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Export `FundingPlatformContent` from the funding platform page so it can be reused
- Replace the minimal empty state in `DashboardOverview` with the full `FundingPlatformContent` component when no programs exist
- Remove unused `FolderOpenIcon` import

## Test plan

- [ ] Navigate to the dashboard overview for a community with no funding programs — verify the full funding platform UI is rendered instead of the old "Create your first program" card
- [ ] Navigate to the funding platform page directly — verify it still works as before
- [ ] Create a program from the dashboard empty state and confirm the flow works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "No programs" empty-state component with customizable title and action (e.g., admin "Create" button).
* **Refactor**
  * Replaced scattered inline empty-state UIs in the dashboard and community management views with the new component for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->