### PR TITLE
fix: use provider-level chain verification for cross-chain donations

### DIFF
--- a/hooks/donation/useSingleProjectDonation.ts
+++ b/hooks/donation/useSingleProjectDonation.ts
@@ -12,6 +12,7 @@ import { useNetworkSwitching } from "@/hooks/useNetworkSwitching";
 import { getPayoutAddressForChain } from "@/src/features/chain-payout-address/hooks/use-chain-payout-address";
 import { DonationType, PaymentMethod } from "@/types/donations";
 import type { DonationPayment } from "@/utilities/donations/donationExecution";
+import { getShortErrorMessage } from "@/utilities/donations/errorMessages";
 
 export const useSingleProjectDonation = (
   project: SingleProjectDonateModalProps["project"],
@@ -129,7 +130,7 @@ export const useSingleProjectDonation = (
       }
     } catch (error) {
       console.error("Donation execution failed:", error);
-      toast.error(error instanceof Error ? error.message : "Donation failed");
+      toast.error(getShortErrorMessage(error));
     }
   }, [
     selectedToken,

--- a/hooks/useDonationTransfer.ts
+++ b/hooks/useDonationTransfer.ts
@@ -1,15 +1,8 @@
 import { useCallback, useState } from "react";
 import { type Address, getAddress, type PublicClient, parseUnits } from "viem";
-import {
-  useAccount,
-  usePublicClient,
-  useWaitForTransactionReceipt,
-  useWalletClient,
-  useWriteContract,
-} from "wagmi";
+import { useAccount, usePublicClient, useWaitForTransactionReceipt, useWalletClient } from "wagmi";
 import { TRANSACTION_CONSTANTS } from "@/constants/donation";
 import type { DonationPayment } from "@/store/donationCart";
-import { validateChainSync } from "@/utilities/chainSyncValidation";
 import {
   BATCH_DONATIONS_CONTRACTS,
   BatchDonationsABI,
@@ -72,7 +65,6 @@ export function useDonationTransfer() {
   const { address } = useAccount();
   const publicClient = usePublicClient();
   const { data: walletClient, refetch: refetchWalletClient } = useWalletClient();
-  const { writeContractAsync } = useWriteContract();
   const [transfers, setTransfers] = useState<TransferResult[]>([]);
   const [isExecuting, setIsExecuting] = useState(false);
   const [executionState, setExecutionState] = useState<DonationExecutionState>({
@@ -356,20 +348,33 @@ export function useDonationTransfer() {
             );
           }
 
-          // Critical: Validate chain synchronization before executing donations
-          try {
-            await validateChainSync(currentWalletClient, chainId, "batch donations");
-          } catch (error) {
-            // Try one more time with a fresh wallet client
-            await new Promise((resolve) => setTimeout(resolve, 2000));
+          // Verify the ACTUAL provider chain, not the wallet client's .chain property.
+          // After wagmi's switchChain, the wallet client object may report the new chain
+          // in .chain.id, but the underlying provider/transport can still be on the old chain.
+          // getChainId() queries the real provider.
+          const actualProviderChainId = await currentWalletClient.getChainId();
+          if (actualProviderChainId !== chainId) {
+            // The provider didn't actually switch — force it via the wallet client
+            if (typeof currentWalletClient.switchChain === "function") {
+              await currentWalletClient.switchChain({ id: chainId });
+              // Wait briefly for the switch to propagate
+              await new Promise((resolve) => setTimeout(resolve, 1500));
+            }
 
+            // Refetch to get a wallet client whose transport is on the correct chain
             const result = await refetchWalletClient();
-            const freshClient = result.data;
-            if (freshClient) {
-              await validateChainSync(freshClient, chainId, "batch donations");
-              currentWalletClient = freshClient;
-            } else {
-              throw error; // Re-throw the original validation error
+            if (result.data) {
+              currentWalletClient = result.data;
+            }
+
+            // Final verification
+            const verifiedChainId = await currentWalletClient.getChainId();
+            if (verifiedChainId !== chainId) {
+              throw new Error(
+                `Failed to switch wallet to chain ${chainId}. ` +
+                  `Wallet is still on chain ${verifiedChainId}. ` +
+                  `Please switch to the correct network in your wallet and try again.`
+              );
             }
           }
 
@@ -485,7 +490,12 @@ export function useDonationTransfer() {
             });
           }
 
-          const hash = await writeContractAsync({
+          // Use viem's walletClient.writeContract directly instead of wagmi's
+          // writeContractAsync. Wagmi's hook checks the connector's chain state,
+          // which can be stale after a network switch.
+          // We omit the `chain` parameter so viem doesn't assert against the
+          // provider's chain — we've already verified it via getChainId() above.
+          const hash = await currentWalletClient.writeContract({
             address: getAddress(contractAddress),
             abi: BatchDonationsABI,
             functionName: hasTokenTransfers ? "batchDonateWithPermit" : "batchDonate",
@@ -493,7 +503,8 @@ export function useDonationTransfer() {
               hasTokenTransfers && permit && permitSignature
                 ? [donations, permit, permitSignature]
                 : [donations],
-            chainId,
+            chain: null,
+            account: address as Address,
             ...(totalEth > 0n ? { value: totalEth } : {}),
           });
 
@@ -600,7 +611,6 @@ export function useDonationTransfer() {
       address,
       publicClient,
       walletClient,
-      writeContractAsync,
       checkApprovals,
       executeApprovalTransactions,
       refetchWalletClient,


### PR DESCRIPTION
## Summary
- Fix cross-chain donation "chain does not match" error by verifying the actual provider chain via `getChainId()` instead of trusting `walletClient.chain.id` (which can be stale after wagmi's `switchChain`)
- Force chain switch directly on the wallet client when the provider hasn't actually switched
- Use viem's `walletClient.writeContract` instead of wagmi's `writeContractAsync` to avoid stale connector state
- Show user-friendly error toasts (e.g., "Transaction cancelled by user") instead of raw viem errors with full request arguments

## Root Cause
After wagmi's `switchChainAsync`, the returned wallet client's `.chain.id` reflects the new chain (from wagmi's config), but the **underlying provider/transport** can still be on the old chain. `validateChainSync` checked `.chain.id` and passed, then viem's `writeContract` queried the actual provider and threw a mismatch.

## Test plan
- [ ] Open a project page (e.g., `/project/desci-asia`)
- [ ] Click Donate, select a token on a **different chain** than your wallet's current chain
- [ ] Enter amount and click Donate — verify the chain switch happens and transaction proceeds
- [ ] Reject the transaction in the wallet — verify a short toast "Transaction cancelled by user" appears (not a giant error dump)
- [ ] Test with same-chain donation to ensure no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for failed donation transactions with clearer feedback
  * Enhanced wallet chain validation to verify correct network before donation processing
  * Added user guidance to switch networks if validation detects a mismatch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->