### PR TITLE
fix: correct requested amount extraction on browse-applications

### DIFF
--- a/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
+++ b/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
@@ -50,17 +50,24 @@ jest.mock("@/features/programs/hooks/use-programs-with-config", () => ({
   })),
 }));
 
+const mockFetchData = jest.fn(() =>
+  Promise.resolve([
+    {
+      applications: [],
+      pagination: { total: 0, page: 1, limit: 100, totalPages: 0 },
+    },
+    null,
+  ])
+);
+
 jest.mock("@/utilities/fetchData", () => ({
   __esModule: true,
-  default: jest.fn(() =>
-    Promise.resolve([
-      {
-        applications: [],
-        pagination: { total: 0, page: 1, limit: 100, totalPages: 0 },
-      },
-      null,
-    ])
-  ),
+  default: (...args: unknown[]) => mockFetchData(...args),
+}));
+
+jest.mock("@/components/FundingPlatform/helper/getProjectTitle", () => ({
+  getProjectTitle: (app: { applicationData?: Record<string, unknown> }) =>
+    (app.applicationData?.["Pod Name"] as string) ?? "Untitled",
 }));
 
 jest.mock("@/src/components/navigation/Link", () => ({
@@ -197,6 +204,112 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
     expect(mockRouterReplace).toHaveBeenCalled();
     const lastCall = mockRouterReplace.mock.calls[mockRouterReplace.mock.calls.length - 1][0];
     expect(lastCall).not.toContain("status=");
+  });
+
+  it('displays requested amount when applicationData has "Funding Request" key', async () => {
+    jest
+      .spyOn(require("next/navigation"), "useSearchParams")
+      .mockReturnValue(new URLSearchParams("programId=program-abc"));
+
+    mockFetchData.mockResolvedValueOnce([
+      {
+        applications: [
+          {
+            id: "app-1",
+            programId: "program-abc",
+            referenceNumber: "APP-TEST01",
+            status: "approved",
+            applicationData: {
+              "Pod Name": "Test Pod",
+              "Funding Request": "$466,000 USD",
+            },
+            createdAt: "2026-02-11T10:36:46.032Z",
+            updatedAt: "2026-02-11T10:36:46.032Z",
+          },
+        ],
+        pagination: { total: 1, page: 1, limit: 100, totalPages: 1 },
+      },
+      null,
+    ]);
+
+    render(<BrowseApplicationsClient communityId="test-community" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(await screen.findByText("$466,000")).toBeInTheDocument();
+  });
+
+  it("prefers Funding Request over long question keys that happen to contain amount and funding", async () => {
+    jest
+      .spyOn(require("next/navigation"), "useSearchParams")
+      .mockReturnValue(new URLSearchParams("programId=program-abc"));
+
+    mockFetchData.mockResolvedValueOnce([
+      {
+        applications: [
+          {
+            id: "app-2",
+            programId: "program-abc",
+            referenceNumber: "APP-TEST02",
+            status: "approved",
+            applicationData: {
+              "Pod Name": "LDO Pod",
+              // This long question key contains both "funding" and "amount" but is NOT the requested amount
+              "Have you received previous Filecoin PGF / PLFIF funding? If yes, specify round, amount, and timing.":
+                "FIDL is funded by PL and FF.",
+              "Funding Request": "$147,630 USD",
+            },
+            createdAt: "2026-01-27T00:00:00.000Z",
+            updatedAt: "2026-01-27T00:00:00.000Z",
+          },
+        ],
+        pagination: { total: 1, page: 1, limit: 100, totalPages: 1 },
+      },
+      null,
+    ]);
+
+    render(<BrowseApplicationsClient communityId="test-community" />, {
+      wrapper: createWrapper(),
+    });
+
+    // Should show the correct funding amount, NOT "FIDL is funded by PL and FF."
+    expect(await screen.findByText("$147,630")).toBeInTheDocument();
+    expect(screen.queryByText(/FIDL is funded/)).not.toBeInTheDocument();
+  });
+
+  it("extracts the first dollar amount when Funding Request contains a sentence with multiple numbers", async () => {
+    jest
+      .spyOn(require("next/navigation"), "useSearchParams")
+      .mockReturnValue(new URLSearchParams("programId=program-abc"));
+
+    mockFetchData.mockResolvedValueOnce([
+      {
+        applications: [
+          {
+            id: "app-3",
+            programId: "program-abc",
+            referenceNumber: "APP-TEST03",
+            status: "pending",
+            applicationData: {
+              "Pod Name": "Web2 Pod",
+              "Funding Request":
+                "$239,000 over next three months (Performance/Milestone based $500,236 expected request for second 3-month period)",
+            },
+            createdAt: "2026-01-28T00:00:00.000Z",
+            updatedAt: "2026-01-28T00:00:00.000Z",
+          },
+        ],
+        pagination: { total: 1, page: 1, limit: 100, totalPages: 1 },
+      },
+      null,
+    ]);
+
+    render(<BrowseApplicationsClient communityId="test-community" />, {
+      wrapper: createWrapper(),
+    });
+
+    // Should extract $239,000 (the first dollar amount), NOT concatenate all numbers
+    expect(await screen.findByText("$239,000")).toBeInTheDocument();
   });
 
   it("removes programId from URL when program is deselected", async () => {

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -55,39 +55,65 @@ function normalizeFieldKey(key: string): string {
   return key.toLowerCase().replace(/[\s_-]/g, "");
 }
 
+function formatAmountValue(value: unknown): string | null {
+  if (typeof value === "number") {
+    return `$${value.toLocaleString()}`;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    // Extract the first dollar amount (e.g. "$239,000" from "$239,000 over next three months...")
+    const dollarMatch = value.match(/\$[\d,]+(?:\.\d+)?/);
+    if (dollarMatch) {
+      const num = Number(dollarMatch[0].replace(/[$,]/g, ""));
+      if (!Number.isNaN(num) && num > 0) {
+        return `$${num.toLocaleString()}`;
+      }
+    }
+    // Fall back to parsing a plain number string (e.g. "50000")
+    const plainNum = Number(value.replace(/[^0-9.]/g, ""));
+    if (value.length <= 20 && !Number.isNaN(plainNum) && plainNum > 0) {
+      return `$${plainNum.toLocaleString()}`;
+    }
+    if (value.trim().length <= 50) {
+      return value;
+    }
+  }
+  return null;
+}
+
 function getRequestedAmount(applicationData: Record<string, unknown>): string | null {
   const preferredKeys = new Set([
     "requestedamount",
     "amountrequested",
     "fundingamount",
+    "fundingrequest",
     "grantamount",
     "budget",
   ]);
 
+  // First pass: check preferred (short, unambiguous) keys
+  for (const [key, value] of Object.entries(applicationData ?? {})) {
+    if (preferredKeys.has(normalizeFieldKey(key))) {
+      const formatted = formatAmountValue(value);
+      if (formatted) return formatted;
+    }
+  }
+
+  // Second pass: fall back to pattern matching on longer keys, but only
+  // when the normalized key is short enough to be a field label (not a question)
   for (const [key, value] of Object.entries(applicationData ?? {})) {
     const normalizedKey = normalizeFieldKey(key);
-    const matchesPreferred = preferredKeys.has(normalizedKey);
+    if (normalizedKey.length > 40) continue;
     const matchesPattern =
       normalizedKey.includes("amount") &&
       (normalizedKey.includes("requested") ||
         normalizedKey.includes("funding") ||
         normalizedKey.includes("grant"));
-
-    if (!matchesPreferred && !matchesPattern) continue;
-
-    if (typeof value === "number") {
-      return `$${value.toLocaleString()}`;
-    }
-    if (typeof value === "string" && value.trim().length > 0) {
-      const num = Number(value.replace(/[^0-9.]/g, ""));
-      if (!Number.isNaN(num) && num > 0) {
-        return `$${num.toLocaleString()}`;
-      }
-      if (value.trim().length <= 50) {
-        return value;
-      }
+    if (matchesPattern) {
+      const formatted = formatAmountValue(value);
+      if (formatted) return formatted;
     }
   }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Fix `getRequestedAmount()` heuristic that was broken for Filecoin program 1039 (ProPGF Batch 2 - Pods Track)
- Three bugs fixed:
  1. **"Funding Request" field not matched** — FOC pod showed no amount at all
  2. **Long question keys false-matching** — LDO Pod showed "FIDL is funded by PL and FF." instead of $147,630 because a question label containing "funding" and "amount" matched first
  3. **Multi-amount string concatenation** — Web2 Pod showed $2.39T instead of $239,000 because all digits from "$239,000 over...($500,236 expected...)" were concatenated

## Changes
- Added `"fundingrequest"` to preferred keys
- Split into two-pass lookup: preferred keys first (exact match), then pattern match only on short keys (<=40 chars) to avoid matching question labels
- Extract first `$X,XXX` pattern from strings instead of stripping all non-digits

## Test plan
- [x] Unit tests for all three bug scenarios pass
- [x] Verified visually on localhost against production data for all 3 applications in program 1039
- [x] Existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved extraction and formatting of funding request amounts from application data.
  * Enhanced handling of monetary value display across different data formats.

* **Tests**
  * Expanded test coverage for funding amount display and extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->