### PR TITLE
fix: throw error when retryUntilConditionMet exhausts retries

### DIFF
--- a/utilities/retries.ts
+++ b/utilities/retries.ts
@@ -40,7 +40,7 @@ export async function retry<T>(
 export const retryUntilConditionMet = async (
   conditionFn: () => Promise<boolean>,
   callbackFn?: () => void,
-  maxRetries: number = 1000,
+  maxRetries: number = 200,
   delay: number = 1500
 ) => {
   let retries = maxRetries;
@@ -57,4 +57,7 @@ export const retryUntilConditionMet = async (
     retries -= 1;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
+  throw new Error(
+    "Condition was not met after maximum retries. The operation may not have completed successfully."
+  );
 };


### PR DESCRIPTION
## Problem

`retryUntilConditionMet` was silently resolving when max retries were exhausted. This caused the UI to show success for operations like milestone deletion even when the indexer hadn't confirmed the operation completed.

## Solution

- **Throw on exhaustion**: Now throws an error instead of silently resolving, so callers can handle the timeout appropriately (e.g., show an error toast instead of a success message)
- **Reduced default maxRetries**: Changed from 1000 to 200 (200 × 1500ms = 5 minutes) to avoid excessive polling while still providing adequate wait time

## Testing

1. Create a project on OP Sepolia
2. Add a grant with a milestone
3. Delete the milestone
4. Verify deletion succeeds and milestone does not reappear after page refresh
5. Verify that if the indexer is slow/down, the user sees an error instead of false success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry operations now throw an error with a descriptive message when they fail, instead of silently failing.
  * Updated retry thresholds for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->