### PR TITLE
fix: prefer short label fields for project title extraction + mobile overflow fix

### DIFF
--- a/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
+++ b/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
@@ -1,0 +1,81 @@
+import type { IFundingApplication } from "@/types/funding-platform";
+import { getProjectTitle } from "../getProjectTitle";
+
+const makeApplication = (
+  applicationData: Record<string, unknown>,
+  referenceNumber = "APP-12345-67890"
+): IFundingApplication =>
+  ({
+    applicationData,
+    referenceNumber,
+  }) as unknown as IFundingApplication;
+
+describe("getProjectTitle", () => {
+  it("returns field matching both project keyword and title/name keyword", () => {
+    const app = makeApplication({
+      "Project Title": "My Project",
+      "Other Field": "other",
+    });
+    expect(getProjectTitle(app)).toBe("My Project");
+  });
+
+  it("returns field matching title/name when no project keyword match", () => {
+    const app = makeApplication({
+      "Pod Name": "My Pod",
+      "Some other field": "value",
+    });
+    expect(getProjectTitle(app)).toBe("My Pod");
+  });
+
+  it("falls back to referenceNumber when no title/name field exists", () => {
+    const app = makeApplication({
+      "Some Field": "value",
+      "Another Field": "value2",
+    });
+    expect(getProjectTitle(app)).toBe("APP-12345-67890");
+  });
+
+  it("prefers short name-like field over long field that incidentally contains 'name'", () => {
+    const app = makeApplication({
+      "What support or collaboration do you need from your Pod (e.g. design reviews, infra access, data support)? Please name the teams / projects with brief details on their scope of support / collaboration.":
+        "We need design reviews",
+      "Pod Name": "Awesome Pod",
+    });
+    expect(getProjectTitle(app)).toBe("Awesome Pod");
+  });
+
+  it("prefers 'Pod Name' over a verbose field containing 'name' regardless of key order", () => {
+    const app = makeApplication({
+      "Team Lead / Point of Contact": "John",
+      "What support or collaboration do you need from your Pod? Please name the teams.":
+        "Infra team",
+      "Pod Name": "Storage Pod",
+    });
+    expect(getProjectTitle(app)).toBe("Storage Pod");
+  });
+
+  it("handles case insensitivity", () => {
+    const app = makeApplication({
+      "PROJECT NAME": "Uppercase Project",
+    });
+    expect(getProjectTitle(app)).toBe("Uppercase Project");
+  });
+
+  it("handles empty applicationData", () => {
+    const app = makeApplication({});
+    expect(getProjectTitle(app)).toBe("APP-12345-67890");
+  });
+
+  it("handles null applicationData", () => {
+    const app = makeApplication(null as unknown as Record<string, unknown>);
+    expect(getProjectTitle(app)).toBe("APP-12345-67890");
+  });
+
+  it("skips field if value is empty", () => {
+    const app = makeApplication({
+      "Project Title": "",
+      "Pod Name": "Fallback Pod",
+    });
+    expect(getProjectTitle(app)).toBe("Fallback Pod");
+  });
+});

--- a/components/FundingPlatform/helper/getProjectTitle.ts
+++ b/components/FundingPlatform/helper/getProjectTitle.ts
@@ -1,30 +1,38 @@
 import type { IFundingApplication } from "@/types/funding-platform";
 
 export const getProjectTitle = (application: IFundingApplication) => {
-  // Search for project name/title field in applicationData using contains approach
   const titleKeywords = ["title", "name"];
   const projectKeywords = ["project", "proposal", "application"];
 
-  // Get all keys from applicationData
   const dataKeys = Object.keys(application.applicationData || {});
 
-  // First priority: Find keys that contain both project-related and title/name keywords
-  let titleKey = dataKeys.find((key) => {
-    const lowerKey = key.toLowerCase();
-    const hasProjectKeyword = projectKeywords.some((keyword) => lowerKey.includes(keyword));
-    const hasTitleKeyword = titleKeywords.some((keyword) => lowerKey.includes(keyword));
+  // Title/name fields are short labels (e.g. "Project Title", "Pod Name"),
+  // not long-form questions that incidentally contain keywords like "name".
+  const MAX_LABEL_LENGTH = 50;
+
+  const findBest = (predicate: (lowerKey: string) => boolean): string | undefined => {
+    const matches = dataKeys.filter(
+      (key) =>
+        key.length <= MAX_LABEL_LENGTH &&
+        predicate(key.toLowerCase()) &&
+        application.applicationData[key]
+    );
+    if (matches.length === 0) return undefined;
+    return matches.reduce((a, b) => (a.length <= b.length ? a : b));
+  };
+
+  // First priority: keys containing both a project keyword and a title/name keyword
+  let titleKey = findBest((lowerKey) => {
+    const hasProjectKeyword = projectKeywords.some((kw) => lowerKey.includes(kw));
+    const hasTitleKeyword = titleKeywords.some((kw) => lowerKey.includes(kw));
     return hasProjectKeyword && hasTitleKeyword;
   });
 
-  // Second priority: Find keys that contain just title or name
+  // Second priority: keys containing just title or name
   if (!titleKey) {
-    titleKey = dataKeys.find((key) => {
-      const lowerKey = key.toLowerCase();
-      return titleKeywords.some((keyword) => lowerKey.includes(keyword));
-    });
+    titleKey = findBest((lowerKey) => titleKeywords.some((kw) => lowerKey.includes(kw)));
   }
 
-  // Return the value if found, otherwise fallback to Application ID
   if (titleKey && application.applicationData[titleKey]) {
     return application.applicationData[titleKey];
   }

--- a/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
+++ b/components/Pages/Admin/ControlCenter/FilterToolbar.tsx
@@ -170,10 +170,10 @@ export function FilterToolbar({
   return (
     <>
       {/* Row 1: Primary controls */}
-      <div className="flex items-center justify-between gap-4 px-4 pb-3 border-b border-gray-100 dark:border-zinc-800/50">
+      <div className="flex flex-wrap items-center justify-between gap-4 px-4 pb-3 border-b border-gray-100 dark:border-zinc-800/50">
         <ProgramFilter onChange={onProgramChange} />
 
-        <div className="relative flex-shrink-0 w-[280px]">
+        <div className="relative w-full sm:w-[280px]">
           <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
           <Input
             value={localSearch}


### PR DESCRIPTION
## Summary
- **Project title extraction bug**: `getProjectTitle` used `.find()` which returned the first key containing "name" as a substring. Long question fields like "Please name the teams / projects..." matched before short labels like "Pod Name". Fix: filter out keys >50 chars and pick the shortest match.
- **Financials mobile overflow**: Program dropdown + search input overflowed on mobile. Fix: add `flex-wrap` to container and responsive width (`w-full sm:w-[280px]`) on search input.

## Test plan
- [x] Added 9 unit tests for `getProjectTitle` covering the bug case, edge cases, and regressions
- [ ] Verify on Filecoin applications page that "Pod Name" is now shown as project title
- [ ] Verify financials page on mobile viewport — program dropdown and search should wrap