### PR TITLE
fix(impact): show last activity date instead of last updated

### DIFF
--- a/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
@@ -332,7 +332,8 @@ export const FilteredOutputsAndOutcomes = ({
             const form = forms.find((f) => f.id === item.id);
             const lastUpdated = filteredOutputs
               .find((subItem) => item.id === subItem.id)
-              ?.datapoints?.sort(
+              ?.datapoints?.filter((dp) => dp.value !== 0 && dp.value !== "0")
+              .sort(
                 (a, b) =>
                   new Date(b.endDate || new Date().toISOString()).getTime() -
                   new Date(a.endDate || new Date().toISOString()).getTime()
@@ -364,7 +365,7 @@ export const FilteredOutputsAndOutcomes = ({
                     <div className="flex flex-row gap-2 items-center">
                       {lastUpdated ? (
                         <span className="text-sm text-gray-500 dark:text-zinc-400">
-                          Last updated {formatDate(new Date(lastUpdated), "UTC")}
+                          Last activity {formatDate(new Date(lastUpdated), "UTC")}
                         </span>
                       ) : null}
                       {autosyncedIndicators.find((i) => i.name === item.name) && (

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -310,7 +310,8 @@ export const OutputsAndOutcomes = () => {
             const form = forms.find((f) => f.id === item.id);
             const lastUpdated = filteredOutputs
               .find((subItem) => item.id === subItem.id)
-              ?.datapoints?.sort(
+              ?.datapoints?.filter((dp) => dp.value !== 0 && dp.value !== "0")
+              .sort(
                 (a, b) =>
                   new Date(b.endDate || new Date().toISOString()).getTime() -
                   new Date(a.endDate || new Date().toISOString()).getTime()
@@ -342,7 +343,7 @@ export const OutputsAndOutcomes = () => {
                     <div className="flex flex-row gap-2 items-center">
                       {lastUpdated ? (
                         <span className="text-sm text-gray-500 dark:text-zinc-400">
-                          Last updated {formatDate(new Date(lastUpdated), "UTC")}
+                          Last activity {formatDate(new Date(lastUpdated), "UTC")}
                         </span>
                       ) : null}
                       {autosyncedIndicators.find((i) => i.name === item.name) && (

--- a/components/Pages/Project/Impact/UniqueUsersSection.tsx
+++ b/components/Pages/Project/Impact/UniqueUsersSection.tsx
@@ -258,7 +258,7 @@ export const UniqueUsersSection = ({ datapoints, indicatorName }: UniqueUsersSec
               </Title>
               {selectedDp && (
                 <span className="text-xs text-gray-400 dark:text-zinc-500">
-                  Last updated: {formatDate(new Date(selectedDp.endDate), "UTC")}
+                  Last activity: {formatDate(new Date(selectedDp.endDate), "UTC")}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Renamed "Last updated" label to "Last activity" on impact charts (`OutputsAndOutcomes`, `FilteredOutputsAndOutcomes`, `UniqueUsersSection`)
- Filters out zero-value datapoints (value `0` or `"0"`) when determining the "Last activity" date, so auto-synced metrics like GitHub Merged PRs show the date of the last real activity instead of the latest zero-value sync entry

## Context
Auto-synced GitHub metrics (Merged PRs, Commits) generate zero-value datapoints on each sync run when there's no new activity. This caused the "Last updated" label to show today's date even when the last real activity was months ago. A follow-up BE change will stop creating these zero-value entries altogether.

## Test plan
- [ ] Navigate to a project's Impact page (e.g., `/project/akiba-miles/impact`)
- [ ] Verify "Last activity" label appears instead of "Last updated"
- [ ] For metrics with recent zero-value periods (e.g., GitHub Merged PRs), verify the date reflects the last non-zero activity
- [ ] Verify metrics with all non-zero values still show the correct latest date
- [ ] Verify metrics with all zero values show no date label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the "Last activity" calculation to exclude zero-valued datapoints when determining the most recent timestamp, ensuring accuracy across Impact-related displays.
  * Updated UI labels from "Last updated" to "Last activity" for improved clarity in project activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->