### PR TITLE
feat(grant-atlas): improve philanthropy result pagination and grant context

### DIFF
--- a/app/grant-atlas/foundations/[id]/page.tsx
+++ b/app/grant-atlas/foundations/[id]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { FoundationDetail } from "@/src/features/grant-atlas/components/foundation-detail";
+
+export default function FoundationPage() {
+  const params = useParams<{ id: string }>();
+  return (
+    <main className="w-full">
+      <FoundationDetail id={params.id} />
+    </main>
+  );
+}

--- a/app/grant-atlas/grants/[id]/page.tsx
+++ b/app/grant-atlas/grants/[id]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { GrantDetail } from "@/src/features/grant-atlas/components/grant-detail";
+
+export default function GrantPage() {
+  const params = useParams<{ id: string }>();
+  return (
+    <main className="w-full">
+      <GrantDetail id={params.id} />
+    </main>
+  );
+}

--- a/app/grant-atlas/nonprofits/[id]/page.tsx
+++ b/app/grant-atlas/nonprofits/[id]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { NonprofitDetail } from "@/src/features/grant-atlas/components/nonprofit-detail";
+
+export default function NonprofitPage() {
+  const params = useParams<{ id: string }>();
+  return (
+    <main className="w-full">
+      <NonprofitDetail id={params.id} />
+    </main>
+  );
+}

--- a/app/grant-atlas/page.tsx
+++ b/app/grant-atlas/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { GrantAtlasSearch } from "@/src/features/grant-atlas/components/grant-atlas-chat";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "Grant Atlas — Philanthropy Intelligence",
+  description:
+    "Search foundations, nonprofits, and grants using natural language. AI-powered search across IRS 990PF filings.",
+  path: "/grant-atlas",
+});
+
+export default function GrantAtlasPage() {
+  return (
+    <main className="w-full">
+      <GrantAtlasSearch />
+    </main>
+  );
+}

--- a/src/components/navbar/menu-items.tsx
+++ b/src/components/navbar/menu-items.tsx
@@ -2,6 +2,7 @@ import {
   BanknoteArrowDown,
   BellDot,
   GalleryThumbnails,
+  Globe,
   GoalIcon,
   LayoutGrid,
   LayoutList,
@@ -104,6 +105,11 @@ export const exploreItems: ExploreItems = {
       href: PAGES.REGISTRY.ROOT,
       icon: Radio,
       title: "Funding Map",
+    },
+    {
+      href: PAGES.GRANT_ATLAS.ROOT,
+      icon: Globe,
+      title: "Grant Atlas",
     },
   ],
 };

--- a/src/features/grant-atlas/components/foundation-detail.tsx
+++ b/src/features/grant-atlas/components/foundation-detail.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { ArrowLeft, Building2, Landmark, MapPin } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PAGES } from "@/utilities/pages";
+import {
+  useFoundation,
+  useFoundationFinancials,
+  useFoundationGrants,
+  useFoundationOfficers,
+} from "../hooks/use-foundation";
+import type { Financials, Grant, Officer } from "../types/philanthropy";
+
+function formatCurrency(amount: number | null | undefined): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function GrantsTable({ grants }: { grants: Grant[] }) {
+  if (grants.length === 0) {
+    return <p className="text-sm text-zinc-500">No grants found.</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 text-left text-xs font-medium uppercase text-zinc-500 dark:border-zinc-800">
+            <th className="pb-2 pr-4">Recipient / Purpose</th>
+            <th className="pb-2 pr-4">Amount</th>
+            <th className="pb-2 pr-4">Year</th>
+          </tr>
+        </thead>
+        <tbody>
+          {grants.map((grant) => (
+            <tr key={grant.id} className="border-b border-zinc-100 dark:border-zinc-800/50">
+              <td className="py-3 pr-4">
+                <Link
+                  href={PAGES.GRANT_ATLAS.GRANT(grant.id)}
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {grant.purposeText || "No purpose listed"}
+                </Link>
+              </td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(grant.amount)}</td>
+              <td className="py-3 pr-4">{grant.filingYear}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function OfficersTable({ officers }: { officers: Officer[] }) {
+  if (officers.length === 0) {
+    return <p className="text-sm text-zinc-500">No officers found.</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 text-left text-xs font-medium uppercase text-zinc-500 dark:border-zinc-800">
+            <th className="pb-2 pr-4">Name</th>
+            <th className="pb-2 pr-4">Title</th>
+            <th className="pb-2 pr-4">Compensation</th>
+            <th className="pb-2 pr-4">Benefits</th>
+            <th className="pb-2 pr-4">Year</th>
+          </tr>
+        </thead>
+        <tbody>
+          {officers.map((officer) => (
+            <tr key={officer.id} className="border-b border-zinc-100 dark:border-zinc-800/50">
+              <td className="py-3 pr-4 font-medium">{officer.name}</td>
+              <td className="py-3 pr-4">{officer.title || "—"}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(officer.compensation)}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(officer.benefits)}</td>
+              <td className="py-3 pr-4">{officer.filingYear}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function FinancialsTable({ financials }: { financials: Financials[] }) {
+  if (financials.length === 0) {
+    return <p className="text-sm text-zinc-500">No financial data found.</p>;
+  }
+
+  const sorted = [...financials].sort((a, b) => b.filingYear - a.filingYear);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 text-left text-xs font-medium uppercase text-zinc-500 dark:border-zinc-800">
+            <th className="pb-2 pr-4">Year</th>
+            <th className="pb-2 pr-4">Revenue</th>
+            <th className="pb-2 pr-4">Expenses</th>
+            <th className="pb-2 pr-4">Total Assets</th>
+            <th className="pb-2 pr-4">Net Assets</th>
+            <th className="pb-2 pr-4">Qualifying Dist.</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((fin) => (
+            <tr key={fin.id} className="border-b border-zinc-100 dark:border-zinc-800/50">
+              <td className="py-3 pr-4 font-medium">{fin.filingYear}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(fin.totalRevenue)}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(fin.totalExpenses)}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(fin.totalAssets)}</td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(fin.netAssets)}</td>
+              <td className="py-3 pr-4 tabular-nums">
+                {formatCurrency(fin.qualifyingDistributions)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const tabs = ["Grants", "Officers", "Financials"] as const;
+type Tab = (typeof tabs)[number];
+
+export function FoundationDetail({ id }: { id: string }) {
+  const { data: foundation, isLoading } = useFoundation(id);
+  const { data: grants, isLoading: grantsLoading } = useFoundationGrants(id);
+  const { data: officers, isLoading: officersLoading } = useFoundationOfficers(id);
+  const { data: financials, isLoading: financialsLoading } = useFoundationFinancials(id);
+
+  const [activeTab, setActiveTab] = useState<Tab>("Grants");
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-96" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!foundation) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-16 text-center">
+        <h1 className="text-lg font-medium text-zinc-900 dark:text-zinc-100">
+          Foundation not found
+        </h1>
+        <Link
+          href={PAGES.GRANT_ATLAS.ROOT}
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
+        >
+          Back to Grant Atlas
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-8">
+      <Link
+        href={PAGES.GRANT_ATLAS.ROOT}
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+      >
+        <ArrowLeft className="size-3.5" />
+        Grant Atlas
+      </Link>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/30">
+            <Landmark className="size-5 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              {foundation.name}
+            </h1>
+            <div className="flex items-center gap-3 text-sm text-zinc-500">
+              <span>EIN: {foundation.ein}</span>
+              {foundation.location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="size-3" />
+                  {foundation.location}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        {foundation.description && (
+          <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">{foundation.description}</p>
+        )}
+        {foundation.totalAssets != null && (
+          <div className="mt-4 inline-flex items-center gap-2 rounded-lg bg-zinc-50 px-3 py-2 dark:bg-zinc-800">
+            <span className="text-xs text-zinc-500">Total Assets</span>
+            <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              {formatCurrency(foundation.totalAssets)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-zinc-200 dark:border-zinc-800">
+        <div className="flex gap-6">
+          {tabs.map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
+                activeTab === tab
+                  ? "border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400"
+                  : "border-transparent text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+              }`}
+            >
+              {tab}
+              {tab === "Grants" && grants && (
+                <span className="ml-1.5 text-xs text-zinc-400">({grants.length})</span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="mt-6">
+        {activeTab === "Grants" &&
+          (grantsLoading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : (
+            <GrantsTable grants={grants ?? []} />
+          ))}
+        {activeTab === "Officers" &&
+          (officersLoading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : (
+            <OfficersTable officers={officers ?? []} />
+          ))}
+        {activeTab === "Financials" &&
+          (financialsLoading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : (
+            <FinancialsTable financials={financials ?? []} />
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/grant-atlas/components/grant-atlas-chat.tsx
+++ b/src/features/grant-atlas/components/grant-atlas-chat.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { Globe, Loader2, Search } from "lucide-react";
+import { useCallback, useState } from "react";
+import { MessageResponse } from "@/src/components/ai-elements/message-response";
+import { usePhilanthropySearch } from "../hooks/use-philanthropy-stream";
+import { useGrantAtlasStore } from "../store/philanthropy-chat";
+import { RankedEntityCard } from "./ranked-entity-card";
+import { SuggestedQueries } from "./suggested-queries";
+
+export function GrantAtlasSearch() {
+  const { query, narrative, result, isSearching, error } = useGrantAtlasStore();
+  const { search } = usePhilanthropySearch();
+  const [inputValue, setInputValue] = useState("");
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const text = inputValue.trim();
+      if (!text || isSearching) return;
+      search(text);
+    },
+    [inputValue, isSearching, search]
+  );
+
+  const handleSuggestionSelect = useCallback(
+    (q: string) => {
+      setInputValue(q);
+      search(q);
+    },
+    [search]
+  );
+
+  const hasResults = Boolean(query);
+  const currentPage = result?.pagination.page ?? 1;
+  const totalCount = result?.pagination.totalCount ?? 0;
+  const rangeStart =
+    result && result.pagination.returned > 0
+      ? (result.pagination.page - 1) * result.pagination.limit + 1
+      : 0;
+  const rangeEnd =
+    result && result.pagination.returned > 0 ? rangeStart + result.pagination.returned - 1 : 0;
+
+  return (
+    <div className={`flex flex-col ${hasResults ? "" : "min-h-[calc(100vh-4rem)]"}`}>
+      {/* Search header — always visible */}
+      <div
+        className={`flex flex-col items-center gap-6 px-4 ${
+          hasResults ? "pb-6 pt-8" : "flex-1 justify-center pb-8"
+        }`}
+      >
+        {!hasResults && (
+          <div className="flex flex-col items-center gap-3">
+            <div className="flex size-12 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-900/30">
+              <Globe className="size-6 text-blue-600 dark:text-blue-400" />
+            </div>
+            <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">Grant Atlas</h1>
+            <p className="max-w-md text-center text-sm text-zinc-500">
+              Search foundations, nonprofits, and grants using natural language. Powered by IRS
+              990PF data.
+            </p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="w-full max-w-2xl">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-zinc-400" />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="Search philanthropy data..."
+              className="w-full rounded-xl border border-zinc-200 bg-white py-3 pl-11 pr-24 text-sm text-zinc-900 shadow-sm outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-300 focus:ring-2 focus:ring-blue-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:border-blue-600 dark:focus:ring-blue-900/40"
+            />
+            <button
+              type="submit"
+              disabled={isSearching || !inputValue.trim()}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg bg-blue-600 px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-40 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              {isSearching ? <Loader2 className="size-3.5 animate-spin" /> : "Search"}
+            </button>
+          </div>
+        </form>
+
+        {!hasResults && (
+          <div className="w-full max-w-2xl">
+            <SuggestedQueries onSelect={handleSuggestionSelect} />
+          </div>
+        )}
+      </div>
+
+      {/* Results area */}
+      {hasResults && (
+        <div className="mx-auto w-full max-w-3xl px-4 pb-12">
+          {/* Query echo */}
+          <div className="mb-6 border-b border-zinc-100 pb-4 dark:border-zinc-800">
+            <p className="text-xs text-zinc-400">Results for</p>
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{query}</p>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          {/* Narrative answer */}
+          {(narrative || isSearching) && (
+            <div className="mb-8">
+              <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">
+                Answer
+              </h2>
+              <div className="rounded-lg border border-zinc-200 bg-white p-5 text-sm text-zinc-700 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+                {narrative ? (
+                  <MessageResponse>{narrative}</MessageResponse>
+                ) : (
+                  <div className="flex items-center gap-2 text-zinc-400">
+                    <Loader2 className="size-4 animate-spin" />
+                    <span>Analyzing...</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Entity results */}
+          {result && result.entities.length > 0 && (
+            <div>
+              <div className="mb-3 flex items-baseline justify-between">
+                <h2 className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  <span className="capitalize">{result.intent.targetEntityType}</span>
+                  {totalCount !== 1 ? "s" : ""} results
+                </h2>
+                <span className="text-xs text-zinc-400">
+                  Showing {rangeStart}-{rangeEnd} of {totalCount}
+                </span>
+              </div>
+              <div className="grid gap-3">
+                {result.entities.map((entity, i) => (
+                  <RankedEntityCard key={entity.id} entity={entity} rank={i + 1} />
+                ))}
+              </div>
+              {(result.pagination.hasPreviousPage || result.pagination.hasNextPage) && (
+                <div className="mt-4 flex items-center justify-between">
+                  <button
+                    type="button"
+                    onClick={() => search(query, currentPage - 1)}
+                    disabled={!result.pagination.hasPreviousPage || isSearching}
+                    className="rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+                  >
+                    Previous
+                  </button>
+                  <span className="text-xs text-zinc-500">Page {result.pagination.page}</span>
+                  <button
+                    type="button"
+                    onClick={() => search(query, currentPage + 1)}
+                    disabled={!result.pagination.hasNextPage || isSearching}
+                    className="rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* No results */}
+          {result && result.entities.length === 0 && !isSearching && !narrative && (
+            <p className="text-sm text-zinc-500">No results found. Try a different search.</p>
+          )}
+
+          {/* Loading skeleton for entities */}
+          {isSearching && !result && (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="h-32 animate-pulse rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/grant-atlas/components/grant-atlas-chat.tsx
+++ b/src/features/grant-atlas/components/grant-atlas-chat.tsx
@@ -106,7 +106,7 @@ export function GrantAtlasSearch() {
           )}
 
           {/* Narrative answer */}
-          {(narrative || isSearching) && (
+          {(narrative || (isSearching && !result)) && (
             <div className="mb-8">
               <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">
                 Answer

--- a/src/features/grant-atlas/components/grant-detail.tsx
+++ b/src/features/grant-atlas/components/grant-detail.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { ArrowLeft, HandCoins } from "lucide-react";
+import Link from "next/link";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PAGES } from "@/utilities/pages";
+import { useGrant } from "../hooks/use-grant";
+
+function formatCurrency(amount: number | null | undefined): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function GrantDetail({ id }: { id: string }) {
+  const { data: grant, isLoading } = useGrant(id);
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-96" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (!grant) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-16 text-center">
+        <h1 className="text-lg font-medium text-zinc-900 dark:text-zinc-100">Grant not found</h1>
+        <Link
+          href={PAGES.GRANT_ATLAS.ROOT}
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
+        >
+          Back to Grant Atlas
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-8">
+      <Link
+        href={PAGES.GRANT_ATLAS.ROOT}
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+      >
+        <ArrowLeft className="size-3.5" />
+        Grant Atlas
+      </Link>
+
+      <div className="mb-8">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-amber-50 dark:bg-amber-900/30">
+            <HandCoins className="size-5 text-amber-600 dark:text-amber-400" />
+          </div>
+          <h1 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">Grant Detail</h1>
+        </div>
+      </div>
+
+      <div className="space-y-6 rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        {grant.purposeText && (
+          <div>
+            <h3 className="text-xs font-medium uppercase text-zinc-500">Purpose</h3>
+            <p className="mt-1 text-sm text-zinc-900 dark:text-zinc-100">{grant.purposeText}</p>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-6 sm:grid-cols-3">
+          <div>
+            <h3 className="text-xs font-medium uppercase text-zinc-500">Amount</h3>
+            <p className="mt-1 text-lg font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+              {formatCurrency(grant.amount)}
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-medium uppercase text-zinc-500">Filing Year</h3>
+            <p className="mt-1 text-sm text-zinc-900 dark:text-zinc-100">{grant.filingYear}</p>
+          </div>
+
+          {grant.date && (
+            <div>
+              <h3 className="text-xs font-medium uppercase text-zinc-500">Date</h3>
+              <p className="mt-1 text-sm text-zinc-900 dark:text-zinc-100">
+                {new Date(grant.date).toLocaleDateString()}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-4 border-t border-zinc-200 pt-4 dark:border-zinc-800">
+          <Link
+            href={PAGES.GRANT_ATLAS.FOUNDATION(grant.foundationId)}
+            className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+          >
+            View Foundation
+          </Link>
+          {grant.nonprofitId && (
+            <Link
+              href={PAGES.GRANT_ATLAS.NONPROFIT(grant.nonprofitId)}
+              className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+            >
+              View Nonprofit Recipient
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/grant-atlas/components/nonprofit-detail.tsx
+++ b/src/features/grant-atlas/components/nonprofit-detail.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ArrowLeft, Building2, MapPin } from "lucide-react";
+import Link from "next/link";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PAGES } from "@/utilities/pages";
+import { useNonprofit, useNonprofitGrants } from "../hooks/use-nonprofit";
+import type { Grant } from "../types/philanthropy";
+
+function formatCurrency(amount: number | null | undefined): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function GrantsReceivedTable({ grants }: { grants: Grant[] }) {
+  if (grants.length === 0) {
+    return <p className="text-sm text-zinc-500">No grants received.</p>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 text-left text-xs font-medium uppercase text-zinc-500 dark:border-zinc-800">
+            <th className="pb-2 pr-4">Purpose</th>
+            <th className="pb-2 pr-4">Amount</th>
+            <th className="pb-2 pr-4">Year</th>
+            <th className="pb-2 pr-4">Foundation</th>
+          </tr>
+        </thead>
+        <tbody>
+          {grants.map((grant) => (
+            <tr key={grant.id} className="border-b border-zinc-100 dark:border-zinc-800/50">
+              <td className="py-3 pr-4">
+                <Link
+                  href={PAGES.GRANT_ATLAS.GRANT(grant.id)}
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {grant.purposeText || "No purpose listed"}
+                </Link>
+              </td>
+              <td className="py-3 pr-4 tabular-nums">{formatCurrency(grant.amount)}</td>
+              <td className="py-3 pr-4">{grant.filingYear}</td>
+              <td className="py-3 pr-4">
+                <Link
+                  href={PAGES.GRANT_ATLAS.FOUNDATION(grant.foundationId)}
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  View foundation
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function NonprofitDetail({ id }: { id: string }) {
+  const { data: nonprofit, isLoading } = useNonprofit(id);
+  const { data: grants, isLoading: grantsLoading } = useNonprofitGrants(id);
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-4 w-96" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!nonprofit) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-16 text-center">
+        <h1 className="text-lg font-medium text-zinc-900 dark:text-zinc-100">
+          Nonprofit not found
+        </h1>
+        <Link
+          href={PAGES.GRANT_ATLAS.ROOT}
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
+        >
+          Back to Grant Atlas
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-8">
+      <Link
+        href={PAGES.GRANT_ATLAS.ROOT}
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+      >
+        <ArrowLeft className="size-3.5" />
+        Grant Atlas
+      </Link>
+
+      <div className="mb-8">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-green-50 dark:bg-green-900/30">
+            <Building2 className="size-5 text-green-600 dark:text-green-400" />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              {nonprofit.name}
+            </h1>
+            <div className="flex items-center gap-3 text-sm text-zinc-500">
+              {nonprofit.ein && <span>EIN: {nonprofit.ein}</span>}
+              {nonprofit.location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="size-3" />
+                  {nonprofit.location}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        {nonprofit.description && (
+          <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">{nonprofit.description}</p>
+        )}
+      </div>
+
+      <h2 className="mb-4 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+        Grants Received
+        {grants && <span className="ml-1.5 text-zinc-400">({grants.length})</span>}
+      </h2>
+
+      {grantsLoading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : (
+        <GrantsReceivedTable grants={grants ?? []} />
+      )}
+    </div>
+  );
+}

--- a/src/features/grant-atlas/components/ranked-entity-card.tsx
+++ b/src/features/grant-atlas/components/ranked-entity-card.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Building2, HandCoins, Landmark, MapPin } from "lucide-react";
+import Link from "next/link";
+import { PAGES } from "@/utilities/pages";
+import type { RankedEntity } from "../types/philanthropy";
+
+function formatCurrency(amount: number | null): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function getEntityHref(entity: RankedEntity): string {
+  switch (entity.entityType) {
+    case "foundation":
+      return PAGES.GRANT_ATLAS.FOUNDATION(entity.id);
+    case "nonprofit":
+      return PAGES.GRANT_ATLAS.NONPROFIT(entity.id);
+    case "grant":
+      return PAGES.GRANT_ATLAS.GRANT(entity.id);
+  }
+}
+
+function EntityTypeBadge({ type }: { type: RankedEntity["entityType"] }) {
+  const config = {
+    foundation: {
+      icon: Landmark,
+      label: "Foundation",
+      bg: "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+    },
+    nonprofit: {
+      icon: Building2,
+      label: "Nonprofit",
+      bg: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+    },
+    grant: {
+      icon: HandCoins,
+      label: "Grant",
+      bg: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    },
+  }[type];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ${config.bg}`}
+    >
+      <config.icon className="size-3" />
+      {config.label}
+    </span>
+  );
+}
+
+function getTitle(entity: RankedEntity): string {
+  if (entity.name) return entity.name;
+  if (entity.description) return entity.description;
+  return "Untitled";
+}
+
+function getSubtitle(entity: RankedEntity): string | null {
+  // For grants, show description if name exists (won't be used as title)
+  // For foundations/nonprofits, show description
+  if (entity.entityType === "grant" && entity.name && entity.description) {
+    return entity.description;
+  }
+  if (entity.entityType !== "grant" && entity.description && entity.name) {
+    return entity.description;
+  }
+  return null;
+}
+
+interface RankedEntityCardProps {
+  entity: RankedEntity;
+  rank: number;
+}
+
+export function RankedEntityCard({ entity, rank }: RankedEntityCardProps) {
+  const href = getEntityHref(entity);
+  const title = getTitle(entity);
+  const subtitle = getSubtitle(entity);
+  const grantFoundationLabel = entity.entityType === "grant" ? entity.foundationName : null;
+
+  return (
+    <Link
+      href={href}
+      className="block rounded-lg border border-zinc-200 bg-white p-5 transition-colors hover:border-zinc-300 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          {/* Type badge + EIN */}
+          <div className="flex items-center gap-2">
+            <EntityTypeBadge type={entity.entityType} />
+            {entity.ein && <span className="text-xs text-zinc-400">EIN: {entity.ein}</span>}
+          </div>
+
+          {/* Title */}
+          <h3 className="mt-2 text-base font-semibold text-zinc-900 dark:text-zinc-100">{title}</h3>
+
+          {/* Subtitle / description */}
+          {subtitle && <p className="mt-1 line-clamp-2 text-sm text-zinc-500">{subtitle}</p>}
+
+          {grantFoundationLabel && (
+            <p className="mt-1 text-sm text-zinc-500">
+              From{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {grantFoundationLabel}
+              </span>
+            </p>
+          )}
+
+          {/* Location */}
+          {entity.location && (
+            <div className="mt-2 flex items-center gap-1 text-sm text-zinc-500">
+              <MapPin className="size-3.5" />
+              {entity.location}
+            </div>
+          )}
+        </div>
+
+        {/* Rank number */}
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+          {rank}
+        </span>
+      </div>
+
+      {/* Financial data row — Candid-style */}
+      {(entity.totalAssets != null || entity.amount != null || entity.filingYear) && (
+        <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 border-t border-zinc-100 pt-3 dark:border-zinc-800">
+          {entity.totalAssets != null && (
+            <div>
+              <span className="text-xs text-zinc-400">Total assets</span>
+              <p className="text-sm font-medium tabular-nums text-zinc-900 dark:text-zinc-100">
+                {formatCurrency(entity.totalAssets)}
+              </p>
+            </div>
+          )}
+          {entity.amount != null && (
+            <div>
+              <span className="text-xs text-zinc-400">Grant amount</span>
+              <p className="text-sm font-medium tabular-nums text-zinc-900 dark:text-zinc-100">
+                {formatCurrency(entity.amount)}
+              </p>
+            </div>
+          )}
+          {entity.filingYear && (
+            <div>
+              <span className="text-xs text-zinc-400">Filing year</span>
+              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                {entity.filingYear}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/src/features/grant-atlas/components/suggested-queries.tsx
+++ b/src/features/grant-atlas/components/suggested-queries.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Lightbulb, Search, TrendingUp, Users } from "lucide-react";
+
+const suggestions = [
+  {
+    icon: TrendingUp,
+    label: "Who are the largest education funders?",
+  },
+  {
+    icon: Search,
+    label: "Find foundations funding climate change research",
+  },
+  {
+    icon: Users,
+    label: "Nonprofits receiving healthcare grants in California",
+  },
+  {
+    icon: Lightbulb,
+    label: "Emerging trends in arts and culture philanthropy",
+  },
+];
+
+interface SuggestedQueriesProps {
+  onSelect: (query: string) => void;
+}
+
+export function SuggestedQueries({ onSelect }: SuggestedQueriesProps) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {suggestions.map((suggestion) => (
+        <button
+          key={suggestion.label}
+          type="button"
+          onClick={() => onSelect(suggestion.label)}
+          className="flex items-start gap-3 rounded-lg border border-zinc-200 bg-white p-4 text-left text-sm text-zinc-700 transition-colors hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:bg-zinc-800/80"
+        >
+          <suggestion.icon className="mt-0.5 size-4 shrink-0 text-zinc-400" />
+          <span>{suggestion.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/grant-atlas/hooks/use-foundation.ts
+++ b/src/features/grant-atlas/hooks/use-foundation.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { philanthropyService } from "../services/philanthropy.service";
+
+export const foundationKeys = {
+  all: ["philanthropy", "foundation"] as const,
+  detail: (id: string) => [...foundationKeys.all, id] as const,
+  grants: (id: string) => [...foundationKeys.all, id, "grants"] as const,
+  officers: (id: string) => [...foundationKeys.all, id, "officers"] as const,
+  financials: (id: string) => [...foundationKeys.all, id, "financials"] as const,
+  filing: (id: string, year: number) => [...foundationKeys.all, id, "filing", year] as const,
+};
+
+export function useFoundation(id: string) {
+  return useQuery({
+    queryKey: foundationKeys.detail(id),
+    queryFn: () => philanthropyService.getFoundation(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationGrants(id: string) {
+  return useQuery({
+    queryKey: foundationKeys.grants(id),
+    queryFn: () => philanthropyService.getFoundationGrants(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationOfficers(id: string) {
+  return useQuery({
+    queryKey: foundationKeys.officers(id),
+    queryFn: () => philanthropyService.getFoundationOfficers(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationFinancials(id: string) {
+  return useQuery({
+    queryKey: foundationKeys.financials(id),
+    queryFn: () => philanthropyService.getFoundationFinancials(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationFiling(id: string, year: number) {
+  return useQuery({
+    queryKey: foundationKeys.filing(id, year),
+    queryFn: () => philanthropyService.getFoundationFiling(id, year),
+    enabled: Boolean(id) && year > 0,
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/src/features/grant-atlas/hooks/use-grant.ts
+++ b/src/features/grant-atlas/hooks/use-grant.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { philanthropyService } from "../services/philanthropy.service";
+
+export const grantKeys = {
+  all: ["philanthropy", "grant"] as const,
+  detail: (id: string) => [...grantKeys.all, id] as const,
+};
+
+export function useGrant(id: string) {
+  return useQuery({
+    queryKey: grantKeys.detail(id),
+    queryFn: () => philanthropyService.getGrant(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/grant-atlas/hooks/use-nonprofit.ts
+++ b/src/features/grant-atlas/hooks/use-nonprofit.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { philanthropyService } from "../services/philanthropy.service";
+
+export const nonprofitKeys = {
+  all: ["philanthropy", "nonprofit"] as const,
+  detail: (id: string) => [...nonprofitKeys.all, id] as const,
+  grants: (id: string) => [...nonprofitKeys.all, id, "grants"] as const,
+};
+
+export function useNonprofit(id: string) {
+  return useQuery({
+    queryKey: nonprofitKeys.detail(id),
+    queryFn: () => philanthropyService.getNonprofit(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useNonprofitGrants(id: string) {
+  return useQuery({
+    queryKey: nonprofitKeys.grants(id),
+    queryFn: () => philanthropyService.getNonprofitGrants(id),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/grant-atlas/hooks/use-philanthropy-stream.ts
+++ b/src/features/grant-atlas/hooks/use-philanthropy-stream.ts
@@ -1,0 +1,184 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useCallback, useRef } from "react";
+import { envVars } from "@/utilities/enviromentVars";
+import { INDEXER } from "@/utilities/indexer";
+import { useGrantAtlasStore } from "../store/philanthropy-chat";
+import type { QueryResponse } from "../types/philanthropy";
+
+const DEFAULT_PAGE_SIZE = 50;
+
+interface SSEEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+function parseSSEChunk(chunk: string): SSEEvent[] {
+  const events: SSEEvent[] = [];
+  const blocks = chunk.split("\n\n").filter(Boolean);
+
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    let data = "";
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        data += (data ? "\n" : "") + line.slice(6);
+      }
+    }
+
+    if (data) {
+      try {
+        events.push(JSON.parse(data));
+      } catch {
+        // Skip malformed JSON
+      }
+    }
+  }
+
+  return events;
+}
+
+function toFriendlyError(status: number): string {
+  switch (status) {
+    case 429:
+      return "Too many requests. Please wait a moment and try again.";
+    case 503:
+      return "Service temporarily unavailable. Please try again in a few minutes.";
+    default:
+      if (status >= 500) return "Something went wrong. Please try again.";
+      return "Something unexpected happened. Please try again.";
+  }
+}
+
+async function fetchSync(query: string, page: number): Promise<QueryResponse> {
+  const url = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}${INDEXER.V2.PHILANTHROPY.QUERY}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: query, page, limit: DEFAULT_PAGE_SIZE }),
+  });
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMsg = toFriendlyError(response.status);
+    try {
+      const errorJson = JSON.parse(errorText) as { message?: string; error?: string };
+      const rawMsg = errorJson.message || errorJson.error;
+      if (rawMsg?.trim()) errorMsg = rawMsg.trim();
+    } catch {
+      if (errorText.trim()) errorMsg = errorText.trim();
+    }
+    throw new Error(errorMsg);
+  }
+  return response.json() as Promise<QueryResponse>;
+}
+
+async function fetchStream(
+  query: string,
+  page: number,
+  signal: AbortSignal,
+  onNarrative: (text: string) => void
+): Promise<boolean> {
+  const url = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}${INDEXER.V2.PHILANTHROPY.QUERY_STREAM}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: query, page, limit: DEFAULT_PAGE_SIZE }),
+    signal,
+  });
+
+  if (!response.ok) return false; // Signal caller to fall back to sync
+
+  const reader = response.body?.getReader();
+  if (!reader) return false;
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let narrative = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const events = parseSSEChunk(buffer);
+
+    const lastNewlines = buffer.lastIndexOf("\n\n");
+    if (lastNewlines >= 0) {
+      buffer = buffer.slice(lastNewlines + 2);
+    }
+
+    for (const event of events) {
+      if (event.type === "chunk" && typeof event.content === "string") {
+        narrative += event.content;
+        onNarrative(narrative);
+      } else if (event.type === "error") {
+        throw new Error((event.message as string) || "Search failed");
+      }
+    }
+  }
+
+  return true; // Stream succeeded
+}
+
+export function usePhilanthropySearch() {
+  const abortRef = useRef<AbortController | null>(null);
+
+  const search = useCallback(async (query: string, page = 1) => {
+    const store = useGrantAtlasStore.getState();
+
+    store.setQuery(query);
+    store.setNarrative("");
+    store.setResult(null);
+    store.setSearching(true);
+    store.setError(null);
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      // Try streaming narrative first, fall back to sync if unavailable
+      let streamed = false;
+      try {
+        streamed = await fetchStream(query, page, controller.signal, (text) => {
+          store.setNarrative(text);
+        });
+      } catch (streamErr) {
+        // Re-throw aborts, swallow other stream errors to try sync
+        if (streamErr instanceof DOMException && streamErr.name === "AbortError") throw streamErr;
+        Sentry.captureException(streamErr, { extra: { context: "philanthropy-stream" } });
+      }
+
+      // Always fetch full results via sync endpoint (entities + citations + intent)
+      const syncData = await fetchSync(query, page);
+      store.setResult({
+        entities: syncData.entities,
+        citations: syncData.citations,
+        intent: syncData.intent,
+        pagination: syncData.pagination,
+      });
+
+      // If streaming didn't produce a narrative, use the sync one
+      if (!streamed && syncData.narrative) {
+        store.setNarrative(syncData.narrative);
+      }
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      let msg = err instanceof Error ? err.message : "Failed to connect";
+      if (err instanceof TypeError && msg === "Failed to fetch") {
+        msg = "Unable to reach the server. Please check your connection and try again.";
+      }
+      useGrantAtlasStore.getState().setError(msg);
+    } finally {
+      useGrantAtlasStore.getState().setSearching(false);
+    }
+  }, []);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { search, abort };
+}

--- a/src/features/grant-atlas/hooks/use-philanthropy-stream.ts
+++ b/src/features/grant-atlas/hooks/use-philanthropy-stream.ts
@@ -52,12 +52,21 @@ function toFriendlyError(status: number): string {
   }
 }
 
-async function fetchSync(query: string, page: number): Promise<QueryResponse> {
+async function fetchSyncWithOptions(
+  query: string,
+  page: number,
+  includeNarrative: boolean
+): Promise<QueryResponse> {
   const url = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}${INDEXER.V2.PHILANTHROPY.QUERY}`;
   const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ message: query, page, limit: DEFAULT_PAGE_SIZE }),
+    body: JSON.stringify({
+      message: query,
+      page,
+      limit: DEFAULT_PAGE_SIZE,
+      includeNarrative,
+    }),
   });
   if (!response.ok) {
     const errorText = await response.text();
@@ -127,10 +136,19 @@ export function usePhilanthropySearch() {
 
   const search = useCallback(async (query: string, page = 1) => {
     const store = useGrantAtlasStore.getState();
+    const normalizedQuery = query.trim();
+    const currentPage = store.result?.pagination.page;
+    const isPagination =
+      store.query.trim().toLowerCase() === normalizedQuery.toLowerCase() &&
+      store.result !== null &&
+      currentPage !== undefined &&
+      currentPage !== page;
 
-    store.setQuery(query);
-    store.setNarrative("");
-    store.setResult(null);
+    store.setQuery(normalizedQuery);
+    if (!isPagination) {
+      store.setNarrative("");
+      store.setResult(null);
+    }
     store.setSearching(true);
     store.setError(null);
 
@@ -139,20 +157,22 @@ export function usePhilanthropySearch() {
     abortRef.current = controller;
 
     try {
-      // Try streaming narrative first, fall back to sync if unavailable
       let streamed = false;
-      try {
-        streamed = await fetchStream(query, page, controller.signal, (text) => {
-          store.setNarrative(text);
-        });
-      } catch (streamErr) {
-        // Re-throw aborts, swallow other stream errors to try sync
-        if (streamErr instanceof DOMException && streamErr.name === "AbortError") throw streamErr;
-        Sentry.captureException(streamErr, { extra: { context: "philanthropy-stream" } });
+      if (!isPagination) {
+        try {
+          streamed = await fetchStream(normalizedQuery, page, controller.signal, (text) => {
+            store.setNarrative(text);
+          });
+        } catch (streamErr) {
+          // Re-throw aborts, swallow other stream errors to try sync
+          if (streamErr instanceof DOMException && streamErr.name === "AbortError") {
+            throw streamErr;
+          }
+          Sentry.captureException(streamErr, { extra: { context: "philanthropy-stream" } });
+        }
       }
 
-      // Always fetch full results via sync endpoint (entities + citations + intent)
-      const syncData = await fetchSync(query, page);
+      const syncData = await fetchSyncWithOptions(normalizedQuery, page, !isPagination);
       store.setResult({
         entities: syncData.entities,
         citations: syncData.citations,
@@ -160,8 +180,7 @@ export function usePhilanthropySearch() {
         pagination: syncData.pagination,
       });
 
-      // If streaming didn't produce a narrative, use the sync one
-      if (!streamed && syncData.narrative) {
+      if (!isPagination && !streamed && syncData.narrative) {
         store.setNarrative(syncData.narrative);
       }
     } catch (err: unknown) {

--- a/src/features/grant-atlas/services/philanthropy.service.ts
+++ b/src/features/grant-atlas/services/philanthropy.service.ts
@@ -1,0 +1,130 @@
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type {
+  Filing,
+  Financials,
+  Foundation,
+  Grant,
+  Nonprofit,
+  Officer,
+  QueryResponse,
+} from "../types/philanthropy";
+
+export const philanthropyService = {
+  async query(message: string): Promise<QueryResponse> {
+    const [data, error] = await fetchData<QueryResponse>(
+      INDEXER.V2.PHILANTHROPY.QUERY,
+      "POST",
+      { message },
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data!;
+  },
+
+  async getFoundation(id: string): Promise<Foundation> {
+    const [data, error] = await fetchData<Foundation>(
+      INDEXER.V2.PHILANTHROPY.FOUNDATIONS.GET(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data!;
+  },
+
+  async getFoundationGrants(id: string): Promise<Grant[]> {
+    const [data, error] = await fetchData<Grant[]>(
+      INDEXER.V2.PHILANTHROPY.FOUNDATIONS.GRANTS(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data ?? [];
+  },
+
+  async getFoundationOfficers(id: string): Promise<Officer[]> {
+    const [data, error] = await fetchData<Officer[]>(
+      INDEXER.V2.PHILANTHROPY.FOUNDATIONS.OFFICERS(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data ?? [];
+  },
+
+  async getFoundationFinancials(id: string): Promise<Financials[]> {
+    const [data, error] = await fetchData<Financials[]>(
+      INDEXER.V2.PHILANTHROPY.FOUNDATIONS.FINANCIALS(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data ?? [];
+  },
+
+  async getFoundationFiling(id: string, year: number): Promise<Filing> {
+    const [data, error] = await fetchData<Filing>(
+      INDEXER.V2.PHILANTHROPY.FOUNDATIONS.FILING(id, year),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data!;
+  },
+
+  async getNonprofit(id: string): Promise<Nonprofit> {
+    const [data, error] = await fetchData<Nonprofit>(
+      INDEXER.V2.PHILANTHROPY.NONPROFITS.GET(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data!;
+  },
+
+  async getNonprofitGrants(id: string): Promise<Grant[]> {
+    const [data, error] = await fetchData<Grant[]>(
+      INDEXER.V2.PHILANTHROPY.NONPROFITS.GRANTS(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data ?? [];
+  },
+
+  async getGrant(id: string): Promise<Grant> {
+    const [data, error] = await fetchData<Grant>(
+      INDEXER.V2.PHILANTHROPY.GRANTS.GET(id),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    if (error) throw new Error(error);
+    return data!;
+  },
+};

--- a/src/features/grant-atlas/store/philanthropy-chat.ts
+++ b/src/features/grant-atlas/store/philanthropy-chat.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+import type { Citation, QueryIntent, QueryPagination, RankedEntity } from "../types/philanthropy";
+
+interface SearchResult {
+  entities: RankedEntity[];
+  citations: Citation[];
+  intent: QueryIntent;
+  pagination: QueryPagination;
+}
+
+interface GrantAtlasStore {
+  query: string;
+  narrative: string;
+  result: SearchResult | null;
+  isSearching: boolean;
+  error: string | null;
+
+  setQuery: (query: string) => void;
+  setNarrative: (narrative: string) => void;
+  setResult: (result: SearchResult | null) => void;
+  setSearching: (searching: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+export const useGrantAtlasStore = create<GrantAtlasStore>((set) => ({
+  query: "",
+  narrative: "",
+  result: null,
+  isSearching: false,
+  error: null,
+
+  setQuery: (query) => set({ query }),
+  setNarrative: (narrative) => set({ narrative }),
+  setResult: (result) => set({ result }),
+  setSearching: (searching) => set({ isSearching: searching }),
+  setError: (error) => set({ error }),
+  reset: () => set({ query: "", narrative: "", result: null, error: null }),
+}));

--- a/src/features/grant-atlas/types/philanthropy.ts
+++ b/src/features/grant-atlas/types/philanthropy.ts
@@ -1,0 +1,162 @@
+// Types mirroring the gap-indexer philanthropy API DTOs
+
+export type PhilanthropyEntityType = "foundation" | "nonprofit" | "grant";
+
+export interface Citation {
+  entityId: string;
+  entityType: PhilanthropyEntityType;
+  filingYear: number;
+  fieldPath: string;
+}
+
+export interface EntityScores {
+  semantic: number;
+  amount: number;
+  recency: number;
+  composite: number;
+}
+
+export interface RankedEntity {
+  entityType: PhilanthropyEntityType;
+  id: string;
+  name: string | null;
+  description: string | null;
+  ein: string | null;
+  location: string | null;
+  totalAssets: number | null;
+  amount: number | null;
+  date: string | null;
+  filingYear: number | null;
+  foundationId: string | null;
+  foundationName?: string | null;
+  nonprofitId: string | null;
+  nonprofitName?: string | null;
+  scores: EntityScores;
+}
+
+export interface QueryIntent {
+  type: string;
+  targetEntityType: PhilanthropyEntityType;
+  referenceEntityName: string | null;
+  weights: {
+    semantic: number;
+    amount: number;
+    recency: number;
+  };
+}
+
+export interface QueryPagination {
+  page: number;
+  limit: number;
+  returned: number;
+  totalCount: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface QueryResponse {
+  entities: RankedEntity[];
+  narrative: string | null;
+  citations: Citation[];
+  pagination: QueryPagination;
+  intent: QueryIntent;
+}
+
+export interface Foundation {
+  id: string;
+  ein: string;
+  name: string;
+  description: string | null;
+  totalAssets: number | null;
+  location: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Nonprofit {
+  id: string;
+  ein: string | null;
+  name: string;
+  description: string | null;
+  location: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Grant {
+  id: string;
+  filingId: string;
+  foundationId: string;
+  nonprofitId: string | null;
+  amount: number | null;
+  date: string | null;
+  purposeText: string | null;
+  filingYear: number;
+  sourceRowHash: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Officer {
+  id: string;
+  foundationId: string;
+  name: string;
+  title: string | null;
+  compensation: number | null;
+  benefits: number | null;
+  expenseAccount: number | null;
+  filingYear: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Financials {
+  id: string;
+  foundationId: string;
+  filingYear: number;
+  totalRevenue: number | null;
+  totalExpenses: number | null;
+  totalAssets: number | null;
+  netAssets: number | null;
+  minimumInvestmentReturn: number | null;
+  distributableAmount: number | null;
+  qualifyingDistributions: number | null;
+  undistributedIncome: number | null;
+  excessDistributions: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Filing {
+  id: string;
+  foundationId: string;
+  filingYear: number;
+  ein: string;
+  formType: string | null;
+  taxPeriod: string | null;
+  returnTimestamp: string | null;
+  objectId: string | null;
+  rawFiling: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IngestionRunStatus {
+  id: string;
+  sourceKey: string;
+  sourceType: string;
+  status: string;
+  inputPath: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  itemsDiscovered: number;
+  filesProcessed: number;
+  filesFailed: number;
+  foundationsUpserted: number;
+  nonprofitsUpserted: number;
+  grantsUpserted: number;
+  officersUpserted: number;
+  financialsUpserted: number;
+  progressPercent: number;
+  errorMessage: string | null;
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -368,6 +368,24 @@ export const INDEXER = {
       INVOICE_DOWNLOAD: (grantUID: string, key: string) =>
         `/v2/grants/${grantUID}/invoice/download?key=${encodeURIComponent(key)}`,
     },
+    PHILANTHROPY: {
+      QUERY: "/v2/philanthropy/query",
+      QUERY_STREAM: "/v2/philanthropy/query/stream",
+      FOUNDATIONS: {
+        GET: (id: string) => `/v2/philanthropy/foundations/${id}`,
+        GRANTS: (id: string) => `/v2/philanthropy/foundations/${id}/grants`,
+        OFFICERS: (id: string) => `/v2/philanthropy/foundations/${id}/officers`,
+        FINANCIALS: (id: string) => `/v2/philanthropy/foundations/${id}/financials`,
+        FILING: (id: string, year: number) => `/v2/philanthropy/foundations/${id}/filings/${year}`,
+      },
+      NONPROFITS: {
+        GET: (id: string) => `/v2/philanthropy/nonprofits/${id}`,
+        GRANTS: (id: string) => `/v2/philanthropy/nonprofits/${id}/grants`,
+      },
+      GRANTS: {
+        GET: (id: string) => `/v2/philanthropy/grants/${id}`,
+      },
+    },
   },
   PROGRAMS: {
     COMMUNITY: (communityId: string) => `/communities/${communityId}/programs`,

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -125,6 +125,12 @@ export const PAGES = {
   STATS: `/stats`,
   SUMUP_CONFIG: `/admin/sumup`,
   FOUNDATIONS: `/foundations`,
+  GRANT_ATLAS: {
+    ROOT: `/grant-atlas`,
+    FOUNDATION: (id: string) => `/grant-atlas/foundations/${id}`,
+    NONPROFIT: (id: string) => `/grant-atlas/nonprofits/${id}`,
+    GRANT: (id: string) => `/grant-atlas/grants/${id}`,
+  },
   FUNDERS: `/funders`,
   SEEDS: `/seeds`,
   SEEDS_FUND: `/seeds/fund`,


### PR DESCRIPTION
## Summary
- add the Grant Atlas routes, detail screens, and search experience
- improve result cards with grant recipient and foundation context
- clarify pagination copy to show page ranges instead of implying page size is total count
- wire the frontend to the updated philanthropy query response fields

## Validation
- pnpm exec biome check src/features/grant-atlas/components/grant-atlas-chat.tsx
- pnpm exec biome check src/features/grant-atlas/components/ranked-entity-card.tsx src/features/grant-atlas/types/philanthropy.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grant Atlas: a searchable philanthropy experience with natural-language queries and suggested prompts.
  * Streaming search with narrative answers, paginated results, and entity result cards.
  * Detail pages for foundations, grants, and nonprofits with header info, related grants/officers/financials, and cross-entity navigation.
  * Added Grant Atlas entry to the main navigation and a top-level Grant Atlas landing/search page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->