### PR TITLE
feat: add reviewer filter to All Milestones tab

### DIFF
--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -132,10 +132,10 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
   );
 
   const reviewerProgramIds = useMemo(() => {
-    if (!isAuthorized || reportData.activeTab !== "pending-verification") return [];
+    if (!isAuthorized) return [];
     const ids = reportData.effectiveProgramIds;
     return ids.length > 0 ? ids : allProgramIds;
-  }, [isAuthorized, reportData.activeTab, reportData.effectiveProgramIds, allProgramIds]);
+  }, [isAuthorized, reportData.effectiveProgramIds, allProgramIds]);
 
   const {
     reviewers,
@@ -211,17 +211,18 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
           <TabsTrigger value="stats">All Milestones</TabsTrigger>
         </TabsList>
 
+        <div className="flex items-center gap-2 my-4">
+          <span className="text-sm text-gray-500 dark:text-zinc-400">Reviewer:</span>
+          <ReviewerFilterDropdown
+            reviewers={reviewers}
+            isLoading={isLoadingReviewers}
+            selectedAddress={reportData.selectedReviewerAddress}
+            onSelect={reportData.handleReviewerAddressChange}
+            currentUserAddress={address}
+          />
+        </div>
+
         <TabsContent value="pending-verification">
-          <div className="flex items-center gap-2 mb-4">
-            <span className="text-sm text-gray-500 dark:text-zinc-400">Reviewer:</span>
-            <ReviewerFilterDropdown
-              reviewers={reviewers}
-              isLoading={isLoadingReviewers}
-              selectedAddress={reportData.selectedReviewerAddress}
-              onSelect={reportData.handleReviewerAddressChange}
-              currentUserAddress={address}
-            />
-          </div>
           <PendingVerificationTable
             milestones={reportData.pendingMilestones}
             isLoading={reportData.isPendingLoading}

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -224,7 +224,8 @@ export function useReportPageData({
       statsPage,
       sortBy,
       sortOrder,
-      effectiveProgramIds
+      effectiveProgramIds,
+      effectiveReviewerAddress
     ),
     queryFn: () =>
       milestoneReportService.getReport(
@@ -233,7 +234,8 @@ export function useReportPageData({
         itemsPerPage,
         sortBy,
         sortOrder,
-        effectiveProgramIds
+        effectiveProgramIds,
+        effectiveReviewerAddress
       ),
     enabled: Boolean(communityId) && isAuthorized,
   });
@@ -306,6 +308,7 @@ export function useReportPageData({
     hasUserSelectedFilter.current = true;
     setSelectedReviewerAddress(address);
     setPendingPage(1);
+    setStatsPage(1);
   }, []);
 
   const isFullyCompleted = useCallback((report: MilestoneCompletion) => {

--- a/services/milestone-report.service.ts
+++ b/services/milestone-report.service.ts
@@ -28,14 +28,18 @@ export const milestoneReportService = {
     pageLimit: number,
     sortBy = "totalMilestones",
     sortOrder = "desc",
-    selectedProgramIds: string[] = []
+    selectedProgramIds: string[] = [],
+    reviewerAddress?: string
   ): Promise<ReportAPIResponse> {
     const normalizedProgramIds = selectedProgramIds.map(normalizeProgramId);
     const queryProgramIds = normalizedProgramIds.join(",");
     const encodedProgramIds = encodeURIComponent(queryProgramIds);
-    const url = `${INDEXER.COMMUNITY.REPORT.GET(communityId)}?limit=${pageLimit}&page=${page}&sort=${sortBy}&sortOrder=${sortOrder}${
+    let url = `${INDEXER.COMMUNITY.REPORT.GET(communityId)}?limit=${pageLimit}&page=${page}&sort=${sortBy}&sortOrder=${sortOrder}${
       queryProgramIds ? `&programIds=${encodedProgramIds}` : ""
     }`;
+    if (reviewerAddress) {
+      url += `&reviewerAddress=${encodeURIComponent(reviewerAddress)}`;
+    }
 
     const [data, error] = await fetchData<ReportAPIResponse>(url);
     if (error) throw new Error(String(error));

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -117,8 +117,9 @@ export const QUERY_KEYS = {
       page: number,
       sortBy: string,
       sortOrder: string,
-      programIds: string[]
-    ) => ["reportMilestones", communityId, page, sortBy, sortOrder, programIds] as const,
+      programIds: string[],
+      reviewerAddress?: string
+    ) => ["reportMilestones", communityId, page, sortBy, sortOrder, programIds, reviewerAddress] as const,
     PENDING_VERIFICATION: (
       communityId: string,
       page: number,


### PR DESCRIPTION
## Summary

- Moved the reviewer filter dropdown above the tab panels so it's visible on both **Pending Verification** and **All Milestones** tabs
- Pass selected `reviewerAddress` to the stats/report API query so the All Milestones table filters by reviewer
- Reset stats page to 1 when reviewer selection changes
- Fetch reviewer list regardless of active tab (previously only fetched on Pending Verification)

## Changed files

- `components/Pages/Admin/ReportMilestonePage.tsx` — moved filter above tabs, removed tab-gated reviewer fetching
- `hooks/useReportPageData.ts` — pass reviewer address to stats query, reset stats page on filter change
- `services/milestone-report.service.ts` — added optional `reviewerAddress` param to `getReport()`
- `utilities/queryKeys.ts` — added `reviewerAddress` to stats query key for correct cache invalidation

## Test plan

- [ ] Navigate to Milestones Report page
- [ ] Verify reviewer filter dropdown appears on both Pending Verification and All Milestones tabs
- [ ] Select a reviewer and confirm All Milestones table filters correctly
- [ ] Switch between tabs and confirm selected reviewer persists
- [ ] Select "All Reviewers" and confirm both tabs show unfiltered data