### PR TITLE
fix: gate invoice-config query on Privy ready and authenticated

### DIFF
--- a/src/features/applications/hooks/use-application-invoice-config.ts
+++ b/src/features/applications/hooks/use-application-invoice-config.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import {
   type ApplicationInvoiceConfig,
@@ -11,10 +12,15 @@ export function useApplicationInvoiceConfig(
   referenceNumber: string | undefined,
   options?: { enabled?: boolean }
 ) {
+  const { ready, authenticated } = usePrivyBridge();
+
   return useQuery<ApplicationInvoiceConfig | null, Error>({
     queryKey: QUERY_KEYS.APPLICATIONS.INVOICE_CONFIG(referenceNumber ?? ""),
     queryFn: () => getApplicationInvoiceConfig(referenceNumber!),
-    enabled: (options?.enabled ?? true) && !!referenceNumber,
+    // Delay until Privy has hydrated and the user is authenticated.
+    // Without this guard, the query fires before a token is available,
+    // gets a 401, caches null, and never retries once auth is ready.
+    enabled: (options?.enabled ?? true) && !!referenceNumber && ready && authenticated,
     staleTime: 1000 * 60 * 5,
   });
 }


### PR DESCRIPTION
## Overview

`useApplicationInvoiceConfig` was firing before Privy finished hydrating, silently caching `null`, and never retrying once the user was actually authenticated.

## Problem

1. Component mounts with `invoiceRequired = true` — query is enabled.
2. Privy hasn't hydrated yet → `TokenManager.getToken()` returns `null` → request is sent without an `Authorization` header.
3. Backend returns **401** (`requireAuthentication()` middleware).
4. `fetchData` catches the error and returns `[null, "...", null, 401]`.
5. The service swallows it: `if (error || !data?.data) return null`.
6. React Query sees a **successful result of `null`** (no throw, no error state).
7. With `staleTime: 5 minutes`, the query is considered fresh — it won't refetch when Privy finishes hydrating and the user is authenticated.

## Solution

Gate the query on `ready && authenticated` from `usePrivyBridge`. React Query automatically triggers the fetch when the `enabled` condition transitions from `false` to `true`, so the query fires exactly once — after a valid token is available.

```ts
const { ready, authenticated } = usePrivyBridge();

enabled: (options?.enabled ?? true) && !!referenceNumber && ready && authenticated,
```

## Why This Approach

- `usePrivyBridge` is the established pattern in this codebase for reading Privy state outside of Privy-wrapped contexts (see `permission-context.tsx`, `use-claim-transaction.ts`).
- No changes needed at the call site — the guard lives entirely in the hook.
- No query key change needed — React Query's disabled→enabled transition already triggers a fresh fetch.

## Testing Steps

1. Open the milestone completion editor on a page that shows invoices.
2. Hard-refresh (clears any cached data).
3. Observe in DevTools: the `/invoice-config` request should **not** fire until Privy finishes initializing.
4. Once authenticated, the request fires and returns invoice config data correctly.
5. Previously, the request fired immediately on mount and got a 401 with no retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of invoice configuration data loading by ensuring it only occurs after user authentication is properly established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->