### PR TITLE
feat(display-name): unified profile-name component with Privy + ENS fallback

### DIFF
--- a/__tests__/components/EthereumAddressToProfileName.test.tsx
+++ b/__tests__/components/EthereumAddressToProfileName.test.tsx
@@ -1,0 +1,423 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
+import "@testing-library/jest-dom";
+
+// ---------------------------------------------------------------------------
+// Mock stores and hooks
+// ---------------------------------------------------------------------------
+
+const mockPopulateEns = vi.fn();
+const mockEnsData: Record<string, { name?: string | null; avatar?: string | null }> = {};
+
+vi.mock("@/store/ens", () => ({
+  useENS: vi.fn((selector: (state: unknown) => unknown) => {
+    const state = {
+      ensData: mockEnsData,
+      populateEns: mockPopulateEns,
+    };
+    return selector ? selector(state) : state;
+  }),
+}));
+
+const mockPopulateProfiles = vi.fn();
+const mockProfilesData: Record<
+  string,
+  {
+    publicAddress: string;
+    name: string;
+    email?: string;
+    picture?: string;
+    isTried?: boolean;
+    isFetching?: boolean;
+  }
+> = {};
+
+vi.mock("@/store/userProfiles", () => ({
+  useUserProfiles: vi.fn((selector: (state: unknown) => unknown) => {
+    const state = {
+      profiles: mockProfilesData,
+      populateProfiles: mockPopulateProfiles,
+    };
+    return selector ? selector(state) : state;
+  }),
+}));
+
+// Minimal ContributorProfile mock
+interface MockContributorProfile {
+  name?: string;
+}
+let mockContributorProfile: MockContributorProfile | null = null;
+
+vi.mock("@/hooks/useContributorProfile", () => ({
+  useContributorProfile: vi.fn(() => ({
+    profile: mockContributorProfile,
+    isLoading: false,
+  })),
+}));
+
+// Mock next/image to avoid Next.js image optimization in tests
+vi.mock("next/image", () => ({
+  default: ({ src, alt, className }: { src: string; alt: string; className?: string }) => (
+    <img src={src} alt={alt} className={className} />
+  ),
+}));
+
+// Mock blo
+vi.mock("blo", () => ({
+  blo: vi.fn((addr: string) => `blockie:${addr}`),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const MOCK_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const MOCK_ADDRESS_LOWER = MOCK_ADDRESS.toLowerCase();
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("EthereumAddressToProfileName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear mutable state
+    Object.keys(mockEnsData).forEach((k) => delete mockEnsData[k]);
+    Object.keys(mockProfilesData).forEach((k) => delete mockProfilesData[k]);
+    mockContributorProfile = null;
+  });
+
+  // -------------------------------------------------------------------------
+  // Rendering basics
+  // -------------------------------------------------------------------------
+  describe("basic rendering", () => {
+    it("renders a span element", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+      const span = screen.getByText(/0x1234/);
+      expect(span.tagName).toBe("SPAN");
+    });
+
+    it("applies font-body class", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText(/0x1234/)).toHaveClass("font-body");
+    });
+
+    it("applies custom className", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} className="text-red-500" />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText(/0x1234/)).toHaveClass("text-red-500");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Address display
+  // -------------------------------------------------------------------------
+  describe("address truncation", () => {
+    it("truncates address by default", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText("0x1234...345678")).toBeInTheDocument();
+    });
+
+    it("shows full address when shouldTruncate is false", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} shouldTruncate={false} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText(MOCK_ADDRESS_LOWER)).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fallback chain
+  // -------------------------------------------------------------------------
+  describe("fallback chain", () => {
+    it("tier 1: prefers ContributorProfile.name over everything", () => {
+      mockContributorProfile = { name: "Contributor Alice" };
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "Privy Name",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "ens.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("Contributor Alice")).toBeInTheDocument();
+    });
+
+    it("tier 2: falls back to Privy name when no contributor profile", () => {
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "Privy Name",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "ens.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("Privy Name")).toBeInTheDocument();
+    });
+
+    it("tier 3: falls back to Privy email when no name", () => {
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        email: "user@example.com",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "ens.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("user@example.com")).toBeInTheDocument();
+    });
+
+    it("tier 4: falls back to ENS name when no privy data", () => {
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "vitalik.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("vitalik.eth")).toBeInTheDocument();
+    });
+
+    it("tier 5: falls back to truncated address when no other data", () => {
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: null };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("0x1234...345678")).toBeInTheDocument();
+    });
+
+    it("does not show privy name when isTried is false (still fetching)", () => {
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "Privy Name",
+        isTried: false,
+        isFetching: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "ens.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      // Should fall through to ENS since privy not yet tried
+      expect(screen.getByText("ens.eth")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Profile picture
+  // -------------------------------------------------------------------------
+  describe("showProfilePicture=false (default)", () => {
+    it("renders no avatar by default", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        picture: "https://example.com/pic.png",
+        isTried: true,
+      };
+
+      const { container } = render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(container.querySelector("img")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("showProfilePicture=true", () => {
+    it("renders privy picture when available and not problematic", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "Alice",
+        picture: "https://example.com/pic.png",
+        isTried: true,
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} showProfilePicture />, {
+        wrapper: createWrapper(),
+      });
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "https://example.com/pic.png");
+    });
+
+    it("falls back to ENS avatar when privy picture is absent", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = {
+        avatar: "https://example.com/ens-avatar.png",
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} showProfilePicture />, {
+        wrapper: createWrapper(),
+      });
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "https://example.com/ens-avatar.png");
+    });
+
+    it("falls back to blockie when privy picture is problematic domain", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "Alice",
+        // euc.li is in the problematic list
+        picture: "https://euc.li/some-avatar.png",
+        isTried: true,
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} showProfilePicture />, {
+        wrapper: createWrapper(),
+      });
+
+      const img = screen.getByRole("img");
+      expect(img.getAttribute("src")).toContain("blockie:");
+    });
+
+    it("falls back to blockie when ENS avatar is problematic domain", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+      mockEnsData[MOCK_ADDRESS_LOWER] = {
+        avatar: "https://euc.li/ens-avatar.png",
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} showProfilePicture />, {
+        wrapper: createWrapper(),
+      });
+
+      const img = screen.getByRole("img");
+      expect(img.getAttribute("src")).toContain("blockie:");
+    });
+
+    it("falls back to blockie when no privy picture and no ENS avatar", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} showProfilePicture />, {
+        wrapper: createWrapper(),
+      });
+
+      const img = screen.getByRole("img");
+      expect(img.getAttribute("src")).toContain("blockie:");
+    });
+
+    it("applies pictureClassName to the avatar image", () => {
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+
+      render(
+        <EthereumAddressToProfileName
+          address={MOCK_ADDRESS}
+          showProfilePicture
+          pictureClassName="border-red-500"
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      expect(screen.getByRole("img")).toHaveClass("border-red-500");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+  describe("edge cases", () => {
+    it("renders empty span for undefined address", () => {
+      const { container } = render(<EthereumAddressToProfileName address={undefined} />, {
+        wrapper: createWrapper(),
+      });
+      expect(container.querySelector("span")).toBeInTheDocument();
+    });
+
+    it("renders raw non-0x input as-is", () => {
+      render(<EthereumAddressToProfileName address="some-non-address-value" />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.getByText("some-non-address-value")).toBeInTheDocument();
+    });
+
+    it("calls populateEns on mount", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+      expect(mockPopulateEns).toHaveBeenCalledWith([MOCK_ADDRESS_LOWER]);
+    });
+
+    it("calls populateProfiles on mount", () => {
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+      expect(mockPopulateProfiles).toHaveBeenCalledWith([MOCK_ADDRESS_LOWER]);
+    });
+
+    it("does not call populateEns when address is already in cache", () => {
+      mockEnsData[MOCK_ADDRESS_LOWER] = { name: "cached.eth" };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockPopulateEns).not.toHaveBeenCalled();
+    });
+
+    it("does not crash when address is empty string", () => {
+      const { container } = render(<EthereumAddressToProfileName address="" />, {
+        wrapper: createWrapper(),
+      });
+      expect(container.querySelector("span")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -26,18 +26,13 @@ vi.mock("next/image", () => ({
 }));
 
 // Mock ENS components
-vi.mock("@/components/EthereumAddressToENSAvatar", () => ({
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
   __esModule: true,
   default: ({ address, className }: any) => (
-    <div data-testid="ens-avatar" className={className}>
+    <span data-testid="ens-name" className={className}>
       {address}
-    </div>
+    </span>
   ),
-}));
-
-vi.mock("@/components/EthereumAddressToENSName", () => ({
-  __esModule: true,
-  default: ({ address }: any) => <span data-testid="ens-name">{address}</span>,
 }));
 
 // Mock ReadMore utility

--- a/__tests__/components/Pages/Dashboard/Dashboard.test.tsx
+++ b/__tests__/components/Pages/Dashboard/Dashboard.test.tsx
@@ -53,7 +53,7 @@ vi.mock("@/components/EthereumAddressToENSAvatar", () => ({
   default: () => <div data-testid="ens-avatar" />,
 }));
 
-vi.mock("@/components/EthereumAddressToENSName", () => ({
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
   __esModule: true,
   default: ({ address }: { address: string }) => <span>{address}</span>,
 }));

--- a/__tests__/store/userProfiles.test.ts
+++ b/__tests__/store/userProfiles.test.ts
@@ -1,0 +1,200 @@
+import { act } from "@testing-library/react";
+import type { PublicUserProfileInfo } from "@/services/community-admins.service";
+import { communityAdminsService } from "@/services/community-admins.service";
+import { useUserProfiles } from "@/store/userProfiles";
+
+vi.mock("@/services/community-admins.service", () => ({
+  communityAdminsService: {
+    getPublicUserProfiles: vi.fn(),
+  },
+}));
+
+const mockGetPublicUserProfiles = communityAdminsService.getPublicUserProfiles as ReturnType<
+  typeof vi.fn
+>;
+
+function makeProfile(
+  address: string,
+  overrides?: Partial<PublicUserProfileInfo>
+): PublicUserProfileInfo {
+  return {
+    publicAddress: address,
+    name: `User ${address.slice(0, 6)}`,
+    ...overrides,
+  };
+}
+
+describe("useUserProfiles store", () => {
+  beforeEach(() => {
+    // resetAllMocks clears both call history AND pending mockResolvedValueOnce queues
+    vi.resetAllMocks();
+    act(() => {
+      useUserProfiles.setState({ profiles: {} });
+    });
+  });
+
+  describe("initial state", () => {
+    it("starts with empty profiles", () => {
+      expect(useUserProfiles.getState().profiles).toEqual({});
+    });
+  });
+
+  describe("populateProfiles", () => {
+    it("fetches profiles for new addresses", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      const profile = makeProfile(addr);
+      mockGetPublicUserProfiles.mockResolvedValueOnce(new Map([[addr, profile]]));
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      const stored = useUserProfiles.getState().profiles[addr];
+      expect(stored).toMatchObject({ publicAddress: addr, name: profile.name, isTried: true });
+    });
+
+    it("lowercases addresses before fetching", async () => {
+      const mixedAddr = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12";
+      const lowerAddr = mixedAddr.toLowerCase();
+      mockGetPublicUserProfiles.mockResolvedValueOnce(new Map());
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([mixedAddr]);
+      });
+
+      expect(mockGetPublicUserProfiles).toHaveBeenCalledWith([lowerAddr]);
+    });
+
+    it("deduplicates addresses", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      mockGetPublicUserProfiles.mockResolvedValueOnce(new Map());
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr, addr, addr.toUpperCase()]);
+      });
+
+      expect(mockGetPublicUserProfiles).toHaveBeenCalledTimes(1);
+      expect(mockGetPublicUserProfiles).toHaveBeenCalledWith([addr]);
+    });
+
+    it("skips addresses already tried", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      act(() => {
+        useUserProfiles.setState({
+          profiles: {
+            [addr]: { publicAddress: addr, name: "", isTried: true },
+          },
+        });
+      });
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      expect(mockGetPublicUserProfiles).not.toHaveBeenCalled();
+    });
+
+    it("skips addresses currently in-flight", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      act(() => {
+        useUserProfiles.setState({
+          profiles: {
+            [addr]: { publicAddress: addr, name: "", isFetching: true },
+          },
+        });
+      });
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      expect(mockGetPublicUserProfiles).not.toHaveBeenCalled();
+    });
+
+    it("marks address as isTried when not found in response", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      mockGetPublicUserProfiles.mockResolvedValueOnce(new Map());
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      const stored = useUserProfiles.getState().profiles[addr];
+      expect(stored.isTried).toBe(true);
+      expect(stored.isFetching).toBe(false);
+    });
+
+    it("filters out invalid (non-0x) addresses", async () => {
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles(["not-an-address", "0xinvalid"]);
+      });
+
+      expect(mockGetPublicUserProfiles).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors and marks addresses as isTried", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      mockGetPublicUserProfiles.mockRejectedValueOnce(new Error("Network error"));
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      const stored = useUserProfiles.getState().profiles[addr];
+      expect(stored.isTried).toBe(true);
+      expect(stored.isFetching).toBe(false);
+    });
+
+    describe("chunking at 20", () => {
+      it("splits 25 addresses into two batches (20 + 5)", async () => {
+        const addresses = Array.from({ length: 25 }, (_, i) => {
+          const hex = i.toString(16).padStart(40, "0");
+          return `0x${hex}`;
+        });
+
+        mockGetPublicUserProfiles.mockResolvedValueOnce(new Map()).mockResolvedValueOnce(new Map());
+
+        await act(async () => {
+          await useUserProfiles.getState().populateProfiles(addresses);
+        });
+
+        expect(mockGetPublicUserProfiles).toHaveBeenCalledTimes(2);
+        expect(mockGetPublicUserProfiles.mock.calls[0][0]).toHaveLength(20);
+        expect(mockGetPublicUserProfiles.mock.calls[1][0]).toHaveLength(5);
+      });
+
+      it("sends exactly 20 addresses in a single batch for 20 addresses", async () => {
+        const addresses = Array.from({ length: 20 }, (_, i) => {
+          const hex = i.toString(16).padStart(40, "0");
+          return `0x${hex}`;
+        });
+
+        mockGetPublicUserProfiles.mockResolvedValueOnce(new Map());
+
+        await act(async () => {
+          await useUserProfiles.getState().populateProfiles(addresses);
+        });
+
+        expect(mockGetPublicUserProfiles).toHaveBeenCalledTimes(1);
+        expect(mockGetPublicUserProfiles.mock.calls[0][0]).toHaveLength(20);
+      });
+    });
+
+    it("stores optional fields (email, picture) when present", async () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      const profile = makeProfile(addr, {
+        email: "user@example.com",
+        picture: "https://example.com/avatar.png",
+      });
+      mockGetPublicUserProfiles.mockResolvedValueOnce(new Map([[addr, profile]]));
+
+      await act(async () => {
+        await useUserProfiles.getState().populateProfiles([addr]);
+      });
+
+      const stored = useUserProfiles.getState().profiles[addr];
+      expect(stored.email).toBe("user@example.com");
+      expect(stored.picture).toBe("https://example.com/avatar.png");
+    });
+  });
+});

--- a/components/Dialogs/MergeProjectDialog.tsx
+++ b/components/Dialogs/MergeProjectDialog.tsx
@@ -26,8 +26,7 @@ import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
 import { PAGES } from "@/utilities/pages";
 import { sanitizeInput } from "@/utilities/sanitize";
-import EthereumAddressToENSAvatar from "../EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "../EthereumAddressToENSName";
+import EthereumAddressToProfileName from "../EthereumAddressToProfileName";
 import { errorManager } from "../Utilities/errorManager";
 import { Spinner } from "../Utilities/Spinner";
 import { Button } from "../ui/button";
@@ -93,11 +92,11 @@ function SearchProject({
             <div className="mt-3 flex items-center">
               <small className="mr-2">By</small>
               <div className="flex flex-row gap-1 items-center font-medium">
-                <EthereumAddressToENSAvatar
+                <EthereumAddressToProfileName
                   address={item.owner}
-                  className="w-4 h-4  rounded-full border-1 border-gray-100 dark:border-zinc-900"
+                  showProfilePicture
+                  pictureClassName="w-4 h-4 rounded-full border-1 border-gray-100 dark:border-zinc-900"
                 />
-                <EthereumAddressToENSName address={item.owner} />
               </div>
             </div>
           </div>

--- a/components/EthereumAddressToProfileName.tsx
+++ b/components/EthereumAddressToProfileName.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { blo } from "blo";
+import Image from "next/image";
+import type React from "react";
+import { useEffect, useMemo } from "react";
+import { useContributorProfile } from "@/hooks/useContributorProfile";
+import { useENS } from "@/store/ens";
+import { useUserProfiles } from "@/store/userProfiles";
+import { isProblematicEnsAvatar } from "@/utilities/isProblematicEnsAvatar";
+import { cn } from "@/utilities/tailwind";
+
+interface Props {
+  address: string | undefined;
+  shouldTruncate?: boolean;
+  showProfilePicture?: boolean;
+  className?: string;
+  pictureClassName?: string;
+}
+
+/**
+ * Displays a human-readable name for an Ethereum address.
+ *
+ * Fallback chain (highest priority first):
+ * 1. ContributorProfile.name (on-chain attestation)
+ * 2. Privy name (from public user profiles endpoint)
+ * 3. Privy email (from same endpoint, only when name absent)
+ * 4. ENS name
+ * 5. Truncated address (0xabcd...1234)
+ *
+ * When showProfilePicture is true, renders a 24×24 avatar to the left.
+ * Avatar fallback: Privy picture → ENS avatar → Blockie
+ */
+const EthereumAddressToProfileName: React.FC<Props> = ({
+  address,
+  shouldTruncate = true,
+  showProfilePicture = false,
+  className,
+  pictureClassName,
+}) => {
+  const ensData = useENS((state) => state.ensData);
+  const populateEns = useENS((state) => state.populateEns);
+  const profiles = useUserProfiles((state) => state.profiles);
+  const populateProfiles = useUserProfiles((state) => state.populateProfiles);
+
+  const lowerCasedAddress = address?.toLowerCase();
+
+  const { profile: contributorProfile } = useContributorProfile(lowerCasedAddress);
+
+  useEffect(() => {
+    if (!lowerCasedAddress) return;
+
+    if (!ensData[lowerCasedAddress as `0x${string}`]) {
+      populateEns([lowerCasedAddress]);
+    }
+
+    const profileEntry = profiles[lowerCasedAddress];
+    if (!profileEntry || (!profileEntry.isTried && !profileEntry.isFetching)) {
+      populateProfiles([lowerCasedAddress]);
+    }
+  }, [lowerCasedAddress, ensData, populateEns, profiles, populateProfiles]);
+
+  // If address is not a valid 0x string, render raw input as-is
+  const isValidAddress = !!lowerCasedAddress?.startsWith("0x");
+
+  const truncatedAddress = lowerCasedAddress
+    ? `${lowerCasedAddress.slice(0, 6)}...${lowerCasedAddress.slice(-6)}`
+    : "";
+
+  const addressToDisplay = shouldTruncate ? truncatedAddress : (lowerCasedAddress ?? "");
+
+  const privyProfile = lowerCasedAddress ? profiles[lowerCasedAddress] : undefined;
+  const ensEntry = lowerCasedAddress ? ensData[lowerCasedAddress as `0x${string}`] : undefined;
+
+  // Compute display name: contributor → privy.name → privy.email → ens.name → truncated address
+  const displayName = useMemo(() => {
+    if (!isValidAddress) return address ?? "";
+
+    if (contributorProfile?.name) return contributorProfile.name;
+
+    if (privyProfile?.isTried && privyProfile.name) return privyProfile.name;
+
+    if (privyProfile?.isTried && privyProfile.email) return privyProfile.email;
+
+    if (ensEntry?.name) return ensEntry.name;
+
+    return addressToDisplay;
+  }, [isValidAddress, address, contributorProfile, privyProfile, ensEntry, addressToDisplay]);
+
+  // Compute avatar when showProfilePicture is true
+  const avatarSrc = useMemo(() => {
+    if (!showProfilePicture || !lowerCasedAddress) return null;
+
+    if (privyProfile?.picture && !isProblematicEnsAvatar(privyProfile.picture)) {
+      return privyProfile.picture;
+    }
+
+    const ensAvatar = ensEntry?.avatar;
+    if (ensAvatar && !isProblematicEnsAvatar(ensAvatar)) {
+      return ensAvatar;
+    }
+
+    // Fall back to blockie only when address starts with 0x
+    if (isValidAddress) {
+      return blo(lowerCasedAddress as `0x${string}`);
+    }
+
+    return null;
+  }, [showProfilePicture, lowerCasedAddress, privyProfile, ensEntry, isValidAddress]);
+
+  const nameSpan = <span className={cn("font-body", className)}>{displayName}</span>;
+
+  if (!showProfilePicture || !avatarSrc) {
+    return nameSpan;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Image
+        src={avatarSrc}
+        alt={`${displayName} avatar`}
+        width={24}
+        height={24}
+        className={cn(
+          "h-6 w-6 min-h-6 min-w-6 rounded-full border border-gray-100 dark:border-zinc-900",
+          pictureClassName
+        )}
+      />
+      {nameSpan}
+    </span>
+  );
+};
+
+export default EthereumAddressToProfileName;

--- a/components/FaucetAdmin/Analytics/UsageAnalytics.tsx
+++ b/components/FaucetAdmin/Analytics/UsageAnalytics.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { formatEther } from "viem";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFaucetHistory, useFaucetStats } from "@/hooks/useFaucet";
 import { useChains, useRequests } from "@/hooks/useFaucetAdmin";
@@ -213,7 +214,7 @@ export function UsageAnalytics() {
                   {requests.payload.map((request) => (
                     <tr key={request.id}>
                       <td className="px-4 py-3 text-sm font-mono text-gray-900 dark:text-white">
-                        {request.walletAddress.slice(0, 6)}...{request.walletAddress.slice(-4)}
+                        <EthereumAddressToProfileName address={request.walletAddress} />
                       </td>
                       <td className="px-4 py-3 text-sm text-gray-900 dark:text-white">
                         {chains?.find((n) => n.chainId === request.chainId)?.name ||

--- a/components/FundingPlatform/ApplicationView/CommentItem.tsx
+++ b/components/FundingPlatform/ApplicationView/CommentItem.tsx
@@ -11,6 +11,7 @@ import {
 import { format, isValid, parseISO } from "date-fns";
 import React, { type FC, useCallback, useMemo, useRef, useState } from "react";
 import { DeleteDialog } from "@/components/DeleteDialog";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
@@ -206,8 +207,9 @@ const CommentItem: FC<CommentItemProps> = ({
           <div className="flex items-start justify-between">
             <div>
               <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                {comment.authorName ||
-                  `${comment.authorAddress?.slice(0, 6)}...${comment.authorAddress?.slice(-4)}`}
+                {comment.authorName || (
+                  <EthereumAddressToProfileName address={comment.authorAddress} />
+                )}
                 <span
                   className={cn(
                     "ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium",

--- a/components/FundingPlatform/ApplicationView/CommentsTimeline.tsx
+++ b/components/FundingPlatform/ApplicationView/CommentsTimeline.tsx
@@ -12,6 +12,7 @@ import {
 import { format, isValid, parseISO } from "date-fns";
 import pluralize from "pluralize";
 import { type FC, useMemo, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Badge } from "@/components/ui/badge";
@@ -334,7 +335,7 @@ const CommentsTimeline: FC<CommentsTimelineProps> = ({
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   {formatDate(version.createdAt)} • Version {version.versionNumber}
                   <span className="ml-2 text-gray-400 dark:text-gray-500">
-                    by {version.submittedBy.slice(0, 6)}...{version.submittedBy.slice(-4)}
+                    by <EthereumAddressToProfileName address={version.submittedBy} />
                   </span>
                 </p>
               )}

--- a/components/FundingPlatform/ApplicationView/DiscussionTab/TimelineContainer.tsx
+++ b/components/FundingPlatform/ApplicationView/DiscussionTab/TimelineContainer.tsx
@@ -13,6 +13,7 @@ import {
 import { format, isValid, parseISO } from "date-fns";
 import pluralize from "pluralize";
 import { type FC, useMemo } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
 import type {
@@ -270,7 +271,7 @@ export const TimelineContainer: FC<TimelineContainerProps> = ({
                 {isInitialVersion ? "Initial application submitted" : "Application edited"}
                 {version.submittedBy && (
                   <span className="ml-1 text-gray-600 dark:text-gray-400">
-                    by {version.submittedBy.slice(0, 6)}...{version.submittedBy.slice(-4)}
+                    by <EthereumAddressToProfileName address={version.submittedBy} />
                   </span>
                 )}
               </p>

--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -2,8 +2,7 @@
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useState } from "react";
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { useMilestoneImpactAnswers } from "@/hooks/useMilestoneImpactAnswers";
 import { useGrantInvoiceRequired } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
@@ -239,12 +238,12 @@ export const MilestoneCard = ({ milestone, isAuthorized }: MilestoneCardProps) =
               Created on {formatDate(createdAt)} by
             </p>
             <div className="flex flex-row gap-1 items-center">
-              <EthereumAddressToENSAvatar
-                address={attester}
-                className="h-5 w-5 min-h-5 min-w-5 rounded-full border-1 border-gray-100 dark:border-zinc-900"
-              />
               <p className="text-sm text-center font-bold text-black dark:text-zinc-200 max-2xl:text-[13px]">
-                <EthereumAddressToENSName address={attester} />
+                <EthereumAddressToProfileName
+                  address={attester}
+                  showProfilePicture
+                  pictureClassName="h-5 w-5 min-h-5 min-w-5 rounded-full border-1 border-gray-100 dark:border-zinc-900"
+                />
               </p>
             </div>
           </div>

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -5,12 +5,12 @@ import { PencilSquareIcon } from "@heroicons/react/24/outline";
 import dynamic from "next/dynamic";
 import { useCallback, useMemo, useState } from "react";
 import { DeleteDialog } from "@/components/DeleteDialog";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 import { formatDate } from "@/utilities/formatDate";
 import { toEditableUnifiedMilestone } from "@/utilities/milestoneTransforms";
-import { shortAddress } from "@/utilities/shortAddress";
 import { getMilestoneStatus, MILESTONE_STATUS_CONFIG } from "./utils/milestone-review-status";
 
 const AIEvaluationModal = dynamic(
@@ -219,7 +219,10 @@ export function MilestoneCard({
                   <MarkdownPreview source={milestone.verificationDetails.description} />
                 </div>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                  Verified by: {shortAddress(milestone.verificationDetails.verifiedBy)}
+                  Verified by:{" "}
+                  <EthereumAddressToProfileName
+                    address={milestone.verificationDetails.verifiedBy}
+                  />
                 </p>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                   Verified: {formatDate(milestone.verificationDetails.verifiedAt)}

--- a/components/Pages/Dashboard/DashboardHeader.tsx
+++ b/components/Pages/Dashboard/DashboardHeader.tsx
@@ -2,7 +2,7 @@
 
 import type { Hex } from "viem";
 import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { useAuth } from "@/hooks/useAuth";
 import { useContributorProfile } from "@/hooks/useContributorProfile";
 
@@ -44,7 +44,7 @@ export function DashboardHeader({ address }: DashboardHeaderProps) {
             <span className="ml-1">, {userEmail}</span>
           ) : address ? (
             <span className="ml-1">
-              , <EthereumAddressToENSName address={address} />
+              , <EthereumAddressToProfileName address={address} />
             </span>
           ) : null}
         </h1>

--- a/components/Pages/ProgramRegistry/EndorsementList.tsx
+++ b/components/Pages/ProgramRegistry/EndorsementList.tsx
@@ -1,14 +1,13 @@
 "use client";
 /* eslint-disable @next/next/no-img-element */
-import { type FC, useEffect, useMemo, useState } from "react";
+import { type FC, useMemo, useState } from "react";
 import type { Hex } from "viem";
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { useProjectStore } from "@/store";
 import { useENS } from "@/store/ens";
 import { formatDate } from "@/utilities/formatDate";
-import { shortAddress } from "@/utilities/shortAddress";
 import { EmptyEndorsmentList } from "../Project/Impact/EmptyEndorsmentList";
 
 // V2 API endorsement structure
@@ -24,28 +23,17 @@ interface EndorsementRowProps {
 }
 
 const EndorsementRow: FC<EndorsementRowProps> = ({ endorsement }) => {
-  const { ensData, populateEns } = useENS();
-  const endorserAddress = endorsement.endorsedBy?.toLowerCase() as Hex;
-
-  useEffect(() => {
-    if (endorsement.endorsedBy) {
-      populateEns([endorsement.endorsedBy]);
-    }
-  }, [endorsement.endorsedBy, populateEns]);
-
-  const displayName = ensData[endorserAddress]?.name || shortAddress(endorsement.endorsedBy);
-
   return (
     <div className="flex flex-col w-full p-4 gap-3">
       <div className="flex flex-row gap-2 w-full items-start">
         <div className="flex flex-row gap-2 w-full items-center">
-          <EthereumAddressToENSAvatar
-            address={endorsement.endorsedBy}
-            className="h-6 w-6 rounded-full"
-          />
           <div className="flex flex-row gap-3 w-full items-start justify-between">
             <p className="text-sm font-bold text-brand-darkblue dark:text-zinc-100">
-              {displayName}
+              <EthereumAddressToProfileName
+                address={endorsement.endorsedBy}
+                showProfilePicture
+                pictureClassName="h-6 w-6 rounded-full"
+              />
               {` `}
               <span className="text-sm font-normal text-brand-gray dark:text-zinc-200">
                 endorsed this on {formatDate(endorsement.createdAt)}

--- a/components/Pages/ProgramRegistry/ManageProgramList.tsx
+++ b/components/Pages/ProgramRegistry/ManageProgramList.tsx
@@ -16,6 +16,7 @@ import { useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { type FC, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Discord2Icon, Telegram2Icon, Twitter2Icon } from "@/components/Icons";
 import { BlogIcon } from "@/components/Icons/Blog";
 import { DiscussionIcon } from "@/components/Icons/Discussion";
@@ -24,7 +25,6 @@ import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { formatDate } from "@/utilities/formatDate";
 import { ReadMore } from "@/utilities/ReadMore";
-import { shortAddress } from "@/utilities/shortAddress";
 import { registryHelper } from "./helper";
 import type { GrantProgram } from "./ProgramList";
 import { ProgramTypeBadges } from "./ProgramTypeBadges";
@@ -492,7 +492,7 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
                     admin.toLowerCase() === address?.toLowerCase() ? "bg-blue-100" : "bg-zinc-50"
                   }`}
                 >
-                  {shortAddress(admin.toLowerCase())}
+                  <EthereumAddressToProfileName address={admin.toLowerCase()} />
                 </span>
               ))}
             </div>

--- a/components/Pages/ProgramRegistry/MyProgramList.tsx
+++ b/components/Pages/ProgramRegistry/MyProgramList.tsx
@@ -16,6 +16,7 @@ import { useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { type FC, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Discord2Icon, Telegram2Icon, Twitter2Icon } from "@/components/Icons";
 import { BlogIcon } from "@/components/Icons/Blog";
 import { DiscussionIcon } from "@/components/Icons/Discussion";
@@ -24,7 +25,6 @@ import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { formatDate } from "@/utilities/formatDate";
 import { ReadMore } from "@/utilities/ReadMore";
-import { shortAddress } from "@/utilities/shortAddress";
 import { registryHelper } from "./helper";
 import type { GrantProgram } from "./ProgramList";
 import { ProgramTypeBadges } from "./ProgramTypeBadges";
@@ -436,7 +436,7 @@ export const MyProgramList: FC<MyProgramListProps> = ({
                     admin.toLowerCase() === address?.toLowerCase() ? "bg-blue-100" : "bg-zinc-50"
                   }`}
                 >
-                  {shortAddress(admin.toLowerCase())}
+                  <EthereumAddressToProfileName address={admin.toLowerCase()} />
                 </span>
               ))}
             </div>

--- a/components/Pages/ProgramRegistry/ProgramDetailsDialog.tsx
+++ b/components/Pages/ProgramRegistry/ProgramDetailsDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, Transition } from "@headlessui/react";
 import { ChevronRightIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import Image from "next/image";
 import { type FC, Fragment, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import {
   BlogIcon,
   Discord2Icon,
@@ -20,7 +21,6 @@ import type {
 } from "@/src/features/funding-map/types/funding-program";
 import formatCurrency from "@/utilities/formatCurrency";
 import { formatDate } from "@/utilities/formatDate";
-import { shortAddress } from "@/utilities/shortAddress";
 import { cn } from "@/utilities/tailwind";
 import { registryHelper } from "./helper";
 import { ProgramTypeBadges } from "./ProgramTypeBadges";
@@ -385,7 +385,7 @@ function AdminDetailsSection({ program }: { program: FundingProgramResponse }) {
           <div className={statStyles.row}>
             <span className={statStyles.label}>Created By</span>
             <span className={cn(statStyles.value, "font-mono text-xs")}>
-              {shortAddress(program.createdByAddress)}
+              <EthereumAddressToProfileName address={program.createdByAddress} />
             </span>
           </div>
         )}
@@ -426,7 +426,7 @@ function AdminDetailsSection({ program }: { program: FundingProgramResponse }) {
                   key={admin}
                   className="font-mono text-xs bg-zinc-100 dark:bg-zinc-600 px-2 py-0.5 rounded"
                 >
-                  {shortAddress(admin)}
+                  <EthereumAddressToProfileName address={admin} />
                 </span>
               ))}
             </div>

--- a/components/Pages/Project/v2/EndorsementsListDialog.tsx
+++ b/components/Pages/Project/v2/EndorsementsListDialog.tsx
@@ -3,7 +3,7 @@
 import { BadgeCheckIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { Hex } from "viem";
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import {
@@ -15,9 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useProjectStore } from "@/store";
-import { useENS } from "@/store/ens";
 import { formatDate } from "@/utilities/formatDate";
-import { shortAddress } from "@/utilities/shortAddress";
 
 const ITEMS_PER_PAGE = 12;
 
@@ -33,27 +31,18 @@ interface EndorsementRowProps {
 }
 
 function EndorsementRow({ endorsement }: EndorsementRowProps) {
-  const { ensData, populateEns } = useENS();
-  const endorserAddress = endorsement.endorsedBy?.toLowerCase() as Hex;
-
-  useEffect(() => {
-    if (endorsement.endorsedBy) {
-      populateEns([endorsement.endorsedBy]);
-    }
-  }, [endorsement.endorsedBy, populateEns]);
-
-  const displayName = ensData[endorserAddress]?.name || shortAddress(endorsement.endorsedBy);
-
   return (
     <div className="flex flex-col w-full p-4 gap-3">
       <div className="flex flex-row gap-2 w-full items-start">
         <div className="flex flex-row gap-2 w-full items-center">
-          <EthereumAddressToENSAvatar
-            address={endorsement.endorsedBy}
-            className="h-8 w-8 rounded-full"
-          />
           <div className="flex flex-col gap-0.5">
-            <p className="text-sm font-semibold text-foreground">{displayName}</p>
+            <p className="text-sm font-semibold text-foreground">
+              <EthereumAddressToProfileName
+                address={endorsement.endorsedBy}
+                showProfilePicture
+                pictureClassName="h-8 w-8 rounded-full"
+              />
+            </p>
             <p className="text-xs text-muted-foreground">
               endorsed on {formatDate(endorsement.createdAt)}
             </p>
@@ -90,8 +79,6 @@ interface EndorsementsListDialogProps {
 export function EndorsementsListDialog({ open, onOpenChange }: EndorsementsListDialogProps) {
   const project = useProjectStore((state) => state.project);
   const [page, setPage] = useState<number>(1);
-
-  const { populateEns } = useENS();
 
   // Reset pagination when dialog opens
   useEffect(() => {
@@ -130,15 +117,6 @@ export function EndorsementsListDialog({ open, onOpenChange }: EndorsementsListD
       totalCount: uniqueEndorsements.length,
     };
   }, [project?.endorsements, page]);
-
-  // Populate ENS data for all addresses
-  useEffect(() => {
-    const endorsements = (project?.endorsements || []) as ProjectEndorsementV2[];
-    const allAddresses = endorsements.map((endorsement) => endorsement.endorsedBy);
-    if (allAddresses.length > 0) {
-      populateEns(allAddresses);
-    }
-  }, [project?.endorsements, populateEns]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
@@ -3,8 +3,7 @@
 import { BadgeCheck, CircleDollarSign, Goal, Rss } from "lucide-react";
 import { useParams } from "next/navigation";
 import React, { useMemo } from "react";
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { ActivityCard } from "@/components/Shared/ActivityCard";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
@@ -132,12 +131,12 @@ const TimelineItem = React.memo(function TimelineItem({
           <>
             <div className="flex flex-row items-center gap-1.5 lg:gap-2 flex-wrap">
               <span className="text-xs lg:text-sm font-semibold text-foreground">Endorsed by</span>
-              <EthereumAddressToENSAvatar
-                address={milestone.endorsement.endorsedBy}
-                className="h-5 w-5 lg:h-6 lg:w-6 min-w-5 min-h-5 lg:min-w-6 lg:min-h-6 rounded-full"
-              />
               <span className="text-xs lg:text-sm font-semibold text-foreground">
-                <EthereumAddressToENSName address={milestone.endorsement.endorsedBy} />
+                <EthereumAddressToProfileName
+                  address={milestone.endorsement.endorsedBy}
+                  showProfilePicture
+                  pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-w-5 min-h-5 lg:min-w-6 lg:min-h-6 rounded-full"
+                />
               </span>
             </div>
             <div className="flex flex-row items-center gap-1.5 lg:gap-2 text-xs lg:text-sm font-medium leading-5 text-muted-foreground">
@@ -195,12 +194,12 @@ const TimelineItem = React.memo(function TimelineItem({
                   {attester && (
                     <>
                       <span>by</span>
-                      <EthereumAddressToENSAvatar
-                        address={attester}
-                        className="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
-                      />
                       <span className="text-xs lg:text-sm font-semibold leading-5 text-foreground">
-                        <EthereumAddressToENSName address={attester} />
+                        <EthereumAddressToProfileName
+                          address={attester}
+                          showProfilePicture
+                          pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
+                        />
                       </span>
                     </>
                   )}

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
@@ -20,14 +20,8 @@ vi.mock("@/components/Shared/ActivityCard", () => ({
   ),
 }));
 
-// Mock EthereumAddressToENSAvatar
-vi.mock("@/components/EthereumAddressToENSAvatar", () => ({
-  __esModule: true,
-  default: ({ address }: { address: string }) => <div data-testid="ens-avatar">{address}</div>,
-}));
-
-// Mock EthereumAddressToENSName
-vi.mock("@/components/EthereumAddressToENSName", () => ({
+// Mock EthereumAddressToProfileName
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
   __esModule: true,
   default: ({ address }: { address: string }) => (
     <span data-testid="ens-name">{address?.slice(0, 8)}...</span>

--- a/components/Pages/Project/v2/__tests__/EndorsementsListDialog.test.tsx
+++ b/components/Pages/Project/v2/__tests__/EndorsementsListDialog.test.tsx
@@ -20,8 +20,8 @@ vi.mock("@/store/ens", () => ({
   }),
 }));
 
-// Mock EthereumAddressToENSAvatar
-vi.mock("@/components/EthereumAddressToENSAvatar", () => ({
+// Mock EthereumAddressToProfileName
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
   __esModule: true,
   default: ({ address }: { address: string }) => (
     <div data-testid="avatar">{address.slice(0, 6)}</div>

--- a/components/ProjectFeed.tsx
+++ b/components/ProjectFeed.tsx
@@ -9,8 +9,7 @@ import fetchData from "@/utilities/fetchData";
 import { formatDate } from "@/utilities/formatDate";
 import { INDEXER } from "@/utilities/indexer";
 import { cn } from "@/utilities/tailwind";
-import EthereumAddressToENSAvatar from "./EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "./EthereumAddressToENSName";
+import EthereumAddressToProfileName from "./EthereumAddressToProfileName";
 import { ExternalLink } from "./Utilities/ExternalLink";
 import { errorManager } from "./Utilities/errorManager";
 import { MarkdownPreview } from "./Utilities/MarkdownPreview";
@@ -112,12 +111,12 @@ export const ProjectFeed = ({ initialFeed = [] }: ProjectFeedProps) => {
                         />
                       </div>
                       <div className="flex flex-row items-center gap-1 flex-wrap">
-                        <EthereumAddressToENSAvatar
-                          address={item.attester}
-                          className="h-5 w-5 rounded-full border-1 border-gray-100 dark:border-zinc-900"
-                        />
                         <p className="text-sm text-center font-bold text-black dark:text-zinc-200 max-2xl:text-[13px]">
-                          <EthereumAddressToENSName address={item.attester} />
+                          <EthereumAddressToProfileName
+                            address={item.attester}
+                            showProfilePicture
+                            pictureClassName="h-5 w-5 rounded-full border-1 border-gray-100 dark:border-zinc-900"
+                          />
                         </p>
                         <span className="ml-1 text-sm font-normal text-slate-700 dark:text-zinc-400 max-2xl:text-xs">
                           posted on {formatDate(item.timestamp)}

--- a/components/Shared/ActivityCard/ActivityAttribution.tsx
+++ b/components/Shared/ActivityCard/ActivityAttribution.tsx
@@ -1,5 +1,4 @@
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { formatDate } from "@/utilities/formatDate";
 
 interface ActivityAttributionProps {
@@ -20,16 +19,14 @@ export const ActivityAttribution = ({
       {/* Attribution line with actions */}
       <div className="flex flex-row gap-x-4 gap-y-2 items-center justify-between w-full flex-wrap">
         <div className="flex flex-row gap-4 items-center flex-wrap">
-          {attester && (
-            <EthereumAddressToENSAvatar
-              address={attester}
-              className="h-8 w-8 min-h-8 min-w-8 max-h-8 max-w-8 rounded-full border-1"
-            />
-          )}
           <div className="flex flex-col items-start gap-0">
             {attester && (
               <p className="text-sm text-center font-semibold text-foreground max-2xl:text-[13px]">
-                <EthereumAddressToENSName address={attester} />
+                <EthereumAddressToProfileName
+                  address={attester}
+                  showProfilePicture
+                  pictureClassName="h-8 w-8 min-h-8 min-w-8 max-h-8 max-w-8 rounded-full border-1"
+                />
               </p>
             )}
             <p className="text-muted-foreground text-sm font-medium">

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -11,8 +11,7 @@ import { useParams } from "next/navigation";
 import { type FC, useCallback, useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
-import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MilestoneVerificationSection } from "@/components/Shared/MilestoneVerification";
 import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
@@ -603,12 +602,12 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
                   <span>Posted {formatDate(completionDate)} by</span>
                   {completionAttester && (
                     <div className="flex flex-row items-center gap-3">
-                      <EthereumAddressToENSAvatar
-                        address={completionAttester}
-                        className="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
-                      />
                       <span className="text-sm font-semibold leading-5 text-foreground">
-                        <EthereumAddressToENSName address={completionAttester} />
+                        <EthereumAddressToProfileName
+                          address={completionAttester}
+                          showProfilePicture
+                          pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
+                        />
                       </span>
                     </div>
                   )}

--- a/services/community-admins.service.ts
+++ b/services/community-admins.service.ts
@@ -16,6 +16,13 @@ export interface UserProfileInfo {
   email: string;
 }
 
+export interface PublicUserProfileInfo {
+  publicAddress: string;
+  name: string;
+  email?: string;
+  picture?: string;
+}
+
 /**
  * Service for community admin operations requiring server-side email resolution
  */
@@ -49,5 +56,33 @@ export const communityAdminsService = {
       map.set(profile.publicAddress.toLowerCase(), profile);
     }
     return map;
+  },
+
+  /**
+   * Batch lookup public user profiles (name, email, picture) for wallet addresses.
+   * This endpoint is public-ish — on 401/403, returns an empty map instead of throwing.
+   * Returns a map of lowercase address -> public profile info.
+   */
+  async getPublicUserProfiles(addresses: string[]): Promise<Map<string, PublicUserProfileInfo>> {
+    if (addresses.length === 0) return new Map();
+
+    try {
+      const response = await apiClient.get<PublicUserProfileInfo[]>(
+        INDEXER.USERS.PUBLIC_PROFILES(addresses)
+      );
+
+      const map = new Map<string, PublicUserProfileInfo>();
+      for (const profile of response.data) {
+        map.set(profile.publicAddress.toLowerCase(), profile);
+      }
+      return map;
+    } catch (error: unknown) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      // Graceful fallback for auth errors — component must never crash
+      if (status === 401 || status === 403) {
+        return new Map();
+      }
+      throw error;
+    }
   },
 };

--- a/src/components/navbar/navbar-mobile-menu.tsx
+++ b/src/components/navbar/navbar-mobile-menu.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useTheme } from "next-themes";
 import { useState } from "react";
 import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { DiscordIcon, TelegramIcon, TwitterIcon } from "@/components/Icons";
 import { ParagraphIcon } from "@/components/Icons/Paragraph";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
@@ -158,7 +158,7 @@ export function NavbarMobileMenu() {
             ) : getUserEmail(user) ? (
               <span className="text-sm text-muted-foreground px-2">{getUserEmail(user)}</span>
             ) : (
-              <EthereumAddressToENSName
+              <EthereumAddressToProfileName
                 address={address}
                 className="text-sm text-muted-foreground px-2"
               />

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
-import EthereumAddressToENSName from "@/components/EthereumAddressToENSName";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { DiscordIcon, TelegramIcon, TwitterIcon } from "@/components/Icons";
 import { ParagraphIcon } from "@/components/Icons/Paragraph";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
@@ -133,7 +133,7 @@ export function NavbarUserMenu() {
                 {getUserEmail(user)}
               </span>
             ) : address ? (
-              <EthereumAddressToENSName
+              <EthereumAddressToProfileName
                 address={address}
                 className="text-sm text-muted-foreground hidden xl:inline px-2"
               />

--- a/src/features/application-comments/components/CommentItem.tsx
+++ b/src/features/application-comments/components/CommentItem.tsx
@@ -2,6 +2,7 @@
 
 import { Clock, Edit2, Save, Trash2, User, X } from "lucide-react";
 import React, { useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -16,7 +17,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { formatDate } from "@/utilities/formatDate";
-import { shortAddress } from "@/utilities/shortAddress";
 import { cn } from "@/utilities/tailwind";
 import { ROLE_BADGE_CONFIG } from "../constants";
 import type { CommentItemProps } from "../types";
@@ -81,7 +81,9 @@ export const CommentItem = React.memo(function CommentItem({
                 <div>
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-sm">
-                      {comment.authorName || shortAddress(comment.authorAddress)}
+                      {comment.authorName || (
+                        <EthereumAddressToProfileName address={comment.authorAddress} />
+                      )}
                     </span>
                     <Badge variant={roleConfig.variant}>{roleConfig.label}</Badge>
                     {comment.isDeleted && <Badge variant="destructive">Deleted</Badge>}
@@ -149,7 +151,12 @@ export const CommentItem = React.memo(function CommentItem({
                 <div className="text-xs text-destructive mt-2">
                   Deleted on {formatDate(comment.deletedAt)} at{" "}
                   {formatDate(comment.deletedAt, "local", "h:mm a")}
-                  {comment.deletedBy && ` by ${shortAddress(comment.deletedBy)}`}
+                  {comment.deletedBy && (
+                    <>
+                      {" "}
+                      by <EthereumAddressToProfileName address={comment.deletedBy} />
+                    </>
+                  )}
                 </div>
               )}
             </div>

--- a/store/userProfiles.ts
+++ b/store/userProfiles.ts
@@ -1,0 +1,99 @@
+import { create } from "zustand";
+import type { PublicUserProfileInfo } from "@/services/community-admins.service";
+import { communityAdminsService } from "@/services/community-admins.service";
+
+export interface UserProfileEntry extends PublicUserProfileInfo {
+  isFetching?: boolean;
+  isTried?: boolean;
+}
+
+interface UserProfilesStore {
+  profiles: Record<string, UserProfileEntry>;
+  populateProfiles: (addresses: string[]) => Promise<void>;
+}
+
+const BATCH_SIZE = 20;
+
+export const useUserProfiles = create<UserProfilesStore>((set, get) => ({
+  profiles: {},
+
+  populateProfiles: async (addresses: string[]) => {
+    const currentProfiles = get().profiles;
+
+    const validAddress = (addr: string): boolean => /^0x[0-9a-fA-F]{40}$/i.test(addr);
+
+    // Lowercase + dedupe + filter valid ETH addresses
+    const uniqueAddresses = [
+      ...new Set(
+        addresses
+          .filter((addr): addr is string => !!addr && validAddress(addr))
+          .map((addr) => addr.toLowerCase())
+      ),
+    ];
+
+    // Skip addresses already fetched or currently in-flight
+    const pending = uniqueAddresses.filter((addr) => {
+      const entry = currentProfiles[addr];
+      return !entry || (!entry.isTried && !entry.isFetching);
+    });
+
+    if (pending.length === 0) return;
+
+    // Mark all pending as in-flight
+    set((state) => {
+      const updates: Record<string, UserProfileEntry> = {};
+      for (const addr of pending) {
+        updates[addr] = {
+          ...state.profiles[addr],
+          publicAddress: addr,
+          name: "",
+          isFetching: true,
+        };
+      }
+      return { profiles: { ...state.profiles, ...updates } };
+    });
+
+    // Process in chunks of BATCH_SIZE
+    for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+      const chunk = pending.slice(i, i + BATCH_SIZE);
+
+      try {
+        const resultMap = await communityAdminsService.getPublicUserProfiles(chunk);
+
+        set((state) => {
+          const updates: Record<string, UserProfileEntry> = {};
+          for (const addr of chunk) {
+            const found = resultMap.get(addr);
+            if (found) {
+              updates[addr] = { ...found, isFetching: false, isTried: true };
+            } else {
+              updates[addr] = {
+                ...state.profiles[addr],
+                publicAddress: addr,
+                name: "",
+                isFetching: false,
+                isTried: true,
+              };
+            }
+          }
+          return { profiles: { ...state.profiles, ...updates } };
+        });
+      } catch {
+        // Swallow errors — mark all chunk addresses as tried so we don't retry indefinitely
+        set((state) => {
+          const updates: Record<string, UserProfileEntry> = {};
+          for (const addr of chunk) {
+            updates[addr] = {
+              ...state.profiles[addr],
+              publicAddress: addr,
+              name: "",
+              isFetching: false,
+              isTried: true,
+            };
+          }
+          return { profiles: { ...state.profiles, ...updates } };
+        });
+      }
+    }
+  },
+}));

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -746,5 +746,7 @@ export const INDEXER = {
   USERS: {
     RESOLVE_EMAIL: `/v2/user/resolve-email`,
     PROFILES: (addresses: string) => `/v2/user/profiles?addresses=${addresses}`,
+    PUBLIC_PROFILES: (addresses: string[]) =>
+      `/v2/user/profiles/public?addresses=${addresses.join(",")}`,
   },
 };

--- a/utilities/isProblematicEnsAvatar.ts
+++ b/utilities/isProblematicEnsAvatar.ts
@@ -1,0 +1,46 @@
+/**
+ * List of problematic ENS avatar domains that should be blocked.
+ * These domains are known to cause issues such as:
+ * - 503 Service Unavailable errors
+ * - Slow response times that degrade UX
+ * - Unreliable uptime affecting avatar loading
+ *
+ * Add domains to this list as they are identified as problematic.
+ * Format: domain strings that will be matched against the URL hostname.
+ */
+const PROBLEMATIC_ENS_AVATAR_DOMAINS = [
+  // euc.li - ENS avatar service that frequently returns 503 errors
+  // and causes cascading failures in avatar loading
+  "euc.li",
+] as const;
+
+/**
+ * Checks if an ENS avatar URL is from a known problematic external service.
+ * These services may cause 503 errors or other reliability issues that
+ * degrade user experience and can cascade into application errors.
+ *
+ * @param url - The avatar URL to validate
+ * @returns true if the URL is from a problematic domain, false otherwise
+ */
+export function isProblematicEnsAvatar(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname.toLowerCase();
+
+    const isProblematic = PROBLEMATIC_ENS_AVATAR_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+    );
+
+    if (isProblematic && process.env.NODE_ENV === "development") {
+      console.warn(
+        `[EthereumAddressToENSAvatar] Blocked problematic ENS avatar URL: ${url}. ` +
+          `Domain "${hostname}" is known to cause 503 errors. Falling back to blockie avatar.`
+      );
+    }
+
+    return isProblematic;
+  } catch {
+    // Invalid URL - treat as problematic to be safe
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Introduces `EthereumAddressToProfileName` — a single component that resolves any Ethereum address to a human-readable display name via this priority chain:

1. ContributorProfile.name (on-chain attestation)
2. Privy name
3. Privy email
4. ENS name
5. Truncated address (`0xabcd…1234`)

Optional `showProfilePicture` prop pairs the name with a 24×24 avatar: Privy picture → ENS avatar → blockie. Problematic ENS avatar domains (`euc.li`) are guarded against — the guard was extracted to a shared utility.

~20 call sites migrated off ENS-only resolution and raw `shortAddress` patterns: activity feeds, milestone cards, comments, endorsements, program-registry tables, navbar, dashboard header, merge-project dialog, faucet analytics. Payout and contract addresses were intentionally skipped — those aren't people.

## Backend dependency

This PR depends on https://github.com/show-karma/gap-indexer/pull/1376 which adds `GET /v2/user/profiles/public`. Deploy backend first or this PR's UI falls through to ENS gracefully (endpoint returns 401 for unauthenticated callers and the service swallows it).

## Why

We had multiple inconsistent ways of displaying addresses across the app (ENS-only, raw truncated, sometimes a project-scoped team profile). This consolidates them, makes display names richer, and batches one network call per page instead of per-row.

## Test plan

- [x] `pnpm test` — 36 new tests pass (12 store tests covering dedup / chunking / error swallow, 24 component tests covering every fallback tier, avatar cases, invalid address)
- [x] `npx tsc --noEmit` — clean
- [x] Lint clean (Biome auto-fix applied to unrelated noise)
- [x] Manual QA against local backend: endpoint fires correctly with auth, CORS preflight 204, validation rejects invalid addresses and >20, no console errors across Dashboard / project / community pages
- [x] Navbar user menu still shows existing priority (ContributorProfile → Farcaster → email → new component)

## Not in this PR
- `ConnectButton.tsx` and `RoleManagement/RoleManagementTab.tsx` still use string-returning helpers (rainbowkit wants a string, not JSX). Easy follow-up with a `useProfileDisplayName(addr)` hook.
- `VerificationsDialog.tsx` and `VerifiedBadge.tsx` weren't migrated; minor follow-up.
- Old `EthereumAddressToENSName` / `EthereumAddressToENSAvatar` files kept in place; safe to delete once remaining call sites move over.