### PR TITLE
perf: remove body * transition-colors CSS rule

### DIFF
--- a/__tests__/styles/transition-colors.test.ts
+++ b/__tests__/styles/transition-colors.test.ts
@@ -1,0 +1,12 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+describe("globals.css performance", () => {
+  const globalsPath = path.resolve(__dirname, "../../styles/globals.css");
+  const css = fs.readFileSync(globalsPath, "utf-8");
+
+  it("should NOT apply transition-colors to all body descendants (causes style recalc on every element)", () => {
+    const bodyStarTransition = /body\s*\*\s*\{[^}]*transition-colors[^}]*\}/;
+    expect(css).not.toMatch(bodyStarTransition);
+  });
+});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -84,9 +84,6 @@
   font-display: swap;
 }
 
-body * {
-  @apply transition-colors duration-500;
-}
 * {
   @apply font-body;
 }


### PR DESCRIPTION
## Summary
- Removed `body * { @apply transition-colors duration-500; }` from `globals.css` which forced the browser to track CSS transitions on **every DOM element**, causing unnecessary style recalculations
- ThemeProvider already uses `disableTransitionOnChange`, making this rule redundant
- Added regression test to prevent reintroduction

## Test plan
- [x] New test in `__tests__/styles/transition-colors.test.ts` verifies `body *` with `transition-colors` is not present
- [x] Existing test suite passes (pre-existing flaky tests in `donation.test.ts` and `chainSyncValidation.test.ts` unrelated)
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a global CSS transition effect that was universally applied, improving page performance and eliminating unintended animations.

* **Tests**
  * Added test validation to prevent regression of CSS performance optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->