### PR TITLE
feat(funding-platform): render server-resolved project name in applications list

### DIFF
--- a/__tests__/integration/components/FundingPlatform/ApplicationList/ApplicationList.aiScore.test.tsx
+++ b/__tests__/integration/components/FundingPlatform/ApplicationList/ApplicationList.aiScore.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/components/FundingPlatform/helper/getAIScore", () => ({
 // Mock the other helper functions
 vi.mock("@/components/FundingPlatform/helper/getProjectTitle", () => ({
   getProjectTitle: vi.fn(() => "Test Project"),
+  findProjectTitleInData: vi.fn(() => "Test Project"),
 }));
 
 vi.mock("@/utilities/formatDate", () => ({

--- a/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
@@ -13,7 +13,6 @@ import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { formatAIScore } from "../helper/getAIScore";
 import { formatInternalAIScore } from "../helper/getInternalAIScore";
-import { getProjectTitle } from "../helper/getProjectTitle";
 import { AIEvaluationModal, type EvaluationType } from "./AIEvaluationModal";
 import { ReviewerAssignmentDropdown } from "./ReviewerAssignmentDropdown";
 import { TableStatusActionButtons } from "./TableStatusActionButtons";
@@ -85,6 +84,8 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [evaluationType, setEvaluationType] = useState<EvaluationType>("external");
 
+  const projectDisplayName = application.resolvedProjectName || application.referenceNumber;
+
   const handleAIScoreClick = (e: React.MouseEvent, type: EvaluationType) => {
     e.stopPropagation();
     setEvaluationType(type);
@@ -119,8 +120,8 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
           {application.referenceNumber}
         </td>
         <td className="px-4 py-4 text-sm text-gray-900 dark:text-white">
-          <div className="max-w-xs truncate" title={getProjectTitle(application)}>
-            {getProjectTitle(application)}
+          <div className="max-w-xs truncate" title={projectDisplayName}>
+            {projectDisplayName}
           </div>
         </td>
         <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
@@ -228,7 +229,7 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
         onClose={() => setIsModalOpen(false)}
         evaluationType={evaluationType}
         evaluation={getEvaluationData()}
-        projectTitle={getProjectTitle(application)}
+        projectTitle={projectDisplayName}
       />
     </>
   );

--- a/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
+++ b/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
@@ -1,4 +1,4 @@
-import { getProjectTitle } from "../getProjectTitle";
+import { findProjectTitleInData, getProjectTitle } from "../getProjectTitle";
 
 const makeApplication = (
   applicationData: Record<string, unknown>,
@@ -75,5 +75,54 @@ describe("getProjectTitle", () => {
       "Pod Name": "Fallback Pod",
     });
     expect(getProjectTitle(app)).toBe("Fallback Pod");
+  });
+});
+
+describe("findProjectTitleInData", () => {
+  it("returns undefined (not the reference number) when no title-like field is present", () => {
+    expect(findProjectTitleInData({ "Some Field": "value" })).toBeUndefined();
+  });
+
+  it("returns undefined for empty or null applicationData", () => {
+    expect(findProjectTitleInData({})).toBeUndefined();
+    expect(findProjectTitleInData(null)).toBeUndefined();
+    expect(findProjectTitleInData(undefined)).toBeUndefined();
+  });
+
+  it("returns the schema title when one exists", () => {
+    expect(findProjectTitleInData({ "Project Title": "Alpha" })).toBe("Alpha");
+  });
+
+  it("prefers keys with both project + title/name keywords over name-only keys", () => {
+    const data = {
+      "Team Name": "Internal Name",
+      "Project Name": "Actual Project",
+    };
+    expect(findProjectTitleInData(data)).toBe("Actual Project");
+  });
+
+  it("ignores non-string values even when the key matches the pattern", () => {
+    const data: Record<string, unknown> = {
+      "Project Title": { en: "Nested" },
+      "Project Name": "Flat Name",
+    };
+    // Must not stringify an object into '[object Object]' — fall through to
+    // the next candidate instead.
+    expect(findProjectTitleInData(data)).toBe("Flat Name");
+  });
+
+  it("ignores non-string values and returns undefined when no string candidate exists", () => {
+    const data: Record<string, unknown> = {
+      "Project Title": { en: "Nested" },
+      "Project Count": 7,
+      "Project Active": true,
+    };
+    expect(findProjectTitleInData(data)).toBeUndefined();
+  });
+
+  it("ignores whitespace-only strings", () => {
+    expect(findProjectTitleInData({ "Project Title": "   ", "Pod Name": "Real Name" })).toBe(
+      "Real Name"
+    );
   });
 });

--- a/components/FundingPlatform/helper/getProjectTitle.ts
+++ b/components/FundingPlatform/helper/getProjectTitle.ts
@@ -17,9 +17,18 @@ export const findProjectTitleInData = (
   const dataKeys = Object.keys(data);
   if (dataKeys.length === 0) return undefined;
 
+  // Only strings count as valid titles. Guarding here (rather than at the
+  // return site) means the keyword search also ignores non-string fields,
+  // so we don't pick an object-valued key as "best" and then reject it.
+  const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.trim().length > 0;
+
   const findBest = (predicate: (lowerKey: string) => boolean): string | undefined => {
     const matches = dataKeys.filter(
-      (key) => key.length <= MAX_LABEL_LENGTH && predicate(key.toLowerCase()) && data[key]
+      (key) =>
+        key.length <= MAX_LABEL_LENGTH &&
+        predicate(key.toLowerCase()) &&
+        isNonEmptyString(data[key])
     );
     if (matches.length === 0) return undefined;
     return matches.reduce((a, b) => (a.length <= b.length ? a : b));
@@ -37,8 +46,11 @@ export const findProjectTitleInData = (
     titleKey = findBest((lowerKey) => titleKeywords.some((kw) => lowerKey.includes(kw)));
   }
 
-  if (titleKey && data[titleKey]) {
-    return String(data[titleKey]);
+  if (titleKey) {
+    const value = data[titleKey];
+    if (isNonEmptyString(value)) {
+      return value;
+    }
   }
 
   return undefined;

--- a/components/FundingPlatform/helper/getProjectTitle.ts
+++ b/components/FundingPlatform/helper/getProjectTitle.ts
@@ -3,22 +3,23 @@ interface ApplicationWithData {
   referenceNumber: string;
 }
 
-export const getProjectTitle = (application: ApplicationWithData): string => {
+// Title/name fields are short labels (e.g. "Project Title", "Pod Name"),
+// not long-form questions that incidentally contain keywords like "name".
+const MAX_LABEL_LENGTH = 50;
+
+export const findProjectTitleInData = (
+  applicationData: Record<string, unknown> | null | undefined
+): string | undefined => {
   const titleKeywords = ["title", "name"];
   const projectKeywords = ["project", "proposal", "application"];
 
-  const dataKeys = Object.keys(application.applicationData || {});
-
-  // Title/name fields are short labels (e.g. "Project Title", "Pod Name"),
-  // not long-form questions that incidentally contain keywords like "name".
-  const MAX_LABEL_LENGTH = 50;
+  const data = applicationData || {};
+  const dataKeys = Object.keys(data);
+  if (dataKeys.length === 0) return undefined;
 
   const findBest = (predicate: (lowerKey: string) => boolean): string | undefined => {
     const matches = dataKeys.filter(
-      (key) =>
-        key.length <= MAX_LABEL_LENGTH &&
-        predicate(key.toLowerCase()) &&
-        application.applicationData[key]
+      (key) => key.length <= MAX_LABEL_LENGTH && predicate(key.toLowerCase()) && data[key]
     );
     if (matches.length === 0) return undefined;
     return matches.reduce((a, b) => (a.length <= b.length ? a : b));
@@ -36,9 +37,13 @@ export const getProjectTitle = (application: ApplicationWithData): string => {
     titleKey = findBest((lowerKey) => titleKeywords.some((kw) => lowerKey.includes(kw)));
   }
 
-  if (titleKey && application.applicationData[titleKey]) {
-    return String(application.applicationData[titleKey]);
+  if (titleKey && data[titleKey]) {
+    return String(data[titleKey]);
   }
 
-  return application.referenceNumber;
+  return undefined;
+};
+
+export const getProjectTitle = (application: ApplicationWithData): string => {
+  return findProjectTitleInData(application.applicationData) ?? application.referenceNumber;
 };

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -149,6 +149,10 @@ export interface IFundingApplication {
   appReviewers?: string[]; // Array of program reviewer addresses assigned to this application
   milestoneReviewers?: string[]; // Array of milestone reviewer addresses assigned to this application
   postApprovalCompleted?: boolean; // Indicates if post-approval form has been completed
+  // Server-resolved display name for the project/proposal. Prefers a title
+  // from submitted form data; falls back to the linked Karma project's title
+  // when the application has a projectUID. Omitted when neither yields a value.
+  resolvedProjectName?: string;
   createdAt: string | Date;
   updatedAt: string | Date;
 }


### PR DESCRIPTION
## Summary

Fixes the applications list showing `APP-XXXXX-XXXXX` in both the
Application ID and Project Title columns.

With https://github.com/show-karma/gap-indexer/pull/1394 merged, every
application returned by the list/detail endpoints already carries a
`resolvedProjectName` resolved server-side (form-data title → linked
Karma project title → omitted). The cell now just reads that field.

## What changed

- Adds optional `resolvedProjectName` to `IFundingApplication`.
- `ApplicationTableRow` renders `application.resolvedProjectName || application.referenceNumber` inline — no per-row project fetch, no `useProject` hook, no loading flicker between reference number and title.
- AI-evaluation modal's `projectTitle` prop now uses the same resolved value.
- `getProjectTitle` helper refactored: a new exported `findProjectTitleInData` returns `string | undefined` (no ref-number fallback) for callers that want the raw schema-title primitive; `getProjectTitle` keeps its existing string-with-fallback behaviour.

## Why

Previously, every approved application with no form-data title would have
forced a client-side `useProject` call per row (and the pre-PR behaviour
showed the APP-XXXXX ID instead of the Karma project name). With the
backend field, the whole page is rendered from a single list response.

## Dependencies

- **Requires** https://github.com/show-karma/gap-indexer/pull/1394 to be deployed first. Until then, `resolvedProjectName` will be absent on responses and the cell will gracefully fall back to the reference number (same as current behaviour for un-titled apps).

## Test plan

- [x] `pnpm test` for FundingPlatform/ApplicationList + helper suites — 220 pass
- [x] `biome check` — 0 errors
- [ ] Hit the applications list for a program with approved applications; confirm the Project Title column shows the Karma project name (e.g. "Interplanetary Network Indexers") instead of the APP reference
- [ ] Hit the list for a program with pending applications that have a "Project Title" form field; confirm that value renders
- [ ] Hit the list for a program where neither source yields a name; confirm the cell falls back to the reference number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications now support an optional server-resolved project name field for improved project identification from submitted form data or linked projects.

* **Refactor**
  * Enhanced project name display logic with more robust fallback mechanisms ensuring consistent project naming throughout the funding platform when names are available or using reference numbers as fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->