### PR TITLE
perf: add SSR LCP shell for project title

### DIFF
--- a/__tests__/app/project-layout-ssr-shell.test.tsx
+++ b/__tests__/app/project-layout-ssr-shell.test.tsx
@@ -84,7 +84,9 @@ describe("Project Layout SSR LCP Shell", () => {
 
   describe("when project data is available", () => {
     const mockProject = createMockProject();
-    beforeEach(() => { mockGetProjectCachedData.mockResolvedValue(mockProject); });
+    beforeEach(() => {
+      mockGetProjectCachedData.mockResolvedValue(mockProject);
+    });
 
     it("renders project title as an h1 in the SSR shell", async () => {
       await renderLayout();
@@ -107,13 +109,11 @@ describe("Project Layout SSR LCP Shell", () => {
       expect(shell).toHaveAttribute("aria-hidden", "true");
     });
 
-    it("includes a style tag to hide shell when client mounts", async () => {
+    it("does not include an inline style tag (CSS moved to globals.css)", async () => {
       await renderLayout();
       const shell = document.getElementById("ssr-lcp-shell");
       const styleTag = shell!.querySelector("style");
-      expect(styleTag).not.toBeNull();
-      expect(styleTag!.textContent).toContain("project-profile-layout");
-      expect(styleTag!.textContent).toContain("display: none");
+      expect(styleTag).toBeNull();
     });
 
     it("renders the SSR shell inside the HydrationBoundary", async () => {
@@ -150,7 +150,9 @@ describe("Project Layout SSR LCP Shell", () => {
   });
 
   describe("when project data is not available", () => {
-    beforeEach(() => { mockGetProjectCachedData.mockRejectedValue(new Error("Not found")); });
+    beforeEach(() => {
+      mockGetProjectCachedData.mockRejectedValue(new Error("Not found"));
+    });
 
     it("does not render the SSR shell", async () => {
       await renderLayout();

--- a/app/project/[projectId]/layout.tsx
+++ b/app/project/[projectId]/layout.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @next/next/no-img-element */
-
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
+import Image from "next/image";
 import { ProjectShareDialogMount } from "@/components/Pages/Project/ProjectShareDialogMount";
 import { E2EStoreExposer } from "@/components/Utilities/E2EStoreExposer";
 import { layoutTheme } from "@/src/helper/theme";
@@ -110,7 +109,7 @@ export default async function RootLayout(props: {
           <div id="ssr-lcp-shell" aria-hidden="true">
             <div className="flex items-center gap-4 py-4">
               {projectData.details?.logoUrl && (
-                <img
+                <Image
                   src={projectData.details.logoUrl}
                   alt=""
                   width={64}
@@ -122,9 +121,6 @@ export default async function RootLayout(props: {
                 {projectData.details?.title}
               </h1>
             </div>
-            <style>{`[data-testid="project-profile-layout"] ~ #ssr-lcp-shell,
-#ssr-lcp-shell:has(~ [data-testid="project-profile-layout"]),
-#ssr-lcp-shell:has(~ [data-testid="project-profile-layout-skeleton"]) { display: none; }`}</style>
           </div>
         )}
         {children}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -712,3 +712,11 @@ body .react-hot-toast * {
   border-color: inherit;
   box-shadow: none;
 }
+
+/* SSR LCP shell — auto-hide when client component mounts */
+[data-testid="project-profile-layout"] ~ #ssr-lcp-shell,
+[data-testid="layout-loading"] ~ #ssr-lcp-shell,
+#ssr-lcp-shell:has(~ [data-testid="project-profile-layout"]),
+#ssr-lcp-shell:has(~ [data-testid="layout-loading"]) {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Renders a lightweight SSR HTML shell with project title (h1) and logo in the initial server response, making the LCP element visible before JS hydration
- Shell auto-hides via CSS `:has()` selector once the client-side `ProjectProfileLayout` mounts
- Reads cached project data from React Query's `queryClient` after prefetch — zero extra API calls

## Test plan
- [x] 8 unit tests covering: title rendering, logo rendering, aria-hidden, CSS hide rules, HydrationBoundary containment, DOM ordering, no-logo case, no-data case
- [ ] Verify Lighthouse LCP improvement on project pages
- [ ] Visual regression check: shell should not flash on hydration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side rendering header shell to the project layout page that displays the project logo and title when available.

* **Tests**
  * Added comprehensive test coverage for the SSR header shell, including scenarios for available project data, missing logos, and unavailable data.

* **Style**
  * Updated styling rules to manage SSR header shell visibility when client components mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->