### PR TITLE
Remove dead updateMilestoneVerification function

### DIFF
--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -157,19 +157,6 @@ export async function updateMilestoneCompletion(
   return response.data.completion;
 }
 
-export async function updateMilestoneVerification(
-  referenceNumber: string,
-  milestoneFieldLabel: string,
-  milestoneTitle: string,
-  verificationComment?: string
-): Promise<void> {
-  await apiClient.post(`/v2/funding-applications/${referenceNumber}/milestone-completions/verify`, {
-    milestoneFieldLabel,
-    milestoneTitle,
-    verificationComment: verificationComment || "",
-  });
-}
-
 /**
  * Attest milestone completion as a program reviewer (backend creates on-chain attestation)
  */


### PR DESCRIPTION
## Summary

- Remove the unused `updateMilestoneVerification()` function from `services/milestones.ts`
- This function was exported but never imported anywhere in the codebase
- It called the now-removed deprecated verify endpoint on the indexer

**Related:** show-karma/gap-indexer PR that removes the backend endpoint

## Test plan
- [x] Verify `pnpm build` passes with no errors
- [x] Grep confirms no remaining references to `updateMilestoneVerification`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed milestone verification functionality from the system. This functionality is no longer available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->