### PR TITLE
feat: add preview for draft portfolio reports

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -24,18 +24,12 @@ vi.mock("react-hot-toast", () => ({
 vi.mock("@/hooks/communities/useCommunityAdminAccess");
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 
-const mockUseCommunityAdminAccess = useCommunityAdminAccess as vi.MockedFunction<
-  typeof useCommunityAdminAccess
->;
-const mockUsePortfolioReports = usePortfolioReports as vi.MockedFunction<
-  typeof usePortfolioReports
->;
-const mockUseGenerateReport = useGenerateReport as vi.MockedFunction<typeof useGenerateReport>;
-const mockUsePublishReport = usePublishReport as vi.MockedFunction<typeof usePublishReport>;
-const mockUseUnpublishReport = useUnpublishReport as vi.MockedFunction<typeof useUnpublishReport>;
-const mockUseRegenerateReport = useRegenerateReport as vi.MockedFunction<
-  typeof useRegenerateReport
->;
+const mockUseCommunityAdminAccess = vi.mocked(useCommunityAdminAccess);
+const mockUsePortfolioReports = vi.mocked(usePortfolioReports);
+const mockUseGenerateReport = vi.mocked(useGenerateReport);
+const mockUsePublishReport = vi.mocked(usePublishReport);
+const mockUseUnpublishReport = vi.mocked(useUnpublishReport);
+const mockUseRegenerateReport = vi.mocked(useRegenerateReport);
 
 describe("PortfolioReportListPage", () => {
   beforeEach(() => {

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PortfolioReportListPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportListPage";
+import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import {
+  useGenerateReport,
+  usePortfolioReports,
+  usePublishReport,
+  useRegenerateReport,
+  useUnpublishReport,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/hooks/communities/useCommunityAdminAccess");
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+
+const mockUseCommunityAdminAccess = useCommunityAdminAccess as vi.MockedFunction<
+  typeof useCommunityAdminAccess
+>;
+const mockUsePortfolioReports = usePortfolioReports as vi.MockedFunction<
+  typeof usePortfolioReports
+>;
+const mockUseGenerateReport = useGenerateReport as vi.MockedFunction<typeof useGenerateReport>;
+const mockUsePublishReport = usePublishReport as vi.MockedFunction<typeof usePublishReport>;
+const mockUseUnpublishReport = useUnpublishReport as vi.MockedFunction<typeof useUnpublishReport>;
+const mockUseRegenerateReport = useRegenerateReport as vi.MockedFunction<
+  typeof useRegenerateReport
+>;
+
+describe("PortfolioReportListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseCommunityAdminAccess.mockReturnValue({
+      hasAccess: true,
+      isLoading: false,
+    } as any);
+
+    mockUseGenerateReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUsePublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseUnpublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseRegenerateReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+  });
+
+  it("shows a Preview action for draft reports and navigates to the admin preview page", async () => {
+    const user = userEvent.setup();
+
+    mockUsePortfolioReports.mockReturnValue({
+      data: [
+        {
+          id: "draft-report",
+          reportConfigId: "config-1",
+          communityId: "community-1",
+          reportMonth: "2026-03",
+          status: "draft",
+          markdown: "# Draft report",
+          dataSnapshot: {},
+          modelId: "gpt-4.1",
+          tokenUsage: null,
+          generatedAt: "2026-04-01T00:00:00.000Z",
+          generationError: null,
+          publishedAt: null,
+          publishedBy: null,
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+    } as any);
+
+    render(
+      <PortfolioReportListPage
+        community={{ uid: "community-1", details: { slug: "filecoin", name: "Filecoin" } } as any}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /preview/i }));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/community/filecoin/manage/portfolio-reports/draft-report/preview"
+    );
+  });
+
+  it("does not show a Preview action for published reports", () => {
+    mockUsePortfolioReports.mockReturnValue({
+      data: [
+        {
+          id: "published-report",
+          reportConfigId: "config-1",
+          communityId: "community-1",
+          reportMonth: "2026-03",
+          status: "published",
+          markdown: "# Published report",
+          dataSnapshot: {},
+          modelId: "gpt-4.1",
+          tokenUsage: null,
+          generatedAt: "2026-04-01T00:00:00.000Z",
+          generationError: null,
+          publishedAt: "2026-04-02T00:00:00.000Z",
+          publishedBy: "user-1",
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-02T00:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+    } as any);
+
+    render(
+      <PortfolioReportListPage
+        community={{ uid: "community-1", details: { slug: "filecoin", name: "Filecoin" } } as any}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /preview/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
+import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
+
+vi.mock("@/hooks/communities/useCommunityAdminAccess");
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source?: string }) => (
+    <div data-testid="markdown-preview">{source}</div>
+  ),
+}));
+
+const mockUseCommunityAdminAccess = useCommunityAdminAccess as vi.MockedFunction<
+  typeof useCommunityAdminAccess
+>;
+const mockUsePortfolioReport = usePortfolioReport as vi.MockedFunction<typeof usePortfolioReport>;
+
+describe("PortfolioReportPreviewPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCommunityAdminAccess.mockReturnValue({
+      hasAccess: true,
+      isLoading: false,
+    } as any);
+  });
+
+  it("renders the draft report in preview mode with a back link to admin portfolio reports", () => {
+    mockUsePortfolioReport.mockReturnValue({
+      data: {
+        id: "draft-report",
+        reportConfigId: "config-1",
+        communityId: "community-1",
+        reportMonth: "2026-03",
+        status: "draft",
+        markdown: "# Draft report body",
+        dataSnapshot: {},
+        modelId: "gpt-4.1",
+        tokenUsage: null,
+        generatedAt: "2026-04-01T00:00:00.000Z",
+        generationError: null,
+        publishedAt: null,
+        publishedBy: null,
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      },
+      isLoading: false,
+    } as any);
+
+    render(
+      <PortfolioReportPreviewPage
+        community={{ uid: "community-1", details: { slug: "filecoin", name: "Filecoin" } } as any}
+        reportId="draft-report"
+      />
+    );
+
+    expect(screen.getByText(/preview mode/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+      "href",
+      "/community/filecoin/manage/portfolio-reports"
+    );
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+    expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
+  });
+});

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
@@ -11,10 +12,39 @@ vi.mock("@/components/Utilities/MarkdownPreview", () => ({
   ),
 }));
 
-const mockUseCommunityAdminAccess = useCommunityAdminAccess as vi.MockedFunction<
-  typeof useCommunityAdminAccess
->;
-const mockUsePortfolioReport = usePortfolioReport as vi.MockedFunction<typeof usePortfolioReport>;
+const mockUseCommunityAdminAccess = vi.mocked(useCommunityAdminAccess);
+const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
+
+const community = {
+  uid: "community-1",
+  details: { slug: "filecoin", name: "Filecoin" },
+} as any;
+
+const draftReport = {
+  id: "draft-report",
+  reportConfigId: "config-1",
+  communityId: "community-1",
+  reportMonth: "2026-03",
+  status: "draft",
+  markdown: "# Draft report body",
+  dataSnapshot: {},
+  modelId: "gpt-4.1",
+  tokenUsage: null,
+  generatedAt: "2026-04-01T00:00:00.000Z",
+  generationError: null,
+  publishedAt: null,
+  publishedBy: null,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+};
+
+const publishedReport = {
+  ...draftReport,
+  id: "published-report",
+  status: "published",
+  publishedAt: "2026-04-02T00:00:00.000Z",
+  publishedBy: "user-1",
+};
 
 describe("PortfolioReportPreviewPage", () => {
   beforeEach(() => {
@@ -25,41 +55,131 @@ describe("PortfolioReportPreviewPage", () => {
     } as any);
   });
 
-  it("renders the draft report in preview mode with a back link to admin portfolio reports", () => {
-    mockUsePortfolioReport.mockReturnValue({
-      data: {
-        id: "draft-report",
-        reportConfigId: "config-1",
-        communityId: "community-1",
-        reportMonth: "2026-03",
-        status: "draft",
-        markdown: "# Draft report body",
-        dataSnapshot: {},
-        modelId: "gpt-4.1",
-        tokenUsage: null,
-        generatedAt: "2026-04-01T00:00:00.000Z",
-        generationError: null,
-        publishedAt: null,
-        publishedBy: null,
-        createdAt: "2026-04-01T00:00:00.000Z",
-        updatedAt: "2026-04-01T00:00:00.000Z",
-      },
-      isLoading: false,
-    } as any);
+  describe("loading state", () => {
+    it("renders a spinner while admin access is being resolved", () => {
+      mockUseCommunityAdminAccess.mockReturnValue({
+        hasAccess: false,
+        isLoading: true,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as any);
 
-    render(
-      <PortfolioReportPreviewPage
-        community={{ uid: "community-1", details: { slug: "filecoin", name: "Filecoin" } } as any}
-        reportId="draft-report"
-      />
-    );
+      const { container } = render(
+        <PortfolioReportPreviewPage community={community} reportId="draft-report" />
+      );
 
-    expect(screen.getByText(/preview mode/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
-      "href",
-      "/community/filecoin/manage/portfolio-reports"
-    );
-    expect(screen.getByText("Draft")).toBeInTheDocument();
-    expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    it("renders a spinner while the report is loading", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as any);
+
+      const { container } = render(
+        <PortfolioReportPreviewPage community={community} reportId="draft-report" />
+      );
+
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+  });
+
+  describe("access denied", () => {
+    it("shows a permission-denied message when the user is not a community admin", () => {
+      mockUseCommunityAdminAccess.mockReturnValue({
+        hasAccess: false,
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+
+      expect(screen.getByText(/don't have permission to view this preview/i)).toBeInTheDocument();
+      expect(screen.queryByTestId("markdown-preview")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("renders a retry button that re-fetches the report", async () => {
+      const user = userEvent.setup();
+      const refetch = vi.fn();
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        refetch,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+
+      expect(screen.getByText(/failed to load the report preview/i)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("not found state", () => {
+    it("shows a not-found message with a back link when the report does not exist", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="missing-report" />);
+
+      expect(screen.getByText(/report not found/i)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+    });
+  });
+
+  describe("success state", () => {
+    it("renders the draft report in preview mode with a back link to admin portfolio reports", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: draftReport,
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+
+      expect(
+        screen.getByText(/preview mode — this draft is only visible to community admins\./i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+      expect(screen.getByText("Draft")).toBeInTheDocument();
+      expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
+    });
+
+    it("uses a neutral preview banner for already-published reports", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: publishedReport,
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="published-report" />);
+
+      expect(screen.getByText(/preview mode — admin view of this report\./i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/this draft is only visible to community admins/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/error.tsx
+++ b/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Link } from "@/src/components/navigation/Link";
+
+export default function PortfolioReportPreviewError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading the portfolio report preview. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/loading.tsx
+++ b/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/loading.tsx
@@ -1,0 +1,12 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <output
+      aria-label="Loading"
+      className="flex w-full items-center min-h-screen h-full justify-center"
+    >
+      <Spinner />
+    </output>
+  );
+}

--- a/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/page.tsx
+++ b/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
+import { defaultMetadata } from "@/utilities/meta";
+import { getCommunityDetails } from "@/utilities/queries/v2/community";
+
+export const metadata = defaultMetadata;
+
+interface Props {
+  params: Promise<{ communityId: string; reportId: string }>;
+}
+
+export default async function Page(props: Props) {
+  const { communityId, reportId } = await props.params;
+  const community = await getCommunityDetails(communityId);
+
+  if (!community) {
+    notFound();
+  }
+
+  return <PortfolioReportPreviewPage community={community} reportId={reportId} />;
+}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -38,10 +38,10 @@ function getPreviousMonth(): string {
 
 interface ReportTableRowProps {
   report: PortfolioReport;
-  slug: string;
   rowPending: boolean;
   activeMutationType: "publish" | "unpublish" | "regenerate" | null;
   onEdit: () => void;
+  onPreview: () => void;
   onPublish: () => void;
   onUnpublish: () => void;
   onRegenerate: () => void;
@@ -52,6 +52,7 @@ function ReportTableRow({
   rowPending,
   activeMutationType,
   onEdit,
+  onPreview,
   onPublish,
   onUnpublish,
   onRegenerate,
@@ -82,6 +83,12 @@ function ReportTableRow({
           <Button variant="ghost" size="sm" onClick={onEdit}>
             Edit
           </Button>
+          {report.status === "draft" ? (
+            <Button variant="ghost" size="sm" onClick={onPreview}>
+              <Eye className="mr-1 h-3 w-3" />
+              Preview
+            </Button>
+          ) : null}
           {report.status === "draft" ? (
             <Button variant="ghost" size="sm" onClick={onPublish} disabled={rowPending}>
               <Eye className="mr-1 h-3 w-3" />
@@ -294,10 +301,12 @@ export function PortfolioReportListPage({ community }: Props) {
                 <ReportTableRow
                   key={report.id}
                   report={report}
-                  slug={slug}
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
                   onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
+                  onPreview={() =>
+                    router.push(PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW(slug, report.id))
+                  }
                   onPublish={() => handlePublish(report.id)}
                   onUnpublish={() => handleUnpublish(report.id)}
                   onRegenerate={() => setRegenerateTargetId(report.id)}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -17,7 +17,14 @@ interface Props {
 export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const slug = community.details.slug;
   const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
-  const { data: report, isLoading, isError, refetch } = usePortfolioReport(slug, reportId);
+  const {
+    data: report,
+    isLoading,
+    isError,
+    refetch,
+  } = usePortfolioReport(slug, reportId, {
+    enabled: hasAccess && !accessLoading,
+  });
   const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
   if (accessLoading || isLoading) {
@@ -77,6 +84,10 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
     );
   }
 
+  const bannerText = report.publishedAt
+    ? "Preview mode — admin view of this report."
+    : "Preview mode — this draft is only visible to community admins.";
+
   return (
     <PortfolioReportDocumentView
       community={community}
@@ -84,7 +95,7 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
       report={report}
       backHref={backHref}
       backLabel="Back to portfolio reports"
-      bannerText="Preview mode — this draft is only visible to community admins."
+      bannerText={bannerText}
     />
   );
 }

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -4,28 +4,34 @@ import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { PortfolioReportDocumentView } from "@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView";
 import { Spinner } from "@/components/Utilities/Spinner";
-import { usePublishedReport } from "@/hooks/portfolio-reports/usePortfolioReports";
+import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
+import { PAGES } from "@/utilities/pages";
 
 interface Props {
   community: Community;
-  month: string;
+  reportId: string;
 }
 
-function formatMonth(month: string): string {
-  const [year, m] = month.split("-").map(Number);
-  const date = new Date(year, m - 1);
-  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
-}
-
-export function PublicReportViewPage({ community, month }: Props) {
+export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const slug = community.details.slug;
-  const { data: report, isLoading, isError, refetch } = usePublishedReport(slug, month);
+  const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
+  const { data: report, isLoading, isError, refetch } = usePortfolioReport(slug, reportId);
+  const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
-  if (isLoading) {
+  if (accessLoading || isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
         <Spinner />
+      </div>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <div className="flex items-center justify-center p-12 text-zinc-500">
+        You don&apos;t have permission to view this preview.
       </div>
     );
   }
@@ -35,7 +41,7 @@ export function PublicReportViewPage({ community, month }: Props) {
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
         <div className="flex flex-col items-center gap-4">
           <AlertTriangle className="h-8 w-8 text-red-400" />
-          <p className="text-zinc-500">Failed to load the report. Please try again.</p>
+          <p className="text-zinc-500">Failed to load the report preview. Please try again.</p>
           <button
             type="button"
             onClick={() => refetch()}
@@ -45,11 +51,11 @@ export function PublicReportViewPage({ community, month }: Props) {
             Retry
           </button>
           <Link
-            href={`/community/${slug}/reports`}
+            href={backHref}
             className="inline-flex items-center text-sm text-blue-600 hover:underline"
           >
             <ArrowLeft className="mr-1 h-4 w-4" />
-            Back to reports
+            Back to portfolio reports
           </Link>
         </div>
       </div>
@@ -59,13 +65,13 @@ export function PublicReportViewPage({ community, month }: Props) {
   if (!report) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
-        <p className="text-zinc-500">No published report found for {formatMonth(month)}.</p>
+        <p className="text-zinc-500">Report not found.</p>
         <Link
-          href={`/community/${slug}/reports`}
+          href={backHref}
           className="mt-4 inline-flex items-center text-sm text-blue-600 hover:underline"
         >
           <ArrowLeft className="mr-1 h-4 w-4" />
-          Back to reports
+          Back to portfolio reports
         </Link>
       </div>
     );
@@ -74,10 +80,11 @@ export function PublicReportViewPage({ community, month }: Props) {
   return (
     <PortfolioReportDocumentView
       community={community}
-      month={month}
+      month={report.reportMonth}
       report={report}
-      backHref={`/community/${slug}/reports`}
-      backLabel="Reports"
+      backHref={backHref}
+      backLabel="Back to portfolio reports"
+      bannerText="Preview mode — this draft is only visible to community admins."
     />
   );
 }

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -1,0 +1,103 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
+import type { PortfolioReport } from "@/types/portfolio-report";
+import type { Community } from "@/types/v2/community";
+import { BackToTop } from "./BackToTop";
+import { ReadingProgress } from "./ReadingProgress";
+
+interface Props {
+  community: Community;
+  month: string;
+  report: PortfolioReport;
+  backHref: string;
+  backLabel?: string;
+  bannerText?: string;
+}
+
+function formatMonth(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const date = new Date(year, m - 1);
+  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+}
+
+export function PortfolioReportDocumentView({
+  community,
+  month,
+  report,
+  backHref,
+  backLabel = "Reports",
+  bannerText,
+}: Props) {
+  const slug = community.details.slug;
+  const monthLabel = formatMonth(month);
+
+  return (
+    <>
+      <ReadingProgress />
+      <div className="px-6 pt-6 pb-10 lg:px-10">
+        {bannerText ? (
+          <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200">
+            {bannerText}
+          </div>
+        ) : null}
+
+        <nav aria-label="Breadcrumb" className="mb-8">
+          <ol className="flex flex-wrap items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
+            <li>
+              <Link
+                href={backHref}
+                className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
+              >
+                {backLabel}
+              </Link>
+            </li>
+            <li aria-hidden="true" className="text-zinc-300 dark:text-zinc-700">
+              <ChevronRight className="h-3.5 w-3.5" />
+            </li>
+            <li aria-current="page" className="font-medium text-zinc-900 dark:text-zinc-100">
+              {monthLabel}
+            </li>
+          </ol>
+        </nav>
+
+        <header className="mb-8 border-b border-zinc-200 pb-8 dark:border-zinc-800">
+          <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {community.details.name ?? slug} · Portfolio report
+          </p>
+          <h1 className="text-4xl font-bold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100">
+            {monthLabel}
+          </h1>
+          <p className="mt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400">
+            {report.publishedAt ? `Published ${formatDate(report.publishedAt)}` : "Draft"}
+          </p>
+        </header>
+
+        <article className="report-article prose prose-zinc max-w-none dark:prose-invert">
+          <MarkdownPreview source={report.markdown} />
+        </article>
+
+        <footer className="mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
+          <span>Generated {formatDate(report.generatedAt)}</span>
+          <span className="mx-2">·</span>
+          <span>{report.modelId}</span>
+          {report.publishedAt ? (
+            <>
+              <span className="mx-2">·</span>
+              <span>Published {formatDate(report.publishedAt)}</span>
+            </>
+          ) : null}
+        </footer>
+      </div>
+      <BackToTop />
+    </>
+  );
+}

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -77,11 +77,16 @@ export function usePortfolioReports(communitySlug: string, status?: string) {
   });
 }
 
-export function usePortfolioReport(communitySlug: string, reportId: string) {
+export function usePortfolioReport(
+  communitySlug: string,
+  reportId: string,
+  options?: { enabled?: boolean }
+) {
+  const enabled = options?.enabled ?? true;
   return useQuery({
     queryKey: QUERY_KEYS.report(communitySlug, reportId),
     queryFn: () => portfolioService.getReport(communitySlug, reportId),
-    enabled: Boolean(communitySlug && reportId),
+    enabled: Boolean(communitySlug && reportId) && enabled,
   });
 }
 

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -96,6 +96,8 @@ export const PAGES = {
     PROGRAM_SCORES: (community: string) => `/community/${community}/manage/program-scores`,
     SEND_EMAIL: (community: string) => `/community/${community}/manage/send-email`,
     PORTFOLIO_REPORTS: (community: string) => `/community/${community}/manage/portfolio-reports`,
+    PORTFOLIO_REPORTS_PREVIEW: (community: string, reportId: string) =>
+      `/community/${community}/manage/portfolio-reports/${reportId}/preview`,
     PORTFOLIO_REPORTS_CONFIG: (community: string) =>
       `/community/${community}/manage/portfolio-reports/config`,
     PROJECT_MILESTONES: (community: string, projectId: string, programId: string) =>


### PR DESCRIPTION
## Summary
- add a Preview action for draft portfolio reports in the admin report list
- add an admin-only preview route that renders the same document layout as the public report page
- extract the shared report document view and add targeted unit coverage for preview behavior

## Test Plan
- `pnpm exec biome check components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx utilities/pages.ts app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/page.tsx __tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx __tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx`
- `pnpm exec vitest run --project unit __tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx __tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx`
- `pnpm run test` *(still fails in this environment due the repo's broader pre-existing Vitest worker crash / EPIPE issue outside this change)*

Related to DEV-163.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview functionality for draft portfolio reports in the admin interface.
  * Preview button now displays for draft reports, allowing admins to review content before publishing.

* **Tests**
  * Added test coverage for portfolio report list and preview pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->