### PR TITLE
fix: stub indexer API in auth journey E2E to prevent flaky timeouts

### DIFF
--- a/cypress/e2e/navbar/authentication-journey.cy.ts
+++ b/cypress/e2e/navbar/authentication-journey.cy.ts
@@ -4,12 +4,14 @@
  */
 
 import {
+  setupIndexerCatchAll,
   setupCommonIntercepts,
   waitForPageLoad,
 } from "../../support/intercepts";
 
 describe("Navbar Authentication Journey", () => {
   beforeEach(() => {
+    setupIndexerCatchAll();
     setupCommonIntercepts();
   });
 


### PR DESCRIPTION
## Summary
- Added `setupIndexerCatchAll()` to the `authentication-journey.cy.ts` E2E test to stub all indexer API responses locally
- Prevents flaky 120s page load timeouts caused by real API requests hanging behind Cloudflare protection
- The test has ~12+ page loads across 5 describe blocks — without stubbing, any slow API response blocks the browser `load` event

## Test plan
- [ ] Verify the `e2e-tests` CI job passes on this PR
- [ ] Confirm the authentication-journey test still validates all 16 test cases (13 pass + 2 pending + 1 previously flaky)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for authentication journey tests to ensure proper initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->