### PR TITLE
feat: show stale deactivation badge on manage programs

### DIFF
--- a/components/Pages/ProgramRegistry/ManageProgramList.tsx
+++ b/components/Pages/ProgramRegistry/ManageProgramList.tsx
@@ -78,6 +78,11 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
                 >
                   {grant?.metadata?.title}
                 </button>
+                {grant.metadata?.deactivationReason === "stale_no_end_date" ? (
+                  <span className="inline-flex items-center rounded-md bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-900/30 dark:text-amber-400 dark:ring-amber-500/30">
+                    Auto-pending: no end date (stale 90+ days)
+                  </span>
+                ) : null}
                 <div className="flex flex-row gap-1 w-full">
                   {grant.metadata?.socialLinks?.grantsSite ? (
                     <ExternalLink

--- a/src/features/funding-map/types/funding-program.ts
+++ b/src/features/funding-map/types/funding-program.ts
@@ -119,6 +119,8 @@ export interface FundingProgramMetadata {
   anyoneCanJoin?: boolean;
   invoiceRequired?: boolean;
   status?: string;
+  deactivationReason?: string;
+  deactivatedAt?: string;
   communityRef?: string[];
   adminEmails?: string[];
   financeEmails?: string[];


### PR DESCRIPTION
## Summary

- Add amber badge in Manage Programs Pending tab for programs auto-deactivated due to missing end date (stale 90+ days)
- Add `deactivationReason` and `deactivatedAt` fields to `FundingProgramMetadata` type

Depends on: show-karma/gap-indexer PR (fix/ingestion-improvements) which adds the `deactivateStale()` backend logic.

## Test plan

- [ ] Verify badge appears for programs with `metadata.deactivationReason === "stale_no_end_date"` in the Pending tab
- [ ] Verify badge does not appear for regular pending programs
- [ ] Verify dark mode styling of the amber badge