### PR TITLE
feat(updates): date range and AI evaluation filters on Updates tab

### DIFF
--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -6,12 +6,22 @@ import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
 import { getActivityFilterType } from "@/services/project-profile.service";
 import { useOwnerStore, useProjectStore } from "@/store";
+import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
 import { ActivityFeed } from "../MainContent/ActivityFeed";
 import { ActivityFilters, type ActivityFilterType } from "../MainContent/ActivityFilters";
 import { ActivityFeedSkeleton } from "../Skeletons";
 
 interface UpdatesContentProps {
   className?: string;
+}
+
+/**
+ * Parses a numeric query param. Returns the number if valid, otherwise undefined.
+ */
+function parseIntParam(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
 }
 
 /**
@@ -43,11 +53,37 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
     return "all" as MilestoneStatusFilter;
   }, [searchParams]);
 
+  // Read the 4 new filter params from URL
+  const dateFrom = searchParams.get("dateFrom") ?? undefined;
+  const dateTo = searchParams.get("dateTo") ?? undefined;
+
+  const hasAIEvaluation = useMemo(() => {
+    const raw = searchParams.get("hasAIEvaluation");
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return undefined;
+  }, [searchParams]);
+
+  const aiScoreMin = useMemo(() => parseIntParam(searchParams.get("aiScoreMin")), [searchParams]);
+  const aiScoreMax = useMemo(() => parseIntParam(searchParams.get("aiScoreMax")), [searchParams]);
+
+  // Compose the extra filters object passed to the hook (omit undefined values)
+  const feedFilters = useMemo((): UpdatesFeedFilters => {
+    const f: UpdatesFeedFilters = {};
+    if (dateFrom) f.dateFrom = dateFrom;
+    if (dateTo) f.dateTo = dateTo;
+    if (hasAIEvaluation !== undefined) f.hasAIEvaluation = hasAIEvaluation;
+    if (aiScoreMin !== undefined) f.aiScoreMin = aiScoreMin;
+    if (aiScoreMax !== undefined) f.aiScoreMax = aiScoreMax;
+    return f;
+  }, [dateFrom, dateTo, hasAIEvaluation, aiScoreMin, aiScoreMax]);
+
   // Pass milestoneStatus to useProjectProfile so filtering happens server-side
   const apiMilestoneStatus = milestoneStatusFilter !== "all" ? milestoneStatusFilter : undefined;
   const { allUpdates, milestonesCount, completedCount, isUpdating } = useProjectProfile(
     projectId as string,
-    apiMilestoneStatus
+    apiMilestoneStatus,
+    feedFilters
   );
 
   // Count items per filter category for badge counters
@@ -81,7 +117,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       const newURL = params.toString() ? `?${params.toString()}` : pathname;
       router.replace(newURL, { scroll: false });
     },
-    [searchParams, router]
+    [searchParams, router, pathname]
   );
 
   // Update URL when milestone status changes
@@ -96,7 +132,78 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       const newURL = params.toString() ? `?${params.toString()}` : pathname;
       router.replace(newURL, { scroll: false });
     },
-    [searchParams, router]
+    [searchParams, router, pathname]
+  );
+
+  // Update URL when date range changes.
+  // Defensive swap (dateFrom > dateTo) happens in the service; we persist whatever the
+  // UI agent provides so the URL is always in sync with the picker state.
+  const handleDateRangeChange = useCallback(
+    (from: string | undefined, to: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (from) {
+        params.set("dateFrom", from);
+      } else {
+        params.delete("dateFrom");
+      }
+      if (to) {
+        params.set("dateTo", to);
+      } else {
+        params.delete("dateTo");
+      }
+      const newURL = params.toString() ? `?${params.toString()}` : pathname;
+      router.replace(newURL, { scroll: false });
+    },
+    [searchParams, router, pathname]
+  );
+
+  // Update URL when AI evaluation filter changes.
+  // Enforces the semantic rule: never persist hasAIEvaluation=false + any score param together.
+  const handleAIFilterChange = useCallback(
+    ({
+      hasEvaluation,
+      scoreMin,
+      scoreMax,
+    }: {
+      hasEvaluation?: boolean;
+      scoreMin?: number;
+      scoreMax?: number;
+    }) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      const hasAnyScore = scoreMin !== undefined || scoreMax !== undefined;
+
+      if (hasAnyScore) {
+        if (scoreMin !== undefined) {
+          params.set("aiScoreMin", String(scoreMin));
+        } else {
+          params.delete("aiScoreMin");
+        }
+        if (scoreMax !== undefined) {
+          params.set("aiScoreMax", String(scoreMax));
+        } else {
+          params.delete("aiScoreMax");
+        }
+        // Omit hasAIEvaluation=false when any score param is set
+        if (hasEvaluation === true) {
+          params.set("hasAIEvaluation", "true");
+        } else {
+          params.delete("hasAIEvaluation");
+        }
+      } else {
+        params.delete("aiScoreMin");
+        params.delete("aiScoreMax");
+        if (hasEvaluation !== undefined) {
+          params.set("hasAIEvaluation", hasEvaluation ? "true" : "false");
+        } else {
+          params.delete("hasAIEvaluation");
+        }
+      }
+
+      const newURL = params.toString() ? `?${params.toString()}` : pathname;
+      router.replace(newURL, { scroll: false });
+    },
+    [searchParams, router, pathname]
   );
 
   const handleFilterToggle = useCallback(
@@ -123,6 +230,13 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
         completedCount={completedCount}
         milestoneStatusFilter={milestoneStatusFilter}
         onMilestoneStatusChange={handleMilestoneStatusChange}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        hasAIEvaluation={hasAIEvaluation}
+        aiScoreMin={aiScoreMin}
+        aiScoreMax={aiScoreMax}
+        onDateRangeChange={handleDateRangeChange}
+        onAIFilterChange={handleAIFilterChange}
       />
 
       {/* Activity Feed with Suspense boundary */}

--- a/components/Pages/Project/v2/Content/__tests__/UpdatesContent.test.tsx
+++ b/components/Pages/Project/v2/Content/__tests__/UpdatesContent.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import { useOwnerStore, useProjectStore } from "@/store";
+import type { ActivityFilterType } from "@/types/v2/project-profile.types";
 import { UpdatesContent } from "../UpdatesContent";
 
 // Mock dependencies
@@ -21,6 +22,10 @@ vi.mock("@/store", () => ({
   useProjectStore: vi.fn(),
 }));
 
+// Capture latest props passed to ActivityFilters so URL round-trip tests can
+// inspect them without coupling to DOM output.
+let capturedFiltersProps: Record<string, unknown> = {};
+
 vi.mock("@/components/Pages/Project/v2/MainContent/ActivityFeed", () => ({
   ActivityFeed: vi.fn(({ isAuthorized }) => (
     <div data-testid="activity-feed" data-authorized={isAuthorized}>
@@ -30,92 +35,289 @@ vi.mock("@/components/Pages/Project/v2/MainContent/ActivityFeed", () => ({
 }));
 
 vi.mock("@/components/Pages/Project/v2/MainContent/ActivityFilters", () => ({
-  ActivityFilters: vi.fn(() => <div data-testid="activity-filters">Mock Filters</div>),
+  ActivityFilters: vi.fn((props) => {
+    capturedFiltersProps = props;
+    return <div data-testid="activity-filters">Mock Filters</div>;
+  }),
 }));
 
-describe("UpdatesContent", () => {
+// ─── Shared test helpers ───────────────────────────────────────────────────────
+
+function mockStores({ isOwner = false, isProjectAdmin = false } = {}) {
+  (useOwnerStore as unknown as vi.Mock).mockImplementation((sel) => sel({ isOwner }));
+  (useProjectStore as unknown as vi.Mock).mockImplementation((sel) => sel({ isProjectAdmin }));
+}
+
+function mockProjectProfile(overrides: Record<string, unknown> = {}) {
+  (useProjectProfile as vi.Mock).mockReturnValue({
+    allUpdates: [],
+    milestonesCount: 0,
+    completedCount: 0,
+    isUpdating: false,
+    ...overrides,
+  });
+}
+
+function buildSearchParams(params: Record<string, string> = {}) {
+  const sp = new URLSearchParams(params);
+  // Attach a typed .get() shim so tests using vi.Mock work transparently
+  return sp;
+}
+
+describe("UpdatesContent — authorization", () => {
   const mockRouter = { replace: vi.fn() };
-  const mockSearchParams = new URLSearchParams();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedFiltersProps = {};
     (useParams as vi.Mock).mockReturnValue({ projectId: "test-project" });
     (useRouter as vi.Mock).mockReturnValue(mockRouter);
-    (useSearchParams as vi.Mock).mockReturnValue(mockSearchParams);
-    (useProjectProfile as vi.Mock).mockReturnValue({
-      allUpdates: [],
-      milestonesCount: 0,
-      completedCount: 0,
-    });
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams());
+    mockProjectProfile();
   });
 
-  it("should pass isAuthorized=true to ActivityFeed when user is owner", () => {
-    (useOwnerStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isOwner: true })
-    );
-    (useProjectStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isProjectAdmin: false })
-    );
-
+  it("passes isAuthorized=true to ActivityFeed when user is owner", () => {
+    mockStores({ isOwner: true });
     render(<UpdatesContent />);
-
-    const activityFeed = screen.getByTestId("activity-feed");
-    expect(activityFeed).toHaveAttribute("data-authorized", "true");
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "true");
   });
 
-  it("should pass isAuthorized=true to ActivityFeed when user is project admin", () => {
-    (useOwnerStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isOwner: false })
-    );
-    (useProjectStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isProjectAdmin: true })
-    );
-
+  it("passes isAuthorized=true to ActivityFeed when user is project admin", () => {
+    mockStores({ isProjectAdmin: true });
     render(<UpdatesContent />);
-
-    const activityFeed = screen.getByTestId("activity-feed");
-    expect(activityFeed).toHaveAttribute("data-authorized", "true");
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "true");
   });
 
-  it("should pass isAuthorized=true when user is both owner and admin", () => {
-    (useOwnerStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isOwner: true })
-    );
-    (useProjectStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isProjectAdmin: true })
-    );
-
+  it("passes isAuthorized=true when user is both owner and admin", () => {
+    mockStores({ isOwner: true, isProjectAdmin: true });
     render(<UpdatesContent />);
-
-    const activityFeed = screen.getByTestId("activity-feed");
-    expect(activityFeed).toHaveAttribute("data-authorized", "true");
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "true");
   });
 
-  it("should pass isAuthorized=false to ActivityFeed when user is neither owner nor admin", () => {
-    (useOwnerStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isOwner: false })
-    );
-    (useProjectStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isProjectAdmin: false })
-    );
-
+  it("passes isAuthorized=false to ActivityFeed when user is neither owner nor admin", () => {
+    mockStores();
     render(<UpdatesContent />);
-
-    const activityFeed = screen.getByTestId("activity-feed");
-    expect(activityFeed).toHaveAttribute("data-authorized", "false");
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "false");
   });
 
-  it("should render activity filters", () => {
-    (useOwnerStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isOwner: false })
-    );
-    (useProjectStore as unknown as vi.Mock).mockImplementation((selector) =>
-      selector({ isProjectAdmin: false })
-    );
-
+  it("renders both activity filters and feed", () => {
+    mockStores();
     render(<UpdatesContent />);
-
     expect(screen.getByTestId("activity-filters")).toBeInTheDocument();
     expect(screen.getByTestId("activity-feed")).toBeInTheDocument();
+  });
+});
+
+// ─── URL round-trip: reading params ───────────────────────────────────────────
+
+describe("UpdatesContent — reads URL params and passes to ActivityFilters", () => {
+  const mockRouter = { replace: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedFiltersProps = {};
+    (useParams as vi.Mock).mockReturnValue({ projectId: "test-project" });
+    (useRouter as vi.Mock).mockReturnValue(mockRouter);
+    mockProjectProfile();
+    mockStores();
+  });
+
+  it("passes dateFrom from URL to ActivityFilters", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams({ dateFrom: "2024-01-01" }));
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.dateFrom).toBe("2024-01-01");
+  });
+
+  it("passes dateTo from URL to ActivityFilters", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(
+      buildSearchParams({ dateFrom: "2024-01-01", dateTo: "2024-01-31" })
+    );
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.dateTo).toBe("2024-01-31");
+  });
+
+  it("passes hasAIEvaluation=true when URL has hasAIEvaluation=true", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams({ hasAIEvaluation: "true" }));
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.hasAIEvaluation).toBe(true);
+  });
+
+  it("passes hasAIEvaluation=false when URL has hasAIEvaluation=false", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams({ hasAIEvaluation: "false" }));
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.hasAIEvaluation).toBe(false);
+  });
+
+  it("passes hasAIEvaluation=undefined when URL param is absent", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams());
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.hasAIEvaluation).toBeUndefined();
+  });
+
+  it("passes aiScoreMin as a number when URL has aiScoreMin", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams({ aiScoreMin: "7" }));
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.aiScoreMin).toBe(7);
+  });
+
+  it("passes aiScoreMin=undefined when URL param is absent", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams());
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.aiScoreMin).toBeUndefined();
+  });
+
+  it("passes aiScoreMin=undefined when URL param is not a valid number", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams({ aiScoreMin: "nope" }));
+    render(<UpdatesContent />);
+    expect(capturedFiltersProps.aiScoreMin).toBeUndefined();
+  });
+});
+
+// ─── URL round-trip: writing params via onDateRangeChange ─────────────────────
+
+describe("UpdatesContent — onDateRangeChange updates URL", () => {
+  const mockReplace = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedFiltersProps = {};
+    (useParams as vi.Mock).mockReturnValue({ projectId: "test-project" });
+    (useRouter as vi.Mock).mockReturnValue({ replace: mockReplace });
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams());
+    mockProjectProfile();
+    mockStores();
+  });
+
+  it("sets dateFrom param in URL when from is provided", () => {
+    render(<UpdatesContent />);
+    const { onDateRangeChange } = capturedFiltersProps as {
+      onDateRangeChange: (f: string | undefined, t: string | undefined) => void;
+    };
+    onDateRangeChange("2024-06-01", undefined);
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("dateFrom=2024-06-01");
+    expect(url).not.toContain("dateTo=");
+  });
+
+  it("sets both dateFrom and dateTo when both are provided", () => {
+    render(<UpdatesContent />);
+    const { onDateRangeChange } = capturedFiltersProps as {
+      onDateRangeChange: (f: string | undefined, t: string | undefined) => void;
+    };
+    onDateRangeChange("2024-06-01", "2024-06-30");
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("dateFrom=2024-06-01");
+    expect(url).toContain("dateTo=2024-06-30");
+  });
+
+  it("removes dateFrom and dateTo from URL when both are undefined", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(
+      buildSearchParams({ dateFrom: "2024-01-01", dateTo: "2024-01-31" })
+    );
+    render(<UpdatesContent />);
+    const { onDateRangeChange } = capturedFiltersProps as {
+      onDateRangeChange: (f: string | undefined, t: string | undefined) => void;
+    };
+    onDateRangeChange(undefined, undefined);
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).not.toContain("dateFrom");
+    expect(url).not.toContain("dateTo");
+  });
+});
+
+// ─── URL round-trip: writing params via onAIFilterChange ──────────────────────
+
+describe("UpdatesContent — onAIFilterChange updates URL", () => {
+  const mockReplace = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedFiltersProps = {};
+    (useParams as vi.Mock).mockReturnValue({ projectId: "test-project" });
+    (useRouter as vi.Mock).mockReturnValue({ replace: mockReplace });
+    (useSearchParams as vi.Mock).mockReturnValue(buildSearchParams());
+    mockProjectProfile();
+    mockStores();
+  });
+
+  it("sets hasAIEvaluation=true param when hasEvaluation=true and no scoreMin", () => {
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    onAIFilterChange({ hasEvaluation: true });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("hasAIEvaluation=true");
+    expect(url).not.toContain("aiScoreMin");
+  });
+
+  it("sets hasAIEvaluation=false when hasEvaluation=false and no scoreMin", () => {
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    onAIFilterChange({ hasEvaluation: false });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("hasAIEvaluation=false");
+    expect(url).not.toContain("aiScoreMin");
+  });
+
+  it("sets aiScoreMin and omits hasAIEvaluation when scoreMin provided without hasEvaluation", () => {
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    // Business rule: scoreMin alone — hasEvaluation omitted means "don't set hasAIEvaluation"
+    onAIFilterChange({ scoreMin: 7 });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("aiScoreMin=7");
+    expect(url).not.toContain("hasAIEvaluation");
+  });
+
+  it("enforces rule: never both hasAIEvaluation=false + aiScoreMin (omits hasAIEvaluation)", () => {
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    // Calling with scoreMin + hasEvaluation=false — hasAIEvaluation must be dropped
+    onAIFilterChange({ hasEvaluation: false, scoreMin: 5 });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("aiScoreMin=5");
+    expect(url).not.toContain("hasAIEvaluation");
+  });
+
+  it("sets both hasAIEvaluation=true and aiScoreMin when both explicitly true+present", () => {
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    onAIFilterChange({ hasEvaluation: true, scoreMin: 8 });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).toContain("aiScoreMin=8");
+    expect(url).toContain("hasAIEvaluation=true");
+  });
+
+  it("removes both params when hasEvaluation=undefined and scoreMin=undefined", () => {
+    (useSearchParams as vi.Mock).mockReturnValue(
+      buildSearchParams({ hasAIEvaluation: "true", aiScoreMin: "5" })
+    );
+    render(<UpdatesContent />);
+    const { onAIFilterChange } = capturedFiltersProps as {
+      onAIFilterChange: (f: { hasEvaluation?: boolean; scoreMin?: number }) => void;
+    };
+    onAIFilterChange({ hasEvaluation: undefined, scoreMin: undefined });
+
+    const [url] = mockReplace.mock.calls[0];
+    expect(url).not.toContain("hasAIEvaluation");
+    expect(url).not.toContain("aiScoreMin");
   });
 });

--- a/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { CalendarIcon } from "@heroicons/react/24/outline";
 import type { LucideIcon } from "lucide-react";
 import { BadgeCheck, CircleDollarSign, Goal, Rss } from "lucide-react";
+import { useCallback, useEffect, useId, useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -9,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
 import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
 import { MILESTONE_STATUS_OPTIONS } from "@/services/milestone-status-filter.service";
 import type { ActivityFilterType, SortOption } from "@/types/v2/project-profile.types";
@@ -29,6 +33,31 @@ interface ActivityFiltersProps {
   milestoneStatusFilter?: MilestoneStatusFilter;
   onMilestoneStatusChange?: (status: MilestoneStatusFilter) => void;
   className?: string;
+  /** ISO 8601 start of the date range. Undefined = no lower bound. */
+  dateFrom?: string;
+  /** ISO 8601 end of the date range. Undefined = no upper bound. */
+  dateTo?: string;
+  /**
+   * Called when the user changes the date range picker.
+   * Pass undefined for either argument to clear that bound.
+   */
+  onDateRangeChange?: (from: string | undefined, to: string | undefined) => void;
+  /**
+   * Whether to restrict results to items with an AI evaluation.
+   */
+  hasAIEvaluation?: boolean;
+  /** Minimum AI score (integer 0–10). */
+  aiScoreMin?: number;
+  /** Maximum AI score (integer 0–10). */
+  aiScoreMax?: number;
+  /**
+   * Called when the user changes the AI evaluation filter controls.
+   */
+  onAIFilterChange?: (filter: {
+    hasEvaluation?: boolean;
+    scoreMin?: number;
+    scoreMax?: number;
+  }) => void;
 }
 
 // Visible filter types
@@ -43,11 +72,417 @@ const FILTER_CONFIG: Partial<Record<ActivityFilterType, { icon: LucideIcon; icon
     endorsements: { icon: BadgeCheck, iconClass: "text-pink-500 dark:text-pink-400" },
   };
 
+// ─── Score color helpers (mirrors MilestoneAIEvaluationBadge) ────────────────
+
+function getScoreColorClass(score: number): string {
+  if (score >= 8) return "text-green-600 dark:text-green-400";
+  if (score >= 5) return "text-yellow-600 dark:text-yellow-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+function getScoreBgClass(score: number): string {
+  if (score >= 8) return "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800";
+  if (score >= 5)
+    return "bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800";
+  return "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800";
+}
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function toISODateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function subtractDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  d.setUTCHours(0, 0, 0, 0);
+  return toISODateString(d);
+}
+
+function formatDateLabel(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${iso}T00:00:00Z`));
+}
+
+function buildDateLabel(from: string | undefined, to: string | undefined): string {
+  if (!from && !to) return "All time";
+  const today = toISODateString(new Date());
+  const sevenDaysAgo = subtractDays(7);
+  const thirtyDaysAgo = subtractDays(30);
+  const ninetyDaysAgo = subtractDays(90);
+
+  if (from === sevenDaysAgo && !to) return "Last 7 days";
+  if (from === thirtyDaysAgo && !to) return "Last 30 days";
+  if (from === ninetyDaysAgo && !to) return "Last 90 days";
+
+  const toLabel = to ? formatDateLabel(to) : formatDateLabel(today);
+  if (from) {
+    return `${formatDateLabel(from)} – ${toLabel}`;
+  }
+  return `Until ${toLabel}`;
+}
+
+// ─── Date Range Picker ────────────────────────────────────────────────────────
+
+interface DateRangePickerProps {
+  dateFrom?: string;
+  dateTo?: string;
+  onDateRangeChange?: (from: string | undefined, to: string | undefined) => void;
+}
+
+function DateRangePicker({ dateFrom, dateTo, onDateRangeChange }: DateRangePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [customFrom, setCustomFrom] = useState(dateFrom ?? "");
+  const [customTo, setCustomTo] = useState(dateTo ?? "");
+  const fromId = useId();
+  const toId = useId();
+
+  const label = buildDateLabel(dateFrom, dateTo);
+  const isActive = !!(dateFrom || dateTo);
+
+  const applyPreset = useCallback(
+    (from: string | undefined) => {
+      setCustomFrom(from ?? "");
+      setCustomTo("");
+      onDateRangeChange?.(from, undefined);
+      setOpen(false);
+    },
+    [onDateRangeChange]
+  );
+
+  const applyCustom = useCallback(() => {
+    let from: string | undefined = customFrom || undefined;
+    let to: string | undefined = customTo || undefined;
+    // Swap if from > to
+    if (from && to && from > to) {
+      [from, to] = [to, from];
+      setCustomFrom(from);
+      setCustomTo(to);
+    }
+    onDateRangeChange?.(from, to);
+    setOpen(false);
+  }, [customFrom, customTo, onDateRangeChange]);
+
+  const clearFilter = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setCustomFrom("");
+      setCustomTo("");
+      onDateRangeChange?.(undefined, undefined);
+    },
+    [onDateRangeChange]
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <div className="relative inline-flex">
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Date range filter: ${label}`}
+            aria-expanded={open}
+            aria-haspopup="dialog"
+            className={cn(
+              "inline-flex items-center gap-1.5 py-[5px] rounded-full border text-[12px] font-medium transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+              isActive
+                ? "pl-2.5 pr-7 border-foreground bg-foreground text-background"
+                : "px-2.5 border-border bg-secondary text-foreground hover:bg-secondary/80"
+            )}
+          >
+            <CalendarIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+            <span>{label}</span>
+          </button>
+        </PopoverTrigger>
+        {isActive && (
+          <button
+            type="button"
+            aria-label="Clear date filter"
+            onClick={clearFilter}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-background hover:opacity-70 cursor-pointer leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-400 rounded"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      <PopoverContent
+        align="start"
+        className="w-72 p-3 space-y-3 bg-white dark:bg-zinc-900 border-border"
+      >
+        {/* Preset buttons */}
+        <div className="flex flex-col gap-1">
+          {(
+            [
+              { label: "Last 7 days", days: 7 },
+              { label: "Last 30 days", days: 30 },
+              { label: "Last 90 days", days: 90 },
+            ] as const
+          ).map(({ label: presetLabel, days }) => {
+            const from = subtractDays(days);
+            const isSelected = dateFrom === from && !dateTo;
+            return (
+              <button
+                key={presetLabel}
+                type="button"
+                onClick={() => applyPreset(from)}
+                aria-pressed={isSelected}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 rounded text-sm transition-colors",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+                  isSelected
+                    ? "bg-foreground text-background font-medium"
+                    : "hover:bg-secondary text-foreground"
+                )}
+              >
+                {presetLabel}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => applyPreset(undefined)}
+            aria-pressed={!dateFrom && !dateTo}
+            className={cn(
+              "w-full text-left px-3 py-1.5 rounded text-sm transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+              !dateFrom && !dateTo
+                ? "bg-foreground text-background font-medium"
+                : "hover:bg-secondary text-foreground"
+            )}
+          >
+            All time
+          </button>
+        </div>
+
+        {/* Divider */}
+        <hr className="border-border" />
+
+        {/* Custom range */}
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Custom range
+          </legend>
+
+          <div className="space-y-1.5">
+            <label htmlFor={fromId} className="block text-xs font-medium text-foreground">
+              From
+            </label>
+            <input
+              id={fromId}
+              type="date"
+              value={customFrom}
+              max={customTo || undefined}
+              onChange={(e) => setCustomFrom(e.target.value)}
+              className={cn(
+                "w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+                "dark:bg-zinc-800 dark:border-zinc-700"
+              )}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor={toId} className="block text-xs font-medium text-foreground">
+              To
+            </label>
+            <input
+              id={toId}
+              type="date"
+              value={customTo}
+              min={customFrom || undefined}
+              onChange={(e) => setCustomTo(e.target.value)}
+              className={cn(
+                "w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+                "dark:bg-zinc-800 dark:border-zinc-700"
+              )}
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={applyCustom}
+            disabled={!customFrom && !customTo}
+            className={cn(
+              "w-full mt-1 px-3 py-1.5 rounded text-sm font-medium transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+              "bg-foreground text-background hover:opacity-90",
+              "disabled:opacity-40 disabled:cursor-not-allowed"
+            )}
+          >
+            Apply
+          </button>
+        </fieldset>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ─── AI Evaluation sub-filter ─────────────────────────────────────────────────
+
+interface AIEvaluationFilterProps {
+  hasAIEvaluation?: boolean;
+  aiScoreMin?: number;
+  aiScoreMax?: number;
+  onAIFilterChange?: (filter: {
+    hasEvaluation?: boolean;
+    scoreMin?: number;
+    scoreMax?: number;
+  }) => void;
+}
+
+const SCORE_MIN = 0;
+const SCORE_MAX = 10;
+
+function AIEvaluationFilter({
+  hasAIEvaluation,
+  aiScoreMin,
+  aiScoreMax,
+  onAIFilterChange,
+}: AIEvaluationFilterProps) {
+  const toggleId = useId();
+
+  const isOn = !!(
+    hasAIEvaluation ||
+    (aiScoreMin !== undefined && aiScoreMin > SCORE_MIN) ||
+    (aiScoreMax !== undefined && aiScoreMax < SCORE_MAX)
+  );
+
+  const committedMin = aiScoreMin ?? SCORE_MIN;
+  const committedMax = aiScoreMax ?? SCORE_MAX;
+
+  // Local draft state drives the slider visually while dragging;
+  // committed only on value-commit (pointer/key release via onValueCommit).
+  const [draftRange, setDraftRange] = useState<[number, number]>([committedMin, committedMax]);
+
+  useEffect(() => {
+    setDraftRange([committedMin, committedMax]);
+  }, [committedMin, committedMax]);
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      if (!checked) {
+        onAIFilterChange?.({ hasEvaluation: undefined, scoreMin: undefined, scoreMax: undefined });
+      } else {
+        onAIFilterChange?.({ hasEvaluation: true, scoreMin: undefined, scoreMax: undefined });
+      }
+    },
+    [onAIFilterChange]
+  );
+
+  const commitRange = useCallback(
+    (values: number[]) => {
+      const [min, max] = values as [number, number];
+      const isDefault = min === SCORE_MIN && max === SCORE_MAX;
+      if (isDefault) {
+        // Range is [0,10] — keep hasEvaluation=true but clear score params
+        onAIFilterChange?.({ hasEvaluation: true, scoreMin: undefined, scoreMax: undefined });
+      } else {
+        onAIFilterChange?.({
+          hasEvaluation: undefined,
+          scoreMin: min === SCORE_MIN ? undefined : min,
+          scoreMax: max === SCORE_MAX ? undefined : max,
+        });
+      }
+    },
+    [onAIFilterChange]
+  );
+
+  const [draftMin, draftMax] = draftRange;
+  const isDefaultRange = draftMin === SCORE_MIN && draftMax === SCORE_MAX;
+
+  return (
+    <fieldset className="flex flex-wrap items-center gap-3 border border-border rounded-lg px-3 py-2 bg-secondary/40 dark:bg-zinc-800/40">
+      <legend className="text-xs font-semibold text-muted-foreground uppercase tracking-wide shrink-0 px-0.5">
+        AI Evaluation
+      </legend>
+
+      {/* Toggle: Has AI evaluation */}
+      <div className="flex items-center gap-1.5">
+        <input
+          id={toggleId}
+          type="checkbox"
+          checked={isOn}
+          onChange={(e) => handleToggle(e.target.checked)}
+          className={cn(
+            "h-4 w-4 rounded border-border text-primary",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-neutral-500 dark:focus-visible:ring-neutral-400",
+            "cursor-pointer accent-foreground"
+          )}
+        />
+        <label
+          htmlFor={toggleId}
+          className="text-xs font-medium text-foreground cursor-pointer whitespace-nowrap select-none"
+        >
+          Has AI evaluation
+        </label>
+      </div>
+
+      {/* Range slider: only when toggle is on */}
+      {isOn && (
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-muted-foreground whitespace-nowrap select-none">
+            Score range
+          </span>
+          <Slider
+            min={SCORE_MIN}
+            max={SCORE_MAX}
+            step={1}
+            value={draftRange}
+            onValueChange={(values) => setDraftRange(values as [number, number])}
+            onValueCommit={commitRange}
+            className="w-32"
+            thumbLabels={["Minimum score", "Maximum score"]}
+          />
+          {isDefaultRange ? (
+            <span className="text-xs text-muted-foreground" aria-hidden="true">
+              Any
+            </span>
+          ) : (
+            <span className="flex items-center gap-1" aria-hidden="true">
+              <span
+                className={cn(
+                  "inline-flex items-center justify-center rounded-full border px-1.5 py-0.5 text-[11px] font-semibold tabular-nums",
+                  getScoreBgClass(draftMin),
+                  getScoreColorClass(draftMin)
+                )}
+              >
+                {`\u2265\u00a0${draftMin}`}
+              </span>
+              <span className="text-xs text-muted-foreground">{"\u2014"}</span>
+              <span
+                className={cn(
+                  "inline-flex items-center justify-center rounded-full border px-1.5 py-0.5 text-[11px] font-semibold tabular-nums",
+                  getScoreBgClass(draftMax),
+                  getScoreColorClass(draftMax)
+                )}
+              >
+                {`\u2264\u00a0${draftMax}`}
+              </span>
+            </span>
+          )}
+        </div>
+      )}
+    </fieldset>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
 /**
  * ActivityFilters provides filtering controls for the activity feed.
  * Includes:
+ * - Date range picker (always visible)
  * - Sort dropdown (Newest/Oldest)
  * - Filter pills with icon + label + count chip (Figma design)
+ * - Milestone status filter (when milestones active)
+ * - AI evaluation filter (when milestones + completed/verified active)
  */
 export function ActivityFilters({
   activeFilters,
@@ -55,11 +490,18 @@ export function ActivityFilters({
   sortBy,
   onSortChange,
   counts = {},
-  milestonesCount = 0,
-  completedCount = 0,
+  milestonesCount: _milestonesCount = 0,
+  completedCount: _completedCount = 0,
   milestoneStatusFilter,
   onMilestoneStatusChange,
   className,
+  dateFrom,
+  dateTo,
+  onDateRangeChange,
+  hasAIEvaluation,
+  aiScoreMin,
+  aiScoreMax,
+  onAIFilterChange,
 }: ActivityFiltersProps) {
   const filterOptions = ACTIVITY_FILTER_OPTIONS.filter((option) =>
     VISIBLE_FILTERS.includes(option.value)
@@ -78,12 +520,22 @@ export function ActivityFilters({
     onMilestoneStatusChange !== undefined &&
     activeFilters.includes("milestones");
 
+  // AI evaluation filter: show when Milestones active, unless status is Pending
+  // (pending milestones never have evaluations, so the filter would always empty the list).
+  // Also show whenever any AI URL param is already active, so users can always see and
+  // clear the filter they landed on — never hide state that is affecting results.
+  const hasActiveAIFilter =
+    hasAIEvaluation !== undefined || aiScoreMin !== undefined || aiScoreMax !== undefined;
+  const showAIEvaluationFilter =
+    (activeFilters.includes("milestones") || hasActiveAIFilter) &&
+    milestoneStatusFilter !== "pending";
+
   return (
     <div className={cn("flex flex-col gap-4", className)} data-testid="activity-filters">
-      {/* Single row: Filter pills on left, Sort on right */}
+      {/* Top row: Filter pills + date picker on left, Sort on right */}
       <div className="flex flex-row items-center justify-between flex-wrap gap-4">
-        {/* Filter pills */}
-        <div className="flex flex-row flex-wrap gap-2" data-testid="filter-badges">
+        {/* Filter pills + date range picker */}
+        <div className="flex flex-row flex-wrap gap-2 items-center" data-testid="filter-badges">
           {/* All button */}
           <button
             type="button"
@@ -172,6 +624,13 @@ export function ActivityFilters({
               </button>
             );
           })}
+
+          {/* Date range picker — always visible, applies to all activity types */}
+          <DateRangePicker
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onDateRangeChange={onDateRangeChange}
+          />
         </div>
 
         {/* Right-side controls: milestone status filter + sort */}
@@ -217,6 +676,18 @@ export function ActivityFilters({
           )}
         </div>
       </div>
+
+      {/* Sub-filter row: AI evaluation filter (gated to milestones + completed/verified) */}
+      {showAIEvaluationFilter && (
+        <div className="flex flex-row flex-wrap gap-2 items-center">
+          <AIEvaluationFilter
+            hasAIEvaluation={hasAIEvaluation}
+            aiScoreMin={aiScoreMin}
+            aiScoreMax={aiScoreMax}
+            onAIFilterChange={onAIFilterChange}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
@@ -1,6 +1,72 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
 import { ActivityFilters, type ActivityFilterType } from "../ActivityFilters";
+
+// ─── Shared mock for Radix Popover ────────────────────────────────────────────
+// Renders content inline so we can assert on it without portal issues.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="popover-root" data-open={String(!!open)}>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-trigger">{children}</div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+// ─── Shared mock for Radix Slider ─────────────────────────────────────────────
+// Renders two native <input type="range"> elements so we can fire events
+// against them without needing a full DOM pointer-events implementation.
+vi.mock("@/components/ui/slider", () => ({
+  Slider: ({
+    value,
+    onValueChange,
+    onValueCommit,
+    thumbLabels,
+    min = 0,
+    max = 10,
+    step = 1,
+  }: {
+    value?: number[];
+    onValueChange?: (v: number[]) => void;
+    onValueCommit?: (v: number[]) => void;
+    thumbLabels?: string[];
+    min?: number;
+    max?: number;
+    step?: number;
+  }) => {
+    const vals = value ?? [min, max];
+    return (
+      <div data-testid="slider-root">
+        {vals.map((v, i) => (
+          <input
+            key={thumbLabels?.[i] ?? i}
+            type="range"
+            aria-label={thumbLabels?.[i]}
+            min={min}
+            max={max}
+            step={step}
+            value={v}
+            onChange={(e) => {
+              const next = [...vals];
+              next[i] = Number(e.target.value);
+              onValueChange?.(next);
+            }}
+            onPointerUp={(e) => {
+              const next = [...vals];
+              next[i] = Number((e.target as HTMLInputElement).value);
+              onValueCommit?.(next);
+            }}
+          />
+        ))}
+      </div>
+    );
+  },
+}));
 
 describe("ActivityFilters - Milestone Status Dropdown Visibility", () => {
   const defaultProps = {
@@ -90,5 +156,435 @@ describe("ActivityFilters - Milestone Status Dropdown Options", () => {
     expect(trigger).toBeInTheDocument();
     // The trigger should display the current value text
     expect(trigger).toHaveTextContent("All statuses");
+  });
+});
+
+// ─── Helpers shared by new suites ─────────────────────────────────────────────
+
+function subtractDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString().slice(0, 10);
+}
+
+const baseProps = {
+  activeFilters: [] as ActivityFilterType[],
+  onFilterToggle: vi.fn(),
+};
+
+function renderFilters(overrides: Partial<Parameters<typeof ActivityFilters>[0]> = {}) {
+  return render(<ActivityFilters {...baseProps} {...overrides} />);
+}
+
+// ─── Date Range Picker ────────────────────────────────────────────────────────
+
+describe("ActivityFilters — DateRangePicker label", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders "All time" trigger label when no dateFrom/dateTo', () => {
+    renderFilters();
+    expect(
+      screen.getByRole("button", { name: /date range filter: all time/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders "Last 7 days" label when dateFrom matches 7-day preset', () => {
+    renderFilters({ dateFrom: subtractDays(7) });
+    expect(
+      screen.getByRole("button", { name: /date range filter: last 7 days/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders "Last 30 days" label when dateFrom matches 30-day preset', () => {
+    renderFilters({ dateFrom: subtractDays(30) });
+    expect(
+      screen.getByRole("button", { name: /date range filter: last 30 days/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders "Last 90 days" label when dateFrom matches 90-day preset', () => {
+    renderFilters({ dateFrom: subtractDays(90) });
+    expect(
+      screen.getByRole("button", { name: /date range filter: last 90 days/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows Clear button only when a date range is active", () => {
+    renderFilters({ dateFrom: subtractDays(7) });
+    expect(screen.getByRole("button", { name: /clear date filter/i })).toBeInTheDocument();
+  });
+
+  it("does NOT show Clear button when no dates set", () => {
+    renderFilters();
+    expect(screen.queryByRole("button", { name: /clear date filter/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("ActivityFilters — DateRangePicker popover content", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("popover always renders preset buttons and custom range inputs", () => {
+    renderFilters();
+    const content = screen.getByTestId("popover-content");
+    expect(within(content).getByRole("button", { name: /last 7 days/i })).toBeInTheDocument();
+    expect(within(content).getByRole("button", { name: /last 30 days/i })).toBeInTheDocument();
+    expect(within(content).getByRole("button", { name: /last 90 days/i })).toBeInTheDocument();
+    expect(within(content).getByRole("button", { name: /^all time$/i })).toBeInTheDocument();
+    expect(within(content).getByLabelText(/^from$/i)).toBeInTheDocument();
+    expect(within(content).getByLabelText(/^to$/i)).toBeInTheDocument();
+  });
+
+  it("Apply button is disabled when both from and to are empty", () => {
+    renderFilters();
+    const content = screen.getByTestId("popover-content");
+    expect(within(content).getByRole("button", { name: /apply/i })).toBeDisabled();
+  });
+});
+
+describe("ActivityFilters — DateRangePicker preset callbacks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clicking 'Last 7 days' calls onDateRangeChange(7-day ISO, undefined)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    fireEvent.click(within(content).getByRole("button", { name: /last 7 days/i }));
+
+    expect(onDateRangeChange).toHaveBeenCalledTimes(1);
+    const [from, to] = onDateRangeChange.mock.calls[0];
+    expect(from).toBe(subtractDays(7));
+    expect(to).toBeUndefined();
+  });
+
+  it("clicking 'Last 30 days' calls onDateRangeChange(30-day ISO, undefined)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    fireEvent.click(within(content).getByRole("button", { name: /last 30 days/i }));
+
+    const [from, to] = onDateRangeChange.mock.calls[0];
+    expect(from).toBe(subtractDays(30));
+    expect(to).toBeUndefined();
+  });
+
+  it("clicking 'Last 90 days' calls onDateRangeChange(90-day ISO, undefined)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    fireEvent.click(within(content).getByRole("button", { name: /last 90 days/i }));
+
+    const [from, to] = onDateRangeChange.mock.calls[0];
+    expect(from).toBe(subtractDays(90));
+    expect(to).toBeUndefined();
+  });
+
+  it("clicking 'All time' calls onDateRangeChange(undefined, undefined)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ dateFrom: subtractDays(7), onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    fireEvent.click(within(content).getByRole("button", { name: /^all time$/i }));
+
+    expect(onDateRangeChange).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it("clicking Clear button calls onDateRangeChange(undefined, undefined)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ dateFrom: subtractDays(7), onDateRangeChange });
+
+    fireEvent.click(screen.getByRole("button", { name: /clear date filter/i }));
+
+    expect(onDateRangeChange).toHaveBeenCalledWith(undefined, undefined);
+  });
+});
+
+describe("ActivityFilters — DateRangePicker custom range", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("typing from/to and clicking Apply calls onDateRangeChange(from, to)", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    fireEvent.change(within(content).getByLabelText(/^from$/i), {
+      target: { value: "2024-01-01" },
+    });
+    fireEvent.change(within(content).getByLabelText(/^to$/i), {
+      target: { value: "2024-01-31" },
+    });
+    fireEvent.click(within(content).getByRole("button", { name: /apply/i }));
+
+    expect(onDateRangeChange).toHaveBeenCalledWith("2024-01-01", "2024-01-31");
+  });
+
+  it("when from > to, values are swapped before callback fires", () => {
+    const onDateRangeChange = vi.fn();
+    renderFilters({ onDateRangeChange });
+
+    const content = screen.getByTestId("popover-content");
+    // Intentionally reversed: later date entered as "from"
+    fireEvent.change(within(content).getByLabelText(/^from$/i), {
+      target: { value: "2024-03-31" },
+    });
+    fireEvent.change(within(content).getByLabelText(/^to$/i), {
+      target: { value: "2024-01-01" },
+    });
+    fireEvent.click(within(content).getByRole("button", { name: /apply/i }));
+
+    // Expect alphabetically/chronologically correct order
+    expect(onDateRangeChange).toHaveBeenCalledWith("2024-01-01", "2024-03-31");
+  });
+
+  it("Apply is enabled when only from is set", () => {
+    renderFilters();
+    const content = screen.getByTestId("popover-content");
+    fireEvent.change(within(content).getByLabelText(/^from$/i), {
+      target: { value: "2024-01-01" },
+    });
+    expect(within(content).getByRole("button", { name: /apply/i })).not.toBeDisabled();
+  });
+});
+
+// ─── AI Evaluation sub-filter visibility ─────────────────────────────────────
+
+describe("ActivityFilters — AI Evaluation filter visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is NOT rendered when 'milestones' is not in activeFilters", () => {
+    renderFilters({
+      activeFilters: ["funding"],
+      milestoneStatusFilter: "completed",
+      onMilestoneStatusChange: vi.fn(),
+    });
+    expect(screen.queryByRole("group", { name: /ai evaluation/i })).not.toBeInTheDocument();
+  });
+
+  it("IS rendered when milestoneStatusFilter is 'all'", () => {
+    renderFilters({
+      activeFilters: ["milestones"],
+      milestoneStatusFilter: "all",
+      onMilestoneStatusChange: vi.fn(),
+    });
+    expect(screen.queryByRole("group", { name: /ai evaluation/i })).toBeInTheDocument();
+  });
+
+  it("is NOT rendered when milestoneStatusFilter is 'pending'", () => {
+    renderFilters({
+      activeFilters: ["milestones"],
+      milestoneStatusFilter: "pending",
+      onMilestoneStatusChange: vi.fn(),
+    });
+    expect(screen.queryByRole("group", { name: /ai evaluation/i })).not.toBeInTheDocument();
+  });
+
+  it("IS rendered when milestones active AND status is 'completed'", () => {
+    renderFilters({
+      activeFilters: ["milestones"],
+      milestoneStatusFilter: "completed",
+      onMilestoneStatusChange: vi.fn(),
+    });
+    // The AIEvaluationFilter renders a <fieldset> with legend "AI Evaluation".
+    // Use getByRole('group') which maps to <fieldset> to avoid ambiguity with
+    // the "Has AI evaluation" label that also matches /ai evaluation/i.
+    expect(screen.getByRole("group", { name: /ai evaluation/i })).toBeInTheDocument();
+  });
+
+  it("IS rendered when milestones active AND status is 'verified'", () => {
+    renderFilters({
+      activeFilters: ["milestones"],
+      milestoneStatusFilter: "verified",
+      onMilestoneStatusChange: vi.fn(),
+    });
+    expect(screen.getByRole("group", { name: /ai evaluation/i })).toBeInTheDocument();
+  });
+});
+
+// ─── AI Evaluation sub-filter interactions ────────────────────────────────────
+
+describe("ActivityFilters — AI Evaluation filter interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Props that put the AI filter in a visible state
+  const aiVisibleProps = {
+    activeFilters: ["milestones"] as ActivityFilterType[],
+    milestoneStatusFilter: "completed" as MilestoneStatusFilter,
+    onMilestoneStatusChange: vi.fn(),
+  };
+
+  it("sliders are hidden when toggle is off (no hasAIEvaluation, no aiScoreMin/Max)", () => {
+    renderFilters({ ...aiVisibleProps });
+    expect(screen.queryAllByRole("slider")).toHaveLength(0);
+  });
+
+  it("toggling on calls onAIFilterChange({ hasEvaluation: true, scoreMin: undefined, scoreMax: undefined })", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({ ...aiVisibleProps, onAIFilterChange });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /has ai evaluation/i }));
+
+    expect(onAIFilterChange).toHaveBeenCalledWith({
+      hasEvaluation: true,
+      scoreMin: undefined,
+      scoreMax: undefined,
+    });
+  });
+
+  it("two slider thumbs are visible when hasAIEvaluation is true", () => {
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true });
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("two slider thumbs are visible when aiScoreMin > 0", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 5 });
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("two slider thumbs are visible when aiScoreMax < 10", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMax: 8 });
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("min thumb has aria-label 'Minimum score'", () => {
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true });
+    expect(screen.getByRole("slider", { name: "Minimum score" })).toBeInTheDocument();
+  });
+
+  it("max thumb has aria-label 'Maximum score'", () => {
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true });
+    expect(screen.getByRole("slider", { name: "Maximum score" })).toBeInTheDocument();
+  });
+
+  it("committing min thumb calls onAIFilterChange with scoreMin set", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true, onAIFilterChange });
+
+    const minSlider = screen.getByRole("slider", { name: "Minimum score" });
+    fireEvent.change(minSlider, { target: { value: "3" } });
+    fireEvent.pointerUp(minSlider, { target: { value: "3" } });
+
+    expect(onAIFilterChange).toHaveBeenCalledWith({
+      hasEvaluation: undefined,
+      scoreMin: 3,
+      scoreMax: undefined,
+    });
+  });
+
+  it("committing max thumb calls onAIFilterChange with scoreMax set", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true, onAIFilterChange });
+
+    const maxSlider = screen.getByRole("slider", { name: "Maximum score" });
+    fireEvent.change(maxSlider, { target: { value: "8" } });
+    fireEvent.pointerUp(maxSlider, { target: { value: "8" } });
+
+    expect(onAIFilterChange).toHaveBeenCalledWith({
+      hasEvaluation: undefined,
+      scoreMin: undefined,
+      scoreMax: 8,
+    });
+  });
+
+  it("committing both min=5 and max=8 calls onAIFilterChange with both set", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true, aiScoreMin: 5, onAIFilterChange });
+
+    const maxSlider = screen.getByRole("slider", { name: "Maximum score" });
+    fireEvent.change(maxSlider, { target: { value: "8" } });
+    fireEvent.pointerUp(maxSlider, { target: { value: "8" } });
+
+    expect(onAIFilterChange).toHaveBeenCalledWith({
+      hasEvaluation: undefined,
+      scoreMin: 5,
+      scoreMax: 8,
+    });
+  });
+
+  it("dragging slider without releasing does NOT commit (no refetch while dragging)", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true, onAIFilterChange });
+
+    fireEvent.change(screen.getByRole("slider", { name: "Minimum score" }), {
+      target: { value: "7" },
+    });
+
+    expect(onAIFilterChange).not.toHaveBeenCalled();
+  });
+
+  it("toggling off clears hasEvaluation, scoreMin, AND scoreMax", () => {
+    const onAIFilterChange = vi.fn();
+    renderFilters({
+      ...aiVisibleProps,
+      hasAIEvaluation: true,
+      aiScoreMin: 3,
+      aiScoreMax: 8,
+      onAIFilterChange,
+    });
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /has ai evaluation/i }));
+
+    expect(onAIFilterChange).toHaveBeenCalledWith({
+      hasEvaluation: undefined,
+      scoreMin: undefined,
+      scoreMax: undefined,
+    });
+  });
+
+  it("default range [0, 10] shows 'Any' label", () => {
+    renderFilters({ ...aiVisibleProps, hasAIEvaluation: true });
+    expect(screen.getByText("Any")).toBeInTheDocument();
+    expect(screen.queryByText(/≥/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/≤/)).not.toBeInTheDocument();
+  });
+
+  it("non-default range shows '≥ min — ≤ max' label", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 3, aiScoreMax: 8 });
+    expect(screen.getByText(/≥\s*3/)).toBeInTheDocument();
+    expect(screen.getByText(/≤\s*8/)).toBeInTheDocument();
+  });
+
+  it("min chip is green when min >= 8", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 8, aiScoreMax: 10 });
+    const minBadge = screen.getByText(/≥\s*8/);
+    expect(minBadge).toHaveClass("text-green-600");
+  });
+
+  it("min chip is yellow when min is 5–7", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 6, aiScoreMax: 9 });
+    const minBadge = screen.getByText(/≥\s*6/);
+    expect(minBadge).toHaveClass("text-yellow-600");
+  });
+
+  it("min chip is red when min is 1–4", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 3, aiScoreMax: 7 });
+    const minBadge = screen.getByText(/≥\s*3/);
+    expect(minBadge).toHaveClass("text-red-600");
+  });
+
+  it("max chip is green when max >= 8", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 5, aiScoreMax: 9 });
+    const maxBadge = screen.getByText(/≤\s*9/);
+    expect(maxBadge).toHaveClass("text-green-600");
+  });
+
+  it("max chip is yellow when max is 5–7", () => {
+    renderFilters({ ...aiVisibleProps, aiScoreMin: 2, aiScoreMax: 7 });
+    const maxBadge = screen.getByText(/≤\s*7/);
+    expect(maxBadge).toHaveClass("text-yellow-600");
   });
 });

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/utilities/tailwind";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+import { cn } from "@/utilities/tailwind";
+
+interface SliderProps extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  /**
+   * aria-label for each thumb, indexed in order.
+   * When provided, overrides the default aria-label on each Thumb.
+   */
+  thumbLabels?: string[];
+}
+
+const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
+  ({ className, thumbLabels, ...props }, ref) => {
+    const values = props.value ?? props.defaultValue ?? [0];
+
+    return (
+      <SliderPrimitive.Root
+        ref={ref}
+        className={cn("relative flex w-full touch-none select-none items-center", className)}
+        {...props}
+      >
+        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-border">
+          <SliderPrimitive.Range className="absolute h-full bg-foreground" />
+        </SliderPrimitive.Track>
+        {values.map((_, index) => (
+          <SliderPrimitive.Thumb
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            aria-label={thumbLabels?.[index]}
+            className={cn(
+              "block h-4 w-4 rounded-full border border-foreground/50 bg-background shadow transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              "disabled:pointer-events-none disabled:opacity-50",
+              "cursor-grab active:cursor-grabbing"
+            )}
+          />
+        ))}
+      </SliderPrimitive.Root>
+    );
+  }
+);
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/hooks/v2/__tests__/useProjectUpdates.test.tsx
+++ b/hooks/v2/__tests__/useProjectUpdates.test.tsx
@@ -175,7 +175,7 @@ describe("useProjectUpdates", () => {
     });
 
     await waitFor(() => {
-      expect(mockGetProjectUpdates).toHaveBeenCalledWith("test-project", "completed");
+      expect(mockGetProjectUpdates).toHaveBeenCalledWith("test-project", "completed", undefined);
     });
   });
 
@@ -192,7 +192,63 @@ describe("useProjectUpdates", () => {
     });
 
     await waitFor(() => {
-      expect(mockGetProjectUpdates).toHaveBeenCalledWith("test-project", undefined);
+      expect(mockGetProjectUpdates).toHaveBeenCalledWith("test-project", undefined, undefined);
+    });
+  });
+
+  it("passes extra filters to getProjectUpdates when provided", async () => {
+    mockGetProjectUpdates.mockResolvedValueOnce({
+      projectUpdates: [],
+      projectMilestones: [],
+      grantMilestones: [],
+      grantUpdates: [],
+    });
+
+    const filters = {
+      dateFrom: "2024-01-01",
+      dateTo: "2024-12-31",
+      hasAIEvaluation: true,
+      aiScoreMin: 5,
+    };
+
+    renderHook(() => useProjectUpdates("test-project", undefined, filters), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(mockGetProjectUpdates).toHaveBeenCalledWith("test-project", undefined, filters);
+    });
+  });
+
+  it("uses distinct query keys for different filter combinations", async () => {
+    mockGetProjectUpdates.mockResolvedValue({
+      projectUpdates: [],
+      projectMilestones: [],
+      grantMilestones: [],
+      grantUpdates: [],
+    });
+
+    const { rerender } = renderHook(
+      ({ scoreMin }: { scoreMin?: number }) =>
+        useProjectUpdates(
+          "test-project",
+          undefined,
+          scoreMin !== undefined ? { aiScoreMin: scoreMin } : undefined
+        ),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { scoreMin: undefined },
+      }
+    );
+
+    await waitFor(() => {
+      expect(mockGetProjectUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ scoreMin: 7 });
+
+    await waitFor(() => {
+      expect(mockGetProjectUpdates).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/hooks/v2/useProjectProfile.ts
+++ b/hooks/v2/useProjectProfile.ts
@@ -10,7 +10,11 @@ import { useMemo } from "react";
 import { useProject } from "@/hooks/useProject";
 import { aggregateProjectProfileData } from "@/services/project-profile.service";
 import type { Project } from "@/types/v2/project";
-import type { ProjectProfileData, ProjectProfileState } from "@/types/v2/project-profile.types";
+import type {
+  ProjectProfileData,
+  ProjectProfileState,
+  UpdatesFeedFilters,
+} from "@/types/v2/project-profile.types";
 import { useProjectGrants } from "./useProjectGrants";
 import { useProjectImpacts } from "./useProjectImpacts";
 import { useProjectUpdates } from "./useProjectUpdates";
@@ -42,11 +46,14 @@ export interface UseProjectProfileResult extends ProjectProfileData, ProjectProf
  * all data into a unified format for the ProjectProfilePage.
  *
  * @param projectId - The project UID or slug
+ * @param milestoneStatus - Optional milestone lifecycle filter
+ * @param filters - Optional extra filters forwarded to the indexer
  * @returns Aggregated project profile data with loading/error states
  */
 export function useProjectProfile(
   projectId: string,
-  milestoneStatus?: "pending" | "completed" | "verified"
+  milestoneStatus?: "pending" | "completed" | "verified",
+  filters?: UpdatesFeedFilters
 ): UseProjectProfileResult {
   // Fetch core project data
   const { project, isLoading: isProjectLoading, isError, error } = useProject(projectId);
@@ -58,13 +65,13 @@ export function useProjectProfile(
     refetch: refetchGrants,
   } = useProjectGrants(project?.uid || projectId);
 
-  // Fetch updates and milestones (pass milestoneStatus for server-side filtering)
+  // Fetch updates and milestones (pass milestoneStatus and extra filters for server-side filtering)
   const {
     milestones = [],
     isLoading: isUpdatesLoading,
     isFetching: isUpdatesFetching,
     refetch: refetchUpdates,
-  } = useProjectUpdates(projectId, milestoneStatus);
+  } = useProjectUpdates(projectId, milestoneStatus, filters);
 
   // Fetch impacts
   const {

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -1,5 +1,6 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { getProjectUpdates } from "@/services/project-updates.service";
+import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
 import type {
   GrantMilestoneWithDetails,
   GrantUpdateWithDetails,
@@ -358,15 +359,26 @@ const sortByDateDescending = (milestones: UnifiedMilestone[]): UnifiedMilestone[
  * that returns all updates, project milestones, and grant milestones.
  *
  * @param projectIdOrSlug - The project UID or slug
+ * @param milestoneStatus - Optional milestone lifecycle filter
+ * @param filters - Optional extra filters forwarded to the indexer
  * @returns Object containing unified milestones, loading state, error, and refetch function
  */
 export function useProjectUpdates(
   projectIdOrSlug: string,
-  milestoneStatus?: "pending" | "completed" | "verified"
+  milestoneStatus?: "pending" | "completed" | "verified",
+  filters?: UpdatesFeedFilters
 ) {
-  const queryKey = milestoneStatus
-    ? ([...QUERY_KEYS.PROJECT.UPDATES(projectIdOrSlug), milestoneStatus] as const)
-    : QUERY_KEYS.PROJECT.UPDATES(projectIdOrSlug);
+  // Build a stable query key that includes all active filter values so that
+  // React Query invalidates the cache whenever any filter changes.
+  const queryKey = [
+    ...QUERY_KEYS.PROJECT.UPDATES(projectIdOrSlug),
+    milestoneStatus ?? null,
+    filters?.dateFrom ?? null,
+    filters?.dateTo ?? null,
+    filters?.hasAIEvaluation ?? null,
+    filters?.aiScoreMin ?? null,
+    filters?.aiScoreMax ?? null,
+  ] as const;
 
   const {
     data,
@@ -376,7 +388,7 @@ export function useProjectUpdates(
     refetch: originalRefetch,
   } = useQuery<UpdatesApiResponse>({
     queryKey,
-    queryFn: () => getProjectUpdates(projectIdOrSlug, milestoneStatus),
+    queryFn: () => getProjectUpdates(projectIdOrSlug, milestoneStatus, filters),
     enabled: !!projectIdOrSlug,
     staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,

--- a/services/__tests__/project-updates.service.test.ts
+++ b/services/__tests__/project-updates.service.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for project-updates.service
+ *
+ * Focuses on the URL construction (query string building) and the semantic rules
+ * enforced before forwarding params to the indexer.
+ */
+
+import { getProjectUpdates } from "../project-updates.service";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      PROJECTS: {
+        UPDATES: (slug: string) => `/v2/projects/${slug}/updates`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+const emptyResponse = {
+  projectUpdates: [],
+  projectMilestones: [],
+  grantMilestones: [],
+  grantUpdates: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchData.mockResolvedValue([emptyResponse, null, null, 200]);
+});
+
+describe("getProjectUpdates — URL construction", () => {
+  it("calls the base URL when no options are given", async () => {
+    await getProjectUpdates("my-project");
+    expect(mockFetchData).toHaveBeenCalledWith("/v2/projects/my-project/updates");
+  });
+
+  it("appends milestoneStatus to the query string", async () => {
+    await getProjectUpdates("my-project", "completed");
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "/v2/projects/my-project/updates?milestoneStatus=completed"
+    );
+  });
+
+  it("appends dateFrom and dateTo to the query string", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      dateFrom: "2024-01-01",
+      dateTo: "2024-12-31",
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("dateFrom")).toBe("2024-01-01");
+    expect(params.get("dateTo")).toBe("2024-12-31");
+  });
+
+  it("swaps dateFrom and dateTo when dateFrom > dateTo (defensive)", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      dateFrom: "2024-12-31",
+      dateTo: "2024-01-01",
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("dateFrom")).toBe("2024-01-01");
+    expect(params.get("dateTo")).toBe("2024-12-31");
+  });
+
+  it("appends hasAIEvaluation=true when set", async () => {
+    await getProjectUpdates("my-project", undefined, { hasAIEvaluation: true });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("hasAIEvaluation")).toBe("true");
+  });
+
+  it("appends hasAIEvaluation=false when explicitly false and no aiScoreMin", async () => {
+    await getProjectUpdates("my-project", undefined, { hasAIEvaluation: false });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("hasAIEvaluation")).toBe("false");
+    expect(params.get("aiScoreMin")).toBeNull();
+  });
+
+  it("appends aiScoreMin and omits hasAIEvaluation=false to avoid backend 400", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      hasAIEvaluation: false,
+      aiScoreMin: 7,
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    // aiScoreMin must be present
+    expect(params.get("aiScoreMin")).toBe("7");
+    // hasAIEvaluation=false must NOT be sent alongside aiScoreMin
+    expect(params.get("hasAIEvaluation")).toBeNull();
+  });
+
+  it("appends both hasAIEvaluation=true and aiScoreMin when both are set positively", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      hasAIEvaluation: true,
+      aiScoreMin: 5,
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("hasAIEvaluation")).toBe("true");
+    expect(params.get("aiScoreMin")).toBe("5");
+  });
+
+  it("omits empty string dateFrom", async () => {
+    await getProjectUpdates("my-project", undefined, { dateFrom: "" });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    expect(url).toBe("/v2/projects/my-project/updates");
+  });
+
+  it("combines milestoneStatus with extra filters in one query string", async () => {
+    await getProjectUpdates("my-project", "pending", {
+      dateFrom: "2024-06-01",
+      aiScoreMin: 3,
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("milestoneStatus")).toBe("pending");
+    expect(params.get("dateFrom")).toBe("2024-06-01");
+    expect(params.get("aiScoreMin")).toBe("3");
+  });
+
+  it("appends aiScoreMax when set", async () => {
+    await getProjectUpdates("my-project", undefined, { aiScoreMax: 8 });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("aiScoreMax")).toBe("8");
+  });
+
+  it("appends both aiScoreMin and aiScoreMax when both set", async () => {
+    await getProjectUpdates("my-project", undefined, { aiScoreMin: 3, aiScoreMax: 8 });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("aiScoreMin")).toBe("3");
+    expect(params.get("aiScoreMax")).toBe("8");
+  });
+
+  it("swaps aiScoreMin and aiScoreMax when min > max (defensive)", async () => {
+    await getProjectUpdates("my-project", undefined, { aiScoreMin: 8, aiScoreMax: 3 });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("aiScoreMin")).toBe("3");
+    expect(params.get("aiScoreMax")).toBe("8");
+  });
+
+  it("omits hasAIEvaluation=false when aiScoreMax is set (no backend 400)", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      hasAIEvaluation: false,
+      aiScoreMax: 7,
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("aiScoreMax")).toBe("7");
+    expect(params.get("hasAIEvaluation")).toBeNull();
+  });
+
+  it("appends hasAIEvaluation=true alongside aiScoreMax when both positively set", async () => {
+    await getProjectUpdates("my-project", undefined, {
+      hasAIEvaluation: true,
+      aiScoreMax: 9,
+    });
+    const url = mockFetchData.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("hasAIEvaluation")).toBe("true");
+    expect(params.get("aiScoreMax")).toBe("9");
+  });
+
+  it("returns empty response on 404 without calling errorManager", async () => {
+    mockFetchData.mockResolvedValueOnce([null, "not found", null, 404]);
+    const result = await getProjectUpdates("unknown-project");
+    expect(result).toEqual(emptyResponse);
+  });
+
+  it("returns empty response on generic error", async () => {
+    mockFetchData.mockResolvedValueOnce([null, "server error", null, 500]);
+    const result = await getProjectUpdates("my-project");
+    expect(result).toEqual(emptyResponse);
+  });
+});

--- a/services/project-updates.service.ts
+++ b/services/project-updates.service.ts
@@ -1,7 +1,67 @@
 import { errorManager } from "@/components/Utilities/errorManager";
+import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
 import type { UpdatesApiResponse } from "@/types/v2/roadmap";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
+
+/**
+ * Options bag for getProjectUpdates.
+ */
+export interface GetProjectUpdatesOptions extends UpdatesFeedFilters {
+  milestoneStatus?: "pending" | "completed" | "verified";
+}
+
+/**
+ * Applies the semantic rules for the AI evaluation params before serialisation:
+ * - Never send `hasAIEvaluation=false` together with `aiScoreMin`/`aiScoreMax` — drop `hasAIEvaluation`.
+ * - When `dateFrom` > `dateTo`, swap them defensively.
+ * - When `aiScoreMin` > `aiScoreMax`, swap them defensively.
+ * - Omit params that are empty string / undefined / null.
+ */
+function buildUpdatesQueryString(opts: GetProjectUpdatesOptions): string {
+  const params = new URLSearchParams();
+
+  // milestoneStatus
+  if (opts.milestoneStatus) {
+    params.set("milestoneStatus", opts.milestoneStatus);
+  }
+
+  // Date range — swap if inverted
+  let { dateFrom, dateTo } = opts;
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    [dateFrom, dateTo] = [dateTo, dateFrom];
+  }
+  if (dateFrom) params.set("dateFrom", dateFrom);
+  if (dateTo) params.set("dateTo", dateTo);
+
+  // AI evaluation — enforce the mutual-exclusion rule:
+  // never send hasAIEvaluation=false alongside aiScoreMin or aiScoreMax.
+  const { hasAIEvaluation } = opts;
+  let { aiScoreMin, aiScoreMax } = opts;
+
+  // Swap min/max if inverted (defensive, matches dateFrom/dateTo swap pattern)
+  if (aiScoreMin !== undefined && aiScoreMax !== undefined && aiScoreMin > aiScoreMax) {
+    [aiScoreMin, aiScoreMax] = [aiScoreMax, aiScoreMin];
+  }
+
+  const hasMinScore = aiScoreMin !== undefined && aiScoreMin !== null;
+  const hasMaxScore = aiScoreMax !== undefined && aiScoreMax !== null;
+  const hasAnyScore = hasMinScore || hasMaxScore;
+
+  if (hasAnyScore) {
+    if (hasMinScore) params.set("aiScoreMin", String(aiScoreMin));
+    if (hasMaxScore) params.set("aiScoreMax", String(aiScoreMax));
+    // Omit hasAIEvaluation=false when any score param is present (backend returns 400)
+    if (hasAIEvaluation === true) {
+      params.set("hasAIEvaluation", "true");
+    }
+  } else if (hasAIEvaluation !== undefined && hasAIEvaluation !== null) {
+    params.set("hasAIEvaluation", hasAIEvaluation ? "true" : "false");
+  }
+
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
 
 /**
  * Fetches project updates, milestones, and grant milestones using the API endpoint.
@@ -10,13 +70,17 @@ import { INDEXER } from "@/utilities/indexer";
  * - projectUpdates: Project activity updates with associations (funding, indicators, deliverables)
  * - projectMilestones: Project milestones with completion details
  * - grantMilestones: Grant milestones with completion and verification details
+ * - grantUpdates: Grant updates
  *
  * @param projectIdOrSlug - The project UID or slug
+ * @param milestoneStatus - Optional milestone lifecycle filter
+ * @param filters - Optional extra filters forwarded to the indexer
  * @returns UpdatesApiResponse containing all updates and milestones
  */
 export const getProjectUpdates = async (
   projectIdOrSlug: string,
-  milestoneStatus?: "pending" | "completed" | "verified"
+  milestoneStatus?: "pending" | "completed" | "verified",
+  filters?: UpdatesFeedFilters
 ): Promise<UpdatesApiResponse> => {
   const emptyResponse: UpdatesApiResponse = {
     projectUpdates: [],
@@ -26,7 +90,8 @@ export const getProjectUpdates = async (
   };
 
   const baseUrl = INDEXER.V2.PROJECTS.UPDATES(projectIdOrSlug);
-  const url = milestoneStatus ? `${baseUrl}?milestoneStatus=${milestoneStatus}` : baseUrl;
+  const qs = buildUpdatesQueryString({ milestoneStatus, ...filters });
+  const url = `${baseUrl}${qs}`;
 
   const [data, error, , status] = await fetchData<UpdatesApiResponse>(url);
 

--- a/types/v2/project-profile.types.ts
+++ b/types/v2/project-profile.types.ts
@@ -8,6 +8,39 @@
 import type { UnifiedMilestone } from "./roadmap";
 
 // =============================================================================
+// Updates Feed Filter Types
+// =============================================================================
+
+/**
+ * Date range filter for the updates feed.
+ * Values are ISO 8601 strings (e.g., "2024-01-01" or full datetime).
+ */
+export interface DateRangeFilter {
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+/**
+ * AI evaluation filter for the updates feed.
+ * - `hasAIEvaluation`: when true, restricts results to items with an AI evaluation.
+ *   Never set to false together with `aiScoreMin`/`aiScoreMax` — omit `hasAIEvaluation` instead.
+ * - `aiScoreMin`: integer 0–10; lower bound of the score range filter.
+ * - `aiScoreMax`: integer 0–10; upper bound of the score range filter.
+ *   If `aiScoreMin > aiScoreMax`, the service swaps them defensively before sending.
+ */
+export interface AIEvaluationFilter {
+  hasAIEvaluation?: boolean;
+  aiScoreMin?: number;
+  aiScoreMax?: number;
+}
+
+/**
+ * Combined extra filter params forwarded to the indexer for the updates feed.
+ * All fields are optional; undefined/null values are omitted from the query string.
+ */
+export interface UpdatesFeedFilters extends DateRangeFilter, AIEvaluationFilter {}
+
+// =============================================================================
 // Activity Feed Types
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Add two new filters to the project Updates tab for easier navigation of long activity feeds:

- **Date range picker** (always visible, applies to all activity types): presets "Last 7 / 30 / 90 days / All time" + custom from/to calendar inputs.
- **AI evaluation filter** (gated to Milestones, hidden when status is Pending): "Has AI evaluation" toggle + two-thumb range slider (0-10) for min/max score, using Radix Slider. Chips use the same color thresholds as `MilestoneAIEvaluationBadge` (≥8 green, ≥5 yellow, <5 red).

Both filters store state in URL params (`dateFrom`, `dateTo`, `hasAIEvaluation`, `aiScoreMin`, `aiScoreMax`) so links are shareable. They compose with the existing `filter` and `milestoneStatus` params.

### UX details

- Slider commits via `onValueCommit` (pointer/key release) — not on every tick — so dragging doesn't refetch 10 times.
- Date range swaps from/to if reversed, presets apply immediately, custom range needs Apply.
- Clear-state guarantee: if any AI URL param is set, the AI control is visible regardless of active pill — prevents orphan filter state from shared links.
- Contradictions (`hasAIEvaluation=false + aiScoreMin`, `min > max`) are resolved client-side before the request.

### New components

- `components/ui/popover.tsx` — shadcn-style wrapper around `@radix-ui/react-popover`
- `components/ui/slider.tsx` — shadcn-style wrapper around `@radix-ui/react-slider`, with per-thumb aria labels

### Backend PR

Pairs with https://github.com/show-karma/gap-indexer/pull/1297 which adds the matching query params and validation.

## Test plan

- [x] `pnpm test` — all new service/hook/component tests pass (2 pre-existing unrelated failures remain)
- [x] `pnpm lint:fix` — no new errors
- [x] Manually verified in browser with running local indexer:
  - Date presets + custom range update URL and filter results
  - AI toggle shows/hides slider
  - Range slider min/max filtering works end-to-end (Vaquita project: 7/10 and 9/10 milestones)
  - Invisible-state fix: `?hasAIEvaluation=true` alone shows the control
  - Pre-existing hydration error (nested button in date pill) fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering with preset options (Last 7, 30, 90 days, and All time) for updates view
  * Added AI evaluation filters with score range slider (0–10 scale) to refine results by AI assessment
  * Filter selections now persist in the URL for easier sharing and bookmarking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->