### PR TITLE
feat(funding-map): UI improvements for hero, types dropdown, and card descriptions

### DIFF
--- a/src/features/funding-map/components/funding-map-description.tsx
+++ b/src/features/funding-map/components/funding-map-description.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
+import { HEADING_AS_BOLD_COMPONENTS } from "../utils/markdown-heading-components";
 
 interface FundingMapDescriptionProps {
   description: string;
@@ -24,6 +25,7 @@ const MarkdownContent = dynamic(
         <mod.MarkdownPreview
           source={description}
           className="text-sm text-muted-foreground line-clamp-3"
+          components={HEADING_AS_BOLD_COMPONENTS}
         />
       ),
     })),

--- a/src/features/funding-map/components/funding-map-filters.tsx
+++ b/src/features/funding-map/components/funding-map-filters.tsx
@@ -390,81 +390,38 @@ export function FundingMapFilters({ totalCount = 0 }: FundingMapFiltersProps) {
               className="z-50 w-64 rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
             >
               <div className="max-h-80 overflow-y-auto p-1">
-                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                  Opportunity Types
-                </div>
-                {UNIFIED_TYPE_OPTIONS.filter((o) => o.section === "opportunityTypes").map(
-                  (option) => {
-                    const count = typeCountMap?.get(option.value);
-                    return (
-                      <button
-                        type="button"
-                        aria-pressed={isUnifiedOptionSelected(option)}
-                        key={option.value}
-                        className="flex w-full items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-                        onClick={() => handleUnifiedTypeToggle(option)}
-                      >
-                        <div
-                          className={cn(
-                            "flex h-4 w-4 items-center justify-center rounded border",
-                            isUnifiedOptionSelected(option)
-                              ? "border-primary bg-primary"
-                              : "border-border"
-                          )}
-                        >
-                          {isUnifiedOptionSelected(option) && (
-                            <Check className="h-3 w-3 text-primary-foreground" />
-                          )}
-                        </div>
-                        {getTypeOptionIcon(option)}
-                        <span className="flex-1 text-left">{option.label}</span>
-                        {count !== undefined && (
-                          <span className="text-xs text-muted-foreground tabular-nums">
-                            ({count})
-                          </span>
+                {UNIFIED_TYPE_OPTIONS.map((option) => {
+                  const count = typeCountMap?.get(option.value);
+                  return (
+                    <button
+                      type="button"
+                      aria-pressed={isUnifiedOptionSelected(option)}
+                      key={option.value}
+                      className="flex w-full items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+                      onClick={() => handleUnifiedTypeToggle(option)}
+                    >
+                      <div
+                        className={cn(
+                          "flex h-4 w-4 items-center justify-center rounded border",
+                          isUnifiedOptionSelected(option)
+                            ? "border-primary bg-primary"
+                            : "border-border"
                         )}
-                      </button>
-                    );
-                  }
-                )}
-                <div className="-mx-1 my-1 h-px bg-muted" />
-                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                  Funding Mechanisms
-                </div>
-                {UNIFIED_TYPE_OPTIONS.filter((o) => o.section === "fundingMechanisms").map(
-                  (option) => {
-                    const count = typeCountMap?.get(option.value);
-                    return (
-                      <button
-                        type="button"
-                        aria-pressed={isUnifiedOptionSelected(option)}
-                        key={option.value}
-                        className="flex w-full items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-                        onClick={() => handleUnifiedTypeToggle(option)}
                       >
-                        <div
-                          className={cn(
-                            "flex h-4 w-4 items-center justify-center rounded border",
-                            isUnifiedOptionSelected(option)
-                              ? "border-primary bg-primary"
-                              : "border-border"
-                          )}
-                        >
-                          {isUnifiedOptionSelected(option) && (
-                            <Check className="h-3 w-3 text-primary-foreground" />
-                          )}
-                        </div>
-                        {getTypeOptionIcon(option)}
-                        <span className="flex-1 text-left">{option.label}</span>
-                        {count !== undefined && (
-                          <span className="text-xs text-muted-foreground tabular-nums">
-                            ({count})
-                          </span>
+                        {isUnifiedOptionSelected(option) && (
+                          <Check className="h-3 w-3 text-primary-foreground" />
                         )}
-                      </button>
-                    );
-                  }
-                )}
+                      </div>
+                      {getTypeOptionIcon(option)}
+                      <span className="flex-1 text-left">{option.label}</span>
+                      {count !== undefined && (
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          ({count})
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
                 {typeCountsError && (
                   <div className="px-2 py-1.5 text-xs text-destructive">Failed to load counts</div>
                 )}

--- a/src/features/funding-map/components/funding-map-search.tsx
+++ b/src/features/funding-map/components/funding-map-search.tsx
@@ -101,7 +101,7 @@ export function FundingMapSearch() {
       <div className="flex w-full max-w-xl flex-col gap-8">
         <div className="flex flex-col items-center justify-center gap-4">
           <h1 className="text-center text-3xl font-semibold tracking-tight lg:text-4xl">
-            {`Find funding for your project`}
+            {`Find funding opportunities`}
           </h1>
 
           <div className="relative w-full">

--- a/src/features/funding-map/utils/markdown-heading-components.tsx
+++ b/src/features/funding-map/utils/markdown-heading-components.tsx
@@ -1,0 +1,14 @@
+const HeadingAsBold = ({ children }: { children?: React.ReactNode }) => (
+  <p>
+    <strong>{children}</strong>
+  </p>
+);
+
+export const HEADING_AS_BOLD_COMPONENTS = {
+  h1: HeadingAsBold,
+  h2: HeadingAsBold,
+  h3: HeadingAsBold,
+  h4: HeadingAsBold,
+  h5: HeadingAsBold,
+  h6: HeadingAsBold,
+};


### PR DESCRIPTION
## Summary
- Update hero text from "Find funding for your project" to "Find funding opportunities"
- Flatten the Types filter dropdown by removing "Opportunity Types" and "Funding Mechanisms" section headers and divider — all options now render in a single flat list
- Render markdown headings as bold text (`<strong>`) in funding map card descriptions only (dialog view unchanged)

## Test plan
- [ ] Visit `/funding-map` and verify the hero reads "Find funding opportunities"
- [ ] Open the Types dropdown and confirm all 9 options appear in one flat list without section headers or dividers
- [ ] Open a program card with markdown headings in its description — headings should appear as bold text, not `<h1>`–`<h6>` elements
- [ ] Open the program details dialog and verify headings still render as actual heading elements
- [ ] Run `pnpm lint:fix` — no new errors introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Consolidated funding opportunity filters into a single unified list for improved clarity and navigation.
  * Enhanced description headings with bold formatting for better readability.
  * Updated search heading text for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->