### PR TITLE
fix: pin axios to 1.14.0 — supply chain attack mitigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "overrides": {
     "pbkdf2": "^3.1.5",
-    "error-ex": "^1.3.4"
+    "error-ex": "^1.3.4",
+    "axios": "1.14.0"
   },
   "dependencies": {
     "@aa-sdk/core": "^4.82.0",
@@ -95,7 +96,7 @@
     "@zerodev/ecdsa-validator": "^5.4.9",
     "@zerodev/sdk": "^5.5.7",
     "ai": "^6.0.75",
-    "axios": "^1.4.0",
+    "axios": "1.14.0",
     "blo": "^1.1.1",
     "boring-avatars": "^1.11.2",
     "class-variance-authority": "^0.7.1",
@@ -212,7 +213,8 @@
     "@noble/hashes": "^1.4.0",
     "@noble/curves": "^1.4.2",
     "@types/react": "19.1.8",
-    "@types/react-dom": "19.1.6"
+    "@types/react-dom": "19.1.6",
+    "axios": "1.14.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,json,css}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@noble/curves': ^1.4.2
   '@types/react': 19.1.8
   '@types/react-dom': 19.1.6
+  axios: 1.14.0
 
 importers:
 
@@ -174,8 +175,8 @@ importers:
         specifier: ^6.0.75
         version: 6.0.97(zod@3.25.76)
       axios:
-        specifier: ^1.4.0
-        version: 1.11.0
+        specifier: 1.14.0
+        version: 1.14.0
       blo:
         specifier: ^1.1.1
         version: 1.2.0
@@ -6326,16 +6327,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: 0.x || 1.x
+      axios: 1.14.0
 
-  axios@0.29.0:
-    resolution: {integrity: sha512-Kjsq1xisgO5DjjNQwZFsy0gpcU1P2j36dZeQDXVhpIU26GVgkDUnROaHLSuluhMqtDE7aKA2hbKXG5yu5DN8Tg==}
-
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
-
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -8108,6 +8103,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   forwarded-parse@2.1.2:
@@ -10597,6 +10596,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -14279,8 +14282,8 @@ snapshots:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.13.2
-      axios-retry: 4.5.0(axios@1.13.2)
+      axios: 1.14.0
+      axios-retry: 4.5.0(axios@1.14.0)
       jose: 6.1.2
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -14849,7 +14852,7 @@ snapshots:
 
   '@gelatonetwork/relay-sdk@5.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
-      axios: 0.29.0
+      axios: 1.14.0
       ethers: 6.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -18830,7 +18833,7 @@ snapshots:
       '@ethereum-attestation-service/eas-sdk': 1.4.2(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@20.2.5)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@gelatonetwork/relay-sdk': 5.6.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@types/sha256': 0.2.2
-      axios: 1.13.2
+      axios: 1.14.0
       dotenv: 17.2.3
       ethers: 6.11.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       sha256: 0.2.0
@@ -22619,7 +22622,7 @@ snapshots:
       '@ethersproject/wallet': 5.8.0
       '@ethersproject/web': 5.8.0
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      axios: 1.13.2
+      axios: 1.14.0
       sturdy-websocket: 0.2.1
       websocket: 1.0.35
     transitivePeerDependencies:
@@ -22780,32 +22783,16 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios-retry@4.5.0(axios@1.13.2):
+  axios-retry@4.5.0(axios@1.14.0):
     dependencies:
-      axios: 1.13.2
+      axios: 1.14.0
       is-retry-allowed: 2.2.0
 
-  axios@0.29.0:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.13.2:
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -24860,6 +24847,15 @@ snapshots:
       webpack: 5.101.3(esbuild@0.25.12)
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    optional: true
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -28037,6 +28033,8 @@ snapshots:
   proxy-compare@3.0.1: {}
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   psl@1.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Security**: Pins axios to `1.14.0` (last safe version) to prevent resolution to compromised `1.14.1`/`0.30.4`
- Adds `overrides` and `resolutions` entries to enforce the pin across all transitive dependencies
- Lock file updated to reflect pinned version

## Context

On March 30, 2026, axios versions `1.14.1` and `0.30.4` were published with a malicious dependency (`plain-crypto-js@4.2.1`) containing a trojan with C2 callback. The axios maintainers have lost control of the npm package — the attacker's permissions exceed theirs.

**Our caret range (`^1.4.0`) could resolve to the compromised version on any fresh install.**

Reference: https://socket.dev/blog/axios-npm-package-compromised

## Test plan

- [x] Verified no compromised versions in lock file
- [x] Verified no `plain-crypto-js` in dependency tree
- [x] `pnpm install` resolves to `1.14.0`
- [ ] CI passes with pinned version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core HTTP library dependency to improve stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->