### PR TITLE
fix: grant staff (SUPER_ADMIN) access to manage-programs page

### DIFF
--- a/__tests__/components/navbar/dashboard-nav.test.tsx
+++ b/__tests__/components/navbar/dashboard-nav.test.tsx
@@ -52,6 +52,20 @@ describe("Dashboard nav updates", () => {
     expect(screen.getByRole("link", { name: "Manage Programs" })).toBeInTheDocument();
   });
 
+  it("shows Manage Programs for staff users (SUPER_ADMIN) in desktop navigation", () => {
+    mockNavbarPermissionsState.current = {
+      ...mockNavbarPermissionsState.current,
+      isStaff: true,
+      isRegistryAdmin: false,
+      isProgramCreator: false,
+      isRegistryAllowed: true,
+    };
+
+    render(<NavbarDesktopNavigation />);
+
+    expect(screen.getByRole("link", { name: "Manage Programs" })).toBeInTheDocument();
+  });
+
   it("shows Dashboard in user menu and removes Review/Admin items", async () => {
     const user = userEvent.setup();
 

--- a/__tests__/navbar/fixtures/auth-fixtures.ts
+++ b/__tests__/navbar/fixtures/auth-fixtures.ts
@@ -311,7 +311,7 @@ export const authFixtures: AuthFixture[] = [
       myProjects: true,
       review: false,
       admin: false,
-      managePrograms: false,
+      managePrograms: true,
     },
   },
 
@@ -461,7 +461,7 @@ export const authFixtures: AuthFixture[] = [
       myProjects: true,
       review: false,
       admin: false,
-      managePrograms: false,
+      managePrograms: true,
     },
   },
 

--- a/__tests__/navbar/utils/test-helpers.tsx
+++ b/__tests__/navbar/utils/test-helpers.tsx
@@ -320,7 +320,7 @@ const updateNavbarPermissionsState = (authMock?: any, permissionsMock?: any) => 
   const isCommunityAdmin = communities.length > 0;
   const isReviewer = reviewerPrograms.length > 0;
   const hasAdminAccess = !isStaffLoading && (isStaff || isOwner || isCommunityAdmin);
-  const isRegistryAllowed = (isRegistryAdmin || isProgramCreator) && isLoggedIn;
+  const isRegistryAllowed = (isRegistryAdmin || isProgramCreator || isStaff) && isLoggedIn;
 
   mockNavbarPermissionsState.current = {
     isLoggedIn,

--- a/components/Pages/ProgramRegistry/ManagePrograms.tsx
+++ b/components/Pages/ProgramRegistry/ManagePrograms.tsx
@@ -30,6 +30,7 @@ import { useSigner } from "@/utilities/eas-wagmi-utils";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { PAGES } from "@/utilities/pages";
+import { LoadingManagePrograms } from "./Loading/ManagePrograms";
 import { LoadingProgramTable } from "./Loading/Programs";
 import { SearchDropdown } from "./SearchDropdown";
 
@@ -309,7 +310,9 @@ export const ManagePrograms = () => {
             </Link>
           </div>
         )}
-        {isAllowed ? (
+        {isPermissionsLoading ? (
+          <LoadingManagePrograms />
+        ) : isAllowed ? (
           isEditing ? (
             <div className="w-full">
               <AddProgram

--- a/src/components/navbar/navbar-permissions-context.tsx
+++ b/src/components/navbar/navbar-permissions-context.tsx
@@ -89,9 +89,9 @@ export function NavbarPermissionsProvider({ children }: NavbarPermissionsProvide
     const isProgramCreator = permissions?.isProgramCreator ?? false;
     const isRegistryAdmin = permissions?.isRegistryAdmin ?? false;
     const hasAdminAccess = !isPermissionsLoading && (isStaff || isOwner || isCommunityAdmin);
-    // User can access Manage Programs if they are registry admin OR have created programs
+    // User can access Manage Programs if they are registry admin, program creator, or staff
     const isRegistryAllowed =
-      !isPermissionsLoading && (isRegistryAdmin || isProgramCreator) && isLoggedIn;
+      !isPermissionsLoading && (isRegistryAdmin || isProgramCreator || isStaff) && isLoggedIn;
 
     return {
       isLoggedIn,


### PR DESCRIPTION
## Summary

- Staff users (SUPER_ADMIN) can now see the "Manage Programs" navbar button and access `/funding-map/manage-programs`
- The manage-programs page now shows a loading skeleton while permissions load instead of flashing a "no programs to manage" error

## Problem

Two bugs prevented staff users from accessing the manage-programs page:

1. **Navbar**: `isRegistryAllowed` only checked `isRegistryAdmin || isProgramCreator`, excluding `isStaff`. Staff users never saw the "Manage Programs" button.
2. **Page**: While permissions were loading, `isAllowed` evaluated to `false` (since `permissions` is `undefined`), showing the "Seems like you do not have programs to manage" error instead of a loading skeleton.

## Solution

1. Added `isStaff` to `isRegistryAllowed` in `navbar-permissions-context.tsx`
2. Added `isPermissionsLoading` check in `ManagePrograms.tsx` to show `LoadingManagePrograms` skeleton during load
3. Updated test fixtures and helpers to reflect the new behavior
4. Added a dedicated test for staff visibility of "Manage Programs"

## Test plan

- [x] All 699 navbar tests pass (`pnpm test --testPathPattern="navbar"`)
- [ ] Log in as SUPER_ADMIN → "Manage Programs" button appears in navbar
- [ ] Navigate to `/funding-map/manage-programs` → loading skeleton shown, then programs list
- [ ] Log in as non-admin/non-staff user → "Manage Programs" button NOT visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff users now have access to the "Manage Programs" feature in the navigation and management interface
  * Added a loading state display while the system determines permissions for program management functionality, improving the user experience during permission resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->