### PR TITLE
chore: remove public verification from project funding page

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/GrantUpdate.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/GrantUpdate.tsx
@@ -22,7 +22,6 @@ import { ReadMore } from "@/utilities/ReadMore";
 import { retryUntilConditionMet } from "@/utilities/retries";
 import { shareOnX } from "@/utilities/share/shareOnX";
 import { SHARE_TEXTS } from "@/utilities/share/text";
-import { VerifyGrantUpdateDialog } from "./VerifyGrantUpdateDialog";
 
 interface UpdateTagProps {
   index: number;
@@ -206,13 +205,7 @@ export const GrantUpdate: FC<GrantUpdateProps> = ({ title, description, index, d
 
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
 
-  const [isVerified, setIsVerified] = useState<boolean>(
-    Array.isArray(update?.verified) && update.verified.length > 0
-  );
-
-  const markAsVerified = () => {
-    setIsVerified(true);
-  };
+  const isVerified: boolean = Array.isArray(update?.verified) && update.verified.length > 0;
 
   /*
    * Check if the grant update was created after the launch date of the feature
@@ -243,11 +236,6 @@ export const GrantUpdate: FC<GrantUpdateProps> = ({ title, description, index, d
               <span className="text-xs font-bold">Verified</span>
             </div>
           ) : null}
-          <VerifyGrantUpdateDialog
-            grantUpdate={update}
-            onVerified={markAsVerified}
-            isVerified={isVerified}
-          />
         </div>
         <div className="flex flex-row gap-3 items-center flex-wrap">
           <p className="text-sm font-semibold text-gray-500 dark:text-zinc-300 max-sm:text-xs">

--- a/components/Shared/MilestoneVerification/MilestoneVerificationSection.tsx
+++ b/components/Shared/MilestoneVerification/MilestoneVerificationSection.tsx
@@ -1,9 +1,8 @@
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useEffect, useState } from "react";
 import {
   type VerificationRecord,
   VerifiedBadge,
 } from "@/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifiedBadge";
-import { VerifyMilestoneUpdateDialog } from "@/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/VerifyMilestoneUpdateDialog";
 import type { GrantMilestone } from "@/types/v2/grant";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 
@@ -22,9 +21,6 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
   title,
   isVerified: isVerifiedProp,
   verifications,
-  onVerified,
-  programId,
-  communityUID,
 }) => {
   // V2: verified is an array of verifications
   const getInitialVerifiedState = (): boolean => {
@@ -50,11 +46,6 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
 
   const [isVerified, setIsVerified] = useState<boolean>(getInitialVerifiedState());
 
-  const markAsVerified = useCallback(() => {
-    setIsVerified(true);
-    onVerified?.();
-  }, [onVerified]);
-
   // Sync state when prop changes
   useEffect(() => {
     if (isVerifiedProp !== undefined) {
@@ -62,49 +53,15 @@ export const MilestoneVerificationSection: FC<MilestoneVerificationSectionProps>
     }
   }, [isVerifiedProp]);
 
-  // Get milestone for dialog
-  const getMilestoneForDialog = (): GrantMilestone | null => {
-    // For GrantMilestone (has refUID which UnifiedMilestone doesn't have at top level)
-    if ("refUID" in milestone && typeof (milestone as GrantMilestone).refUID === "string") {
-      return milestone as GrantMilestone;
-    }
-
-    // For UnifiedMilestone
-    if ("source" in milestone && (milestone as UnifiedMilestone).source?.grantMilestone) {
-      return (milestone as UnifiedMilestone).source.grantMilestone?.milestone || null;
-    }
-
-    return null;
-  };
-
-  const milestoneForDialog = getMilestoneForDialog();
-
-  // Extract grant context for permission checks
-  const grantContext =
-    "source" in milestone
-      ? (milestone as UnifiedMilestone).source.grantMilestone?.grant
-      : undefined;
-  const derivedProgramId = programId ?? grantContext?.details?.programId;
-  const derivedCommunityUID = communityUID ?? grantContext?.community?.uid;
+  if (!isVerified) return null;
 
   return (
     <div className="flex flex-row gap-4 items-center flex-wrap w-max max-w-full">
-      {isVerified && (
-        <VerifiedBadge
-          verifications={verifications && verifications.length > 0 ? verifications : undefined}
-          isVerified={!(verifications && verifications.length > 0) ? isVerified : undefined}
-          title={title}
-        />
-      )}
-      {milestoneForDialog && (
-        <VerifyMilestoneUpdateDialog
-          milestone={milestoneForDialog}
-          onVerified={markAsVerified}
-          isVerified={isVerified}
-          programId={derivedProgramId}
-          communityUID={derivedCommunityUID}
-        />
-      )}
+      <VerifiedBadge
+        verifications={verifications && verifications.length > 0 ? verifications : undefined}
+        isVerified={!(verifications && verifications.length > 0) ? isVerified : undefined}
+        title={title}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removed the public **Verify** buttons from grant updates (`GrantUpdate.tsx`) and milestones (`MilestoneVerificationSection.tsx`) on the project funding pages.
- The **Verified** badge is still rendered when a milestone/update has verifications.
- Admin verification flows under `components/Pages/Admin/MilestonesReview/` are untouched — admins can still verify from the admin review page.

## Test plan
- [ ] Visit `/project/[id]/funding/[grantUid]/milestones-and-updates` as a non-admin wallet — no "Verify" button on updates or milestones.
- [ ] Visit the same page on a milestone/update that is already verified — "Verified" badge still renders.
- [ ] Visit `/community/[id]/admin/milestones-review` as an authorized reviewer — admin verify flow still works.
- [ ] `pnpm lint:fix` passes.