### PR TITLE
fix: allow zero-amount payment to mark milestones as paid

### DIFF
--- a/src/features/payout-disbursement/components/RecordPaymentDialog.tsx
+++ b/src/features/payout-disbursement/components/RecordPaymentDialog.tsx
@@ -196,7 +196,7 @@ function RecordPaymentDialogInner({
   }, []);
 
   const isValid =
-    amount.trim() !== "" && Number(amount) > 0 && paymentDate !== "" && selectedKeys.length > 0;
+    !Number.isNaN(Number(amount)) && Number(amount) >= 0 && paymentDate !== "" && selectedKeys.length > 0;
 
   const handleSubmit = useCallback(() => {
     if (!isValid || recordPayment.isPending) return;
@@ -204,7 +204,7 @@ function RecordPaymentDialogInner({
     const effectiveChainID = chainSupported ? chainID : DEFAULT_USDC_CHAIN_ID;
     const tokenAddress =
       nativeUsdcAddress ?? (getUsdcAddressForChain(DEFAULT_USDC_CHAIN_ID) as string);
-    const disbursedAmount = toSmallestUnit(amount, USDC_DECIMALS);
+    const disbursedAmount = toSmallestUnit(amount || "0", USDC_DECIMALS);
 
     const selectedMilestones = milestoneOptions.filter((m) => selectedKeys.includes(m.key));
 


### PR DESCRIPTION
## Overview

Allows `0` (or empty) to be submitted as the payment amount in the **Record Payment** dialog, enabling users to mark a milestone as paid without recording a financial disbursement.

## Problem

The frontend blocked form submission when `amount` was `0` or empty, making it impossible to mark a milestone as paid when no actual token transfer occurred (e.g. the payment happened off-chain, was already tracked elsewhere, or the intent is purely to flip the milestone status to disbursed).

The backend already accepted `"0"` — the Zod schema validates `disbursedAmount` as a non-empty string (`min(1)`), and the `recordPayment` service path has no zero-amount guard — so this was purely a frontend restriction.

## Solution

Two changes in `RecordPaymentDialog.tsx`:

**`isValid` guard** — relaxed from `> 0` to `>= 0`, and replaced the `trim() !== ""` check with `!Number.isNaN(Number(amount))` so an empty field is also valid (treated as zero):

```diff
- amount.trim() !== "" && Number(amount) > 0 && paymentDate !== "" && selectedKeys.length > 0;
+ !Number.isNaN(Number(amount)) && Number(amount) >= 0 && paymentDate !== "" && selectedKeys.length > 0;
```

**`handleSubmit`** — ensures `toSmallestUnit` always receives `"0"` when the field is blank:

```diff
- const disbursedAmount = toSmallestUnit(amount, USDC_DECIMALS);
+ const disbursedAmount = toSmallestUnit(amount || "0", USDC_DECIMALS);
```

## Why This Approach

- No backend changes required — the existing Zod schema and service already handle `"0"` correctly
- Minimal surface area — two-line change confined to the validation/submission logic
- Empty field → `"0"` default prevents `NaN` from reaching `toSmallestUnit`

## Testing Steps

1. Open the Record Payment dialog for a grant with milestone allocations
2. Select a milestone, leave the **Amount** field empty (or type `0`), fill in a payment date
3. Confirm the **Record Payment** button is enabled
4. Submit — the milestone should be marked as paid with a `disbursedAmount` of `"0"`
5. Verify a positive amount (e.g. `5000`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation behavior for payment amount input to accept zero and negative values.
  * Enhanced handling of empty amount entries by defaulting to zero during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->