### PR TITLE
feat(notifications): one-tap add-to-group via t.me deep link

### DIFF
--- a/__tests__/components/Admin/TelegramPairChatModal.test.tsx
+++ b/__tests__/components/Admin/TelegramPairChatModal.test.tsx
@@ -66,14 +66,16 @@ describe("TelegramPairChatModal", () => {
     expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
   });
 
-  it("starts a pairing session and displays the token + countdown when opened", async () => {
+  it("starts a pairing session and displays the /karma-pair command + countdown when opened", async () => {
     const futureIso = new Date(Date.now() + 5 * 60 * 1000).toISOString();
-    mockFetchData.mockResolvedValue([
-      { token: "KARMA-PAIR-ab3f9k", expiresAt: futureIso },
-      null,
-      null,
-      200,
-    ]);
+    // `/start` returns the token; any subsequent `/verify` poll returns 422
+    // (pending — bot hasn't claimed yet) so the polling loop stays quiet.
+    mockFetchData.mockImplementation(async (url: string) => {
+      if (url.includes("/telegram-pair/start")) {
+        return [{ token: "KARMA-PAIR-ab3f9k", expiresAt: futureIso }, null, null, 200];
+      }
+      return [null, "pending", null, 422];
+    });
 
     render(<TelegramPairChatModal communitySlug="filecoin" open={true} onOpenChange={vi.fn()} />, {
       wrapper,
@@ -83,11 +85,16 @@ describe("TelegramPairChatModal", () => {
     expect(screen.getByText(/Pair a Telegram chat/i)).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByTestId("telegram-pair-token")).toHaveTextContent("KARMA-PAIR-ab3f9k");
+      expect(screen.getByTestId("telegram-pair-command")).toHaveTextContent(
+        "/karma-pair KARMA-PAIR-ab3f9k"
+      );
     });
 
     // Countdown is rendered in m:ss format
     expect(screen.getByTestId("telegram-pair-countdown").textContent).toMatch(/^\d+:\d{2}$/);
+
+    // Polling indicator replaces the old "Verify now" CTA
+    expect(screen.getByRole("status")).toHaveTextContent(/Waiting for the bot/i);
 
     // Pairing /start was hit
     expect(mockFetchData).toHaveBeenCalledWith(

--- a/__tests__/components/Admin/TelegramPairChatModal.test.tsx
+++ b/__tests__/components/Admin/TelegramPairChatModal.test.tsx
@@ -66,7 +66,7 @@ describe("TelegramPairChatModal", () => {
     expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
   });
 
-  it("starts a pairing session and displays the /karma-pair command + countdown when opened", async () => {
+  it("starts a pairing session and displays the /karma_pair command + countdown when opened", async () => {
     const futureIso = new Date(Date.now() + 5 * 60 * 1000).toISOString();
     // `/start` returns the token; any subsequent `/verify` poll returns 422
     // (pending — bot hasn't claimed yet) so the polling loop stays quiet.
@@ -86,7 +86,7 @@ describe("TelegramPairChatModal", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("telegram-pair-command")).toHaveTextContent(
-        "/karma-pair KARMA-PAIR-ab3f9k"
+        "/karma_pair KARMA-PAIR-ab3f9k"
       );
     });
 

--- a/components/Pages/Admin/TelegramPairChatModal.tsx
+++ b/components/Pages/Admin/TelegramPairChatModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, Copy, Loader2, MessageSquare, RefreshCw } from "lucide-react";
+import { AlertCircle, Copy, ExternalLink, Loader2, MessageSquare, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/Utilities/Button";
@@ -116,6 +116,18 @@ export function TelegramPairChatModal({
   const isExpired = Boolean(expiresAt) && msRemaining === 0;
   const isLowTime = !isExpired && msRemaining > 0 && msRemaining < 30_000;
 
+  // One-tap "add bot" deep link. Opens Telegram's group picker pre-scoped to
+  // the Karma bot so the admin doesn't have to search for its username. The
+  // token rides along as the `startgroup` payload — Telegram surfaces it back
+  // to the bot on some clients, but we do NOT rely on that (payload delivery
+  // isn't consistent across clients). The token still has to be posted in
+  // the group for the current verify flow to find it; the deep link just
+  // collapses "search for bot → add to group" into a single tap.
+  const addBotDeepLink = useMemo(() => {
+    if (!token) return null;
+    return `https://t.me/${KARMA_TELEGRAM_BOT_HANDLE}?startgroup=${encodeURIComponent(token)}`;
+  }, [token]);
+
   const handleCopy = useCallback(() => {
     if (!token) return;
     copy(token, "Token copied to clipboard");
@@ -214,19 +226,29 @@ export function TelegramPairChatModal({
             </div>
           </div>
 
+          {/* One-tap add-to-group deep link */}
+          {addBotDeepLink ? (
+            <a
+              href={addBotDeepLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 rounded-lg border border-sky-200 dark:border-sky-900/40 bg-sky-50 dark:bg-sky-900/10 px-4 py-2.5 text-sm font-medium text-sky-700 dark:text-sky-300 transition hover:border-sky-300 hover:bg-sky-100 dark:hover:border-sky-700 dark:hover:bg-sky-900/20"
+            >
+              <ExternalLink className="w-4 h-4" />
+              Open Telegram — add Karma bot to a group
+            </a>
+          ) : null}
+
           {/* Instructions */}
           <ol className="space-y-2 text-sm text-gray-700 dark:text-gray-300 list-decimal list-inside marker:text-sky-600 dark:marker:text-sky-400">
             <li>
-              Add{" "}
-              <code className="px-1 py-0.5 rounded bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 text-sky-700 dark:text-sky-300 text-xs">
-                @{KARMA_TELEGRAM_BOT_HANDLE}
-              </code>{" "}
-              to your Telegram group if you haven&apos;t already.
+              Click <strong>Open Telegram</strong> above and pick the group you want to pair. If the
+              Karma bot is already in the group, skip this step.
             </li>
             <li>Copy the token above and post it as a message in that group.</li>
             <li>
-              Click <strong>Verify now</strong> below. Karma will detect which chat the token was
-              posted in and add it automatically.
+              Come back here and click <strong>Verify now</strong> below. Karma will detect which
+              chat the token was posted in and add it automatically.
             </li>
           </ol>
 

--- a/components/Pages/Admin/TelegramPairChatModal.tsx
+++ b/components/Pages/Admin/TelegramPairChatModal.tsx
@@ -135,7 +135,10 @@ export function TelegramPairChatModal({
   // token rides along as the `startgroup` payload — Telegram surfaces it back
   // to the bot on some clients, but we do NOT rely on that (payload delivery
   // isn't consistent across clients). The grantee still sends
-  // `/karma-pair <token>` in the group to complete the flow.
+  // `/karma_pair <token>` in the group to complete the flow. Command uses
+  // an underscore rather than a hyphen — Telegram's native bot command
+  // syntax only permits `[a-z0-9_]`, and `/karma-pair` would not register
+  // as a proper command with BotFather.
   const addBotDeepLink = useMemo(() => {
     if (!token) return null;
     return `https://t.me/${KARMA_TELEGRAM_BOT_HANDLE}?startgroup=${encodeURIComponent(token)}`;
@@ -143,7 +146,7 @@ export function TelegramPairChatModal({
 
   // The exact command the grantee should paste in the group. Shown verbatim
   // in the copy box so they can paste without modification.
-  const slashCommand = useMemo(() => (token ? `/karma-pair ${token}` : null), [token]);
+  const slashCommand = useMemo(() => (token ? `/karma_pair ${token}` : null), [token]);
 
   const handleCopy = useCallback(() => {
     if (!slashCommand) return;
@@ -288,7 +291,7 @@ export function TelegramPairChatModal({
               Karma bot is already in the group, skip this step.
             </li>
             <li>
-              Send the <strong>/karma-pair</strong> command above as a message in that group.
+              Send the <strong>/karma_pair</strong> command above as a message in that group.
             </li>
             <li>
               Come back here — Karma auto-detects the pairing and this modal closes. No extra click

--- a/components/Pages/Admin/TelegramPairChatModal.tsx
+++ b/components/Pages/Admin/TelegramPairChatModal.tsx
@@ -17,13 +17,19 @@ interface TelegramPairChatModalProps {
   communitySlug: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  // Fires on successful verify (both newly-paired and already-paired). The
+  // Fires on successful pair (both newly-paired and already-paired). The
   // parent's local `tgChats` state is seeded once from server data and never
   // re-synced from props (see NotificationSettingsPage.tsx:1074-1078 — sync
   // would clobber unsaved edits). Without this callback the provider card's
   // Chat-IDs list stays empty until the page is remounted.
   onPaired?: (chat: { id: string; name: string }) => void;
 }
+
+// Poll every 3s. The backend rate-limits verify at 10/min per community
+// (service constant), so 20 polls/min would trip it. 3s → 20 attempts over
+// the full 2-min TTL, well under the cap. Quick enough that pairing feels
+// instant once the grantee sends the slash command.
+const POLL_INTERVAL_MS = 3_000;
 
 const formatCountdown = (msRemaining: number): string => {
   const total = Math.max(0, Math.floor(msRemaining / 1000));
@@ -32,13 +38,19 @@ const formatCountdown = (msRemaining: number): string => {
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 };
 
-const resolveVerifyErrorMessage = (error: Error | null): string | null => {
+/**
+ * Translate a verify-error into a user-facing banner. 422 (pending — bot
+ * hasn't claimed yet) is filtered out BEFORE this — it fires every poll
+ * tick until pairing completes and is not a real error.
+ */
+const resolveFatalErrorMessage = (error: Error | null): string | null => {
   if (!error) return null;
-  // Real-class instanceof check (TelegramPairingError is now a proper Error
-  // subclass — see hooks/useTelegramPairing.ts).
   if (error instanceof TelegramPairingError) {
     if (error.status === 404) {
-      return "Token not found yet. Make sure you posted it in the group and the Karma bot is a member.";
+      return "Token expired. Generate a new one and try again.";
+    }
+    if (error.status === 403) {
+      return "This token doesn't belong to the current community.";
     }
     if (error.status === 503) {
       return "Telegram integration is not configured yet. Contact support.";
@@ -56,6 +68,9 @@ export function TelegramPairChatModal({
   const [token, setToken] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
   const [now, setNow] = useState<number>(() => Date.now());
+  // Terminal state — set when the bot claims (success) or when polling hits
+  // a non-retryable error. Stops the polling loop.
+  const [pollingHalted, setPollingHalted] = useState(false);
 
   const [, copy] = useCopyToClipboard();
 
@@ -64,27 +79,25 @@ export function TelegramPairChatModal({
 
   const startMutate = startPairing.mutate;
   const startReset = startPairing.reset;
+  const verifyMutate = verifyPairing.mutate;
   const verifyReset = verifyPairing.reset;
 
   // Per-open session id. Incremented every time the modal opens. Async
-  // mutation callbacks compare the captured id at fire-time against the
-  // current ref — late responses from a previous session are silently
-  // dropped. This is the lighter-weight equivalent of an AbortController
-  // (which fetchData doesn't currently surface) and is sufficient because
-  // the only side effects are local setState calls.
+  // callbacks compare the captured id at fire-time against the current ref —
+  // late responses from a previous session are silently dropped. Lighter
+  // than an AbortController (which fetchData doesn't currently surface).
   const sessionIdRef = useRef(0);
 
   const handleStart = useCallback(() => {
-    // Snapshot the session id at call time. Subsequent reopens bump the ref.
     const sessionId = sessionIdRef.current;
     startMutate(undefined, {
       onSuccess: (data) => {
-        if (sessionId !== sessionIdRef.current) return; // stale — drop
+        if (sessionId !== sessionIdRef.current) return;
         setToken(data.token);
         setExpiresAt(data.expiresAt);
       },
       onError: (err) => {
-        if (sessionId !== sessionIdRef.current) return; // stale — drop
+        if (sessionId !== sessionIdRef.current) return;
         toast.error(err.message || "Could not generate pairing token");
       },
     });
@@ -96,6 +109,7 @@ export function TelegramPairChatModal({
     sessionIdRef.current += 1;
     setToken(null);
     setExpiresAt(null);
+    setPollingHalted(false);
     verifyReset();
     startReset();
     handleStart();
@@ -120,54 +134,82 @@ export function TelegramPairChatModal({
   // the Karma bot so the admin doesn't have to search for its username. The
   // token rides along as the `startgroup` payload — Telegram surfaces it back
   // to the bot on some clients, but we do NOT rely on that (payload delivery
-  // isn't consistent across clients). The token still has to be posted in
-  // the group for the current verify flow to find it; the deep link just
-  // collapses "search for bot → add to group" into a single tap.
+  // isn't consistent across clients). The grantee still sends
+  // `/karma-pair <token>` in the group to complete the flow.
   const addBotDeepLink = useMemo(() => {
     if (!token) return null;
     return `https://t.me/${KARMA_TELEGRAM_BOT_HANDLE}?startgroup=${encodeURIComponent(token)}`;
   }, [token]);
 
+  // The exact command the grantee should paste in the group. Shown verbatim
+  // in the copy box so they can paste without modification.
+  const slashCommand = useMemo(() => (token ? `/karma-pair ${token}` : null), [token]);
+
   const handleCopy = useCallback(() => {
-    if (!token) return;
-    copy(token, "Token copied to clipboard");
-  }, [copy, token]);
+    if (!slashCommand) return;
+    copy(slashCommand, "Command copied to clipboard");
+  }, [copy, slashCommand]);
 
-  const handleVerify = useCallback(() => {
-    if (!token) return;
-    // Reset clears the previous error from the mutation result so the inline
-    // banner disappears on retry. (Local error mirror state was previously
-    // duplicating verifyPairing.error — dropped in favour of reading the
-    // mutation result directly.)
-    verifyReset();
+  // Polling loop: once a token is live, ask the backend "has the bot
+  // claimed this yet?" on an interval. On 200 → close modal + toast. On
+  // 422 (pending) → keep polling silently. On 404/403/503 → halt polling
+  // and surface as an inline error. Re-fires on token change / re-open.
+  useEffect(() => {
+    if (!open || !token || isExpired || pollingHalted) return;
+
     const sessionId = sessionIdRef.current;
-    verifyPairing.mutate(
-      { token },
-      {
-        onSuccess: (data) => {
-          if (sessionId !== sessionIdRef.current) return; // stale — drop
-          const label = data.chatTitle || "chat";
-          if (data.alreadyPaired) {
-            toast.success(`"${label}" is already paired`, { icon: "ℹ️" });
-          } else {
-            toast.success(`Paired "${label}"`);
-          }
-          // Fire even on already-paired: server truth includes the chat but
-          // the parent's local state may not (e.g. it was paired in another
-          // tab / session). Parent de-dupes by id.
-          onPaired?.({ id: data.chatId, name: data.chatTitle });
-          onOpenChange(false);
-        },
-        // No onError handler needed — verifyPairing.error drives the inline
-        // banner via the resolveVerifyErrorMessage call below.
-      }
-    );
-  }, [token, verifyPairing, verifyReset, onOpenChange, onPaired]);
+    const pollOnce = () => {
+      verifyMutate(
+        { token },
+        {
+          onSuccess: (data) => {
+            if (sessionId !== sessionIdRef.current) return;
+            setPollingHalted(true);
+            const label = data.chatTitle || "chat";
+            if (data.alreadyPaired) {
+              toast.success(`"${label}" is already paired`, { icon: "ℹ️" });
+            } else {
+              toast.success(`Paired "${label}"`);
+            }
+            // Fire even on already-paired: server truth includes the chat
+            // but the parent's local state may not (paired in another tab).
+            // Parent de-dupes by id.
+            onPaired?.({ id: data.chatId, name: data.chatTitle });
+            onOpenChange(false);
+          },
+          onError: (err) => {
+            if (sessionId !== sessionIdRef.current) return;
+            // 422 = "pending" (bot hasn't claimed yet). Keep polling silently.
+            // 429 = rate limit (shouldn't happen at 3s cadence). Keep polling.
+            // 404 / 403 / 503 = terminal. Halt and surface the error.
+            if (err instanceof TelegramPairingError) {
+              if (err.status === 422 || err.status === 429) return;
+            }
+            setPollingHalted(true);
+          },
+        }
+      );
+    };
 
-  // Read the error directly from the mutation result. Single source of truth.
-  const inlineError = resolveVerifyErrorMessage(verifyPairing.error);
+    // Kick off the first poll immediately so state flips fast when the
+    // grantee sends the command quickly.
+    pollOnce();
+    const interval = setInterval(pollOnce, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [open, token, isExpired, pollingHalted, verifyMutate, onOpenChange, onPaired]);
+
+  // Terminal error (not the 422 "still waiting" polling signal).
+  const inlineError = useMemo(() => {
+    const err = verifyPairing.error;
+    if (!err) return null;
+    if (err instanceof TelegramPairingError) {
+      if (err.status === 422 || err.status === 429) return null;
+    }
+    return resolveFatalErrorMessage(err);
+  }, [verifyPairing.error]);
+
   const isStarting = startPairing.isPending;
-  const isVerifying = verifyPairing.isPending;
+  const showWaiting = Boolean(token) && !isExpired && !pollingHalted && !inlineError;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -178,25 +220,25 @@ export function TelegramPairChatModal({
         </DialogTitle>
 
         <div className="mt-2 space-y-5">
-          {/* Token display */}
+          {/* Slash-command display */}
           <div>
             <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
-              Pairing token
+              Send this command in the group
             </p>
             <div className="flex items-stretch gap-2">
-              <div className="flex-1 flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800 px-4 py-3 font-mono text-base font-semibold tracking-wider text-gray-900 dark:text-white min-h-[52px]">
-                {isStarting || !token ? (
+              <div className="flex-1 flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800 px-4 py-3 font-mono text-sm font-semibold tracking-wide text-gray-900 dark:text-white min-h-[52px] break-all">
+                {isStarting || !slashCommand ? (
                   <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
                 ) : (
-                  <span data-testid="telegram-pair-token">{token}</span>
+                  <span data-testid="telegram-pair-command">{slashCommand}</span>
                 )}
               </div>
               <button
                 type="button"
                 onClick={handleCopy}
-                disabled={!token || isStarting}
+                disabled={!slashCommand || isStarting}
                 className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 text-gray-500 hover:text-sky-600 hover:border-sky-300 dark:hover:text-sky-400 dark:hover:border-sky-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
-                aria-label="Copy token"
+                aria-label="Copy command"
               >
                 <Copy className="w-4 h-4" />
               </button>
@@ -245,14 +287,26 @@ export function TelegramPairChatModal({
               Click <strong>Open Telegram</strong> above and pick the group you want to pair. If the
               Karma bot is already in the group, skip this step.
             </li>
-            <li>Copy the token above and post it as a message in that group.</li>
             <li>
-              Come back here and click <strong>Verify now</strong> below. Karma will detect which
-              chat the token was posted in and add it automatically.
+              Send the <strong>/karma-pair</strong> command above as a message in that group.
+            </li>
+            <li>
+              Come back here — Karma auto-detects the pairing and this modal closes. No extra click
+              needed.
             </li>
           </ol>
 
-          {/* Inline error */}
+          {/* Waiting indicator / inline error */}
+          {showWaiting ? (
+            <output
+              aria-live="polite"
+              className="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800/50 px-3 py-2.5 text-xs text-gray-600 dark:text-gray-400"
+            >
+              <Loader2 className="w-3.5 h-3.5 animate-spin shrink-0" />
+              <p>Waiting for the bot to see your command…</p>
+            </output>
+          ) : null}
+
           {inlineError ? (
             <div
               role="alert"
@@ -263,17 +317,12 @@ export function TelegramPairChatModal({
             </div>
           ) : null}
 
-          {/* Actions */}
+          {/* Actions: close, plus regenerate when expired */}
           <div className="flex items-center justify-end gap-2 pt-1">
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => onOpenChange(false)}
-              disabled={isVerifying}
-            >
-              Cancel
+            <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+              Close
             </Button>
-            {isExpired ? (
+            {isExpired || inlineError ? (
               <Button type="button" onClick={handleStart} disabled={isStarting}>
                 {isStarting ? (
                   <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
@@ -282,16 +331,7 @@ export function TelegramPairChatModal({
                 )}
                 Generate new token
               </Button>
-            ) : (
-              <Button
-                type="button"
-                onClick={handleVerify}
-                disabled={!token || isStarting || isVerifying}
-              >
-                {isVerifying ? <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" /> : null}
-                Verify now
-              </Button>
-            )}
+            ) : null}
           </div>
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary

Replace the "search Telegram for the bot username, then add it to a group" step with a single deep-link button that opens Telegram's native group picker pre-scoped to the Karma bot.

## UX

Before:

1. Open Telegram
2. Search for `@karmahqbot`
3. Tap the profile → Add to group → pick group
4. Post the pairing token
5. Click Verify

After:

1. Click **Open Telegram — add Karma bot to a group** → group picker appears
2. Pick group
3. Post the pairing token
4. Click Verify

## Why the token still has to be pasted

`?startgroup=<token>` attaches the token to the deep link, but Telegram's delivery of that payload to the bot is inconsistent across clients. We don't rely on it — the backend verify flow stays unchanged, which means the admin still pastes the token in the group so the bot can forward it via the existing webhook. If upstream ever reliably surfaces the payload, a backend follow-up can remove the paste step.

## Paired backend change

Token TTL reducing from 10min → 2min to shrink the replay window: https://github.com/show-karma/gap-indexer/pull/TBD

## Test plan

- [ ] Click **Open Telegram** button → Telegram app opens with group picker (mobile + desktop)
- [ ] URL encoding: tokens with `-`/`_` survive the round trip unchanged
- [ ] Modal still works when the bot is already in the group (skipping step 1 is fine)
- [ ] Vitest: `pnpm test __tests__/components/Admin/TelegramPairChatModal.test.tsx __tests__/components/Admin/NotificationSettingsPage.test.tsx` — all green (42 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open Telegram" button for quick access to bot pairing.
  * Implemented one-tap deep link with token support for streamlined setup.

* **UI/UX Improvements**
  * Updated on-screen instructions to guide users through the new direct linking method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->