### PR TITLE
feat(funding-map): show status-aware type counts

### DIFF
--- a/src/features/funding-map/components/funding-map-filters.tsx
+++ b/src/features/funding-map/components/funding-map-filters.tsx
@@ -2,7 +2,7 @@
 
 import * as Popover from "@radix-ui/react-popover";
 import { Check, ChevronDown, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,6 +29,10 @@ import type { OpportunityType } from "../types/funding-program";
 import { getGrantTypeConfig } from "../utils/grant-type-config";
 import { getOpportunityTypeConfig } from "../utils/opportunity-type-config";
 import { OnKarmaBadge } from "./on-karma-badge";
+
+function getStatusCount(tc: { count: number; activeCount: number }, status: string): number {
+  return status === "Inactive" ? tc.count - tc.activeCount : tc.activeCount;
+}
 
 function getTypeOptionIcon(option: UnifiedTypeOption): React.ReactNode {
   if (option.filterTarget === "type") {
@@ -91,11 +95,14 @@ export function FundingMapFilters({ totalCount = 0 }: FundingMapFiltersProps) {
     : null;
   const resultLabel = typeLabel ? typeLabel.toLowerCase() : null;
 
-  const getTypeCount = (type: string): number | undefined => {
-    if (!typeCounts) return undefined;
-    const found = typeCounts.find((tc) => tc.type === type);
-    return found?.count;
-  };
+  const typeCountMap = useMemo(() => {
+    if (!typeCounts) return null;
+    const map = new Map<string, number>();
+    for (const tc of typeCounts) {
+      map.set(tc.type, getStatusCount(tc, filters.status));
+    }
+    return map;
+  }, [typeCounts, filters.status]);
 
   const handleKarmaToggle = useCallback(() => {
     const newValue = !onlyOnKarma;
@@ -388,7 +395,7 @@ export function FundingMapFilters({ totalCount = 0 }: FundingMapFiltersProps) {
                 </div>
                 {UNIFIED_TYPE_OPTIONS.filter((o) => o.section === "opportunityTypes").map(
                   (option) => {
-                    const count = getTypeCount(option.value);
+                    const count = typeCountMap?.get(option.value);
                     return (
                       <button
                         type="button"
@@ -426,7 +433,7 @@ export function FundingMapFilters({ totalCount = 0 }: FundingMapFiltersProps) {
                 </div>
                 {UNIFIED_TYPE_OPTIONS.filter((o) => o.section === "fundingMechanisms").map(
                   (option) => {
-                    const count = getTypeCount(option.value);
+                    const count = typeCountMap?.get(option.value);
                     return (
                       <button
                         type="button"

--- a/src/features/funding-map/components/opportunity-type-tabs.tsx
+++ b/src/features/funding-map/components/opportunity-type-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/utilities/tailwind";
 import { OPPORTUNITY_TYPES } from "../constants/filter-options";
@@ -8,6 +8,10 @@ import { useFundingFilters } from "../hooks/use-funding-filters";
 import { useTypeCounts } from "../hooks/use-funding-programs";
 import type { OpportunityType } from "../types/funding-program";
 import { getOpportunityTypeConfig } from "../utils/opportunity-type-config";
+
+function getStatusCount(tc: { count: number; activeCount: number }, status: string): number {
+  return status === "Inactive" ? tc.count - tc.activeCount : tc.activeCount;
+}
 
 export function OpportunityTypeTabs() {
   const { filters, setSelectedTypes } = useFundingFilters();
@@ -23,13 +27,17 @@ export function OpportunityTypeTabs() {
 
   const isAllSelected = filters.selectedTypes.length === 0;
 
-  const getCount = (type: OpportunityType): number | undefined => {
-    if (!typeCounts) return undefined;
-    const found = typeCounts.find((tc) => tc.type === type);
-    return found?.count;
-  };
-
-  const totalCount = typeCounts?.reduce((sum, tc) => sum + tc.count, 0);
+  const { countsByType, totalCount } = useMemo(() => {
+    if (!typeCounts) return { countsByType: null, totalCount: undefined };
+    const map = new Map<string, number>();
+    let total = 0;
+    for (const tc of typeCounts) {
+      const c = getStatusCount(tc, filters.status);
+      map.set(tc.type, c);
+      total += c;
+    }
+    return { countsByType: map, totalCount: total };
+  }, [typeCounts, filters.status]);
 
   const handleTypeClick = (type: OpportunityType | null) => {
     if (type === null) {
@@ -81,7 +89,7 @@ export function OpportunityTypeTabs() {
       {OPPORTUNITY_TYPES.map((type, idx) => {
         const config = getOpportunityTypeConfig(type);
         const Icon = config.icon;
-        const count = isError ? undefined : getCount(type);
+        const count = isError ? undefined : countsByType?.get(type);
 
         return (
           <TypeChip


### PR DESCRIPTION
## Summary

- Type counts in the opportunity type chips and the Types filter popover now reflect the selected status filter (Active/Inactive) instead of always showing total counts
- Counts are memoized with `useMemo` using a `Map<string, number>` for O(1) per-type lookups instead of repeated `.find()` scans
- Pure `getStatusCount` helper extracted to module level to avoid recreation on every render

## Test plan

- [ ] Navigate to `/funding-map` with "Active" status selected — type counts should show `activeCount` values
- [ ] Switch to "Inactive" — counts should show `count - activeCount` values
- [ ] Verify the "All" chip total updates accordingly
- [ ] Open the Types filter popover — counts there should also reflect the status selection
- [ ] Toggle "Hosted on Karma" checkbox — counts should update based on the filtered type data