### PR TITLE
fix(reports): pass isActive on report config create + toast modelId errors

### DIFF
--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -103,10 +103,11 @@ export function ReportConfigPage({ community }: Props) {
     );
   }
 
-  // Show validation toasts for both fields if anything fails.
+  // Show validation toasts for any failing field.
   const onInvalid = (formErrors: typeof errors) => {
     if (formErrors.programIds?.message) toast.error(formErrors.programIds.message);
     if (formErrors.prompt?.message) toast.error(formErrors.prompt.message);
+    if (formErrors.modelId?.message) toast.error(formErrors.modelId.message);
   };
 
   const onSubmit = async (values: FormValues) => {
@@ -129,6 +130,7 @@ export function ReportConfigPage({ community }: Props) {
           programIds: parsedProgramIds,
           modelId: values.modelId,
           prompt: values.prompt,
+          isActive: values.isActive,
         });
         toast.success("Config created");
       }

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -41,6 +41,7 @@ export interface CreateReportConfigRequest {
   reportType?: string;
   modelId: string;
   prompt: string;
+  isActive?: boolean;
 }
 
 export interface UpdateReportConfigRequest {


### PR DESCRIPTION
## Summary

Follow-up to #1266 addressing the dogfood QA findings on https://github.com/show-karma/gap-app-v2/pull/1266#issuecomment-4308594120 that landed too late to make the merge.

- **Medium** — \`CreateReportConfigRequest\` type was missing \`isActive\`, so the "Active (auto-generate monthly)" checkbox on the config form was silently dropped the first time a user created a config. Added \`isActive\` to the create-request type and pass it through in the create call.
- **Low** — \`onInvalid\` handler now also fires a toast for \`modelId\` failures (the path is unreachable via the fixed \`<select>\`, but the inconsistency was flagged).

## Test plan

- [ ] Create a brand-new report config with the "Active" checkbox unchecked → resulting config persists with \`isActive: false\`
- [ ] Existing update flow still passes \`isActive\` correctly
- [ ] Form-validation toasts still surface for empty \`programIds\` / empty \`prompt\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation feedback to display model ID field errors to users.
  * Report configuration creation now properly respects and persists the active status, ensuring consistency with update functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->