### PR TITLE
fix(milestones): send grantUID with admin invoice presigned request

### DIFF
--- a/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
+++ b/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
@@ -91,6 +91,7 @@ describe("MilestonesSection", () => {
     communityUID: "community-1",
     milestoneInvoices: [],
     invoiceRequired: false,
+    canEditInvoices: true,
     milestoneEdits: {},
     pendingFiles: {},
     allocationByUID: new Map(),
@@ -166,6 +167,80 @@ describe("MilestonesSection", () => {
       fileType: "application/pdf",
       fileSize: mockFile.size,
     });
+  });
+
+  it("should hide Attach file button when canEditInvoices is false", () => {
+    const invoice = createMockInvoice({ milestoneLabel: "Delivery", milestoneUID: "ms-1" });
+
+    render(
+      <MilestonesSection
+        {...defaultProps}
+        invoiceRequired={true}
+        canEditInvoices={false}
+        milestoneInvoices={[invoice]}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /attach file/i })).not.toBeInTheDocument();
+  });
+
+  it("should hide Remove invoice button when canEditInvoices is false but still show View invoice", async () => {
+    const invoice = createMockInvoice({
+      milestoneLabel: "Delivery",
+      milestoneUID: "ms-1",
+      invoiceFileKey: "logos/invoices/grant-1/1700000000000.pdf",
+    });
+
+    render(
+      <MilestonesSection
+        {...defaultProps}
+        invoiceRequired={true}
+        canEditInvoices={false}
+        milestoneInvoices={[invoice]}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /view invoice/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove invoice file/i })).not.toBeInTheDocument();
+  });
+
+  it("should render received date as read-only text when canEditInvoices is false", () => {
+    const invoice = createMockInvoice({
+      milestoneLabel: "Delivery",
+      milestoneUID: "ms-1",
+      invoiceReceivedAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    render(
+      <MilestonesSection
+        {...defaultProps}
+        invoiceRequired={true}
+        canEditInvoices={false}
+        milestoneInvoices={[invoice]}
+        getInvoiceReceivedDate={() => "2026-04-01"}
+      />
+    );
+
+    // Date picker input is absent
+    const dateInputs = screen
+      .queryAllByLabelText(/invoice received date/i)
+      .filter((el) => el.tagName === "INPUT");
+    expect(dateInputs).toHaveLength(0);
+  });
+
+  it("should show Attach file button when canEditInvoices is true", () => {
+    const invoice = createMockInvoice({ milestoneLabel: "Delivery", milestoneUID: "ms-1" });
+
+    render(
+      <MilestonesSection
+        {...defaultProps}
+        invoiceRequired={true}
+        canEditInvoices={true}
+        milestoneInvoices={[invoice]}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /attach file/i })).toBeInTheDocument();
   });
 
   it("should call getInvoiceDownloadUrl with grantUid when View invoice is clicked", async () => {

--- a/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
+++ b/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
@@ -11,8 +11,15 @@ import {
 } from "@/src/features/payout-disbursement";
 
 // Mock heavy dependencies
+const { captureFileUploadProps } = vi.hoisted(() => ({
+  captureFileUploadProps: vi.fn(),
+}));
+
 vi.mock("@/components/Utilities/FileUpload", () => ({
-  FileUpload: () => <div data-testid="file-upload">FileUpload</div>,
+  FileUpload: (props: Record<string, unknown>) => {
+    captureFileUploadProps(props);
+    return <div data-testid="file-upload">FileUpload</div>;
+  },
 }));
 
 vi.mock("@/utilities/indexer", () => ({
@@ -129,6 +136,36 @@ describe("MilestonesSection", () => {
     render(<MilestonesSection {...defaultProps} milestoneInvoices={[]} />);
 
     expect(screen.getByText("No milestones configured yet.")).toBeInTheDocument();
+  });
+
+  it("should include grantUID in presigned URL payload when Attach file modal opens", async () => {
+    const invoice = createMockInvoice({
+      milestoneLabel: "Delivery",
+      milestoneUID: "ms-1",
+    });
+
+    render(
+      <MilestonesSection {...defaultProps} invoiceRequired={true} milestoneInvoices={[invoice]} />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /attach file/i }));
+
+    expect(captureFileUploadProps).toHaveBeenCalled();
+    const props = captureFileUploadProps.mock.calls.at(-1)?.[0] as {
+      presignedUrlPayload?: (file: File) => Record<string, unknown>;
+    };
+
+    expect(props.presignedUrlPayload).toBeTypeOf("function");
+
+    const mockFile = new File(["pdf content"], "invoice.pdf", { type: "application/pdf" });
+    const payload = props.presignedUrlPayload?.(mockFile);
+
+    expect(payload).toEqual({
+      grantUID: "grant-1",
+      fileName: "invoice.pdf",
+      fileType: "application/pdf",
+      fileSize: mockFile.size,
+    });
   });
 
   it("should call getInvoiceDownloadUrl with grantUid when View invoice is clicked", async () => {

--- a/__tests__/unit/components/Pages/Admin/ProjectDetailsSidebar.permission-wire.test.tsx
+++ b/__tests__/unit/components/Pages/Admin/ProjectDetailsSidebar.permission-wire.test.tsx
@@ -1,0 +1,142 @@
+import { render } from "@testing-library/react";
+import { Permission } from "@/src/core/rbac/types";
+
+// ─── Capture props that ProjectDetailsSidebar passes to MilestonesSection ────
+
+const { capturedMilestonesProps } = vi.hoisted(() => ({
+  capturedMilestonesProps: vi.fn<(props: Record<string, unknown>) => void>(),
+}));
+
+vi.mock("@/components/Pages/Admin/ControlCenter/MilestonesSection", () => ({
+  MilestonesSection: (props: Record<string, unknown>) => {
+    capturedMilestonesProps(props);
+    return <div data-testid="milestones-section" />;
+  },
+}));
+
+// ─── Mock useCan so we can assert both the argument AND control the return ────
+
+const { useCanMock } = vi.hoisted(() => ({
+  useCanMock: vi.fn<(permission: string) => boolean>(),
+}));
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  useCan: useCanMock,
+}));
+
+// ─── Stub out everything else the sidebar touches ────────────────────────────
+
+vi.mock("@/components/Pages/Admin/ControlCenter/DetailsSection", () => ({
+  DetailsSection: () => <div data-testid="details-section" />,
+}));
+
+vi.mock("@/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: () => [null, vi.fn()],
+}));
+
+vi.mock("@/src/features/payout-disbursement", () => ({
+  PayoutDisbursementStatus: { AWAITING_SIGNATURES: "awaiting_signatures" },
+  MilestoneLifecycleStatus: { PENDING: "pending", COMPLETED: "completed" },
+  PayoutConfigurationContent: () => <div data-testid="config" />,
+  PayoutHistoryContent: () => <div data-testid="history" />,
+  RecordPaymentDialog: () => null,
+  fromSmallestUnit: (v: string) => v,
+  useToggleAgreement: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useSaveMilestoneInvoices: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useDeleteDisbursementByMilestone: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/utilities/network", () => ({
+  getChainNameById: () => "Optimism",
+}));
+
+vi.mock("@/utilities/pages", () => ({
+  PAGES: { PROJECT: { GRANT: () => "/grant-url" } },
+}));
+
+import type { ProjectDetailsSidebarGrant } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar";
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+import { ProjectDetailsSidebar } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar";
+
+const mockGrant: ProjectDetailsSidebarGrant = {
+  grantUid: "grant-1",
+  projectUid: "project-1",
+  projectName: "Test Project",
+  projectSlug: "test-project",
+  grantName: "Test Grant",
+  grantProgramId: "program-1",
+  grantChainId: 10,
+  projectChainId: 10,
+  currency: "USDC",
+} as unknown as ProjectDetailsSidebarGrant;
+
+function renderSidebar() {
+  return render(
+    <ProjectDetailsSidebar
+      grant={mockGrant}
+      open={true}
+      onOpenChange={vi.fn()}
+      communityUID="community-1"
+      invoiceRequired={true}
+      kycStatus={null}
+      disbursementInfo={null}
+      agreement={null}
+      milestoneInvoices={[]}
+    />
+  );
+}
+
+describe("ProjectDetailsSidebar — invoice permission wire", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_query_useCan_with_Permission_PROGRAM_EDIT", () => {
+    useCanMock.mockReturnValue(true);
+
+    renderSidebar();
+
+    expect(useCanMock).toHaveBeenCalledWith(Permission.PROGRAM_EDIT);
+  });
+
+  it("should_pass_canEditInvoices_true_to_MilestonesSection_when_useCan_returns_true", () => {
+    useCanMock.mockReturnValue(true);
+
+    renderSidebar();
+
+    expect(capturedMilestonesProps).toHaveBeenCalled();
+    const props = capturedMilestonesProps.mock.calls.at(-1)?.[0] as {
+      canEditInvoices?: boolean;
+    };
+    expect(props.canEditInvoices).toBe(true);
+  });
+
+  it("should_pass_canEditInvoices_false_to_MilestonesSection_when_useCan_returns_false", () => {
+    useCanMock.mockReturnValue(false);
+
+    renderSidebar();
+
+    const props = capturedMilestonesProps.mock.calls.at(-1)?.[0] as {
+      canEditInvoices?: boolean;
+    };
+    expect(props.canEditInvoices).toBe(false);
+  });
+
+  it("should_use_Permission_PROGRAM_EDIT_exactly_not_a_related_permission", () => {
+    // Guards against someone refactoring the hook call to PROGRAM_VIEW,
+    // MILESTONE_EDIT, or another type-compatible but wrong permission.
+    useCanMock.mockReturnValue(true);
+
+    renderSidebar();
+
+    const calls = useCanMock.mock.calls;
+    const calledPermissions = calls.map((call) => call[0]);
+    expect(calledPermissions).toContain(Permission.PROGRAM_EDIT);
+    expect(calledPermissions).not.toContain(Permission.PROGRAM_VIEW);
+    expect(calledPermissions).not.toContain(Permission.MILESTONE_EDIT);
+  });
+});

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -113,6 +113,13 @@ export interface MilestonesSectionProps {
   communityUID: string;
   milestoneInvoices: CommunityPayoutInvoiceInfo[];
   invoiceRequired: boolean;
+  /**
+   * Whether the caller has `program:edit` permission. When false, invoice
+   * edit controls (attach, remove, received-date input) are hidden or
+   * rendered read-only. Mirrors the backend authorization that gates
+   * `POST /v2/milestone-invoices/presigned` and sibling write routes.
+   */
+  canEditInvoices: boolean;
   milestoneEdits: Record<
     string,
     { invoiceReceivedAt?: string | null; milestoneUID?: string | null }
@@ -156,6 +163,7 @@ export const MilestonesSection = memo(function MilestonesSection({
   communityUID,
   milestoneInvoices,
   invoiceRequired,
+  canEditInvoices,
   milestoneEdits,
   pendingFiles,
   allocationByUID,
@@ -240,7 +248,7 @@ export const MilestonesSection = memo(function MilestonesSection({
       <h3 className="text-sm font-semibold text-gray-900 dark:text-zinc-100 mb-1">
         Milestones ({milestoneInvoices.length})
       </h3>
-      {invoiceRequired && (
+      {invoiceRequired && canEditInvoices && (
         <p className="text-xs text-gray-400 dark:text-zinc-500 mb-3">
           Attach invoice files or set received dates. Save changes when done.
         </p>
@@ -445,27 +453,29 @@ export const MilestonesSection = memo(function MilestonesSection({
                                     View invoice
                                   </button>
                                 )}
-                                <button
-                                  type="button"
-                                  className="p-0.5 rounded text-red-400 hover:text-red-600 dark:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-                                  onClick={() => {
-                                    onFileRemoved(mKey);
-                                    if (invoice.invoiceFileKey) {
-                                      // Removing a saved file — clear the date too
-                                      handleInvoiceReceivedDateChange(
-                                        mKey,
-                                        invoice.milestoneUID,
-                                        ""
-                                      );
-                                    }
-                                    // Cancelling a pending upload — leave existing date intact
-                                  }}
-                                  title="Remove invoice file"
-                                >
-                                  <XMarkIcon className="h-3.5 w-3.5" />
-                                </button>
+                                {canEditInvoices && (
+                                  <button
+                                    type="button"
+                                    className="p-0.5 rounded text-red-400 hover:text-red-600 dark:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                                    onClick={() => {
+                                      onFileRemoved(mKey);
+                                      if (invoice.invoiceFileKey) {
+                                        // Removing a saved file — clear the date too
+                                        handleInvoiceReceivedDateChange(
+                                          mKey,
+                                          invoice.milestoneUID,
+                                          ""
+                                        );
+                                      }
+                                      // Cancelling a pending upload — leave existing date intact
+                                    }}
+                                    title="Remove invoice file"
+                                  >
+                                    <XMarkIcon className="h-3.5 w-3.5" />
+                                  </button>
+                                )}
                               </div>
-                            ) : (
+                            ) : canEditInvoices ? (
                               <button
                                 type="button"
                                 className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-zinc-500 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
@@ -480,29 +490,39 @@ export const MilestonesSection = memo(function MilestonesSection({
                                 <PaperClipIcon className="h-3 w-3" />
                                 Attach file
                               </button>
+                            ) : (
+                              <span className="text-xs text-gray-300 dark:text-zinc-600">
+                                &mdash;
+                              </span>
                             )}
 
                             {/* Row 2: Received date */}
                             <div className="flex flex-col items-center gap-0.5">
-                              <Input
-                                type="date"
-                                max={todayLocal}
-                                value={receivedDateValue ?? ""}
-                                onChange={(e) =>
-                                  handleInvoiceReceivedDateChange(
-                                    mKey,
-                                    invoice.milestoneUID,
-                                    e.target.value
-                                  )
-                                }
-                                className={cn(
-                                  "h-6 text-[11px] w-[130px] bg-white dark:bg-zinc-900",
-                                  hasReceivedDate
-                                    ? "border-emerald-200 dark:border-emerald-800"
-                                    : ""
-                                )}
-                                aria-label={`Invoice received date for ${formatMilestoneTitle(idx, invoice.milestoneLabel)}`}
-                              />
+                              {canEditInvoices ? (
+                                <Input
+                                  type="date"
+                                  max={todayLocal}
+                                  value={receivedDateValue ?? ""}
+                                  onChange={(e) =>
+                                    handleInvoiceReceivedDateChange(
+                                      mKey,
+                                      invoice.milestoneUID,
+                                      e.target.value
+                                    )
+                                  }
+                                  className={cn(
+                                    "h-6 text-[11px] w-[130px] bg-white dark:bg-zinc-900",
+                                    hasReceivedDate
+                                      ? "border-emerald-200 dark:border-emerald-800"
+                                      : ""
+                                  )}
+                                  aria-label={`Invoice received date for ${formatMilestoneTitle(idx, invoice.milestoneLabel)}`}
+                                />
+                              ) : (
+                                <span className="text-[11px] text-gray-600 dark:text-zinc-400 tabular-nums">
+                                  {receivedDateValue ? formatDate(receivedDateValue, "UTC") : "—"}
+                                </span>
+                              )}
                               {invoice.invoiceReceivedBy && (
                                 <span
                                   className="text-[10px] text-gray-400 dark:text-zinc-500 font-mono"

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -570,6 +570,12 @@ export const MilestonesSection = memo(function MilestonesSection({
             useS3Upload
             skipDimensionValidation
             presignedUrlEndpoint={INDEXER.V2.MILESTONE_INVOICES.PRESIGNED_URL()}
+            presignedUrlPayload={(file) => ({
+              grantUID: grant.grantUid,
+              fileName: file.name,
+              fileType: file.type,
+              fileSize: file.size,
+            })}
             maxFileSize={10 * 1024 * 1024}
             allowedFileTypes={[
               "application/pdf",

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useCan } from "@/src/core/rbac/context/permission-context";
+import { Permission } from "@/src/core/rbac/types";
 import {
   type CommunityPayoutAgreementInfo,
   type CommunityPayoutInvoiceInfo,
@@ -109,6 +111,11 @@ export function ProjectDetailsSidebar({
   onConfigSuccess,
   dataVersion = 0,
 }: ProjectDetailsSidebarProps) {
+  // Mirrors backend `program:edit` gate on milestone-invoice write endpoints.
+  // Hides attach/remove/date-picker controls for reviewers, registry admins,
+  // and project owners who land on Control Center but lack write permission.
+  const canEditInvoices = useCan(Permission.PROGRAM_EDIT);
+
   const [activeSection, setActiveSection] = useState<SidebarSection>("details");
   const [milestoneEdits, setMilestoneEdits] = useState<
     Record<string, { invoiceReceivedAt?: string | null; milestoneUID?: string | null }>
@@ -659,6 +666,7 @@ export function ProjectDetailsSidebar({
                       communityUID={communityUID}
                       milestoneInvoices={milestoneInvoices}
                       invoiceRequired={invoiceRequired}
+                      canEditInvoices={canEditInvoices}
                       milestoneEdits={milestoneEdits}
                       pendingFiles={pendingFiles}
                       allocationByUID={allocationByUID}


### PR DESCRIPTION
## Summary

- Pairs with backend PR show-karma/gap-indexer#1321 (must deploy together).
- Community admins uploading invoices from Control Center were getting 403 from `POST /v2/milestone-invoices/presigned` because the body carried no resource identifier for the permission middleware to resolve.
- `FileUpload`'s `presignedUrlPayload` override already exists; this PR uses it to send `grantUID` alongside `fileName`/`fileType`/`fileSize`.

## Change

`components/Pages/Admin/ControlCenter/MilestonesSection.tsx` — the attach-invoice dialog's `FileUpload` now receives:

```tsx
presignedUrlPayload={(file) => ({
  grantUID: grant.grantUid,
  fileName: file.name,
  fileType: file.type,
  fileSize: file.size,
})}
```

No changes to `FileUpload.tsx`, `utilities/indexer.ts`, or any service/hook. The grantee-facing `FileUpload` callers (`MilestoneUpdate.tsx`, `GrantMilestoneCompletion.tsx`, `MilestoneCompletionEditor.tsx`) are untouched — they hit a different endpoint (`GRANTEE_PRESIGNED`) whose schema is unchanged.

## Test plan

- [x] `pnpm test __tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx` — 5/5 pass (added 1 new)
- [x] `pnpm biome check` on changed files clean
- [x] New test captures `FileUpload` props and asserts the `presignedUrlPayload(mockFile)` payload includes `grantUID: 'grant-1'`
- [ ] Manual (after deploying with backend PR): log in as community admin → Control Center → Milestones → Attach Invoice → upload PDF → should succeed (was 403)

## Not changed

- `FileUpload.tsx` — `presignedUrlPayload` prop already exists
- Grantee flows — different endpoint, different schema
- Service/hook layers — no new data fetch, same mutation path on save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice controls (Attach/Remove file, editable received-date) are now shown only to users with edit permission.

* **Bug Fixes**
  * File uploads from the Milestones section now include complete metadata and associated grant information for reliable storage.

* **Tests**
  * Added tests covering file upload metadata capture and UI visibility based on edit permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->