### PR TITLE
fix(impact): render chart for indicators with a single datapoint

### DIFF
--- a/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/FilteredOutputsAndOutcomes.tsx
@@ -380,7 +380,7 @@ export const FilteredOutputsAndOutcomes = ({
                 </div>
                 <div className="flex max-md:flex-col-reverse flex-row-reverse gap-4">
                   <div className="flex flex-1 flex-col gap-5">
-                    {item.datapoints?.length > 1 && (
+                    {(item.datapoints?.length ?? 0) >= 1 && (
                       <Card className="bg-white dark:bg-zinc-800 rounded">
                         <Title className="text-sm font-medium text-gray-700 dark:text-zinc-300 mb-4">
                           Historical Values

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -399,7 +399,7 @@ export const OutputsAndOutcomes = () => {
                 <div className="flex flex-row gap-4 max-md:flex-col-reverse">
                   <div className="flex flex-1 flex-col gap-5">
                     {/* Raw Historical Values Chart */}
-                    {item.datapoints?.length > 1 ? (
+                    {(item.datapoints?.length ?? 0) >= 1 ? (
                       <Card className="bg-white dark:bg-zinc-800 rounded h-full">
                         <Title className="text-sm font-medium text-gray-700 dark:text-zinc-300 mb-4">
                           Historical Values


### PR DESCRIPTION
## Summary

The indicator chart gate in `OutputsAndOutcomes.tsx` and `FilteredOutputsAndOutcomes.tsx` required strictly more than one datapoint (`length > 1`). Any indicator with exactly one historical value fell through to the "Awaiting grantees to submit values" empty state — even though real data was present.

Most visible on **titan-network's Impact tab**: `Client Verified Claims`, `Client Data Onboarded`, `Client Unique Providers`, `SP Data Expired` all have exactly 1 OSO-published row → chart hidden, card showed the empty message instead.

Switching the gate to `>= 1` makes Tremor's `AreaChart` render the single point. No behavior change for indicators with 2+ datapoints.

## Changes

```diff
- {item.datapoints?.length > 1 ? (
+ {(item.datapoints?.length ?? 0) >= 1 ? (
```

Same 1-char fix in both `OutputsAndOutcomes.tsx:402` and `FilteredOutputsAndOutcomes.tsx:383`. Adds the `?? 0` to satisfy the stricter comparator against an optional field.

## Test plan

- [ ] Open `/project/titan-network/impact`. Previously-empty Client_* and SP Data Expired cards now show a single-point chart instead of the "Awaiting grantees" message.
- [ ] Open any project with a 2+ datapoint indicator (e.g. `cidgravity-filecoin-gateway` → Storage Providers, 530 points). Chart still renders identically.
- [ ] Projects with no datapoints at all (none of the OR conditions match in the filter at L188-195) still don't show the card — filter is untouched.

## Out of scope

- Backend indexer changes — the data was always correct on the API, this is purely a display gate.
- The broader "autosynced cards shown even when empty" issue (criterion 3 of the filter at L194). That's a separate follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data visibility by enabling the Historical Values chart to display with a single data point, rather than requiring multiple entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->