### PR TITLE
fix: show milestone update row for off-chain completions

### DIFF
--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -116,6 +116,8 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
       milestoneAny.data?.attester ||
       milestoneAny.data?.recipient ||
       "";
+    // Off-chain completions use fundingApplicationCompletion instead of completionDetails
+    const appCompletion = milestone.fundingApplicationCompletion;
     const chainID =
       parseChainId(milestone.chainId) ||
       parseChainId(milestoneAny?.grant?.chainID) ||
@@ -155,10 +157,14 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
       description: milestone.description,
       completed: isCompleted
         ? {
-            createdAt: milestone.completionDetails?.completedAt || milestone.createdAt || "",
+            createdAt:
+              milestone.completionDetails?.completedAt ||
+              appCompletion?.createdAt ||
+              milestone.createdAt ||
+              "",
             data: {
               proofOfWork: milestone.completionDetails?.proofOfWork,
-              reason: milestone.completionDetails?.description,
+              reason: milestone.completionDetails?.description || appCompletion?.completionText,
               completionPercentage: milestone.completionDetails?.completionPercentage,
               deliverables: milestone.completionDetails?.deliverables,
             },
@@ -181,11 +187,16 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
             endsAt: milestoneEndsAt,
             completed: isCompleted
               ? {
-                  createdAt: milestone.completionDetails?.completedAt || milestone.createdAt || "",
-                  attester: milestone.completionDetails?.completedBy,
+                  createdAt:
+                    milestone.completionDetails?.completedAt ||
+                    appCompletion?.createdAt ||
+                    milestone.createdAt ||
+                    "",
+                  attester: milestone.completionDetails?.completedBy || appCompletion?.ownerAddress,
                   data: {
                     proofOfWork: milestone.completionDetails?.proofOfWork,
-                    reason: milestone.completionDetails?.description,
+                    reason:
+                      milestone.completionDetails?.description || appCompletion?.completionText,
                     completionPercentage: milestone.completionDetails?.completionPercentage,
                     deliverables: milestone.completionDetails?.deliverables,
                   },


### PR DESCRIPTION
## Summary
- Off-chain milestone completions (via funding application form) were missing the "Milestone Update" row in the project Updates tab, even though the "Completed" badge displayed correctly
- Root cause: `convertToUnifiedMilestones()` only extracted completion data from `completionDetails` (on-chain), but off-chain completions have `completionDetails: null` with data in `fundingApplicationCompletion` instead
- Added fallback to `fundingApplicationCompletion` fields (`completionText`, `createdAt`, `ownerAddress`) when `completionDetails` is null — on-chain data still takes precedence

## Test plan
- [ ] Navigate to a project with an off-chain completed milestone (e.g., `/project/venus-implementation-maintenance`)
- [ ] Verify the "Milestone Update" row now appears below the completed milestone card
- [ ] Verify the completion text from the funding application form is displayed
- [ ] Verify the posted date and attester address are shown correctly
- [ ] Verify on-chain completed milestones still render their update row as before (no regression)
- [ ] Verify pending milestones are unaffected