### PR TITLE
fix: show authorized team member emails in project about

### DIFF
--- a/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
+++ b/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
@@ -159,12 +159,13 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
           </button>
         </div>
         {profile?.data.email ? (
-          <p
-            className="text-sm text-zinc-500 dark:text-zinc-400 break-all"
+          <a
+            href={`mailto:${profile.data.email}`}
+            className="text-sm text-zinc-500 dark:text-zinc-400 break-all hover:underline"
             data-testid="member-email"
           >
             {profile.data.email}
-          </p>
+          </a>
         ) : null}
         {profile?.data.aboutMe && (
           <p className="text-sm text-zinc-600 dark:text-zinc-400 pt-2" data-testid="member-about">

--- a/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
+++ b/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
@@ -44,7 +44,6 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
   );
   const [, copy] = useCopyToClipboard();
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
   const { address } = useAccount();
   const isAuthorized = isProjectOwner || isContractOwner;
@@ -159,6 +158,14 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
             />
           </button>
         </div>
+        {profile?.data.email ? (
+          <p
+            className="text-sm text-zinc-500 dark:text-zinc-400 break-all"
+            data-testid="member-email"
+          >
+            {profile.data.email}
+          </p>
+        ) : null}
         {profile?.data.aboutMe && (
           <p className="text-sm text-zinc-600 dark:text-zinc-400 pt-2" data-testid="member-about">
             {profile.data.aboutMe}

--- a/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
+++ b/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
@@ -72,10 +72,13 @@ vi.mock("@/store/modals/contributorProfile", () => ({
   }),
 }));
 
-// Mock team profiles hook
-let mockTeamProfiles: TeamProfile[] = [
-  {
-    recipient: "0x1234567890123456789012345678901234567890",
+// Mock team profiles hook with factory for per-test overrides
+const createMockTeamProfile = (
+  overrides: Partial<TeamProfile["data"]> & { recipient?: string } = {}
+): TeamProfile => {
+  const { recipient, ...dataOverrides } = overrides;
+  return {
+    recipient: recipient ?? "0x1234567890123456789012345678901234567890",
     data: {
       name: "John Doe",
       email: "john@example.com",
@@ -84,9 +87,12 @@ let mockTeamProfiles: TeamProfile[] = [
       github: "johndoe",
       linkedin: "johndoe",
       farcaster: "johndoe",
+      ...dataOverrides,
     },
-  } as TeamProfile,
-];
+  } as TeamProfile;
+};
+
+let mockTeamProfiles: TeamProfile[] = [createMockTeamProfile()];
 
 vi.mock("@/hooks/useTeamProfiles", () => ({
   useTeamProfiles: () => ({
@@ -171,20 +177,7 @@ describe("TeamMemberCard", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockTeamProfiles = [
-      {
-        recipient: "0x1234567890123456789012345678901234567890",
-        data: {
-          name: "John Doe",
-          email: "john@example.com",
-          aboutMe: "A test user",
-          twitter: "johndoe",
-          github: "johndoe",
-          linkedin: "johndoe",
-          farcaster: "johndoe",
-        },
-      } as TeamProfile,
-    ];
+    mockTeamProfiles = [createMockTeamProfile()];
   });
 
   describe("Rendering", () => {
@@ -236,13 +229,13 @@ describe("TeamMemberCard", () => {
 
     it("should not display member email when unavailable", () => {
       mockTeamProfiles = [
-        {
-          recipient: defaultMember,
-          data: {
-            name: "John Doe",
-            aboutMe: "A test user",
-          },
-        } as TeamProfile,
+        createMockTeamProfile({
+          email: undefined,
+          twitter: undefined,
+          github: undefined,
+          linkedin: undefined,
+          farcaster: undefined,
+        }),
       ];
 
       render(<TeamMemberCard member={defaultMember} />);

--- a/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
+++ b/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { TeamProfile } from "@/types/team-profile";
 import "@testing-library/jest-dom";
 import { TeamMemberCard } from "../TeamContent/TeamMemberCard";
 
@@ -72,21 +73,24 @@ vi.mock("@/store/modals/contributorProfile", () => ({
 }));
 
 // Mock team profiles hook
+let mockTeamProfiles: TeamProfile[] = [
+  {
+    recipient: "0x1234567890123456789012345678901234567890",
+    data: {
+      name: "John Doe",
+      email: "john@example.com",
+      aboutMe: "A test user",
+      twitter: "johndoe",
+      github: "johndoe",
+      linkedin: "johndoe",
+      farcaster: "johndoe",
+    },
+  } as TeamProfile,
+];
+
 vi.mock("@/hooks/useTeamProfiles", () => ({
   useTeamProfiles: () => ({
-    teamProfiles: [
-      {
-        recipient: "0x1234567890123456789012345678901234567890",
-        data: {
-          name: "John Doe",
-          aboutMe: "A test user",
-          twitter: "johndoe",
-          github: "johndoe",
-          linkedin: "johndoe",
-          farcaster: "johndoe",
-        },
-      },
-    ],
+    teamProfiles: mockTeamProfiles,
   }),
 }));
 
@@ -167,6 +171,20 @@ describe("TeamMemberCard", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTeamProfiles = [
+      {
+        recipient: "0x1234567890123456789012345678901234567890",
+        data: {
+          name: "John Doe",
+          email: "john@example.com",
+          aboutMe: "A test user",
+          twitter: "johndoe",
+          github: "johndoe",
+          linkedin: "johndoe",
+          farcaster: "johndoe",
+        },
+      } as TeamProfile,
+    ];
   });
 
   describe("Rendering", () => {
@@ -194,6 +212,12 @@ describe("TeamMemberCard", () => {
       expect(screen.getByTestId("member-address")).toHaveTextContent(defaultMember);
     });
 
+    it("should display member email when available", () => {
+      render(<TeamMemberCard member={defaultMember} />);
+
+      expect(screen.getByTestId("member-email")).toHaveTextContent("john@example.com");
+    });
+
     it("should display about me text when available", () => {
       render(<TeamMemberCard member={defaultMember} />);
 
@@ -208,6 +232,22 @@ describe("TeamMemberCard", () => {
       expect(screen.getByTestId("github-icon")).toBeInTheDocument();
       expect(screen.getByTestId("linkedin-icon")).toBeInTheDocument();
       expect(screen.getByTestId("farcaster-icon")).toBeInTheDocument();
+    });
+
+    it("should not display member email when unavailable", () => {
+      mockTeamProfiles = [
+        {
+          recipient: defaultMember,
+          data: {
+            name: "John Doe",
+            aboutMe: "A test user",
+          },
+        } as TeamProfile,
+      ];
+
+      render(<TeamMemberCard member={defaultMember} />);
+
+      expect(screen.queryByTestId("member-email")).not.toBeInTheDocument();
     });
   });
 

--- a/hooks/__tests__/useTeamProfiles.test.tsx
+++ b/hooks/__tests__/useTeamProfiles.test.tsx
@@ -1,0 +1,193 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useTeamProfiles } from "@/hooks/useTeamProfiles";
+import { communityAdminsService } from "@/services/community-admins.service";
+import { getContributorProfiles } from "@/utilities/indexer/getContributorProfiles";
+
+const mockSetTeamProfiles = vi.fn();
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer/getContributorProfiles", () => ({
+  getContributorProfiles: vi.fn(),
+}));
+
+vi.mock("@/services/community-admins.service", () => ({
+  communityAdminsService: {
+    getUserProfiles: vi.fn(),
+  },
+}));
+
+vi.mock("@/store", () => ({
+  useProjectStore: vi.fn((selector?: (state: unknown) => unknown) => {
+    const state = {
+      setTeamProfiles: mockSetTeamProfiles,
+    };
+
+    if (typeof selector === "function") {
+      return selector(state);
+    }
+
+    return state;
+  }),
+}));
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockGetContributorProfiles = vi.mocked(getContributorProfiles);
+const mockGetUserProfiles = vi.mocked(communityAdminsService.getUserProfiles);
+
+describe("useTeamProfiles", () => {
+  let queryClient: QueryClient;
+
+  const project = {
+    owner: "0x1111111111111111111111111111111111111111",
+    members: [
+      { address: "0x2222222222222222222222222222222222222222" },
+      { address: "0x1111111111111111111111111111111111111111" },
+    ],
+  } as any;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("merges backend-authorized email onto team profiles when authenticated", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: true } as any);
+    mockGetContributorProfiles.mockResolvedValue([
+      {
+        recipient: "0x1111111111111111111111111111111111111111",
+        data: { name: "Owner Name" },
+      },
+      {
+        recipient: "0x2222222222222222222222222222222222222222",
+        data: { aboutMe: "Contributor" },
+      },
+    ] as any);
+    mockGetUserProfiles.mockResolvedValue(
+      new Map([
+        [
+          "0x1111111111111111111111111111111111111111",
+          {
+            publicAddress: "0x1111111111111111111111111111111111111111",
+            name: "Owner Name",
+            email: "owner@example.com",
+          },
+        ],
+      ])
+    );
+
+    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockGetContributorProfiles).toHaveBeenCalledWith([
+      "0x1111111111111111111111111111111111111111",
+      "0x2222222222222222222222222222222222222222",
+    ]);
+    expect(mockGetUserProfiles).toHaveBeenCalledWith([
+      "0x1111111111111111111111111111111111111111",
+      "0x2222222222222222222222222222222222222222",
+    ]);
+    expect(result.current.teamProfiles?.[0].data.email).toBe("owner@example.com");
+    expect(result.current.teamProfiles?.[1].data.email).toBeUndefined();
+    expect(mockSetTeamProfiles).toHaveBeenCalledWith(result.current.teamProfiles);
+  });
+
+  it("creates a minimal team profile when email is only available from the authorized backend", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: true } as any);
+    mockGetContributorProfiles.mockResolvedValue([] as any);
+    mockGetUserProfiles.mockResolvedValue(
+      new Map([
+        [
+          "0x1111111111111111111111111111111111111111",
+          {
+            publicAddress: "0x1111111111111111111111111111111111111111",
+            name: "Owner Name",
+            email: "owner@example.com",
+          },
+        ],
+      ])
+    );
+
+    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.teamProfiles).toEqual([
+      {
+        recipient: "0x1111111111111111111111111111111111111111",
+        data: {
+          name: "Owner Name",
+          email: "owner@example.com",
+        },
+      },
+    ]);
+  });
+
+  it("falls back to public profiles when the authorized backend lookup is unavailable", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: true } as any);
+    mockGetContributorProfiles.mockResolvedValue([
+      {
+        recipient: "0x2222222222222222222222222222222222222222",
+        data: { name: "Member Name" },
+      },
+    ] as any);
+    mockGetUserProfiles.mockRejectedValue(new Error("Forbidden"));
+
+    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.teamProfiles).toEqual([
+      {
+        recipient: "0x2222222222222222222222222222222222222222",
+        data: { name: "Member Name" },
+      },
+    ]);
+  });
+
+  it("does not request backend-authorized profiles for unauthenticated users", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: false } as any);
+    mockGetContributorProfiles.mockResolvedValue([
+      {
+        recipient: "0x2222222222222222222222222222222222222222",
+        data: { name: "Member Name" },
+      },
+    ] as any);
+
+    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockGetUserProfiles).not.toHaveBeenCalled();
+    expect(result.current.teamProfiles?.[0].data.email).toBeUndefined();
+  });
+});

--- a/hooks/__tests__/useTeamProfiles.test.tsx
+++ b/hooks/__tests__/useTeamProfiles.test.tsx
@@ -22,6 +22,10 @@ vi.mock("@/services/community-admins.service", () => ({
   },
 }));
 
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
 vi.mock("@/store", () => ({
   useProjectStore: vi.fn((selector?: (state: unknown) => unknown) => {
     const state = {
@@ -71,123 +75,137 @@ describe("useTeamProfiles", () => {
     queryClient.clear();
   });
 
-  it("merges backend-authorized email onto team profiles when authenticated", async () => {
-    mockUseAuth.mockReturnValue({ authenticated: true } as any);
-    mockGetContributorProfiles.mockResolvedValue([
-      {
-        recipient: "0x1111111111111111111111111111111111111111",
-        data: { name: "Owner Name" },
-      },
-      {
-        recipient: "0x2222222222222222222222222222222222222222",
-        data: { aboutMe: "Contributor" },
-      },
-    ] as any);
-    mockGetUserProfiles.mockResolvedValue(
-      new Map([
-        [
-          "0x1111111111111111111111111111111111111111",
-          {
-            publicAddress: "0x1111111111111111111111111111111111111111",
-            name: "Owner Name",
-            email: "owner@example.com",
-          },
-        ],
-      ])
-    );
-
-    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
+  describe("authenticated", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({ authenticated: true } as any);
     });
 
-    expect(mockGetContributorProfiles).toHaveBeenCalledWith([
-      "0x1111111111111111111111111111111111111111",
-      "0x2222222222222222222222222222222222222222",
-    ]);
-    expect(mockGetUserProfiles).toHaveBeenCalledWith([
-      "0x1111111111111111111111111111111111111111",
-      "0x2222222222222222222222222222222222222222",
-    ]);
-    expect(result.current.teamProfiles?.[0].data.email).toBe("owner@example.com");
-    expect(result.current.teamProfiles?.[1].data.email).toBeUndefined();
-    expect(mockSetTeamProfiles).toHaveBeenCalledWith(result.current.teamProfiles);
-  });
-
-  it("creates a minimal team profile when email is only available from the authorized backend", async () => {
-    mockUseAuth.mockReturnValue({ authenticated: true } as any);
-    mockGetContributorProfiles.mockResolvedValue([] as any);
-    mockGetUserProfiles.mockResolvedValue(
-      new Map([
-        [
-          "0x1111111111111111111111111111111111111111",
-          {
-            publicAddress: "0x1111111111111111111111111111111111111111",
-            name: "Owner Name",
-            email: "owner@example.com",
-          },
-        ],
-      ])
-    );
-
-    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.teamProfiles).toEqual([
-      {
-        recipient: "0x1111111111111111111111111111111111111111",
-        data: {
-          name: "Owner Name",
-          email: "owner@example.com",
+    it("merges backend-authorized email onto team profiles", async () => {
+      mockGetContributorProfiles.mockResolvedValue([
+        {
+          recipient: "0x1111111111111111111111111111111111111111",
+          data: { name: "Owner Name" },
         },
-      },
-    ]);
-  });
+        {
+          recipient: "0x2222222222222222222222222222222222222222",
+          data: { aboutMe: "Contributor" },
+        },
+      ] as any);
+      mockGetUserProfiles.mockResolvedValue(
+        new Map([
+          [
+            "0x1111111111111111111111111111111111111111",
+            {
+              publicAddress: "0x1111111111111111111111111111111111111111",
+              name: "Owner Name",
+              email: "owner@example.com",
+            },
+          ],
+        ])
+      );
 
-  it("falls back to public profiles when the authorized backend lookup is unavailable", async () => {
-    mockUseAuth.mockReturnValue({ authenticated: true } as any);
-    mockGetContributorProfiles.mockResolvedValue([
-      {
-        recipient: "0x2222222222222222222222222222222222222222",
-        data: { name: "Member Name" },
-      },
-    ] as any);
-    mockGetUserProfiles.mockRejectedValue(new Error("Forbidden"));
+      const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
 
-    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
+      expect(mockGetContributorProfiles).toHaveBeenCalledWith([
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+      ]);
+      expect(mockGetUserProfiles).toHaveBeenCalledWith([
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+      ]);
+      expect(result.current.teamProfiles?.[0].data.email).toBe("owner@example.com");
+      expect(result.current.teamProfiles?.[1].data.email).toBeUndefined();
+      expect(mockSetTeamProfiles).toHaveBeenCalledWith(result.current.teamProfiles);
     });
 
-    expect(result.current.teamProfiles).toEqual([
-      {
-        recipient: "0x2222222222222222222222222222222222222222",
-        data: { name: "Member Name" },
-      },
-    ]);
+    it("creates a minimal team profile when email is only available from the authorized backend", async () => {
+      mockGetContributorProfiles.mockResolvedValue([] as any);
+      mockGetUserProfiles.mockResolvedValue(
+        new Map([
+          [
+            "0x1111111111111111111111111111111111111111",
+            {
+              publicAddress: "0x1111111111111111111111111111111111111111",
+              name: "Owner Name",
+              email: "owner@example.com",
+            },
+          ],
+        ])
+      );
+
+      const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.teamProfiles).toEqual([
+        {
+          recipient: "0x1111111111111111111111111111111111111111",
+          data: {
+            name: "Owner Name",
+            email: "owner@example.com",
+          },
+        },
+      ]);
+    });
   });
 
-  it("does not request backend-authorized profiles for unauthenticated users", async () => {
-    mockUseAuth.mockReturnValue({ authenticated: false } as any);
-    mockGetContributorProfiles.mockResolvedValue([
-      {
-        recipient: "0x2222222222222222222222222222222222222222",
-        data: { name: "Member Name" },
-      },
-    ] as any);
-
-    const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
+  describe("unauthenticated", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({ authenticated: false } as any);
     });
 
-    expect(mockGetUserProfiles).not.toHaveBeenCalled();
-    expect(result.current.teamProfiles?.[0].data.email).toBeUndefined();
+    it("does not request backend-authorized profiles", async () => {
+      mockGetContributorProfiles.mockResolvedValue([
+        {
+          recipient: "0x2222222222222222222222222222222222222222",
+          data: { name: "Member Name" },
+        },
+      ] as any);
+
+      const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockGetUserProfiles).not.toHaveBeenCalled();
+      expect(result.current.teamProfiles?.[0].data.email).toBeUndefined();
+    });
+  });
+
+  describe("error", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({ authenticated: true } as any);
+    });
+
+    it("falls back to public profiles when the authorized backend lookup is unavailable", async () => {
+      mockGetContributorProfiles.mockResolvedValue([
+        {
+          recipient: "0x2222222222222222222222222222222222222222",
+          data: { name: "Member Name" },
+        },
+      ] as any);
+      mockGetUserProfiles.mockRejectedValue(new Error("Forbidden"));
+
+      const { result } = renderHook(() => useTeamProfiles(project), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.teamProfiles).toEqual([
+        {
+          recipient: "0x2222222222222222222222222222222222222222",
+          data: { name: "Member Name" },
+        },
+      ]);
+    });
   });
 });

--- a/hooks/useTeamProfiles.ts
+++ b/hooks/useTeamProfiles.ts
@@ -1,24 +1,71 @@
-import type { ContributorProfile } from "@show-karma/karma-gap-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { communityAdminsService } from "@/services/community-admins.service";
 import { useProjectStore } from "@/store";
+import type { TeamProfile } from "@/types/team-profile";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import { getContributorProfiles } from "@/utilities/indexer/getContributorProfiles";
 
 export const useTeamProfiles = (project: ProjectResponse | undefined) => {
   const setTeamProfiles = useProjectStore((state) => state.setTeamProfiles);
+  const { authenticated } = useAuth();
 
-  const rawAddresses = project?.members?.map((member) => member.address).filter(Boolean) || [];
+  const rawAddresses = [
+    project?.owner,
+    ...(project?.members?.map((member) => member.address).filter(Boolean) || []),
+  ].filter(Boolean) as string[];
   const uniqueLowercasedAddresses = Array.from(
     new Set(rawAddresses.map((address) => address.toLowerCase()))
   );
 
-  const query = useQuery<ContributorProfile[] | undefined>({
-    queryKey: ["contributor-profiles", uniqueLowercasedAddresses],
+  const query = useQuery<TeamProfile[] | undefined>({
+    queryKey: ["contributor-profiles", uniqueLowercasedAddresses, authenticated],
     queryFn: async () => {
       if (!project || uniqueLowercasedAddresses.length === 0) return [];
-      const profiles = (await getContributorProfiles(uniqueLowercasedAddresses)) || [];
-      return profiles;
+      const profiles = ((await getContributorProfiles(uniqueLowercasedAddresses)) ||
+        []) as TeamProfile[];
+
+      if (!authenticated) return profiles;
+
+      try {
+        const authorizedProfiles =
+          await communityAdminsService.getUserProfiles(uniqueLowercasedAddresses);
+        const publicProfilesByAddress = new Map(
+          profiles.map((profile) => [profile.recipient.toLowerCase(), profile] as const)
+        );
+
+        return uniqueLowercasedAddresses
+          .map((address) => {
+            const publicProfile = publicProfilesByAddress.get(address);
+            const authorizedProfile = authorizedProfiles.get(address);
+
+            if (publicProfile) {
+              if (!authorizedProfile?.email) return publicProfile;
+
+              return {
+                ...publicProfile,
+                data: {
+                  ...publicProfile.data,
+                  email: authorizedProfile.email,
+                },
+              };
+            }
+
+            if (!authorizedProfile) return undefined;
+
+            return {
+              recipient: authorizedProfile.publicAddress,
+              data: {
+                name: authorizedProfile.name,
+                email: authorizedProfile.email,
+              },
+            } as TeamProfile;
+          })
+          .filter((profile): profile is TeamProfile => Boolean(profile));
+      } catch {
+        return profiles;
+      }
     },
     enabled: uniqueLowercasedAddresses.length > 0,
     staleTime: 10 * 60 * 1000, // 10 minutes

--- a/hooks/useTeamProfiles.ts
+++ b/hooks/useTeamProfiles.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
 import { useAuth } from "@/hooks/useAuth";
 import { communityAdminsService } from "@/services/community-admins.service";
 import { useProjectStore } from "@/store";
@@ -11,13 +12,13 @@ export const useTeamProfiles = (project: ProjectResponse | undefined) => {
   const setTeamProfiles = useProjectStore((state) => state.setTeamProfiles);
   const { authenticated } = useAuth();
 
-  const rawAddresses = [
-    project?.owner,
-    ...(project?.members?.map((member) => member.address).filter(Boolean) || []),
-  ].filter(Boolean) as string[];
-  const uniqueLowercasedAddresses = Array.from(
-    new Set(rawAddresses.map((address) => address.toLowerCase()))
-  );
+  const uniqueLowercasedAddresses = useMemo(() => {
+    const rawAddresses = [
+      project?.owner,
+      ...(project?.members?.map((member) => member.address).filter(Boolean) || []),
+    ].filter(Boolean) as string[];
+    return Array.from(new Set(rawAddresses.map((address) => address.toLowerCase())));
+  }, [project?.owner, project?.members]);
 
   const query = useQuery<TeamProfile[] | undefined>({
     queryKey: ["contributor-profiles", uniqueLowercasedAddresses, authenticated],
@@ -55,7 +56,7 @@ export const useTeamProfiles = (project: ProjectResponse | undefined) => {
             if (!authorizedProfile) return undefined;
 
             return {
-              recipient: authorizedProfile.publicAddress,
+              recipient: address,
               data: {
                 name: authorizedProfile.name,
                 email: authorizedProfile.email,
@@ -63,7 +64,12 @@ export const useTeamProfiles = (project: ProjectResponse | undefined) => {
             } as TeamProfile;
           })
           .filter((profile): profile is TeamProfile => Boolean(profile));
-      } catch {
+      } catch (error) {
+        errorManager(
+          "Failed to fetch authorized user profiles; falling back to public profiles",
+          error,
+          { addresses: uniqueLowercasedAddresses }
+        );
         return profiles;
       }
     },

--- a/store/project.ts
+++ b/store/project.ts
@@ -1,7 +1,7 @@
-import type { ContributorProfile } from "@show-karma/karma-gap-sdk";
 import { create } from "zustand";
 import { getProject } from "@/services/project.service";
 import { getProjectGrants } from "@/services/project-grants.service";
+import type { TeamProfile } from "@/types/team-profile";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import { queryClient } from "@/utilities/query-client";
 import { useGrantStore } from "./grant";
@@ -16,8 +16,8 @@ interface ProjectStore {
   setIsProjectAdmin: (isProjectAdmin: boolean) => void;
   isProjectOwner: boolean;
   setIsProjectOwner: (isProjectOwner: boolean) => void;
-  teamProfiles: ContributorProfile[] | undefined;
-  setTeamProfiles: (profiles: ContributorProfile[] | undefined) => void;
+  teamProfiles: TeamProfile[] | undefined;
+  setTeamProfiles: (profiles: TeamProfile[] | undefined) => void;
 }
 
 export const useProjectStore = create<ProjectStore>((set, get) => ({

--- a/types/team-profile.ts
+++ b/types/team-profile.ts
@@ -1,0 +1,7 @@
+import type { ContributorProfile } from "@show-karma/karma-gap-sdk";
+
+export type TeamProfile = ContributorProfile & {
+  data: ContributorProfile["data"] & {
+    email?: string;
+  };
+};


### PR DESCRIPTION
## Summary
- merge backend-authorized user profile emails into team profiles on project pages
- render team member email in the About/Team section only when returned by the authorized backend lookup
- add tests for authorized merge, unauthenticated fallback, and conditional email rendering

## Test plan
- pnpm exec vitest run --project unit hooks/__tests__/useTeamProfiles.test.tsx components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
- pnpm exec biome check hooks/useTeamProfiles.ts components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx hooks/__tests__/useTeamProfiles.test.tsx store/project.ts types/team-profile.ts
- pnpm test *(fails in this environment with a Vitest worker EPIPE after startup; targeted tests above pass)*

Closes DEV-141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team member profile cards now display email addresses alongside existing profile details for authenticated users, with data sourced from backend services.

* **Tests**
  * Expanded test coverage for team profile data retrieval, email field display for authenticated users, and fallback behavior in unauthenticated scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->