### PR TITLE
fix: sync paragraph.com embed theme with app theme

### DIFF
--- a/__tests__/components/footer/newsletter.test.tsx
+++ b/__tests__/components/footer/newsletter.test.tsx
@@ -2,7 +2,18 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Newsletter } from "@/src/components/footer/newsletter";
 
+// Mock next-themes
+const mockUseTheme = jest.fn();
+jest.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
 describe("Newsletter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+  });
+
   it("should render iframes with loading='lazy' attribute", () => {
     render(<Newsletter />);
 
@@ -11,6 +22,36 @@ describe("Newsletter", () => {
 
     for (const iframe of iframes) {
       expect(iframe).toHaveAttribute("loading", "lazy");
+    }
+  });
+
+  it("should pass theme=light to iframe src when app theme is light", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+    render(<Newsletter />);
+
+    const iframes = screen.getAllByTitle(/Subscribe to KarmaHQ/);
+    for (const iframe of iframes) {
+      expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=light"));
+    }
+  });
+
+  it("should pass theme=dark to iframe src when app theme is dark", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark" });
+    render(<Newsletter />);
+
+    const iframes = screen.getAllByTitle(/Subscribe to KarmaHQ/);
+    for (const iframe of iframes) {
+      expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=dark"));
+    }
+  });
+
+  it("should default to light theme when resolvedTheme is undefined", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: undefined });
+    render(<Newsletter />);
+
+    const iframes = screen.getAllByTitle(/Subscribe to KarmaHQ/);
+    for (const iframe of iframes) {
+      expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=light"));
     }
   });
 });

--- a/__tests__/funding-map/unit/funding-map-sidebar-theme.test.tsx
+++ b/__tests__/funding-map/unit/funding-map-sidebar-theme.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FundingMapSidebar } from "@/src/features/funding-map/components/funding-map-sidebar";
+
+// Mock next-themes
+const mockUseTheme = jest.fn();
+jest.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+// Mock dependencies
+jest.mock("@/hooks/useMixpanel", () => ({
+  useMixpanel: () => ({
+    mixpanel: { reportEvent: jest.fn() },
+  }),
+}));
+
+jest.mock("next/dynamic", () => {
+  return jest.fn(() => {
+    const Component = () => <button type="button">Create a profile</button>;
+    Component.displayName = "DynamicComponent";
+    return Component;
+  });
+});
+
+jest.mock("@/src/features/funding-map/components/funding-map-agent-card", () => ({
+  FundingMapAgentCard: () => <div data-testid="agent-card" />,
+}));
+
+describe("FundingMapSidebar iframe theme", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+  });
+
+  it("should pass theme=light to iframe src when app theme is light", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "light" });
+    render(<FundingMapSidebar />);
+
+    const iframe = screen.getByTitle("Subscribe to Karma");
+    expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=light"));
+  });
+
+  it("should pass theme=dark to iframe src when app theme is dark", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: "dark" });
+    render(<FundingMapSidebar />);
+
+    const iframe = screen.getByTitle("Subscribe to Karma");
+    expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=dark"));
+  });
+
+  it("should default to light theme when resolvedTheme is undefined", () => {
+    mockUseTheme.mockReturnValue({ resolvedTheme: undefined });
+    render(<FundingMapSidebar />);
+
+    const iframe = screen.getByTitle("Subscribe to Karma");
+    expect(iframe).toHaveAttribute("src", expect.stringContaining("&theme=light"));
+  });
+});

--- a/src/components/footer/newsletter.tsx
+++ b/src/components/footer/newsletter.tsx
@@ -1,13 +1,18 @@
 "use client";
 
+import { useTheme } from "next-themes";
+
 export function Newsletter() {
+  const { resolvedTheme } = useTheme();
+  const embedTheme = resolvedTheme === "dark" ? "dark" : "light";
+
   return (
     <div className="flex flex-col gap-4">
       <h3 className="font-semibold text-base leading-6 text-foreground">Stay up to date</h3>
       {/* Mobile: vertical, taller */}
       <div className="block md:hidden">
         <iframe
-          src="https://paragraph.com/@karmahq/embed?minimal=true&vertical=true"
+          src={`https://paragraph.com/@karmahq/embed?minimal=true&vertical=true&theme=${embedTheme}`}
           width="256"
           height="90"
           frameBorder="0"
@@ -19,7 +24,7 @@ export function Newsletter() {
       {/* Desktop: horizontal, shorter */}
       <div className="hidden md:block">
         <iframe
-          src="https://paragraph.com/@karmahq/embed?minimal=true"
+          src={`https://paragraph.com/@karmahq/embed?minimal=true&theme=${embedTheme}`}
           width="320"
           height="45"
           frameBorder="0"

--- a/src/features/funding-map/components/funding-map-sidebar.tsx
+++ b/src/features/funding-map/components/funding-map-sidebar.tsx
@@ -3,6 +3,7 @@
 import { Bell, CircleUser, CopyPlus } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import { useTheme } from "next-themes";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { useMixpanel } from "@/hooks/useMixpanel";
@@ -11,6 +12,8 @@ import { FundingMapAgentCard } from "./funding-map-agent-card";
 
 export function FundingMapSidebar() {
   const { mixpanel } = useMixpanel("karma");
+  const { resolvedTheme } = useTheme();
+  const embedTheme = resolvedTheme === "dark" ? "dark" : "light";
 
   const ProjectDialog = useMemo(
     () =>
@@ -38,7 +41,7 @@ export function FundingMapSidebar() {
           Be the first to know when a new program launches
         </p>
         <iframe
-          src="https://paragraph.com/@karmahq/embed?minimal=true&vertical=true"
+          src={`https://paragraph.com/@karmahq/embed?minimal=true&vertical=true&theme=${embedTheme}`}
           width="100%"
           height="90"
           title="Subscribe to Karma"


### PR DESCRIPTION
## Summary
- The newsletter subscribe iframe (paragraph.com embed) used a static URL that relied on the browser's `prefers-color-scheme` media query to pick light/dark theme
- When the app theme differed from the OS theme (e.g. OS in dark mode, app in light mode), the embed rendered with a black background in a light-themed app
- Now passes the app's `resolvedTheme` from `next-themes` as a `&theme=` query parameter to the embed URL

## Changes
- `src/components/footer/newsletter.tsx` — use `useTheme()`, pass dynamic `&theme=` param to both mobile and desktop iframes
- `src/features/funding-map/components/funding-map-sidebar.tsx` — same fix for the funding map sidebar embed
- `__tests__/components/footer/newsletter.test.tsx` — added theme sync tests
- `__tests__/funding-map/unit/funding-map-sidebar-theme.test.tsx` — new test file for sidebar theme sync

## Test plan
- [ ] Toggle app theme to light while OS is in dark mode — embed should render with light background
- [ ] Toggle app theme to dark while OS is in light mode — embed should render with dark background
- [ ] Verify both footer newsletter and funding map sidebar embeds match app theme
- [ ] Run `pnpm test` — all tests pass (7 new theme tests + existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded newsletter content now respects the app's theme preference, automatically switching between light and dark modes to match your selected theme.

* **Tests**
  * Added comprehensive test coverage for theme-aware embed functionality across newsletter and sidebar components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213740487502219