### PR TITLE
fix: milestone completion edit fails with missing refUID

### DIFF
--- a/__tests__/hooks/useProjectUpdates.test.ts
+++ b/__tests__/hooks/useProjectUpdates.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for convertToUnifiedMilestones utility function
+ *
+ * Regression test for bug: grantMilestone.milestone.refUID was missing,
+ * causing "There was an error updating the milestone completion" when editing
+ * milestone completions on-chain.
+ */
+import { describe, expect, it } from "vitest";
+import { convertToUnifiedMilestones } from "@/hooks/v2/useProjectUpdates";
+import type { UpdatesApiResponse } from "@/types/v2/roadmap";
+
+const createMinimalApiResponse = (
+  overrides: Partial<UpdatesApiResponse> = {}
+): UpdatesApiResponse => ({
+  projectUpdates: [],
+  projectMilestones: [],
+  grantMilestones: [],
+  grantUpdates: [],
+  endorsements: [],
+  grantReceived: [],
+  ...overrides,
+});
+
+describe("convertToUnifiedMilestones", () => {
+  describe("grant milestones", () => {
+    it("should set refUID on grantMilestone.milestone to the grant UID", () => {
+      const grantUID = "0xabc123";
+      const milestoneUID = "0xdef456";
+
+      const response = createMinimalApiResponse({
+        grantMilestones: [
+          {
+            uid: milestoneUID,
+            title: "Test Milestone",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: {
+              uid: grantUID,
+              title: "Test Grant",
+              communitySlug: "optimism",
+              communityName: "Optimism",
+              communityImage: "",
+            },
+          } as any,
+        ],
+      });
+
+      const result = convertToUnifiedMilestones(response);
+
+      const grantMilestone = result.find((m) => m.uid === milestoneUID);
+      expect(grantMilestone).toBeDefined();
+      expect(grantMilestone?.source.grantMilestone?.milestone.refUID).toBe(grantUID);
+    });
+
+    it("should set refUID to empty string when grant has no UID", () => {
+      const response = createMinimalApiResponse({
+        grantMilestones: [
+          {
+            uid: "0xmilestone",
+            title: "Test Milestone",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: null,
+          } as any,
+        ],
+      });
+
+      const result = convertToUnifiedMilestones(response);
+
+      const grantMilestone = result.find((m) => m.uid === "0xmilestone");
+      expect(grantMilestone).toBeDefined();
+      expect(grantMilestone?.source.grantMilestone?.milestone.refUID).toBe("");
+    });
+
+    it("should also set the top-level UnifiedMilestone refUID to the grant UID", () => {
+      // MilestoneUpdate.tsx reads milestone.refUID directly (not just the nested source path)
+      // to resolve grantInstance for UI display and for completeMilestone(). Both fields
+      // must be consistent.
+      const grantUID = "0xgrant999";
+      const response = createMinimalApiResponse({
+        grantMilestones: [
+          {
+            uid: "0xmilestone999",
+            title: "Consistency Check",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: {
+              uid: grantUID,
+              title: "Grant",
+              communitySlug: "test",
+              communityName: "Test",
+              communityImage: "",
+            },
+          } as any,
+        ],
+      });
+
+      const result = convertToUnifiedMilestones(response);
+      const m = result.find((x) => x.uid === "0xmilestone999");
+
+      expect(m?.refUID).toBe(grantUID);
+      expect(m?.source.grantMilestone?.milestone.refUID).toBe(grantUID);
+    });
+
+    it("should set refUID to empty string when grant uid is an empty string", () => {
+      // guard against grant object being present but uid being falsy
+      const response = createMinimalApiResponse({
+        grantMilestones: [
+          {
+            uid: "0xmilestone_empty",
+            title: "Empty UID",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: {
+              uid: "",
+              title: "Grant",
+              communitySlug: "test",
+              communityName: "Test",
+              communityImage: "",
+            },
+          } as any,
+        ],
+      });
+
+      const result = convertToUnifiedMilestones(response);
+      const m = result.find((x) => x.uid === "0xmilestone_empty");
+
+      expect(m?.source.grantMilestone?.milestone.refUID).toBe("");
+    });
+
+    it("should assign independent refUIDs to milestones from different grants", () => {
+      const grant1UID = "0xgrant_one";
+      const grant2UID = "0xgrant_two";
+      const response = createMinimalApiResponse({
+        grantMilestones: [
+          {
+            uid: "0xmilestone_a",
+            title: "Milestone A",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: {
+              uid: grant1UID,
+              title: "Grant 1",
+              communitySlug: "s1",
+              communityName: "C1",
+              communityImage: "",
+            },
+          } as any,
+          {
+            uid: "0xmilestone_b",
+            title: "Milestone B",
+            status: "pending",
+            recipient: "0xrecipient",
+            chainId: "10",
+            grant: {
+              uid: grant2UID,
+              title: "Grant 2",
+              communitySlug: "s2",
+              communityName: "C2",
+              communityImage: "",
+            },
+          } as any,
+        ],
+      });
+
+      const result = convertToUnifiedMilestones(response);
+      const a = result.find((x) => x.uid === "0xmilestone_a");
+      const b = result.find((x) => x.uid === "0xmilestone_b");
+
+      expect(a?.source.grantMilestone?.milestone.refUID).toBe(grant1UID);
+      expect(b?.source.grantMilestone?.milestone.refUID).toBe(grant2UID);
+    });
+  });
+});

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -20,7 +20,7 @@ import { QUERY_KEYS } from "@/utilities/queryKeys";
  * - recipient field for the milestone creator
  * - grant object with title and community info
  */
-const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMilestone[] => {
+export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMilestone[] => {
   const unified: UnifiedMilestone[] = [];
 
   // Convert project updates to unified format
@@ -173,6 +173,7 @@ const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMilestone[
           milestone: {
             uid: milestone.uid,
             chainID,
+            refUID: grantInfo?.uid || "",
             attester,
             title: milestone.title,
             description: milestone.description,


### PR DESCRIPTION
## Summary

- `grantMilestone.milestone.refUID` was never populated in `convertToUnifiedMilestones` (`hooks/v2/useProjectUpdates.ts`), even though `grantInfo?.uid` was already available and set on the top-level `UnifiedMilestone.refUID`
- `MilestoneUpdate.tsx`'s `updateMilestoneCompletion()` guards with `if (!milestone.refUID) throw new Error(...)`, so every edit attempt immediately threw — caught and shown as **"There was an error updating the milestone completion."**
- Fix: add `refUID: grantInfo?.uid || ""` to the nested `grantMilestone.milestone` object, consistent with the top-level field already set on line 152

## Test plan

- [x] Reproduced the error toast in browser **before** the fix (on-chain edit → immediate error, no wallet prompt)
- [x] Confirmed fix in browser **after** applying it (on-chain edit → Privy sign dialog → success toast "The milestone completion has been updated!")
- [x] Unit tests added for `convertToUnifiedMilestones` covering: primary `refUID` propagation, `null` grant fallback, empty-string grant UID, and multi-grant isolation
- [x] All 2629 unit tests pass (5 pre-existing unrelated failures unchanged)
- [x] Lint clean, typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grant milestone identifiers are now correctly populated with their parent grant references instead of empty values.

* **Tests**
  * Added comprehensive test coverage for milestone conversion functionality, including edge cases with null or empty grant references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->