### PR TITLE
fix: render plain newlines as line breaks in markdown preview

### DIFF
--- a/components/Utilities/MarkdownPreview.tsx
+++ b/components/Utilities/MarkdownPreview.tsx
@@ -23,6 +23,7 @@ interface MarkdownPreviewProps {
 
 type StreamdownType = typeof import("streamdown").Streamdown;
 type CodePluginType = typeof import("@streamdown/code").code;
+type RemarkBreaksType = typeof import("remark-breaks").default;
 
 export const MarkdownPreview = ({
   source,
@@ -33,15 +34,18 @@ export const MarkdownPreview = ({
   const { resolvedTheme } = useTheme();
   const [StreamdownComponent, setStreamdownComponent] = useState<StreamdownType | null>(null);
   const [codePlugin, setCodePlugin] = useState<CodePluginType | null>(null);
+  const [remarkBreaksPlugin, setRemarkBreaksPlugin] = useState<RemarkBreaksType | null>(null);
   useEffect(() => {
     Promise.all([
       import("streamdown").then((m) => m.Streamdown),
       import("@streamdown/code").then((m) => m.code),
+      import("remark-breaks").then((m) => m.default),
       import("streamdown/styles.css" as string),
     ])
-      .then(([Streamdown, code]) => {
+      .then(([Streamdown, code, remarkBreaks]) => {
         setStreamdownComponent(() => Streamdown);
         setCodePlugin(() => code);
+        setRemarkBreaksPlugin(() => remarkBreaks);
       })
       .catch((err) => {
         console.error("Failed to load markdown preview dependencies:", err);
@@ -50,7 +54,7 @@ export const MarkdownPreview = ({
 
   if (!source) return null;
 
-  if (!StreamdownComponent || !codePlugin) {
+  if (!StreamdownComponent || !codePlugin || !remarkBreaksPlugin) {
     return <div className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded h-4 w-full" />;
   }
 
@@ -71,6 +75,7 @@ export const MarkdownPreview = ({
       <StreamdownComponent
         mode="static"
         plugins={{ code: codePlugin }}
+        remarkPlugins={[remarkBreaksPlugin]}
         className={cn("wmdeMarkdown", styles.wmdeMarkdown, className)}
         allowElement={allowElement ?? undefined}
         components={mergedComponents}

--- a/utilities/markdown.ts
+++ b/utilities/markdown.ts
@@ -4,6 +4,7 @@ import MarkdownIt from "markdown-it";
 const markdownIt = new MarkdownIt({
   linkify: true,
   html: false,
+  breaks: true,
 });
 
 const defaultLinkOpen =


### PR DESCRIPTION
## Summary
- Off-chain milestone completions save descriptions with plain `\n` newlines, but Markdown renderers ignore single `\n` — causing multi-line text to collapse into one paragraph
- Added `remark-breaks` plugin (already a project dependency) to `MarkdownPreview`'s Streamdown renderer so `\n` produces `<br>` tags
- Enabled `breaks: true` on the `markdown-it` instance in `renderToHTML()` for consistency

## How it works
| Input | Before | After |
|-------|--------|-------|
| `\n` (plain newline) | Ignored (same paragraph) | Line break `<br>` |
| `  \n` (two-space + newline) | Line break | Line break (unchanged) |
| `\n\n` (double newline) | Paragraph break | Paragraph break (unchanged) |

## Test plan
- [x] All 12 `MarkdownPreview` tests pass
- [x] All 11 XSS sanitization tests pass
- [ ] Verify milestone descriptions with plain `\n` render line breaks on project pages
- [ ] Verify existing markdown content (bold, headers, lists, links) still renders correctly
- [ ] Verify paragraph breaks (`\n\n`) still create separate paragraphs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Markdown preview now correctly renders line breaks as hard line breaks, improving text visibility and formatting in markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->