### PR TITLE
feat: add milestone index numbering to list views

### DIFF
--- a/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
+++ b/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import {
+  MilestonesSection,
+  type MilestonesSectionProps,
+} from "@/components/Pages/Admin/ControlCenter/MilestonesSection";
+import type { ProjectDetailsSidebarGrant } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar";
+import {
+  type CommunityPayoutInvoiceInfo,
+  MilestoneLifecycleStatus,
+} from "@/src/features/payout-disbursement";
+
+// Mock heavy dependencies
+vi.mock("@/components/Utilities/FileUpload", () => ({
+  FileUpload: () => <div data-testid="file-upload">FileUpload</div>,
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      MILESTONE_INVOICES: {
+        PRESIGNED_URL: () => "/mock-presigned-url",
+        UPDATE_PAYMENT_STATUS: () => "/mock-update-payment-status",
+      },
+    },
+  },
+}));
+
+vi.mock("@/src/features/payout-disbursement", async () => {
+  const actual = await vi.importActual<typeof import("@/src/features/payout-disbursement")>(
+    "@/src/features/payout-disbursement"
+  );
+  return {
+    ...actual,
+    getInvoiceDownloadUrl: vi.fn(),
+    formatDisplayAmount: (amount: string) => amount,
+    useUpdateMilestonePaymentStatus: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+  };
+});
+
+vi.mock("@/components/Pages/Admin/ControlCenter/PaymentStatusDropdown", () => ({
+  PaymentStatusDropdown: ({ status }: { status: string }) => (
+    <span data-testid="payment-status-dropdown">{status}</span>
+  ),
+}));
+
+function createMockInvoice(
+  overrides: Partial<CommunityPayoutInvoiceInfo> = {}
+): CommunityPayoutInvoiceInfo {
+  return {
+    milestoneLabel: "Untitled milestone",
+    milestoneUID: null,
+    milestoneStatus: MilestoneLifecycleStatus.PENDING,
+    milestoneStatusUpdatedAt: null,
+    milestoneDueDate: null,
+    paymentStatus: "unpaid",
+    paymentStatusDate: null,
+    allocatedAmount: null,
+    invoiceReceivedAt: null,
+    invoiceReceivedBy: null,
+    invoiceFileKey: null,
+    ...overrides,
+  };
+}
+
+describe("MilestonesSection", () => {
+  const mockGrant: ProjectDetailsSidebarGrant = {
+    uid: "grant-1",
+    title: "Test Grant",
+    currency: "USDC",
+    milestones: [],
+    updates: [],
+  } as unknown as ProjectDetailsSidebarGrant;
+
+  const defaultProps: MilestonesSectionProps = {
+    grant: mockGrant,
+    communityUID: "community-1",
+    milestoneInvoices: [],
+    invoiceRequired: false,
+    milestoneEdits: {},
+    pendingFiles: {},
+    allocationByUID: new Map(),
+    todayLocal: "2026-03-31",
+    getMilestoneKey: (_inv: CommunityPayoutInvoiceInfo, idx: number) => `key-${idx}`,
+    getInvoiceReceivedDate: () => null,
+    handleInvoiceReceivedDateChange: vi.fn(),
+    onFileUploaded: vi.fn(),
+    removedFiles: new Set(),
+    onFileRemoved: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should prepend milestone index numbering to milestone labels", () => {
+    const invoices = [
+      createMockInvoice({ milestoneLabel: "Design phase", milestoneUID: "ms-1" }),
+      createMockInvoice({ milestoneLabel: "Build prototype", milestoneUID: "ms-2" }),
+      createMockInvoice({ milestoneLabel: "Final delivery", milestoneUID: "ms-3" }),
+    ];
+
+    render(<MilestonesSection {...defaultProps} milestoneInvoices={invoices} />);
+
+    expect(screen.getByText("Milestone 1: Design phase")).toBeInTheDocument();
+    expect(screen.getByText("Milestone 2: Build prototype")).toBeInTheDocument();
+    expect(screen.getByText("Milestone 3: Final delivery")).toBeInTheDocument();
+  });
+
+  it("should not double-prefix labels that already have milestone numbering", () => {
+    const invoices = [
+      createMockInvoice({ milestoneLabel: "Milestone 1: Design", milestoneUID: "ms-1" }),
+    ];
+
+    render(<MilestonesSection {...defaultProps} milestoneInvoices={invoices} />);
+
+    expect(screen.getByText("Milestone 1: Design")).toBeInTheDocument();
+    expect(screen.queryByText("Milestone 1: Milestone 1: Design")).not.toBeInTheDocument();
+  });
+
+  it("should show empty state when no milestones", () => {
+    render(<MilestonesSection {...defaultProps} milestoneInvoices={[]} />);
+
+    expect(screen.getByText("No milestones configured yet.")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/utilities/format-milestone-title.test.ts
+++ b/__tests__/unit/utilities/format-milestone-title.test.ts
@@ -1,0 +1,25 @@
+import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
+
+describe("formatMilestoneTitle", () => {
+  it("prepends 'Milestone N:' to the title using 1-based index", () => {
+    expect(formatMilestoneTitle(0, "Setup infrastructure")).toBe(
+      "Milestone 1: Setup infrastructure"
+    );
+    expect(formatMilestoneTitle(1, "Build prototype")).toBe("Milestone 2: Build prototype");
+    expect(formatMilestoneTitle(9, "Final delivery")).toBe("Milestone 10: Final delivery");
+  });
+
+  it("trims whitespace from the title", () => {
+    expect(formatMilestoneTitle(0, "  Spaced title  ")).toBe("Milestone 1: Spaced title");
+  });
+
+  it("returns 'Milestone N' when title is empty", () => {
+    expect(formatMilestoneTitle(0, "")).toBe("Milestone 1");
+    expect(formatMilestoneTitle(2, "   ")).toBe("Milestone 3");
+  });
+
+  it("does not double-prefix if title already starts with 'Milestone N'", () => {
+    expect(formatMilestoneTitle(0, "Milestone 1: Setup")).toBe("Milestone 1: Setup");
+    expect(formatMilestoneTitle(2, "Milestone 3")).toBe("Milestone 3");
+  });
+});

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/src/features/payout-disbursement";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { formatDate } from "@/utilities/formatDate";
+import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { INDEXER } from "@/utilities/indexer";
 import { cn } from "@/utilities/tailwind";
 import type { ProjectDetailsSidebarGrant } from "./ProjectDetailsSidebar";
@@ -302,7 +303,10 @@ export const MilestonesSection = memo(function MilestonesSection({
 
                   return (
                     <tr
-                      key={invoice.milestoneUID || `${invoice.milestoneLabel}-${idx}`}
+                      key={
+                        invoice.milestoneUID ||
+                        `${formatMilestoneTitle(idx, invoice.milestoneLabel)}-${idx}`
+                      }
                       className={cn(
                         "transition-colors",
                         isCleared
@@ -323,7 +327,7 @@ export const MilestonesSection = memo(function MilestonesSection({
                             />
                           )}
                           <span className="font-medium text-gray-900 dark:text-zinc-100 line-clamp-2">
-                            {invoice.milestoneLabel}
+                            {formatMilestoneTitle(idx, invoice.milestoneLabel)}
                           </span>
                         </div>
                       </td>
@@ -461,7 +465,7 @@ export const MilestonesSection = memo(function MilestonesSection({
                                     ? "border-emerald-200 dark:border-emerald-800"
                                     : ""
                                 )}
-                                aria-label={`Invoice received date for ${invoice.milestoneLabel}`}
+                                aria-label={`Invoice received date for ${formatMilestoneTitle(idx, invoice.milestoneLabel)}`}
                               />
                               {invoice.invoiceReceivedBy && (
                                 <span

--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/Milestone.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/Milestone.tsx
@@ -14,6 +14,7 @@ import { DatePicker } from "@/components/Utilities/DatePicker";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { formatDate } from "@/utilities/formatDate";
+import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { useGrantFormStore } from "./store";
 
 interface MilestoneProps {
@@ -341,7 +342,9 @@ export const Milestone: FC<MilestoneProps> = ({ currentMilestone, index }) => {
       <div className="flex w-full flex-col gap-2" data-color-mode="light">
         <div className="flex w-full  flex-row items-center justify-between gap-6">
           <div className="flex flex-col gap-2">
-            <h3 className="text-lg font-bold">{currentMilestone.title}</h3>
+            <h3 className="text-lg font-bold">
+              {formatMilestoneTitle(index, currentMilestone.title)}
+            </h3>
             <p>
               {currentMilestone.startsAt ? `${formatDate(currentMilestone.startsAt)} - ` : null}
               {formatDate(currentMilestone.endsAt)}

--- a/src/features/applications/components/MilestoneDisplay.tsx
+++ b/src/features/applications/components/MilestoneDisplay.tsx
@@ -3,6 +3,7 @@
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { MilestoneData } from "@/types/whitelabel-entities";
 import { formatDate } from "@/utilities/formatDate";
+import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { useMilestoneCompletions } from "../hooks/use-milestone-completions";
 import { formatFieldLabel, isMarkdownContent, MILESTONE_CORE_FIELDS } from "../lib/milestone-utils";
 
@@ -40,7 +41,7 @@ export function MilestoneDisplay({
             key={`${fieldLabel}-${index}`}
             className="border-l-2 border-zinc-200 dark:border-zinc-700 pl-4 space-y-1"
           >
-            <p className="font-medium text-sm">{milestone.title}</p>
+            <p className="font-medium text-sm">{formatMilestoneTitle(index, milestone.title)}</p>
 
             {milestone.description && (
               <div className="text-sm text-zinc-600 dark:text-zinc-400">

--- a/src/features/payout-disbursement/__tests__/MilestoneSelectionStep.test.tsx
+++ b/src/features/payout-disbursement/__tests__/MilestoneSelectionStep.test.tsx
@@ -68,6 +68,25 @@ describe("MilestoneSelectionStep", () => {
       expect(screen.queryByText("Test Grant")).not.toBeInTheDocument();
       expect(screen.queryByText("Test Project")).not.toBeInTheDocument();
     });
+
+    it("should prepend milestone index numbering to allocation labels", () => {
+      const allocationsWithPlainLabels: MilestoneAllocation[] = [
+        { id: "alloc-1", milestoneUID: "ms-1", label: "Design phase", amount: "1" },
+        { id: "alloc-2", milestoneUID: "ms-2", label: "Build prototype", amount: "2" },
+      ];
+      render(<MilestoneSelectionStep {...defaultProps} allocations={allocationsWithPlainLabels} />);
+
+      expect(screen.getByText("Milestone 1: Design phase")).toBeInTheDocument();
+      expect(screen.getByText("Milestone 2: Build prototype")).toBeInTheDocument();
+    });
+
+    it("should not double-prefix labels that already have milestone numbering", () => {
+      render(<MilestoneSelectionStep {...defaultProps} />);
+
+      // Labels are "Milestone 1", "Milestone 2", "Milestone 3" - should not become "Milestone 1: Milestone 1"
+      expect(screen.getByText("Milestone 1")).toBeInTheDocument();
+      expect(screen.queryByText("Milestone 1: Milestone 1")).not.toBeInTheDocument();
+    });
   });
 
   describe("with paid allocations", () => {

--- a/src/features/payout-disbursement/components/MilestoneSelectionStep.tsx
+++ b/src/features/payout-disbursement/components/MilestoneSelectionStep.tsx
@@ -6,6 +6,7 @@ import {
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useMemo } from "react";
+import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { cn } from "@/utilities/tailwind";
 import type { MilestoneAllocation, PayoutDisbursement } from "../types/payout-disbursement";
 
@@ -64,6 +65,15 @@ export function MilestoneSelectionStep({
 
     return { paidAllocations: paid, unpaidAllocations: unpaid };
   }, [allocations, paidIds]);
+
+  // Map allocation IDs to their original index for consistent numbering
+  const allocationIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < allocations.length; i++) {
+      map.set(allocations[i].id, i);
+    }
+    return map;
+  }, [allocations]);
 
   // Calculate totals
   // Note: Allocation amounts are stored in human-readable format (e.g., "50000" for 50000 USDC)
@@ -261,7 +271,10 @@ export function MilestoneSelectionStep({
                     compact && "text-sm"
                   )}
                 >
-                  {allocation.label}
+                  {formatMilestoneTitle(
+                    allocationIndexById.get(allocation.id) ?? 0,
+                    allocation.label
+                  )}
                 </p>
                 {allocation.milestoneUID && !compact && (
                   <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
@@ -296,7 +309,12 @@ export function MilestoneSelectionStep({
                 className="flex items-center gap-3 p-2 rounded-lg bg-gray-50 dark:bg-zinc-800/50 opacity-60"
               >
                 <CheckCircleIcon className="h-4 w-4 text-green-500" />
-                <span className="flex-1 truncate">{allocation.label}</span>
+                <span className="flex-1 truncate">
+                  {formatMilestoneTitle(
+                    allocationIndexById.get(allocation.id) ?? 0,
+                    allocation.label
+                  )}
+                </span>
                 <span className="text-gray-500 dark:text-gray-400">
                   {formatAmount(allocation.amount)} {tokenSymbol}
                 </span>

--- a/utilities/formatMilestoneTitle.ts
+++ b/utilities/formatMilestoneTitle.ts
@@ -1,0 +1,24 @@
+/**
+ * Formats a milestone title with a "Milestone N:" prefix.
+ * Uses 0-based index input, displays as 1-based.
+ *
+ * @param index - 0-based position of the milestone in the list
+ * @param title - The milestone's original title
+ * @returns Formatted string like "Milestone 1: Setup infrastructure"
+ */
+export function formatMilestoneTitle(index: number, title: string): string {
+  const number = index + 1;
+  const trimmed = title.trim();
+
+  if (!trimmed) {
+    return `Milestone ${number}`;
+  }
+
+  // Avoid double-prefixing if title already starts with "Milestone N"
+  const milestonePrefix = new RegExp(`^Milestone\\s+${number}(\\s*:|$)`);
+  if (milestonePrefix.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `Milestone ${number}: ${trimmed}`;
+}


### PR DESCRIPTION
## Summary
- Prepend "Milestone 1", "Milestone 2" etc. to milestone labels across all list views
- New `formatMilestoneTitle` utility with double-prefix protection
- Updated: MilestoneDisplay, MilestoneSelectionStep, MilestonesSection (Control Center), NewGrant Milestone form

## Test plan
- [ ] Verify milestones show "Milestone 1: Title", "Milestone 2: Title" in project milestone views
- [ ] Verify numbering in payout milestone selection
- [ ] Verify numbering in Control Center milestone table
- [ ] Verify no double-prefix for labels already containing "Milestone N"
- [ ] 9 new unit tests pass (4 utility + 3 section + 2 selection)