### PR TITLE
feat: context-aware labels for funding activity items

### DIFF
--- a/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
@@ -49,8 +49,11 @@ function getActivityTypeLabel(type: string, milestone?: UnifiedMilestone): strin
   switch (type) {
     case "grant_update":
       return "Grant Update";
-    case "grant_received":
-      return "Grant Received";
+    case "grant_received": {
+      const programType = milestone?.grantReceived?.programType;
+      if (programType === "hackathon") return "Hackathon Participation";
+      return "Grant Approved";
+    }
     case "project":
     case "activity":
     case "update":
@@ -143,7 +146,9 @@ const TimelineItem = React.memo(function TimelineItem({
           <>
             <div className="flex flex-row items-center gap-1.5 lg:gap-2 flex-wrap">
               <span className="text-xs lg:text-sm font-semibold text-foreground">
-                Funding received
+                {milestone.grantReceived?.programType === "hackathon"
+                  ? "Hackathon participation"
+                  : "Grant approved"}
               </span>
             </div>
             <div className="flex flex-row items-center gap-1.5 lg:gap-2 text-xs lg:text-sm font-medium leading-5 text-muted-foreground">

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
@@ -101,7 +101,7 @@ describe("ActivityFeed - Activity Type Labels", () => {
     expect(screen.getByText("Milestone created")).toBeInTheDocument();
   });
 
-  it("should display 'Funding received' for type 'grant_received'", () => {
+  it("should display 'Grant approved' for type 'grant_received' with no programType", () => {
     const milestones = [
       createMilestone("grant_received", {
         grantReceived: {
@@ -109,12 +109,49 @@ describe("ActivityFeed - Activity Type Labels", () => {
           communityName: "Test Community",
           communityImage: "https://example.com/image.png",
           grantTitle: "Test Grant",
+          grantUID: "0xgrant1",
         },
       }),
     ];
     render(<ActivityFeed milestones={milestones} />);
 
-    expect(screen.getByText("Funding received")).toBeInTheDocument();
+    expect(screen.getByText("Grant approved")).toBeInTheDocument();
+  });
+
+  it("should display 'Grant approved' for type 'grant_received' with programType 'grant'", () => {
+    const milestones = [
+      createMilestone("grant_received", {
+        grantReceived: {
+          amount: "1000 USDC",
+          communityName: "Test Community",
+          communityImage: "https://example.com/image.png",
+          grantTitle: "Test Grant",
+          grantUID: "0xgrant1",
+          programType: "grant",
+        },
+      }),
+    ];
+    render(<ActivityFeed milestones={milestones} />);
+
+    expect(screen.getByText("Grant approved")).toBeInTheDocument();
+  });
+
+  it("should display 'Hackathon participation' for type 'grant_received' with programType 'hackathon'", () => {
+    const milestones = [
+      createMilestone("grant_received", {
+        grantReceived: {
+          amount: "500 ETH",
+          communityName: "Hackathon Org",
+          communityImage: "https://example.com/hack.png",
+          grantTitle: "ETHGlobal",
+          grantUID: "0xhack1",
+          programType: "hackathon",
+        },
+      }),
+    ];
+    render(<ActivityFeed milestones={milestones} />);
+
+    expect(screen.getByText("Hackathon participation")).toBeInTheDocument();
   });
 
   it("should show empty state when no milestones", () => {

--- a/components/Shared/ActivityCard/FundingReceivedCard.tsx
+++ b/components/Shared/ActivityCard/FundingReceivedCard.tsx
@@ -12,13 +12,26 @@ interface FundingReceivedCardProps {
   projectId?: string;
 }
 
+function getHeadingText(programType?: string): string {
+  if (programType === "hackathon") return "Participated in hackathon";
+  return "Grant received from";
+}
+
+function getButtonLabel(programType?: string): string {
+  if (programType === "hackathon") return "View hackathon";
+  return "View grant";
+}
+
 export const FundingReceivedCard: FC<FundingReceivedCardProps> = ({ milestone, projectId }) => {
   if (!milestone.grantReceived) {
     return null;
   }
 
-  const { amount, communityName, communityImage, grantUID } = milestone.grantReceived;
+  const { amount, communityName, communityImage, grantUID, programType } = milestone.grantReceived;
   const formattedAmount = formatGrantAmount(amount);
+  const isHackathon = programType === "hackathon";
+  const headingText = getHeadingText(programType);
+  const buttonLabel = getButtonLabel(programType);
 
   return (
     <div className="flex flex-col gap-4 w-full px-6 py-6">
@@ -27,28 +40,42 @@ export const FundingReceivedCard: FC<FundingReceivedCardProps> = ({ milestone, p
         <p className="text-xl font-semibold text-foreground tabular-nums">{formattedAmount}</p>
       )}
 
-      {/* Heading: "Funds received from [avatar] Community name" */}
+      {/* Heading */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-2 flex-wrap">
-        <span className="text-xl font-semibold text-foreground">Funds received from</span>
-        <div className="flex flex-row items-center gap-2">
-          <ProfilePicture
-            imageURL={communityImage}
-            name={communityName || "Community"}
-            size="24"
-            className="h-6 w-6 min-w-6 min-h-6 rounded-full"
-            alt={communityName || "Community"}
-          />
-          <span className="text-xl font-semibold text-foreground">
-            {communityName || "Community"}
-          </span>
-        </div>
+        <span className="text-xl font-semibold text-foreground">{headingText}</span>
+        {!isHackathon && (
+          <div className="flex flex-row items-center gap-2">
+            <ProfilePicture
+              imageURL={communityImage}
+              name={communityName || "Community"}
+              size="24"
+              className="h-6 w-6 min-w-6 min-h-6 rounded-full"
+              alt={communityName || "Community"}
+            />
+            <span className="text-xl font-semibold text-foreground">
+              {communityName || "Community"}
+            </span>
+          </div>
+        )}
+        {isHackathon && communityName && (
+          <div className="flex flex-row items-center gap-2">
+            <ProfilePicture
+              imageURL={communityImage}
+              name={communityName}
+              size="24"
+              className="h-6 w-6 min-w-6 min-h-6 rounded-full"
+              alt={communityName}
+            />
+            <span className="text-xl font-semibold text-foreground">{communityName}</span>
+          </div>
+        )}
       </div>
 
-      {/* View grant button */}
+      {/* View grant/hackathon button */}
       {projectId && grantUID && (
         <Button variant="outline" size="sm" asChild className="w-full sm:w-auto">
           <Link href={PAGES.PROJECT.GRANT(projectId, grantUID)}>
-            View grant <ExternalLink className="w-3.5 h-3.5" />
+            {buttonLabel} <ExternalLink className="w-3.5 h-3.5" />
           </Link>
         </Button>
       )}

--- a/services/__tests__/project-profile.service.test.ts
+++ b/services/__tests__/project-profile.service.test.ts
@@ -162,6 +162,7 @@ describe("transformGrantsToMilestones", () => {
         communityImage: "https://example.com/logo.png",
         grantTitle: "Test Grant",
         grantUID: "0x1234",
+        programType: undefined,
       },
     });
   });
@@ -220,6 +221,34 @@ describe("transformGrantsToMilestones", () => {
   it("should return empty array for empty input", () => {
     const result = transformGrantsToMilestones([]);
     expect(result).toEqual([]);
+  });
+
+  it("should pass through programType to grantReceived", () => {
+    const hackathonGrant: Grant = {
+      ...mockGrant,
+      programType: "hackathon",
+    };
+
+    const result = transformGrantsToMilestones([hackathonGrant]);
+
+    expect(result[0].grantReceived?.programType).toBe("hackathon");
+  });
+
+  it("should handle grant programType", () => {
+    const grantWithType: Grant = {
+      ...mockGrant,
+      programType: "grant",
+    };
+
+    const result = transformGrantsToMilestones([grantWithType]);
+
+    expect(result[0].grantReceived?.programType).toBe("grant");
+  });
+
+  it("should handle undefined programType", () => {
+    const result = transformGrantsToMilestones([mockGrant]);
+
+    expect(result[0].grantReceived?.programType).toBeUndefined();
   });
 });
 

--- a/services/project-profile.service.ts
+++ b/services/project-profile.service.ts
@@ -95,6 +95,7 @@ export function transformGrantsToMilestones(grants: Grant[]): UnifiedMilestone[]
         communityImage: grant.community?.details?.imageURL,
         grantTitle: grant.details?.title,
         grantUID: grant.uid,
+        programType: grant.programType,
       },
     };
   });

--- a/types/v2/grant.ts
+++ b/types/v2/grant.ts
@@ -148,6 +148,8 @@ export interface GrantCompleted {
   };
 }
 
+export type ProgramType = "grant" | "hackathon" | "bounty" | "accelerator" | "vc_fund" | "rfp";
+
 export interface Grant {
   uid: string;
   chainID: number;
@@ -156,6 +158,7 @@ export interface Grant {
   projectUID?: string;
   communityUID?: string;
   programId?: string | null;
+  programType?: ProgramType;
   originalProjectUID?: string | null;
   recipient?: string;
   attester?: string;

--- a/types/v2/roadmap.ts
+++ b/types/v2/roadmap.ts
@@ -267,6 +267,7 @@ export type UnifiedMilestone = {
     communityImage?: string;
     grantTitle?: string;
     grantUID: string;
+    programType?: "grant" | "hackathon" | "bounty" | "accelerator" | "vc_fund" | "rfp";
   };
   /** Endorsement info for endorsement type items */
   endorsement?: {


### PR DESCRIPTION
## Summary
- Replaces generic "Funding received" labels with context-aware ones: "Grant approved" or "Hackathon participation"
- Adds `ProgramType` to the `Grant` and `UnifiedMilestone` types
- Updates `FundingReceivedCard` headings and button labels based on `programType`
- Passes `programType` through `transformGrantsToMilestones`

## Why
Different funding program types (grants vs hackathons) should display distinct labels in the activity feed to give users clearer context about their project's funding history.

## Test plan
- [x] Unit tests for `ActivityFeed` label rendering with grant, hackathon, and undefined programType
- [x] Unit tests for `transformGrantsToMilestones` programType passthrough
- [ ] Manual: verify activity feed shows "Grant approved" for grants and "Hackathon participation" for hackathons

**Depends on**: show-karma/gap-indexer#(indexer PR) for the `programType` API field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity labels now distinguish between different funding program types, displaying "Hackathon participation" for hackathon programs
  * Funding activity headers and buttons dynamically update based on program type (e.g., "View hackathon" vs "View grant")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->