### PR TITLE
fix: resolve markdown list rendering, table parsing, and field ID selector crash

### DIFF
--- a/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
@@ -37,11 +37,22 @@ const inputStyle =
   "mt-2 w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 placeholder:text-gray-300 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100 dark:placeholder:text-zinc-300";
 
 /**
+ * Derives a safe field name from a label — valid as both a form key and DOM id.
+ * Replaces whitespace with underscores and strips characters invalid in CSS selectors.
+ */
+function toFieldName(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_-]/g, "");
+}
+
+/**
  * Finds the original key in initialData that matches the given field.
  * Uses multiple matching strategies to handle different key formats.
  */
 function findOriginalKey(field: IFormField, initialData: Record<string, any>): string | undefined {
-  const fieldName = field.label.toLowerCase().replace(/\s+/g, "_");
+  const fieldName = toFieldName(field.label);
 
   // Strategy 1: Match with field.id (if available) - most reliable
   if (field.id && field.id in initialData) {
@@ -109,7 +120,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
     const schemaObject: Record<string, any> = {};
 
     schema.fields.forEach((field) => {
-      const fieldName = field.label.toLowerCase().replace(/\s+/g, "_");
+      const fieldName = toFieldName(field.label);
       let fieldSchema: z.ZodTypeAny;
 
       switch (field.type) {
@@ -357,7 +368,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
   const getDefaultValues = useCallback((): Partial<FormData> => {
     const defaults: Record<string, any> = {};
     formSchema.fields.forEach((field) => {
-      const fieldName = field.label.toLowerCase().replace(/\s+/g, "_");
+      const fieldName = toFieldName(field.label);
       // Use field.id if available, otherwise fall back to fieldName (consistent with validation schema)
       const fieldKey = field.id || fieldName;
       if (field.type === "checkbox") {
@@ -394,7 +405,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
   const fieldIdToLabelMapping = useMemo(() => {
     const mapping: Record<string, string> = {};
     formSchema.fields.forEach((field) => {
-      const fieldKey = field.id || field.label.toLowerCase().replace(/\s+/g, "_");
+      const fieldKey = field.id || toFieldName(field.label);
       mapping[fieldKey] = field.label;
     });
     return mapping;
@@ -407,7 +418,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
 
     const mapping: Record<string, string> = {};
     formSchema.fields.forEach((field) => {
-      const fieldKey = field.id || field.label.toLowerCase().replace(/\s+/g, "_");
+      const fieldKey = field.id || toFieldName(field.label);
       const originalKey = findOriginalKey(field, initialData);
 
       if (originalKey) {
@@ -430,7 +441,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
 
     // Track which fields matched
     formSchema.fields.forEach((field) => {
-      const fieldKey = field.id || field.label.toLowerCase().replace(/\s+/g, "_");
+      const fieldKey = field.id || toFieldName(field.label);
       const originalKey = findOriginalKey(field, initialData);
 
       if (originalKey) {
@@ -498,7 +509,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
         const formData: Record<string, any> = {};
 
         formSchema.fields.forEach((field) => {
-          const fieldName = field.label.toLowerCase().replace(/\s+/g, "_");
+          const fieldName = toFieldName(field.label);
           // Use field.id if available, otherwise fall back to fieldName (consistent with validation schema)
           const fieldKey = field.id || fieldName;
 
@@ -621,7 +632,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
   };
 
   const renderField = (field: any, index: number) => {
-    const fieldName = field.label.toLowerCase().replace(/\s+/g, "_");
+    const fieldName = toFieldName(field.label);
     // Use field.id if available, otherwise fall back to fieldName (consistent with validation schema)
     const fieldKey = (field.id || fieldName) as keyof FormData;
     const error = errors[fieldKey];

--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -59,6 +59,8 @@ const EXCLUDED_TOOLBARS = [
   "mermaid",
   "katex",
   "htmlPreview",
+  "preview",
+  "previewOnly",
 ] as const;
 
 /**
@@ -112,6 +114,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
+
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
 
   // Ensure client-side only rendering to prevent hydration mismatches

--- a/components/Utilities/MarkdownPreview.tsx
+++ b/components/Utilities/MarkdownPreview.tsx
@@ -23,8 +23,6 @@ interface MarkdownPreviewProps {
 
 type StreamdownType = typeof import("streamdown").Streamdown;
 type CodePluginType = typeof import("@streamdown/code").code;
-// biome-ignore lint/suspicious/noExplicitAny: remark plugin type is generic
-type RemarkPlugin = any;
 
 export const MarkdownPreview = ({
   source,
@@ -35,19 +33,15 @@ export const MarkdownPreview = ({
   const { resolvedTheme } = useTheme();
   const [StreamdownComponent, setStreamdownComponent] = useState<StreamdownType | null>(null);
   const [codePlugin, setCodePlugin] = useState<CodePluginType | null>(null);
-  const [breaksPlugin, setBreaksPlugin] = useState<RemarkPlugin | null>(null);
-
   useEffect(() => {
     Promise.all([
       import("streamdown").then((m) => m.Streamdown),
       import("@streamdown/code").then((m) => m.code),
-      import("remark-breaks").then((m) => m.default),
       import("streamdown/styles.css" as string),
     ])
-      .then(([Streamdown, code, breaks]) => {
+      .then(([Streamdown, code]) => {
         setStreamdownComponent(() => Streamdown);
         setCodePlugin(() => code);
-        setBreaksPlugin(() => breaks);
       })
       .catch((err) => {
         console.error("Failed to load markdown preview dependencies:", err);
@@ -56,7 +50,7 @@ export const MarkdownPreview = ({
 
   if (!source) return null;
 
-  if (!StreamdownComponent || !codePlugin || !breaksPlugin) {
+  if (!StreamdownComponent || !codePlugin) {
     return <div className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-4 w-full" />;
   }
 
@@ -77,7 +71,6 @@ export const MarkdownPreview = ({
       <StreamdownComponent
         mode="static"
         plugins={{ code: codePlugin }}
-        remarkPlugins={[breaksPlugin]}
         className={cn("wmdeMarkdown", styles.wmdeMarkdown, className)}
         allowElement={allowElement ?? undefined}
         components={mergedComponents}

--- a/styles/markdown.module.css
+++ b/styles/markdown.module.css
@@ -12,6 +12,11 @@
     white-space: normal;
   }
 
+  li > p {
+    display: inline;
+    margin-bottom: 0;
+  }
+
   @media (max-width: 1440px) {
     @apply text-[14px];
   }


### PR DESCRIPTION
## Summary
Follow-up to #1187. Fixes regressions and additional issues found during testing:

- Remove `remark-breaks` plugin — was converting single newlines to `<br>` inside list items, breaking bullet point rendering
- Stop overriding Streamdown's built-in `remark-gfm` — restores table, strikethrough, and task list parsing
- Fix bullet points appearing on separate line from text via CSS (`li > p { display: inline }`)
- Remove `md-editor-rt` built-in preview modes (`preview`, `previewOnly`) — only our `MarkdownPreview` toggle is available, ensuring consistent rendering
- Extract `toFieldName()` utility to sanitize field labels into valid CSS IDs — fixes `querySelector` crash with labels containing parentheses (e.g., "Description (2-3 sentences)")

## Test plan
- [x] Verify markdown tables render correctly (e.g., curio-storage-2 "Time Commitment Breakdown")
- [x] Verify bullet points render inline with text (e.g., mobarter/about Features)
- [x] Verify editor preview toggle matches read-only display
- [x] Verify application edit form loads without querySelector crash for fields with special characters
- [x] Unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field value handling and synchronization during edit mode.

* **Improvements**
  * Enhanced paragraph formatting within markdown lists for better readability.
  * Refined markdown preview rendering.

* **Changes**
  * Removed preview-related toolbar controls from the markdown editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->