### PR TITLE
fix: address dogfood findings on portfolio report preview

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -1,10 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
-import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 
-vi.mock("@/hooks/communities/useCommunityAdminAccess");
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 vi.mock("@/components/Utilities/MarkdownPreview", () => ({
   MarkdownPreview: ({ source }: { source?: string }) => (
@@ -12,7 +10,6 @@ vi.mock("@/components/Utilities/MarkdownPreview", () => ({
   ),
 }));
 
-const mockUseCommunityAdminAccess = vi.mocked(useCommunityAdminAccess);
 const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
 
 const community = {
@@ -49,30 +46,9 @@ const publishedReport = {
 describe("PortfolioReportPreviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseCommunityAdminAccess.mockReturnValue({
-      hasAccess: true,
-      isLoading: false,
-    } as any);
   });
 
   describe("loading state", () => {
-    it("renders a spinner while admin access is being resolved", () => {
-      mockUseCommunityAdminAccess.mockReturnValue({
-        hasAccess: false,
-        isLoading: true,
-      } as any);
-      mockUsePortfolioReport.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-      } as any);
-
-      const { container } = render(
-        <PortfolioReportPreviewPage community={community} reportId="draft-report" />
-      );
-
-      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
-    });
-
     it("renders a spinner while the report is loading", () => {
       mockUsePortfolioReport.mockReturnValue({
         data: undefined,
@@ -84,24 +60,6 @@ describe("PortfolioReportPreviewPage", () => {
       );
 
       expect(container.querySelector(".animate-spin")).toBeInTheDocument();
-    });
-  });
-
-  describe("access denied", () => {
-    it("shows a permission-denied message when the user is not a community admin", () => {
-      mockUseCommunityAdminAccess.mockReturnValue({
-        hasAccess: false,
-        isLoading: false,
-      } as any);
-      mockUsePortfolioReport.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-      } as any);
-
-      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
-
-      expect(screen.getByText(/don't have permission to view this preview/i)).toBeInTheDocument();
-      expect(screen.queryByTestId("markdown-preview")).not.toBeInTheDocument();
     });
   });
 

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Eye, EyeOff, FileText, Plus, RefreshCw, Settings } from "lucide-react";
+import { Eye, EyeOff, FileSearch, FileText, Plus, RefreshCw, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -85,7 +85,7 @@ function ReportTableRow({
           </Button>
           {report.status === "draft" ? (
             <Button variant="ghost" size="sm" onClick={onPreview}>
-              <Eye className="mr-1 h-3 w-3" />
+              <FileSearch className="mr-1 h-3 w-3" />
               Preview
             </Button>
           ) : null}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -4,7 +4,6 @@ import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { PortfolioReportDocumentView } from "@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView";
 import { Spinner } from "@/components/Utilities/Spinner";
-import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
@@ -16,29 +15,13 @@ interface Props {
 
 export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const slug = community.details.slug;
-  const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
-  const {
-    data: report,
-    isLoading,
-    isError,
-    refetch,
-  } = usePortfolioReport(slug, reportId, {
-    enabled: hasAccess && !accessLoading,
-  });
+  const { data: report, isLoading, isError, refetch } = usePortfolioReport(slug, reportId);
   const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
-  if (accessLoading || isLoading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
         <Spinner />
-      </div>
-    );
-  }
-
-  if (!hasAccess) {
-    return (
-      <div className="flex items-center justify-center p-12 text-zinc-500">
-        You don&apos;t have permission to view this preview.
       </div>
     );
   }

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -77,16 +77,11 @@ export function usePortfolioReports(communitySlug: string, status?: string) {
   });
 }
 
-export function usePortfolioReport(
-  communitySlug: string,
-  reportId: string,
-  options?: { enabled?: boolean }
-) {
-  const enabled = options?.enabled ?? true;
+export function usePortfolioReport(communitySlug: string, reportId: string) {
   return useQuery({
     queryKey: QUERY_KEYS.report(communitySlug, reportId),
     queryFn: () => portfolioService.getReport(communitySlug, reportId),
-    enabled: Boolean(communitySlug && reportId) && enabled,
+    enabled: Boolean(communitySlug && reportId),
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1288 addressing the two issues raised in the dogfood QA on that PR (https://github.com/show-karma/gap-app-v2/pull/1288#issuecomment-4329751105):

- **Preview/Publish icon collision (Medium UX/UI)** — the new Preview button shared the `Eye` icon with Publish, making the two actions visually indistinguishable on draft rows. Preview now uses `FileSearch`. Publish/Unpublish keep the `Eye`/`EyeOff` pair.
- **Unreachable `!hasAccess` branch (Low Code Quality)** — `ManageLayoutShell` already gates every `/manage/*` route, so the page-level `useCommunityAdminAccess` check and "You don't have permission to view this preview." UI were dead code. Removed the hook, the branch, and the now-unused `enabled` option I had added to `usePortfolioReport`.

## Test plan

- [x] `pnpm exec vitest run --project unit __tests__/components/Pages/Admin/PortfolioReports/` — 7 tests pass
- [ ] Manual: open a draft on `/community/{slug}/manage/portfolio-reports`, verify the Preview button shows the `FileSearch` icon and Publish shows the `Eye` icon side-by-side
- [ ] Manual: navigate to a draft preview and confirm the page renders normally (loading → success / error / not-found)