### PR TITLE
feat: include program reviewers in @mention autocomplete

### DIFF
--- a/components/FundingPlatform/ApplicationView/MentionAutocomplete.tsx
+++ b/components/FundingPlatform/ApplicationView/MentionAutocomplete.tsx
@@ -11,8 +11,8 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
+import { useAllReviewers } from "@/hooks/useAllReviewers";
 import type { CaretPosition } from "@/hooks/useMentionEditor";
-import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { cn } from "@/utilities/tailwind";
 
 interface MentionAutocompleteProps {
@@ -37,7 +37,7 @@ const MentionAutocomplete: FC<MentionAutocompleteProps> = ({
   onSelect,
   onInviteNew,
 }) => {
-  const { data: reviewers, isLoading, isError, error, refetch } = useMilestoneReviewers(programId);
+  const { data: reviewers, isLoading, isError, error, refetch } = useAllReviewers(programId);
 
   const filteredReviewers = useMemo(() => {
     if (!reviewers) return [];

--- a/hooks/useAllReviewers.ts
+++ b/hooks/useAllReviewers.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
+import { useProgramReviewers } from "@/hooks/useProgramReviewers";
+
+/**
+ * Merges milestone and program reviewers into a single deduplicated list.
+ * Deduplicates by email — milestone reviewers take priority on conflict.
+ */
+export function useAllReviewers(programId: string) {
+  const milestone = useMilestoneReviewers(programId);
+  const program = useProgramReviewers(programId);
+
+  const data = useMemo(() => {
+    const milestoneData = milestone.data ?? [];
+    const programData = program.data ?? [];
+
+    const seen = new Map<string, (typeof milestoneData)[number]>();
+    for (const reviewer of milestoneData) {
+      seen.set(reviewer.email, reviewer);
+    }
+    for (const reviewer of programData) {
+      if (!seen.has(reviewer.email)) {
+        seen.set(reviewer.email, reviewer);
+      }
+    }
+
+    return Array.from(seen.values());
+  }, [milestone.data, program.data]);
+
+  return useMemo(
+    () => ({
+      data,
+      isLoading: milestone.isLoading || program.isLoading,
+      isError: milestone.isError || program.isError,
+      error: milestone.error || program.error,
+      refetch: () => {
+        milestone.refetch();
+        program.refetch();
+      },
+    }),
+    [data, milestone, program]
+  );
+}

--- a/src/features/application-comments/components/CommentInput.tsx
+++ b/src/features/application-comments/components/CommentInput.tsx
@@ -5,8 +5,8 @@ import { useCallback, useMemo, useRef } from "react";
 import InviteReviewerModal from "@/components/FundingPlatform/ApplicationView/InviteReviewerModal";
 import MentionAutocomplete from "@/components/FundingPlatform/ApplicationView/MentionAutocomplete";
 import { Button } from "@/components/ui/button";
+import { useAllReviewers } from "@/hooks/useAllReviewers";
 import { useMentionEditor } from "@/hooks/useMentionEditor";
-import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import type { CommentInputProps } from "../types";
 import { CommentMarkdownInput } from "./CommentMarkdownInput";
 
@@ -30,7 +30,7 @@ export function CommentInput({
     editorRef: editorContainerRef,
   });
 
-  const { data: reviewers } = useMilestoneReviewers(programId ?? "");
+  const { data: reviewers } = useAllReviewers(programId ?? "");
 
   const filteredReviewers = useMemo(() => {
     if (!reviewers) return [];


### PR DESCRIPTION
## Summary

- Add `useAllReviewers` hook that merges milestone + program reviewers with email-based deduplication
- Swap `useMilestoneReviewers` → `useAllReviewers` in `MentionAutocomplete` and `CommentInput`
- Milestone reviewers take priority on duplicate emails (preserves existing data)

## Test plan

- [ ] Open an application comment box and type `@` — verify both program and milestone reviewers appear
- [ ] Confirm no duplicate entries when a reviewer exists in both lists
- [ ] Verify filtering by name/email still works correctly
- [ ] Check loading and error states render properly
- [ ] All 7814 existing tests pass (`pnpm test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded reviewer availability in mention and assignment features to include both milestone and program-level reviewers, improving collaboration options across the funding platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->