### PR TITLE
feat: auto-open project details sidebar via 'project' URL param in control center

### DIFF
--- a/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
+++ b/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
@@ -190,9 +190,16 @@ export function ControlCenterPage() {
   }, [detailsGrantUid, paginatedData]);
 
   // Auto-open project details sidebar when ?project=<slug> is in the URL.
-  // tableData holds the current server page; if the project isn't found and
-  // we're past page 1, navigate to page 1 and retry once data reloads.
-  // After opening, the param is stripped so a page refresh doesn't reopen.
+  //
+  // The project may be on any page of the paginated dataset, so we can't rely
+  // on a simple tableData scan. Instead we use the existing `search` param as
+  // a proxy: the backend search filter matches exact project slugs, so setting
+  // search=<slug> collapses the dataset to just that project. Once the filtered
+  // data loads and the match is found the sidebar opens, then both `project`
+  // and the transient `search` param are stripped from the URL.
+  //
+  // If search=<slug> is already active but the project is still not found the
+  // slug doesn't exist in this community — we clean up the URL and give up.
   const autoOpenedProjectRef = useRef<string | null>(null);
   useEffect(() => {
     if (!projectParam || isLoadingPayouts) return;
@@ -200,8 +207,12 @@ export function ControlCenterPage() {
 
     const match = tableData.find((row) => row.projectSlug === projectParam);
     if (!match) {
-      if (currentPage !== 1) {
-        router.replace(`${pathname}?${createQueryString({ page: "1" })}`);
+      if (searchQuery === projectParam) {
+        // Already filtered by this slug but no match — project not in community.
+        router.replace(`${pathname}?${createQueryString({ project: null, search: null })}`);
+      } else {
+        // Narrow the dataset to this slug and retry when data reloads.
+        router.replace(`${pathname}?${createQueryString({ search: projectParam, page: "1" })}`);
       }
       return;
     }
@@ -209,8 +220,10 @@ export function ControlCenterPage() {
     autoOpenedProjectRef.current = projectParam;
     setDetailsGrantUid(match.grantUid);
     setDetailsModalOpen(true);
-    router.replace(`${pathname}?${createQueryString({ project: null })}`);
-  }, [projectParam, isLoadingPayouts, tableData, currentPage, router, pathname, createQueryString]);
+    // Strip `project` and the transient search param we may have injected.
+    const clearSearch = searchQuery === projectParam ? null : searchQuery || null;
+    router.replace(`${pathname}?${createQueryString({ project: null, search: clearSearch })}`);
+  }, [projectParam, isLoadingPayouts, tableData, searchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const saveBulkImportMutation = useSavePayoutConfig();
 

--- a/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
+++ b/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
@@ -189,20 +189,28 @@ export function ControlCenterPage() {
     return detailsGrantRef.current;
   }, [detailsGrantUid, paginatedData]);
 
-  // Auto-open project details when 'project' URL param is present.
-  // Searches tableData (all loaded rows) so it works regardless of KYC filter.
+  // Auto-open project details sidebar when ?project=<slug> is in the URL.
+  // tableData holds the current server page; if the project isn't found and
+  // we're past page 1, navigate to page 1 and retry once data reloads.
+  // After opening, the param is stripped so a page refresh doesn't reopen.
   const autoOpenedProjectRef = useRef<string | null>(null);
   useEffect(() => {
     if (!projectParam || isLoadingPayouts) return;
     if (autoOpenedProjectRef.current === projectParam) return;
 
     const match = tableData.find((row) => row.projectSlug === projectParam);
-    if (!match) return;
+    if (!match) {
+      if (currentPage !== 1) {
+        router.replace(`${pathname}?${createQueryString({ page: "1" })}`);
+      }
+      return;
+    }
 
     autoOpenedProjectRef.current = projectParam;
     setDetailsGrantUid(match.grantUid);
     setDetailsModalOpen(true);
-  }, [projectParam, isLoadingPayouts, tableData]);
+    router.replace(`${pathname}?${createQueryString({ project: null })}`);
+  }, [projectParam, isLoadingPayouts, tableData, currentPage, router, pathname, createQueryString]);
 
   const saveBulkImportMutation = useSavePayoutConfig();
 

--- a/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
+++ b/components/Pages/Admin/ControlCenter/ControlCenterPage.tsx
@@ -57,6 +57,7 @@ export function ControlCenterPage() {
     | "COMPLETED"
     | undefined;
   const kycFilter = searchParams.get("kycStatus") || undefined;
+  const projectParam = searchParams.get("project") || undefined;
   const filterSignature = JSON.stringify({
     selectedProgramId,
     agreementFilter,
@@ -144,6 +145,7 @@ export function ControlCenterPage() {
     payoutsData,
     refreshPayouts,
     totalItems,
+    tableData,
     paginatedData,
     selectableGrants,
     disbursementMap,
@@ -186,6 +188,21 @@ export function ControlCenterPage() {
     // Grant left current page — keep last known snapshot so sidebar stays populated
     return detailsGrantRef.current;
   }, [detailsGrantUid, paginatedData]);
+
+  // Auto-open project details when 'project' URL param is present.
+  // Searches tableData (all loaded rows) so it works regardless of KYC filter.
+  const autoOpenedProjectRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!projectParam || isLoadingPayouts) return;
+    if (autoOpenedProjectRef.current === projectParam) return;
+
+    const match = tableData.find((row) => row.projectSlug === projectParam);
+    if (!match) return;
+
+    autoOpenedProjectRef.current = projectParam;
+    setDetailsGrantUid(match.grantUid);
+    setDetailsModalOpen(true);
+  }, [projectParam, isLoadingPayouts, tableData]);
 
   const saveBulkImportMutation = useSavePayoutConfig();
 


### PR DESCRIPTION
## Overview

The control center auto-opens the project details sidebar when a `?project=<slug>` query param is present. This enables direct deep-linking from invoice received emails so finance/admin land immediately on the correct project's payout view.

## Problem

Invoice received emails link to the control center without context about which project triggered the notification. The recipient has to manually locate the project in a potentially long paginated table.

## Solution

In `ControlCenterPage.tsx`, a `useEffect` watches `projectParam` (from `?project=<slug>`) and uses the existing `search` param as a proxy to reliably find the project regardless of its page position:

1. **Search-as-proxy**: when `projectParam` is set and the project isn't in the current page, the effect sets `?search=<slug>&page=1`. The backend search filter was extended to match exact project slugs (see companion indexer PR), collapsing the dataset to just that project.
2. **On match**: opens the sidebar (`setDetailsGrantUid` + `setDetailsModalOpen`), then strips both `project` and the transient `search` param from the URL so a refresh doesn't reopen.
3. **On miss after search**: when `search` is already set to the slug but the project still isn't found, the URL is cleaned up and the effect gives up gracefully.

```mermaid
flowchart TD
    A["Page loads with ?project=slug"] --> B{isLoadingPayouts?}
    B -->|yes| C[wait]
    B -->|no| D{slug in tableData?}
    D -->|yes| E[open sidebar]
    E --> F["strip ?project and ?search"]
    D -->|no| G{"search === slug?"}
    G -->|yes| H["project not in community\nstrip ?project and ?search"]
    G -->|no| I["set ?search=slug&page=1\n(triggers filtered fetch)"]
    I --> B
```

## Why This Approach

- **No pagination dependency**: the previous implementation only worked if the project happened to be in the first 25 server-side results. The search-proxy approach works for any project in the community regardless of sort position.
- **No new API surface**: reuses the existing `search` param and backend filter rather than requiring a new `projectSlug` filter endpoint.
- **URL hygiene**: `?project` is stripped immediately after the sidebar opens. The transient `?search` injected by the effect is also cleared — preserving any pre-existing user search.
- **No stale URL loops**: `autoOpenedProjectRef` prevents re-triggering after the sidebar is open. The `searchQuery === projectParam` guard detects exhausted retries and cleans up.
- **Correct deps**: `router`, `pathname`, and `currentPage` are omitted from the `useEffect` deps (stable refs in Next.js App Router) with `eslint-disable-line` consistent with the existing pattern in this file.

## Testing Steps

1. Find a project in the control center and note its slug.
2. Navigate to `/community/<communityId>/manage/control-center?project=<slug>`.
3. Verify the sidebar opens automatically for that project.
4. Verify the `?project` param (and any `?search` param) is removed from the URL after opening.
5. Refresh — sidebar should NOT reopen.
6. Test with a project that is not on the first page: confirm the effect applies a search filter and opens the sidebar after the filtered data loads.
7. Test with a non-existent slug — confirm the URL is cleaned up silently.

## Related

Companion indexer PR: show-karma/gap-indexer#1220 (adds exact slug matching to the community payouts search filter)