### PR TITLE
feat(reviewer): add slack field and allow editing reviewer contact info

### DIFF
--- a/__tests__/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.test.tsx
@@ -532,6 +532,7 @@ describe("ReviewerManagementTab", () => {
         name: "Alice",
         email: "alice@example.com",
         telegram: "alice",
+        slack: "",
       });
     });
 

--- a/__tests__/components/Generic/RoleManagement/RoleManagementTab.test.tsx
+++ b/__tests__/components/Generic/RoleManagement/RoleManagementTab.test.tsx
@@ -254,7 +254,7 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      expect(screen.getByLabelText("Edit roles for Alice")).toBeInTheDocument();
+      expect(screen.getByLabelText("Edit Alice")).toBeInTheDocument();
     });
 
     it("does not render edit button when onEditRoles is not provided", () => {
@@ -278,7 +278,7 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      expect(screen.queryByLabelText("Edit roles for Alice")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Edit Alice")).not.toBeInTheDocument();
     });
 
     it("shows inline edit form when edit button is clicked", async () => {
@@ -304,10 +304,10 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      await user.click(screen.getByLabelText("Edit roles for Alice"));
+      await user.click(screen.getByLabelText("Edit Alice"));
 
       // Edit form shows checkboxes for roles
-      expect(screen.getByLabelText("Save role changes")).toBeInTheDocument();
+      expect(screen.getByLabelText("Save changes")).toBeInTheDocument();
       expect(screen.getByLabelText("Cancel editing")).toBeInTheDocument();
     });
 
@@ -336,14 +336,14 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      await user.click(screen.getByLabelText("Edit roles for Alice"));
+      await user.click(screen.getByLabelText("Edit Alice"));
 
       // The program checkbox should be checked, milestone unchecked
       // Check the milestone checkbox
       const uncheckedCheckbox = screen.getByRole("checkbox", { checked: false });
       await user.click(uncheckedCheckbox);
 
-      await user.click(screen.getByLabelText("Save role changes"));
+      await user.click(screen.getByLabelText("Save changes"));
 
       expect(onEditRoles).toHaveBeenCalledWith("alice@example.com", ["program", "milestone"]);
     });
@@ -371,11 +371,11 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      await user.click(screen.getByLabelText("Edit roles for Alice"));
-      expect(screen.getByLabelText("Save role changes")).toBeInTheDocument();
+      await user.click(screen.getByLabelText("Edit Alice"));
+      expect(screen.getByLabelText("Save changes")).toBeInTheDocument();
 
       await user.click(screen.getByLabelText("Cancel editing"));
-      expect(screen.queryByLabelText("Save role changes")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Save changes")).not.toBeInTheDocument();
     });
 
     it("uses DeleteDialog instead of confirm() when removing with zero roles", async () => {
@@ -403,14 +403,14 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      await user.click(screen.getByLabelText("Edit roles for Alice"));
+      await user.click(screen.getByLabelText("Edit Alice"));
 
       // Uncheck the only checked role
       const checkedCheckbox = screen.getByRole("checkbox", { checked: true });
       await user.click(checkedCheckbox);
 
       // Click save - should show DeleteDialog, not browser confirm()
-      await user.click(screen.getByLabelText("Save role changes"));
+      await user.click(screen.getByLabelText("Save changes"));
 
       expect(screen.getByTestId("delete-dialog")).toBeInTheDocument();
     });
@@ -438,12 +438,12 @@ describe("RoleManagementTab", () => {
         />
       );
 
-      await user.click(screen.getByLabelText("Edit roles for Alice"));
+      await user.click(screen.getByLabelText("Edit Alice"));
 
       // Role badges should be hidden during edit
       expect(screen.queryByText("App")).not.toBeInTheDocument();
       // Edit/remove buttons should be hidden during edit
-      expect(screen.queryByLabelText("Edit roles for Alice")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Edit Alice")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Remove Alice")).not.toBeInTheDocument();
     });
   });

--- a/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
+++ b/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
@@ -13,6 +13,7 @@ export interface ReviewerBase {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   assignedAt: string;
   assignedBy?: string;
 }

--- a/components/FundingPlatform/ApplicationView/InviteReviewerModal.tsx
+++ b/components/FundingPlatform/ApplicationView/InviteReviewerModal.tsx
@@ -16,12 +16,14 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
+import { slackHandleSchema } from "@/utilities/validation/slack-handle";
 import { telegramUsernameSchema } from "@/utilities/validation/telegram-username";
 
 const inviteSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   email: z.string().email("Invalid email address"),
   telegram: telegramUsernameSchema.optional(),
+  slack: slackHandleSchema.optional(),
 });
 
 type InviteFormData = z.infer<typeof inviteSchema>;
@@ -52,6 +54,7 @@ const InviteReviewerModal: FC<InviteReviewerModalProps> = ({
       name: "",
       email: "",
       telegram: "",
+      slack: "",
     },
   });
 
@@ -157,6 +160,26 @@ const InviteReviewerModal: FC<InviteReviewerModalProps> = ({
             {errors.telegram && (
               <p className="mt-1 text-xs text-red-500">{errors.telegram.message}</p>
             )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="reviewer-slack"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Slack (optional)
+            </label>
+            <Input
+              id="reviewer-slack"
+              {...register("slack")}
+              placeholder="username"
+              aria-describedby="reviewer-slack-helper"
+              disabled={isAdding}
+            />
+            <p id="reviewer-slack-helper" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Reviewer&apos;s Slack handle (without @). Used to tag them in team channels.
+            </p>
+            {errors.slack && <p className="mt-1 text-xs text-red-500">{errors.slack.message}</p>}
           </div>
 
           <DialogFooter>

--- a/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
@@ -16,7 +16,7 @@ import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { Permission } from "@/src/core/rbac/types/permission";
-import { validateEmail, validateTelegram } from "@/utilities/validators";
+import { validateEmail, validateSlack, validateTelegram } from "@/utilities/validators";
 import { PAGE_HEADER_CONTENT, PageHeader } from "../PageHeader";
 
 interface ReviewerManagementTabProps {
@@ -42,6 +42,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
     refetch: refetchProgramReviewers,
     addReviewer: addProgramReviewer,
     removeReviewer: removeProgramReviewer,
+    updateReviewerContact: updateProgramReviewerContact,
   } = useProgramReviewers(programId);
 
   const {
@@ -50,6 +51,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
     refetch: refetchMilestoneReviewers,
     addReviewer: addMilestoneReviewer,
     removeReviewer: removeMilestoneReviewer,
+    updateReviewerContact: updateMilestoneReviewerContact,
   } = useMilestoneReviewers(programId);
 
   const commonFields: RoleManagementConfig["fields"] = useMemo(
@@ -90,9 +92,24 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
         type: "text" as const,
         placeholder: "@username",
         required: false,
+        editable: true,
         validation: (value: string) => {
           if (value && !validateTelegram(value)) {
             return "Please enter a valid Telegram username (5-32 characters)";
+          }
+          return true;
+        },
+      },
+      {
+        name: "slack",
+        label: "Slack",
+        type: "text" as const,
+        placeholder: "@username",
+        required: false,
+        editable: true,
+        validation: (value: string) => {
+          if (value && !validateSlack(value)) {
+            return "Please enter a valid Slack handle (2-80 characters)";
           }
           return true;
         },
@@ -159,6 +176,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           name: reviewer.name,
           email: reviewer.email.trim(),
           telegram: reviewer.telegram || "",
+          slack: reviewer.slack || "",
           assignedAt: reviewer.assignedAt,
           roles: ["program"],
         });
@@ -174,6 +192,12 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
         if (!existingRoles.includes("milestone")) {
           existing.roles = [...existingRoles, "milestone"];
         }
+        if (!existing.slack && reviewer.slack) {
+          existing.slack = reviewer.slack;
+        }
+        if (!existing.telegram && reviewer.telegram) {
+          existing.telegram = reviewer.telegram;
+        }
       } else {
         emailToMember.set(key, {
           id: key,
@@ -181,6 +205,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           name: reviewer.name,
           email: reviewer.email.trim(),
           telegram: reviewer.telegram || "",
+          slack: reviewer.slack || "",
           assignedAt: reviewer.assignedAt,
           roles: ["milestone"],
         });
@@ -260,6 +285,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
         name: member.name,
         email: member.email,
         telegram: member.telegram || "",
+        slack: member.slack || "",
       };
 
       for (const role of rolesToAdd) {
@@ -286,6 +312,38 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
       removeProgramReviewer,
       removeMilestoneReviewer,
     ]
+  );
+
+  const handleEditContact = useCallback(
+    async (memberId: string, patch: Record<string, string>) => {
+      const member = members.find((m) => m.id === memberId);
+      if (!member || !member.email) {
+        toast.error("Reviewer not found. Please refresh and try again.");
+        return;
+      }
+
+      const contactPayload = {
+        email: member.email,
+        ...(patch.telegram !== undefined && { telegram: patch.telegram }),
+        ...(patch.slack !== undefined && { slack: patch.slack }),
+      };
+
+      const roles = member.roles || [];
+      const promises: Promise<unknown>[] = [];
+      if (roles.includes("program")) {
+        promises.push(updateProgramReviewerContact(contactPayload));
+      }
+      if (roles.includes("milestone")) {
+        promises.push(updateMilestoneReviewerContact(contactPayload));
+      }
+
+      const results = await Promise.allSettled(promises);
+      const firstFailure = results.find((r) => r.status === "rejected");
+      if (firstFailure && firstFailure.status === "rejected") {
+        throw firstFailure.reason;
+      }
+    },
+    [members, updateProgramReviewerContact, updateMilestoneReviewerContact]
   );
 
   const handleRefresh = useCallback(async () => {
@@ -342,6 +400,7 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           selectedRoles={selectedRoles}
           onRolesChange={(roles) => setSelectedRoles(roles as ReviewerRole[])}
           onEditRoles={!readOnly ? handleEditRoles : undefined}
+          onEditContact={!readOnly ? handleEditContact : undefined}
         />
       </div>
     </div>

--- a/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
@@ -16,7 +16,13 @@ import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { Permission } from "@/src/core/rbac/types/permission";
-import { validateEmail, validateSlack, validateTelegram } from "@/utilities/validators";
+import {
+  sanitizeSlack,
+  sanitizeTelegram,
+  validateEmail,
+  validateSlack,
+  validateTelegram,
+} from "@/utilities/validators";
 import { PAGE_HEADER_CONTENT, PageHeader } from "../PageHeader";
 
 interface ReviewerManagementTabProps {
@@ -90,7 +96,8 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
         name: "telegram",
         label: "Telegram",
         type: "text" as const,
-        placeholder: "@username",
+        placeholder: "username",
+        helperText: "Telegram handle (without @). Used for group notifications.",
         required: false,
         editable: true,
         validation: (value: string) => {
@@ -104,7 +111,8 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
         name: "slack",
         label: "Slack",
         type: "text" as const,
-        placeholder: "@username",
+        placeholder: "username",
+        helperText: "Slack handle (without @). Used to tag in team channels.",
         required: false,
         editable: true,
         validation: (value: string) => {
@@ -324,8 +332,10 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
 
       const contactPayload = {
         email: member.email,
-        ...(patch.telegram !== undefined && { telegram: patch.telegram }),
-        ...(patch.slack !== undefined && { slack: patch.slack }),
+        ...(patch.telegram !== undefined && {
+          telegram: sanitizeTelegram(patch.telegram),
+        }),
+        ...(patch.slack !== undefined && { slack: sanitizeSlack(patch.slack) }),
       };
 
       const roles = member.roles || [];

--- a/components/Generic/RoleManagement/RoleManagementTab.tsx
+++ b/components/Generic/RoleManagement/RoleManagementTab.tsx
@@ -19,7 +19,13 @@ import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { getMemberRoles, getRoleShortLabel } from "./helpers";
-import type { RoleFieldConfig, RoleManagementConfig, RoleMember, RoleOption } from "./types";
+import type {
+  ReviewerRole,
+  RoleFieldConfig,
+  RoleManagementConfig,
+  RoleMember,
+  RoleOption,
+} from "./types";
 
 interface RoleManagementTabProps {
   config: RoleManagementConfig;
@@ -35,6 +41,8 @@ interface RoleManagementTabProps {
   onRolesChange?: (roles: string[]) => void;
   // Edit roles support
   onEditRoles?: (memberId: string, roles: string[]) => Promise<void>;
+  // Edit contact fields (telegram/slack) for existing members
+  onEditContact?: (memberId: string, patch: Record<string, string>) => Promise<void>;
   // Legacy single-role support (backward compatibility)
   selectedRole?: string;
   onRoleChange?: (role: string) => void;
@@ -52,6 +60,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
   selectedRoles,
   onRolesChange,
   onEditRoles,
+  onEditContact,
   selectedRole,
   onRoleChange,
 }) => {
@@ -63,6 +72,8 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
   const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
   const [editingMemberId, setEditingMemberId] = useState<string | null>(null);
   const [editRoles, setEditRoles] = useState<string[]>([]);
+  const [editContactValues, setEditContactValues] = useState<Record<string, string>>({});
+  const [editContactErrors, setEditContactErrors] = useState<Record<string, string>>({});
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [removeDialogMemberId, setRemoveDialogMemberId] = useState<string | null>(null);
   const [showEmptyRolesDialog, setShowEmptyRolesDialog] = useState(false);
@@ -258,39 +269,121 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
     }
   }, [removeDialogMemberId, onRemove, onRefresh]);
 
-  const handleStartEdit = useCallback((memberId: string) => {
-    const member = membersRef.current.find((m) => m.id === memberId);
-    if (member) {
-      setEditingMemberId(memberId);
-      setEditRoles([...getMemberRoles(member)]);
-    }
-  }, []);
+  const editableFields = useMemo(
+    () => activeConfig.fields.filter((f) => f.editable),
+    [activeConfig.fields]
+  );
+
+  const handleStartEdit = useCallback(
+    (memberId: string) => {
+      const member = membersRef.current.find((m) => m.id === memberId);
+      if (member) {
+        setEditingMemberId(memberId);
+        setEditRoles([...getMemberRoles(member)]);
+        const initial: Record<string, string> = {};
+        for (const field of editableFields) {
+          const value = member[field.name];
+          initial[field.name] = typeof value === "string" ? value : "";
+        }
+        setEditContactValues(initial);
+        setEditContactErrors({});
+      }
+    },
+    [editableFields]
+  );
 
   const handleCancelEdit = useCallback(() => {
     setEditingMemberId(null);
     setEditRoles([]);
+    setEditContactValues({});
+    setEditContactErrors({});
   }, []);
 
+  const handleEditContactFieldChange = useCallback((fieldName: string, value: string) => {
+    setEditContactValues((prev) => ({ ...prev, [fieldName]: value }));
+    setEditContactErrors((prev) => {
+      if (prev[fieldName]) {
+        return { ...prev, [fieldName]: "" };
+      }
+      return prev;
+    });
+  }, []);
+
+  const validateEditContact = useCallback((): boolean => {
+    const errors: Record<string, string> = {};
+    let isValid = true;
+
+    for (const field of editableFields) {
+      const error = validateField(field, editContactValues[field.name] || "");
+      if (error) {
+        errors[field.name] = error;
+        isValid = false;
+      }
+    }
+
+    setEditContactErrors(errors);
+    return isValid;
+  }, [editableFields, editContactValues, validateField]);
+
   const handleSaveEdit = useCallback(async () => {
-    if (!editingMemberId || !onEditRoles) return;
+    if (!editingMemberId) return;
 
     if (editRoles.length === 0) {
       setShowEmptyRolesDialog(true);
       return;
     }
 
+    if (!validateEditContact()) {
+      return;
+    }
+
+    const member = membersRef.current.find((m) => m.id === editingMemberId);
+    const contactPatch: Record<string, string> = {};
+    if (member) {
+      for (const field of editableFields) {
+        const newValue = editContactValues[field.name] ?? "";
+        const currentValue =
+          typeof member[field.name] === "string" ? (member[field.name] as string) : "";
+        if (newValue !== currentValue) {
+          contactPatch[field.name] = newValue;
+        }
+      }
+    }
+
+    const hasContactChanges = Object.keys(contactPatch).length > 0;
+    const currentRoles = member ? getMemberRoles(member) : [];
+    const hasRoleChanges =
+      editRoles.length !== currentRoles.length ||
+      !editRoles.every((r) => currentRoles.includes(r as ReviewerRole));
+
     setIsSavingEdit(true);
     try {
-      await onEditRoles(editingMemberId, editRoles);
+      if (hasContactChanges && onEditContact) {
+        await onEditContact(editingMemberId, contactPatch);
+      }
+      if (hasRoleChanges && onEditRoles) {
+        await onEditRoles(editingMemberId, editRoles);
+      }
       setEditingMemberId(null);
       setEditRoles([]);
+      setEditContactValues({});
+      setEditContactErrors({});
       if (onRefresh) {
         await onRefresh();
       }
     } finally {
       setIsSavingEdit(false);
     }
-  }, [editingMemberId, editRoles, onEditRoles, onRefresh]);
+  }, [
+    editingMemberId,
+    editRoles,
+    editableFields,
+    editContactValues,
+    validateEditContact,
+    onEditContact,
+    onEditRoles,
+    onRefresh,
+  ]);
 
   const handleEmptyRolesConfirm = useCallback(async () => {
     if (!editingMemberId || !onEditRoles) return;
@@ -603,7 +696,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                                     onClick={handleSaveEdit}
                                     disabled={isSavingEdit}
                                     className="p-1 rounded text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-50"
-                                    aria-label="Save role changes"
+                                    aria-label="Save changes"
                                   >
                                     {isSavingEdit ? (
                                       <Spinner className="h-4 w-4" />
@@ -623,17 +716,62 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                               </div>
                             )}
 
-                            {/* Email and Telegram */}
-                            {(member.email || member.telegram) && (
-                              <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
+                            {/* Inline edit form for contact fields */}
+                            {isEditing && onEditContact && editableFields.length > 0 && (
+                              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 py-1">
+                                {editableFields.map((field) => (
+                                  <div key={field.name}>
+                                    <label
+                                      htmlFor={`edit-${member.id}-${field.name}`}
+                                      className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+                                    >
+                                      {field.label}
+                                    </label>
+                                    <input
+                                      id={`edit-${member.id}-${field.name}`}
+                                      type="text"
+                                      value={editContactValues[field.name] ?? ""}
+                                      onChange={(e) =>
+                                        handleEditContactFieldChange(field.name, e.target.value)
+                                      }
+                                      placeholder={field.placeholder}
+                                      disabled={isSavingEdit}
+                                      aria-invalid={!!editContactErrors[field.name]}
+                                      className={cn(
+                                        "block w-full rounded-md border-gray-300 dark:border-gray-600",
+                                        "bg-white dark:bg-gray-700",
+                                        "text-gray-900 dark:text-gray-100",
+                                        "shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm",
+                                        "disabled:opacity-50 disabled:cursor-not-allowed",
+                                        editContactErrors[field.name] &&
+                                          "border-red-500 focus:border-red-500 focus:ring-red-500"
+                                      )}
+                                    />
+                                    {editContactErrors[field.name] && (
+                                      <p
+                                        className="mt-1 text-xs text-red-600 dark:text-red-400"
+                                        role="alert"
+                                        aria-live="polite"
+                                      >
+                                        {editContactErrors[field.name]}
+                                      </p>
+                                    )}
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+
+                            {/* Email, Telegram, Slack */}
+                            {!isEditing && (member.email || member.telegram || member.slack) && (
+                              <div className="flex items-center text-sm text-gray-600 dark:text-gray-400 flex-wrap gap-x-2">
                                 {member.email && (
                                   <span className="flex items-center space-x-1">
                                     <EnvelopeIcon className="h-3.5 w-3.5 text-gray-400 dark:text-gray-500" />
                                     <span>{member.email}</span>
                                   </span>
                                 )}
-                                {member.email && member.telegram && (
-                                  <span className="mx-2 text-gray-400 dark:text-gray-500">|</span>
+                                {member.email && (member.telegram || member.slack) && (
+                                  <span className="text-gray-400 dark:text-gray-500">|</span>
                                 )}
                                 {member.telegram && (
                                   <span className="flex items-center space-x-1">
@@ -641,6 +779,20 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                                     <span>
                                       {member.telegram?.[0] === "@" ? "" : "@"}
                                       {member.telegram}
+                                    </span>
+                                  </span>
+                                )}
+                                {member.telegram && member.slack && (
+                                  <span className="text-gray-400 dark:text-gray-500">|</span>
+                                )}
+                                {member.slack && (
+                                  <span className="flex items-center space-x-1">
+                                    <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                                      Slack:
+                                    </span>
+                                    <span>
+                                      {member.slack?.[0] === "@" ? "" : "@"}
+                                      {member.slack}
                                     </span>
                                   </span>
                                 )}
@@ -688,10 +840,10 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                     </div>
                     {canManage && !isEditing && (
                       <div className="flex items-center space-x-1 ml-4">
-                        {onEditRoles && roleOptions && (
+                        {((onEditRoles && roleOptions) || onEditContact) && (
                           <button
                             onClick={() => handleStartEdit(member.id)}
-                            aria-label={`Edit roles for ${member.name || member.id}`}
+                            aria-label={`Edit ${member.name || member.id}`}
                             className={cn(
                               "p-2 rounded-md",
                               "text-gray-400 hover:text-blue-600 dark:text-gray-500 dark:hover:text-blue-400",

--- a/components/Generic/RoleManagement/types.ts
+++ b/components/Generic/RoleManagement/types.ts
@@ -9,6 +9,11 @@ export interface RoleFieldConfig {
   required: boolean;
   helperText?: string;
   validation?: (value: string) => boolean | string;
+  /**
+   * When true, the field is included in the inline edit form for existing
+   * members. Email/name are typically not editable; telegram/slack are.
+   */
+  editable?: boolean;
 }
 
 /**
@@ -37,6 +42,7 @@ export interface RoleMember {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   assignedAt?: string;
   role?: ReviewerRole; // Optional single role field for backward compatibility
   roles?: ReviewerRole[]; // Multiple roles for combined view

--- a/hooks/useMilestoneReviewers.ts
+++ b/hooks/useMilestoneReviewers.ts
@@ -30,6 +30,7 @@ export function useMilestoneReviewers(programId: string) {
         name: data.name,
         email: data.email,
         telegram: data.telegram,
+        slack: data.slack,
       });
 
       if (!validation.valid) {
@@ -65,6 +66,22 @@ export function useMilestoneReviewers(programId: string) {
     },
   });
 
+  // Mutation for updating milestone reviewer contact (telegram/slack) by email
+  const updateContactMutation = useMutation({
+    mutationFn: async (patch: { email: string; telegram?: string; slack?: string }) => {
+      return milestoneReviewersService.updateReviewerContact(programId, patch);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.REVIEWERS.MILESTONE(programId),
+      });
+      toast.success("Milestone reviewer updated successfully");
+    },
+    onError: (error) => {
+      toast.error(getReviewerErrorMessage(error, "Failed to update milestone reviewer"));
+    },
+  });
+
   return useMemo(
     () => ({
       // Query data and state
@@ -81,7 +98,11 @@ export function useMilestoneReviewers(programId: string) {
       // Remove mutation
       removeReviewer: removeMutation.mutateAsync,
       isRemoving: removeMutation.isPending,
+
+      // Update contact mutation
+      updateReviewerContact: updateContactMutation.mutateAsync,
+      isUpdatingContact: updateContactMutation.isPending,
     }),
-    [query, addMutation, removeMutation]
+    [query, addMutation, removeMutation, updateContactMutation]
   );
 }

--- a/hooks/useProgramReviewers.ts
+++ b/hooks/useProgramReviewers.ts
@@ -30,6 +30,7 @@ export function useProgramReviewers(programId: string) {
         name: data.name,
         email: data.email,
         telegram: data.telegram,
+        slack: data.slack,
       });
 
       if (!validation.valid) {
@@ -65,6 +66,22 @@ export function useProgramReviewers(programId: string) {
     },
   });
 
+  // Mutation for updating reviewer contact (telegram/slack) by email
+  const updateContactMutation = useMutation({
+    mutationFn: async (patch: { email: string; telegram?: string; slack?: string }) => {
+      return programReviewersService.updateReviewerContact(programId, patch);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.REVIEWERS.PROGRAM(programId),
+      });
+      toast.success("Program reviewer updated successfully");
+    },
+    onError: (error) => {
+      toast.error(getReviewerErrorMessage(error, "Failed to update program reviewer"));
+    },
+  });
+
   return useMemo(
     () => ({
       // Query data and state
@@ -81,7 +98,11 @@ export function useProgramReviewers(programId: string) {
       // Remove mutation
       removeReviewer: removeMutation.mutateAsync,
       isRemoving: removeMutation.isPending,
+
+      // Update contact mutation
+      updateReviewerContact: updateContactMutation.mutateAsync,
+      isUpdatingContact: updateContactMutation.isPending,
     }),
-    [query, addMutation, removeMutation]
+    [query, addMutation, removeMutation, updateContactMutation]
   );
 }

--- a/services/milestone-reviewers.service.ts
+++ b/services/milestone-reviewers.service.ts
@@ -23,6 +23,7 @@ export interface UserProfile {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -47,6 +48,7 @@ export interface MilestoneReviewer {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   assignedAt: string;
   assignedBy?: string;
 }
@@ -58,6 +60,16 @@ export interface AddMilestoneReviewerRequest {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
+}
+
+/**
+ * Update milestone reviewer contact request (PATCH by email)
+ */
+export interface UpdateMilestoneReviewerContactRequest {
+  email: string;
+  telegram?: string;
+  slack?: string;
 }
 
 /**
@@ -91,6 +103,7 @@ export const milestoneReviewersService = {
       name: reviewer.userProfile?.name || "",
       email: reviewer.userProfile?.email || "",
       telegram: reviewer.userProfile?.telegram || "",
+      slack: reviewer.userProfile?.slack || "",
       assignedAt: reviewer.assignedAt,
       assignedBy: reviewer.assignedBy,
     }));
@@ -117,6 +130,7 @@ export const milestoneReviewersService = {
         name: reviewerData.name,
         email: reviewerData.email,
         telegram: reviewerData.telegram,
+        slack: reviewerData.slack,
         assignedAt: new Date().toISOString(),
         assignedBy: undefined,
       };
@@ -127,6 +141,7 @@ export const milestoneReviewersService = {
       name: reviewer.userProfile?.name || reviewerData.name,
       email: reviewer.userProfile?.email || reviewerData.email,
       telegram: reviewer.userProfile?.telegram || reviewerData.telegram,
+      slack: reviewer.userProfile?.slack || reviewerData.slack,
       assignedAt: reviewer.assignedAt,
       assignedBy: reviewer.assignedBy,
     };
@@ -139,6 +154,16 @@ export const milestoneReviewersService = {
     await apiClient.delete(`/v2/programs/${programId}/milestone-reviewers/by-email`, {
       data: { email },
     });
+  },
+
+  /**
+   * Update milestone reviewer contact fields (telegram/slack) by email
+   */
+  async updateReviewerContact(
+    programId: string,
+    patch: UpdateMilestoneReviewerContactRequest
+  ): Promise<void> {
+    await apiClient.patch(`/v2/programs/${programId}/milestone-reviewers/by-email`, patch);
   },
 
   /**

--- a/services/program-reviewers.service.ts
+++ b/services/program-reviewers.service.ts
@@ -23,6 +23,7 @@ export interface UserProfile {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -47,6 +48,7 @@ export interface ProgramReviewer {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
   assignedAt: string;
   assignedBy?: string;
 }
@@ -58,6 +60,16 @@ export interface AddReviewerRequest {
   name: string;
   email: string;
   telegram?: string;
+  slack?: string;
+}
+
+/**
+ * Update reviewer contact request (PATCH by email)
+ */
+export interface UpdateReviewerContactRequest {
+  email: string;
+  telegram?: string;
+  slack?: string;
 }
 
 /**
@@ -91,6 +103,7 @@ export const programReviewersService = {
       name: reviewer.userProfile?.name || "",
       email: reviewer.userProfile?.email || "",
       telegram: reviewer.userProfile?.telegram || "",
+      slack: reviewer.userProfile?.slack || "",
       assignedAt: reviewer.assignedAt,
       assignedBy: reviewer.assignedBy,
     }));
@@ -115,6 +128,7 @@ export const programReviewersService = {
         name: reviewerData.name,
         email: reviewerData.email,
         telegram: reviewerData.telegram,
+        slack: reviewerData.slack,
         assignedAt: new Date().toISOString(),
         assignedBy: undefined,
       };
@@ -125,6 +139,7 @@ export const programReviewersService = {
       name: reviewer.userProfile?.name || reviewerData.name,
       email: reviewer.userProfile?.email || reviewerData.email,
       telegram: reviewer.userProfile?.telegram || reviewerData.telegram,
+      slack: reviewer.userProfile?.slack || reviewerData.slack,
       assignedAt: reviewer.assignedAt,
       assignedBy: reviewer.assignedBy,
     };
@@ -137,6 +152,16 @@ export const programReviewersService = {
     await apiClient.delete(`/v2/funding-program-configs/${programId}/reviewers/by-email`, {
       data: { email },
     });
+  },
+
+  /**
+   * Update reviewer contact fields (telegram/slack) by email
+   */
+  async updateReviewerContact(
+    programId: string,
+    patch: UpdateReviewerContactRequest
+  ): Promise<void> {
+    await apiClient.patch(`/v2/funding-program-configs/${programId}/reviewers/by-email`, patch);
   },
 
   /**

--- a/utilities/__tests__/validators.test.ts
+++ b/utilities/__tests__/validators.test.ts
@@ -7,6 +7,7 @@ import {
   validateProgramIdentifier,
   validateProgramIdentifiers,
   validateReviewerData,
+  validateSlack,
   validateTelegram,
   validateWalletAddress,
 } from "../validators";
@@ -100,6 +101,36 @@ describe("validators", () => {
     it("should validate exactly 5 characters (minimum)", () => {
       expect(validateTelegram("abcde")).toBe(true);
       expect(validateTelegram("@abcde")).toBe(true); // @ + 5 chars = 6 total (5 alphanumeric minimum)
+    });
+  });
+
+  describe("validateSlack", () => {
+    it("should validate correct Slack handles", () => {
+      expect(validateSlack("alice")).toBe(true);
+      expect(validateSlack("@alice")).toBe(true);
+      expect(validateSlack("alice.cooper")).toBe(true);
+      expect(validateSlack("alice_cooper")).toBe(true);
+      expect(validateSlack("alice-cooper")).toBe(true);
+      expect(validateSlack("a1")).toBe(true); // minimum length
+      expect(validateSlack("a".repeat(80))).toBe(true); // maximum length
+    });
+
+    it("should reject invalid Slack handles", () => {
+      expect(validateSlack("a")).toBe(false); // too short
+      expect(validateSlack("a".repeat(81))).toBe(false); // too long
+      expect(validateSlack("alice cooper")).toBe(false); // space
+      expect(validateSlack("alice/cooper")).toBe(false); // invalid char
+    });
+
+    it("should handle edge cases", () => {
+      expect(validateSlack("")).toBe(false);
+      expect(validateSlack(null as any)).toBe(false);
+      expect(validateSlack(undefined as any)).toBe(false);
+    });
+
+    it("should trim whitespace before validation", () => {
+      expect(validateSlack("  alice  ")).toBe(true);
+      expect(validateSlack("  @alice  ")).toBe(true);
     });
   });
 
@@ -384,6 +415,26 @@ describe("validators", () => {
       });
       expect(result.valid).toBe(false);
       expect(result.errors.some((e) => e.includes("Telegram"))).toBe(true);
+    });
+
+    it("should reject invalid slack handle", () => {
+      const result = validateReviewerData({
+        name: "John Doe",
+        email: "john@example.com",
+        slack: "a",
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("Slack"))).toBe(true);
+    });
+
+    it("should accept valid slack handle and return sanitized value", () => {
+      const result = validateReviewerData({
+        name: "John Doe",
+        email: "john@example.com",
+        slack: "@john.doe",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.sanitized.slack).toBe("john.doe");
     });
 
     it("should accept name with whitespace trimmed to valid length", () => {

--- a/utilities/validation/slack-handle.ts
+++ b/utilities/validation/slack-handle.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+/**
+ * Slack handle constraints (flexible, practical subset):
+ * - 2–80 characters total
+ * - Letters, digits, dots, underscores, and hyphens
+ *
+ * A leading "@" is allowed on input but should be stripped by the caller
+ * before storage.
+ */
+export const SLACK_HANDLE_REGEX = /^@?[a-zA-Z0-9._-]{2,80}$/;
+
+export const SLACK_HANDLE_ERROR =
+  "Use 2-80 letters, digits, '.', '_' or '-', with an optional leading @";
+
+/**
+ * Reusable Zod schema for an optional Slack handle field. Accepts either a
+ * valid handle or an empty string (to allow clearing the field).
+ */
+export const slackHandleSchema = z
+  .string()
+  .regex(SLACK_HANDLE_REGEX, SLACK_HANDLE_ERROR)
+  .or(z.literal(""));
+
+export const validateSlackHandle = (value: string): boolean => {
+  if (value === "") return true;
+  return SLACK_HANDLE_REGEX.test(value);
+};

--- a/utilities/validators.ts
+++ b/utilities/validators.ts
@@ -57,6 +57,29 @@ export function sanitizeTelegram(telegram: string): string {
 }
 
 /**
+ * Validates a Slack handle format
+ * Accepts 2-80 characters of letters, digits, dot, underscore, or dash.
+ * Optional leading @.
+ */
+export function validateSlack(slack: string): boolean {
+  if (!slack || typeof slack !== "string") {
+    return false;
+  }
+  const slackRegex = /^@?[a-zA-Z0-9._-]{2,80}$/;
+  return slackRegex.test(slack.trim());
+}
+
+/**
+ * Strips leading @ from a Slack handle and trims whitespace
+ */
+export function sanitizeSlack(slack: string): string {
+  if (!slack || typeof slack !== "string") {
+    return "";
+  }
+  return slack.trim().replace(/^@/, "");
+}
+
+/**
  * Validates a program ID format (alphanumeric with optional dashes/underscores)
  * @param programId - The program ID to validate
  * @returns true if valid, false otherwise
@@ -267,16 +290,23 @@ export function sanitizeString(input: string): string {
  * @param data - Reviewer data to validate
  * @returns Object with validation result and errors
  */
-export function validateReviewerData(data: { name: string; email: string; telegram?: string }): {
+export function validateReviewerData(data: {
+  name: string;
+  email: string;
+  telegram?: string;
+  slack?: string;
+}): {
   valid: boolean;
   errors: string[];
-  sanitized: { name: string; email: string; telegram?: string };
+  sanitized: { name: string; email: string; telegram?: string; slack?: string };
 } {
   const errors: string[] = [];
   const sanitizedName = sanitizeString(data.name);
   const sanitizedEmail = data.email?.trim().toLowerCase() || "";
   const sanitizedTelegram = data.telegram ? sanitizeTelegram(data.telegram) : undefined;
   const hasTelegramInput = Boolean(data.telegram?.trim());
+  const sanitizedSlack = data.slack ? sanitizeSlack(data.slack) : undefined;
+  const hasSlackInput = Boolean(data.slack?.trim());
 
   if (!sanitizedName) {
     errors.push("Name is required");
@@ -296,10 +326,22 @@ export function validateReviewerData(data: { name: string; email: string; telegr
     errors.push("Invalid Telegram handle format (5-32 alphanumeric characters, optional @ prefix)");
   }
 
-  const sanitized: { name: string; email: string; telegram?: string } = {
+  if (hasSlackInput && (!sanitizedSlack || !validateSlack(sanitizedSlack))) {
+    errors.push(
+      "Invalid Slack handle format (2-80 characters of letters, digits, '.', '_' or '-', optional @ prefix)"
+    );
+  }
+
+  const sanitized: {
+    name: string;
+    email: string;
+    telegram?: string;
+    slack?: string;
+  } = {
     name: sanitizedName,
     email: sanitizedEmail,
     telegram: sanitizedTelegram || undefined,
+    slack: sanitizedSlack || undefined,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Adds an optional **Slack handle** field to reviewer creation: the Add Reviewer form (`ReviewerManagementTab`) and the Invite Milestone Reviewer modal
- Extends the inline "edit member" affordance in the shared `RoleManagementTab` so admins can now update **Telegram AND Slack** for an existing reviewer, not just their roles
- New `updateReviewerContact` mutation on `useProgramReviewers` / `useMilestoneReviewers`, wired to the new backend PATCH `/reviewers/by-email` endpoints with toast feedback and React Query invalidation
- Adds `validateSlack` / `sanitizeSlack` and a reusable `slackHandleSchema` mirroring the existing Telegram validators
- Renders the Slack handle next to Telegram in the reviewer list when set

## UX

- **Add Reviewer form**: now shows Email / Name / Telegram / Slack — Slack is optional with `@username` placeholder and client-side validation
- **Edit mode** (pencil icon on a reviewer row): role checkboxes + Telegram input pre-populated with the current value + Slack input (empty placeholder when unset). Save commits both contact and role changes in one user action
- **Clearing**: empty string clears the stored value

## Design decisions (carried from planning)

- **Single user profile**: Telegram/Slack live on the shared `user_profiles` document. Editing a reviewer's handle in program A updates it everywhere — matches the existing telegram-on-add behavior and is the intended design
- **Handle format** (must match backend whitelist): slack = `^@?[a-zA-Z0-9._-]{2,80}$`, telegram unchanged at 5–32 alphanumerics + underscore

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run utilities/__tests__/validators.test.ts __tests__/components/Generic/RoleManagement __tests__/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.test.tsx` — 96 tests green
- [x] Biome clean on all changed files (only pre-existing `useButtonType` warnings remain, unrelated)
- [x] Browser smoke via Claude-in-Chrome against localhost:3000 with a community-admin session:
  - [x] Reviewer management tab loads, Slack field visible in Add Reviewer form
  - [x] Edit mode renders Telegram (pre-populated) + Slack (empty placeholder)
  - [x] Zero JS console errors
  - [x] PATCH mutation success → toast + invalidated list refreshes
- [x] Requires paired backend PR with new PATCH endpoints

## Paired backend PR

https://github.com/show-karma/gap-indexer/pull/1395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reviewers can include Slack handles when added, displayed, or edited alongside email and Telegram.
  * Inline contact editing added to role management (edit/save contact fields; Slack included); contact updates persist via reviewer update endpoints.
  * Field-level config now supports marking contact fields as editable.

* **Tests**
  * Updated tests for new Slack validation and reviewer flows.
  * UI tests adjusted to new button/label wording and save behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->