### PR TITLE
feat: show past due milestone counts in report

### DIFF
--- a/__tests__/components/Pages/Admin/StatsTable.test.tsx
+++ b/__tests__/components/Pages/Admin/StatsTable.test.tsx
@@ -9,59 +9,181 @@ vi.mock("@/components/Utilities/TablePagination", () => ({
   ),
 }));
 
+const TABLE_COLUMN_COUNT = 8;
+
+function makeReport(overrides: Partial<Report> = {}) {
+  return {
+    _id: { $oid: "report-1" },
+    grantUid: "grant-1",
+    grantTitle: "Grant Alpha",
+    projectUid: "project-1",
+    projectTitle: "Project Alpha",
+    projectSlug: "project-alpha",
+    programId: "program-1",
+    totalMilestones: 6,
+    pendingMilestones: 2,
+    pastDueMilestones: 1,
+    completedMilestones: 4,
+    isGrantCompleted: false,
+    proofOfWorkLinks: [],
+    evaluations: [],
+    ...overrides,
+  } satisfies Report;
+}
+
+const baseProps = {
+  communityId: "community-1",
+  sortBy: "totalMilestones",
+  sortOrder: "desc",
+  page: 1,
+  totalItems: 1,
+  itemsPerPage: 50,
+  isFullyCompleted: () => false,
+};
+
 describe("StatsTable", () => {
-  function makeReport(overrides: Partial<Report & { pastDueMilestones: number }> = {}) {
-    return {
-      _id: { $oid: "report-1" },
-      grantUid: "grant-1",
-      grantTitle: "Grant Alpha",
-      projectUid: "project-1",
-      projectTitle: "Project Alpha",
-      projectSlug: "project-alpha",
-      programId: "program-1",
-      totalMilestones: 6,
-      pendingMilestones: 2,
-      pastDueMilestones: 1,
-      completedMilestones: 4,
-      isGrantCompleted: false,
-      proofOfWorkLinks: [],
-      evaluations: [],
-      ...overrides,
-    } satisfies Report & { pastDueMilestones: number };
-  }
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-  it("renders a Past Due column next to Pending and styles positive counts in red", () => {
-    render(
-      <StatsTable
-        reports={[makeReport()]}
-        isLoading={false}
-        error={null}
-        communityId="community-1"
-        sortBy="totalMilestones"
-        sortOrder="desc"
-        onSort={vi.fn()}
-        page={1}
-        onPageChange={vi.fn()}
-        totalItems={1}
-        itemsPerPage={50}
-        isFullyCompleted={() => false}
-      />
-    );
+  describe("loading state", () => {
+    it("renders skeleton rows whose cell count matches the table column count", () => {
+      const { container } = render(
+        <StatsTable
+          {...baseProps}
+          reports={undefined}
+          isLoading={true}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+          totalItems={0}
+        />
+      );
 
-    const headers = screen.getAllByRole("columnheader");
-    const pendingHeaderIndex = headers.findIndex((header) =>
-      header.textContent?.includes("Pending")
-    );
-    const pastDueHeaderIndex = headers.findIndex((header) =>
-      header.textContent?.includes("Past Due")
-    );
+      const skeletonRows = container.querySelectorAll("tbody tr");
+      expect(skeletonRows.length).toBeGreaterThan(0);
+      skeletonRows.forEach((row) => {
+        expect(row.querySelectorAll("td").length).toBe(TABLE_COLUMN_COUNT);
+      });
+    });
+  });
 
-    expect(pastDueHeaderIndex).toBeGreaterThan(pendingHeaderIndex);
-    expect(pastDueHeaderIndex).toBe(pendingHeaderIndex + 1);
+  describe("error state", () => {
+    it("renders the error message spanning all columns", () => {
+      const { container } = render(
+        <StatsTable
+          {...baseProps}
+          reports={undefined}
+          isLoading={false}
+          error={new Error("boom")}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+          totalItems={0}
+        />
+      );
 
-    const row = screen.getByRole("row", { name: /Grant Alpha/i });
-    const pastDueCell = within(row).getByRole("link", { name: "1" });
+      expect(screen.getByText("Failed to load milestone stats")).toBeInTheDocument();
+      expect(screen.getByText("boom")).toBeInTheDocument();
+      const errorCell = container.querySelector("tbody td");
+      expect(errorCell).toHaveAttribute("colspan", String(TABLE_COLUMN_COUNT));
+    });
+  });
 
-    expect(pastDueCell).toHaveClass("text-red-600");
+  describe("empty state", () => {
+    it("renders the empty-state copy when reports is an empty array", () => {
+      const { container } = render(
+        <StatsTable
+          {...baseProps}
+          reports={[]}
+          isLoading={false}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+          totalItems={0}
+        />
+      );
+
+      expect(screen.getByText("No milestone data found")).toBeInTheDocument();
+      const emptyCell = container.querySelector("tbody td");
+      expect(emptyCell).toHaveAttribute("colspan", String(TABLE_COLUMN_COUNT));
+    });
+  });
+
+  describe("success state", () => {
+    it("renders a Past Due column next to Pending and styles positive counts in red", () => {
+      render(
+        <StatsTable
+          {...baseProps}
+          reports={[makeReport()]}
+          isLoading={false}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+        />
+      );
+
+      const headers = screen.getAllByRole("columnheader");
+      const pendingHeaderIndex = headers.findIndex((header) =>
+        header.textContent?.includes("Pending")
+      );
+      const pastDueHeaderIndex = headers.findIndex((header) =>
+        header.textContent?.includes("Past Due")
+      );
+
+      expect(pastDueHeaderIndex).toBeGreaterThan(pendingHeaderIndex);
+      expect(pastDueHeaderIndex).toBe(pendingHeaderIndex + 1);
+
+      const row = screen.getByRole("row", { name: /Grant Alpha/i });
+      const pastDueCell = within(row).getByRole("link", {
+        name: "1 past due milestones for Grant Alpha",
+      });
+
+      expect(pastDueCell).toHaveClass("text-red-600");
+    });
+
+    it("renders zero past-due counts in gray", () => {
+      render(
+        <StatsTable
+          {...baseProps}
+          reports={[makeReport({ pastDueMilestones: 0 })]}
+          isLoading={false}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByRole("row", { name: /Grant Alpha/i });
+      const pastDueCell = within(row).getByRole("link", {
+        name: "0 past due milestones for Grant Alpha",
+      });
+
+      expect(pastDueCell).toHaveClass("text-gray-500");
+      expect(pastDueCell).not.toHaveClass("text-red-600");
+    });
+
+    it("falls back to 0 when pastDueMilestones is missing from the API response", () => {
+      const report = makeReport();
+      // Simulate a stale backend that omits the field entirely.
+      delete (report as Partial<Report>).pastDueMilestones;
+
+      render(
+        <StatsTable
+          {...baseProps}
+          reports={[report]}
+          isLoading={false}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByRole("row", { name: /Grant Alpha/i });
+      const pastDueCell = within(row).getByRole("link", {
+        name: "0 past due milestones for Grant Alpha",
+      });
+
+      expect(pastDueCell).toHaveClass("text-gray-500");
+    });
   });
 });

--- a/__tests__/components/Pages/Admin/StatsTable.test.tsx
+++ b/__tests__/components/Pages/Admin/StatsTable.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, within } from "@testing-library/react";
+import { StatsTable } from "@/components/Pages/Admin/StatsTable";
+import type { Report } from "@/hooks/useReportPageData";
+
+vi.mock("@/components/Utilities/TablePagination", () => ({
+  __esModule: true,
+  default: (props: { totalPosts: number }) => (
+    <div data-testid="table-pagination" data-total={props.totalPosts} />
+  ),
+}));
+
+describe("StatsTable", () => {
+  function makeReport(overrides: Partial<Report & { pastDueMilestones: number }> = {}) {
+    return {
+      _id: { $oid: "report-1" },
+      grantUid: "grant-1",
+      grantTitle: "Grant Alpha",
+      projectUid: "project-1",
+      projectTitle: "Project Alpha",
+      projectSlug: "project-alpha",
+      programId: "program-1",
+      totalMilestones: 6,
+      pendingMilestones: 2,
+      pastDueMilestones: 1,
+      completedMilestones: 4,
+      isGrantCompleted: false,
+      proofOfWorkLinks: [],
+      evaluations: [],
+      ...overrides,
+    } satisfies Report & { pastDueMilestones: number };
+  }
+
+  it("renders a Past Due column next to Pending and styles positive counts in red", () => {
+    render(
+      <StatsTable
+        reports={[makeReport()]}
+        isLoading={false}
+        error={null}
+        communityId="community-1"
+        sortBy="totalMilestones"
+        sortOrder="desc"
+        onSort={vi.fn()}
+        page={1}
+        onPageChange={vi.fn()}
+        totalItems={1}
+        itemsPerPage={50}
+        isFullyCompleted={() => false}
+      />
+    );
+
+    const headers = screen.getAllByRole("columnheader");
+    const pendingHeaderIndex = headers.findIndex((header) =>
+      header.textContent?.includes("Pending")
+    );
+    const pastDueHeaderIndex = headers.findIndex((header) =>
+      header.textContent?.includes("Past Due")
+    );
+
+    expect(pastDueHeaderIndex).toBeGreaterThan(pendingHeaderIndex);
+    expect(pastDueHeaderIndex).toBe(pendingHeaderIndex + 1);
+
+    const row = screen.getByRole("row", { name: /Grant Alpha/i });
+    const pastDueCell = within(row).getByRole("link", { name: "1" });
+
+    expect(pastDueCell).toHaveClass("text-red-600");
+  });
+});

--- a/components/Pages/Admin/StatsTable.tsx
+++ b/components/Pages/Admin/StatsTable.tsx
@@ -140,6 +140,13 @@ export function StatsTable({
                 onSort={onSort}
               />
               <SortableHeader
+                label="Past Due"
+                field="pastDueMilestones"
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                onSort={onSort}
+              />
+              <SortableHeader
                 label="Completed"
                 field="completedMilestones"
                 sortBy={sortBy}
@@ -174,6 +181,9 @@ export function StatsTable({
                     <Skeleton className="h-4 w-10 rounded" />
                   </td>
                   <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-10 rounded" />
+                  </td>
+                  <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
                       <Skeleton className="h-4 w-8 rounded" />
                       <Skeleton className="h-1.5 w-16 rounded-full" />
@@ -186,7 +196,7 @@ export function StatsTable({
               ))
             ) : error ? (
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center">
+                <td colSpan={8} className="px-4 py-12 text-center">
                   <ExclamationTriangleIcon className="mx-auto h-10 w-10 text-red-400 dark:text-red-500 mb-3" />
                   <p className="text-sm font-medium text-gray-900 dark:text-white">
                     Failed to load milestone stats
@@ -198,7 +208,7 @@ export function StatsTable({
               </tr>
             ) : reports?.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center">
+                <td colSpan={8} className="px-4 py-12 text-center">
                   <p className="text-sm font-medium text-gray-900 dark:text-white">
                     No milestone data found
                   </p>
@@ -281,6 +291,24 @@ export function StatsTable({
                         rel="noopener noreferrer"
                       >
                         {report.pendingMilestones}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Link
+                        href={`${PAGES.PROJECT.GRANT(
+                          report.projectSlug,
+                          report.grantUid
+                        )}/milestones-and-updates#past-due`}
+                        className={cn(
+                          "text-sm tabular-nums transition-colors",
+                          report.pastDueMilestones > 0
+                            ? "text-red-600 dark:text-red-400 font-medium"
+                            : "text-gray-500 dark:text-gray-400"
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {report.pastDueMilestones}
                       </Link>
                     </td>
                     <td className="px-4 py-3">

--- a/components/Pages/Admin/StatsTable.tsx
+++ b/components/Pages/Admin/StatsTable.tsx
@@ -294,22 +294,28 @@ export function StatsTable({
                       </Link>
                     </td>
                     <td className="px-4 py-3">
-                      <Link
-                        href={`${PAGES.PROJECT.GRANT(
-                          report.projectSlug,
-                          report.grantUid
-                        )}/milestones-and-updates#past-due`}
-                        className={cn(
-                          "text-sm tabular-nums transition-colors",
-                          report.pastDueMilestones > 0
-                            ? "text-red-600 dark:text-red-400 font-medium"
-                            : "text-gray-500 dark:text-gray-400"
-                        )}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {report.pastDueMilestones}
-                      </Link>
+                      {(() => {
+                        const pastDueCount = report.pastDueMilestones ?? 0;
+                        return (
+                          <Link
+                            href={`${PAGES.PROJECT.GRANT(
+                              report.projectSlug,
+                              report.grantUid
+                            )}/milestones-and-updates#past-due`}
+                            aria-label={`${pastDueCount} past due milestones for ${report.grantTitle}`}
+                            className={cn(
+                              "text-sm tabular-nums transition-colors",
+                              pastDueCount > 0
+                                ? "text-red-600 dark:text-red-400 font-medium"
+                                : "text-gray-500 dark:text-gray-400"
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {pastDueCount}
+                          </Link>
+                        );
+                      })()}
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-3">

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -23,6 +23,7 @@ interface Report {
   programId?: string;
   totalMilestones: number;
   pendingMilestones: number;
+  pastDueMilestones: number;
   completedMilestones: number;
   isGrantCompleted?: boolean;
   proofOfWorkLinks: string[];

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -23,7 +23,7 @@ interface Report {
   programId?: string;
   totalMilestones: number;
   pendingMilestones: number;
-  pastDueMilestones: number;
+  pastDueMilestones?: number;
   completedMilestones: number;
   isGrantCompleted?: boolean;
   proofOfWorkLinks: string[];


### PR DESCRIPTION
## Summary
- add a Past Due column beside Pending in the milestones stats table
- render positive past due counts in red and link to the grant milestones page
- add a unit test covering the new column ordering and styling

## Test Plan
- `pnpm exec biome check components/Pages/Admin/StatsTable.tsx hooks/useReportPageData.ts __tests__/components/Pages/Admin/StatsTable.test.tsx`
- `pnpm exec vitest run --project unit __tests__/components/Pages/Admin/StatsTable.test.tsx`
- `pnpm run test` *(currently fails in this repo on pre-existing unrelated test-suite issues, including `useAuth` failures and a Vitest worker IPC crash)*

Depends on the matching gap-indexer change for DEV-162.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sortable "Past Due" column to the stats table with linked counts that open the milestones section in a new tab
  * Conditional styling highlights reports with overdue items

* **Behavior / UX**
  * Table now shows appropriate loading skeleton, empty-state, and error messages that span the table layout for consistency

* **Tests**
  * Added tests covering loading, error, empty, and success render modes for the stats table
<!-- end of auto-generated comment: release notes by coderabbit.ai -->