### PR TITLE
fix: funding opportunities default filter + /updates crash + nav pill

### DIFF
--- a/__tests__/components/Community/CommunityMilestoneCard.test.tsx
+++ b/__tests__/components/Community/CommunityMilestoneCard.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 
-// Mock the entire component module path to avoid deep dependency chain
-vi.mock("@/components/Shared/ActivityCard", () => ({
+// Mock the styles module to avoid deep dependency chain
+vi.mock("@/components/Shared/ActivityCard/styles", () => ({
   containerClassName:
     "border border-gray-300 dark:border-zinc-400 rounded-xl bg-white dark:bg-zinc-800",
-  ActivityCard: vi.fn(),
 }));
 
 // Mock ActivityAttribution component

--- a/components/Pages/Communities/CommunityPageNavigator.tsx
+++ b/components/Pages/Communities/CommunityPageNavigator.tsx
@@ -1,5 +1,13 @@
 "use client";
-import { ChartLine, DollarSign, FileSearch, FileText, LandPlot, SquareUser, Wallet } from "lucide-react";
+import {
+  ChartLine,
+  DollarSign,
+  FileSearch,
+  FileText,
+  LandPlot,
+  SquareUser,
+  Wallet,
+} from "lucide-react";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
@@ -20,7 +28,7 @@ const baseLinkStyle =
 
 const NewTag = () => {
   return (
-    <div className="rounded-2xl py-1 px-3 bg-brand-blue dark:bg-brand-blue/80 text-white dark:text-zinc-100 text-xs font-bold">
+    <div className="rounded-2xl py-0.5 px-2 bg-brand-blue dark:bg-brand-blue/80 text-white dark:text-zinc-100 text-[11px] font-bold leading-none">
       New!
     </div>
   );

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -1,8 +1,8 @@
 import { CheckCircleIcon, ClockIcon } from "@heroicons/react/24/outline";
 import dynamic from "next/dynamic";
 import { type FC, memo } from "react";
-import { containerClassName } from "@/components/Shared/ActivityCard";
 import { ActivityAttribution } from "@/components/Shared/ActivityCard/ActivityAttribution";
+import { containerClassName } from "@/components/Shared/ActivityCard/styles";
 import { Link } from "@/src/components/navigation/Link";
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 import { formatDate } from "@/utilities/formatDate";

--- a/components/Pages/Community/Updates/MilestoneCompletionInfo.tsx
+++ b/components/Pages/Community/Updates/MilestoneCompletionInfo.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { type FC, memo } from "react";
-import { containerClassName } from "@/components/Shared/ActivityCard";
 import { ActivityAttribution } from "@/components/Shared/ActivityCard/ActivityAttribution";
 import { ActivityStatusHeader } from "@/components/Shared/ActivityCard/ActivityStatusHeader";
+import { containerClassName } from "@/components/Shared/ActivityCard/styles";
 import { ReadMore } from "@/utilities/ReadMore";
 import { cn } from "@/utilities/tailwind";
 

--- a/components/Shared/ActivityCard.tsx
+++ b/components/Shared/ActivityCard.tsx
@@ -14,6 +14,7 @@ import { EndorsementCard } from "./ActivityCard/EndorsementCard";
 import { FundingReceivedCard } from "./ActivityCard/FundingReceivedCard";
 import { MilestoneCard } from "./ActivityCard/MilestoneCard";
 import { ProjectUpdateCard } from "./ActivityCard/ProjectUpdateCard";
+import { containerClassName } from "./ActivityCard/styles";
 import { UpdateCard } from "./ActivityCard/UpdateCard";
 
 type SdkUpdateType =
@@ -48,9 +49,6 @@ interface ActivityCardProps {
   activity: ActivityType;
   isAuthorized?: boolean;
 }
-
-export const containerClassName =
-  "border bg-background rounded-xl gap-0 flex flex-col items-start justify-start";
 
 export const ActivityCard: FC<ActivityCardProps> = ({ activity, isAuthorized = false }) => {
   const isOwner = useOwnerStore((state) => state.isOwner);

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -31,11 +31,11 @@ import { ReadMore } from "@/utilities/ReadMore";
 import { shareOnX } from "@/utilities/share/shareOnX";
 import { SHARE_TEXTS } from "@/utilities/share/text";
 import { cn } from "@/utilities/tailwind";
-import { containerClassName } from "../ActivityCard";
 import { ActivityActionsWrapper } from "./ActivityActionsWrapper";
 import { ActivityAttribution } from "./ActivityAttribution";
 import { ActivityStatusHeader } from "./ActivityStatusHeader";
 import { GrantAssociation } from "./GrantAssociation";
+import { containerClassName } from "./styles";
 
 const ProjectObjectiveCompletion = dynamic(
   () =>

--- a/components/Shared/ActivityCard/styles.ts
+++ b/components/Shared/ActivityCard/styles.ts
@@ -1,0 +1,2 @@
+export const containerClassName =
+  "border bg-background rounded-xl gap-0 flex flex-col items-start justify-start";

--- a/src/features/programs/components/program-filters.tsx
+++ b/src/features/programs/components/program-filters.tsx
@@ -14,8 +14,9 @@ export function ProgramFilters({ filters, onChange, totalCount }: ProgramFilters
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
 
     timeoutRef.current = setTimeout(() => {
-      if (searchValue !== filters.search) {
-        onChange({ ...filters, search: searchValue || undefined });
+      const next = searchValue || undefined;
+      if (next !== filters.search) {
+        onChange({ ...filters, search: next });
       }
     }, 300);
 

--- a/src/features/programs/hooks/use-programs.ts
+++ b/src/features/programs/hooks/use-programs.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { FundingProgram, ProgramFilters, ProgramStatus } from "@/types/whitelabel-entities";
 import fetchData from "@/utilities/fetchData";
 import { useProgramsStore } from "../lib/store";
@@ -34,7 +34,12 @@ export function usePrograms(
   communityId: string,
   initialFilters?: ProgramFilters
 ): UseProgramsReturn {
-  const { filters: storeFilters, setFilters } = useProgramsStore();
+  const {
+    filters: storeFilters,
+    setFilters,
+    applyAutoFilters,
+    hasUserChangedFilters,
+  } = useProgramsStore();
   const filters = { ...initialFilters, ...storeFilters };
 
   const { data, isLoading, error, refetch } = useQuery<{
@@ -78,6 +83,21 @@ export function usePrograms(
     }
     return result;
   }, [allPrograms, filters.status, filters.search]);
+
+  // If the default Active filter is in effect but the community has no active
+  // programs, fall back to showing all so the page isn't empty by default.
+  // Only triggers on the default state — once the user changes the filter,
+  // their choice is respected even on subsequent visits.
+  const fetchedPrograms = data?.programs;
+  useEffect(() => {
+    if (!fetchedPrograms || fetchedPrograms.length === 0) return;
+    if (hasUserChangedFilters) return;
+    if (storeFilters.status !== "active") return;
+    if (fetchedPrograms.some((p) => matchesStatus(p, "active"))) return;
+
+    const { status: _status, ...rest } = storeFilters;
+    applyAutoFilters(rest);
+  }, [fetchedPrograms, hasUserChangedFilters, storeFilters, applyAutoFilters]);
 
   return {
     programs,

--- a/src/features/programs/lib/store.ts
+++ b/src/features/programs/lib/store.ts
@@ -3,18 +3,22 @@ import type { FundingProgram, ProgramFilters } from "@/types/whitelabel-entities
 import type { ProgramsUIState } from "../types";
 
 interface ProgramsStore extends ProgramsUIState {
+  hasUserChangedFilters: boolean;
   setSelectedProgram: (program: FundingProgram | null) => void;
   setFilters: (filters: ProgramFilters) => void;
+  // Internal: applies a default-derived filter change without marking it as a user interaction.
+  applyAutoFilters: (filters: ProgramFilters) => void;
   toggleViewMode: () => void;
   toggleFilterPanel: () => void;
   reset: () => void;
 }
 
-const initialState: ProgramsUIState = {
+const initialState: ProgramsUIState & { hasUserChangedFilters: boolean } = {
   selectedProgram: null,
   filters: { status: "active" },
   viewMode: "grid",
   isFilterPanelOpen: false,
+  hasUserChangedFilters: false,
 };
 
 export const useProgramsStore = create<ProgramsStore>((set) => ({
@@ -23,6 +27,12 @@ export const useProgramsStore = create<ProgramsStore>((set) => ({
   setSelectedProgram: (program) => set({ selectedProgram: program }),
 
   setFilters: (filters) =>
+    set(() => ({
+      filters,
+      hasUserChangedFilters: true,
+    })),
+
+  applyAutoFilters: (filters) =>
     set(() => ({
       filters,
     })),


### PR DESCRIPTION
## Summary

Three small frontend fixes:

- **`/community/<id>/updates` crashes on direct navigation** with `TypeError: Class extends value undefined is not a constructor or null`. Caused by a circular import: `CommunityMilestoneCard` and `MilestoneCompletionInfo` imported `containerClassName` from the `ActivityCard` barrel, which transitively initialized `ProjectMilestone` from `karma-gap-sdk` before its base class was ready. Fix: extract `containerClassName` to its own module and import it directly. Tabs/in-app navigation worked because by then the SDK had finished initializing — direct URLs hit the broken init order.
- **Financials "New!" pill overflows the nav tab row**, pushing the active-tab underline misaligned. Shrunk padding/font so the pill fits inside the tab's bottom-border indicator.
- **`/community/<id>/funding-opportunities` is empty for communities with no Active programs**. The Status filter defaulted to "Active" so users saw an empty page even when ended/upcoming programs existed. Now the default Active filter is auto-cleared on first load when no programs match it. Once the user picks a status manually, the choice is respected. While debugging this we also fixed a spurious `onChange` in the debounced search effect (`"" !== undefined` triggered an extra render on mount).

Note: there's a separate inconsistency between the program badge (`getProgramStatus` in `program-list.tsx`) and the filter (`matchesStatus` in `use-programs.ts`) — the badge ignores `applicationConfig.isEnabled` and labels disabled programs as "Open", while the filter correctly excludes them from "Active". Out of scope here; flagged for a follow-up that consolidates on the existing `getProgramStatusInfo` utility.

## Test plan

- [x] Direct-nav to `/community/<id>/updates` no longer throws; Updates page renders.
- [x] Financials nav pill stays inside the tab row; active-tab underline is aligned across all tabs.
- [x] On `/community/gitcoin/funding-opportunities` (no Active programs) the Status filter auto-clears to "All Status" and 8 programs render.
- [x] Manually selecting "Active" sticks and shows the empty state — auto-clear does not re-fire.
- [x] `__tests__/components/Community/CommunityMilestoneCard.test.tsx` passes (41 tests) after updating the `containerClassName` mock target.
- [ ] Verify in deploy preview on a community with at least one Active program — auto-clear should not fire.