### PR TITLE
feat: update Filecoin navbar to match filpgf.io

### DIFF
--- a/src/infrastructure/config/tenant-config.ts
+++ b/src/infrastructure/config/tenant-config.ts
@@ -298,12 +298,20 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
     header: { title: "Filecoin Community", shouldHaveTitle: true, poweredBy: true },
     items: [
       {
-        label: "Programs",
+        label: "ProPGF",
         items: [
-          { label: "ProPGF", href: "https://filpgf.io/propgf/", isExternal: true },
-          { label: "RetroPGF", href: "https://www.fil-retropgf.io/", isExternal: true },
+          { label: "Overview", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "Grants", href: "https://karmahq.xyz/community/filecoin", isExternal: true },
+          { label: "Applications", href: "/community/filecoin/browse-applications" },
+          {
+            label: "Payout process",
+            href: "https://docs.google.com/document/d/1WIyL8zj1ToTEVujRvCV6E4mlle5srwLP3DhEarWn3Ug/edit?usp=sharing",
+            isExternal: true,
+          },
+          { label: "Financials", href: "/community/filecoin/financials" },
         ],
       },
+      { label: "RetroPGF", href: "https://www.fil-retropgf.io/", isExternal: true },
       {
         label: "More",
         items: [

--- a/utilities/whitelabel-config.ts
+++ b/utilities/whitelabel-config.ts
@@ -11,6 +11,13 @@ export interface WhitelabelDomain {
 
 const DEFAULT_WHITELABEL_DOMAINS: WhitelabelDomain[] = [
   {
+    domain: "localhost",
+    communitySlug: "filecoin",
+    tenantId: "filecoin",
+    name: "Filecoin (Local)",
+    theme: { primaryColor: "#0090ff" },
+  },
+  {
     domain: "optimism.localhost",
     communitySlug: "optimism",
     tenantId: "optimism",


### PR DESCRIPTION
## Summary
- Updated Filecoin tenant navigation to match the structure on filpgf.io
- ProPGF is now a dropdown with sub-items: Overview, Grants, Applications, Payout process, Financials
- RetroPGF moved to a standalone external link
- Added localhost as Filecoin whitelabel domain for local development

## Test plan
- [ ] Run dev server locally and verify Filecoin navbar renders at localhost
- [ ] Verify ProPGF dropdown shows all 5 sub-items
- [ ] Verify RetroPGF links externally to fil-retropgf.io
- [ ] Verify More dropdown has About Filecoin, Upcoming Events, Forum, Community
- [ ] Verify Resources dropdown renders from socialLinks (no duplicate)
- [ ] Compare navbar structure with https://filpgf.io