### PR TITLE
fix: add theme toggle to whitelabel navbar

### DIFF
--- a/__tests__/navbar/unit/whitelabel-navbar-theme-toggle.test.tsx
+++ b/__tests__/navbar/unit/whitelabel-navbar-theme-toggle.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Unit Tests: WhitelabelNavbar Theme Toggle
+ * Verifies that the WhitelabelNavbar includes a theme toggle button,
+ * matching the behavior of the main Navbar.
+ */
+
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WhitelabelNavbar } from "@/src/components/navbar/whitelabel-navbar";
+import type { TenantConfig } from "@/src/infrastructure/types/tenant";
+import {
+  cleanupAfterEach,
+  createMockPermissions,
+  createMockUsePrivy,
+  createMockUseTheme,
+  renderWithProviders,
+} from "../utils/test-helpers";
+import { getAuthFixture } from "../fixtures/auth-fixtures";
+
+// Mock useTenantSafe to return a tenant config
+const mockTenant: TenantConfig = {
+  id: "filpgf",
+  name: "Fil PGF",
+  theme: {
+    primaryColor: "#0090FF",
+    secondaryColor: "#E5F3FF",
+    mode: "light",
+  } as any,
+  assets: {
+    logo: "/images/filpgf-logo.png",
+  } as any,
+  karmaAssets: {} as any,
+  navigation: {
+    header: { shouldHaveTitle: true, title: "Fil PGF" },
+    items: [],
+    showBrowseApplications: true,
+    socialLinks: {},
+  } as any,
+  seo: {} as any,
+  chainId: 314,
+  claimGrants: {} as any,
+};
+
+jest.mock("@/store/tenant", () => ({
+  useTenantSafe: jest.fn(() => mockTenant),
+}));
+
+describe("WhitelabelNavbar Theme Toggle", () => {
+  afterEach(() => {
+    cleanupAfterEach();
+  });
+
+  describe("Desktop", () => {
+    it("should render a theme toggle button", () => {
+      const authFixture = getAuthFixture("authenticated-basic");
+
+      renderWithProviders(<WhitelabelNavbar />, {
+        mockUsePrivy: createMockUsePrivy(authFixture.authState),
+        mockPermissions: createMockPermissions(authFixture.permissions),
+        mockUseTheme: createMockUseTheme("light"),
+      });
+
+      const themeToggles = screen.getAllByLabelText(/toggle theme/i);
+      expect(themeToggles.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should call setTheme when clicked", async () => {
+      const user = userEvent.setup();
+      const mockSetTheme = jest.fn();
+      const authFixture = getAuthFixture("authenticated-basic");
+
+      renderWithProviders(<WhitelabelNavbar />, {
+        mockUsePrivy: createMockUsePrivy(authFixture.authState),
+        mockPermissions: createMockPermissions(authFixture.permissions),
+        mockUseTheme: createMockUseTheme({
+          theme: "light",
+          setTheme: mockSetTheme,
+        }),
+      });
+
+      const themeToggles = screen.getAllByLabelText(/toggle theme/i);
+      await user.click(themeToggles[0]);
+
+      expect(mockSetTheme).toHaveBeenCalledWith("dark");
+    });
+  });
+
+  describe("Mobile", () => {
+    it("should render a theme toggle visible in the mobile header area", () => {
+      const authFixture = getAuthFixture("authenticated-basic");
+
+      renderWithProviders(<WhitelabelNavbar />, {
+        mockUsePrivy: createMockUsePrivy(authFixture.authState),
+        mockPermissions: createMockPermissions(authFixture.permissions),
+        mockUseTheme: createMockUseTheme("light"),
+      });
+
+      // There should be at least 2 theme toggles (desktop + mobile header area)
+      const themeToggles = screen.getAllByLabelText(/toggle theme/i);
+      expect(themeToggles.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("Unauthenticated", () => {
+    it("should render a theme toggle button when not logged in", () => {
+      const authFixture = getAuthFixture("unauthenticated");
+
+      renderWithProviders(<WhitelabelNavbar />, {
+        mockUsePrivy: createMockUsePrivy(authFixture.authState),
+        mockPermissions: createMockPermissions(authFixture.permissions),
+        mockUseTheme: createMockUseTheme("dark"),
+      });
+
+      const themeToggles = screen.getAllByLabelText(/toggle theme/i);
+      expect(themeToggles.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/src/components/navbar/whitelabel-navbar.tsx
+++ b/src/components/navbar/whitelabel-navbar.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/utilities/tailwind";
 import { NavbarAuthButtons } from "./navbar-auth-buttons";
 import { NavbarPermissionsProvider } from "./navbar-permissions-context";
 import { NavbarUserMenu } from "./navbar-user-menu";
+import { ThemeToggleButton } from "./theme-toggle-button";
 
 const navStyles = {
   desktopLink:
@@ -312,6 +313,9 @@ export function WhitelabelNavbar() {
               </DropdownMenu>
             )}
 
+            {/* Theme toggle */}
+            <ThemeToggleButton />
+
             {/* Separator */}
             <div className="mx-2 h-6 w-px bg-zinc-200 dark:bg-zinc-700" />
 
@@ -321,6 +325,7 @@ export function WhitelabelNavbar() {
 
           {/* Mobile: menu toggle */}
           <div className="flex items-center gap-2 lg:hidden">
+            <ThemeToggleButton />
             <button
               type="button"
               className="rounded-lg p-2 text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800"


### PR DESCRIPTION
## Summary
- Added `ThemeToggleButton` to `WhitelabelNavbar` (desktop and mobile layouts)
- Whitelabel tenant instances (e.g. app.filpgf.io) were missing the theme switch that karmahq.xyz has

## Test plan
- [x] Added unit tests in `__tests__/navbar/unit/whitelabel-navbar-theme-toggle.test.tsx`
- [ ] Verify theme toggle appears on a whitelabel instance (e.g. app.filpgf.io)
- [ ] Verify toggle works in both desktop and mobile viewports
- [ ] Verify no regression on karmahq.xyz navbar