### PR TITLE
feat: use whitelabel community as default agent chat context

### DIFF
--- a/__tests__/hooks/useAgentContextSync.test.ts
+++ b/__tests__/hooks/useAgentContextSync.test.ts
@@ -17,6 +17,13 @@ vi.mock("next/navigation", () => ({
   useParams: () => mockParams(),
 }));
 
+// Mock whitelabel context
+const mockWhitelabel = vi.fn<() => { communitySlug: string | null }>();
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: () => mockWhitelabel(),
+}));
+
 describe("useAgentContextSync", () => {
   beforeEach(() => {
     useAgentChatStore.setState({
@@ -24,6 +31,7 @@ describe("useAgentContextSync", () => {
     });
     mockPathname.mockReturnValue(null);
     mockParams.mockReturnValue({});
+    mockWhitelabel.mockReturnValue({ communitySlug: null });
   });
 
   describe("project pages", () => {
@@ -150,7 +158,7 @@ describe("useAgentContextSync", () => {
   });
 
   describe("non-context pages", () => {
-    it("should clear context on homepage", () => {
+    it("should clear context on homepage when not whitelabel", () => {
       useAgentChatStore.setState({
         agentContext: { projectId: "proj-old" },
       });
@@ -163,7 +171,7 @@ describe("useAgentContextSync", () => {
       expect(useAgentChatStore.getState().agentContext).toBeNull();
     });
 
-    it("should clear context on settings page", () => {
+    it("should clear context on settings page when not whitelabel", () => {
       useAgentChatStore.setState({
         agentContext: { programId: "prog-old" },
       });
@@ -187,6 +195,57 @@ describe("useAgentContextSync", () => {
       renderHook(() => useAgentContextSync());
 
       expect(useAgentChatStore.getState().agentContext).toBeNull();
+    });
+  });
+
+  describe("whitelabel community fallback", () => {
+    it("should use whitelabel communitySlug on non-context pages", () => {
+      mockWhitelabel.mockReturnValue({ communitySlug: "filecoin" });
+      mockPathname.mockReturnValue("/");
+      mockParams.mockReturnValue({});
+
+      renderHook(() => useAgentContextSync());
+
+      expect(useAgentChatStore.getState().agentContext).toEqual({
+        communityId: "filecoin",
+      });
+    });
+
+    it("should use whitelabel communitySlug on funding-map page", () => {
+      mockWhitelabel.mockReturnValue({ communitySlug: "filecoin" });
+      mockPathname.mockReturnValue("/funding-map");
+      mockParams.mockReturnValue({});
+
+      renderHook(() => useAgentContextSync());
+
+      expect(useAgentChatStore.getState().agentContext).toEqual({
+        communityId: "filecoin",
+      });
+    });
+
+    it("should prefer URL communityId over whitelabel fallback", () => {
+      mockWhitelabel.mockReturnValue({ communitySlug: "filecoin" });
+      mockPathname.mockReturnValue("/community/arbitrum/manage/");
+      mockParams.mockReturnValue({ communityId: "arbitrum" });
+
+      renderHook(() => useAgentContextSync());
+
+      expect(useAgentChatStore.getState().agentContext).toEqual({
+        communityId: "arbitrum",
+      });
+    });
+
+    it("should use whitelabel fallback on project pages alongside projectId", () => {
+      mockWhitelabel.mockReturnValue({ communitySlug: "filecoin" });
+      mockPathname.mockReturnValue("/project/my-project");
+      mockParams.mockReturnValue({ projectId: "proj-123" });
+
+      renderHook(() => useAgentContextSync());
+
+      // Project context takes priority — projectId is the primary context
+      expect(useAgentChatStore.getState().agentContext).toEqual({
+        projectId: "proj-123",
+      });
     });
   });
 

--- a/hooks/useAgentContextSync.ts
+++ b/hooks/useAgentContextSync.ts
@@ -3,6 +3,7 @@
 import { useParams, usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { useAgentChatStore } from "@/store/agentChat";
+import { useWhitelabel } from "@/utilities/whitelabel-context";
 
 /**
  * Syncs the current page context (project, program, or application) to
@@ -16,6 +17,7 @@ export function useAgentContextSync() {
   const pathname = usePathname();
   const params = useParams();
   const setAgentContext = useAgentChatStore((s) => s.setAgentContext);
+  const { communitySlug: whitelabelCommunity } = useWhitelabel();
 
   const projectId = params?.projectId as string | undefined;
   const applicationId = params?.applicationId as string | undefined;
@@ -44,7 +46,19 @@ export function useAgentContextSync() {
       return;
     }
 
-    // No recognized context page — clear context
-    setAgentContext(null);
-  }, [pathname, projectId, applicationId, communityId, cleanProgramId, setAgentContext]);
+    // No recognized context page — fall back to whitelabel community if available
+    if (whitelabelCommunity) {
+      setAgentContext({ communityId: whitelabelCommunity });
+    } else {
+      setAgentContext(null);
+    }
+  }, [
+    pathname,
+    projectId,
+    applicationId,
+    communityId,
+    cleanProgramId,
+    whitelabelCommunity,
+    setAgentContext,
+  ]);
 }


### PR DESCRIPTION
## Overview

On whitelabel domains (e.g. `app.filpgf.io`), the agent chat now automatically knows which community it's in — even on pages that don't have a community ID in the URL.

## Problem

When a user on `app.filpgf.io` asks the agent chat about "this community" on the homepage, `/funding-map`, or any non-community-scoped page, the agent had no community context. It only received `communityId` when the URL contained `/community/[communityId]/manage/...`.

## Solution

`useAgentContextSync` now falls back to the whitelabel's `communitySlug` when no URL-based context is detected. The priority chain:

1. **URL params** — `/community/arbitrum/manage/...` → `arbitrum` (unchanged)
2. **Whitelabel domain** — `app.filpgf.io` on any other page → `filecoin`
3. **No whitelabel** — `karmahq.xyz` → `null` (unchanged)

## Why This Approach

The whitelabel context (`useWhitelabel`) already resolves the domain to a `communitySlug` — we just weren't using it in the agent chat context sync. This is the minimal change: one import, one fallback branch.

## Technical Details

**Files changed:**
- `hooks/useAgentContextSync.ts` — Import `useWhitelabel`, use `communitySlug` as fallback when no URL context matches
- `__tests__/hooks/useAgentContextSync.test.ts` — 4 new tests covering whitelabel fallback, URL precedence, and non-whitelabel behavior

```mermaid
graph TD
    A[useAgentContextSync] --> B{URL has /project/:id?}
    B -->|Yes| C[setAgentContext projectId]
    B -->|No| D{URL has /manage/ + communityId?}
    D -->|Yes| E[setAgentContext from URL params]
    D -->|No| F{Whitelabel domain?}
    F -->|Yes| G["setAgentContext { communityId: communitySlug }"]
    F -->|No| H[setAgentContext null]
```

## Testing Steps

1. Visit `app.filpgf.io` homepage → agent chat should have `communityId: "filecoin"` context
2. Visit `app.filpgf.io/funding-map` → same Filecoin context
3. Visit `app.filpgf.io/community/arbitrum/manage/` → context should be `arbitrum` (URL takes precedence)
4. Visit `karmahq.xyz/` → agent context should be `null` (no whitelabel fallback)

## Checklist

- [x] Tests added (4 new tests, all passing)
- [x] Existing tests updated and passing (18 total)
- [x] No breaking changes
- [x] Linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent context now utilizes whitelabel community settings as a fallback on applicable pages
  * Community context is preserved from whitelabel configuration when navigating certain routes

* **Tests**
  * Expanded test coverage for whitelabel community fallback scenarios and context precedence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->