### PR TITLE
fix: hide project settings for unauthorized users

### DIFF
--- a/__tests__/components/ProjectOptionsMenu.test.tsx
+++ b/__tests__/components/ProjectOptionsMenu.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ProjectOptionsMenu } from "@/components/Pages/Project/ProjectOptionsMenu";
+import type { Role } from "@/src/core/rbac/types";
+
+const mockAuthState = {
+  authenticated: false,
+};
+
+const mockProjectStoreState = {
+  project: {
+    uid: "0xproject",
+    chainID: 10,
+  },
+  isProjectAdmin: false,
+  isProjectOwner: false,
+  refreshProject: vi.fn(),
+};
+
+const mockOwnerStoreState = {
+  isOwner: false,
+};
+
+const mockPermissionsState = {
+  isLoading: false,
+  roles: [] as Role[],
+};
+
+const mockCommunityAdminState = {
+  isCommunityAdmin: false,
+};
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    const MockDynamicComponent = () => null;
+    MockDynamicComponent.displayName = "MockDynamicComponent";
+    return MockDynamicComponent;
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "karma" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ address: undefined, chain: undefined }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock("@/hooks/useContactInfo", () => ({
+  useContactInfo: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ switchChainAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAttestationToast", () => ({
+  useAttestationToast: () => ({
+    startAttestation: vi.fn(),
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    changeStepperStep: vi.fn(),
+    setIsStepper: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useSetupChainAndWallet", () => ({
+  useSetupChainAndWallet: () => ({
+    setupChainAndWallet: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  useIsCommunityAdmin: () => mockCommunityAdminState.isCommunityAdmin,
+}));
+
+vi.mock("@/src/core/rbac/hooks/use-permissions", () => ({
+  usePermissionsQuery: () => ({
+    data: { roles: { roles: mockPermissionsState.roles } },
+    isLoading: mockPermissionsState.isLoading,
+  }),
+}));
+
+vi.mock("@/store", () => ({
+  useProjectStore: (selector?: (state: typeof mockProjectStoreState) => unknown) =>
+    selector ? selector(mockProjectStoreState) : mockProjectStoreState,
+  useOwnerStore: (selector?: (state: typeof mockOwnerStoreState) => unknown) =>
+    selector ? selector(mockOwnerStoreState) : mockOwnerStoreState,
+}));
+
+vi.mock("@/store/modals/projectEdit", () => ({
+  useProjectEditModalStore: () => ({
+    openProjectEditModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/modals/merge", () => ({
+  useMergeModalStore: () => ({
+    openMergeModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/modals/genie", () => ({
+  useGrantGenieModalStore: () => ({
+    openGrantGenieModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/modals/transferOwnership", () => ({
+  useTransferOwnershipModalStore: () => ({
+    openTransferOwnershipModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/modals/adminTransferOwnership", () => ({
+  useAdminTransferOwnershipModalStore: () => ({
+    openAdminTransferOwnershipModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@/components/Icons", () => ({
+  GithubIcon: () => <span>GitHub</span>,
+}));
+
+vi.mock("@/src/features/chain-payout-address", () => ({
+  SetChainPayoutAddressModal: () => null,
+}));
+
+vi.mock("@/utilities/sdk", () => ({
+  deleteProject: vi.fn(),
+  getProjectById: vi.fn(),
+}));
+
+vi.mock("@/components/Pages/Project/LinkContractAddressButton", () => ({
+  LinkContractAddressButton: () => null,
+}));
+
+vi.mock("@/components/Pages/Project/LinkDivviWalletButton", () => ({
+  LinkDivviWalletButton: () => null,
+}));
+
+vi.mock("@/components/Pages/Project/LinkGithubRepoButton", () => ({
+  LinkGithubRepoButton: () => null,
+}));
+
+vi.mock("@/components/Pages/Project/LinkOSOProfileButton", () => ({
+  LinkOSOProfileButton: () => null,
+}));
+
+describe("ProjectOptionsMenu", () => {
+  beforeEach(() => {
+    mockAuthState.authenticated = false;
+    mockProjectStoreState.isProjectAdmin = false;
+    mockProjectStoreState.isProjectOwner = false;
+    mockOwnerStoreState.isOwner = false;
+    mockPermissionsState.isLoading = false;
+    mockPermissionsState.roles = [];
+    mockCommunityAdminState.isCommunityAdmin = false;
+    vi.clearAllMocks();
+  });
+
+  it("does not render the project settings button for logged out users", () => {
+    render(<ProjectOptionsMenu />);
+
+    expect(screen.queryByTestId("project-options-menu")).not.toBeInTheDocument();
+  });
+
+  it("does not render the project settings button for authenticated users without admin access", () => {
+    mockAuthState.authenticated = true;
+
+    render(<ProjectOptionsMenu />);
+
+    expect(screen.queryByTestId("project-options-menu")).not.toBeInTheDocument();
+  });
+
+  it("renders the project settings button for project admins", () => {
+    mockAuthState.authenticated = true;
+    mockProjectStoreState.isProjectAdmin = true;
+
+    render(<ProjectOptionsMenu />);
+
+    expect(screen.getByTestId("project-options-menu")).toBeInTheDocument();
+    expect(screen.getByText("Project Settings")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/ProjectOptionsMenu.test.tsx
+++ b/__tests__/components/ProjectOptionsMenu.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { ProjectOptionsMenu } from "@/components/Pages/Project/ProjectOptionsMenu";
-import type { Role } from "@/src/core/rbac/types";
+import { Role } from "@/src/core/rbac/types";
 
 const mockAuthState = {
   authenticated: false,
@@ -194,5 +194,23 @@ describe("ProjectOptionsMenu", () => {
 
     expect(screen.getByTestId("project-options-menu")).toBeInTheDocument();
     expect(screen.getByText("Project Settings")).toBeInTheDocument();
+  });
+
+  it("renders the project settings button for super admins", () => {
+    mockAuthState.authenticated = true;
+    mockPermissionsState.roles = [Role.SUPER_ADMIN];
+
+    render(<ProjectOptionsMenu />);
+
+    expect(screen.getByTestId("project-options-menu")).toBeInTheDocument();
+  });
+
+  it("renders the project settings button for community admins", () => {
+    mockAuthState.authenticated = true;
+    mockCommunityAdminState.isCommunityAdmin = true;
+
+    render(<ProjectOptionsMenu />);
+
+    expect(screen.getByTestId("project-options-menu")).toBeInTheDocument();
   });
 });

--- a/components/Pages/Project/ProjectOptionsMenu.tsx
+++ b/components/Pages/Project/ProjectOptionsMenu.tsx
@@ -119,7 +119,6 @@ export const ProjectOptionsMenu = () => {
   const projectId = params.projectId as string;
   const [isDeleting, setIsDeleting] = useState(false);
   const [showLinkContractsDialog, setShowLinkContractsDialog] = useState(false);
-  const [showViewContractsDialog, setShowViewContractsDialog] = useState(false);
   const [showLinkGithubDialog, setShowLinkGithubDialog] = useState(false);
   const [showLinkOSODialog, setShowLinkOSODialog] = useState(false);
   const [showLinkDivviDialog, setShowLinkDivviDialog] = useState(false);
@@ -151,10 +150,6 @@ export const ProjectOptionsMenu = () => {
   // Event handlers to reset state when dialogs close
   const handleLinkContractsDialogClose = () => {
     setShowLinkContractsDialog(false);
-  };
-
-  const handleViewContractsDialogClose = () => {
-    setShowViewContractsDialog(false);
   };
 
   const handleLinkGithubDialogClose = () => {
@@ -230,15 +225,6 @@ export const ProjectOptionsMenu = () => {
               buttonClassName={buttonClassName}
               project={project}
               onClose={handleLinkContractsDialogClose}
-            />
-          )}
-          {showViewContractsDialog && (
-            <LinkContractAddressButton
-              buttonElement={null}
-              buttonClassName={buttonClassName}
-              project={project}
-              onClose={handleViewContractsDialogClose}
-              readOnly={true}
             />
           )}
           {showLinkGithubDialog && (
@@ -383,16 +369,6 @@ export const ProjectOptionsMenu = () => {
                   Delete project
                 </DropdownMenuItem>
               </>
-            )}
-            {/* Non-authorized but logged-in users: View Contracts only */}
-            {!isAuthorized && !isSuperAdmin && isAuthenticated && project && (
-              <DropdownMenuItem
-                onClick={() => setShowViewContractsDialog(true)}
-                className={buttonClassName}
-              >
-                <LinkIcon className="h-5 w-5" aria-hidden="true" />
-                View Contracts
-              </DropdownMenuItem>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/components/Pages/Project/ProjectOptionsMenu.tsx
+++ b/components/Pages/Project/ProjectOptionsMenu.tsx
@@ -126,7 +126,7 @@ export const ProjectOptionsMenu = () => {
   const [showSetPayoutDialog, setShowSetPayoutDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const { address, chain } = useAccount();
-  const { authenticated: isAuthenticated } = useAuth();
+  const { authenticated } = useAuth();
   const { switchChainAsync } = useWallet();
   const router = useRouter();
   const { startAttestation, showSuccess, showError, changeStepperStep, setIsStepper } =
@@ -137,12 +137,11 @@ export const ProjectOptionsMenu = () => {
   const { openGrantGenieModal } = useGrantGenieModalStore();
   const { openTransferOwnershipModal } = useTransferOwnershipModalStore();
   const { openAdminTransferOwnershipModal } = useAdminTransferOwnershipModalStore();
-  const { isProjectOwner, refreshProject } = useProjectStore();
+  const { isProjectAdmin, isProjectOwner, refreshProject } = useProjectStore();
   const { data: contactsInfo } = useContactInfo(projectId);
   const { isOwner: isContractOwner } = useOwnerStore();
   const isCommunityAdmin = useIsCommunityAdmin();
-  const isAuthorized = isProjectOwner || isContractOwner || isCommunityAdmin;
-  const { authenticated } = useAuth();
+  const isAuthorized = isProjectAdmin || isProjectOwner || isContractOwner || isCommunityAdmin;
   const { data: permissions, isLoading: isPermissionsLoading } = usePermissionsQuery(
     {},
     { enabled: authenticated }
@@ -292,7 +291,7 @@ export const ProjectOptionsMenu = () => {
         </>
       )}
 
-      {!isPermissionsLoading && (isAuthorized || isSuperAdmin || isAuthenticated) && (
+      {!isPermissionsLoading && (isAuthorized || isSuperAdmin) && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button


### PR DESCRIPTION
## Summary
- remove the authenticated-user fallback from the Project Settings button gate
- require project admin/owner/authorized roles (or super admin) before showing the menu
- add a focused ProjectOptionsMenu test covering logged-out, non-admin, and admin behavior

## Test Plan
- pnpm exec vitest run __tests__/components/ProjectOptionsMenu.test.tsx --project unit
- pnpm exec biome check components/Pages/Project/ProjectOptionsMenu.tsx __tests__/components/ProjectOptionsMenu.test.tsx

## Notes
- Focused test passed.
- Focused biome check returned warnings in the existing component file but no lint errors for the touched files.

Closes DEV-155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Project Settings access control to properly enforce admin and owner-level permissions.

* **Tests**
  * Added comprehensive test coverage for ProjectOptionsMenu authorization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->