### PR TITLE
fix: remove duplicate custom allocation block in payout config

### DIFF
--- a/src/features/payout-disbursement/components/PayoutConfigurationContent.tsx
+++ b/src/features/payout-disbursement/components/PayoutConfigurationContent.tsx
@@ -209,19 +209,6 @@ export function PayoutConfigurationContent({
         amount: existingFinal?.amount || "",
       });
 
-      // Preserve custom allocations (not linked to milestones, not first/final)
-      if (existingAllocations) {
-        const milestoneUIDs = new Set(milestones.map((m) => m.uid));
-        const customAllocations = existingAllocations.filter(
-          (a) =>
-            a.label !== FIRST_PAYMENT_LABEL &&
-            a.label !== FINAL_PAYMENT_LABEL &&
-            !a.milestoneUID &&
-            !milestoneUIDs.has(a.milestoneUID ?? "")
-        );
-        allocations.push(...customAllocations);
-      }
-
       return allocations;
     },
     [milestones]


### PR DESCRIPTION
## Summary

- The second `customAllocations` block (lines 212-223) re-added custom line items that were already restored and tracked by `usedIds` in the first block (187-200), causing duplicate custom line items to appear in the payout configuration form.
- Removed the redundant second block entirely — the first block already handles custom allocation restoration correctly via the `usedIds` Set.

## Test plan

- [ ] Open payout configuration for a grant that has saved custom line items
- [ ] Verify custom line items appear exactly once (not duplicated)
- [ ] Save and reload to confirm persistence still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom allocations in payout configurations to ensure consistent and correct processing.

* **Refactor**
  * Simplified allocation processing logic by consolidating duplicate filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->