### PR TITLE
fix: wrap Tooltip with TooltipProvider in claim-funds CampaignCard

### DIFF
--- a/src/features/claim-funds/components/CampaignCard.tsx
+++ b/src/features/claim-funds/components/CampaignCard.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { cn } from "@/utilities/tailwind";
 import { formatTokenAmount } from "../lib/hedgey-contract";
@@ -46,15 +46,17 @@ function LockupWarning({ cliffDate }: { cliffDate: string }) {
     <div className="mb-2 p-3 rounded-lg bg-yellow-50 border border-yellow-200 dark:bg-yellow-950/20 dark:border-yellow-800">
       <div className="text-sm text-yellow-700 dark:text-yellow-400 flex items-center gap-1">
         <span>Funds will be locked until {cliffDate}</span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Info className="w-4 h-4 cursor-help flex-shrink-0" aria-hidden="true" />
-          </TooltipTrigger>
-          <TooltipContent>
-            This claim has a vesting period. Your tokens will be locked in a vesting contract until
-            the specified date.
-          </TooltipContent>
-        </Tooltip>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="w-4 h-4 cursor-help flex-shrink-0" aria-hidden="true" />
+            </TooltipTrigger>
+            <TooltipContent>
+              This claim has a vesting period. Your tokens will be locked in a vesting contract
+              until the specified date.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </div>
   );
@@ -254,15 +256,17 @@ function CampaignCardComponent({
             (isLockupActive && formattedCliffDate ? (
               <output className="w-full flex items-center justify-center gap-1 py-2 text-muted-foreground">
                 <span>Claim funds after {formattedCliffDate}</span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="w-4 h-4 cursor-help" aria-hidden="true" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Your funds are locked for vesting until {formattedCliffDate}. Login and claim
-                    your funds after that date.
-                  </TooltipContent>
-                </Tooltip>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="w-4 h-4 cursor-help" aria-hidden="true" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Your funds are locked for vesting until {formattedCliffDate}. Login and claim
+                      your funds after that date.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </output>
             ) : (
               <Button


### PR DESCRIPTION
## Summary
- Wrapped both `<Tooltip>` usages in `CampaignCard.tsx` with `<TooltipProvider>`, fixing a runtime error when claiming funds
- The component was ported from the whitelabel app which uses HeroUI's self-contained `Tooltip`, but the gap-app-v2 version uses Shadcn/Radix which requires a `TooltipProvider` ancestor
- Follows the same pattern used across the rest of the codebase (e.g., `AgentChatBubble`, `KycStatusIcon`, `grant-type-badge`)

## Test plan
- [ ] Navigate to a community claim-funds page with active campaigns
- [ ] Verify the lockup warning tooltip (Info icon next to "Funds will be locked until...") renders without errors
- [ ] Verify the post-claim lockup tooltip (Info icon next to "Claim funds after...") renders without errors
- [ ] Hover over both Info icons and confirm tooltip content displays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tooltip component structure to improve initialization and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->