### PR TITLE
feat: add AI evaluation badge to community milestone cards

### DIFF
--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleIcon, ClockIcon } from "@heroicons/react/24/outline";
+import dynamic from "next/dynamic";
 import { type FC, memo } from "react";
 import { containerClassName } from "@/components/Shared/ActivityCard";
 import { ActivityAttribution } from "@/components/Shared/ActivityCard/ActivityAttribution";
@@ -8,6 +9,14 @@ import { formatDate } from "@/utilities/formatDate";
 import { ReadMore } from "@/utilities/ReadMore";
 import { cn } from "@/utilities/tailwind";
 import { MilestoneCompletionInfo } from "./MilestoneCompletionInfo";
+
+const MilestoneAIEvaluationBadge = dynamic(
+  () =>
+    import("@/components/Milestone/MilestoneAIEvaluationBadge").then(
+      (m) => m.MilestoneAIEvaluationBadge
+    ),
+  { ssr: false }
+);
 
 interface CommunityMilestoneCardProps {
   milestone: CommunityMilestoneUpdate;
@@ -77,6 +86,9 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
                 Due {formatDate(milestone.details.dueDate)}
               </span>
             )}
+            {isCompleted && milestone.uid ? (
+              <MilestoneAIEvaluationBadge milestoneUID={milestone.uid} />
+            ) : null}
           </div>
 
           {/* Title */}


### PR DESCRIPTION
## Problem

Completed milestones on the community updates view (`/community/:slug/updates`) did not show the AI evaluation score badge, even when evaluations existed.

## Solution

```mermaid
graph LR
    CM["CommunityMilestoneCard"] -->|"isCompleted && milestone.uid"| BADGE["MilestoneAIEvaluationBadge"]
    BADGE --> HOOK["useMilestoneEvaluation(milestoneUID)"]
    HOOK --> API["GET /v2/milestone-evaluation/:milestoneUID"]
    API --> EVAL["milestone_evaluations table"]
```

Added a dynamically-imported `MilestoneAIEvaluationBadge` next to the status indicator on `CommunityMilestoneCard`. This follows the exact same pattern used by:

- `components/Shared/ActivityCard/MilestoneCard.tsx`
- `components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx`
- `components/Pages/Admin/ControlCenter/MilestonesSection.tsx`
- `components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx`

### Changes
- `components/Pages/Community/Updates/CommunityMilestoneCard.tsx` — dynamic import of badge, rendered conditionally when milestone is completed and has a UID

### Testing
- `tsc --noEmit` passes
- Follows established codebase patterns exactly
- Component is already `memo()`-wrapped so no unnecessary re-renders

### Depends on
- gap-indexer PR #1243 (provides the off-chain completion enrichment that makes milestones show as completed)
