### PR TITLE
fix(whitelabel): prime karma-gap-sdk module graph in slim navbar

### DIFF
--- a/src/components/navbar/whitelabel-navbar.tsx
+++ b/src/components/navbar/whitelabel-navbar.tsx
@@ -1,5 +1,17 @@
 "use client";
 
+// Side-effect import: evaluates `@show-karma/karma-gap-sdk` via its main entry
+// (`core/index.js`), which loads `class/GAP` first and primes the `Schema` /
+// `GapSchema` / `Attestation` module graph in the safe order. Without this,
+// whitelabel pages whose first SDK touch is a deep import into
+// `core/class/entities/ProjectMilestone` (e.g. `hooks/useMilestone.ts`) hit a
+// CJS circular dependency and crash with:
+//   "Class extends value undefined is not a constructor or null"
+// The main-site navbar happens to prime the SDK transitively; this restores
+// parity for the slim whitelabel shell. Keep before the other SDK-touching
+// imports in this file so Turbopack evaluates it first.
+import "@show-karma/karma-gap-sdk";
+
 import { ChevronDown, Menu, X } from "lucide-react";
 import Image from "next/image";
 import { Fragment, useMemo, useState } from "react";


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: Class extends value undefined is not a constructor or null` that crashed every whitelabel page whose first SDK evaluation was a deep import into `@show-karma/karma-gap-sdk/core/class/entities/*` (e.g. `/updates` on `app.filpgf.io` via `useMilestone.ts`).
- Adds a one-line side-effect import of `@show-karma/karma-gap-sdk` at the top of `whitelabel-navbar.tsx` so Turbopack evaluates the SDK's main entry (`core/index.js`) as part of the navbar's dep graph, priming the module cache in the safe order before any page-level deep import runs.

## Root cause

The SDK has a CommonJS circular dependency:

```
Schema -> contract/GapContract -> utils/gelato/send-gelato-txn
       -> class/GAP -> class/GapSchema -> (needs) Schema
```

CJS hands a module that is still mid-evaluation its partial `exports = {}`. Depending on where the cycle is *entered*, the outcome differs:

- **Entering at `class/GAP`** (what the SDK's main entry does): the cycle closes at `send-gelato-txn -> GAP`. Harmless — `send-gelato-txn` only touches `GAP.GAP` at runtime inside async functions, never at module eval.
- **Entering at `Attestation`/`ProjectMilestone`** (what a deep import into `core/class/entities/*` does): the cycle closes at `GapSchema extends Schema_1.Schema` — but `Schema.js` is still mid-load and its `exports.Schema` hasn't been assigned yet, so `Schema_1.Schema` is `undefined`, and the class declaration throws.

On the main domain, the full `<Navbar />`'s transitive imports happen to load the SDK root first, priming the module cache via the safe GAP-first path. The slim `<WhitelabelNavbar />` shell did not — so a page whose first SDK touch was `useMilestone.ts:1`'s `import { ProjectMilestone } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone"` went down the bad path.

## Why this spot

- `whitelabel-navbar.tsx` is statically imported by `app/layout.tsx` and mounted above `{children}` on every whitelabel page, so it is reliably part of the client bundle and evaluated before page-level components in Turbopack's topological order.
- One-line change localizes the workaround to the tenant shell that actually needs it. The main navbar is unaffected.
- An explanatory comment block is attached so a future reader does not remove a "seemingly unused" bare import.

## Follow-up

The proper long-term fix is in `karma-gap-sdk`: move the top-level `require("../../class/GAP")` in `core/utils/gelato/send-gelato-txn.ts` inside the functions that actually use it. That would break the cycle edge altogether and make every downstream consumer immune regardless of import order. This PR is the minimal app-side stopgap.

## Test plan

- [ ] Load `/updates` on `app.filpgf.io` (or any whitelabel domain) — no console error, page renders.
- [ ] Load `/community/filecoin/updates` on `karmahq.xyz` — still renders as before (no regression on the non-whitelabel path).
- [ ] Load other whitelabel routes (`/`, `/projects`, `/dashboard`) — no new errors.
- [ ] Local repro: in `gap-app-v2/.env.local` set `WHITELABEL_EXTRA_DOMAINS_JSON='[{"domain":"localhost","communitySlug":"filecoin","tenantId":"filecoin","name":"Filecoin Local","theme":{"primaryColor":"#0090ff"}}]'`, then `pnpm dev` and visit `http://localhost:3000/updates`. Confirmed passing locally.