### PR TITLE
fix: handle ghost member removal gracefully

### DIFF
--- a/components/Dialogs/Member/DeleteMember.tsx
+++ b/components/Dialogs/Member/DeleteMember.tsx
@@ -64,7 +64,12 @@ export const DeleteMemberDialog: FC<DeleteMemberDialogProps> = ({ memberAddress 
       );
       if (!member) {
         // Ghost member: attestation already revoked in V1, clean up V2 data
-        await fetchData(INDEXER.ATTESTATION_LISTENER(project.uid, project.chainID), "POST", {});
+        const [, error] = await fetchData(
+          INDEXER.ATTESTATION_LISTENER(project.uid, project.chainID),
+          "POST",
+          {}
+        );
+        if (error) throw new Error("Failed to clean up ghost member data");
         await refreshProject();
         showSuccess("Member removed successfully");
         closeModal();

--- a/components/Dialogs/Member/__tests__/DeleteMember.test.tsx
+++ b/components/Dialogs/Member/__tests__/DeleteMember.test.tsx
@@ -274,6 +274,33 @@ describe("DeleteMemberDialog", () => {
       expect(mockShowError).not.toHaveBeenCalled();
     });
 
+    it("should show error when ghost member V2 cleanup fails", async () => {
+      const sdkProjectWithoutGhostMember = {
+        uid: PROJECT_UID,
+        chainID: 42220,
+        members: [
+          {
+            uid: "0xd90a079c20d16e2d099fbfd8cc0dd5be40142527394dab33e20bdbcaf36a5aed",
+            recipient: PROJECT_OWNER_ADDRESS,
+            chainID: 42220,
+            revoke: jest.fn(),
+            schema: { uid: "0xb4186a24" },
+          },
+        ],
+      };
+
+      mockGetProjectById.mockResolvedValue(sdkProjectWithoutGhostMember);
+      mockFetchData.mockResolvedValue([null, new Error("API error")]);
+
+      await openDialogAndConfirm(GHOST_MEMBER_ADDRESS);
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalled();
+      });
+
+      expect(mockShowSuccess).not.toHaveBeenCalled();
+    });
+
     it("should successfully remove a member that exists in both V1 and V2 data", async () => {
       // SETUP: Normal case — member exists in both V1 (SDK) and V2
       const mockRevoke = jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

- When a member exists in V2 but their MemberOf attestation is already revoked in V1 (ghost member), the delete button would throw "Member not found" and show an error toast
- Now detects this scenario and gracefully cleans up the V2 data, showing a success toast instead
- Root cause: V1/V2 data inconsistency where revocation cleanup failed silently on the indexer side (fixed separately in show-karma/gap-indexer#987)

## Test plan

- [x] Added regression test for ghost member scenario (member in V2 but not V1)
- [x] Verified normal member removal still works correctly
- [ ] Manual test: attempt to remove a ghost member from a project team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member deletion to handle ghost members by performing cleanup, refreshing project data, and showing success feedback instead of surfacing errors.
* **Tests**
  * Added comprehensive tests covering ghost-member scenarios (success and failure) and normal member removal flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->