### PR TITLE
fix: replace native date input with DatePicker in agreement signing

### DIFF
--- a/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsModal.tsx
@@ -573,6 +573,7 @@ export function ProjectDetailsModal({
                       maxDate={new Date()}
                       placeholder="Pick a date"
                       buttonClassName="h-6 text-xs px-2 py-0.5 bg-white dark:bg-zinc-900"
+                      ariaLabel="Set agreement signed date"
                     />
                     {toggleAgreementMutation.isPending && (
                       <span className="text-[11px] text-gray-400 dark:text-zinc-500 animate-pulse">

--- a/components/Utilities/DatePicker.tsx
+++ b/components/Utilities/DatePicker.tsx
@@ -16,6 +16,7 @@ interface DatePickerProps {
   buttonClassName?: string;
   clearButtonClassName?: string;
   clearButtonFn?: () => void;
+  ariaLabel?: string;
 }
 
 export const DatePicker = ({
@@ -28,6 +29,7 @@ export const DatePicker = ({
   buttonClassName,
   clearButtonClassName,
   clearButtonFn,
+  ariaLabel,
 }: DatePickerProps) => {
   return (
     <div className={className}>
@@ -38,6 +40,7 @@ export const DatePicker = ({
               "w-max text-sm flex-row flex gap-2 items-center bg-white dark:bg-zinc-800 px-4 py-2 rounded-md border border-gray-200 dark:border-zinc-700",
               buttonClassName
             )}
+            aria-label={ariaLabel}
           >
             {selected ? formatDate(selected) : <span>{placeholder}</span>}
             <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />


### PR DESCRIPTION
## Summary
- Replaced native HTML `<input type="date">` with the existing `DatePicker` component (react-day-picker + Radix Popover) in the control center agreement signing flow
- Fixes bug where navigating to a previous month in the native date picker auto-selected a date (current date minus 1 month), making it impossible to pick past dates
- The `DatePicker` component is already used across milestones and project updates — this aligns the agreement UI with the rest of the app

## Changes
- `ProjectDetailsModal.tsx`: Swapped `<Input type="date">` for `<DatePicker>`, updated `agreementDate` state from `string` to `Date | undefined`, and simplified date serialization for the API

## Test plan
- [ ] Open Control Center → select a project with an unsigned agreement
- [ ] Click "Pick a date" → verify the DatePicker popover opens
- [ ] Navigate to a previous month → confirm no date is auto-selected
- [ ] Pick a date → verify the agreement is marked as signed with the correct date
- [ ] Unsign the agreement → verify it resets correctly
- [ ] Verify `maxDate` constraint prevents selecting future dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved date handling in the project details modal with an enhanced date picker interface for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->