### PR TITLE
fix(notifications): don't flash 'token expired' after successful TG pair

### DIFF
--- a/components/Pages/Admin/TelegramPairChatModal.tsx
+++ b/components/Pages/Admin/TelegramPairChatModal.tsx
@@ -71,6 +71,12 @@ export function TelegramPairChatModal({
   // Terminal state — set when the bot claims (success) or when polling hits
   // a non-retryable error. Stops the polling loop.
   const [pollingHalted, setPollingHalted] = useState(false);
+  // Ref mirror of `pollingHalted`. State updates don't propagate into
+  // closures captured by already-scheduled setInterval ticks or in-flight
+  // mutation callbacks; a ref read does. This closes the race where a
+  // scheduled verify tick fires AFTER a successful one, the stale POST
+  // comes back 404 (token consumed), and the UI flashes "Token expired".
+  const pollingHaltedRef = useRef(false);
 
   const [, copy] = useCopyToClipboard();
 
@@ -110,6 +116,7 @@ export function TelegramPairChatModal({
     setToken(null);
     setExpiresAt(null);
     setPollingHalted(false);
+    pollingHaltedRef.current = false;
     verifyReset();
     startReset();
     handleStart();
@@ -162,11 +169,17 @@ export function TelegramPairChatModal({
 
     const sessionId = sessionIdRef.current;
     const pollOnce = () => {
+      // Skip stale ticks: if polling already halted (success or fatal
+      // error), a setInterval tick queued before the state update propagated
+      // would otherwise fire a POST whose 404 (one-time-use token is now
+      // gone) stomps the mutation's success-state with an error banner.
+      if (pollingHaltedRef.current) return;
       verifyMutate(
         { token },
         {
           onSuccess: (data) => {
             if (sessionId !== sessionIdRef.current) return;
+            pollingHaltedRef.current = true;
             setPollingHalted(true);
             const label = data.chatTitle || "chat";
             if (data.alreadyPaired) {
@@ -182,12 +195,18 @@ export function TelegramPairChatModal({
           },
           onError: (err) => {
             if (sessionId !== sessionIdRef.current) return;
+            // Late response from a poll that fired just before a success.
+            // The successful poll already consumed the token server-side;
+            // this 404/422 is expected noise. Drop it so React Query's
+            // mutation-error state doesn't overwrite the success branch.
+            if (pollingHaltedRef.current) return;
             // 422 = "pending" (bot hasn't claimed yet). Keep polling silently.
             // 429 = rate limit (shouldn't happen at 3s cadence). Keep polling.
             // 404 / 403 / 503 = terminal. Halt and surface the error.
             if (err instanceof TelegramPairingError) {
               if (err.status === 422 || err.status === 429) return;
             }
+            pollingHaltedRef.current = true;
             setPollingHalted(true);
           },
         }


### PR DESCRIPTION
## Summary

FE-only race fix. After a successful pair, the modal occasionally flashes *"Token expired. Generate a new one and try again."* before closing — even though the pair itself worked (chat bound to community, toast fires, `onPaired` callback runs). The problem is purely a React Query state update on a stale late response; no server change needed.

## The race

```
T+0ms     poll N  → mutate() sends POST
T+100ms   poll N  ← 200 success. onSuccess runs, setPollingHalted(true),
                    toast, onOpenChange(false).
                    (but setInterval already has a tick queued)
T+3000ms  poll N+1 → mutate() sends POST (stale tick slipped through)
T+3100ms  poll N+1 ← 404. onError runs, verifyPairing.error is set to
                    TelegramPairingError{status:404}.
                    inlineError re-computes → "Token expired".
                    (flashes before the modal fully unmounts)
```

The server 404 is correct — `verifyPairing` deletes the cache entry on success; the token is one-time-use by design. The FE just shouldn't let a stale-tick response overwrite its own success branch.

## Fix

Mirror `pollingHalted` into a ref. State updates don't propagate into closures already captured by scheduled `setInterval` ticks or in-flight mutation callbacks; a ref read does. Two guards:

1. **`pollOnce` entry** — check `pollingHaltedRef.current`, skip the mutate entirely if already halted. Kills the stale tick before it hits the wire.
2. **`onError`** — drop any late response when the ref is set. Kills a stale tick's response if it slipped past guard 1 because the mutate was already in flight when we succeeded.

Ref is reset to `false` alongside the state when the modal reopens.

## What this doesn't change

- No backend change. The one-time-use semantic (`verifyPairing` deletes the cache entry on bind) is correct and intentional. Manual curl replays against a consumed token will still return 404 — that's the right answer for the server, just not something the UI should surface as an error when it was the UI's own late poll that triggered it.
- No change to the rate at which polls fire, the error messaging for legitimate terminal errors (token truly expired before claim, wrong community, 503), or the toast/chat-list update on success.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean
- [x] `pnpm test __tests__/components/Admin/TelegramPairChatModal.test.tsx __tests__/components/Admin/NotificationSettingsPage.test.tsx hooks/__tests__/useTelegramPairing.test.tsx` — 49 tests green
- [ ] Manual: open pair modal → wait for bot claim → observe modal close cleanly, no "Token expired" flash
- [ ] Manual: generate token → don't post `/karma_pair` → let it expire → *does* show "Token expired" with Regenerate button (legitimate error path still works)
- [ ] Manual: generate token → send wrong-community attempt → *does* show community-mismatch error (legitimate error path still works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in Telegram pair verification where late request failures could incorrectly override successful verification states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->