### PR TITLE
fix: default project milestone filter to completed

### DIFF
--- a/__tests__/components/MilestoneStatusFilter.test.tsx
+++ b/__tests__/components/MilestoneStatusFilter.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { ActivityFilters } from "@/components/Pages/Project/v2/MainContent/ActivityFilters";
-import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
 import type { ActivityFilterType } from "@/types/v2/project-profile.types";
 
 // Mock next/navigation
@@ -30,7 +28,7 @@ describe("MilestoneStatusFilter visibility in ActivityFilters", () => {
     vi.clearAllMocks();
   });
 
-  it("shows milestone status dropdown when no filter is active (All selected)", () => {
+  it("hides milestone status dropdown when no filter is active (All selected)", () => {
     render(
       <ActivityFilters
         {...defaultProps}
@@ -40,7 +38,7 @@ describe("MilestoneStatusFilter visibility in ActivityFilters", () => {
       />
     );
 
-    expect(screen.getByTestId("milestone-status-filter")).toBeInTheDocument();
+    expect(screen.queryByTestId("milestone-status-filter")).not.toBeInTheDocument();
   });
 
   it("shows milestone status dropdown when milestones filter is active", () => {
@@ -101,11 +99,11 @@ describe("MilestoneStatusFilter visibility in ActivityFilters", () => {
     expect(screen.queryByTestId("milestone-status-filter")).not.toBeInTheDocument();
   });
 
-  it("shows 'All statuses' as default placeholder", () => {
+  it("shows 'All statuses' as default placeholder when milestones filter is active", () => {
     render(
       <ActivityFilters
         {...defaultProps}
-        activeFilters={[]}
+        activeFilters={["milestones"]}
         milestoneStatusFilter="all"
         onMilestoneStatusChange={vi.fn()}
       />

--- a/__tests__/components/UpdatesContentMilestoneStatus.test.tsx
+++ b/__tests__/components/UpdatesContentMilestoneStatus.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
 
 // Track URL operations
 const mockReplace = vi.fn();
@@ -45,6 +44,16 @@ vi.mock("@/components/Pages/Project/v2/MainContent/ActivityFilters", () => ({
       <span data-testid="milestone-status-value">{props.milestoneStatusFilter ?? "none"}</span>
       <button
         type="button"
+        data-testid="trigger-milestones-filter"
+        onClick={() => props.onFilterToggle?.("milestones")}
+      />
+      <button
+        type="button"
+        data-testid="trigger-funding-filter"
+        onClick={() => props.onFilterToggle?.("funding")}
+      />
+      <button
+        type="button"
         data-testid="trigger-status-change"
         onClick={() => props.onMilestoneStatusChange?.("completed")}
       />
@@ -80,13 +89,61 @@ describe("UpdatesContent - milestone status filter URL sync", () => {
     expect(screen.getByTestId("milestone-status-value")).toHaveTextContent("completed");
   });
 
-  it("defaults to 'all' when milestoneStatus param is not in URL", async () => {
+  it("defaults to 'all' when milestone filters are not active", async () => {
     mockSearchParams = new URLSearchParams();
 
     const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
     render(<UpdatesContent />);
 
     expect(screen.getByTestId("milestone-status-value")).toHaveTextContent("all");
+  });
+
+  it("keeps 'all' when milestones are active without an explicit status in the URL", async () => {
+    mockSearchParams = new URLSearchParams("filter=milestones");
+
+    const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
+    render(<UpdatesContent />);
+
+    expect(screen.getByTestId("milestone-status-value")).toHaveTextContent("all");
+  });
+
+  it("adds completed milestoneStatus when milestones filter is enabled from the default view", async () => {
+    mockSearchParams = new URLSearchParams();
+
+    const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
+    render(<UpdatesContent />);
+
+    await userEvent.click(screen.getByTestId("trigger-milestones-filter"));
+
+    expect(mockReplace).toHaveBeenCalledWith("?filter=milestones&milestoneStatus=completed", {
+      scroll: false,
+    });
+  });
+
+  it("writes an explicit all-status choice when users switch milestones back to all statuses", async () => {
+    mockSearchParams = new URLSearchParams("filter=milestones&milestoneStatus=completed");
+
+    const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
+    render(<UpdatesContent />);
+
+    await userEvent.click(screen.getByTestId("trigger-status-all"));
+
+    expect(mockReplace).toHaveBeenCalledWith("?filter=milestones&milestoneStatus=all", {
+      scroll: false,
+    });
+  });
+
+  it("preserves an explicit all-status choice when other filters change", async () => {
+    mockSearchParams = new URLSearchParams("filter=milestones&milestoneStatus=all");
+
+    const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
+    render(<UpdatesContent />);
+
+    await userEvent.click(screen.getByTestId("trigger-funding-filter"));
+
+    expect(mockReplace).toHaveBeenCalledWith("?filter=milestones%2Cfunding&milestoneStatus=all", {
+      scroll: false,
+    });
   });
 
   it("passes milestoneStatusFilter to ActivityFilters dropdown", async () => {
@@ -99,7 +156,7 @@ describe("UpdatesContent - milestone status filter URL sync", () => {
     expect(screen.getByTestId("milestone-status-value")).toHaveTextContent("verified");
   });
 
-  it("uses pathname from usePathname when clearing all params", async () => {
+  it("writes an explicit all-status param when selecting all statuses from the default view", async () => {
     mockSearchParams = new URLSearchParams();
 
     const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
@@ -108,8 +165,6 @@ describe("UpdatesContent - milestone status filter URL sync", () => {
     const button = screen.getByTestId("trigger-status-all");
     await userEvent.click(button);
 
-    // The router.replace call should use the pathname from usePathname ("/project/test-project"),
-    // not window.location.pathname which returns "/" in jsdom
-    expect(mockReplace).toHaveBeenCalledWith("/project/test-project", { scroll: false });
+    expect(mockReplace).toHaveBeenCalledWith("?milestoneStatus=all", { scroll: false });
   });
 });

--- a/__tests__/services/milestone-status-filter.test.ts
+++ b/__tests__/services/milestone-status-filter.test.ts
@@ -1,6 +1,7 @@
 import {
   filterByMilestoneStatus,
   getMilestoneStatus,
+  isMilestoneStatusFilter,
   MILESTONE_STATUS_OPTIONS,
   type MilestoneStatusFilter,
 } from "@/services/milestone-status-filter.service";
@@ -258,6 +259,19 @@ describe("filterByMilestoneStatus", () => {
     expect(result).toHaveLength(1);
     expect(result[0].uid).toBe("pending-1");
   });
+});
+
+describe("isMilestoneStatusFilter", () => {
+  it.each(["all", "pending", "completed", "verified"])("returns true for %s", (value) => {
+    expect(isMilestoneStatusFilter(value)).toBe(true);
+  });
+
+  it.each([null, "", "ALL", "done", "unknown", "Pending"])(
+    "returns false for invalid value %s",
+    (value) => {
+      expect(isMilestoneStatusFilter(value as string | null)).toBe(false);
+    }
+  );
 });
 
 describe("MILESTONE_STATUS_OPTIONS", () => {

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -3,7 +3,10 @@
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo } from "react";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
-import type { MilestoneStatusFilter } from "@/services/milestone-status-filter.service";
+import {
+  isMilestoneStatusFilter,
+  type MilestoneStatusFilter,
+} from "@/services/milestone-status-filter.service";
 import { getActivityFilterType } from "@/services/project-profile.service";
 import { useOwnerStore, useProjectStore } from "@/store";
 import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
@@ -45,17 +48,9 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
   }, [searchParams]);
 
   // Read milestone status filter from URL
-  const milestoneStatusFilter = useMemo(() => {
+  const milestoneStatusFilter = useMemo<MilestoneStatusFilter>(() => {
     const statusParam = searchParams.get("milestoneStatus");
-    if (
-      statusParam === "all" ||
-      statusParam === "pending" ||
-      statusParam === "completed" ||
-      statusParam === "verified"
-    ) {
-      return statusParam as MilestoneStatusFilter;
-    }
-    return "all" as MilestoneStatusFilter;
+    return isMilestoneStatusFilter(statusParam) ? statusParam : "all";
   }, [searchParams]);
 
   // Read the 4 new filter params from URL
@@ -116,14 +111,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
 
       // Default milestones to completed when no explicit status is present.
       if (newFilters.includes("milestones")) {
-        const currentStatus = params.get("milestoneStatus");
-        const hasExplicitMilestoneStatus =
-          currentStatus === "all" ||
-          currentStatus === "pending" ||
-          currentStatus === "completed" ||
-          currentStatus === "verified";
-
-        if (!hasExplicitMilestoneStatus) {
+        if (!isMilestoneStatusFilter(params.get("milestoneStatus"))) {
           params.set("milestoneStatus", "completed");
         }
       } else {
@@ -140,11 +128,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
   const handleMilestoneStatusChange = useCallback(
     (status: MilestoneStatusFilter) => {
       const params = new URLSearchParams(searchParams.toString());
-      if (status === "all") {
-        params.set("milestoneStatus", "all");
-      } else {
-        params.set("milestoneStatus", status);
-      }
+      params.set("milestoneStatus", status);
       const newURL = params.toString() ? `?${params.toString()}` : pathname;
       router.replace(newURL, { scroll: false });
     },

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -47,8 +47,13 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
   // Read milestone status filter from URL
   const milestoneStatusFilter = useMemo(() => {
     const statusParam = searchParams.get("milestoneStatus");
-    if (statusParam === "pending" || statusParam === "completed" || statusParam === "verified") {
-      return statusParam;
+    if (
+      statusParam === "all" ||
+      statusParam === "pending" ||
+      statusParam === "completed" ||
+      statusParam === "verified"
+    ) {
+      return statusParam as MilestoneStatusFilter;
     }
     return "all" as MilestoneStatusFilter;
   }, [searchParams]);
@@ -109,8 +114,19 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       }
       params.delete("sort");
 
-      // Clear milestone status when milestones tab is no longer active
-      if (!newFilters.includes("milestones")) {
+      // Default milestones to completed when no explicit status is present.
+      if (newFilters.includes("milestones")) {
+        const currentStatus = params.get("milestoneStatus");
+        const hasExplicitMilestoneStatus =
+          currentStatus === "all" ||
+          currentStatus === "pending" ||
+          currentStatus === "completed" ||
+          currentStatus === "verified";
+
+        if (!hasExplicitMilestoneStatus) {
+          params.set("milestoneStatus", "completed");
+        }
+      } else {
         params.delete("milestoneStatus");
       }
 
@@ -125,7 +141,7 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
     (status: MilestoneStatusFilter) => {
       const params = new URLSearchParams(searchParams.toString());
       if (status === "all") {
-        params.delete("milestoneStatus");
+        params.set("milestoneStatus", "all");
       } else {
         params.set("milestoneStatus", status);
       }

--- a/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
@@ -580,6 +580,10 @@ export function ActivityFilters({
             const isActive = activeFilters.includes(filter.value);
             const count = counts[filter.value];
             const isEmpty = !count;
+            // Keep active pills clickable so users can always toggle them off,
+            // even when the current filter selection produces zero results
+            // (e.g. milestones=completed on a project without completed milestones).
+            const isDisabled = isEmpty && !isActive;
             const config = FILTER_CONFIG[filter.value];
             const Icon = config?.icon;
 
@@ -588,7 +592,7 @@ export function ActivityFilters({
                 key={filter.value}
                 type="button"
                 onClick={() => onFilterToggle(filter.value)}
-                disabled={isEmpty}
+                disabled={isDisabled}
                 data-testid={`filter-${filter.value}`}
                 aria-pressed={isActive}
                 aria-label={`Filter by ${filter.label}`}

--- a/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFilters.tsx
@@ -582,7 +582,7 @@ export function ActivityFilters({
             const isEmpty = !count;
             // Keep active pills clickable so users can always toggle them off,
             // even when the current filter selection produces zero results
-            // (e.g. milestones=completed on a project without completed milestones).
+            // (e.g. `milestones=completed` on a project without completed milestones).
             const isDisabled = isEmpty && !isActive;
             const config = FILTER_CONFIG[filter.value];
             const Icon = config?.icon;

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
@@ -79,10 +79,10 @@ describe("ActivityFilters - Milestone Status Dropdown Visibility", () => {
     onMilestoneStatusChange: vi.fn(),
   };
 
-  it("shows milestone status dropdown when no filters are active (All)", () => {
+  it("hides milestone status dropdown when no filters are active (All)", () => {
     render(<ActivityFilters {...defaultProps} activeFilters={[]} />);
 
-    expect(screen.getByTestId("milestone-status-filter")).toBeInTheDocument();
+    expect(screen.queryByTestId("milestone-status-filter")).not.toBeInTheDocument();
   });
 
   it("shows milestone status dropdown when milestones filter is active", () => {
@@ -144,7 +144,7 @@ describe("ActivityFilters - Milestone Status Dropdown Options", () => {
   it("renders the milestone status trigger with correct value", () => {
     render(
       <ActivityFilters
-        activeFilters={[]}
+        activeFilters={["milestones"]}
         onFilterToggle={vi.fn()}
         counts={{ milestones: 3 }}
         milestoneStatusFilter="all"

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx
@@ -68,6 +68,40 @@ vi.mock("@/components/ui/slider", () => ({
   },
 }));
 
+describe("ActivityFilters - Filter pill disabled state", () => {
+  const baseProps = {
+    activeFilters: [] as ActivityFilterType[],
+    onFilterToggle: vi.fn(),
+    milestoneStatusFilter: "all" as MilestoneStatusFilter,
+    onMilestoneStatusChange: vi.fn(),
+  };
+
+  it("disables a filter pill when the count is zero and the pill is not active", () => {
+    render(
+      <ActivityFilters {...baseProps} activeFilters={[]} counts={{ milestones: 0, funding: 1 }} />
+    );
+
+    expect(screen.getByTestId("filter-milestones")).toBeDisabled();
+  });
+
+  it("keeps the milestones pill clickable when active even if the filtered count is zero", () => {
+    render(
+      <ActivityFilters
+        {...baseProps}
+        activeFilters={["milestones"]}
+        counts={{ milestones: 0, funding: 1 }}
+        milestoneStatusFilter="completed"
+      />
+    );
+
+    const pill = screen.getByTestId("filter-milestones");
+    expect(pill).not.toBeDisabled();
+
+    fireEvent.click(pill);
+    expect(baseProps.onFilterToggle).toHaveBeenCalledWith("milestones");
+  });
+});
+
 describe("ActivityFilters - Milestone Status Dropdown Visibility", () => {
   const defaultProps = {
     activeFilters: [] as ActivityFilterType[],

--- a/services/milestone-status-filter.service.ts
+++ b/services/milestone-status-filter.service.ts
@@ -36,6 +36,21 @@ export const MILESTONE_STATUS_OPTIONS: MilestoneStatusOption[] = [
   { value: "verified", label: "Verified" },
 ] as const;
 
+const VALID_MILESTONE_STATUSES = new Set<MilestoneStatusFilter>([
+  "all",
+  "pending",
+  "completed",
+  "verified",
+]);
+
+/**
+ * Type guard for {@link MilestoneStatusFilter}. Useful when validating raw URL
+ * params or other untrusted string inputs.
+ */
+export function isMilestoneStatusFilter(value: string | null): value is MilestoneStatusFilter {
+  return value !== null && VALID_MILESTONE_STATUSES.has(value as MilestoneStatusFilter);
+}
+
 // Milestone types in the unified feed
 const MILESTONE_TYPES: ReadonlySet<string> = new Set(["milestone", "grant", "impact"]);
 


### PR DESCRIPTION
## Summary
- default the project Updates page to the Completed milestone sub-filter when someone first turns on the Milestones pill
- preserve an explicit `All statuses` choice in the URL so later filter changes do not silently reset back to Completed
- align/update milestone status tests with the current ActivityFilters visibility behavior

## Test evidence
- `pnpm exec biome check components/Pages/Project/v2/Content/UpdatesContent.tsx components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx __tests__/components/UpdatesContentMilestoneStatus.test.tsx __tests__/components/MilestoneStatusFilter.test.tsx`
- `pnpm exec vitest run __tests__/components/UpdatesContentMilestoneStatus.test.tsx components/Pages/Project/v2/MainContent/__tests__/ActivityFilters.test.tsx __tests__/components/MilestoneStatusFilter.test.tsx hooks/v2/__tests__/useProjectUpdates.test.tsx services/__tests__/project-updates.service.test.ts --project unit`
- `pnpm run test` *(currently fails in unrelated pre-existing suites such as donation cart/auth, plus a Vitest `EPIPE`; no failures were in the touched project-updates files)*

## Risk
- Changes are scoped to project-updates URL state and related tests only.

Linear: DEV-172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone status filter visibility now depends on whether the milestones filter is selected
  * URL milestone status parameter now properly recognizes and persists all status values, including "all statuses"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->