### PR TITLE
fix: prevent false logout when re-logging with a different wallet

### DIFF
--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -51,8 +51,9 @@ jest.mock("@/contexts/privy-bridge-context", () => ({
 }));
 
 // Mock @wagmi/core for dynamic import in watchAccount effect
+const mockWatchAccount = jest.fn(() => jest.fn());
 jest.mock("@wagmi/core", () => ({
-  watchAccount: jest.fn(() => jest.fn()),
+  watchAccount: (...args: unknown[]) => mockWatchAccount(...args),
 }));
 
 // Mock privy-config for dynamic import in watchAccount effect
@@ -386,6 +387,66 @@ describe("useAuth - Re-login with different wallet", () => {
     // this is a fresh login (went through logout first), not a
     // cross-tab shared auth switch.
     expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("should NOT force-logout via watchAccount when re-logging with different wallet", async () => {
+    // Simulate watchAccount firing with stale address from previous session
+    let capturedOnChange: ((account: { address?: string }) => void) | null = null;
+    const mockUnwatch = jest.fn();
+    mockWatchAccount.mockImplementation(
+      (_config: unknown, opts: { onChange: (account: { address?: string }) => void }) => {
+        capturedOnChange = opts.onChange;
+        return mockUnwatch;
+      }
+    );
+
+    const { rerender } = renderHook(() => useAuth(), { wrapper });
+
+    // Let the dynamic import resolve
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Step 1: Logout
+    setBridgeState({
+      authenticated: false,
+      user: null,
+      wallets: [],
+      isConnected: false,
+    });
+    await act(async () => {
+      rerender();
+    });
+
+    mockLogout.mockClear();
+
+    // Step 2: Login with wallet B
+    setBridgeState({
+      authenticated: true,
+      user: walletUserB,
+      wallets: [mockWalletB],
+      isConnected: true,
+    });
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // watchAccount fires with stale address from user A's session
+    // (wagmi hasn't fully updated yet)
+    if (capturedOnChange) {
+      act(() => {
+        capturedOnChange!({ address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" });
+      });
+    }
+
+    // Should NOT trigger logout — we just logged in, stale wagmi state is expected
+    expect(mockLogout).not.toHaveBeenCalled();
+
+    // Reset mock
+    mockWatchAccount.mockImplementation(() => jest.fn());
   });
 
   it("should NOT force-logout when Privy user object lingers after logout", async () => {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -4,8 +4,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { usePrivyBridge } from "@/contexts/privy-bridge-context";
-import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { useProjectCreateModalStore } from "@/store/modals/projectCreate";
+import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { getCypressMockAuthState } from "@/utilities/auth/cypress-auth";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { PAGES } from "@/utilities/pages";
@@ -143,6 +143,8 @@ export const useAuth = () => {
   const authFailureCount = useRef(0);
   // Snapshot of wallet addresses captured at auth time (security: use ref, not live array)
   const walletsSnapshotRef = useRef<string[]>([]);
+  // Grace period after login — suppresses watchAccount false positives from stale wagmi state
+  const loginGraceRef = useRef(false);
 
   /**
    * AUTH STATE CHANGE DETECTION
@@ -157,6 +159,13 @@ export const useAuth = () => {
   useEffect(() => {
     // Detect login: was not authenticated, now authenticated
     if (!prevAuthRef.current && authenticated) {
+      // Suppress watchAccount checks briefly — wagmi state may be stale
+      // from the previous session during the Privy↔wagmi sync gap.
+      loginGraceRef.current = true;
+      setTimeout(() => {
+        loginGraceRef.current = false;
+      }, 2000);
+
       // Only redirect if we're on the default landing page.
       // In whitelabel mode, "/" is the community homepage (funding opportunities),
       // not a generic landing page — don't redirect away from it.
@@ -308,7 +317,8 @@ export const useAuth = () => {
   const hasExternalWallet = useMemo(() => {
     if (!user?.linkedAccounts) return false;
     return user.linkedAccounts.some(
-      (a) => a.type === "wallet" && (a as { walletClientType?: string }).walletClientType !== "privy"
+      (a) =>
+        a.type === "wallet" && (a as { walletClientType?: string }).walletClientType !== "privy"
     );
   }, [user]);
 
@@ -316,11 +326,18 @@ export const useAuth = () => {
     if (!ready || !authenticated || !hasExternalWallet) return;
 
     let unwatch: (() => void) | undefined;
+    let cancelled = false;
 
     Promise.all([import("@wagmi/core"), import("@/utilities/wagmi/privy-config")]).then(
       ([{ watchAccount }, { privyConfig }]) => {
+        if (cancelled) return;
         unwatch = watchAccount(privyConfig, {
           onChange(account) {
+            if (cancelled) return;
+            // Skip during login grace period — wagmi state may be stale
+            // from the previous session during the Privy↔wagmi sync gap.
+            if (loginGraceRef.current) return;
+
             const newAddress = account.address?.toLowerCase();
             if (!newAddress) return;
 
@@ -332,7 +349,10 @@ export const useAuth = () => {
       }
     );
 
-    return () => unwatch?.();
+    return () => {
+      cancelled = true;
+      unwatch?.();
+    };
   }, [ready, authenticated, hasExternalWallet, user, logout]);
 
   const adaptedLogin = useCallback(async () => {


### PR DESCRIPTION
## Summary

- Fixes a bug where logging out and logging back in with a different wallet would immediately log the user out again
- Three race conditions identified and fixed in `useAuth.ts`:
  1. **User-switch detection false positive**: `prevUserIdRef` retained the old user ID through logout, so a new login was mistaken for a cross-tab shared auth switch
  2. **watchAccount stale state**: After login, wagmi's `watchAccount` fires immediately with potentially stale `privyConfig` state from the previous wallet session
  3. **Orphaned watchAccount watcher**: The async `import()` in the watchAccount effect could leave an uncleaned watcher from the previous session

## Test plan

- [x] Log in with Wallet A
- [x] Log out
- [x] Log in with Wallet B → should stay logged in (was previously kicked out)
- [ ] Verify cross-tab shared auth switch detection still works (different user logs in on another subdomain)
- [ ] Verify wallet-switching detection still works (switch to unlinked wallet in MetaMask while logged in)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where re-logging in with a different wallet could incorrectly trigger a logout.
  * Improved wallet switching logic to prevent false logouts from stale account data during re-authentication.

* **Tests**
  * Enhanced test coverage for authentication scenarios involving wallet re-authentication and switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->