### PR TITLE
perf: dynamically import dialog components in ProjectProfileLayout

### DIFF
--- a/__tests__/components/ProjectProfileLayout.dynamic-imports.test.tsx
+++ b/__tests__/components/ProjectProfileLayout.dynamic-imports.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @file Verifies dialog components in ProjectProfileLayout use dynamic imports
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const sourceFilePath = path.resolve(
+  __dirname,
+  "../../components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx"
+);
+const sourceCode = fs.readFileSync(sourceFilePath, "utf-8");
+
+describe("ProjectProfileLayout - Dynamic Imports", () => {
+  it("should not have a static import for ProgressDialog", () => {
+    expect(sourceCode).not.toMatch(/^import\s.*ProgressDialog.*from/m);
+  });
+
+  it("should not have a static import for EndorsementDialog", () => {
+    expect(sourceCode).not.toMatch(/^import\s.*EndorsementDialog.*from/m);
+  });
+
+  it("should not have a static import for IntroDialog", () => {
+    expect(sourceCode).not.toMatch(/^import\s.*IntroDialog.*from/m);
+  });
+
+  it("should not have a static import for EndorsementsListDialog", () => {
+    expect(sourceCode).not.toMatch(/^import\s.*EndorsementsListDialog.*from/m);
+  });
+
+  it("should not have a static import for ProjectOptionsDialogs or ProjectOptionsMenu", () => {
+    expect(sourceCode).not.toMatch(/^import\s.*ProjectOptionsDialogs.*from/m);
+    expect(sourceCode).not.toMatch(/^import\s.*ProjectOptionsMenu.*from/m);
+  });
+
+  it("should use dynamic() for all dialog components", () => {
+    const dialogs = [
+      "ProgressDialog",
+      "EndorsementDialog",
+      "IntroDialog",
+      "EndorsementsListDialog",
+      "ProjectOptionsDialogs",
+      "ProjectOptionsMenu",
+    ];
+    for (const name of dialogs) {
+      expect(sourceCode).toMatch(new RegExp("dynamic\\([\\s\\S]*?" + name));
+    }
+  });
+
+  it("should set ssr: false for all dynamic imports", () => {
+    const dynamicCalls = sourceCode.match(/\bdynamic\(/g);
+    const ssrFalse = sourceCode.match(/ssr:\s*false/g);
+    expect(dynamicCalls?.length).toBe(ssrFalse?.length);
+  });
+});

--- a/__tests__/components/ProjectProfileLayout.invite-code.test.tsx
+++ b/__tests__/components/ProjectProfileLayout.invite-code.test.tsx
@@ -28,6 +28,17 @@ jest.mock("next/navigation", () => ({
   }),
 }));
 
+// Mock next/dynamic — needed because dialogs are now dynamically imported
+jest.mock("next/dynamic", () => {
+  const mockDynamic = (loader: () => Promise<any>, _options?: { ssr?: boolean }) => {
+    const DynamicComponent = () => null;
+    DynamicComponent.displayName = "DynamicMock";
+    return DynamicComponent;
+  };
+  mockDynamic.default = mockDynamic;
+  return mockDynamic;
+});
+
 // Mock all stores
 jest.mock("@/hooks/useProjectPermissions", () => ({
   useProjectPermissions: () => ({}),
@@ -53,6 +64,10 @@ jest.mock("@/store/modals/intro", () => ({
 
 jest.mock("@/store/modals/progress", () => ({
   useProgressModalStore: () => ({ isProgressModalOpen: false }),
+}));
+
+jest.mock("@/store/modals/shareDialog", () => ({
+  useShareDialogStore: () => ({ isOpen: false }),
 }));
 
 jest.mock("@/store/modals/contributorProfile", () => ({
@@ -91,8 +106,16 @@ jest.mock("@/components/Pages/Project/v2/Mobile/MobileProfileContent", () => ({
   MobileProfileContent: () => null,
 }));
 
+jest.mock("@/components/Pages/Project/v2/Mobile/MobileSupportContent", () => ({
+  MobileSupportContent: () => null,
+}));
+
 jest.mock("@/components/Pages/Project/v2/SidePanel/ProjectSidePanel", () => ({
   ProjectSidePanel: () => null,
+}));
+
+jest.mock("@/components/Pages/Project/v2/SidePanel/SidebarProfileCard", () => ({
+  SidebarProfileCard: () => null,
 }));
 
 jest.mock("@/components/Pages/Project/v2/StatsBar/ProjectStatsBar", () => ({
@@ -118,6 +141,10 @@ jest.mock("@/components/Pages/Project/ProjectOptionsMenu", () => ({
 
 jest.mock("@/components/ErrorBoundary", () => ({
   ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/utilities/tailwind", () => ({
+  cn: (...a: string[]) => a.filter(Boolean).join(" "),
 }));
 
 import { ProjectProfileLayout } from "@/components/Pages/Project/v2/Layout/ProjectProfileLayout";

--- a/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
+++ b/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
@@ -4,12 +4,13 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { type ReactNode, useEffect, useState } from "react";
-import { ProgressDialog } from "@/components/Dialogs/ProgressDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
-// Lazy-load ShareDialog because js-confetti (a heavy canvas library) is imported
-// at the module level. Eagerly loading it in the main layout chunk can block
-// client-side hydration in some environments (e.g., Cypress Electron).
+const ProgressDialog = dynamic(
+  () => import("@/components/Dialogs/ProgressDialog").then((mod) => mod.ProgressDialog),
+  { ssr: false }
+);
+
 const ShareDialog = dynamic(
   () =>
     import(
@@ -18,12 +19,38 @@ const ShareDialog = dynamic(
   { ssr: false }
 );
 
-import { EndorsementDialog } from "@/components/Pages/Project/Impact/EndorsementDialog";
-import { IntroDialog } from "@/components/Pages/Project/IntroDialog";
-import {
-  ProjectOptionsDialogs,
-  ProjectOptionsMenu,
-} from "@/components/Pages/Project/ProjectOptionsMenu";
+const EndorsementDialog = dynamic(
+  () =>
+    import("@/components/Pages/Project/Impact/EndorsementDialog").then(
+      (mod) => mod.EndorsementDialog
+    ),
+  { ssr: false }
+);
+
+const IntroDialog = dynamic(
+  () => import("@/components/Pages/Project/IntroDialog").then((mod) => mod.IntroDialog),
+  { ssr: false }
+);
+
+const ProjectOptionsDialogs = dynamic(
+  () =>
+    import("@/components/Pages/Project/ProjectOptionsMenu").then(
+      (mod) => mod.ProjectOptionsDialogs
+    ),
+  { ssr: false }
+);
+
+const ProjectOptionsMenu = dynamic(
+  () =>
+    import("@/components/Pages/Project/ProjectOptionsMenu").then((mod) => mod.ProjectOptionsMenu),
+  { ssr: false }
+);
+
+const EndorsementsListDialog = dynamic(
+  () => import("../EndorsementsListDialog").then((mod) => mod.EndorsementsListDialog),
+  { ssr: false }
+);
+
 import { useProjectPermissions } from "@/hooks/useProjectPermissions";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
@@ -32,7 +59,6 @@ import { useIntroModalStore } from "@/store/modals/intro";
 import { useProgressModalStore } from "@/store/modals/progress";
 import { useShareDialogStore } from "@/store/modals/shareDialog";
 import { cn } from "@/utilities/tailwind";
-import { EndorsementsListDialog } from "../EndorsementsListDialog";
 import { type ContentTab, ContentTabs } from "../MainContent/ContentTabs";
 import { MobileSupportContent } from "../Mobile/MobileSupportContent";
 import { ProjectSidePanel } from "../SidePanel/ProjectSidePanel";


### PR DESCRIPTION
## Summary
- Replace eager static imports with `next/dynamic` for 6 dialog components in `ProjectProfileLayout`: `ProgressDialog`, `EndorsementDialog`, `IntroDialog`, `EndorsementsListDialog`, `ProjectOptionsDialogs`, and `ProjectOptionsMenu`
- All dialogs are conditionally rendered (gated by store flags), so they don't need to be in the initial bundle chunk
- Follows the existing `ShareDialog` dynamic import pattern already in the file

## Test plan
- [x] Added static analysis tests verifying no static imports remain for dialog components
- [x] Added tests verifying all dialogs use `dynamic()` with `ssr: false`
- [x] Updated existing invite-code test to work with dynamic imports
- [x] All 10 tests pass across both test suites
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)