### PR TITLE
test: add render utilities, RPC failure transport, and contract schemas

### DIFF
--- a/__tests__/contracts/__tests__/schemas.test.ts
+++ b/__tests__/contracts/__tests__/schemas.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  applicationStatisticsSchema,
+  createDisbursementsResponseSchema,
+  fundingApplicationSchema,
+  paginatedApplicationsResponseSchema,
+  paginatedDisbursementsResponseSchema,
+  paginatedProjectsResponseSchema,
+  payoutDisbursementSchema,
+  payoutGrantConfigSchema,
+  projectSchema,
+  savePayoutConfigResponseSchema,
+  totalDisbursedResponseSchema,
+} from "../schemas";
+
+// ---------------------------------------------------------------------------
+// Payout schemas
+// ---------------------------------------------------------------------------
+describe("payout schemas", () => {
+  const validDisbursement = {
+    id: "d-1",
+    grantUID: "0xgrant1",
+    projectUID: "0xproj1",
+    communityUID: "0xcomm1",
+    chainID: 10,
+    safeAddress: "0xsafe",
+    safeTransactionHash: null,
+    disbursedAmount: "50000",
+    token: "USDC",
+    tokenAddress: "0xtoken",
+    tokenDecimals: 6,
+    payoutAddress: "0xrecip",
+    milestoneBreakdown: null,
+    paidAllocationIds: [],
+    status: "PENDING" as const,
+    executedAt: null,
+    createdBy: "0xcreator",
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  };
+
+  it("validates a valid PayoutDisbursement", () => {
+    const result = payoutDisbursementSchema.safeParse(validDisbursement);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects PayoutDisbursement with missing required fields", () => {
+    const { id, ...incomplete } = validDisbursement;
+    const result = payoutDisbursementSchema.safeParse(incomplete);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid status", () => {
+    const result = payoutDisbursementSchema.safeParse({
+      ...validDisbursement,
+      status: "UNKNOWN",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates PaginatedDisbursementsResponse", () => {
+    const result = paginatedDisbursementsResponseSchema.safeParse({
+      payload: [validDisbursement],
+      pagination: {
+        totalCount: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+        nextPage: null,
+        prevPage: null,
+        hasNextPage: false,
+        hasPrevPage: false,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates TotalDisbursedResponse", () => {
+    const result = totalDisbursedResponseSchema.safeParse({
+      totalDisbursed: "100000",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates PayoutGrantConfig", () => {
+    const result = payoutGrantConfigSchema.safeParse({
+      id: "cfg-1",
+      grantUID: "0xgrant",
+      projectUID: "0xproj",
+      communityUID: "0xcomm",
+      payoutAddress: "0xaddr",
+      totalGrantAmount: "100000",
+      tokenAddress: "0xtoken",
+      chainID: 10,
+      milestoneAllocations: [{ id: "alloc-1", label: "Milestone 1", amount: "50000" }],
+      createdBy: "0xcreator",
+      updatedBy: null,
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-01-01T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates SavePayoutConfigResponse", () => {
+    const result = savePayoutConfigResponseSchema.safeParse({
+      success: [],
+      failed: [{ grantUID: "0xgrant", error: "not found" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates CreateDisbursementsResponse", () => {
+    const result = createDisbursementsResponseSchema.safeParse({
+      disbursements: [validDisbursement],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Application schemas
+// ---------------------------------------------------------------------------
+describe("application schemas", () => {
+  const validApplication = {
+    id: "app-1",
+    programId: "prog-1",
+    chainID: 10,
+    applicantEmail: "test@example.com",
+    ownerAddress: "0xowner",
+    applicationData: { name: "Test Project" },
+    status: "pending" as const,
+    statusHistory: [{ status: "pending" as const, timestamp: "2025-01-01T00:00:00Z" }],
+    referenceNumber: "APP-12345-67890",
+    submissionIP: "127.0.0.1",
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  };
+
+  it("validates a valid FundingApplication", () => {
+    const result = fundingApplicationSchema.safeParse(validApplication);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid application status", () => {
+    const result = fundingApplicationSchema.safeParse({
+      ...validApplication,
+      status: "invalid_status",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates ApplicationStatistics", () => {
+    const result = applicationStatisticsSchema.safeParse({
+      totalApplications: 100,
+      pendingApplications: 30,
+      approvedApplications: 50,
+      rejectedApplications: 20,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates PaginatedApplicationsResponse", () => {
+    const result = paginatedApplicationsResponseSchema.safeParse({
+      applications: [validApplication],
+      pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional fields", () => {
+    const result = fundingApplicationSchema.safeParse({
+      ...validApplication,
+      projectUID: "0xproject",
+      appReviewers: ["0xreviewer1"],
+      milestoneReviewers: ["0xreviewer2"],
+      postApprovalCompleted: true,
+      aiEvaluation: { evaluation: "good", promptId: "p1" },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project schemas
+// ---------------------------------------------------------------------------
+describe("project schemas", () => {
+  const validProject = {
+    uid: "0x1234abcd",
+    chainID: 10,
+    owner: "0xowner",
+    details: {
+      title: "Test Project",
+      slug: "test-project",
+    },
+    members: [{ address: "0xmember1", role: "admin", joinedAt: "2025-01-01T00:00:00Z" }],
+  };
+
+  it("validates a minimal valid Project", () => {
+    const result = projectSchema.safeParse(validProject);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects project with non-hex uid", () => {
+    const result = projectSchema.safeParse({
+      ...validProject,
+      uid: "not-hex",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates project with all optional fields", () => {
+    const result = projectSchema.safeParse({
+      ...validProject,
+      payoutAddress: "0xpayout",
+      chainPayoutAddress: { "10": "0xaddr" },
+      communities: ["community-1"],
+      stats: { grantsCount: 5, grantMilestonesCount: 10, roadmapItemsCount: 3 },
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-06-01T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates PaginatedProjectsResponse", () => {
+    const result = paginatedProjectsResponseSchema.safeParse({
+      payload: [validProject],
+      pagination: {
+        totalCount: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+        nextPage: null,
+        prevPage: null,
+        hasNextPage: false,
+        hasPrevPage: false,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects project missing required details.title", () => {
+    const result = projectSchema.safeParse({
+      ...validProject,
+      details: { slug: "no-title" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/__tests__/contracts/schemas/application.schema.ts
+++ b/__tests__/contracts/schemas/application.schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const fundingApplicationStatusSchema = z.enum([
+  "pending",
+  "under_review",
+  "revision_requested",
+  "approved",
+  "rejected",
+  "resubmitted",
+]);
+
+export const statusHistoryEntrySchema = z.object({
+  status: fundingApplicationStatusSchema,
+  timestamp: z.union([z.string(), z.date()]),
+  reason: z.string().optional(),
+});
+
+export const fundingApplicationSchema = z.object({
+  id: z.string(),
+  programId: z.string(),
+  chainID: z.number(),
+  applicantEmail: z.string(),
+  ownerAddress: z.string(),
+  applicationData: z.record(z.string(), z.unknown()),
+  postApprovalData: z.record(z.string(), z.unknown()).optional(),
+  status: fundingApplicationStatusSchema,
+  statusHistory: z.array(statusHistoryEntrySchema),
+  referenceNumber: z.string(),
+  submissionIP: z.string(),
+  projectUID: z.string().optional(),
+  aiEvaluation: z
+    .object({
+      evaluation: z.string().optional(),
+      promptId: z.string().optional(),
+    })
+    .optional(),
+  internalAIEvaluation: z
+    .object({
+      evaluation: z.string().optional(),
+      promptId: z.string().optional(),
+      evaluatedAt: z.union([z.string(), z.date()]).optional(),
+    })
+    .optional(),
+  appReviewers: z.array(z.string()).optional(),
+  milestoneReviewers: z.array(z.string()).optional(),
+  postApprovalCompleted: z.boolean().optional(),
+  createdAt: z.union([z.string(), z.date()]),
+  updatedAt: z.union([z.string(), z.date()]),
+});
+
+export const applicationStatisticsSchema = z.object({
+  totalApplications: z.number(),
+  pendingApplications: z.number(),
+  approvedApplications: z.number(),
+  rejectedApplications: z.number(),
+  revisionRequestedApplications: z.number().optional(),
+  underReviewApplications: z.number().optional(),
+  resubmittedApplications: z.number().optional(),
+});
+
+export const paginatedApplicationsResponseSchema = z.object({
+  applications: z.array(fundingApplicationSchema),
+  pagination: z.object({
+    page: z.number(),
+    limit: z.number(),
+    total: z.number(),
+    totalPages: z.number(),
+  }),
+});

--- a/__tests__/contracts/schemas/index.ts
+++ b/__tests__/contracts/schemas/index.ts
@@ -1,0 +1,27 @@
+export {
+  applicationStatisticsSchema,
+  fundingApplicationSchema,
+  fundingApplicationStatusSchema,
+  paginatedApplicationsResponseSchema,
+  statusHistoryEntrySchema,
+} from "./application.schema";
+
+export {
+  createDisbursementsResponseSchema,
+  milestoneAllocationSchema,
+  milestoneBreakdownSchema,
+  paginatedDisbursementsResponseSchema,
+  payoutDisbursementSchema,
+  payoutDisbursementStatusSchema,
+  payoutGrantConfigSchema,
+  savePayoutConfigResponseSchema,
+  tokenTotalSchema,
+  totalDisbursedResponseSchema,
+} from "./payout.schema";
+export {
+  paginatedProjectsResponseSchema,
+  projectDetailsSchema,
+  projectSchema,
+  projectStatsSchema,
+} from "./project.schema";
+export { paginationInfoSchema } from "./shared.schema";

--- a/__tests__/contracts/schemas/payout.schema.ts
+++ b/__tests__/contracts/schemas/payout.schema.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { paginationInfoSchema } from "./shared.schema";
+
+export const payoutDisbursementStatusSchema = z.enum([
+  "CONFIGURED",
+  "PENDING",
+  "AWAITING_SIGNATURES",
+  "DISBURSED",
+  "CANCELLED",
+  "FAILED",
+]);
+
+export const milestoneBreakdownSchema = z.record(z.string(), z.string());
+
+export const payoutDisbursementSchema = z.object({
+  id: z.string(),
+  grantUID: z.string(),
+  projectUID: z.string(),
+  communityUID: z.string(),
+  chainID: z.number(),
+  safeAddress: z.string(),
+  safeTransactionHash: z.string().nullable(),
+  disbursedAmount: z.string(),
+  token: z.string(),
+  tokenAddress: z.string(),
+  tokenDecimals: z.number(),
+  payoutAddress: z.string(),
+  milestoneBreakdown: milestoneBreakdownSchema.nullable(),
+  paidAllocationIds: z.array(z.string()),
+  status: payoutDisbursementStatusSchema,
+  executedAt: z.string().nullable(),
+  createdBy: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const paginatedDisbursementsResponseSchema = z.object({
+  payload: z.array(payoutDisbursementSchema),
+  pagination: paginationInfoSchema,
+});
+
+export const totalDisbursedResponseSchema = z.object({
+  totalDisbursed: z.string(),
+});
+
+export const tokenTotalSchema = z.object({
+  token: z.string(),
+  tokenDecimals: z.number(),
+  tokenAddress: z.string(),
+  chainID: z.number(),
+  totalAmount: z.string(),
+});
+
+export const milestoneAllocationSchema = z.object({
+  id: z.string(),
+  milestoneUID: z.string().optional(),
+  label: z.string(),
+  amount: z.string(),
+});
+
+export const payoutGrantConfigSchema = z.object({
+  id: z.string(),
+  grantUID: z.string(),
+  projectUID: z.string(),
+  communityUID: z.string(),
+  payoutAddress: z.string().nullable(),
+  totalGrantAmount: z.string().nullable(),
+  tokenAddress: z.string().nullable(),
+  chainID: z.number().nullable(),
+  milestoneAllocations: z.array(milestoneAllocationSchema).nullable(),
+  createdBy: z.string(),
+  updatedBy: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const savePayoutConfigResponseSchema = z.object({
+  success: z.array(payoutGrantConfigSchema),
+  failed: z.array(
+    z.object({
+      grantUID: z.string(),
+      error: z.string(),
+    })
+  ),
+});
+
+export const createDisbursementsResponseSchema = z.object({
+  disbursements: z.array(payoutDisbursementSchema),
+});

--- a/__tests__/contracts/schemas/project.schema.ts
+++ b/__tests__/contracts/schemas/project.schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { paginationInfoSchema } from "./shared.schema";
+
+export const projectDetailsSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  problem: z.string().optional(),
+  solution: z.string().optional(),
+  missionSummary: z.string().optional(),
+  locationOfImpact: z.string().optional(),
+  slug: z.string(),
+  logoUrl: z.string().optional(),
+  businessModel: z.string().optional(),
+  stageIn: z.string().optional(),
+  raisedMoney: z.string().optional(),
+  pathToTake: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  links: z.array(z.object({ url: z.string(), type: z.string() })).optional(),
+  lastDetailsUpdate: z.string().optional(),
+});
+
+export const projectStatsSchema = z.object({
+  grantsCount: z.number(),
+  grantMilestonesCount: z.number(),
+  roadmapItemsCount: z.number(),
+});
+
+export const projectSchema = z.object({
+  uid: z.string().startsWith("0x"),
+  chainID: z.number(),
+  owner: z.string().startsWith("0x"),
+  payoutAddress: z.string().optional(),
+  chainPayoutAddress: z.record(z.string(), z.string()).optional(),
+  details: projectDetailsSchema,
+  external: z
+    .object({
+      gitcoin: z.array(z.unknown()).optional(),
+      oso: z.array(z.unknown()).optional(),
+      divvi_wallets: z.array(z.unknown()).optional(),
+      github: z.array(z.unknown()).optional(),
+      network_addresses: z.array(z.unknown()).optional(),
+      network_addresses_verified: z
+        .array(
+          z.object({
+            network: z.string(),
+            address: z.string(),
+            verified: z.boolean(),
+            verifiedAt: z.string().optional(),
+            verifiedBy: z.string().optional(),
+          })
+        )
+        .optional(),
+    })
+    .optional(),
+  members: z.array(
+    z.object({
+      address: z.string(),
+      role: z.string(),
+      joinedAt: z.string(),
+    })
+  ),
+  endorsements: z.array(z.unknown()).optional(),
+  communities: z.array(z.string()).optional(),
+  symlinks: z.array(z.unknown()).optional(),
+  pointers: z
+    .array(
+      z.object({
+        uid: z.string(),
+        originalProjectUID: z.string(),
+        createdAt: z.string(),
+      })
+    )
+    .optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  stats: projectStatsSchema.optional(),
+});
+
+export const paginatedProjectsResponseSchema = z.object({
+  payload: z.array(projectSchema),
+  pagination: paginationInfoSchema,
+});

--- a/__tests__/contracts/schemas/shared.schema.ts
+++ b/__tests__/contracts/schemas/shared.schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Pagination info schema shared across paginated API responses.
+ * Matches the backend PaginationInfo / PaginatedContext.Pagination structure.
+ */
+export const paginationInfoSchema = z.object({
+  totalCount: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  totalPages: z.number(),
+  nextPage: z.number().nullable(),
+  prevPage: z.number().nullable(),
+  hasNextPage: z.boolean(),
+  hasPrevPage: z.boolean(),
+});

--- a/__tests__/utils/__tests__/render.test.tsx
+++ b/__tests__/utils/__tests__/render.test.tsx
@@ -1,0 +1,80 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createTestQueryClient, renderHookWithProviders, renderWithProviders } from "../render";
+
+describe("createTestQueryClient", () => {
+  it("creates a QueryClient with retry disabled", () => {
+    const qc = createTestQueryClient();
+    const defaults = qc.getDefaultOptions();
+    expect(defaults.queries?.retry).toBe(false);
+    expect(defaults.mutations?.retry).toBe(false);
+  });
+
+  it("sets gcTime and staleTime to 0", () => {
+    const qc = createTestQueryClient();
+    const defaults = qc.getDefaultOptions();
+    expect(defaults.queries?.gcTime).toBe(0);
+    expect(defaults.queries?.staleTime).toBe(0);
+  });
+});
+
+describe("renderWithProviders", () => {
+  it("renders a simple component", () => {
+    renderWithProviders(<div data-testid="hello">Hello</div>);
+    expect(screen.getByTestId("hello")).toBeDefined();
+    expect(screen.getByTestId("hello").textContent).toBe("Hello");
+  });
+
+  it("provides React Query context so useQuery works", async () => {
+    function TestComponent() {
+      const { data, isSuccess } = useQuery({
+        queryKey: ["test"],
+        queryFn: () => Promise.resolve("ok"),
+      });
+      if (isSuccess) return <span data-testid="result">{data}</span>;
+      return <span data-testid="loading">loading</span>;
+    }
+
+    renderWithProviders(<TestComponent />);
+    await waitFor(() => {
+      expect(screen.getByTestId("result").textContent).toBe("ok");
+    });
+  });
+
+  it("accepts a custom QueryClient", async () => {
+    const qc = createTestQueryClient();
+    qc.setQueryData(["pre-seeded"], "seeded-value");
+
+    function TestComponent() {
+      const { data } = useQuery({
+        queryKey: ["pre-seeded"],
+        queryFn: () => Promise.resolve("should not be called"),
+        initialData: undefined,
+      });
+      return <span data-testid="val">{data ?? "empty"}</span>;
+    }
+
+    renderWithProviders(<TestComponent />, { queryClient: qc });
+    expect(screen.getByTestId("val").textContent).toBe("seeded-value");
+  });
+});
+
+describe("renderHookWithProviders", () => {
+  it("renders a hook that uses React Query", async () => {
+    const { result } = renderHookWithProviders(() =>
+      useQuery({ queryKey: ["hook-test"], queryFn: () => Promise.resolve(42) })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBe(42);
+  });
+
+  it("returns the queryClient for cache inspection", () => {
+    const { queryClient } = renderHookWithProviders(() => useQueryClient());
+    expect(queryClient).toBeDefined();
+    expect(typeof queryClient.getQueryData).toBe("function");
+  });
+});

--- a/__tests__/utils/__tests__/rpc-failure.test.ts
+++ b/__tests__/utils/__tests__/rpc-failure.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createFailingTransport } from "../rpc-failure";
+
+/**
+ * Helper: calls the transport's request function for a given RPC method.
+ * The custom() wrapper from viem returns a transport factory; we invoke it
+ * to get the actual transport, then call its `request` method.
+ */
+async function callTransport(transport: ReturnType<typeof createFailingTransport>, method: string) {
+  const instance = transport({ chain: { id: 1 } as any, retryCount: 0 });
+  return instance.request({ method } as any);
+}
+
+describe("createFailingTransport", () => {
+  it("passes through methods not in the failure list", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_sendTransaction", failure: "revert" },
+    ]);
+    const result = await callTransport(transport, "eth_blockNumber");
+    expect(result).toBeNull();
+  });
+
+  it("simulates network-error", async () => {
+    const transport = createFailingTransport([{ method: "eth_call", failure: "network-error" }]);
+    await expect(callTransport(transport, "eth_call")).rejects.toThrow("Failed to fetch");
+  });
+
+  it("simulates gas-estimation-error", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_estimateGas", failure: "gas-estimation-error" },
+    ]);
+    await expect(callTransport(transport, "eth_estimateGas")).rejects.toThrow(
+      "gas estimation failed"
+    );
+  });
+
+  it("simulates nonce-too-low", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_sendTransaction", failure: "nonce-too-low" },
+    ]);
+    await expect(callTransport(transport, "eth_sendTransaction")).rejects.toThrow("nonce too low");
+  });
+
+  it("simulates revert", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_sendTransaction", failure: "revert" },
+    ]);
+    await expect(callTransport(transport, "eth_sendTransaction")).rejects.toThrow(
+      "execution reverted"
+    );
+  });
+
+  it("simulates quota-exceeded", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_sendTransaction", failure: "quota-exceeded" },
+    ]);
+    await expect(callTransport(transport, "eth_sendTransaction")).rejects.toThrow(
+      "relay quota exceeded"
+    );
+  });
+
+  it("simulates rate-limit with code 429", async () => {
+    const transport = createFailingTransport([{ method: "eth_call", failure: "rate-limit" }]);
+    try {
+      await callTransport(transport, "eth_call");
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      // viem may wrap the error; check that the original message is present
+      expect(err.message).toContain("Too Many Requests");
+    }
+  });
+
+  it("simulates timeout with custom delay", async () => {
+    const transport = createFailingTransport([
+      { method: "eth_call", failure: "timeout", delayMs: 50 },
+    ]);
+    const start = Date.now();
+    await expect(callTransport(transport, "eth_call")).rejects.toThrow("Request timed out");
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+  });
+});

--- a/__tests__/utils/mock-wallet-client.ts
+++ b/__tests__/utils/mock-wallet-client.ts
@@ -1,0 +1,53 @@
+import { vi } from "vitest";
+
+/**
+ * Creates a mock viem WalletClient for testing transaction-related code.
+ */
+export function createMockWalletClient(
+  options: {
+    address?: `0x${string}`;
+    writeContractResult?: `0x${string}`;
+    writeContractError?: Error;
+    signTypedDataResult?: `0x${string}`;
+    signTypedDataError?: Error;
+  } = {}
+) {
+  const address: `0x${string}` = options.address ?? "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  return {
+    account: { address },
+    chain: { id: 10, name: "OP Mainnet" },
+    writeContract: options.writeContractError
+      ? vi.fn().mockRejectedValue(options.writeContractError)
+      : vi.fn().mockResolvedValue(options.writeContractResult ?? (`0x${"a".repeat(64)}` as const)),
+    signTypedData: options.signTypedDataError
+      ? vi.fn().mockRejectedValue(options.signTypedDataError)
+      : vi.fn().mockResolvedValue(options.signTypedDataResult ?? (`0x${"b".repeat(130)}` as const)),
+    signMessage: vi.fn().mockResolvedValue(`0x${"c".repeat(130)}` as const),
+  };
+}
+
+/**
+ * Creates a mock viem PublicClient for testing read-only chain interactions.
+ */
+export function createMockPublicClient(
+  options: {
+    receiptStatus?: "success" | "reverted";
+    receiptError?: Error;
+    readContractResults?: Record<string, unknown>;
+  } = {}
+) {
+  return {
+    waitForTransactionReceipt: options.receiptError
+      ? vi.fn().mockRejectedValue(options.receiptError)
+      : vi.fn().mockResolvedValue({
+          status: options.receiptStatus ?? "success",
+        }),
+    readContract: vi
+      .fn()
+      .mockImplementation(({ functionName }: { functionName: string }) =>
+        Promise.resolve(options.readContractResults?.[functionName] ?? 0n)
+      ),
+    getBalance: vi.fn().mockResolvedValue(1000000000000000000n),
+    getBytecode: vi.fn().mockResolvedValue("0x6080"),
+  };
+}

--- a/__tests__/utils/render.tsx
+++ b/__tests__/utils/render.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type RenderOptions, render, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+interface TestProviderOptions {
+  queryClient?: QueryClient;
+}
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function TestProviders({
+  children,
+  options = {},
+}: {
+  children: ReactNode;
+  options?: TestProviderOptions;
+}) {
+  const qc = options.queryClient ?? createTestQueryClient();
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: TestProviderOptions & Omit<RenderOptions, "wrapper">
+) {
+  const { queryClient, ...renderOptions } = options ?? {};
+  return render(ui, {
+    wrapper: ({ children }) => <TestProviders options={{ queryClient }}>{children}</TestProviders>,
+    ...renderOptions,
+  });
+}
+
+export function renderHookWithProviders<T>(hook: () => T, options?: TestProviderOptions) {
+  const queryClient = options?.queryClient ?? createTestQueryClient();
+  return {
+    ...renderHook(hook, {
+      wrapper: ({ children }) => (
+        <TestProviders options={{ queryClient }}>{children}</TestProviders>
+      ),
+    }),
+    queryClient,
+  };
+}

--- a/__tests__/utils/rpc-failure.ts
+++ b/__tests__/utils/rpc-failure.ts
@@ -1,0 +1,52 @@
+import { custom } from "viem";
+
+export type FailureMode =
+  | "timeout"
+  | "network-error"
+  | "gas-estimation-error"
+  | "nonce-too-low"
+  | "revert"
+  | "quota-exceeded"
+  | "rate-limit";
+
+export interface FailureConfig {
+  /** RPC method to intercept, e.g. 'eth_sendTransaction', 'eth_estimateGas' */
+  method: string;
+  /** The type of failure to simulate */
+  failure: FailureMode;
+  /** Delay in ms before throwing (used for timeout simulation) */
+  delayMs?: number;
+}
+
+/**
+ * Creates a viem custom transport that simulates RPC failures for specified methods.
+ * Methods not in the failure list pass through and return null.
+ */
+export function createFailingTransport(failures: FailureConfig[]) {
+  const failureMap = new Map(failures.map((f) => [f.method, f]));
+
+  return custom({
+    async request({ method }: { method: string }) {
+      const failure = failureMap.get(method);
+      if (!failure) return null;
+
+      switch (failure.failure) {
+        case "timeout":
+          await new Promise((r) => setTimeout(r, failure.delayMs ?? 30_000));
+          throw new Error("Request timed out");
+        case "network-error":
+          throw new Error("Failed to fetch");
+        case "gas-estimation-error":
+          throw new Error("execution reverted: gas estimation failed");
+        case "nonce-too-low":
+          throw new Error("nonce too low");
+        case "revert":
+          throw new Error("execution reverted");
+        case "quota-exceeded":
+          throw new Error("relay quota exceeded");
+        case "rate-limit":
+          throw Object.assign(new Error("Too Many Requests"), { code: 429 });
+      }
+    },
+  });
+}

--- a/__tests__/utils/wait-helpers.ts
+++ b/__tests__/utils/wait-helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * Flushes pending microtasks / promises by yielding to the event loop once.
+ */
+export async function flushPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Polls `check()` until it returns `true`, or throws after `timeout` ms.
+ */
+export async function waitForCondition(
+  check: () => boolean,
+  { timeout = 5000, interval = 50 } = {}
+): Promise<void> {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeout) {
+      throw new Error("Condition not met within timeout");
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  resolve: {
+    alias: {
+      "@/features": path.resolve(__dirname, "src/features"),
+      "@/src": path.resolve(__dirname, "src"),
+      "@/__tests__": path.resolve(__dirname, "__tests__"),
+      "@": path.resolve(__dirname),
+    },
+  },
+  test: {
+    name: "unit",
+    environment: "jsdom",
+    include: [
+      "__tests__/utils/__tests__/**/*.test.{ts,tsx}",
+      "__tests__/contracts/__tests__/**/*.test.{ts,tsx}",
+    ],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `renderWithProviders` and `renderHookWithProviders` utilities that wrap components/hooks in React Query context for testing
- Add `createFailingTransport` for simulating RPC failures (timeout, revert, nonce-too-low, rate-limit, etc.)
- Add mock wallet/public client factories for transaction-related tests
- Add Zod contract schemas for payout, application, and project API responses with shared pagination schema
- Add async wait helpers (`flushPromises`, `waitForCondition`)
- Add `vitest.unit.config.ts` for running infrastructure tests separately from Storybook browser tests

## Test plan
- [x] All 33 tests pass: `npx vitest run --config vitest.unit.config.ts`
- [x] Render utilities correctly provide React Query context
- [x] All 7 RPC failure modes throw expected errors
- [x] Zod schemas validate matching data shapes and reject invalid ones
- [x] Existing `testProviders.tsx` is NOT modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite coverage for contract schemas and data validation across applications, payouts, and projects.
  * Added testing utilities for rendering components with providers, mocking wallet and RPC clients, and simulating RPC failures.

* **Chores**
  * Added Vitest unit test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->