### PR TITLE
fix(manage-programs): use rawData.link as source URL

### DIFF
--- a/components/Pages/ProgramRegistry/ProgramDetailsDialog.tsx
+++ b/components/Pages/ProgramRegistry/ProgramDetailsDialog.tsx
@@ -48,28 +48,11 @@ function normalizeUrl(url: string | undefined): string | null {
 }
 
 function extractSourceUrl(program: FundingProgramResponse): string | null {
-  const rawData = program.metadata?.rawData;
-  if (rawData) {
-    for (const key of [
-      "url",
-      "sourceUrl",
-      "source_url",
-      "link",
-      "tweetUrl",
-      "tweet_url",
-      "listing_url",
-      "event_url",
-    ]) {
-      const val = rawData[key];
-      if (typeof val === "string" && val.length > 0) {
-        return normalizeUrl(val);
-      }
-    }
+  const link = program.metadata?.rawData?.link;
+  if (typeof link === "string" && link.length > 0) {
+    return normalizeUrl(link);
   }
-  if (program.metadata?.applicationUrl) {
-    return normalizeUrl(program.metadata.applicationUrl);
-  }
-  return normalizeUrl(program.metadata?.socialLinks?.grantsSite);
+  return null;
 }
 
 const sectionStyles = {


### PR DESCRIPTION
## Summary
- Fix `extractSourceUrl` to read source URL exclusively from `metadata.rawData.link` instead of guessing across multiple rawData keys and falling back to unrelated fields (`applicationUrl`, `grantsSite`)
- Programs without `rawData` or `rawData.link` will simply show no source URL

## Test plan
- [ ] Open manage-programs page as admin
- [ ] Verify programs with `metadata.rawData.link` show the correct source URL
- [ ] Verify programs without `rawData` or without `rawData.link` show no source URL (not a fallback to applicationUrl/grantsSite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source URL extraction in Program Registry details dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->