### PR TITLE
fix(notifications): refresh chat list after successful telegram pair

### DIFF
--- a/components/Pages/Admin/NotificationSettingsPage.tsx
+++ b/components/Pages/Admin/NotificationSettingsPage.tsx
@@ -776,6 +776,19 @@ function TelegramProviderCard(props: TelegramProviderProps) {
         communitySlug={props.communitySlug}
         open={isPairModalOpen}
         onOpenChange={setIsPairModalOpen}
+        onPaired={(chat) => {
+          // Parent seeds tgChats from props ONCE (see NotificationSettingsPageContent)
+          // and never re-syncs from the query cache, so the verify hook's cache
+          // patch alone does not repopulate the Chat-IDs list. Push the paired
+          // chat into local state here: drop blank sentinel rows, keep existing
+          // entries, de-dupe by id.
+          const withoutBlanks = props.chats.filter((c) => c.id.trim());
+          const alreadyPresent = withoutBlanks.some((c) => c.id === chat.id);
+          const next = alreadyPresent
+            ? withoutBlanks.map((c) => (c.id === chat.id ? chat : c))
+            : [...withoutBlanks, chat];
+          props.onChatsChange(next);
+        }}
       />
     </ProviderCardChrome>
   );

--- a/components/Pages/Admin/TelegramPairChatModal.tsx
+++ b/components/Pages/Admin/TelegramPairChatModal.tsx
@@ -17,6 +17,12 @@ interface TelegramPairChatModalProps {
   communitySlug: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  // Fires on successful verify (both newly-paired and already-paired). The
+  // parent's local `tgChats` state is seeded once from server data and never
+  // re-synced from props (see NotificationSettingsPage.tsx:1074-1078 — sync
+  // would clobber unsaved edits). Without this callback the provider card's
+  // Chat-IDs list stays empty until the page is remounted.
+  onPaired?: (chat: { id: string; name: string }) => void;
 }
 
 const formatCountdown = (msRemaining: number): string => {
@@ -45,6 +51,7 @@ export function TelegramPairChatModal({
   communitySlug,
   open,
   onOpenChange,
+  onPaired,
 }: TelegramPairChatModalProps) {
   const [token, setToken] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
@@ -133,13 +140,17 @@ export function TelegramPairChatModal({
           } else {
             toast.success(`Paired "${label}"`);
           }
+          // Fire even on already-paired: server truth includes the chat but
+          // the parent's local state may not (e.g. it was paired in another
+          // tab / session). Parent de-dupes by id.
+          onPaired?.({ id: data.chatId, name: data.chatTitle });
           onOpenChange(false);
         },
         // No onError handler needed — verifyPairing.error drives the inline
         // banner via the resolveVerifyErrorMessage call below.
       }
     );
-  }, [token, verifyPairing, verifyReset, onOpenChange]);
+  }, [token, verifyPairing, verifyReset, onOpenChange, onPaired]);
 
   // Read the error directly from the mutation result. Single source of truth.
   const inlineError = resolveVerifyErrorMessage(verifyPairing.error);


### PR DESCRIPTION
## Summary

- After a successful pair the modal closed and the success toast fired, but the Chat-IDs editor stayed empty until a remount. Now the editor reflects the newly-paired chat immediately.

## Root cause

`NotificationSettingsPageContent` seeds `tgChats` once from props via `useState` and intentionally does not re-sync from prop changes (a `useEffect` would clobber unsaved edits whenever an unrelated mutation invalidated the `community-config` query). `useVerifyTelegramPairing` patches the query cache, but the inner editor never reads from it after mount.

## Fix

- `TelegramPairChatModal` gains an optional `onPaired(chat)` prop, fired on both newly-paired and already-paired verify results (so a chat paired in another tab / session still repopulates the list).
- `TelegramProviderCard` wires `onPaired` through the existing `onChatsChange` path: drops blank sentinel rows and de-dupes by id. The "don't clobber unsaved edits" guarantee is preserved since nothing new reacts to prop changes.

## Paired indexer change

Backend for this flow: https://github.com/show-karma/gap-indexer/pull/1327

## Test plan

- [ ] Pair a new chat → editor shows the new entry, toast fires, modal closes
- [ ] Pair a chat that is already paired → editor leaves the existing row untouched (no duplicate)
- [ ] Pair while the editor has an unsaved blank row → blank row is dropped, new chat appended
- [ ] Make an unsaved edit to an existing chat name, then pair a new one → the unsaved edit is NOT clobbered
- [ ] Vitest: `pnpm test __tests__/components/Admin/TelegramPairChatModal.test.tsx __tests__/components/Admin/NotificationSettingsPage.test.tsx` — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Telegram chat pairing to ensure newly paired chats are properly saved and displayed in your notification settings chat list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->