### PR TITLE
docs(ui): clarify public comments toggle enables commenting

### DIFF
--- a/components/QuestionBuilder/SettingsConfiguration.tsx
+++ b/components/QuestionBuilder/SettingsConfiguration.tsx
@@ -492,7 +492,8 @@ export function SettingsConfiguration({
                       Show comments on public page
                     </label>
                     <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      Display comments on public application pages.
+                      Display comments on public application pages. When enabled, any
+                      signed-in user will be able to post comments on applications.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Updates the helper text beneath the "Show comments on public page" toggle in the QuestionBuilder settings so admins understand the toggle also enables any signed-in user to post comments on applications, not just to display existing ones.

## Context
The toggle drives the backend `applicationConfig.formSchema.showCommentsOnPublicPage` flag, which gates the public comments endpoint (`gap-indexer` `application-comment.write.service.ts` `createPublic`). When on, any authenticated user can post a comment — the prior copy ("Display comments on public application pages.") only described the display side, so admins couldn't tell the feature opened up a write surface.

## Test plan
- [ ] Open the QuestionBuilder settings panel and verify the updated copy renders under the toggle in both light and dark modes.
- [ ] Confirm no layout changes to the Privacy Summary section below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the helper text for the "Show comments on public page" privacy setting to explicitly state that when enabled, any signed-in user can post comments on applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->