### PR TITLE
test: add API boundary trust tests (fetchData, services, React Query, contract bugs)

### DIFF
--- a/__tests__/trust/api/application-services.test.ts
+++ b/__tests__/trust/api/application-services.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPost, mockPut, mockDelete } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockPut: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/auth/api-client", () => ({
+  createAuthenticatedApiClient: () => ({
+    post: mockPost,
+    put: mockPut,
+    delete: mockDelete,
+  }),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      APPLICATIONS: {
+        COMMENTS: (id: string) => `/v2/applications/${id}/comments`,
+        BY_PROJECT_UID: (uid: string) => `/v2/applications/by-project/${uid}`,
+        DELETE: (ref: string) => `/v2/applications/${ref}`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+import { applicationCommentsService } from "@/services/application-comments.service";
+import { deleteApplication, fetchApplicationByProjectUID } from "@/services/funding-applications";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("application-comments service trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- getComments ---
+
+  describe("getComments", () => {
+    it("calls fetchData with correct endpoint", async () => {
+      mockFetchData.mockResolvedValue([{ comments: [] }, null, null, 200]);
+
+      await applicationCommentsService.getComments("app-1");
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/applications/app-1/comments",
+        "GET",
+        {},
+        expect.any(Object)
+      );
+    });
+
+    it("passes admin flag as param when isAdmin=true", async () => {
+      mockFetchData.mockResolvedValue([{ comments: [] }, null, null, 200]);
+
+      await applicationCommentsService.getComments("app-1", true);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.any(String),
+        "GET",
+        {},
+        expect.objectContaining({ admin: "true" })
+      );
+    });
+
+    it("does not pass admin param when isAdmin is false/undefined", async () => {
+      mockFetchData.mockResolvedValue([{ comments: [] }, null, null, 200]);
+
+      await applicationCommentsService.getComments("app-1", false);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.any(String),
+        "GET",
+        {},
+        expect.not.objectContaining({ admin: "true" })
+      );
+    });
+
+    it("returns comments array", async () => {
+      const comments = [
+        { id: "c1", content: "Great work!" },
+        { id: "c2", content: "Needs revision" },
+      ];
+      mockFetchData.mockResolvedValue([{ comments }, null, null, 200]);
+
+      const result = await applicationCommentsService.getComments("app-1");
+
+      expect(result).toEqual(comments);
+    });
+
+    it("throws on fetchData error", async () => {
+      mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+      await expect(applicationCommentsService.getComments("app-1")).rejects.toThrow("Not Found");
+    });
+  });
+
+  // --- createComment ---
+
+  describe("createComment", () => {
+    it("uses apiClient.post with content", async () => {
+      mockPost.mockResolvedValue({
+        data: { comment: { id: "c1", content: "New comment" } },
+      });
+
+      const result = await applicationCommentsService.createComment("app-1", "New comment");
+
+      expect(mockPost).toHaveBeenCalledWith("/v2/applications/app-1/comments", {
+        content: "New comment",
+      });
+      expect(result).toEqual({ id: "c1", content: "New comment" });
+    });
+  });
+
+  // --- editComment ---
+
+  describe("editComment", () => {
+    it("uses apiClient.put with comment ID", async () => {
+      mockPut.mockResolvedValue({
+        data: { comment: { id: "c1", content: "Updated" } },
+      });
+
+      const result = await applicationCommentsService.editComment("c1", "Updated");
+
+      expect(mockPut).toHaveBeenCalledWith("/v2/comments/c1", {
+        content: "Updated",
+      });
+      expect(result).toEqual({ id: "c1", content: "Updated" });
+    });
+  });
+
+  // --- deleteComment ---
+
+  describe("deleteComment", () => {
+    it("uses apiClient.delete with comment ID", async () => {
+      mockDelete.mockResolvedValue({});
+
+      await applicationCommentsService.deleteComment("c1");
+
+      expect(mockDelete).toHaveBeenCalledWith("/v2/comments/c1", {
+        params: {},
+      });
+    });
+
+    it("passes admin flag when isAdmin=true", async () => {
+      mockDelete.mockResolvedValue({});
+
+      await applicationCommentsService.deleteComment("c1", true);
+
+      expect(mockDelete).toHaveBeenCalledWith("/v2/comments/c1", {
+        params: { admin: "true" },
+      });
+    });
+  });
+});
+
+describe("funding-applications service trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- fetchApplicationByProjectUID ---
+
+  describe("fetchApplicationByProjectUID", () => {
+    it("returns application data on success", async () => {
+      const app = { id: "a1", projectUID: "p1", status: "submitted" };
+      mockFetchData.mockResolvedValue([app, null, null, 200]);
+
+      const result = await fetchApplicationByProjectUID("p1");
+
+      expect(result).toEqual(app);
+    });
+
+    it("returns null when no application found (404 error string)", async () => {
+      mockFetchData.mockResolvedValue([null, "404 not found", null, 404]);
+
+      const result = await fetchApplicationByProjectUID("p1");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when error contains 'not found'", async () => {
+      mockFetchData.mockResolvedValue([null, "Application not found", null, 404]);
+
+      const result = await fetchApplicationByProjectUID("p1");
+
+      expect(result).toBeNull();
+    });
+
+    it("throws on non-404 errors", async () => {
+      mockFetchData.mockResolvedValue([null, "Internal server error", null, 500]);
+
+      await expect(fetchApplicationByProjectUID("p1")).rejects.toThrow("Internal server error");
+    });
+
+    it("returns null when data is null but no error", async () => {
+      mockFetchData.mockResolvedValue([null, null, null, 200]);
+
+      const result = await fetchApplicationByProjectUID("p1");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // --- deleteApplication ---
+
+  describe("deleteApplication", () => {
+    it("calls apiClient.delete with reference number", async () => {
+      mockDelete.mockResolvedValue({});
+
+      await deleteApplication("REF-001");
+
+      expect(mockDelete).toHaveBeenCalledWith("/v2/applications/REF-001");
+    });
+
+    it("rethrows error from apiClient", async () => {
+      const axiosError = new Error("Forbidden") as any;
+      axiosError.response = { status: 403, statusText: "Forbidden" };
+      mockDelete.mockRejectedValue(axiosError);
+
+      await expect(deleteApplication("REF-001")).rejects.toThrow("Forbidden");
+    });
+  });
+});

--- a/__tests__/trust/api/community-services.test.ts
+++ b/__tests__/trust/api/community-services.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    COMMUNITY: {
+      V2: {
+        GRANTS: (slug: string) => `/v2/communities/${slug}/grants`,
+      },
+    },
+    V2: {
+      PROJECTS: {
+        LIST: (limit?: number) => `/v2/projects${limit ? `?limit=${limit}` : ""}`,
+        SEARCH: (query: string, limit?: number) =>
+          `/v2/projects/search?q=${query}${limit ? `&limit=${limit}` : ""}`,
+        LIST_PAGINATED: (params: any) => {
+          const qs = new URLSearchParams();
+          if (params.q) qs.set("q", params.q);
+          if (params.page) qs.set("page", params.page.toString());
+          if (params.limit) qs.set("limit", params.limit.toString());
+          if (params.sortBy) qs.set("sortBy", params.sortBy);
+          if (params.sortOrder) qs.set("sortOrder", params.sortOrder);
+          if (params.includeStats) qs.set("includeStats", "true");
+          if (params.excludeTestProjects) qs.set("excludeTestProjects", "true");
+          if (params.hasPayoutAddress) qs.set("hasPayoutAddress", "true");
+          return `/v2/projects/paginated?${qs.toString()}`;
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+vi.mock("@/constants/projects-explorer", () => ({
+  PROJECTS_EXPLORER_CONSTANTS: {
+    RESULT_LIMIT: 50,
+    DEBOUNCE_DELAY_MS: 300,
+    MIN_SEARCH_LENGTH: 3,
+    STALE_TIME_MS: 60000,
+  },
+}));
+
+import { getCommunityGrants } from "@/services/community-grants.service";
+import {
+  getExplorerProjects,
+  getExplorerProjectsPaginated,
+} from "@/services/projects-explorer.service";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("community-grants service trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getCommunityGrants", () => {
+    it("returns array of grants on success", async () => {
+      const grants = [
+        { uid: "g1", title: "Grant 1" },
+        { uid: "g2", title: "Grant 2" },
+      ];
+      mockFetchData.mockResolvedValue([grants, null, null, 200]);
+
+      const result = await getCommunityGrants("my-community");
+
+      expect(result).toEqual(grants);
+    });
+
+    it("calls fetchData with community slug in endpoint", async () => {
+      mockFetchData.mockResolvedValue([[], null, null, 200]);
+
+      await getCommunityGrants("test-community");
+
+      expect(mockFetchData).toHaveBeenCalledWith("/v2/communities/test-community/grants");
+    });
+
+    it("returns empty array on error (does not throw)", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      const result = await getCommunityGrants("my-community");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when data is null but no error", async () => {
+      mockFetchData.mockResolvedValue([null, null, null, 200]);
+
+      const result = await getCommunityGrants("my-community");
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("projects-explorer service trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- getExplorerProjects ---
+
+  describe("getExplorerProjects", () => {
+    it("uses LIST endpoint when no search query", async () => {
+      mockFetchData.mockResolvedValue([[], null, null, 200]);
+
+      await getExplorerProjects({});
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("/v2/projects"));
+      expect(mockFetchData).toHaveBeenCalledWith(expect.not.stringContaining("search"));
+    });
+
+    it("uses SEARCH endpoint when query length >= 3", async () => {
+      mockFetchData.mockResolvedValue([[], null, null, 200]);
+
+      await getExplorerProjects({ search: "test" });
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("search"));
+    });
+
+    it("uses LIST endpoint when query length < 3", async () => {
+      mockFetchData.mockResolvedValue([[], null, null, 200]);
+
+      await getExplorerProjects({ search: "ab" });
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.not.stringContaining("search"));
+    });
+
+    it("filters out test projects from results", async () => {
+      const projects = [
+        { details: { title: "Real Project" } },
+        { details: { title: "test project" } },
+        { details: { title: "My Test App" } },
+        { details: { title: "Production App" } },
+      ];
+      mockFetchData.mockResolvedValue([projects, null, null, 200]);
+
+      const result = await getExplorerProjects({});
+
+      expect(result).toHaveLength(2);
+      expect(result[0].details.title).toBe("Real Project");
+      expect(result[1].details.title).toBe("Production App");
+    });
+
+    it("returns empty array on error (does not throw)", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      const result = await getExplorerProjects({});
+
+      expect(result).toEqual([]);
+    });
+
+    it("includes projects without titles (not filtered out)", async () => {
+      const projects = [{ details: {} }, { details: { title: "Normal" } }];
+      mockFetchData.mockResolvedValue([projects, null, null, 200]);
+
+      const result = await getExplorerProjects({});
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // --- getExplorerProjectsPaginated ---
+
+  describe("getExplorerProjectsPaginated", () => {
+    it("passes pagination params to endpoint", async () => {
+      const response = {
+        projects: [],
+        total: 0,
+        page: 2,
+        limit: 10,
+      };
+      mockFetchData.mockResolvedValue([response, null, null, 200]);
+
+      await getExplorerProjectsPaginated({ page: 2, limit: 10 });
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("page=2"));
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("limit=10"));
+    });
+
+    it("passes sortBy and sortOrder params", async () => {
+      mockFetchData.mockResolvedValue([{ projects: [], total: 0 }, null, null, 200]);
+
+      await getExplorerProjectsPaginated({
+        page: 1,
+        sortBy: "updatedAt" as any,
+        sortOrder: "desc" as any,
+      });
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("sortBy=updatedAt"));
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("sortOrder=desc"));
+    });
+
+    it("throws on error (unlike getExplorerProjects which returns [])", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      await expect(getExplorerProjectsPaginated({ page: 1 })).rejects.toThrow();
+    });
+
+    it("excludes search query when length < 3", async () => {
+      mockFetchData.mockResolvedValue([{ projects: [], total: 0 }, null, null, 200]);
+
+      await getExplorerProjectsPaginated({ page: 1, search: "ab" });
+
+      // Should not have q param
+      const callArg = mockFetchData.mock.calls[0][0] as string;
+      expect(callArg).not.toMatch(/q=ab/);
+    });
+
+    it("always sends excludeTestProjects=true", async () => {
+      mockFetchData.mockResolvedValue([{ projects: [], total: 0 }, null, null, 200]);
+
+      await getExplorerProjectsPaginated({ page: 1 });
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.stringContaining("excludeTestProjects=true")
+      );
+    });
+  });
+});

--- a/__tests__/trust/api/fetchData-trust.test.ts
+++ b/__tests__/trust/api/fetchData-trust.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => {
+  const mockRequest = vi.fn();
+  return {
+    default: { request: mockRequest },
+    __mockRequest: mockRequest,
+  };
+});
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+vi.mock("@/utilities/sanitize", () => ({
+  sanitizeObject: vi.fn((obj: unknown) => obj),
+}));
+
+import axios from "axios";
+import { TokenManager } from "@/utilities/auth/token-manager";
+import fetchData from "@/utilities/fetchData";
+import { sanitizeObject } from "@/utilities/sanitize";
+
+const mockRequest = (axios as unknown as { request: ReturnType<typeof vi.fn> }).request;
+
+function makeAxiosResponse<T>(data: T, status: number): AxiosResponse<T> {
+  return {
+    data,
+    status,
+    statusText: "OK",
+    headers: {},
+    config: {} as any,
+  };
+}
+
+function makeAxiosError(status: number, message: string, hasResponse = true): AxiosError {
+  if (!hasResponse) {
+    const err = new Error("Network Error") as any;
+    err.response = undefined;
+    err.isAxiosError = true;
+    return err;
+  }
+  const err = new Error(message) as any;
+  err.response = {
+    data: { message },
+    status,
+    statusText: "Error",
+    headers: {},
+    config: {} as any,
+  };
+  err.isAxiosError = true;
+  return err;
+}
+
+describe("fetchData trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (TokenManager.getToken as ReturnType<typeof vi.fn>).mockResolvedValue("mock-token");
+  });
+
+  // --- Successful requests ---
+
+  describe("successful requests", () => {
+    it("GET returns [data, null, pageInfo, status] for 200", async () => {
+      const responseData = { items: [1, 2, 3], pageInfo: { next: 2 } };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 200));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toEqual(responseData);
+      expect(error).toBeNull();
+      expect(pageInfo).toEqual({ next: 2 });
+      expect(status).toBe(200);
+    });
+
+    it("POST returns [data, null, null, 201] for created", async () => {
+      const responseData = { id: "new-item" };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 201));
+
+      const [data, error, pageInfo, status] = await fetchData("/test", "POST", { name: "item" });
+
+      expect(data).toEqual({ id: "new-item" });
+      expect(error).toBeNull();
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(201);
+    });
+
+    it("PUT returns [data, null, null, 200] for updated", async () => {
+      const responseData = { id: "item", updated: true };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 200));
+
+      const [data, error, pageInfo, status] = await fetchData("/test/1", "PUT", {
+        name: "updated",
+      });
+
+      expect(data).toEqual(responseData);
+      expect(error).toBeNull();
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(200);
+    });
+
+    it("DELETE returns [data, null, null, 200]", async () => {
+      const responseData = { deleted: true };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 200));
+
+      const [data, error, pageInfo, status] = await fetchData("/test/1", "DELETE");
+
+      expect(data).toEqual(responseData);
+      expect(error).toBeNull();
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(200);
+    });
+
+    it("returns pageInfo from response when present", async () => {
+      const responseData = {
+        results: [],
+        pageInfo: { page: 1, total: 50, hasMore: true },
+      };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 200));
+
+      const [, , pageInfo] = await fetchData("/test");
+
+      expect(pageInfo).toEqual({ page: 1, total: 50, hasMore: true });
+    });
+
+    it("returns null pageInfo when response has no pageInfo", async () => {
+      const responseData = { items: [] };
+      mockRequest.mockResolvedValue(makeAxiosResponse(responseData, 200));
+
+      const [, , pageInfo] = await fetchData("/test");
+
+      expect(pageInfo).toBeNull();
+    });
+  });
+
+  // --- Error responses ---
+
+  describe("error responses (tuple pattern)", () => {
+    it("400 returns [null, error message, null, 400]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(400, "Validation failed"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Validation failed");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(400);
+    });
+
+    it("401 returns [null, error message, null, 401]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(401, "Unauthorized"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Unauthorized");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(401);
+    });
+
+    it("403 returns [null, error message, null, 403]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(403, "Insufficient permissions"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Insufficient permissions");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(403);
+    });
+
+    it("404 returns [null, error message, null, 404]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(404, "Not Found"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Not Found");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(404);
+    });
+
+    it("429 returns [null, error message, null, 429]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(429, "Rate limit exceeded"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Rate limit exceeded");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(429);
+    });
+
+    it("500 returns [null, error message, null, 500]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(500, "Internal server error"));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Internal server error");
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(500);
+    });
+
+    it("network error (no response) returns [null, Error object, null, 500]", async () => {
+      mockRequest.mockRejectedValue(makeAxiosError(0, "", false));
+
+      const [data, error, pageInfo, status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(Error);
+      expect(pageInfo).toBeNull();
+      expect(status).toBe(500);
+    });
+
+    it("falls back to err.message when response.data.message is missing", async () => {
+      const err = new Error("Timeout") as any;
+      err.response = {
+        data: {},
+        status: 504,
+        statusText: "Gateway Timeout",
+        headers: {},
+        config: {} as any,
+      };
+      err.isAxiosError = true;
+      mockRequest.mockRejectedValue(err);
+
+      const [data, error, , status] = await fetchData("/test");
+
+      expect(data).toBeNull();
+      expect(error).toBe("Timeout");
+      expect(status).toBe(504);
+    });
+  });
+
+  // --- Auth header ---
+
+  describe("auth header", () => {
+    it("attaches Bearer token when isAuthorized=true and indexer URL", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.headers.Authorization).toBe("Bearer mock-token");
+    });
+
+    it("does NOT attach token when isAuthorized=false", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, false);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.headers.Authorization).toBeUndefined();
+    });
+
+    it("does NOT attach token when baseUrl is not indexer", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true, false, "https://other-api.example.com");
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.headers.Authorization).toBeUndefined();
+    });
+
+    it("does not attach Authorization header when token is null", async () => {
+      (TokenManager.getToken as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.headers.Authorization).toBeUndefined();
+    });
+  });
+
+  // --- Request sanitization ---
+
+  describe("request sanitization", () => {
+    it("calls sanitizeObject on request body", async () => {
+      const body = { name: "  test  ", nested: { value: " inner " } };
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "POST", body);
+
+      expect(sanitizeObject).toHaveBeenCalledWith(body);
+    });
+
+    it("passes sanitized data to axios request", async () => {
+      const sanitized = { name: "clean" };
+      (sanitizeObject as ReturnType<typeof vi.fn>).mockReturnValue(sanitized);
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "POST", { name: "  dirty  " });
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.data).toEqual(sanitized);
+    });
+  });
+
+  // --- Cache parameter ---
+
+  describe("cache parameter", () => {
+    it("appends ?cache=true when cache=true and no existing params", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true, true);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.url).toContain("?cache=true");
+    });
+
+    it("appends &cache=true when URL has existing params", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test?page=1", "GET", {}, {}, {}, true, true);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.url).toContain("&cache=true");
+    });
+
+    it("does not append cache parameter when cache=false", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true, false);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.url).not.toContain("cache=");
+    });
+
+    it("does not append cache param when baseUrl is not indexer", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true, true, "https://other-api.example.com");
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.url).not.toContain("cache=");
+    });
+  });
+
+  // --- Timeout ---
+
+  describe("timeout", () => {
+    it("sets 360s timeout for authorized indexer requests", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.timeout).toBe(360000);
+    });
+
+    it("does not set timeout for non-authorized requests", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, false);
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.timeout).toBeUndefined();
+    });
+
+    it("does not set timeout for non-indexer requests", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, {}, true, false, "https://other.com");
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.timeout).toBeUndefined();
+    });
+  });
+
+  // --- Request config ---
+
+  describe("request configuration", () => {
+    it("passes params to axios config", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, { page: 1, limit: 10 });
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.params).toEqual({ page: 1, limit: 10 });
+    });
+
+    it("passes custom headers to axios config", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test", "GET", {}, {}, { "X-Custom": "value" });
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.headers["X-Custom"]).toBe("value");
+    });
+
+    it("uses GET as default method", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/test");
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.method).toBe("GET");
+    });
+
+    it("constructs URL with baseUrl + endpoint", async () => {
+      mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
+
+      await fetchData("/v2/projects");
+
+      const config = mockRequest.mock.calls[0][0];
+      expect(config.url).toBe("https://indexer.example.com/v2/projects");
+    });
+  });
+});

--- a/__tests__/trust/api/payout-service.test.ts
+++ b/__tests__/trust/api/payout-service.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      PAYOUTS: {
+        CREATE: "/v2/payouts/create",
+        RECORD_SAFE_TX: (id: string) => `/v2/payouts/${id}/safe-tx`,
+        GRANT_HISTORY: (uid: string, page?: number, limit?: number) => {
+          const params = new URLSearchParams();
+          if (page) params.set("page", page.toString());
+          if (limit) params.set("limit", limit.toString());
+          const qs = params.toString();
+          return `/v2/payouts/grants/${uid}/history${qs ? `?${qs}` : ""}`;
+        },
+        GRANT_TOTAL_DISBURSED: (uid: string) => `/v2/payouts/grants/${uid}/total`,
+        COMMUNITY_PENDING: (uid: string, page?: number, limit?: number) => {
+          const params = new URLSearchParams();
+          if (page) params.set("page", page.toString());
+          if (limit) params.set("limit", limit.toString());
+          const qs = params.toString();
+          return `/v2/payouts/communities/${uid}/pending${qs ? `?${qs}` : ""}`;
+        },
+        UPDATE_STATUS: (id: string) => `/v2/payouts/${id}/status`,
+        SAFE_AWAITING: (addr: string, page?: number, limit?: number) =>
+          `/v2/payouts/safe/${addr}/awaiting`,
+        COMMUNITY_RECENT: (uid: string, page?: number, limit?: number, status?: string) =>
+          `/v2/payouts/communities/${uid}/recent`,
+        COMMUNITY_PAYOUTS: (uid: string, _opts?: any) => `/v2/payouts/communities/${uid}/payouts`,
+      },
+      PAYOUT_CONFIG: {
+        SAVE: "/v2/payout-configs",
+        BY_COMMUNITY: (uid: string) => `/v2/payout-configs/community/${uid}`,
+        BY_GRANT: (uid: string) => `/v2/payout-configs/grant/${uid}`,
+        DELETE: (uid: string) => `/v2/payout-configs/grant/${uid}`,
+      },
+      GRANT_AGREEMENTS: {
+        TOGGLE: (uid: string) => `/v2/grant-agreements/${uid}/toggle`,
+      },
+      MILESTONE_INVOICES: {
+        BATCH_SAVE: (uid: string) => `/v2/milestone-invoices/grants/${uid}/batch`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+import {
+  createDisbursements,
+  deletePayoutConfig,
+  getPayoutConfigByGrant,
+  getPayoutHistory,
+  getPendingDisbursements,
+  getTotalDisbursed,
+  recordSafeTransaction,
+  savePayoutConfigs,
+  updateDisbursementStatus,
+} from "@/features/payout-disbursement/services/payout-disbursement.service";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("payout-disbursement service trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- createDisbursements ---
+
+  describe("createDisbursements", () => {
+    it("calls fetchData with correct endpoint and POST method", async () => {
+      const disbursements = [{ id: "d1", grantUID: "g1" }];
+      mockFetchData.mockResolvedValue([{ disbursements }, null, null, 201]);
+
+      await createDisbursements({
+        communityUID: "c1",
+        disbursements: [
+          {
+            grantUID: "g1",
+            amount: "100",
+            tokenAddress: "0x1",
+            chainId: 1,
+          },
+        ],
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/payouts/create",
+        "POST",
+        expect.any(Object),
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("returns disbursements array from response", async () => {
+      const disbursements = [
+        { id: "d1", grantUID: "g1", amount: "100" },
+        { id: "d2", grantUID: "g2", amount: "200" },
+      ];
+      mockFetchData.mockResolvedValue([{ disbursements }, null, null, 201]);
+
+      const result = await createDisbursements({
+        communityUID: "c1",
+        disbursements: [],
+      } as any);
+
+      expect(result).toEqual(disbursements);
+    });
+
+    it("throws when fetchData returns error", async () => {
+      mockFetchData.mockResolvedValue([null, "Bad Request", null, 400]);
+
+      await expect(
+        createDisbursements({ communityUID: "c1", disbursements: [] } as any)
+      ).rejects.toThrow("Failed to create disbursements");
+    });
+  });
+
+  // --- recordSafeTransaction ---
+
+  describe("recordSafeTransaction", () => {
+    it("calls fetchData with correct endpoint containing disbursement ID", async () => {
+      mockFetchData.mockResolvedValue([
+        { id: "d1", safeTransactionHash: "0xabc" },
+        null,
+        null,
+        200,
+      ]);
+
+      await recordSafeTransaction("d1", {
+        safeTransactionHash: "0xabc",
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/payouts/d1/safe-tx",
+        "POST",
+        expect.objectContaining({ safeTransactionHash: "0xabc" }),
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("returns updated disbursement", async () => {
+      const updated = { id: "d1", safeTransactionHash: "0xabc" };
+      mockFetchData.mockResolvedValue([updated, null, null, 200]);
+
+      const result = await recordSafeTransaction("d1", {
+        safeTransactionHash: "0xabc",
+      } as any);
+
+      expect(result).toEqual(updated);
+    });
+
+    it("throws with context when error occurs", async () => {
+      mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+      await expect(
+        recordSafeTransaction("d1", {
+          safeTransactionHash: "0xabc",
+        } as any)
+      ).rejects.toThrow("Failed to record Safe transaction");
+    });
+  });
+
+  // --- getPayoutHistory ---
+
+  describe("getPayoutHistory", () => {
+    it("calls fetchData with grant UID and pagination params", async () => {
+      const response = { disbursements: [], total: 0, page: 1, limit: 10 };
+      mockFetchData.mockResolvedValue([response, null, null, 200]);
+
+      await getPayoutHistory("g1", 1, 10);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.stringContaining("g1"),
+        "GET",
+        {},
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("returns paginated response", async () => {
+      const response = {
+        disbursements: [{ id: "d1" }],
+        total: 1,
+        page: 1,
+        limit: 10,
+      };
+      mockFetchData.mockResolvedValue([response, null, null, 200]);
+
+      const result = await getPayoutHistory("g1");
+
+      expect(result).toEqual(response);
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      await expect(getPayoutHistory("g1")).rejects.toThrow("Failed to fetch payout history");
+    });
+  });
+
+  // --- getTotalDisbursed ---
+
+  describe("getTotalDisbursed", () => {
+    it("returns totalDisbursed string", async () => {
+      mockFetchData.mockResolvedValue([{ totalDisbursed: "5000.00" }, null, null, 200]);
+
+      const result = await getTotalDisbursed("g1");
+
+      expect(result).toBe("5000.00");
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Error", null, 500]);
+
+      await expect(getTotalDisbursed("g1")).rejects.toThrow("Failed to fetch total disbursed");
+    });
+  });
+
+  // --- getPendingDisbursements ---
+
+  describe("getPendingDisbursements", () => {
+    it("calls fetchData with community UID", async () => {
+      const response = { disbursements: [], total: 0, page: 1, limit: 10 };
+      mockFetchData.mockResolvedValue([response, null, null, 200]);
+
+      await getPendingDisbursements("c1", 1, 20);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.stringContaining("c1"),
+        "GET",
+        {},
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("returns paginated pending disbursements", async () => {
+      const response = {
+        disbursements: [{ id: "d1", status: "pending" }],
+        total: 1,
+        page: 1,
+        limit: 10,
+      };
+      mockFetchData.mockResolvedValue([response, null, null, 200]);
+
+      const result = await getPendingDisbursements("c1");
+
+      expect(result).toEqual(response);
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Unauthorized", null, 401]);
+
+      await expect(getPendingDisbursements("c1")).rejects.toThrow(
+        "Failed to fetch pending disbursements"
+      );
+    });
+  });
+
+  // --- updateDisbursementStatus ---
+
+  describe("updateDisbursementStatus", () => {
+    it("calls fetchData with PATCH method", async () => {
+      mockFetchData.mockResolvedValue([{ id: "d1", status: "completed" }, null, null, 200]);
+
+      await updateDisbursementStatus("d1", {
+        status: "completed",
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/payouts/d1/status",
+        "PATCH",
+        expect.objectContaining({ status: "completed" }),
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("passes status and reason in request body", async () => {
+      mockFetchData.mockResolvedValue([{ id: "d1", status: "rejected" }, null, null, 200]);
+
+      await updateDisbursementStatus("d1", {
+        status: "rejected",
+        reason: "Invalid data",
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.any(String),
+        "PATCH",
+        expect.objectContaining({
+          status: "rejected",
+          reason: "Invalid data",
+        }),
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Forbidden", null, 403]);
+
+      await expect(updateDisbursementStatus("d1", { status: "completed" } as any)).rejects.toThrow(
+        "Failed to update disbursement status"
+      );
+    });
+  });
+
+  // --- savePayoutConfigs ---
+
+  describe("savePayoutConfigs", () => {
+    it("calls fetchData with POST method", async () => {
+      mockFetchData.mockResolvedValue([{ configs: [] }, null, null, 201]);
+
+      await savePayoutConfigs({ configs: [] } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/payout-configs",
+        "POST",
+        expect.any(Object),
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("returns save response", async () => {
+      const response = { configs: [{ grantUID: "g1" }] };
+      mockFetchData.mockResolvedValue([response, null, null, 201]);
+
+      const result = await savePayoutConfigs({ configs: [] } as any);
+
+      expect(result).toEqual(response);
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Bad Request", null, 400]);
+
+      await expect(savePayoutConfigs({ configs: [] } as any)).rejects.toThrow(
+        "Failed to save payout configs"
+      );
+    });
+  });
+
+  // --- getPayoutConfigByGrant ---
+
+  describe("getPayoutConfigByGrant", () => {
+    it("returns config when found", async () => {
+      const config = { grantUID: "g1", payoutAddress: "0x1" };
+      mockFetchData.mockResolvedValue([{ config }, null, null, 200]);
+
+      const result = await getPayoutConfigByGrant("g1");
+
+      expect(result).toEqual(config);
+    });
+
+    it("returns null when config is null", async () => {
+      mockFetchData.mockResolvedValue([{ config: null }, null, null, 200]);
+
+      const result = await getPayoutConfigByGrant("g1");
+
+      expect(result).toBeNull();
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+      await expect(getPayoutConfigByGrant("g1")).rejects.toThrow("Failed to fetch payout config");
+    });
+  });
+
+  // --- deletePayoutConfig ---
+
+  describe("deletePayoutConfig", () => {
+    it("calls fetchData with DELETE method", async () => {
+      mockFetchData.mockResolvedValue([{}, null, null, 200]);
+
+      await deletePayoutConfig("g1");
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/payout-configs/grant/g1",
+        "DELETE",
+        {},
+        {},
+        {},
+        true,
+        false
+      );
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Forbidden", null, 403]);
+
+      await expect(deletePayoutConfig("g1")).rejects.toThrow("Failed to delete payout config");
+    });
+
+    it("resolves void on success", async () => {
+      mockFetchData.mockResolvedValue([{}, null, null, 200]);
+
+      await expect(deletePayoutConfig("g1")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/__tests__/trust/api/permissions-service.test.ts
+++ b/__tests__/trust/api/permissions-service.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      FUNDING_PROGRAMS: {
+        CHECK_PERMISSION: (programId: string, action?: string) =>
+          `/v2/funding-program-configs/${programId}/check-permission${action ? `?action=${action}` : ""}`,
+        MY_REVIEWER_PROGRAMS: () => "/v2/funding-program-configs/my-reviewer-programs",
+        REVIEWERS: (programId: string) => `/v2/funding-program-configs/${programId}/reviewers`,
+      },
+      USER: {
+        PERMISSIONS: (resource?: string) =>
+          `/v2/user/permissions${resource ? `?resource=${resource}` : ""}`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+vi.mock("@/utilities/auth/api-client", () => ({
+  createAuthenticatedApiClient: () => ({
+    post: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+  }),
+}));
+
+vi.mock("@/services/fundingPlatformService", () => ({}));
+
+import { PermissionsService } from "@/services/permissions.service";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("PermissionsService trust tests", () => {
+  let service: PermissionsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PermissionsService();
+  });
+
+  // --- checkPermission ---
+
+  describe("checkPermission", () => {
+    it("throws when programId is missing", async () => {
+      await expect(service.checkPermission({ action: "review" })).rejects.toThrow(
+        "Program ID is required for permission check"
+      );
+    });
+
+    it("calls fetchData with correct endpoint including programId", async () => {
+      mockFetchData.mockResolvedValue([
+        { hasPermission: true, permissions: ["review"] },
+        null,
+        null,
+        200,
+      ]);
+
+      await service.checkPermission({
+        programId: "p1",
+        action: "review",
+      });
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("p1"));
+    });
+
+    it("returns permission check response", async () => {
+      mockFetchData.mockResolvedValue([
+        { hasPermission: true, permissions: ["review", "approve"] },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await service.checkPermission({
+        programId: "p1",
+        action: "review",
+      });
+
+      expect(result.hasPermission).toBe(true);
+      expect(result.permissions).toContain("review");
+    });
+
+    it("throws on fetchData error", async () => {
+      mockFetchData.mockResolvedValue([null, "Forbidden", null, 403]);
+
+      await expect(service.checkPermission({ programId: "p1" })).rejects.toThrow("Forbidden");
+    });
+  });
+
+  // --- getUserPermissions ---
+
+  describe("getUserPermissions", () => {
+    it("calls fetchData with resource param", async () => {
+      mockFetchData.mockResolvedValue([{ permissions: [] }, null, null, 200]);
+
+      await service.getUserPermissions("programs");
+
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("resource=programs"));
+    });
+
+    it("returns user permissions response", async () => {
+      const perms = {
+        permissions: [{ resource: "programs", actions: ["read", "write"], role: "admin" }],
+      };
+      mockFetchData.mockResolvedValue([perms, null, null, 200]);
+
+      const result = await service.getUserPermissions();
+
+      expect(result.permissions).toHaveLength(1);
+      expect(result.permissions[0].actions).toContain("read");
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Unauthorized", null, 401]);
+
+      await expect(service.getUserPermissions()).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  // --- getReviewerPrograms ---
+
+  describe("getReviewerPrograms", () => {
+    it("returns programs array", async () => {
+      const programs = [
+        { programId: "p1", name: "Program 1" },
+        { programId: "p2", name: "Program 2" },
+      ];
+      mockFetchData.mockResolvedValue([programs, null, null, 200]);
+
+      const result = await service.getReviewerPrograms();
+
+      expect(result).toEqual(programs);
+      expect(result).toHaveLength(2);
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      await expect(service.getReviewerPrograms()).rejects.toThrow("Server Error");
+    });
+  });
+
+  // --- hasRole ---
+
+  describe("hasRole", () => {
+    it("returns true when reviewer programs exist", async () => {
+      mockFetchData.mockResolvedValue([[{ programId: "p1" }], null, null, 200]);
+
+      const result = await service.hasRole("reviewer");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when reviewer programs are empty", async () => {
+      mockFetchData.mockResolvedValue([[], null, null, 200]);
+
+      const result = await service.hasRole("reviewer");
+
+      expect(result).toBe(false);
+    });
+
+    it("checks role against resource permissions when resource provided", async () => {
+      mockFetchData.mockResolvedValue([
+        {
+          permissions: [{ resource: "program-123", actions: ["review"], role: "admin" }],
+        },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await service.hasRole("admin", "program-123");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when role does not match", async () => {
+      mockFetchData.mockResolvedValue([
+        {
+          permissions: [{ resource: "program-123", actions: ["read"], role: "viewer" }],
+        },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await service.hasRole("admin", "program-123");
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false for non-reviewer role without resource", async () => {
+      const result = await service.hasRole("admin");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // --- canPerformAction ---
+
+  describe("canPerformAction", () => {
+    it("returns true when action is in permissions", async () => {
+      mockFetchData.mockResolvedValue([
+        {
+          permissions: [{ resource: "programs", actions: ["read", "write", "delete"] }],
+        },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await service.canPerformAction("programs", "write");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when action is not in permissions", async () => {
+      mockFetchData.mockResolvedValue([
+        {
+          permissions: [{ resource: "programs", actions: ["read"] }],
+        },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await service.canPerformAction("programs", "delete");
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when resource is not found", async () => {
+      mockFetchData.mockResolvedValue([{ permissions: [] }, null, null, 200]);
+
+      const result = await service.canPerformAction("nonexistent", "read");
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/__tests__/trust/api/program-services.test.ts
+++ b/__tests__/trust/api/program-services.test.ts
@@ -1,0 +1,410 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockApiPost, mockApiDelete } = vi.hoisted(() => ({
+  mockApiPost: vi.fn(),
+  mockApiDelete: vi.fn(),
+}));
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/auth/api-client", () => ({
+  createAuthenticatedApiClient: () => ({
+    post: mockApiPost,
+    delete: mockApiDelete,
+  }),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    REGISTRY: {
+      V2: {
+        CREATE: "/v2/program-registry",
+        UPDATE: (id: string) => `/v2/program-registry/${id}`,
+        APPROVE: "/v2/program-registry/approve",
+        GET_BY_ID: (id: string) => `/v2/program-registry/${id}`,
+        GET_ALL: (params?: any) => {
+          const qs = new URLSearchParams();
+          if (params?.page) qs.set("page", params.page.toString());
+          if (params?.limit) qs.set("limit", params.limit.toString());
+          if (params?.isValid) qs.set("isValid", params.isValid);
+          const q = qs.toString();
+          return `/v2/program-registry${q ? `?${q}` : ""}`;
+        },
+      },
+    },
+    V2: {
+      FUNDING_PROGRAMS: {
+        REVIEWERS: (programId: string) => `/v2/funding-program-configs/${programId}/reviewers`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+vi.mock("@/utilities/validators", () => ({
+  validateEmail: vi.fn(() => true),
+  validateTelegram: vi.fn(() => true),
+  validateReviewerData: vi.fn(() => ({ valid: true, errors: [] })),
+}));
+
+vi.mock("axios", () => ({
+  default: { isAxiosError: vi.fn(() => false) },
+  isAxiosError: vi.fn(() => false),
+}));
+
+import { programReviewersService } from "@/services/program-reviewers.service";
+import { ProgramRegistryService } from "@/services/programRegistry.service";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("ProgramRegistryService trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- createProgram ---
+
+  describe("createProgram", () => {
+    it("calls fetchData with POST to V2 create endpoint", async () => {
+      mockFetchData.mockResolvedValue([{ programId: "new-123", isValid: true }, null, null, 201]);
+
+      await ProgramRegistryService.createProgram("0xowner", 1, {
+        title: "Test Program",
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/program-registry",
+        "POST",
+        expect.objectContaining({
+          chainId: 1,
+          metadata: expect.objectContaining({ title: "Test Program" }),
+        }),
+        {},
+        {},
+        true
+      );
+    });
+
+    it("returns programId and success status", async () => {
+      mockFetchData.mockResolvedValue([{ programId: "new-123", isValid: true }, null, null, 201]);
+
+      const result = await ProgramRegistryService.createProgram("0xowner", 1, {
+        title: "Test",
+      } as any);
+
+      expect(result.programId).toBe("new-123");
+      expect(result.success).toBe(true);
+      expect(result.requiresManualApproval).toBe(false);
+    });
+
+    it("sets requiresManualApproval=true when isValid is not true", async () => {
+      mockFetchData.mockResolvedValue([{ programId: "new-123" }, null, null, 201]);
+
+      const result = await ProgramRegistryService.createProgram("0xowner", 1, {
+        title: "Test",
+      } as any);
+
+      expect(result.requiresManualApproval).toBe(true);
+    });
+
+    it("throws on fetchData error", async () => {
+      mockFetchData.mockResolvedValue([null, "Validation Error", null, 400]);
+
+      await expect(ProgramRegistryService.createProgram("0xowner", 1, {} as any)).rejects.toThrow(
+        "Validation Error"
+      );
+    });
+  });
+
+  // --- updateProgram ---
+
+  describe("updateProgram", () => {
+    it("calls fetchData with PUT method", async () => {
+      mockFetchData.mockResolvedValue([{}, null, null, 200]);
+
+      await ProgramRegistryService.updateProgram("p1", {
+        title: "Updated",
+      } as any);
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/program-registry/p1",
+        "PUT",
+        expect.objectContaining({
+          metadata: expect.objectContaining({ title: "Updated" }),
+        }),
+        {},
+        {},
+        true
+      );
+    });
+
+    it("throws on error", async () => {
+      mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+      await expect(ProgramRegistryService.updateProgram("p1", {} as any)).rejects.toThrow(
+        "Not Found"
+      );
+    });
+  });
+
+  // --- approveProgram ---
+
+  describe("approveProgram", () => {
+    it("calls POST with programId and isValid status", async () => {
+      mockFetchData.mockResolvedValue([{}, null, null, 200]);
+
+      await ProgramRegistryService.approveProgram("p1", "accepted");
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        "/v2/program-registry/approve",
+        "POST",
+        expect.objectContaining({
+          programId: "p1",
+          isValid: "accepted",
+        }),
+        {},
+        {},
+        true
+      );
+    });
+
+    it("defaults to accepted when no status provided", async () => {
+      mockFetchData.mockResolvedValue([{}, null, null, 200]);
+
+      await ProgramRegistryService.approveProgram("p1");
+
+      expect(mockFetchData).toHaveBeenCalledWith(
+        expect.any(String),
+        "POST",
+        expect.objectContaining({ isValid: "accepted" }),
+        {},
+        {},
+        true
+      );
+    });
+  });
+
+  // --- extractProgramId ---
+
+  describe("extractProgramId", () => {
+    it("extracts from V2 format {programId}", () => {
+      expect(ProgramRegistryService.extractProgramId({ programId: "abc" })).toBe("abc");
+    });
+
+    it("extracts from V1 format {_id: {$oid}}", () => {
+      expect(
+        ProgramRegistryService.extractProgramId({
+          _id: { $oid: "mongo-id" },
+        })
+      ).toBe("mongo-id");
+    });
+
+    it("extracts from {id} format", () => {
+      expect(ProgramRegistryService.extractProgramId({ id: "simple-id" })).toBe("simple-id");
+    });
+
+    it("returns undefined for null/undefined", () => {
+      expect(ProgramRegistryService.extractProgramId(null)).toBeUndefined();
+      expect(ProgramRegistryService.extractProgramId(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe("programReviewersService trust tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- getReviewers ---
+
+  describe("getReviewers", () => {
+    it("maps API response to ProgramReviewer format", async () => {
+      mockFetchData.mockResolvedValue([
+        {
+          reviewers: [
+            {
+              publicAddress: "0x123",
+              programId: "p1",
+              chainID: 1,
+              userProfile: {
+                name: "Alice",
+                email: "alice@example.com",
+                telegram: "@alice",
+              },
+              assignedAt: "2024-01-01",
+              assignedBy: "0xadmin",
+            },
+          ],
+        },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await programReviewersService.getReviewers("p1");
+
+      expect(result).toEqual([
+        {
+          publicAddress: "0x123",
+          name: "Alice",
+          email: "alice@example.com",
+          telegram: "@alice",
+          assignedAt: "2024-01-01",
+          assignedBy: "0xadmin",
+        },
+      ]);
+    });
+
+    it("returns empty array when 'No reviewers found' error", async () => {
+      mockFetchData.mockResolvedValue([null, "No reviewers found", null, 404]);
+
+      const result = await programReviewersService.getReviewers("p1");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when 'Program Reviewer Not Found' error", async () => {
+      mockFetchData.mockResolvedValue([null, "Program Reviewer Not Found", null, 404]);
+
+      const result = await programReviewersService.getReviewers("p1");
+
+      expect(result).toEqual([]);
+    });
+
+    it("throws on other errors", async () => {
+      mockFetchData.mockResolvedValue([null, "Internal server error", null, 500]);
+
+      await expect(programReviewersService.getReviewers("p1")).rejects.toThrow(
+        "Internal server error"
+      );
+    });
+  });
+
+  // --- addReviewer ---
+
+  describe("addReviewer", () => {
+    it("calls apiClient.post with reviewer data", async () => {
+      mockApiPost.mockResolvedValue({
+        data: {
+          reviewer: {
+            publicAddress: "0x456",
+            userProfile: {
+              name: "Bob",
+              email: "bob@example.com",
+            },
+            assignedAt: "2024-01-01",
+          },
+        },
+      });
+
+      const result = await programReviewersService.addReviewer("p1", {
+        name: "Bob",
+        email: "bob@example.com",
+      });
+
+      expect(mockApiPost).toHaveBeenCalledWith("/v2/funding-program-configs/p1/reviewers", {
+        name: "Bob",
+        email: "bob@example.com",
+      });
+      expect(result.publicAddress).toBe("0x456");
+      expect(result.name).toBe("Bob");
+    });
+
+    it("returns fallback when API returns no reviewer data", async () => {
+      mockApiPost.mockResolvedValue({ data: {} });
+
+      const result = await programReviewersService.addReviewer("p1", {
+        name: "Charlie",
+        email: "charlie@example.com",
+        telegram: "@charlie",
+      });
+
+      expect(result.name).toBe("Charlie");
+      expect(result.email).toBe("charlie@example.com");
+      expect(result.telegram).toBe("@charlie");
+      expect(result.assignedAt).toBeDefined();
+    });
+  });
+
+  // --- removeReviewer ---
+
+  describe("removeReviewer", () => {
+    it("calls apiClient.delete with program ID and address", async () => {
+      mockApiDelete.mockResolvedValue({});
+
+      await programReviewersService.removeReviewer("p1", "0x123");
+
+      expect(mockApiDelete).toHaveBeenCalledWith("/v2/funding-program-configs/p1/reviewers/0x123");
+    });
+  });
+
+  // --- addMultipleReviewers ---
+
+  describe("addMultipleReviewers", () => {
+    it("adds multiple reviewers and collects errors", async () => {
+      // First reviewer succeeds
+      mockApiPost.mockResolvedValueOnce({
+        data: {
+          reviewer: {
+            publicAddress: "0x1",
+            userProfile: { name: "A", email: "a@test.com" },
+            assignedAt: "2024-01-01",
+          },
+        },
+      });
+      // Second reviewer fails
+      mockApiPost.mockRejectedValueOnce(new Error("Duplicate reviewer"));
+
+      const result = await programReviewersService.addMultipleReviewers("p1", [
+        { name: "A", email: "a@test.com" },
+        { name: "B", email: "b@test.com" },
+      ]);
+
+      expect(result.added).toHaveLength(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].error).toBe("Duplicate reviewer");
+    });
+
+    it("returns all added when no errors", async () => {
+      mockApiPost.mockResolvedValue({
+        data: {
+          reviewer: {
+            publicAddress: "0x1",
+            userProfile: { name: "A", email: "a@test.com" },
+            assignedAt: "2024-01-01",
+          },
+        },
+      });
+
+      const result = await programReviewersService.addMultipleReviewers("p1", [
+        { name: "A", email: "a@test.com" },
+      ]);
+
+      expect(result.added).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // --- Known Bug: error.includes() crash ---
+
+  describe("KNOWN BUG: error.includes() crash on Error objects", () => {
+    it("crashes when fetchData returns an Error object instead of string", async () => {
+      // fetchData returns Error objects for network errors (no response),
+      // but getReviewers calls error.includes() which throws on Error objects
+      const networkError = new Error("Network Error");
+      mockFetchData.mockResolvedValue([null, networkError, null, 500]);
+
+      // This demonstrates the bug: .includes() is called on an Error object
+      // Error objects don't have .includes(), so it throws TypeError
+      await expect(programReviewersService.getReviewers("p1")).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/__tests__/trust/api/react-query-integration.test.ts
+++ b/__tests__/trust/api/react-query-integration.test.ts
@@ -1,0 +1,337 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    COMMUNITY: {
+      V2: {
+        GRANTS: (slug: string) => `/v2/communities/${slug}/grants`,
+      },
+    },
+    V2: {
+      PROJECTS: {
+        LIST: (limit?: number) => `/v2/projects${limit ? `?limit=${limit}` : ""}`,
+        SEARCH: (query: string, limit?: number) =>
+          `/v2/projects/search?q=${query}${limit ? `&limit=${limit}` : ""}`,
+        LIST_PAGINATED: () => "/v2/projects/paginated",
+      },
+      APPLICATIONS: {
+        BY_PROJECT_UID: (uid: string) => `/v2/applications/by-project/${uid}`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.example.com",
+  },
+}));
+
+vi.mock("@/constants/projects-explorer", () => ({
+  PROJECTS_EXPLORER_CONSTANTS: {
+    RESULT_LIMIT: 50,
+    DEBOUNCE_DELAY_MS: 300,
+    MIN_SEARCH_LENGTH: 3,
+    STALE_TIME_MS: 60000,
+  },
+}));
+
+import { fetchApplicationByProjectUID } from "@/services/funding-applications";
+import { getExplorerProjects } from "@/services/projects-explorer.service";
+import fetchData from "@/utilities/fetchData";
+import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+describe("React Query integration trust tests", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable for unit test speed
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  // --- Default query options ---
+
+  describe("default query options", () => {
+    it("retry is set to 1 (retries once on failure)", () => {
+      expect(defaultQueryOptions.retry).toBe(1);
+    });
+
+    it("staleTime is 1 minute", () => {
+      expect(defaultQueryOptions.staleTime).toBe(60000);
+    });
+
+    it("gcTime is 1 minute", () => {
+      expect(defaultQueryOptions.gcTime).toBe(60000);
+    });
+
+    it("refetchOnWindowFocus is disabled", () => {
+      expect(defaultQueryOptions.refetchOnWindowFocus).toBe(false);
+    });
+
+    it("refetchOnMount is enabled", () => {
+      expect(defaultQueryOptions.refetchOnMount).toBe(true);
+    });
+
+    it("refetchOnReconnect is disabled", () => {
+      expect(defaultQueryOptions.refetchOnReconnect).toBe(false);
+    });
+  });
+
+  // --- Cache behavior via QueryClient ---
+
+  describe("cache behavior", () => {
+    it("fetchQuery caches results and returns cached data on second call", async () => {
+      let callCount = 0;
+      const queryFn = async () => {
+        callCount++;
+        return [{ id: "p1" }];
+      };
+
+      const result1 = await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", ""],
+        queryFn,
+        staleTime: 60000,
+      });
+
+      const result2 = queryClient.getQueryData(["projects-explorer", ""]);
+
+      expect(result1).toEqual([{ id: "p1" }]);
+      expect(result2).toEqual([{ id: "p1" }]);
+      expect(callCount).toBe(1); // Only fetched once
+    });
+
+    it("different query keys result in separate cache entries", async () => {
+      await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", "dao"],
+        queryFn: async () => [{ id: "dao-project" }],
+      });
+
+      await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", "protocol"],
+        queryFn: async () => [{ id: "protocol-project" }],
+      });
+
+      const daoData = queryClient.getQueryData(["projects-explorer", "dao"]);
+      const protocolData = queryClient.getQueryData(["projects-explorer", "protocol"]);
+
+      expect(daoData).toEqual([{ id: "dao-project" }]);
+      expect(protocolData).toEqual([{ id: "protocol-project" }]);
+    });
+  });
+
+  // --- Cache invalidation ---
+
+  describe("cache invalidation", () => {
+    it("invalidating by prefix removes all matching entries", async () => {
+      await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", "dao"],
+        queryFn: async () => [{ id: "1" }],
+      });
+      await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", ""],
+        queryFn: async () => [{ id: "2" }],
+      });
+
+      queryClient.removeQueries({
+        queryKey: ["projects-explorer"],
+      });
+
+      const data1 = queryClient.getQueryData(["projects-explorer", "dao"]);
+      const data2 = queryClient.getQueryData(["projects-explorer", ""]);
+
+      expect(data1).toBeUndefined();
+      expect(data2).toBeUndefined();
+    });
+
+    it("invalidating specific key does not affect other keys", async () => {
+      await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", "dao"],
+        queryFn: async () => [{ id: "1" }],
+      });
+      await queryClient.fetchQuery({
+        queryKey: ["application-by-project-uid", "p1"],
+        queryFn: async () => ({ id: "app1" }),
+      });
+
+      queryClient.removeQueries({
+        queryKey: ["projects-explorer"],
+      });
+
+      const explorerData = queryClient.getQueryData(["projects-explorer", "dao"]);
+      const appData = queryClient.getQueryData(["application-by-project-uid", "p1"]);
+
+      expect(explorerData).toBeUndefined();
+      expect(appData).toEqual({ id: "app1" });
+    });
+  });
+
+  // --- KNOWN BUG: 429 retried ---
+
+  describe("KNOWN BUG: 429 rate-limited requests are retried", () => {
+    it("default retry=1 means rate-limited 429 requests get retried once", () => {
+      // The defaultQueryOptions sets retry: 1
+      // This means ALL failed requests (including 429 rate limits) are retried once.
+      // 429 responses should ideally NOT be retried, as retrying a rate-limited
+      // request immediately will likely fail again and adds unnecessary load.
+      //
+      // This test documents the current behavior as a known bug.
+      expect(defaultQueryOptions.retry).toBe(1);
+
+      // A proper fix would use a retry function:
+      // retry: (failureCount, error) => {
+      //   if (error?.response?.status === 429) return false;
+      //   return failureCount < 1;
+      // }
+    });
+
+    it("demonstrates 429 retry behavior with QueryClient", async () => {
+      let callCount = 0;
+
+      const retryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            ...defaultQueryOptions,
+            // Use the actual default retry value
+          },
+        },
+      });
+
+      try {
+        await retryClient.fetchQuery({
+          queryKey: ["test-429"],
+          queryFn: async () => {
+            callCount++;
+            const err = new Error("Rate limited") as any;
+            err.response = { status: 429 };
+            throw err;
+          },
+          retry: defaultQueryOptions.retry,
+        });
+      } catch {
+        // Expected to throw after retries exhausted
+      }
+
+      // With retry=1, the function is called twice: initial + 1 retry
+      expect(callCount).toBe(2);
+
+      retryClient.clear();
+    });
+  });
+
+  // --- Enabled condition ---
+
+  describe("enabled condition patterns", () => {
+    it("application query is disabled when projectUID is empty", () => {
+      const projectUID = "";
+      const enabled = !!projectUID;
+
+      expect(enabled).toBe(false);
+    });
+
+    it("application query is enabled when projectUID is provided", () => {
+      const projectUID = "project-123";
+      const enabled = !!projectUID;
+
+      expect(enabled).toBe(true);
+    });
+
+    it("explorer search normalization: short searches treated as empty", () => {
+      const search = "ab";
+      const MIN_SEARCH_LENGTH = 3;
+      const effectiveSearch = search.length >= MIN_SEARCH_LENGTH ? search : "";
+
+      expect(effectiveSearch).toBe("");
+    });
+
+    it("explorer search normalization: valid search passes through", () => {
+      const search = "dao";
+      const MIN_SEARCH_LENGTH = 3;
+      const effectiveSearch = search.length >= MIN_SEARCH_LENGTH ? search : "";
+
+      expect(effectiveSearch).toBe("dao");
+    });
+  });
+
+  // --- Stale time ---
+
+  describe("stale time configuration", () => {
+    it("explorer uses PROJECTS_EXPLORER_CONSTANTS.STALE_TIME_MS (60s)", () => {
+      const STALE_TIME_MS = 60 * 1000;
+      expect(STALE_TIME_MS).toBe(60000);
+    });
+
+    it("default staleTime is also 1 minute", () => {
+      expect(defaultQueryOptions.staleTime).toBe(1000 * 60);
+    });
+  });
+
+  // --- Service integration ---
+
+  describe("service function integration", () => {
+    it("getExplorerProjects can be used as queryFn", async () => {
+      mockFetchData.mockResolvedValue([[{ details: { title: "Project 1" } }], null, null, 200]);
+
+      const result = await queryClient.fetchQuery({
+        queryKey: ["projects-explorer", ""],
+        queryFn: () => getExplorerProjects({}),
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("fetchApplicationByProjectUID can be used as queryFn", async () => {
+      mockFetchData.mockResolvedValue([{ id: "app-1", status: "submitted" }, null, null, 200]);
+
+      const result = await queryClient.fetchQuery({
+        queryKey: ["application-by-project-uid", "p1"],
+        queryFn: () => fetchApplicationByProjectUID("p1"),
+      });
+
+      expect(result).toEqual({ id: "app-1", status: "submitted" });
+    });
+
+    it("failed service call causes QueryClient to enter error state", async () => {
+      mockFetchData.mockResolvedValue([null, "Server Error", null, 500]);
+
+      const state = queryClient.getQueryState(["application-by-project-uid", "p-fail"]);
+
+      // Before any fetch, state is undefined
+      expect(state).toBeUndefined();
+
+      try {
+        await queryClient.fetchQuery({
+          queryKey: ["application-by-project-uid", "p-fail"],
+          queryFn: () => fetchApplicationByProjectUID("p-fail"),
+          retry: false,
+        });
+      } catch {
+        // Expected - fetchApplicationByProjectUID throws on 500
+      }
+
+      const afterState = queryClient.getQueryState(["application-by-project-uid", "p-fail"]);
+
+      expect(afterState?.status).toBe("error");
+    });
+  });
+});

--- a/vitest.trust.config.ts
+++ b/vitest.trust.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/features": path.resolve(__dirname, "src/features"),
+      "@/src": path.resolve(__dirname, "src"),
+      "@": path.resolve(__dirname),
+    },
+  },
+  test: {
+    include: ["__tests__/trust/**/*.test.ts", "__tests__/trust/**/*.test.tsx"],
+    environment: "node",
+    globals: true,
+    testTimeout: 10000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add 148 trust tests across 7 test files covering the API request boundary layer
- Tests cover: fetchData utility (HTTP methods, error tuples, auth, sanitization, cache, timeout), payout-disbursement service, permissions service, application comments/funding services, program registry/reviewers services, community grants/explorer services, and React Query integration patterns (cache, invalidation, retry, stale time)
- Documents two known bugs: `error.includes()` crash in program-reviewers when fetchData returns Error objects for network errors, and 429 rate-limited requests being retried due to default `retry=1`
- Includes dedicated vitest config (`vitest.trust.config.ts`) for running trust tests independently

## Test plan
- [x] All 148 tests pass via `npx vitest run __tests__/trust/api/ --config vitest.trust.config.ts`
- [x] No existing test files modified
- [x] Biome lint passes (enforced by pre-commit hook)