### PR TITLE
fix: fallback to configured RPC for gas estimation when wallet RPC fails

### DIFF
--- a/__tests__/unit/utilities/fallback-gas-provider.test.ts
+++ b/__tests__/unit/utilities/fallback-gas-provider.test.ts
@@ -1,0 +1,81 @@
+import { wrapSignerWithFallbackGas } from "@/utilities/fallback-gas-provider";
+import { getRPCUrlByChainId } from "@/utilities/rpcClient";
+
+jest.mock("@/utilities/rpcClient", () => ({
+  getRPCUrlByChainId: jest.fn(),
+}));
+
+const mockEstimateGas = jest.fn();
+const mockFallbackEstimateGas = jest.fn();
+
+jest.mock("ethers", () => ({
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({
+    estimateGas: mockFallbackEstimateGas,
+  })),
+}));
+
+const mockGetRPCUrlByChainId = getRPCUrlByChainId as jest.Mock;
+
+function createMockSigner(estimateGasFn: jest.Mock) {
+  return {
+    provider: {
+      estimateGas: estimateGasFn,
+    },
+  } as any;
+}
+
+describe("wrapSignerWithFallbackGas", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should_return_original_signer_when_no_rpc_url_configured", async () => {
+    mockGetRPCUrlByChainId.mockReturnValue(undefined);
+    const signer = createMockSigner(mockEstimateGas);
+
+    const result = await wrapSignerWithFallbackGas(signer, 42220);
+
+    expect(result).toBe(signer);
+  });
+
+  it("should_use_original_estimateGas_when_it_succeeds", async () => {
+    mockGetRPCUrlByChainId.mockReturnValue("https://forno.celo.org");
+    mockEstimateGas.mockResolvedValue(100000n);
+    const signer = createMockSigner(mockEstimateGas);
+    const tx = { to: "0x123", data: "0x" };
+
+    const wrapped = await wrapSignerWithFallbackGas(signer, 42220);
+    const gas = await wrapped.provider.estimateGas(tx);
+
+    expect(gas).toBe(100000n);
+    expect(mockEstimateGas).toHaveBeenCalledWith(tx);
+    expect(mockFallbackEstimateGas).not.toHaveBeenCalled();
+  });
+
+  it("should_fallback_to_configured_rpc_when_wallet_rpc_fails", async () => {
+    mockGetRPCUrlByChainId.mockReturnValue("https://forno.celo.org");
+    mockEstimateGas.mockRejectedValue(new Error("UNKNOWN_ERROR"));
+    mockFallbackEstimateGas.mockResolvedValue(150000n);
+    const signer = createMockSigner(mockEstimateGas);
+    const tx = { to: "0x123", data: "0x" };
+
+    const wrapped = await wrapSignerWithFallbackGas(signer, 42220);
+    const gas = await wrapped.provider.estimateGas(tx);
+
+    expect(gas).toBe(150000n);
+    expect(mockEstimateGas).toHaveBeenCalledWith(tx);
+    expect(mockFallbackEstimateGas).toHaveBeenCalledWith(tx);
+  });
+
+  it("should_throw_when_both_original_and_fallback_fail", async () => {
+    mockGetRPCUrlByChainId.mockReturnValue("https://forno.celo.org");
+    mockEstimateGas.mockRejectedValue(new Error("UNKNOWN_ERROR"));
+    mockFallbackEstimateGas.mockRejectedValue(new Error("Fallback also failed"));
+    const signer = createMockSigner(mockEstimateGas);
+    const tx = { to: "0x123", data: "0x" };
+
+    const wrapped = await wrapSignerWithFallbackGas(signer, 42220);
+
+    await expect(wrapped.provider.estimateGas(tx)).rejects.toThrow("Fallback also failed");
+  });
+});

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -8,6 +8,7 @@ import { createWalletClient, custom } from "viem";
 import { useChainId } from "wagmi";
 import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { walletClientToSigner } from "@/utilities/eas-wagmi-utils";
+import { wrapSignerWithFallbackGas } from "@/utilities/fallback-gas-provider";
 import {
   createGaslessClient,
   createPrivySignerForGasless,
@@ -145,7 +146,8 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
           await embeddedWallet.switchChain(targetChainId);
           const provider = await embeddedWallet.getEthereumProvider();
           const ethersProvider = new BrowserProvider(provider);
-          return await ethersProvider.getSigner();
+          const embeddedSigner = await ethersProvider.getSigner();
+          return wrapSignerWithFallbackGas(embeddedSigner, targetChainId);
         } catch (error) {
           console.warn("[Gasless] Embedded wallet error:", error);
         }
@@ -173,7 +175,7 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
           if (!signer) {
             throw new Error("Failed to create signer from Privy wallet client");
           }
-          return signer;
+          return wrapSignerWithFallbackGas(signer, targetChainId);
         } catch (privyError) {
           console.warn(
             "[External Wallet] Privy provider failed, falling back to wagmi:",
@@ -191,7 +193,7 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
             throw new Error("Failed to create signer from wallet client");
           }
 
-          return signer;
+          return wrapSignerWithFallbackGas(signer, targetChainId);
         }
       }
 

--- a/utilities/fallback-gas-provider.ts
+++ b/utilities/fallback-gas-provider.ts
@@ -1,0 +1,34 @@
+import type { JsonRpcSigner, TransactionRequest } from "ethers";
+import { getRPCUrlByChainId } from "@/utilities/rpcClient";
+
+/**
+ * Wraps a signer so that gas estimation falls back to our configured RPC
+ * when the wallet's RPC (e.g. MetaMask) returns an error.
+ *
+ * Signing and sending still go through the original wallet provider.
+ * Only `estimateGas` is retried with the fallback.
+ */
+export async function wrapSignerWithFallbackGas(
+  signer: JsonRpcSigner,
+  chainId: number
+): Promise<JsonRpcSigner> {
+  const rpcUrl = getRPCUrlByChainId(chainId);
+  if (!rpcUrl) return signer;
+
+  const originalProvider = signer.provider;
+  if (!originalProvider) return signer;
+
+  const originalEstimateGas = originalProvider.estimateGas.bind(originalProvider);
+
+  originalProvider.estimateGas = async (tx: TransactionRequest) => {
+    try {
+      return await originalEstimateGas(tx);
+    } catch {
+      const { JsonRpcProvider } = await import("ethers");
+      const fallbackProvider = new JsonRpcProvider(rpcUrl);
+      return fallbackProvider.estimateGas(tx);
+    }
+  };
+
+  return signer;
+}


### PR DESCRIPTION
## Summary
- Adds `wrapSignerWithFallbackGas` utility that patches `provider.estimateGas` on signers
- When the wallet's RPC (MetaMask) fails gas estimation (e.g. Celo `UNKNOWN_ERROR`), retries with our configured RPC from `getRPCUrlByChainId`
- Signing and sending still go through the wallet — only gas estimation falls back
- Applied to all signer creation paths in `useZeroDevSigner` (external wallet + embedded wallet)

### Root cause
A user on Celo was getting "There was an error marking the milestone as completed" without MetaMask ever appearing. The error was `code=UNKNOWN_ERROR, version=6.11.0 at getRpcError` — ethers v6 couldn't parse the Celo RPC's gas estimation response, so the transaction never reached MetaMask.

### Changes
- `utilities/fallback-gas-provider.ts`: new utility wrapping signer with fallback estimateGas
- `hooks/useZeroDevSigner.ts`: wrap signers before returning them
- `__tests__/unit/utilities/fallback-gas-provider.test.ts`: 4 tests

## Test plan
- [x] 4 unit tests: original RPC success, fallback on failure, both fail, no RPC configured
- [ ] Test milestone completion on Celo with MetaMask
- [ ] Test attestations on other chains still work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented fallback gas estimation mechanism that allows transactions to retry gas calculations using an alternative RPC provider when the primary estimation fails, improving transaction robustness.

* **Tests**
  * Added comprehensive unit tests for fallback gas estimation behavior, including success, failure, and mixed-result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->