### PR TITLE
feat(auth): auto-open login modal when ?login=true is present

### DIFF
--- a/src/components/navbar/navbar-auth-buttons.tsx
+++ b/src/components/navbar/navbar-auth-buttons.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
@@ -8,8 +10,23 @@ import { useWhitelabel } from "@/utilities/whitelabel-context";
 import { NavbarAuthButtonsSkeleton } from "./navbar-user-skeleton";
 
 export function NavbarAuthButtons() {
-  const { authenticate: login, ready } = useAuth();
+  const { authenticate: login, ready, authenticated } = useAuth();
   const { isWhitelabel } = useWhitelabel();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const hasTriggeredRef = useRef(false);
+
+  useEffect(() => {
+    if (!ready || authenticated || hasTriggeredRef.current) return;
+    if (searchParams?.get("login") !== "true") return;
+    hasTriggeredRef.current = true;
+    login();
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("login");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  }, [ready, authenticated, searchParams, login, pathname, router]);
 
   if (!ready) {
     return <NavbarAuthButtonsSkeleton />;


### PR DESCRIPTION
## Summary
- Adds a small effect in `NavbarAuthButtons` that fires `login()` when the URL contains `?login=true` and the user is not yet authenticated, then strips the param via `router.replace`.
- Enables external landing pages (e.g. filpgf.io, opgrants.io static sites) to deep-link into the app with the Privy login modal opening automatically.
- No-op for already-authenticated users since `NavbarAuthButtons` is only rendered when unauthenticated.

## Companion PRs
- show-karma/filecoin-grants#13 — switches `filpgf.io` nav button to `https://app.filpgf.io/?login=true`
- show-karma/op-grants-council#5 — switches `opgrants.io` nav button to `https://app.opgrants.io/?login=true`

## Test plan
- [x] Manually tested locally: visiting `http://localhost:3000/?login=true` while logged out opens the Privy `log in or sign up` dialog and rewrites the URL to `/`.
- [x] Authenticated user visiting `?login=true` does not pop the modal (component doesn't mount); no console errors.
- [ ] Verify on a preview deployment using both whitelabel domains.