### PR TITLE
fix(layout): mount user dialogs on whitelabel domains

### DIFF
--- a/__tests__/components/DeferredLayoutComponents.test.tsx
+++ b/__tests__/components/DeferredLayoutComponents.test.tsx
@@ -1,64 +1,123 @@
-import { render } from "@testing-library/react";
+/**
+ * Behavioral integration test for the deferred layout component mounts.
+ *
+ * Bug context (regression): on whitelabel domains (e.g. app.filpgf.io), the
+ * navbar's "Edit profile" / "API Keys" / "Walkthrough" buttons trigger Zustand
+ * store actions to open dialogs, but if the corresponding dialog component is
+ * never rendered, the click is a no-op and nothing appears on screen.
+ *
+ * Earlier tests counted dynamic imports — that only enforced the existing
+ * (buggy) wiring. This test instead does the real thing: render the layout,
+ * fire the same store action the navbar fires, and verify the dialog appears.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
 import "@testing-library/jest-dom";
 
-vi.mock("next/dynamic", () => {
-  const dynamicImports: Array<{ ssr: boolean }> = [];
-  const mockDynamic = (importFn: () => Promise<any>, options?: { ssr?: boolean }) => {
-    dynamicImports.push({ ssr: options?.ssr ?? true });
-    const DynamicComponent = (props: any) => <div data-testid="dynamic-component" {...props} />;
-    return DynamicComponent;
+// Make next/dynamic resolve as quickly as possible. The lazy loader runs once
+// per dynamic() call; the component instance subscribes via useSyncExternalStore
+// so the first React render after the loader resolves picks up the resolved
+// component without needing a parent re-render.
+vi.mock("next/dynamic", async () => {
+  const React = await import("react");
+  return {
+    default: (loader: () => Promise<any>) => {
+      const listeners = new Set<() => void>();
+      let Component: any = null;
+      loader().then((mod: any) => {
+        Component = mod?.default ?? mod;
+        for (const l of listeners) l();
+      });
+      const subscribe = (l: () => void) => {
+        listeners.add(l);
+        return () => listeners.delete(l);
+      };
+      const getSnapshot = () => Component;
+      const DynamicComponent = (props: any) => {
+        const Resolved = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+        if (!Resolved) return null;
+        return React.createElement(Resolved, props);
+      };
+      DynamicComponent.displayName = "DynamicMock";
+      return DynamicComponent;
+    },
   };
-  mockDynamic._imports = dynamicImports;
-  return { default: mockDynamic };
 });
 
-import dynamic from "next/dynamic";
-import { DeferredLayoutComponents } from "@/components/DeferredLayoutComponents";
+// Stub the heavy dialog component with a thin component that subscribes to
+// the REAL Zustand store. This keeps the test fast and isolated from the
+// dialog's wagmi/react-hook-form/headlessui dependencies, while still proving
+// the store -> mounted-component wire is intact.
+vi.mock("@/components/Dialogs/ContributorProfileDialog", async () => {
+  const { useContributorProfileModalStore } = await vi.importActual<
+    typeof import("@/store/modals/contributorProfile")
+  >("@/store/modals/contributorProfile");
+  return {
+    ContributorProfileDialog: () => {
+      const isOpen = useContributorProfileModalStore((s) => s.isModalOpen);
+      return isOpen ? <div data-testid="contributor-profile-dialog">Profile</div> : null;
+    },
+  };
+});
 
-const defaultToasterConfig = {
+vi.mock("@/components/Dialogs/OnboardingDialog", () => ({
+  OnboardingDialog: () => <div data-testid="onboarding-dialog-mount" hidden />,
+}));
+
+vi.mock("@/src/features/api-keys/components/api-key-management-modal", () => ({
+  ApiKeyManagementModal: () => <div data-testid="api-key-modal-mount" hidden />,
+}));
+
+// The other deferred components are not under test here. Stub them to no-op
+// so the test environment doesn't try to load analytics/toast/etc.
+vi.mock("react-hot-toast", () => ({ Toaster: () => null }));
+vi.mock("@vercel/analytics/react", () => ({ Analytics: () => null }));
+vi.mock("@vercel/speed-insights/next", () => ({ SpeedInsights: () => null }));
+vi.mock("@/components/AgentChat/AgentChatBubble", () => ({ AgentChatBubble: () => null }));
+vi.mock("@/components/ProgressBarWrapper", () => ({ ProgressBarWrapper: () => null }));
+vi.mock("@/components/Utilities/HotjarAnalytics", () => ({ default: () => null }));
+
+import { DeferredLayoutComponents } from "@/components/DeferredLayoutComponents";
+import { useContributorProfileModalStore } from "@/store/modals/contributorProfile";
+
+const toasterConfig = {
   position: "top-right" as const,
   toastOptions: {},
   containerStyle: {},
 };
 
 describe("DeferredLayoutComponents", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe("rendering", () => {
-    it("renders without errors", () => {
-      const { container } = render(
-        <DeferredLayoutComponents isWhitelabel={false} toasterConfig={defaultToasterConfig} />
-      );
-      expect(container).toBeTruthy();
-    });
-
-    it("renders all 9 components when isWhitelabel is false", () => {
-      const { container } = render(
-        <DeferredLayoutComponents isWhitelabel={false} toasterConfig={defaultToasterConfig} />
-      );
-      const dynamicComponents = container.querySelectorAll('[data-testid="dynamic-component"]');
-      expect(dynamicComponents.length).toBe(9);
-    });
-
-    it("renders chatbot plus always-on components when isWhitelabel is true", () => {
-      const { container } = render(
-        <DeferredLayoutComponents isWhitelabel={true} toasterConfig={defaultToasterConfig} />
-      );
-      const dynamicComponents = container.querySelectorAll('[data-testid="dynamic-component"]');
-      // 5 always-on + 1 chatbot = 6
-      expect(dynamicComponents.length).toBe(6);
+  afterEach(() => {
+    act(() => {
+      useContributorProfileModalStore.getState().closeModal();
     });
   });
 
-  describe("dynamic imports", () => {
-    it("uses ssr: false for all 9 deferred components", () => {
-      const imports = (dynamic as any)._imports as Array<{ ssr: boolean }>;
-      expect(imports.length).toBe(9);
-      for (const entry of imports) {
-        expect(entry.ssr).toBe(false);
-      }
+  it("opens the contributor profile dialog when the store action fires", async () => {
+    render(<DeferredLayoutComponents toasterConfig={toasterConfig} />);
+
+    // Wait for next/dynamic to resolve the lazy ContributorProfileDialog mount.
+    await waitFor(() => {
+      expect(screen.queryByTestId("contributor-profile-dialog")).not.toBeInTheDocument();
+    });
+
+    // This is what NavbarUserMenu's "Edit profile" item does.
+    act(() => {
+      useContributorProfileModalStore.getState().openModal({ isGlobal: true });
+    });
+
+    expect(await screen.findByTestId("contributor-profile-dialog")).toBeInTheDocument();
+  });
+
+  it("mounts ContributorProfileDialog, OnboardingDialog, and ApiKeyManagementModal on every domain", async () => {
+    // Regression: at app.filpgf.io (whitelabel) these were unmounted, so the
+    // navbar's trigger buttons did nothing. They must mount unconditionally
+    // because the navbar UI that opens them is shown on all domains.
+    render(<DeferredLayoutComponents toasterConfig={toasterConfig} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("onboarding-dialog-mount")).toBeInTheDocument();
+      expect(screen.getByTestId("api-key-modal-mount")).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/integration/pages/layout.test.tsx
+++ b/__tests__/integration/pages/layout.test.tsx
@@ -86,9 +86,7 @@ vi.mock("@/components/Seo/OrganizationJsonLd", () => ({
 }));
 
 vi.mock("@/components/DeferredLayoutComponents", () => ({
-  DeferredLayoutComponents: (props: { isWhitelabel: boolean }) => (
-    <div data-testid="deferred-layout-components" data-whitelabel={props.isWhitelabel} />
-  ),
+  DeferredLayoutComponents: () => <div data-testid="deferred-layout-components" />,
 }));
 
 vi.mock("@/utilities/whitelabel-server", () => ({
@@ -113,13 +111,11 @@ describe("RootLayout", () => {
     expect(screen.getByTestId("organization-json-ld")).toBeInTheDocument();
   });
 
-  it("renders DeferredLayoutComponents with correct props", async () => {
+  it("renders DeferredLayoutComponents", async () => {
     const jsx = await RootLayout({ children: <>Test Content</> });
     render(jsx);
 
-    const deferred = screen.getByTestId("deferred-layout-components");
-    expect(deferred).toBeInTheDocument();
-    expect(deferred).toHaveAttribute("data-whitelabel", "false");
+    expect(screen.getByTestId("deferred-layout-components")).toBeInTheDocument();
   });
 
   it("renders children content", async () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -149,7 +149,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <TenantStoreInitializer tenant={tenantConfig}>{null}</TenantStoreInitializer>
               )}
               <PermissionsProvider />
-              <DeferredLayoutComponents isWhitelabel={isWhitelabel} toasterConfig={toasterConfig} />
+              <DeferredLayoutComponents toasterConfig={toasterConfig} />
               <div className="min-h-screen flex flex-col justify-between h-full text-gray-700 bg-white dark:bg-black dark:text-white">
                 <div className="flex flex-col w-full h-full">
                   {isWhitelabel ? (

--- a/components/DeferredLayoutComponents.tsx
+++ b/components/DeferredLayoutComponents.tsx
@@ -49,7 +49,6 @@ const HotjarAnalytics = dynamic(() => import("@/components/Utilities/HotjarAnaly
 });
 
 interface DeferredLayoutComponentsProps {
-  isWhitelabel: boolean;
   toasterConfig: {
     position: "top-right";
     toastOptions: Record<string, unknown>;
@@ -57,10 +56,13 @@ interface DeferredLayoutComponentsProps {
   };
 }
 
-export function DeferredLayoutComponents({
-  isWhitelabel,
-  toasterConfig,
-}: DeferredLayoutComponentsProps) {
+export function DeferredLayoutComponents({ toasterConfig }: DeferredLayoutComponentsProps) {
+  // Every dialog below subscribes to a Zustand store and is opened by
+  // navbar UI that renders on every domain (whitelabel and non-whitelabel).
+  // They MUST be mounted unconditionally — gating the mount on isWhitelabel
+  // is what caused the profile-modal bug at app.filpgf.io (see issue
+  // "fix-profile-on-app-filpgf"). The dialogs are loaded via next/dynamic
+  // with ssr:false, so the chunk cost is paid only when first rendered.
   return (
     <>
       <Toaster {...toasterConfig} />
@@ -68,13 +70,9 @@ export function DeferredLayoutComponents({
       <Analytics />
       <SpeedInsights />
       <HotjarAnalytics />
-      {!isWhitelabel && (
-        <>
-          <ContributorProfileDialog />
-          <ApiKeyManagementModal />
-          <OnboardingDialog />
-        </>
-      )}
+      <ContributorProfileDialog />
+      <ApiKeyManagementModal />
+      <OnboardingDialog />
       <AgentChatBubble />
     </>
   );


### PR DESCRIPTION
## Summary

- The "Edit profile" / "API Keys" buttons in `NavbarUserMenu` did nothing on whitelabel domains (e.g. `app.filpgf.io`). The Zustand store action fired, but the dialog component was never mounted.
- Root cause: `DeferredLayoutComponents` gated `ContributorProfileDialog`, `ApiKeyManagementModal`, and `OnboardingDialog` behind `!isWhitelabel`. The gate is a vestige from when whitelabel had no Privy auth at all (commit 24c5fd4b); auth was later re-added but the gate stayed.
- Fix: mount the dialogs unconditionally. They remain code-split via `next/dynamic`, so the chunk still loads only on first open. Drops the now-unused `isWhitelabel` prop.
- Replaces the existing count-based test (which silently encoded the buggy behavior, expecting only 6 deferred components on whitelabel) with a real behavioral test: render the layout, fire the actual store action the navbar fires, assert the dialog appears in the DOM.

## Why tests didn't catch it

The previous test asserted `dynamicComponents.length === 6` on whitelabel — i.e. it ratified the missing dialog as intended. The navbar integration tests mocked `useContributorProfileModalStore` away entirely, so they verified `openModal` was called but never that the dialog actually appeared.

The new test (`__tests__/components/DeferredLayoutComponents.test.tsx`) uses the real Zustand store and fails when the dialog isn't mounted. Verified by temporarily re-introducing the gate — both new tests fail as expected.

## Test plan

- [x] `pnpm test __tests__/components/DeferredLayoutComponents.test.tsx` — 2 passed
- [x] `pnpm test __tests__/integration/pages/layout.test.tsx` — 4 passed (one assertion updated to drop the removed prop)
- [x] Browser-tested on a local whitelabel domain: started dev server with `WHITELABEL_EXTRA_DOMAINS_JSON` mapping `localhost` → `filecoin` tenant, opened user menu, clicked "Edit profile" — modal opened with the user's wallet address pre-filled.
- [x] Lint passes (`biome check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog and modal components (Contributor Profile, API Key Management, Onboarding) to consistently mount and properly respond to state changes.

* **Tests**
  * Enhanced test coverage to verify actual modal mounting behavior and store state integration rather than component structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->