### PR TITLE
fix: prevent double /community/ prefix on legacy umbrella redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -100,6 +100,11 @@ export async function middleware(request: NextRequest) {
     const mainDomain = domainInfo.isProduction ? "karmahq.xyz" : "staging.karmahq.xyz";
     const protocol = request.nextUrl.protocol;
 
+    // Path already starts with /community/ — redirect as-is to the main domain
+    if (slug === "community") {
+      return NextResponse.redirect(new URL(`${protocol}//${mainDomain}${path}`), 301);
+    }
+
     if (slug && isKnownTenant(slug)) {
       const whitelabelDomain = getWhitelabelDomainForSlug(slug, domainInfo.isProduction);
       const restPath = `/${segments.slice(1).join("/")}` || "/";


### PR DESCRIPTION
## Summary
- URLs like `app.karmahq.xyz/community/celo/programs/1059/apply` were returning 404
- The legacy umbrella middleware treated `"community"` as a tenant slug, redirecting to `karmahq.xyz/community/community/celo/...` (double prefix)
- Added early check: if path already starts with `/community/`, redirect as-is to the main domain

## Test plan
- [ ] Visit `app.karmahq.xyz/community/celo/programs/1059/apply` — should redirect to `karmahq.xyz/community/celo/programs/1059/apply` and load the apply page
- [ ] Visit `app.karmahq.xyz/celo/programs/1059/apply` — existing tenant redirect still works
- [ ] Visit `app.karmahq.xyz/community/celo` — redirects correctly without double prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)