### PR TITLE
fix(milestones): skip re-attestation when only adding an invoice

### DIFF
--- a/components/Forms/MilestoneUpdate.tsx
+++ b/components/Forms/MilestoneUpdate.tsx
@@ -31,6 +31,7 @@ import { useOwnerStore, useProjectStore } from "@/store";
 import { useShareDialogStore } from "@/store/modals/shareDialog";
 import type { GrantMilestone } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
+import { hasAnyDirtyField } from "@/utilities/hasAnyDirtyField";
 import {
   deleteMilestoneImpactAnswers,
   sendMilestoneImpactAnswers,
@@ -68,16 +69,6 @@ interface MilestoneUpdateFormProps {
 const labelStyle = "text-slate-700 text-sm font-bold leading-tight dark:text-slate-200";
 
 const inputStyle = "bg-white border border-gray-300 rounded-md p-2 dark:bg-zinc-900";
-
-// Recursively checks react-hook-form `dirtyFields`. Returns true if any leaf is truthy.
-// Handles objects, arrays (RHF represents dirty array items as sparse objects), and primitives.
-const hasAnyDirtyField = (value: unknown): boolean => {
-  if (value == null) return false;
-  if (typeof value === "boolean") return value;
-  if (Array.isArray(value)) return value.some(hasAnyDirtyField);
-  if (typeof value === "object") return Object.values(value).some(hasAnyDirtyField);
-  return Boolean(value);
-};
 
 const schema = z.object({
   description: z.string().optional(),
@@ -538,7 +529,6 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
   };
 
   const onSubmit = async (data: SchemaType) => {
-    const sanitizedData = sanitizeObject(data);
     const hasFieldChanges = hasAnyDirtyField(dirtyFields);
 
     // Nothing-to-save guard: editing with no field changes and no new invoice would
@@ -573,7 +563,12 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
         cancelEditing(false);
         parentSetIsUpdating?.(false);
       } catch (invoiceError) {
-        errorManager("Invoice-only submission failed", invoiceError);
+        errorManager("Invoice-only submission failed", invoiceError, {
+          grantUID,
+          projectUID: project?.uid,
+          address,
+          milestoneUID: milestone.uid,
+        });
         toast.error("Invoice submission failed. Please try again.", { id: loadingToastId });
       } finally {
         setIsSubmitLoading(false);
@@ -581,6 +576,7 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
       return;
     }
 
+    const sanitizedData = sanitizeObject(data);
     try {
       if (isEditing) {
         await updateMilestoneCompletion(milestone, sanitizedData);
@@ -592,7 +588,7 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
       return;
     }
 
-    // Submit invoice after successful milestone operation
+    // Submit invoice only after successful milestone operation
     if (invoiceFile && grantUID) {
       try {
         await submitGranteeInvoice(grantUID, {

--- a/components/Forms/MilestoneUpdate.tsx
+++ b/components/Forms/MilestoneUpdate.tsx
@@ -69,6 +69,16 @@ const labelStyle = "text-slate-700 text-sm font-bold leading-tight dark:text-sla
 
 const inputStyle = "bg-white border border-gray-300 rounded-md p-2 dark:bg-zinc-900";
 
+// Recursively checks react-hook-form `dirtyFields`. Returns true if any leaf is truthy.
+// Handles objects, arrays (RHF represents dirty array items as sparse objects), and primitives.
+const hasAnyDirtyField = (value: unknown): boolean => {
+  if (value == null) return false;
+  if (typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.some(hasAnyDirtyField);
+  if (typeof value === "object") return Object.values(value).some(hasAnyDirtyField);
+  return Boolean(value);
+};
+
 const schema = z.object({
   description: z.string().optional(),
   completionPercentage: z.string().refine(
@@ -166,7 +176,7 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
     handleSubmit,
     watch,
     control,
-    formState: { errors, isValid },
+    formState: { errors, isValid, dirtyFields },
   } = useForm<SchemaType>({
     resolver: zodResolver(schema),
     reValidateMode: "onChange",
@@ -529,6 +539,48 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
 
   const onSubmit = async (data: SchemaType) => {
     const sanitizedData = sanitizeObject(data);
+    const hasFieldChanges = hasAnyDirtyField(dirtyFields);
+
+    // Nothing-to-save guard: editing with no field changes and no new invoice would
+    // otherwise trigger a no-op on-chain re-attestation (wastes gas + orphans verifications).
+    if (isEditing && !hasFieldChanges && !invoiceFile) {
+      toast.error("No changes to save");
+      return;
+    }
+
+    // Invoice-only fast path: when editing an already-completed milestone, if the user
+    // only added an invoice (no tracked form fields changed), skip the on-chain
+    // re-attestation. Re-attesting creates a new MilestoneCompleted UID and orphans any
+    // verifications referencing the original completion attestation.
+    const isInvoiceOnlyEdit = isEditing && !!invoiceFile && !!grantUID && !hasFieldChanges;
+
+    if (isInvoiceOnlyEdit) {
+      setIsSubmitLoading(true);
+      const loadingToastId = toast.loading("Saving invoice...");
+      try {
+        await submitGranteeInvoice(grantUID, {
+          milestoneLabel: milestone.title,
+          milestoneUID: milestone.uid,
+          invoiceFileKey: invoiceFile.fileKey,
+          invoiceFileUrl: invoiceFile.fileUrl,
+        });
+        toast.success("Invoice submitted successfully", { id: loadingToastId });
+
+        await queryClient.invalidateQueries({
+          predicate: createProjectQueryPredicate(project?.uid || ""),
+        });
+
+        cancelEditing(false);
+        parentSetIsUpdating?.(false);
+      } catch (invoiceError) {
+        errorManager("Invoice-only submission failed", invoiceError);
+        toast.error("Invoice submission failed. Please try again.", { id: loadingToastId });
+      } finally {
+        setIsSubmitLoading(false);
+      }
+      return;
+    }
+
     try {
       if (isEditing) {
         await updateMilestoneCompletion(milestone, sanitizedData);
@@ -540,7 +592,7 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
       return;
     }
 
-    // Submit invoice only after successful milestone operation
+    // Submit invoice after successful milestone operation
     if (invoiceFile && grantUID) {
       try {
         await submitGranteeInvoice(grantUID, {
@@ -581,6 +633,7 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
               onChange={(newValue: string) => {
                 setValue("description", newValue || "", {
                   shouldValidate: true,
+                  shouldDirty: true,
                 });
               }}
             />

--- a/utilities/__tests__/hasAnyDirtyField.test.ts
+++ b/utilities/__tests__/hasAnyDirtyField.test.ts
@@ -1,0 +1,112 @@
+import { hasAnyDirtyField } from "../hasAnyDirtyField";
+
+describe("hasAnyDirtyField", () => {
+  describe("pristine shapes", () => {
+    it("returns false for empty object (pristine form)", () => {
+      expect(hasAnyDirtyField({})).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(hasAnyDirtyField(undefined)).toBe(false);
+    });
+
+    it("returns false for null", () => {
+      expect(hasAnyDirtyField(null)).toBe(false);
+    });
+
+    it("returns false for empty array", () => {
+      expect(hasAnyDirtyField([])).toBe(false);
+    });
+
+    it("returns false when every leaf is explicitly false", () => {
+      expect(hasAnyDirtyField({ description: false, completionPercentage: false })).toBe(false);
+    });
+
+    it("returns false for sparse array with only undefined entries", () => {
+      // RHF shape when a useFieldArray field exists but no item is dirty
+      // biome-ignore lint/suspicious/noSparseArray: replicating RHF's sparse-array dirtyFields shape
+      const sparse = [, , ,];
+      expect(hasAnyDirtyField(sparse)).toBe(false);
+    });
+  });
+
+  describe("primitive field edits", () => {
+    it("returns true when a top-level boolean is true (edited text field)", () => {
+      expect(hasAnyDirtyField({ description: true })).toBe(true);
+    });
+
+    it("returns true when one of several fields is dirty", () => {
+      expect(hasAnyDirtyField({ description: false, completionPercentage: true })).toBe(true);
+    });
+  });
+
+  describe("array field edits (useFieldArray shapes)", () => {
+    it("returns true for sparse array with a dirty item at index > 0", () => {
+      // User edited deliverables[1].proof; index 0 is pristine
+      const dirtyFields = {
+        deliverables: [undefined, { proof: true }],
+      };
+      expect(hasAnyDirtyField(dirtyFields)).toBe(true);
+    });
+
+    it("returns true for fully populated dirty array item", () => {
+      const dirtyFields = {
+        outputs: [{ outputId: true, value: true, proof: true }],
+      };
+      expect(hasAnyDirtyField(dirtyFields)).toBe(true);
+    });
+
+    it("returns false when array item object has no truthy leaves", () => {
+      const dirtyFields = {
+        outputs: [{ outputId: false, value: false }],
+      };
+      expect(hasAnyDirtyField(dirtyFields)).toBe(false);
+    });
+  });
+
+  describe("nested shapes", () => {
+    it("returns true when a deeply nested leaf is dirty", () => {
+      const dirtyFields = {
+        outputs: [{ metadata: { label: true } }],
+      };
+      expect(hasAnyDirtyField(dirtyFields)).toBe(true);
+    });
+
+    it("returns false for deeply nested pristine structure", () => {
+      const dirtyFields = {
+        outputs: [{ metadata: { label: false, tags: [] } }],
+      };
+      expect(hasAnyDirtyField(dirtyFields)).toBe(false);
+    });
+  });
+
+  describe("realistic MilestoneUpdate scenarios", () => {
+    it("pristine edit (only invoice attached, no fields touched) → false", () => {
+      expect(hasAnyDirtyField({})).toBe(false);
+    });
+
+    it("user typed in description → true", () => {
+      expect(hasAnyDirtyField({ description: true })).toBe(true);
+    });
+
+    it("user changed completion percentage → true", () => {
+      expect(hasAnyDirtyField({ completionPercentage: true })).toBe(true);
+    });
+
+    it("user edited one deliverable proof → true", () => {
+      expect(
+        hasAnyDirtyField({
+          deliverables: [{ name: false, proof: true, description: false }],
+        })
+      ).toBe(true);
+    });
+
+    it("user changed an output value → true", () => {
+      expect(
+        hasAnyDirtyField({
+          outputs: [{ outputId: false, value: true }],
+        })
+      ).toBe(true);
+    });
+  });
+});

--- a/utilities/hasAnyDirtyField.ts
+++ b/utilities/hasAnyDirtyField.ts
@@ -1,0 +1,11 @@
+// Recursively checks react-hook-form `dirtyFields`. Returns true if any leaf is truthy.
+// RHF represents `dirtyFields` as a nested structure mirroring the form values:
+// primitives become booleans, arrays become sparse arrays of booleans/objects,
+// and objects become objects whose values follow the same rule recursively.
+export const hasAnyDirtyField = (value: unknown): boolean => {
+  if (value == null) return false;
+  if (typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.some(hasAnyDirtyField);
+  if (typeof value === "object") return Object.values(value).some(hasAnyDirtyField);
+  return Boolean(value);
+};


### PR DESCRIPTION
## Summary

Editing a completed milestone to attach an invoice previously called `milestone.complete()` unconditionally, producing a **new** `MilestoneCompleted` attestation with a fresh UID. Any `MilestoneCompletedVerified` attestations linked by `refUID` to the original completion are orphaned — the UI surfaces the new (zero-verification) completion instead.

This PR adds an invoice-only fast path and tightens the form's dirty-state tracking.

## Changes

- **`components/Forms/MilestoneUpdate.tsx`**
  - Invoice-only fast path in `onSubmit`: if `isEditing && invoiceFile && grantUID && !hasAnyDirtyField(dirtyFields)`, skip the on-chain `complete()` call and go straight to `submitGranteeInvoice`. The invoice is attached by milestone UID (not completion UID), so existing verifications on the original completion are preserved.
  - Added `hasAnyDirtyField` helper — recursively walks RHF's `dirtyFields` (handles nested objects/arrays that RHF uses for `outputs`/`deliverables`).
  - `setValue("description", ...)` now passes `shouldDirty: true`. Without it, RHF never flagged description edits via the `MarkdownEditor`, which meant a user who typed into description would silently take the fast path and lose their edit.
  - Invoice-only path wraps in `setIsSubmitLoading(true/false)` and `toast.loading("Saving invoice...")` so the submit button spins and the user sees feedback (previously the button sat inert).
  - Guard for no-op edits: if editing with no dirty fields and no new invoice, show `toast.error("No changes to save")` and return — avoids a pointless re-attestation.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Edit: attach invoice only (no field changes) | Re-attests, new UID, orphans verifications | No on-chain call. Invoice uploaded. Existing verifications preserved. |
| Edit: change description + attach invoice | Re-attests, new UID | Re-attests, new UID (unchanged — still needed when fields changed) |
| Edit: submit with no changes | Re-attests, new UID | Blocked with toast, no chain call |
| New completion (not editing) | Attests + uploads invoice | Unchanged |

## Test plan

- [ ] Complete a milestone without invoice, then edit to add only an invoice — confirm no wallet prompt, no stepper, button spins while uploading, success toast shown, list refreshes with invoice attached.
- [ ] Verify the original `MilestoneCompleted` attestation UID on-chain is unchanged after the invoice-only edit.
- [ ] Verify any existing verifications remain visible on the milestone after the invoice-only edit.
- [ ] Edit the same milestone changing description (with or without new invoice) — confirm the old path runs (stepper, wallet signature, new attestation) and invoice is submitted after.
- [ ] Edit an already-completed milestone and submit without changing anything — confirm "No changes to save" toast and no on-chain activity.
- [ ] New completion flow (non-edit) — confirm unchanged behavior.
- [ ] Edit outputs/deliverables only (no invoice) — confirm the re-attestation path runs (outputs setValue already passes `shouldDirty: true`).

## Out of scope / follow-ups

- Existing code paths where milestone completions have *already* been orphaned by past edits. This PR only prevents new orphaning — it does not migrate or re-link historical verifications.
- The `useMilestoneEdit.ts` alternate API path already performs revoke+recreate; we could similarly adopt that pattern for cases where field changes *do* require re-attestation, but that's a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expedited invoice upload for milestone updates, streamlining submission when only invoice changes are needed
  * Enhanced form change detection to prevent submissions without actual modifications to tracked fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->