### PR TITLE
test(smoke) + fix: community subpages across standard & whitelabel hosts

### DIFF
--- a/e2e/tests/smoke/community-pages.smoke.spec.ts
+++ b/e2e/tests/smoke/community-pages.smoke.spec.ts
@@ -1,0 +1,249 @@
+import { MOCK_COMMUNITIES } from "../../data/communities";
+import { createMockProgram } from "../../data/programs";
+import { expect, mockJson, test } from "../../fixtures";
+import { assertNoJsErrors, collectJsErrors } from "../../helpers/assertions";
+import { GOTO_OPTIONS, waitForPageReady } from "../../helpers/navigation";
+
+// These community subpages rely on SSR data fetching. Playwright route mocks
+// only intercept browser requests, so we use "optimism" — a real community
+// slug that exists in the staging indexer — to keep SSR happy while still
+// exercising the page shell and client components.
+const COMMUNITY_SLUG = MOCK_COMMUNITIES.optimism.slug;
+
+/**
+ * Smoke coverage for the four community subpages the product surfaces
+ * (projects, grants, updates, stats) across both URL shapes that the
+ * middleware supports:
+ *
+ *   1. Standard host:  karmahq.xyz/community/<slug>/<page>
+ *   2. Whitelabel host: app.opgrants.io/<page>  (rewritten by middleware)
+ *
+ * The whitelabel variants also act as regression tests for the slim
+ * <WhitelabelNavbar/> SDK module-graph bug fixed in d8e1e67d, where the
+ * first SDK deep-import on /updates crashed render with
+ * "Class extends value undefined is not a constructor or null".
+ * collectJsErrors / assertNoJsErrors will surface that class of failure.
+ */
+test.describe("Smoke Tests — Community Pages", () => {
+  test.describe("Standard host (/community/:slug/...)", () => {
+    test("T-COMM-01: /community/:slug/projects loads", async ({ page, withApiMocks }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/funding-program-configs/community/${COMMUNITY_SLUG}**`]: mockJson([
+          createMockProgram({ title: "Retro Funding" }),
+        ]),
+      });
+
+      await page.goto(`/community/${COMMUNITY_SLUG}/projects`, GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-02: /community/:slug/grants redirects to /funding-opportunities", async ({
+      page,
+      withApiMocks,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/funding-program-configs/community/${COMMUNITY_SLUG}**`]: mockJson([
+          createMockProgram({ title: "Open Funding" }),
+        ]),
+      });
+
+      await page.goto(`/community/${COMMUNITY_SLUG}/grants`, GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      // next.config.ts:148 permanently redirects /community/:slug/grants -> /funding-opportunities
+      await expect(page).toHaveURL(/\/funding-opportunities\/?$/);
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-03: /community/:slug/updates loads", async ({ page, withApiMocks }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/communities/${COMMUNITY_SLUG}/project-updates**`]: mockJson({
+          payload: [],
+          pagination: { page: 1, limit: 25, total: 0 },
+        }),
+        [`**/v2/communities/${COMMUNITY_SLUG}/projects**`]: mockJson({
+          payload: [],
+          pagination: { page: 1, limit: 25, total: 0 },
+        }),
+        [`**/v2/communities/${COMMUNITY_SLUG}/milestone-allocations**`]: mockJson([]),
+      });
+
+      await page.goto(`/community/${COMMUNITY_SLUG}/updates`, GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-04: /community/:slug/stats renders without crashing", async ({
+      page,
+      withApiMocks,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/communities/${COMMUNITY_SLUG}/stats`]: mockJson(MOCK_COMMUNITIES.optimism.stats),
+      });
+
+      await page.goto(`/community/${COMMUNITY_SLUG}/stats`, GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      // /community/:slug/stats is not a defined route today — the app should
+      // handle it gracefully (not-found page or future stats content) with no
+      // JS errors.
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+  });
+
+  test.describe("Whitelabel host (clean URLs, middleware rewrite)", () => {
+    test("T-COMM-WL-01: /projects loads on whitelabel domain", async ({
+      page,
+      withApiMocks,
+      withTenant,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withTenant("optimism");
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/funding-program-configs/community/${COMMUNITY_SLUG}**`]: mockJson([
+          createMockProgram({ title: "Retro Funding" }),
+        ]),
+      });
+
+      // Whitelabel clean URL — middleware rewrites to /community/optimism/projects
+      await page.goto("/projects", GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      // Browser URL must stay on the clean whitelabel path
+      expect(new URL(page.url()).pathname).not.toContain("/community/");
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-WL-02: /grants on whitelabel domain renders without crashing", async ({
+      page,
+      withApiMocks,
+      withTenant,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withTenant("optimism");
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/funding-program-configs/community/${COMMUNITY_SLUG}**`]: mockJson([
+          createMockProgram({ title: "Open Funding" }),
+        ]),
+      });
+
+      // /grants is NOT in COMMUNITY_SUB_ROUTE_SEGMENTS, so on whitelabel it passes
+      // through as a top-level route. Whatever the app serves (404 shell or
+      // future route) must render without throwing.
+      await page.goto("/grants", GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-WL-03: /updates loads on whitelabel domain (regression: d8e1e67d)", async ({
+      page,
+      withApiMocks,
+      withTenant,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withTenant("optimism");
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        [`**/v2/communities/${COMMUNITY_SLUG}/project-updates**`]: mockJson({
+          payload: [],
+          pagination: { page: 1, limit: 25, total: 0 },
+        }),
+        [`**/v2/communities/${COMMUNITY_SLUG}/projects**`]: mockJson({
+          payload: [],
+          pagination: { page: 1, limit: 25, total: 0 },
+        }),
+        [`**/v2/communities/${COMMUNITY_SLUG}/milestone-allocations**`]: mockJson([]),
+      });
+
+      // Whitelabel clean URL — middleware rewrites to /community/optimism/updates.
+      // This is the page that threw "Class extends value undefined is not a
+      // constructor or null" before the slim <WhitelabelNavbar/> was primed
+      // with a bare `import "@show-karma/karma-gap-sdk"`. jsErrors captures
+      // that exact failure mode.
+      await page.goto("/updates", GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      expect(new URL(page.url()).pathname).not.toContain("/community/");
+
+      // Assert the specific SDK-init error class does NOT surface, in addition
+      // to the general "no JS errors" guard.
+      const sdkInitError = jsErrors.find((msg) =>
+        /Class extends value undefined|is not a constructor/i.test(msg)
+      );
+      expect(sdkInitError).toBeUndefined();
+
+      assertNoJsErrors(jsErrors);
+    });
+
+    test("T-COMM-WL-04: /stats on whitelabel domain renders without crashing", async ({
+      page,
+      withApiMocks,
+      withTenant,
+    }) => {
+      const jsErrors = collectJsErrors(page);
+
+      await withTenant("optimism");
+      await withApiMocks({
+        [`**/v2/communities/${COMMUNITY_SLUG}`]: mockJson(MOCK_COMMUNITIES.optimism),
+        "**/v2/communities/stats**": mockJson({
+          totalCommunities: 5,
+          totalProjects: 100,
+          totalGrants: 50,
+        }),
+      });
+
+      // /stats is not in COMMUNITY_SUB_ROUTE_SEGMENTS — on whitelabel it passes
+      // through as a top-level route and hits the global /stats page.
+      await page.goto("/stats", GOTO_OPTIONS);
+      await waitForPageReady(page);
+
+      await expect(page.locator("body")).toBeVisible();
+      await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 10000 });
+
+      assertNoJsErrors(jsErrors);
+    });
+  });
+});

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+// Side-effect import: evaluates `@show-karma/karma-gap-sdk` via its main entry
+// (`core/index.js`), which loads `class/GAP` first and primes the `Schema` /
+// `GapSchema` / `Attestation` module graph in the safe order. Without this,
+// pages whose first SDK touch is a deep import into
+// `core/class/entities/ProjectMilestone` (e.g. `hooks/useMilestone.ts` on
+// `/community/:slug/updates`) hit a CJS circular dependency and crash with:
+//   "Class extends value undefined is not a constructor or null"
+// This mirrors the same priming added to `whitelabel-navbar.tsx` in d8e1e67d:
+// the main navbar was assumed to prime the SDK transitively, but in a
+// production build the dynamic imports below can split chunks in a way that
+// lets the page's deep import evaluate first. Keep this before other
+// SDK-touching imports so Turbopack evaluates it first.
+import "@show-karma/karma-gap-sdk";
+
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/utilities/tailwind";


### PR DESCRIPTION
## Summary

Two related changes in one PR because the tests surfaced a real bug:

1. **Smoke coverage** for the four community subpages (`projects`, `grants`, `updates`, `stats`) across **both** URL shapes the middleware supports (standard host `karmahq.xyz/community/:slug/<page>` and whitelabel clean URLs rewritten from e.g. `app.opgrants.io/<page>`).
2. **Fix**: extends d8e1e67d's SDK module-graph prime from `whitelabel-navbar.tsx` to `navbar.tsx` — the main navbar had the same latent crash on `/community/:slug/updates` in production builds.

## Why the fix

d8e1e67d added a side-effect `import "@show-karma/karma-gap-sdk"` to `whitelabel-navbar.tsx` to work around a CJS circular dependency in the SDK (`Schema → GapContract → send-gelato-txn → GAP → GapSchema → Schema`). The commit assumed the main navbar was fine because it "happens to load the SDK root first."

That assumption doesn't hold in production. The main navbar `dynamic()`-lazy-loads `NavbarMobileMenu` (`navbar.tsx:9`), which lets the Next.js prod bundler split chunks such that `CommunityMilestoneCard` on `/community/:slug/updates` evaluates `core/class/entities/ProjectMilestone` before the navbar chunk primes the SDK root. Result: the same `"Class extends value undefined is not a constructor or null"` the whitelabel fix addressed.

`T-COMM-03` failed reliably 3/3 retries on `main` (after d8e1e67d) until this fix was added. Applying the same one-line prime to `navbar.tsx` restores parity.

## Test matrix (8 new tests)

| Path | Standard host | Whitelabel host |
|---|---|---|
| `projects` | `T-COMM-01` — page loads | `T-COMM-WL-01` — rewritten, URL stays clean |
| `grants` | `T-COMM-02` — 301 to `/funding-opportunities` (per `next.config.ts:148`) | `T-COMM-WL-02` — passes through as top-level, no crash |
| `updates` | `T-COMM-03` — page loads (**catches the bug fixed here**) | `T-COMM-WL-03` — regression guard for d8e1e67d (already green) |
| `stats` | `T-COMM-04` — renders gracefully (not a defined route today) | `T-COMM-WL-04` — passes through to global `/stats` |

Every test uses `collectJsErrors` / `assertNoJsErrors` so any `pageerror` fails the test. `T-COMM-WL-03` also asserts on the specific SDK-init error substring for a clearer signal.

## Implementation notes

- Uses `withTenant("optimism")` for whitelabel tests (same pattern as `tenant-theme.smoke.spec.ts`).
- Real `optimism` slug keeps SSR fetches happy — Playwright mocks only intercept browser requests, consistent with existing smoke tests.
- Fix is a minimal one-line side-effect import + a comment pointing back to d8e1e67d.

## Test plan

- [ ] CI smoke workflow green (expected now that navbar fix is included)
- [ ] `pnpm exec playwright test e2e/tests/smoke/community-pages.smoke.spec.ts` — 8 tests pass locally
- [ ] Sanity-check `/community/:slug/updates` in prod preview for Optimism and one whitelabel tenant