### PR TITLE
ci: optimize PR pipeline and remove Blacksmith runners

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: dogfood
+description: Systematically explore and test a web application to find bugs, UX issues, and other problems. Use when asked to "dogfood", "QA", "exploratory test", "find issues", "bug hunt", "test this app/site/platform", or review the quality of a web application. Produces a structured report with full reproduction evidence -- step-by-step screenshots, repro videos, and detailed repro steps for every issue -- so findings can be handed directly to the responsible teams.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+---
+
+# Dogfood
+
+Systematically explore a web application, find issues, and produce a report with full reproduction evidence for every finding.
+
+## Setup
+
+Only the **Target URL** is required. Everything else has sensible defaults -- use them unless the user explicitly provides an override.
+
+| Parameter | Default | Example override |
+|-----------|---------|-----------------|
+| **Target URL** | _(required)_ | `vercel.com`, `http://localhost:3000` |
+| **Session name** | Slugified domain (e.g., `vercel.com` -> `vercel-com`) | `--session my-session` |
+| **Output directory** | `./dogfood-output/` | `Output directory: /tmp/qa` |
+| **Scope** | Full app | `Focus on the billing page` |
+| **Authentication** | None | `Sign in to user@example.com` |
+
+If the user says something like "dogfood vercel.com", start immediately with defaults. Do not ask clarifying questions unless authentication is mentioned but credentials are missing.
+
+Always use `agent-browser` directly -- never `npx agent-browser`. The direct binary uses the fast Rust client. `npx` routes through Node.js and is significantly slower.
+
+## Workflow
+
+```
+1. Initialize    Set up session, output dirs, report file
+2. Authenticate  Sign in if needed, save state
+3. Orient        Navigate to starting point, take initial snapshot
+4. Explore       Systematically visit pages and test features
+5. Document      Screenshot + record each issue as found
+6. Wrap up       Update summary counts, close session
+```
+
+### 1. Initialize
+
+```bash
+mkdir -p {OUTPUT_DIR}/screenshots {OUTPUT_DIR}/videos
+```
+
+Copy the report template into the output directory and fill in the header fields:
+
+```bash
+cp {SKILL_DIR}/templates/dogfood-report-template.md {OUTPUT_DIR}/report.md
+```
+
+Start a named session:
+
+```bash
+agent-browser --session {SESSION} open {TARGET_URL}
+agent-browser --session {SESSION} wait --load networkidle
+```
+
+### 2. Authenticate
+
+If the app requires login:
+
+```bash
+agent-browser --session {SESSION} snapshot -i
+# Identify login form refs, fill credentials
+agent-browser --session {SESSION} fill @e1 "{EMAIL}"
+agent-browser --session {SESSION} fill @e2 "{PASSWORD}"
+agent-browser --session {SESSION} click @e3
+agent-browser --session {SESSION} wait --load networkidle
+```
+
+For OTP/email codes: ask the user, wait for their response, then enter the code.
+
+After successful login, save state for potential reuse:
+
+```bash
+agent-browser --session {SESSION} state save {OUTPUT_DIR}/auth-state.json
+```
+
+### 3. Orient
+
+Take an initial annotated screenshot and snapshot to understand the app structure:
+
+```bash
+agent-browser --session {SESSION} screenshot --annotate {OUTPUT_DIR}/screenshots/initial.png
+agent-browser --session {SESSION} snapshot -i
+```
+
+Identify the main navigation elements and map out the sections to visit.
+
+### 4. Explore
+
+Read [references/issue-taxonomy.md](references/issue-taxonomy.md) for the full list of what to look for and the exploration checklist.
+
+**Strategy -- work through the app systematically:**
+
+- Start from the main navigation. Visit each top-level section.
+- Within each section, test interactive elements: click buttons, fill forms, open dropdowns/modals.
+- Check edge cases: empty states, error handling, boundary inputs.
+- Try realistic end-to-end workflows (create, edit, delete flows).
+- Check the browser console for errors periodically.
+
+**At each page:**
+
+```bash
+agent-browser --session {SESSION} snapshot -i
+agent-browser --session {SESSION} screenshot --annotate {OUTPUT_DIR}/screenshots/{page-name}.png
+agent-browser --session {SESSION} errors
+agent-browser --session {SESSION} console
+```
+
+Use your judgment on how deep to go. Spend more time on core features and less on peripheral pages. If you find a cluster of issues in one area, investigate deeper.
+
+### 5. Document Issues (Repro-First)
+
+Steps 4 and 5 happen together -- explore and document in a single pass. When you find an issue, stop exploring and document it immediately before moving on. Do not explore the whole app first and document later.
+
+Every issue must be reproducible. When you find something wrong, do not just note it -- prove it with evidence. The goal is that someone reading the report can see exactly what happened and replay it.
+
+**Choose the right level of evidence for the issue:**
+
+#### Interactive / behavioral issues (functional, ux, console errors on action)
+
+These require user interaction to reproduce -- use full repro with video and step-by-step screenshots:
+
+1. **Start a repro video** _before_ reproducing:
+
+```bash
+agent-browser --session {SESSION} record start {OUTPUT_DIR}/videos/issue-{NNN}-repro.webm
+```
+
+2. **Walk through the steps at human pace.** Pause 1-2 seconds between actions so the video is watchable. Take a screenshot at each step:
+
+```bash
+agent-browser --session {SESSION} screenshot {OUTPUT_DIR}/screenshots/issue-{NNN}-step-1.png
+sleep 1
+# Perform action (click, fill, etc.)
+sleep 1
+agent-browser --session {SESSION} screenshot {OUTPUT_DIR}/screenshots/issue-{NNN}-step-2.png
+sleep 1
+# ...continue until the issue manifests
+```
+
+3. **Capture the broken state.** Pause so the viewer can see it, then take an annotated screenshot:
+
+```bash
+sleep 2
+agent-browser --session {SESSION} screenshot --annotate {OUTPUT_DIR}/screenshots/issue-{NNN}-result.png
+```
+
+4. **Stop the video:**
+
+```bash
+agent-browser --session {SESSION} record stop
+```
+
+5. Write numbered repro steps in the report, each referencing its screenshot.
+
+#### Static / visible-on-load issues (typos, placeholder text, clipped text, misalignment, console errors on load)
+
+These are visible without interaction -- a single annotated screenshot is sufficient. No video, no multi-step repro:
+
+```bash
+agent-browser --session {SESSION} screenshot --annotate {OUTPUT_DIR}/screenshots/issue-{NNN}.png
+```
+
+Write a brief description and reference the screenshot in the report. Set **Repro Video** to `N/A`.
+
+---
+
+**For all issues:**
+
+1. **Append to the report immediately.** Do not batch issues for later. Write each one as you find it so nothing is lost if the session is interrupted.
+
+2. **Increment the issue counter** (ISSUE-001, ISSUE-002, ...).
+
+### 6. Wrap Up
+
+Aim to find **5-10 well-documented issues**, then wrap up. Depth of evidence matters more than total count -- 5 issues with full repro beats 20 with vague descriptions.
+
+After exploring:
+
+1. Re-read the report and update the summary severity counts so they match the actual issues. Every `### ISSUE-` block must be reflected in the totals.
+2. Close the session:
+
+```bash
+agent-browser --session {SESSION} close
+```
+
+3. Tell the user the report is ready and summarize findings: total issues, breakdown by severity, and the most critical items.
+
+## Guidance
+
+- **Repro is everything.** Every issue needs proof -- but match the evidence to the issue. Interactive bugs need video and step-by-step screenshots. Static bugs (typos, placeholder text, visual glitches visible on load) only need a single annotated screenshot.
+- **Don't record video for static issues.** A typo or clipped text doesn't benefit from a video. Save video for issues that involve user interaction, timing, or state changes.
+- **For interactive issues, screenshot each step.** Capture the before, the action, and the after -- so someone can see the full sequence.
+- **Write repro steps that map to screenshots.** Each numbered step in the report should reference its corresponding screenshot. A reader should be able to follow the steps visually without touching a browser.
+- **Be thorough but use judgment.** You are not following a test script -- you are exploring like a real user would. If something feels off, investigate.
+- **Write findings incrementally.** Append each issue to the report as you discover it. If the session is interrupted, findings are preserved. Never batch all issues for the end.
+- **Never delete output files.** Do not `rm` screenshots, videos, or the report mid-session. Do not close the session and restart. Work forward, not backward.
+- **Never read the target app's source code.** You are testing as a user, not auditing code. Do not read HTML, JS, or config files of the app under test. All findings must come from what you observe in the browser.
+- **Check the console.** Many issues are invisible in the UI but show up as JS errors or failed requests.
+- **Test like a user, not a robot.** Try common workflows end-to-end. Click things a real user would click. Enter realistic data.
+- **Type like a human.** When filling form fields during video recording, use `type` instead of `fill` -- it types character-by-character. Use `fill` only outside of video recording when speed matters.
+- **Pace repro videos for humans.** Add `sleep 1` between actions and `sleep 2` before the final result screenshot. Videos should be watchable at 1x speed -- a human reviewing the report needs to see what happened, not a blur of instant state changes.
+- **Be efficient with commands.** Batch multiple `agent-browser` commands in a single shell call when they are independent (e.g., `agent-browser ... screenshot ... && agent-browser ... console`). Use `agent-browser --session {SESSION} scroll down 300` for scrolling -- do not use `key` or `evaluate` to scroll.
+
+## References
+
+| Reference | When to Read |
+|-----------|--------------|
+| [references/issue-taxonomy.md](references/issue-taxonomy.md) | Start of session -- calibrate what to look for, severity levels, exploration checklist |
+
+## Templates
+
+| Template | Purpose |
+|----------|---------|
+| [templates/dogfood-report-template.md](templates/dogfood-report-template.md) | Copy into output directory as the report file |

--- a/.claude/skills/qa-executor/SKILL.md
+++ b/.claude/skills/qa-executor/SKILL.md
@@ -17,6 +17,7 @@ Execute the QA plan from Stage 1. You are a strict, rigid QA engineer. If expect
 | PR number | `$PR_NUMBER` env var |
 | Test email | `$QA_TEST_EMAIL` env var (Privy test account) |
 | Test OTP | `$QA_TEST_OTP` env var (fixed OTP from Privy dashboard) |
+| Shard | `$SHARD_ID` env var (optional: `public`, `auth`, or unset = all). When set, execute ONLY scenarios matching that shard (see "Sharded Execution"). |
 
 ## Setup
 
@@ -25,6 +26,56 @@ mkdir -p qa-output/screenshots qa-output/videos
 ```
 
 Always use `agent-browser` directly — never `npx agent-browser`. The direct binary uses the fast Rust client.
+
+## Speed Rules (CRITICAL — these dominate runtime)
+
+Each scenario averages 20-50 agent turns. Wasted seconds compound.
+
+### Wait Strategy
+
+- **NEVER `wait --load networkidle` after a click, fill, or in-page action.** networkidle blocks for 1-3s waiting for ALL network to settle, even unrelated tracking pixels. Across 200+ turns this costs 5-15 minutes per run.
+- **DO wait for the specific thing you need next.** Use one of:
+  - `agent-browser --session $S wait @{ref}` — wait for a known element ref
+  - `agent-browser --session $S find role <r> "<label>" first` — locate next element (also waits)
+  - `agent-browser --session $S get url` followed by a check — for navigations
+- **Acceptable `wait --load networkidle` uses:**
+  - First `open` of a brand-new page
+  - After `state load` of an auth-restored session
+  - Inside the Privy auth flow (iframe makes many requests — needed)
+- **Anti-patterns to avoid:**
+  - `wait 2000` (sleep N ms) — only ever use for failure-evidence replays at human pace, never in normal flow
+  - `wait --load networkidle` after a click that opens a modal — wait for the modal element instead
+
+### Snapshot Strategy
+
+`snapshot -i` returns the entire accessibility tree (often 5-20KB). Big snapshots = slower agent turns and noisier prompts.
+
+- Prefer **scoped snapshots** when you know roughly where you're working: `agent-browser --session $S find role dialog first` then operate on that subtree.
+- Use **direct find commands** for stable elements instead of snapshot+ref: `agent-browser --session $S find role button "Submit" first click`.
+- Only call `snapshot -i` when you genuinely need the full tree (e.g. first time on a new page).
+
+### Per-Turn Discipline
+
+- Batch related actions in one turn instead of one-action-then-snapshot loops. Example: navigate + screenshot + assert in three sequential commands without an intermediate snapshot.
+- After a successful action, assume success and move on — only re-snapshot if the next action depends on dynamic content.
+
+## Sharded Execution
+
+When `$SHARD_ID` is set, execute only the matching subset:
+
+| `$SHARD_ID` | Run scenarios |
+|-------------|---------------|
+| `public` | P1, P2, P3, ... (all P-prefixed). **Skip Privy login entirely.** |
+| `auth` | A1, A2, A3, ... (all A-prefixed). Login first, then execute. |
+| (unset) | All scenarios — public first, then auth. |
+
+After execution, **rename the result file** to include the shard:
+
+```bash
+mv qa-results.json qa-results-${SHARD_ID:-all}.json
+```
+
+This lets parallel shards upload distinct artifacts that the verdict job aggregates.
 
 ## Authentication via Privy Test Account
 
@@ -76,11 +127,16 @@ Read `qa-plan.md`. Parse both tables:
 - **Public Scenarios** (P1, P2...) — execute without login
 - **Authenticated Scenarios** (A1, A2...) — execute after Privy test account login
 
+If `$SHARD_ID` is set, filter to only the matching subset (see "Sharded Execution" above) and skip the rest entirely — including auth login when `$SHARD_ID == public`.
+
 ### 2. Execute Public Scenarios First
+
+Skip this section entirely if `$SHARD_ID == auth`.
 
 Initialize a session without auth:
 
 ```bash
+# First open of a fresh page — networkidle is OK here.
 agent-browser --session qa-pub open "http://localhost:3000"
 agent-browser --session qa-pub wait --load networkidle
 ```
@@ -89,6 +145,7 @@ For each public scenario (P1, P2...), in risk-priority order:
 
 **a. Navigate:**
 ```bash
+# First-load on a new path — networkidle OK.
 agent-browser --session qa-pub open "http://localhost:3000/{path}"
 agent-browser --session qa-pub wait --load networkidle
 ```
@@ -98,7 +155,9 @@ agent-browser --session qa-pub wait --load networkidle
 agent-browser --session qa-pub screenshot qa-output/screenshots/P{N}-baseline.png
 ```
 
-**c. Execute steps** as written in the plan. Use `snapshot -i` before interacting.
+**c. Execute steps** as written in the plan. Follow the **Speed Rules** above:
+- Use scoped finds (`find role <r> "<label>" first`) instead of full `snapshot -i` whenever possible.
+- After clicks/fills, wait for the **next expected element** (`wait @{ref}`), NOT `wait --load networkidle`.
 
 **d. Evaluate:** PASS if actual matches expected exactly. FAIL otherwise.
 
@@ -116,9 +175,13 @@ agent-browser --session qa-pub errors > qa-output/P{N}-errors.txt
 
 ### 3. Login with Privy Test Account
 
-After all public scenarios, authenticate using the flow above.
+Skip this section entirely if `$SHARD_ID == public`.
+
+After all public scenarios (or first if running an `auth` shard), authenticate using the flow above. Note: the auth flow is the **one place** where `wait --load networkidle` is acceptable — Privy's iframe has many concurrent requests.
 
 ### 4. Execute Authenticated Scenarios
+
+Skip this section entirely if `$SHARD_ID == public`.
 
 For each authenticated scenario (A1, A2...), in risk-priority order:
 
@@ -126,6 +189,7 @@ Same process as public scenarios but:
 - Use the `qa-auth` session (already logged in)
 - If session expires, reload auth state: `agent-browser --session qa-auth state load qa-output/auth-state.json`
 - Scenario IDs are A1, A2...
+- **Apply Speed Rules**: targeted waits, scoped finds, no `wait --load networkidle` after in-page actions.
 
 ### 5. Console Error Sweep
 
@@ -176,7 +240,16 @@ If 3 or more Critical issues are found, stop execution. Document what was tested
 
 ## Output
 
-Save results to `qa-results.json`:
+Save results to `qa-results.json`, then rename to include the shard suffix so parallel shards do not overwrite each other's artifacts:
+
+```bash
+# After Claude writes qa-results.json:
+mv qa-results.json "qa-results-${SHARD_ID:-all}.json"
+```
+
+The verdict job downloads all `qa-results-*.json` files and aggregates them.
+
+JSON shape:
 
 ```json
 {

--- a/.claude/skills/qa-executor/SKILL.md
+++ b/.claude/skills/qa-executor/SKILL.md
@@ -201,7 +201,7 @@ Post a PR comment. **Comment format — follow exactly:**
 ```markdown
 ## QA Execution (2/3)
 
-**Result**: X/Y passed | Z failed
+**Result**: X/Y passed | Z failed | B blocked
 **Blocking**: Yes/No
 
 ### Public Scenarios

--- a/.claude/skills/qa-executor/SKILL.md
+++ b/.claude/skills/qa-executor/SKILL.md
@@ -46,6 +46,52 @@ Each scenario averages 20-50 agent turns. Wasted seconds compound.
   - `wait 2000` (sleep N ms) — only ever use for failure-evidence replays at human pace, never in normal flow
   - `wait --load networkidle` after a click that opens a modal — wait for the modal element instead
 
+## Session Lifecycle
+
+One `agent-browser` session corresponds to one persistent browser context. Sessions are expensive to create (new browser process, cold JS parse). Reuse them across scenarios within a shard rather than opening a fresh session per scenario.
+
+### Correct pattern — reuse session, navigate between scenarios
+
+```bash
+# Start the session ONCE at the top of the shard.
+agent-browser --session qa-pub open "http://localhost:3000"
+agent-browser --session qa-pub wait --load networkidle
+
+# Scenario P1
+agent-browser --session qa-pub screenshot qa-output/screenshots/P1-baseline.png
+# ... execute P1 steps ...
+
+# Between scenarios: clear per-scenario state, then goto the next URL.
+# UNVERIFIED FLAG: agent-browser --session qa-pub storage clear --cookies --local-storage
+# If the flag above is not available, reload the session state instead:
+#   agent-browser --session qa-pub state load qa-output/public-clean-state.json
+agent-browser --session qa-pub goto "http://localhost:3000/{P2-path}"
+agent-browser --session qa-pub wait --load networkidle
+
+# Scenario P2
+agent-browser --session qa-pub screenshot qa-output/screenshots/P2-baseline.png
+# ... execute P2 steps ...
+```
+
+### Session Anti-Patterns
+
+- **Do NOT call `open` for every scenario.** `open` starts a new page/context. Use `goto` to navigate within an existing session.
+- **Do NOT close and re-open a session between scenarios.** Session teardown + startup adds 3-8 s per scenario.
+- **Do NOT leave scenario-local state (filled forms, opened modals, injected cookies) leaking into the next scenario.** Clear or navigate away cleanly.
+
+### State-Load Fallback for Mid-Shard Session Expiry
+
+Privy auth tokens expire. If an authenticated scenario fails with an auth error mid-shard, reload the saved state rather than re-running the full login flow:
+
+```bash
+# Detected auth expiry (e.g. 401 response, redirect to /login, missing user avatar)
+agent-browser --session qa-auth state load qa-output/auth-state.json
+agent-browser --session qa-auth wait --load networkidle
+# Then retry the current scenario from its first step.
+```
+
+If `state load` also fails (token expired on disk), fall back to the full Privy login flow from section 3 and overwrite `qa-output/auth-state.json`.
+
 ### Snapshot Strategy
 
 `snapshot -i` returns the entire accessibility tree (often 5-20KB). Big snapshots = slower agent turns and noisier prompts.
@@ -145,9 +191,15 @@ For each public scenario (P1, P2...), in risk-priority order:
 
 **a. Navigate:**
 ```bash
-# First-load on a new path — networkidle OK.
-agent-browser --session qa-pub open "http://localhost:3000/{path}"
+# Use goto (not open) to navigate within the existing session.
+# open would spin up a new page/context — use it only for the very first URL.
+agent-browser --session qa-pub goto "http://localhost:3000/{path}"
 agent-browser --session qa-pub wait --load networkidle
+
+# Before each scenario, clear per-scenario browser state to prevent leakage.
+# UNVERIFIED FLAG: agent-browser --session qa-pub storage clear --cookies --local-storage
+# If the flag above is unavailable, reload the clean baseline state:
+#   agent-browser --session qa-pub state load qa-output/public-clean-state.json
 ```
 
 **b. Baseline screenshot:**
@@ -186,8 +238,15 @@ Skip this section entirely if `$SHARD_ID == public`.
 For each authenticated scenario (A1, A2...), in risk-priority order:
 
 Same process as public scenarios but:
-- Use the `qa-auth` session (already logged in)
-- If session expires, reload auth state: `agent-browser --session qa-auth state load qa-output/auth-state.json`
+- Use the `qa-auth` session (already logged in).
+- Navigate between scenarios with `goto`, not `open` — the session is already live.
+- Before each scenario, clear per-scenario state the same way as for public scenarios (see "Session Anti-Patterns").
+- If a scenario fails with an auth error (401, redirect to `/login`, missing user avatar): reload auth state and retry before marking it FAIL.
+  ```bash
+  agent-browser --session qa-auth state load qa-output/auth-state.json
+  agent-browser --session qa-auth wait --load networkidle
+  ```
+  If `state load` also fails, re-run the full Privy login flow (section 3) and overwrite `qa-output/auth-state.json`.
 - Scenario IDs are A1, A2...
 - **Apply Speed Rules**: targeted waits, scoped finds, no `wait --load networkidle` after in-page actions.
 

--- a/.claude/skills/qa-executor/SKILL.md
+++ b/.claude/skills/qa-executor/SKILL.md
@@ -164,6 +164,16 @@ If 3 or more Critical issues are found, stop execution. Document what was tested
 | Medium | Feature works with noticeable problems, workaround exists |
 | Low | Cosmetic, minor polish |
 
+## Result Values
+
+| Result | When to use |
+|--------|-------------|
+| PASS | Actual matched expected exactly. |
+| FAIL | Actual did not match expected, AND the failure is plausibly caused by changes in this PR (or by code in the repo even if not changed by this PR). |
+| BLOCKED | Scenario could not be executed due to a cause unrelated to the PR's code: third-party service outage (Privy / Sentry / RPC down), missing test fixture data, infra/network failure, or missing environment capability (e.g. `agent-browser` unavailable). The PR did not modify the relevant code path. Use evidence to justify why this is environmental, not regression. |
+
+`BLOCKED` does NOT contribute to the blocking verdict — but you must justify the classification in `evidence`. When in doubt between FAIL and BLOCKED, choose FAIL. A genuine regression mislabeled as BLOCKED would let a real bug ship.
+
 ## Output
 
 Save results to `qa-results.json`:
@@ -173,14 +183,18 @@ Save results to `qa-results.json`:
   "total": 15,
   "passed": 12,
   "failed": 3,
+  "blocked": 0,
   "skipped": 0,
   "blocking": true,
   "scenarios": [
     { "id": "P1", "name": "...", "result": "PASS", "severity": null, "evidence": null },
-    { "id": "A1", "name": "...", "result": "FAIL", "severity": "High", "evidence": "qa-output/screenshots/A1-fail.png" }
+    { "id": "A1", "name": "...", "result": "FAIL", "severity": "High", "evidence": "qa-output/screenshots/A1-fail.png" },
+    { "id": "A2", "name": "...", "result": "BLOCKED", "severity": null, "evidence": "Privy returned a 5xx service error; PR did not modify auth code." }
   ]
 }
 ```
+
+`result === "BLOCKED"` rows have `severity: null` (severity describes regression impact; blocked scenarios were never tested). Always include an `evidence` string explaining why the failure is environmental, not regression.
 
 Post a PR comment. **Comment format — follow exactly:**
 
@@ -212,9 +226,10 @@ Post a PR comment. **Comment format — follow exactly:**
 **Rules:**
 - PASS rows: no severity, no evidence.
 - FAIL rows: severity required. For evidence, describe what you observed inline (1-2 sentences) — do NOT link to local file paths like `qa-output/screenshots/...` because those are not accessible from GitHub. Screenshots are saved as workflow artifacts and can be downloaded from the workflow run link.
-- Sort: FAILs first (by severity), then PASSes.
+- BLOCKED rows: no severity. Evidence must justify why the failure is environmental (third-party outage, missing fixture, infra issue) and NOT a regression in this PR's code.
+- Sort: FAILs first (by severity), then BLOCKED, then PASSes.
 - No prose. Just the tables.
-- `Blocking: Yes` if any Critical or High severity failure.
+- `Blocking: Yes` if any Critical or High severity FAIL. BLOCKED never makes a PR blocking.
 
 ## Strictness Rules
 

--- a/.github/workflows/anvil-nightly.yml
+++ b/.github/workflows/anvil-nightly.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -27,12 +27,12 @@ jobs:
         run: anvil --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: anvil-test-report
           path: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,13 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  # Cancel an in-progress Claude run when a new commit is pushed to the same PR.
+  # Falls back to run_id for non-PR triggers (issue comments, reviews) so each
+  # of those still runs independently.
+  group: claude-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |
@@ -75,10 +82,12 @@ jobs:
             console.log(`Checking Vercel deployment for PR #${pr_number}, SHA: ${head_sha}`);
             core.setOutput('pr_number', pr_number);
 
-            // Wait for Vercel deployment (max 10 minutes)
+            // Wait for Vercel deployment (max 3 minutes — Vercel preview is
+            // typically ready in 90-120s; if not, we fall back to a degraded
+            // run without PREVIEW_URL rather than blocking for 10 minutes).
             let deploymentUrl = '';
             let attempts = 0;
-            const maxAttempts = 60; // 60 * 10 seconds = 10 minutes
+            const maxAttempts = 18; // 18 * 10 seconds = 3 minutes
 
             while (attempts < maxAttempts && !deploymentUrl) {
               attempts++;
@@ -370,5 +379,5 @@ jobs:
             ${{ github.event_name == 'pull_request' && 'Review this PR against the rules in custom_instructions. IMPORTANT: First run `git diff origin/main...HEAD` and ONLY review lines that were added or modified in the diff. Never flag pre-existing code. Triage: security/bugs first, then performance, then architecture. Only report MEDIUM+ issues with emoji severity indicators. For each: file:line, rule, severity, problem, root cause, fix. Flag any AI slop. DEDUPLICATION: Before reporting an issue, check previous review comments on this PR (from karma-coding-ai or github-actions[bot]). If an issue was flagged before AND the current diff shows it has been fixed (the problematic code no longer exists in the diff), do NOT re-flag it. Only flag issues that are still present in the current diff. End with the verdict section: Score X/100, then Status (APPROVE / APPROVE WITH SUGGESTIONS / REQUEST CHANGES). No strengths, no praise.' || '' }}
 
           max_turns: '30'
-          timeout_minutes: '45'
+          timeout_minutes: '15'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,14 +37,14 @@ jobs:
       deployments: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # Wait for Vercel deployment and extract URL
       - name: Wait for Vercel Deployment
         id: deployment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -181,7 +181,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ concurrency:
   # Cancel an in-progress Claude run when a new commit is pushed to the same PR.
   # Falls back to run_id for non-PR triggers (issue comments, reviews) so each
   # of those still runs independently.
-  group: claude-${{ github.event.pull_request.number || github.run_id }}
+  group: claude-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: e2e/playwright-report
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Playwright screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-screenshots
           path: e2e/test-results
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Comment PR with E2E test results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,6 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: ['**']
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'  # Nightly at 4 AM UTC
@@ -16,7 +13,7 @@ env:
 
 jobs:
   playwright:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -80,7 +77,7 @@ jobs:
           if-no-files-found: ignore
 
   report:
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'workflow_dispatch'
     needs: [playwright]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,6 +2,11 @@ name: E2E Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Optional PR number to comment results back to'
+        required: false
+        type: string
   schedule:
     - cron: '0 4 * * *'  # Nightly at 4 AM UTC
 
@@ -77,7 +82,10 @@ jobs:
           if-no-files-found: ignore
 
   report:
-    if: always() && github.event_name == 'workflow_dispatch'
+    # Only comment when triggered manually with an explicit PR number.
+    # workflow_dispatch has no `context.issue.number`, so commenting without
+    # a PR number would fail.
+    if: always() && github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
     needs: [playwright]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -85,27 +93,30 @@ jobs:
     steps:
       - name: Comment PR with E2E test results
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const playwrightStatus = '${{ needs.playwright.result }}';
             const allPassed = playwrightStatus === 'success';
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const marker = '<!-- e2e-tests-report -->';
 
             const icon = (status) => status === 'success' ? '✅' : status === 'skipped' ? '⏭️' : '❌';
 
             const body = allPassed
-              ? `## ✅ E2E Tests Passed!\n\nAll Playwright end-to-end tests completed successfully.\n\n| Suite | Status |\n|-------|--------|\n| Playwright | ${icon(playwrightStatus)} ${playwrightStatus} |`
-              : `## ❌ E2E Tests Failed\n\nSome E2E tests failed. Check the workflow logs and artifacts for details.\n\n| Suite | Status |\n|-------|--------|\n| Playwright | ${icon(playwrightStatus)} ${playwrightStatus} |\n\n**Artifacts available on failure:** report + traces (Playwright)`;
+              ? `${marker}\n## ✅ E2E Tests Passed!\n\nAll Playwright end-to-end tests completed successfully.\n\n| Suite | Status |\n|-------|--------|\n| Playwright | ${icon(playwrightStatus)} ${playwrightStatus} |`
+              : `${marker}\n## ❌ E2E Tests Failed\n\nSome E2E tests failed. Check the workflow logs and artifacts for details.\n\n| Suite | Status |\n|-------|--------|\n| Playwright | ${icon(playwrightStatus)} ${playwrightStatus} |\n\n**Artifacts available on failure:** report + traces (Playwright)`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: prNumber,
             });
 
             const e2eComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('E2E Tests')
+              comment.user.type === 'Bot' && comment.body.includes(marker)
             );
 
             if (e2eComment) {
@@ -119,7 +130,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 body,
               });
             }

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -43,7 +43,7 @@ jobs:
           pnpm run test -- --json --outputFile=test-results-${RUN_NUMBER}.json
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ matrix.run }}
           path: test-results-${{ matrix.run }}.json
@@ -56,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: test-results
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload flaky test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: flaky-test-report
           path: flaky-tests.json
@@ -158,7 +158,7 @@ jobs:
 
       - name: Create issue for flaky tests
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -19,15 +19,15 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -12,6 +12,8 @@ on:
       - '**/*.jpeg'
       - '**/*.svg'
       - '**/*.gif'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
       - 'LICENSE'
       - '.gitignore'
 
@@ -28,22 +30,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Shallow checkout — we only need PR HEAD plus enough base history
-          # to diff against. Two-dot diff below avoids needing the merge-base.
+          # Shallow checkout — we only need PR HEAD plus the immutable PR
+          # base SHA below.
           fetch-depth: 1
 
-      - name: Fetch base ref
+      - name: Fetch immutable PR base SHA
         env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-        run: git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
 
       - name: Run anti-pattern checks
         id: antipatterns
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           chmod +x scripts/check-anti-patterns.sh
-          # Two-dot diff (origin/BASE..HEAD) — files different between base
-          # tip and PR HEAD. Doesn't require fetching the merge-base.
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF..HEAD" -- '*.tsx' '*.ts' | head -200)
+          # Diff against the immutable PR base SHA (frozen at PR creation/sync).
+          # Avoids drift if the base branch advances mid-CI, which would
+          # otherwise pull in unrelated files via two-dot vs origin/BASE.
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$PR_BASE_SHA..HEAD" -- '*.tsx' '*.ts' | head -200)
 
           ISSUES=""
           ISSUE_COUNT=0
@@ -69,16 +74,16 @@ jobs:
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Check for missing route files
         id: missing_routes
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           MISSING=""
           MISSING_COUNT=0
 
-          NEW_PAGES=$(git diff --name-only --diff-filter=A "origin/$GITHUB_BASE_REF..HEAD" -- '**/page.tsx' || true)
+          NEW_PAGES=$(git diff --name-only --diff-filter=A "$PR_BASE_SHA..HEAD" -- '**/page.tsx' || true)
 
           while IFS= read -r PAGE; do
             [ -z "$PAGE" ] && continue
@@ -103,8 +108,6 @@ jobs:
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Comment PR with results
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ['**']
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.svg'
+      - '**/*.gif'
+      - 'LICENSE'
+      - '.gitignore'
+
+concurrency:
+  group: pr-checklist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   checklist:

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -28,14 +28,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow checkout — we only need PR HEAD plus enough base history
+          # to diff against. Two-dot diff below avoids needing the merge-base.
+          fetch-depth: 1
+
+      - name: Fetch base ref
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
 
       - name: Run anti-pattern checks
         id: antipatterns
         run: |
           chmod +x scripts/check-anti-patterns.sh
-          # Check only changed TSX/TS files
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF"...HEAD -- '*.tsx' '*.ts' | head -200)
+          # Two-dot diff (origin/BASE..HEAD) — files different between base
+          # tip and PR HEAD. Doesn't require fetching the merge-base.
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF..HEAD" -- '*.tsx' '*.ts' | head -200)
 
           ISSUES=""
           ISSUE_COUNT=0
@@ -70,7 +78,7 @@ jobs:
           MISSING=""
           MISSING_COUNT=0
 
-          NEW_PAGES=$(git diff --name-only --diff-filter=A "origin/$GITHUB_BASE_REF"...HEAD -- '**/page.tsx' || true)
+          NEW_PAGES=$(git diff --name-only --diff-filter=A "origin/$GITHUB_BASE_REF..HEAD" -- '**/page.tsx' || true)
 
           while IFS= read -r PAGE; do
             [ -z "$PAGE" ] && continue

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Shallow checkout — we only need PR HEAD plus the immutable PR
           # base SHA below.
@@ -111,7 +111,7 @@ jobs:
 
       - name: Comment PR with results
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-demo-video.yml
+++ b/.github/workflows/pr-demo-video.yml
@@ -50,14 +50,11 @@ jobs:
             fi
           else
             SHA="${{ github.sha }}"
-            # Look up the PR associated with this merge commit.
-            PR=$(gh pr list \
-              --repo "${{ github.repository }}" \
-              --state merged \
-              --search "$SHA" \
-              --json number,mergeCommit \
-              | jq -r --arg sha "$SHA" '.[] | select(.mergeCommit.oid==$sha) | .number' \
-              | head -1)
+            # Look up the PR associated with this commit via the commits API
+            # (more reliable than gh pr list --search which depends on search indexing).
+            PR=$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" \
+              --jq '.[0].number // ""' \
+              2>/dev/null || echo "")
           fi
           if [ -z "$PR" ]; then
             echo "No PR found for $SHA — skipping"

--- a/.github/workflows/pr-demo-video.yml
+++ b/.github/workflows/pr-demo-video.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Checkout merge commit
         if: steps.pr.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
@@ -96,13 +96,13 @@ jobs:
 
       - name: Setup pnpm
         if: steps.detect.outputs.exists == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
         if: steps.detect.outputs.exists == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -287,7 +287,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.detect.outputs.exists == 'true' && steps.convert.outputs.count != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-demo-video.yml
+++ b/.github/workflows/pr-demo-video.yml
@@ -42,7 +42,12 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR="${{ github.event.inputs.pr_number }}"
-            SHA=$(gh pr view "$PR" --repo "${{ github.repository }}" --json mergeCommit --jq '.mergeCommit.oid')
+            SHA=$(gh pr view "$PR" --repo "${{ github.repository }}" --json mergeCommit --jq '.mergeCommit.oid // ""')
+            if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+              echo "PR #$PR has no merge commit yet — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             SHA="${{ github.sha }}"
             # Look up the PR associated with this merge commit.

--- a/.github/workflows/pr-demo-video.yml
+++ b/.github/workflows/pr-demo-video.yml
@@ -1,17 +1,22 @@
 name: PR Demo Video
 
-# Records short walkthroughs of the features added by a PR and posts them
-# as a final comment, once every other required check has gone green.
+# Records short walkthroughs of the features added by a merged PR and posts
+# them as a comment on the now-closed PR. Triggered post-merge to keep the
+# expensive recording work off the PR critical path.
 #
 # Sources of truth:
 #   .github/workflows/pr-demo-video.yml  — this file
 #   e2e/demos/                           — specs + descriptions
 
 on:
-  workflow_run:
-    workflows: ["E2E Tests"]
-    types:
-      - completed
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to record demos for'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -25,124 +30,64 @@ concurrency:
 
 jobs:
   record:
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Resolve PR number
+      - name: Resolve PR from merge commit
         id: pr
         run: |
           set -euo pipefail
-          SHA="${{ github.event.workflow_run.head_sha }}"
-          # `gh`'s `--jq` accepts only a single filter expression — it doesn't
-          # forward `--arg` to jq. Pipe through standalone jq so the SHA can
-          # be safely bound as a parameter.
-          PR=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --state open \
-            --search "$SHA" \
-            --json number,headRefOid \
-            | jq -r --arg sha "$SHA" '.[] | select(.headRefOid==$sha) | .number' \
-            | head -1)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR="${{ github.event.inputs.pr_number }}"
+            SHA=$(gh pr view "$PR" --repo "${{ github.repository }}" --json mergeCommit --jq '.mergeCommit.oid')
+          else
+            SHA="${{ github.sha }}"
+            # Look up the PR associated with this merge commit.
+            PR=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --state merged \
+              --search "$SHA" \
+              --json number,mergeCommit \
+              | jq -r --arg sha "$SHA" '.[] | select(.mergeCommit.oid==$sha) | .number' \
+              | head -1)
+          fi
           if [ -z "$PR" ]; then
-            echo "No open PR found for $SHA — skipping"
+            echo "No PR found for $SHA — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "number=$PR" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for required checks to settle
-        id: checks
+      - name: Checkout merge commit
         if: steps.pr.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          PR="${{ steps.pr.outputs.number }}"
-          settled=0
-          # Poll up to 30 minutes; bail early if something failed.
-          for _ in $(seq 1 60); do
-            if ! json=$(gh pr checks "$PR" \
-                --repo "${{ github.repository }}" \
-                --json name,bucket 2>/dev/null); then
-              echo "gh pr checks request failed — retrying"
-              sleep 30
-              continue
-            fi
-            total=$(echo "$json" | jq 'length')
-            if [ "$total" -eq 0 ]; then
-              echo "No checks reported yet — retrying"
-              sleep 30
-              continue
-            fi
-            failures=$(echo "$json" \
-              | jq '[.[] | select(.bucket=="fail" and .name != "pr-demo-video")] | length')
-            pending=$(echo "$json" \
-              | jq '[.[] | select(.bucket=="pending" and .name != "pr-demo-video")] | length')
-            if [ "$failures" -gt 0 ]; then
-              echo "Other checks failed — skipping demo"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            if [ "$pending" -eq 0 ]; then
-              echo "All required checks green"
-              settled=1
-              break
-            fi
-            echo "Pending checks: $pending — waiting"
-            sleep 30
-          done
-          if [ "$settled" -ne 1 ]; then
-            echo "Checks did not settle within the polling window — skipping demo"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-      - name: Resolve Vercel preview URL
-        if: steps.pr.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
-        id: preview
-        run: |
-          set -euo pipefail
-          PR="${{ steps.pr.outputs.number }}"
-          # Vercel's GitHub App posts comments under both `vercel` and
-          # `vercel[bot]` depending on context — match both.
-          URL=$(gh pr view "$PR" \
-            --repo "${{ github.repository }}" \
-            --json comments \
-            --jq '[.comments[] | select(.author.login=="vercel" or .author.login=="vercel[bot]")] | last | .body' \
-            | grep -oE 'https://[a-z0-9-]+\.vercel\.app' \
-            | head -1 || true)
-          if [ -z "${URL:-}" ]; then
-            echo "No Vercel preview URL found — skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Preview URL: $URL"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout PR head
-        if: steps.preview.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.sha }}
           fetch-depth: 1
 
       - name: Detect demo specs
-        if: steps.preview.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true'
         id: detect
         run: |
           if compgen -G "e2e/demos/*.demo.ts" > /dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             ls e2e/demos/*.demo.ts
           else
-            echo "No demo specs in this PR — skipping"
+            echo "No demo specs in this commit — skipping"
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Resolve preview URL (staging)
+        if: steps.detect.outputs.exists == 'true'
+        id: preview
+        run: |
+          # Demos record against staging post-merge — preview deployments are
+          # gone by the time this runs.
+          echo "url=https://staging.karmahq.xyz" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
         if: steps.detect.outputs.exists == 'true'
@@ -169,7 +114,7 @@ jobs:
         if: steps.detect.outputs.exists == 'true'
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - name: Record demos against the Vercel preview
+      - name: Record demos
         if: steps.detect.outputs.exists == 'true'
         env:
           DEMO_BASE_URL: ${{ steps.preview.outputs.url }}
@@ -330,7 +275,7 @@ jobs:
               echo "---"
               echo
             done
-            echo "_Recorded against the Vercel preview at \`${{ steps.pr.outputs.sha }}\`._"
+            echo "_Recorded post-merge against staging at \`${{ steps.pr.outputs.sha }}\`._"
           } > comment.md
 
           cat comment.md

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -22,18 +22,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Step 1: determine test scope ────────────────────────────────────────────
+  # Fast pre-job (<30s): counts changed source files and decides whether to run
+  # only affected tests ("changed" mode, 1 shard) or the full suite ("full"
+  # mode, 2 shards). Config-file changes always force full mode.
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      mode: ${{ steps.detect.outputs.mode }}
+      shard_count: ${{ steps.detect.outputs.shard_count }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect test scope
+        id: detect
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+
+          # All changed TS/TSX source files (including test files — they affect scope)
+          CHANGED_FILES=$(git diff --name-only "${BASE}...HEAD" -- '*.ts' '*.tsx' 2>/dev/null || echo "")
+          CHANGED_COUNT=$(echo "${CHANGED_FILES}" | grep -c '.' || true)
+          # grep -c returns 1 for empty input, so normalise:
+          [ -z "${CHANGED_FILES}" ] && CHANGED_COUNT=0
+
+          echo "Changed TS/TSX files: ${CHANGED_COUNT}"
+          echo "${CHANGED_FILES}"
+
+          # Config files that invalidate the incremental "changed" mode
+          CONFIG_CHANGED=$(git diff --name-only "${BASE}...HEAD" -- \
+            'vitest.config.*' \
+            'tsconfig.json' \
+            'package.json' \
+            'pnpm-lock.yaml' \
+            '.github/workflows/pr-tests.yml' \
+          2>/dev/null || echo "")
+
+          if [ -n "${CONFIG_CHANGED}" ]; then
+            echo "Config files changed — forcing full mode:"
+            echo "${CONFIG_CHANGED}"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "shard_count=2" >> "$GITHUB_OUTPUT"
+          elif [ "${CHANGED_COUNT}" -le 30 ]; then
+            echo "mode=changed" >> "$GITHUB_OUTPUT"
+            echo "shard_count=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "shard_count=2" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Step 2: run tests (matrix of 1 or 2 shards) ─────────────────────────────
   test:
+    needs: [scope]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Expose the actual test step outcome so the report job can see real
-    # pass/fail. needs.test.result alone is always 'success' because the
-    # step uses continue-on-error to mask pre-existing failures (#1306).
-    outputs:
-      tests_outcome: ${{ steps.tests.outcome }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.scope.outputs.shard_count == '2' && '[1,2]' || '[1]') }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          # changed mode needs history to resolve the base SHA
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -63,41 +119,110 @@ jobs:
             ${{ runner.os }}-vitest-${{ hashFiles('**/pnpm-lock.yaml') }}-
             ${{ runner.os }}-vitest-
 
-      - name: Run tests
+      # changed mode: only test files affected by this PR's diff.
+      # --passWithNoTests guards against "no tests found" exit 1 (e.g. docs-only PRs
+      # that slip past paths-ignore because they also touch a .ts file).
+      - name: Run tests (changed mode)
         id: tests
+        if: needs.scope.outputs.mode == 'changed'
         # Pre-existing test debt (issue #1306) — main currently fails dozens
         # of test files but is hidden by this same flag. Removing it is
         # tracked as separate cleanup; do not gate this CI-optimization PR
         # on a pre-existing red baseline. The step's `outcome` is still
         # surfaced via the job output so the report comment shows reality.
         continue-on-error: true
-        run: pnpm run test -- --reporter=dot
+        run: |
+          pnpm run test -- \
+            --reporter=dot \
+            --changed=${{ github.event.pull_request.base.sha }} \
+            --passWithNoTests
         env:
           NODE_ENV: test
           NODE_OPTIONS: --max-old-space-size=8192
 
+      # full mode: run the entire suite split across N shards.
+      - name: Run tests (full mode, shard ${{ matrix.shard }}/2)
+        id: tests_full
+        if: needs.scope.outputs.mode == 'full'
+        continue-on-error: true
+        run: |
+          pnpm run test -- \
+            --reporter=dot \
+            --shard=${{ matrix.shard }}/2
+        env:
+          NODE_ENV: test
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      # Upload a tiny outcome artifact so the report job can aggregate across
+      # shards. Matrix job outputs only return the LAST shard's value, so
+      # artifacts are the reliable cross-shard signal.
+      - name: Upload shard outcome
+        if: always()
+        run: |
+          # Prefer the changed-mode step; fall back to the full-mode step.
+          OUTCOME="${{ steps.tests.outcome }}"
+          [ -z "${OUTCOME}" ] || [ "${OUTCOME}" = "skipped" ] && OUTCOME="${{ steps.tests_full.outcome }}"
+          echo "${OUTCOME}" > /tmp/shard-${{ matrix.shard }}-outcome.txt
+
+      - name: Upload shard outcome artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.shard }}-outcome
+          path: /tmp/shard-${{ matrix.shard }}-outcome.txt
+          retention-days: 1
+
+  # ── Step 3 & 4: aggregate results and post PR comment ───────────────────────
   report:
     if: always() && github.event_name == 'pull_request'
-    needs: [test]
+    needs: [scope, test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Download all shard outcome artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: shard-*-outcome
+          path: /tmp/outcomes
+          merge-multiple: true
+
       - name: Comment PR with test results
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Use the step outcome (exposed as job output) instead of the
-            // job result. The job always succeeds because `Run tests` is
-            // marked continue-on-error to mask pre-existing failures
-            // (#1306); the step `outcome` reflects real pass/fail.
-            const testsOutcome = '${{ needs.test.outputs.tests_outcome }}';
-            const passed = testsOutcome === 'success';
+            const fs = require('fs');
+            const path = require('path');
+
+            const outcomesDir = '/tmp/outcomes';
+            const mode = '${{ needs.scope.outputs.mode }}';
+            const shardCount = parseInt('${{ needs.scope.outputs.shard_count }}', 10);
+
+            // Read all shard outcome files; if any is not 'success' → failed.
+            let passed = true;
+            try {
+              const files = fs.readdirSync(outcomesDir);
+              for (const file of files) {
+                const content = fs.readFileSync(path.join(outcomesDir, file), 'utf8').trim();
+                if (content !== 'success') {
+                  passed = false;
+                  break;
+                }
+              }
+            } catch (e) {
+              // Artifact download failed (e.g. test job never ran) — treat as failure.
+              passed = false;
+            }
+
+            const modeLabel = mode === 'changed'
+              ? '`changed` (affected files only)'
+              : `\`full\` (${shardCount} shards)`;
+
             const marker = '<!-- pr-tests-report -->';
 
             const body = passed
-              ? `${marker}\n## ✅ All Tests Passed!\n\n---\n*Automated test report*`
-              : `${marker}\n## ❌ Tests Failed\n\nCheck the workflow logs for details.\n\n_Note: this PR's test job uses \`continue-on-error\` to allow merging while pre-existing test debt is being cleaned up (issue #1306). Failures here will not block merge until #1306 is resolved._\n\n---\n*Automated test report*`;
+              ? `${marker}\n## ✅ All Tests Passed!\n\nRan in **${modeLabel}** mode.\n\n---\n*Automated test report*`
+              : `${marker}\n## ❌ Tests Failed\n\nRan in **${modeLabel}** mode. Check the workflow logs for details.\n\n_Note: this PR's test job uses \`continue-on-error\` to allow merging while pre-existing test debt is being cleaned up (issue #1306). Failures here will not block merge until #1306 is resolved._\n\n---\n*Automated test report*`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,7 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout code
@@ -28,102 +32,43 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests
-        run: pnpm run test -- --pool-options.forks.maxForks=2 --reporter=verbose
-        continue-on-error: true
+      - name: Run tests (shard ${{ matrix.shard }}/4)
+        run: pnpm run test -- --shard=${{ matrix.shard }}/4 --reporter=dot
         env:
           NODE_ENV: test
           NODE_OPTIONS: --max-old-space-size=8192
 
-      - name: Generate test summary
-        id: test-summary
-        if: always()
-        run: |
-          if [ -f coverage/coverage-summary.json ]; then
-            LINES=$(node -p "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json', 'utf-8')).total.lines.pct.toFixed(2)")
-            STATEMENTS=$(node -p "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json', 'utf-8')).total.statements.pct.toFixed(2)")
-            FUNCTIONS=$(node -p "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json', 'utf-8')).total.functions.pct.toFixed(2)")
-            BRANCHES=$(node -p "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json', 'utf-8')).total.branches.pct.toFixed(2)")
-            
-            echo "lines=${LINES}" >> $GITHUB_OUTPUT
-            echo "statements=${STATEMENTS}" >> $GITHUB_OUTPUT
-            echo "functions=${FUNCTIONS}" >> $GITHUB_OUTPUT
-            echo "branches=${BRANCHES}" >> $GITHUB_OUTPUT
-            echo "has_coverage=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_coverage=false" >> $GITHUB_OUTPUT
-          fi
-
+  report:
+    if: always() && github.event_name == 'pull_request'
+    needs: [test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
       - name: Comment PR with test results
-        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const hasCoverage = '${{ steps.test-summary.outputs.has_coverage }}' === 'true';
-            
-            let body = '';
-            
-            if (context.payload.workflow_run && context.payload.workflow_run.conclusion === 'failure') {
-              body = `## ❌ Tests Failed\n\nSome tests failed. Please check the workflow logs for details.`;
-            } else if ('${{ job.status }}' === 'success') {
-              body = `## ✅ All Tests Passed!\n\n`;
-              
-              if (hasCoverage) {
-                const lines = '${{ steps.test-summary.outputs.lines }}';
-                const statements = '${{ steps.test-summary.outputs.statements }}';
-                const functions = '${{ steps.test-summary.outputs.functions }}';
-                const branches = '${{ steps.test-summary.outputs.branches }}';
-                
-                const coverageColor = (pct) => {
-                  const num = parseFloat(pct);
-                  if (num >= 80) return '🟢';
-                  if (num >= 70) return '🟡';
-                  if (num >= 50) return '🟠';
-                  return '🔴';
-                };
-                
-                body += `### 📊 Test Coverage\n\n`;
-                body += `| Metric | Coverage | Status |\n`;
-                body += `|--------|----------|--------|\n`;
-                body += `| Lines | ${lines}% | ${coverageColor(lines)} |\n`;
-                body += `| Statements | ${statements}% | ${coverageColor(statements)} |\n`;
-                body += `| Functions | ${functions}% | ${coverageColor(functions)} |\n`;
-                body += `| Branches | ${branches}% | ${coverageColor(branches)} |\n\n`;
-                
-                const minCoverage = 50;
-                if (parseFloat(lines) >= minCoverage) {
-                  body += `✅ Coverage meets the minimum threshold of ${minCoverage}%\n\n`;
-                } else {
-                  body += `⚠️ **Warning:** Coverage is below the ${minCoverage}% threshold\n\n`;
-                }
-              } else {
-                body += `Coverage report not available.\n\n`;
-              }
-              
-              body += `**Linting:** ✅ Passed\n`;
-              body += `**Tests:** ✅ All tests passed\n\n`;
-            } else {
-              body = `## ⚠️ Tests Completed with Issues\n\nPlease check the workflow logs for details.`;
-            }
-            
-            body += `\n---\n*Automated test report*`;
-            
-            // Find existing comment
+            const testsResult = '${{ needs.test.result }}';
+            const passed = testsResult === 'success';
+
+            const body = passed
+              ? `## ✅ All Tests Passed!\n\nAll 4 shards completed successfully.\n\n---\n*Automated test report*`
+              : `## ❌ Tests Failed\n\nOne or more test shards failed. Check the workflow logs for details.\n\n---\n*Automated test report*`;
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' && 
-              (comment.body.includes('All Tests Passed') || 
+              comment.user.type === 'Bot' &&
+              (comment.body.includes('All Tests Passed') ||
                comment.body.includes('Tests Failed') ||
                comment.body.includes('Tests Completed with Issues'))
             );
-            
+
             if (botComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -139,15 +84,3 @@ jobs:
                 body,
               });
             }
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: |
-            coverage/
-            test-results.json
-          retention-days: 7
-          if-no-files-found: ignore
-

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,6 +25,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Expose the actual test step outcome so the report job can see real
+    # pass/fail. needs.test.result alone is always 'success' because the
+    # step uses continue-on-error to mask pre-existing failures (#1306).
+    outputs:
+      tests_outcome: ${{ steps.tests.outcome }}
 
     steps:
       - name: Checkout code
@@ -59,10 +64,12 @@ jobs:
             ${{ runner.os }}-vitest-
 
       - name: Run tests
+        id: tests
         # Pre-existing test debt (issue #1306) — main currently fails dozens
         # of test files but is hidden by this same flag. Removing it is
         # tracked as separate cleanup; do not gate this CI-optimization PR
-        # on a pre-existing red baseline.
+        # on a pre-existing red baseline. The step's `outcome` is still
+        # surfaced via the job output so the report comment shows reality.
         continue-on-error: true
         run: pnpm run test -- --reporter=dot
         env:
@@ -80,13 +87,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const testsResult = '${{ needs.test.result }}';
-            const passed = testsResult === 'success';
+            // Use the step outcome (exposed as job output) instead of the
+            // job result. The job always succeeds because `Run tests` is
+            // marked continue-on-error to mask pre-existing failures
+            // (#1306); the step `outcome` reflects real pass/fail.
+            const testsOutcome = '${{ needs.test.outputs.tests_outcome }}';
+            const passed = testsOutcome === 'success';
             const marker = '<!-- pr-tests-report -->';
 
             const body = passed
               ? `${marker}\n## ✅ All Tests Passed!\n\n---\n*Automated test report*`
-              : `${marker}\n## ❌ Tests Failed\n\nCheck the workflow logs for details.\n\n---\n*Automated test report*`;
+              : `${marker}\n## ❌ Tests Failed\n\nCheck the workflow logs for details.\n\n_Note: this PR's test job uses \`continue-on-error\` to allow merging while pre-existing test debt is being cleaned up (issue #1306). Failures here will not block merge until #1306 is resolved._\n\n---\n*Automated test report*`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,15 +33,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -53,7 +53,7 @@ jobs:
       # transformed module graph across runs. Keyed on lockfile + source
       # hash so dep or code changes invalidate cleanly.
       - name: Cache vitest transform
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules/.vite
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Comment PR with test results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -49,6 +49,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests (shard ${{ matrix.shard }}/4)
+        # Pre-existing test debt (issue #1306) — main currently fails dozens
+        # of test files but is hidden by this same flag. Removing it is
+        # tracked as separate cleanup; do not gate this CI-optimization PR
+        # on a pre-existing red baseline.
+        continue-on-error: true
         run: pnpm run test -- --shard=${{ matrix.shard }}/4 --reporter=dot
         env:
           NODE_ENV: test
@@ -67,10 +72,11 @@ jobs:
           script: |
             const testsResult = '${{ needs.test.result }}';
             const passed = testsResult === 'success';
+            const marker = '<!-- pr-tests-report -->';
 
             const body = passed
-              ? `## ✅ All Tests Passed!\n\nAll 4 shards completed successfully.\n\n---\n*Automated test report*`
-              : `## ❌ Tests Failed\n\nOne or more test shards failed. Check the workflow logs for details.\n\n---\n*Automated test report*`;
+              ? `${marker}\n## ✅ All Tests Passed!\n\nAll 4 shards completed successfully.\n\n---\n*Automated test report*`
+              : `${marker}\n## ❌ Tests Failed\n\nOne or more test shards failed. Check the workflow logs for details.\n\n---\n*Automated test report*`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -78,11 +84,9 @@ jobs:
               issue_number: context.issue.number,
             });
 
+            // Match by hidden marker so we don't clobber unrelated bot comments.
             const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              (comment.body.includes('All Tests Passed') ||
-               comment.body.includes('Tests Failed') ||
-               comment.body.includes('Tests Completed with Issues'))
+              comment.user.type === 'Bot' && comment.body.includes(marker)
             );
 
             if (botComment) {

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,10 +25,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout code
@@ -48,13 +44,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests (shard ${{ matrix.shard }}/4)
+      # Vite/vitest transform cache — speeds up cold-start by reusing
+      # transformed module graph across runs. Keyed on lockfile + source
+      # hash so dep or code changes invalidate cleanly.
+      - name: Cache vitest transform
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.vite
+            node_modules/.cache/vitest
+          key: ${{ runner.os }}-vitest-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**/*.ts', '**/*.tsx', '!node_modules/**', '!.next/**') }}
+          restore-keys: |
+            ${{ runner.os }}-vitest-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-vitest-
+
+      - name: Run tests
         # Pre-existing test debt (issue #1306) — main currently fails dozens
         # of test files but is hidden by this same flag. Removing it is
         # tracked as separate cleanup; do not gate this CI-optimization PR
         # on a pre-existing red baseline.
         continue-on-error: true
-        run: pnpm run test -- --shard=${{ matrix.shard }}/4 --reporter=dot
+        run: pnpm run test -- --reporter=dot
         env:
           NODE_ENV: test
           NODE_OPTIONS: --max-old-space-size=8192
@@ -75,8 +85,8 @@ jobs:
             const marker = '<!-- pr-tests-report -->';
 
             const body = passed
-              ? `${marker}\n## ✅ All Tests Passed!\n\nAll 4 shards completed successfully.\n\n---\n*Automated test report*`
-              : `${marker}\n## ❌ Tests Failed\n\nOne or more test shards failed. Check the workflow logs for details.\n\n---\n*Automated test report*`;
+              ? `${marker}\n## ✅ All Tests Passed!\n\n---\n*Automated test report*`
+              : `${marker}\n## ❌ Tests Failed\n\nCheck the workflow logs for details.\n\n---\n*Automated test report*`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,6 +4,22 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ['**'] # Run on PRs targeting any branch
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.svg'
+      - '**/*.gif'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - name: Checkout (tag push)
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag }}
 
@@ -46,12 +46,12 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -271,19 +271,20 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Pack .next into tarball
+        # actions/upload-artifact@v4 rejects filenames containing `:` (NTFS
+        # incompatibility). Next.js + Turbopack emits chunks like
+        # `[externals]_node:inspector_*.js`, so uploading raw `.next/` fails.
+        # Packaging into a single tarball sidesteps the per-file validator.
+        run: tar --exclude='.next/cache' -czf next-build.tar.gz .next
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: qa-build
-          # Glob form (`**`) is required for `actions/upload-artifact@v4`
-          # to honor the negation pattern; the directory shorthand `.next/`
-          # silently misses files and the negation never applies.
-          path: |
-            .next/**
-            !.next/cache/**
+          path: next-build.tar.gz
           retention-days: 1
           if-no-files-found: error
-          include-hidden-files: true
 
   # qa-execution and dogfood run IN PARALLEL after the shared build,
   # each downloading the prebuilt .next/ artifact instead of rebuilding.
@@ -322,7 +323,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: qa-build
-          path: .next/
+
+      - name: Unpack .next tarball
+        run: tar -xzf next-build.tar.gz
 
       - name: Start local server
         run: pnpm start &
@@ -434,7 +437,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: qa-build
-          path: .next/
+
+      - name: Unpack .next tarball
+        run: tar -xzf next-build.tar.gz
 
       - name: Start local server
         run: pnpm start &

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -75,7 +75,10 @@ jobs:
             // Poll for verdict comment
             if (!isManual) {
               let reviewComment = null;
-              const maxAttempts = 12;
+              // Claude Code workflow_run completes only after posting the
+              // verdict comment, so the comment is essentially always there
+              // by the time we poll. Keep a short retry for race conditions.
+              const maxAttempts = 5;
 
               for (let attempt = 1; attempt <= maxAttempts; attempt++) {
                 const { data: comments } = await github.rest.issues.listComments({
@@ -89,7 +92,7 @@ jobs:
 
                 if (reviewComment) break;
                 console.log('Waiting for review verdict... (' + attempt + '/' + maxAttempts + ')');
-                await new Promise(r => setTimeout(r, 15000));
+                await new Promise(r => setTimeout(r, 10000));
               }
 
               if (!reviewComment) {
@@ -141,7 +144,7 @@ jobs:
     needs: gate-check
     if: needs.gate-check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -171,7 +174,7 @@ jobs:
             Generate a QA plan for this PR. Save to qa-plan.md.
             Then post the QA plan as a comment on PR #$PR_NUMBER using the GitHub CLI (gh pr comment $PR_NUMBER --body-file qa-plan-comment.md). Write the comment content to qa-plan-comment.md first, then use gh to post it.
             Be strict. Be concise. No fluff."
-        timeout-minutes: 25
+        timeout-minutes: 15
 
       - name: Upload QA plan artifact
         if: always()
@@ -206,11 +209,13 @@ jobs:
             }
 
   # Build the app ONCE and share with both qa-execution and dogfood via artifact.
-  # Saves ~2m 30s of duplicated build work compared to building in each job.
+  # Runs IN PARALLEL with qa-plan (qa-plan only reads source, doesn't need .next/)
+  # so the build doesn't sit idle waiting for Claude to draft the plan.
   build:
-    needs: [gate-check, qa-plan]
+    needs: [gate-check]
+    if: needs.gate-check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -262,7 +267,7 @@ jobs:
   qa-execution:
     needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -301,7 +306,16 @@ jobs:
           PORT: 3000
 
       - name: Wait for server
-        run: npx wait-on http://localhost:3000 --timeout 120000
+        run: |
+          for i in $(seq 1 60); do
+            if curl --silent --fail --max-time 2 http://localhost:3000/ >/dev/null 2>&1; then
+              echo "Server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start within 60s"
+          exit 1
 
       - name: Generate GitHub App token
         id: app-token
@@ -329,7 +343,7 @@ jobs:
             IMPORTANT: Always use http://localhost:3000 as the target URL. Never use a preview/vercel URL.
             Post the results as a comment on PR #$PR_NUMBER using gh pr comment.
             Save results to qa-results.json."
-        timeout-minutes: 40
+        timeout-minutes: 20
 
       - name: Upload QA execution artifacts
         if: always()
@@ -345,7 +359,7 @@ jobs:
   dogfood:
     needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -385,7 +399,16 @@ jobs:
           PORT: 3000
 
       - name: Wait for server
-        run: npx wait-on http://localhost:3000 --timeout 120000
+        run: |
+          for i in $(seq 1 60); do
+            if curl --silent --fail --max-time 2 http://localhost:3000/ >/dev/null 2>&1; then
+              echo "Server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start within 60s"
+          exit 1
 
       - name: Generate GitHub App token
         id: app-token
@@ -442,7 +465,7 @@ jobs:
 
             Save to dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
             critical/high counts = PR-caused only."
-        timeout-minutes: 40
+        timeout-minutes: 20
 
       - name: Upload dogfood artifacts
         if: always()

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -1,9 +1,21 @@
 name: QA Pipeline
 
 on:
-  workflow_run:
-    workflows: ['Claude Code']
-    types: [completed]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.svg'
+      - '**/*.gif'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/CODEOWNERS'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -16,11 +28,14 @@ env:
   NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
   NEXT_PUBLIC_GAP_INDEXER_URL: https://gapstagapi.karmahq.xyz
 
+concurrency:
+  group: qa-pipeline-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   gate-check:
-    if: >
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      github.event_name == 'workflow_dispatch'
+    # For pull_request events: always run gate-check (we check Claude Code check-run inside).
+    # For workflow_dispatch: always run.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -28,7 +43,7 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
       head_sha: ${{ steps.check.outputs.head_sha }}
     steps:
-      - name: Check review verdict
+      - name: Check Claude Code verdict and PR state
         id: check
         uses: actions/github-script@v7
         with:
@@ -49,20 +64,10 @@ jobs:
                 return;
               }
             } else {
-              headSha = context.payload.workflow_run.head_sha;
-              const headBranch = context.payload.workflow_run.head_branch;
-              const { data: prs } = await github.rest.pulls.list({
-                owner, repo, state: 'open',
-                head: `${owner}:${headBranch}`, per_page: 1
-              });
-              if (prs.length === 0) {
-                console.log('No open PR found');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-              const pr = prs[0];
-              prNumber = pr.number;
-              if (pr.draft) {
+              // pull_request event — use event payload directly
+              prNumber = context.payload.pull_request.number;
+              headSha = context.payload.pull_request.head.sha;
+              if (context.payload.pull_request.draft) {
                 console.log('PR is draft, skipping');
                 core.setOutput('should_run', 'false');
                 return;
@@ -72,48 +77,67 @@ jobs:
             core.setOutput('head_sha', headSha);
             core.setOutput('pr_number', prNumber);
 
-            // Poll for verdict comment
+            // For pull_request events: verify the latest "Claude Code" check-run
+            // on this commit has succeeded. If it hasn't run yet or is in progress,
+            // skip gracefully — Claude Code will trigger another push event when
+            // it completes, which will start a fresh QA pipeline run.
             if (!isManual) {
-              let reviewComment = null;
-              // Claude Code workflow_run completes only after posting the
-              // verdict comment, so the comment is essentially always there
-              // by the time we poll. Keep a short retry for race conditions.
-              const maxAttempts = 5;
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner, repo, ref: headSha, per_page: 100
+              });
 
-              for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                const { data: comments } = await github.rest.issues.listComments({
-                  owner, repo, issue_number: prNumber, per_page: 100
-                });
+              const claudeRuns = checkRuns.check_runs
+                .filter(r => r.name === 'Claude Code')
+                .sort((a, b) => new Date(b.started_at) - new Date(a.started_at));
 
-                reviewComment = [...comments].reverse().find(c =>
-                  (c.user.login === 'github-actions[bot]' || c.user.login.includes('claude') || c.user.login.includes('karma')) &&
-                  (c.body.includes('APPROVE') || c.body.includes('REQUEST CHANGES'))
-                );
-
-                if (reviewComment) break;
-                console.log('Waiting for review verdict... (' + attempt + '/' + maxAttempts + ')');
-                await new Promise(r => setTimeout(r, 10000));
-              }
-
-              if (!reviewComment) {
-                console.log('No Claude Code review verdict found after polling');
+              if (claudeRuns.length === 0) {
+                console.log('No "Claude Code" check-run found on this commit — skipping (Claude Code will trigger QA when it finishes)');
                 core.setOutput('should_run', 'false');
                 return;
               }
 
-              const verdict = reviewComment.body;
-              const isApproved = (verdict.includes('✅') || verdict.includes('⚠️')) && verdict.includes('APPROVE') && !verdict.includes('REQUEST CHANGES');
-              if (!isApproved) {
-                console.log('Review verdict is REQUEST CHANGES — skipping QA');
+              const latest = claudeRuns[0];
+              if (latest.status !== 'completed') {
+                console.log(`"Claude Code" check is ${latest.status} — skipping (will re-run when Claude Code finishes)`);
                 core.setOutput('should_run', 'false');
                 return;
               }
-              console.log('✅ Review approved');
+
+              if (latest.conclusion !== 'success') {
+                console.log(`"Claude Code" check concluded with ${latest.conclusion} — skipping QA`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+
+              console.log('✅ Claude Code check succeeded');
+
+              // Additionally verify the PR-review verdict comment is APPROVE
+              const { data: comments } = await github.rest.issues.listComments({
+                owner, repo, issue_number: prNumber, per_page: 100
+              });
+
+              const reviewComment = [...comments].reverse().find(c =>
+                (c.user.login === 'github-actions[bot]' || c.user.login.includes('claude') || c.user.login.includes('karma')) &&
+                (c.body.includes('APPROVE') || c.body.includes('REQUEST CHANGES'))
+              );
+
+              if (reviewComment) {
+                const verdict = reviewComment.body;
+                const isApproved = (verdict.includes('✅') || verdict.includes('⚠️')) && verdict.includes('APPROVE') && !verdict.includes('REQUEST CHANGES');
+                if (!isApproved) {
+                  console.log('Review verdict is REQUEST CHANGES — skipping QA');
+                  core.setOutput('should_run', 'false');
+                  return;
+                }
+                console.log('✅ Review approved');
+              } else {
+                console.log('No review verdict comment found — proceeding (Claude Code check was successful)');
+              }
             } else {
-              console.log('Manual trigger — skipping verdict check');
+              console.log('Manual trigger — skipping Claude Code check');
             }
 
-            // Set pending commit status + post progress comment
+            // Set pending commit status + post/update consolidated progress comment
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: headSha,
               state: 'pending',
@@ -122,21 +146,32 @@ jobs:
               target_url: `https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
             });
 
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: prNumber,
-              body: [
-                '## QA Pipeline',
-                '',
-                '| Stage | Status |',
-                '|-------|--------|',
-                '| QA Plan | ⏳ Running... |',
-                '| QA Execution | ⏳ Waiting |',
-                '| Dogfood | ⏳ Waiting |',
-                '| Verdict | ⏳ Waiting |',
-                '',
-                `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID})`
-              ].join('\n')
+            const marker = '<!-- qa-pipeline-status -->';
+            const progressBody = [
+              marker,
+              '## QA Pipeline',
+              '',
+              '| Stage | Status |',
+              '|-------|--------|',
+              '| QA Plan | ⏳ Running... |',
+              '| Build | ⏳ Running... |',
+              '| QA Execution | ⏳ Waiting |',
+              '| Dogfood | ⏳ Waiting |',
+              '| Verdict | ⏳ Waiting |',
+              '',
+              `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID})`
+            ].join('\n');
+
+            // Find existing pipeline comment by marker; update or create.
+            const { data: allComments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber, per_page: 100
             });
+            const existing = allComments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: progressBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: progressBody });
+            }
 
             core.setOutput('should_run', 'true');
 
@@ -152,7 +187,24 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
+      - name: Compute changed-file list for cache key
+        id: changed-files
+        # Write inside $GITHUB_WORKSPACE so hashFiles() can read it — hashFiles
+        # only sees workspace-relative paths, not /tmp.
+        run: |
+          git diff --name-only origin/main...HEAD | sort > .qa-plan-changed-files.txt
+          echo "Changed files:"
+          cat .qa-plan-changed-files.txt
+
+      - name: Cache QA plan output
+        id: qa-plan-cache
+        uses: actions/cache@v4
+        with:
+          path: qa-plan.md
+          key: qa-plan-${{ hashFiles('.qa-plan-changed-files.txt') }}
+
       - name: Generate GitHub App token
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -160,10 +212,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Get ISO week for cache key
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         id: weeknum
         run: echo "weeknum=$(date -u +'%G-W%V')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Claude Code install
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         id: claude-cache
         uses: actions/cache@v4
         with:
@@ -173,16 +227,18 @@ jobs:
             claude-code-${{ runner.os }}-
 
       - name: Install Claude Code
-        if: steps.claude-cache.outputs.cache-hit != 'true'
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true' && steps.claude-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.npm-global
           npm config set prefix ~/.npm-global
           npm install -g @anthropic-ai/claude-code
 
       - name: Add Claude Code to PATH
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Generate QA Plan
+        if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
@@ -192,7 +248,6 @@ jobs:
             "You are a strict senior QA engineer. Read and follow the skill at .claude/skills/qa-plan-generator/SKILL.md exactly.
             PR number: $PR_NUMBER.
             Generate a QA plan for this PR. Save to qa-plan.md.
-            Then post the QA plan as a comment on PR #$PR_NUMBER using the GitHub CLI (gh pr comment $PR_NUMBER --body-file qa-plan-comment.md). Write the comment content to qa-plan-comment.md first, then use gh to post it.
             Be strict. Be concise. No fluff."
         timeout-minutes: 15
 
@@ -205,7 +260,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      - name: Update progress comment
+      - name: Update progress comment (QA Plan done)
         if: always()
         uses: actions/github-script@v7
         env:
@@ -217,13 +272,20 @@ jobs:
             const repo = context.repo.repo;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const planOk = process.env.PLAN_RESULT === 'success';
+            const marker = '<!-- qa-pipeline-status -->';
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber, per_page: 100 });
-            const pc = [...comments].reverse().find(c => c.body.includes('## QA Pipeline') && c.body.includes('QA Plan'));
+            const pc = comments.find(c => c.body.includes(marker));
             if (pc) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: pc.id,
-                body: ['## QA Pipeline','','| Stage | Status |','|-------|--------|',
+                body: [
+                  marker,
+                  '## QA Pipeline', '',
+                  '| Stage | Status |', '|-------|--------|',
                   `| QA Plan | ${planOk ? '✅ Done' : '❌ Failed'} |`,
-                  '| QA Execution | ⏳ Building & running... |','| Dogfood | ⏳ Building & running... |','| Verdict | ⏳ Waiting |','',
+                  '| Build | ⏳ Running... |',
+                  '| QA Execution | ⏳ Building & running... |',
+                  '| Dogfood | ⏳ Building & running... |',
+                  '| Verdict | ⏳ Waiting |', '',
                   `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID})`
                 ].join('\n') });
             }
@@ -285,6 +347,36 @@ jobs:
           path: next-build.tar.gz
           retention-days: 1
           if-no-files-found: error
+
+      - name: Update progress comment (Build done)
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
+          BUILD_RESULT: ${{ job.status }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const buildOk = process.env.BUILD_RESULT === 'success';
+            const marker = '<!-- qa-pipeline-status -->';
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber, per_page: 100 });
+            const pc = comments.find(c => c.body.includes(marker));
+            if (pc) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: pc.id,
+                body: [
+                  marker,
+                  '## QA Pipeline', '',
+                  '| Stage | Status |', '|-------|--------|',
+                  '| QA Plan | ✅ Done |',
+                  `| Build | ${buildOk ? '✅ Done' : '❌ Failed'} |`,
+                  `| QA Execution | ${buildOk ? '⏳ Running...' : '⏭️ Skipped (build failed)'} |`,
+                  `| Dogfood | ${buildOk ? '⏳ Running...' : '⏭️ Skipped (build failed)'} |`,
+                  '| Verdict | ⏳ Waiting |', '',
+                  `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID})`
+                ].join('\n') });
+            }
 
   # qa-execution and dogfood run IN PARALLEL after the shared build,
   # each downloading the prebuilt .next/ artifact instead of rebuilding.
@@ -404,7 +496,7 @@ jobs:
             For authenticated scenarios, login with QA_TEST_EMAIL + QA_TEST_OTP env vars.
             Apply the skill's 'Speed Rules' strictly — targeted waits, no networkidle after in-page actions.
             After execution, rename qa-results.json to qa-results-\$SHARD_ID.json (the skill describes this).
-            Post results as a comment on PR #$PR_NUMBER via gh pr comment, with the shard label in the heading (e.g. 'QA Execution — public shard')."
+            Do NOT post a separate PR comment — results will be aggregated in the pipeline verdict comment."
         timeout-minutes: 20
 
       - name: Upload QA execution artifacts (shard ${{ matrix.shard }})
@@ -422,6 +514,11 @@ jobs:
     needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Note: dogfood is intentionally NOT matrix-split. The exploratory nature
+    # of dogfood (navigating changed pages, classifying PR-caused vs pre-existing
+    # issues, filing GitHub issues for pre-existing bugs) does not decompose
+    # cleanly by P/A shard — the skill prompt is holistic and stateful. Splitting
+    # it would risk double-filing issues and producing incoherent results.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -530,25 +627,10 @@ jobs:
             - **PR-caused**: Affected file appears in the git diff.
             - **Pre-existing**: Does NOT appear in the git diff. Create a GitHub issue using gh issue create --title '[QA] <title>' --body '<description>' --label bug.
 
-            Post results as a comment on PR #$PR_NUMBER using gh pr comment. Format:
-
-            ## Dogfood (3/3)
-
-            **PR-caused issues**: X found (Y critical, Z high)
-            **Pre-existing issues**: N found (created as GitHub issues)
-
-            ### PR-Caused
-            | # | Issue | Severity | Category |
-            |---|-------|----------|----------|
-
-            ### Pre-existing (filed as issues)
-            | # | Issue | Severity | GitHub Issue |
-            |---|-------|----------|-------------|
-
-            **Verdict**: PASS or FAIL (based on PR-caused Critical/High only)
-
             Save to dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
-            critical/high counts = PR-caused only."
+            critical/high counts = PR-caused only.
+
+            Do NOT post a separate PR comment — results will be aggregated in the pipeline verdict comment."
         timeout-minutes: 20
 
       - name: Upload dogfood artifacts
@@ -667,27 +749,28 @@ jobs:
               target_url: `https://github.com/${owner}/${repo}/actions/runs/${process.env.RUN_ID}`
             });
 
-            // Update progress comment with actual job results
+            // Update the single consolidated pipeline comment with final verdict
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const icon = (r) => r === 'success' ? '✅ Done' : r === 'skipped' ? '⏭️ Skipped' : '❌ Failed';
             const verdictIcon = hasBlockingIssues ? '❌' : '✅';
             const verdictText = hasBlockingIssues ? `FAIL — ${description}` : 'PASS — no blocking issues';
+            const marker = '<!-- qa-pipeline-status -->';
 
             const { data: cmts } = await github.rest.issues.listComments({
               owner, repo, issue_number: prNumber, per_page: 100
             });
-            const pc = [...cmts].reverse().find(c =>
-              c.body.includes('## QA Pipeline') && c.body.includes('QA Plan')
-            );
+            const pc = cmts.find(c => c.body.includes(marker));
             if (pc) {
               await github.rest.issues.updateComment({
                 owner, repo, comment_id: pc.id,
                 body: [
+                  marker,
                   '## QA Pipeline',
                   '',
                   '| Stage | Status |',
                   '|-------|--------|',
                   '| QA Plan | ✅ Done |',
+                  '| Build | ✅ Done |',
                   `| QA Execution | ${icon(execResult)} |`,
                   `| Dogfood | ${icon(dogfoodResult)} |`,
                   `| **Verdict** | **${verdictIcon} ${verdictText}** |`,

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -327,14 +327,15 @@ jobs:
 
       - name: Wait for server
         run: |
+          start=$SECONDS
           for i in $(seq 1 60); do
             if curl --silent --fail --max-time 2 http://localhost:3000/ >/dev/null 2>&1; then
-              echo "Server is up after ${i}s"
+              echo "Server is up after $((SECONDS - start))s (attempt ${i})"
               exit 0
             fi
             sleep 1
           done
-          echo "Server failed to start within 60s"
+          echo "Server failed to start within $((SECONDS - start))s (60 attempts)"
           exit 1
 
       - name: Generate GitHub App token
@@ -438,14 +439,15 @@ jobs:
 
       - name: Wait for server
         run: |
+          start=$SECONDS
           for i in $(seq 1 60); do
             if curl --silent --fail --max-time 2 http://localhost:3000/ >/dev/null 2>&1; then
-              echo "Server is up after ${i}s"
+              echo "Server is up after $((SECONDS - start))s (attempt ${i})"
               exit 0
             fi
             sleep 1
           done
-          echo "Server failed to start within 60s"
+          echo "Server failed to start within $((SECONDS - start))s (60 attempts)"
           exit 1
 
       - name: Generate GitHub App token

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -289,10 +289,20 @@ jobs:
   # qa-execution and dogfood run IN PARALLEL after the shared build,
   # each downloading the prebuilt .next/ artifact instead of rebuilding.
 
+  # Sharded QA execution: split scenarios across parallel jobs to roughly
+  # halve wall time. The `public` shard runs P-prefixed scenarios with no
+  # auth (fastest); the `auth` shard runs A-prefixed scenarios after Privy
+  # login. Each shard reads $SHARD_ID and self-filters via the qa-executor
+  # skill. Each uploads `qa-results-<shard>.json`; the verdict job
+  # aggregates by globbing all shards.
   qa-execution:
     needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [public, auth]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -375,30 +385,36 @@ jobs:
       - name: Add Claude Code to PATH
         run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
-      - name: Execute QA Plan
+      - name: Execute QA Plan (shard ${{ matrix.shard }})
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
           QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
           QA_TEST_OTP: ${{ secrets.QA_TEST_OTP }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHARD_ID: ${{ matrix.shard }}
         run: |
           claude --print --dangerously-skip-permissions \
             "You are a strict senior QA executor. Read and follow the skill at .claude/skills/qa-executor/SKILL.md exactly.
             PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
-            QA Plan is at qa-plan.md. Execute ALL scenarios — both Public (P1, P2...) and Authenticated (A1, A2...).
+            SHARD_ID=$SHARD_ID — execute ONLY scenarios in this shard per the skill's 'Sharded Execution' section.
+              - SHARD_ID=public: run P-prefixed scenarios. Skip Privy login entirely.
+              - SHARD_ID=auth: run A-prefixed scenarios. Login first, then execute.
+            QA Plan is at qa-plan.md.
             For authenticated scenarios, login with QA_TEST_EMAIL + QA_TEST_OTP env vars.
-            Post results as a comment on PR #$PR_NUMBER via gh pr comment. Save results to qa-results.json."
+            Apply the skill's 'Speed Rules' strictly — targeted waits, no networkidle after in-page actions.
+            After execution, rename qa-results.json to qa-results-\$SHARD_ID.json (the skill describes this).
+            Post results as a comment on PR #$PR_NUMBER via gh pr comment, with the shard label in the heading (e.g. 'QA Execution — public shard')."
         timeout-minutes: 20
 
-      - name: Upload QA execution artifacts
+      - name: Upload QA execution artifacts (shard ${{ matrix.shard }})
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: qa-execution-results
+          name: qa-execution-results-${{ matrix.shard }}
           path: |
             qa-output/
-            qa-results.json
+            qa-results-${{ matrix.shard }}.json
           retention-days: 7
           if-no-files-found: ignore
 
@@ -552,10 +568,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Download QA results
+      - name: Download QA results (all shards)
         uses: actions/download-artifact@v4
         with:
-          name: qa-execution-results
+          # Pull every per-shard artifact (qa-execution-results-public,
+          # qa-execution-results-auth, ...) into the same directory so
+          # the aggregator can glob qa-results-*.json.
+          pattern: qa-execution-results-*
+          merge-multiple: true
         continue-on-error: true
 
       - name: Download dogfood results
@@ -586,16 +606,32 @@ jobs:
             let criticalCount = 0;
             let highCount = 0;
 
+            // Aggregate qa-results-*.json from all sharded qa-execution jobs
+            // (qa-results-public.json, qa-results-auth.json, ...). A missing
+            // file means that shard didn't upload — counted as exec failure
+            // already via QA_EXEC_RESULT, so we silently skip here.
             try {
-              const qaResults = JSON.parse(fs.readFileSync('qa-results.json', 'utf8'));
-              for (const s of (qaResults.scenarios || [])) {
-                if (s.result === 'FAIL') {
-                  if (s.severity?.toLowerCase() === 'critical') criticalCount++;
-                  if (s.severity?.toLowerCase() === 'high') highCount++;
+              const shardFiles = fs.readdirSync('.').filter(f =>
+                /^qa-results-.+\.json$/.test(f)
+              );
+              if (shardFiles.length === 0) {
+                console.log('No qa-results-*.json files found from sharded jobs');
+              }
+              for (const file of shardFiles) {
+                try {
+                  const r = JSON.parse(fs.readFileSync(file, 'utf8'));
+                  for (const s of (r.scenarios || [])) {
+                    if (s.result === 'FAIL') {
+                      if (s.severity?.toLowerCase() === 'critical') criticalCount++;
+                      if (s.severity?.toLowerCase() === 'high') highCount++;
+                    }
+                  }
+                } catch (e) {
+                  console.log(`Could not parse ${file}: ${e.message}`);
                 }
               }
             } catch (e) {
-              console.log('Could not parse qa-results.json: ' + e.message);
+              console.log('Could not enumerate qa-results-*.json: ' + e.message);
             }
 
             try {

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Check Claude Code verdict and PR state
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -182,7 +182,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
@@ -198,7 +198,7 @@ jobs:
 
       - name: Cache QA plan output
         id: qa-plan-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: qa-plan.md
           key: qa-plan-${{ hashFiles('.qa-plan-changed-files.txt') }}
@@ -206,7 +206,7 @@ jobs:
       - name: Generate GitHub App token
         if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -219,7 +219,7 @@ jobs:
       - name: Cache Claude Code install
         if: steps.qa-plan-cache.outputs.cache-hit != 'true'
         id: claude-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm-global
           key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload QA plan artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qa-plan
           path: qa-plan.md
@@ -262,7 +262,7 @@ jobs:
 
       - name: Update progress comment (QA Plan done)
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
           PLAN_RESULT: ${{ job.status }}
@@ -300,18 +300,18 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -320,7 +320,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .next/cache
           key: ${{ runner.os }}-nextjs-qa-${{ needs.gate-check.outputs.head_sha }}
@@ -334,14 +334,14 @@ jobs:
           NODE_ENV: production
 
       - name: Pack .next into tarball
-        # actions/upload-artifact@v4 rejects filenames containing `:` (NTFS
+        # actions/upload-artifact@v5 rejects filenames containing `:` (NTFS
         # incompatibility). Next.js + Turbopack emits chunks like
         # `[externals]_node:inspector_*.js`, so uploading raw `.next/` fails.
         # Packaging into a single tarball sidesteps the per-file validator.
         run: tar --exclude='.next/cache' -czf next-build.tar.gz .next
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qa-build
           path: next-build.tar.gz
@@ -350,7 +350,7 @@ jobs:
 
       - name: Update progress comment (Build done)
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
           BUILD_RESULT: ${{ job.status }}
@@ -397,23 +397,23 @@ jobs:
         shard: [public, auth]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
       - name: Download QA plan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qa-plan
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -422,7 +422,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prebuilt .next
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qa-build
 
@@ -449,7 +449,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -460,7 +460,7 @@ jobs:
 
       - name: Cache Claude Code install
         id: claude-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm-global
           key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
@@ -501,7 +501,7 @@ jobs:
 
       - name: Upload QA execution artifacts (shard ${{ matrix.shard }})
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qa-execution-results-${{ matrix.shard }}
           path: |
@@ -521,24 +521,24 @@ jobs:
     # it would risk double-filing issues and producing incoherent results.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
       - name: Download QA plan for scope context
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qa-plan
         continue-on-error: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -547,7 +547,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download prebuilt .next
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qa-build
 
@@ -574,7 +574,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -585,7 +585,7 @@ jobs:
 
       - name: Cache Claude Code install
         id: claude-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm-global
           key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
@@ -635,7 +635,7 @@ jobs:
 
       - name: Upload dogfood artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dogfood-results
           path: |
@@ -651,7 +651,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download QA results (all shards)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           # Pull every per-shard artifact (qa-execution-results-public,
           # qa-execution-results-auth, ...) into the same directory so
@@ -661,13 +661,13 @@ jobs:
         continue-on-error: true
 
       - name: Download dogfood results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dogfood-results
         continue-on-error: true
 
       - name: Evaluate and set commit status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           HEAD_SHA: ${{ needs.gate-check.outputs.head_sha }}
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -159,8 +159,28 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Get ISO week for cache key
+        id: weeknum
+        run: echo "weeknum=$(date -u +'%G-W%V')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Claude Code install
+        id: claude-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
+          restore-keys: |
+            claude-code-${{ runner.os }}-
+
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        if: steps.claude-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.npm-global
+          npm config set prefix ~/.npm-global
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Add Claude Code to PATH
+        run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Generate QA Plan
         env:
@@ -324,8 +344,28 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Get ISO week for cache key
+        id: weeknum
+        run: echo "weeknum=$(date -u +'%G-W%V')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Claude Code install
+        id: claude-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
+          restore-keys: |
+            claude-code-${{ runner.os }}-
+
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        if: steps.claude-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.npm-global
+          npm config set prefix ~/.npm-global
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Add Claude Code to PATH
+        run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Execute QA Plan
         env:
@@ -337,12 +377,10 @@ jobs:
         run: |
           claude --print --dangerously-skip-permissions \
             "You are a strict senior QA executor. Read and follow the skill at .claude/skills/qa-executor/SKILL.md exactly.
-            PR number: $PR_NUMBER. Target URL: http://localhost:3000.
+            PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
             QA Plan is at qa-plan.md. Execute ALL scenarios — both Public (P1, P2...) and Authenticated (A1, A2...).
-            For authenticated scenarios, login using the Privy test account (email from QA_TEST_EMAIL env var, OTP from QA_TEST_OTP env var).
-            IMPORTANT: Always use http://localhost:3000 as the target URL. Never use a preview/vercel URL.
-            Post the results as a comment on PR #$PR_NUMBER using gh pr comment.
-            Save results to qa-results.json."
+            For authenticated scenarios, login with QA_TEST_EMAIL + QA_TEST_OTP env vars.
+            Post results as a comment on PR #$PR_NUMBER via gh pr comment. Save results to qa-results.json."
         timeout-minutes: 20
 
       - name: Upload QA execution artifacts
@@ -417,8 +455,28 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Get ISO week for cache key
+        id: weeknum
+        run: echo "weeknum=$(date -u +'%G-W%V')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Claude Code install
+        id: claude-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ runner.os }}-${{ steps.weeknum.outputs.weeknum }}
+          restore-keys: |
+            claude-code-${{ runner.os }}-
+
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        if: steps.claude-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.npm-global
+          npm config set prefix ~/.npm-global
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Add Claude Code to PATH
+        run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Run Dogfood Exploration
         env:
@@ -430,10 +488,9 @@ jobs:
         run: |
           claude --print --dangerously-skip-permissions \
             "You are a strict senior QA engineer doing focused exploratory dogfood testing.
-            PR number: $PR_NUMBER. Target URL: http://localhost:3000.
-            IMPORTANT: Always use http://localhost:3000. Never use a preview/vercel URL.
+            PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
 
-            TIME BUDGET: You have 15 minutes of active exploration. Be fast and focused. Do not wander.
+            TIME BUDGET: 15 minutes of active exploration. Be fast and focused. Do not wander.
 
             1. Run git diff origin/main...HEAD --name-only to identify changed files.
             2. Open http://localhost:3000 in agent-browser. Navigate ONLY to pages affected by the changed files.

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -510,15 +510,18 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  dogfood:
-    needs: [gate-check, qa-plan, build]
+  # dogfood-plan: compute changed UI pages and bucket them into shards.
+  # Runs after qa-plan (to reuse the checkout + diff already done for QA plan)
+  # and in parallel with build (it only inspects file paths, not the build).
+  # Emits dogfood-plan.json: { should_run, shard_count, groups: [["/a"], ["/b"]] }
+  dogfood-plan:
+    needs: [gate-check, qa-plan]
+    if: needs.gate-check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-    # Note: dogfood is intentionally NOT matrix-split. The exploratory nature
-    # of dogfood (navigating changed pages, classifying PR-caused vs pre-existing
-    # issues, filing GitHub issues for pre-existing bugs) does not decompose
-    # cleanly by P/A shard — the skill prompt is holistic and stateful. Splitting
-    # it would risk double-filing issues and producing incoherent results.
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.plan.outputs.should_run }}
+      shards: ${{ steps.plan.outputs.shards }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -526,11 +529,135 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
-      - name: Download QA plan for scope context
+      - name: Compute dogfood page scope
+        id: plan
+        run: |
+          # Find changed UI files that map to navigable pages.
+          # We include page.tsx / layout.tsx (direct route files) and
+          # feature/component TSX files (they may affect multiple pages,
+          # so we emit the changed-file list and let the agent figure out
+          # the precise URLs during exploration).
+          CHANGED=$(git diff --name-only origin/main...HEAD -- \
+            'app/**/page.tsx' \
+            'app/**/layout.tsx' \
+            'src/features/**/*.tsx' \
+            'components/**/*.tsx' 2>/dev/null || true)
+
+          # Derive URL paths from app/*/page.tsx paths.
+          # For feature/component changes we can't deterministically map to
+          # a single URL, so we emit the file paths and let the dogfood agent
+          # resolve them. The agent is instructed to derive the affected pages
+          # from the file context.
+          declare -a PATHS=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if [[ "$f" == app/**/page.tsx ]] || [[ "$f" =~ ^app/.*page\.tsx$ ]]; then
+              # Convert app/some/route/page.tsx -> /some/route
+              route=$(echo "$f" | sed 's|^app/||; s|/page\.tsx$||; s|^$|/|')
+              # Strip route-group parens e.g. (with-header) -> drop segment
+              route=$(echo "$route" | sed 's|([^)]*)/||g; s|(.*)||g')
+              [ -z "$route" ] && route="/"
+              PATHS+=("/$route")
+            else
+              # For components/features, emit the file path prefixed with "file:"
+              # so the agent knows to resolve URLs from context.
+              PATHS+=("file:$f")
+            fi
+          done <<< "$CHANGED"
+
+          TOTAL=${#PATHS[@]}
+          echo "Total changed UI items: $TOTAL"
+
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "No changed UI pages — skipping dogfood"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "shards=[]" >> "$GITHUB_OUTPUT"
+            # Write minimal plan artifact
+            echo '{"should_run":false,"shard_count":0,"groups":[]}' > dogfood-plan.json
+          elif [ "$TOTAL" -le 2 ]; then
+            # Tiny diff — single shard, no splitting overhead
+            GROUP_A=$(printf '%s,' "${PATHS[@]}" | sed 's/,$//')
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo 'shards=["1"]' >> "$GITHUB_OUTPUT"
+            python3 -c "
+          import json
+          paths = '${GROUP_A}'.split(',')
+          print(json.dumps({'should_run': True, 'shard_count': 1, 'groups': [paths]}))
+          " > dogfood-plan.json
+          else
+            # Split into 2 roughly-equal groups (round-robin by index)
+            GROUP_A=()
+            GROUP_B=()
+            for i in "${!PATHS[@]}"; do
+              if (( i % 2 == 0 )); then
+                GROUP_A+=("${PATHS[$i]}")
+              else
+                GROUP_B+=("${PATHS[$i]}")
+              fi
+            done
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo 'shards=["1","2"]' >> "$GITHUB_OUTPUT"
+            python3 -c "
+          import json, sys
+          ga = [x for x in '$(IFS=','; echo "${GROUP_A[*]}")'.split(',') if x]
+          gb = [x for x in '$(IFS=','; echo "${GROUP_B[*]}")'.split(',') if x]
+          print(json.dumps({'should_run': True, 'shard_count': 2, 'groups': [ga, gb]}))
+          " > dogfood-plan.json
+          fi
+
+          echo "dogfood-plan.json contents:"
+          cat dogfood-plan.json
+
+      - name: Upload dogfood plan artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: dogfood-plan
+          path: dogfood-plan.json
+          retention-days: 1
+          if-no-files-found: error
+
+  # Sharded dogfood exploration: each shard explores its assigned pages,
+  # writes findings to dogfood-findings-{shard}.json (NO issue filing),
+  # and uploads the artifact. The dogfood-aggregate job dedupes and files.
+  dogfood:
+    needs: [gate-check, build, dogfood-plan]
+    if: needs.gate-check.outputs.should_run == 'true' && needs.dogfood-plan.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.dogfood-plan.outputs.shards) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-check.outputs.head_sha }}
+
+      - name: Download dogfood plan
         uses: actions/download-artifact@v7
         with:
-          name: qa-plan
-        continue-on-error: true
+          name: dogfood-plan
+
+      - name: Extract page scope for this shard
+        id: scope
+        run: |
+          SHARD_INDEX=$(( ${{ matrix.shard }} - 1 ))
+          # Extract the pages assigned to this shard from dogfood-plan.json
+          PAGES=$(python3 -c "
+          import json, sys
+          with open('dogfood-plan.json') as f:
+              plan = json.load(f)
+          groups = plan.get('groups', [])
+          idx = $SHARD_INDEX
+          if idx < len(groups):
+              print(','.join(groups[idx]))
+          else:
+              print('')
+          ")
+          echo "scope_pages=$PAGES" >> "$GITHUB_OUTPUT"
+          echo "Shard ${{ matrix.shard }} scope: $PAGES"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -602,50 +729,203 @@ jobs:
       - name: Add Claude Code to PATH
         run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
-      - name: Run Dogfood Exploration
+      - name: Run Dogfood Exploration (shard ${{ matrix.shard }})
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
           QA_TEST_EMAIL: ${{ secrets.QA_TEST_EMAIL }}
           QA_TEST_OTP: ${{ secrets.QA_TEST_OTP }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHARD_ID: ${{ matrix.shard }}
+          SCOPE_PAGES: ${{ steps.scope.outputs.scope_pages }}
         run: |
           claude --print --dangerously-skip-permissions \
             "You are a strict senior QA engineer doing focused exploratory dogfood testing.
             PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
+            SHARD_ID=$SHARD_ID. SCOPE_PAGES=$SCOPE_PAGES.
 
-            TIME BUDGET: 15 minutes of active exploration. Be fast and focused. Do not wander.
+            TIME BUDGET: 7 minutes of active exploration per shard. Be fast and focused.
 
-            1. Run git diff origin/main...HEAD --name-only to identify changed files.
-            2. Open http://localhost:3000 in agent-browser. Navigate ONLY to pages affected by the changed files.
-            3. On each page: take a screenshot, check console errors, interact with changed components.
-            4. For authenticated pages: login with Privy test account (email from QA_TEST_EMAIL, OTP from QA_TEST_OTP). Save auth state.
-            5. Find 3-5 issues max. Quality over quantity. Do NOT explore unrelated pages.
-            6. Do NOT repeat scenarios already covered by qa-plan.md (QA Execution already tested those).
+            Read and follow the skill at .claude/skills/dogfood/SKILL.md. You are running in CI SHARD MODE
+            because SCOPE_PAGES is set. Key rules for shard mode:
+            1. Explore ONLY the pages listed in SCOPE_PAGES (comma-separated paths). For 'file:' prefixed
+               entries, infer which URL(s) the component affects and visit those.
+            2. On each page: take a screenshot, check console errors, interact with changed components.
+            3. For authenticated pages: login with Privy test account (email from QA_TEST_EMAIL, OTP from QA_TEST_OTP).
+            4. Find up to 5 issues per shard. Quality over quantity.
+            5. Do NOT repeat scenarios already covered by qa-plan.md (if present).
+            6. CLASSIFY EVERY ISSUE: 'pr-caused' (file in git diff) or 'pre-existing' (not in diff).
+            7. Do NOT call 'gh issue create'. Write findings to dogfood-findings-\$SHARD_ID.json per the
+               skill's CI Pipeline Mode schema (includes fingerprint field).
+            8. Also write dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
+               where critical/high counts = PR-caused only.
+            9. Do NOT post a separate PR comment."
+        timeout-minutes: 15
 
-            CLASSIFY EVERY ISSUE:
-            - **PR-caused**: Affected file appears in the git diff.
-            - **Pre-existing**: Does NOT appear in the git diff. Create a GitHub issue using gh issue create --title '[QA] <title>' --body '<description>' --label bug.
-
-            Save to dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
-            critical/high counts = PR-caused only.
-
-            Do NOT post a separate PR comment — results will be aggregated in the pipeline verdict comment."
-        timeout-minutes: 20
-
-      - name: Upload dogfood artifacts
+      - name: Upload dogfood shard artifacts
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: dogfood-results
+          name: dogfood-findings-${{ matrix.shard }}
           path: |
             dogfood-output/
+            dogfood-findings-${{ matrix.shard }}.json
             dogfood-results.json
           retention-days: 7
           if-no-files-found: ignore
 
+  # dogfood-aggregate: single job that runs after all dogfood shards complete.
+  # Downloads all dogfood-findings-*.json artifacts, dedupes by fingerprint,
+  # and files GitHub issues for unique pre-existing findings not yet tracked.
+  dogfood-aggregate:
+    needs: [gate-check, dogfood-plan, dogfood]
+    if: always() && needs.gate-check.outputs.should_run == 'true' && needs.dogfood-plan.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Download all dogfood findings artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: dogfood-findings-*
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Deduplicate findings and file GitHub issues
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, glob, subprocess, sys
+
+          repo = os.environ['REPO']
+          pr_number = os.environ['PR_NUMBER']
+
+          # Load all findings files
+          findings_files = glob.glob('dogfood-findings-*.json')
+          print(f"Found findings files: {findings_files}")
+
+          all_findings = []
+          seen_fps = set()
+
+          for fpath in sorted(findings_files):
+              try:
+                  with open(fpath) as f:
+                      data = json.load(f)
+                  for finding in data.get('findings', []):
+                      fp = finding.get('fingerprint', '')
+                      if not fp:
+                          continue
+                      if fp in seen_fps:
+                          print(f"  [dedup] Skipping duplicate fingerprint {fp}: {finding.get('title')}")
+                          continue
+                      seen_fps.add(fp)
+                      all_findings.append(finding)
+              except Exception as e:
+                  print(f"  [warn] Could not parse {fpath}: {e}")
+
+          print(f"Total unique findings after dedup: {len(all_findings)}")
+
+          # Separate PR-caused vs pre-existing
+          preexisting = [f for f in all_findings if f.get('classification') == 'pre-existing']
+          pr_caused = [f for f in all_findings if f.get('classification') == 'pr-caused']
+
+          print(f"  PR-caused: {len(pr_caused)}, Pre-existing: {len(preexisting)}")
+
+          # For each pre-existing finding: check if a GitHub issue already exists
+          # with the fingerprint marker in its body, then file if absent.
+          filed = 0
+          skipped = 0
+          for finding in preexisting:
+              fp = finding['fingerprint']
+              marker = f"<!-- dogfood-fp:{fp} -->"
+
+              # Search for existing open issues with this fingerprint marker
+              result = subprocess.run(
+                  ['gh', 'issue', 'list', '--repo', repo, '--state', 'open',
+                   '--search', f'dogfood-fp:{fp}', '--json', 'number,title', '--limit', '5'],
+                  capture_output=True, text=True
+              )
+              existing_issues = []
+              if result.returncode == 0 and result.stdout.strip():
+                  try:
+                      existing_issues = json.loads(result.stdout)
+                  except Exception:
+                      pass
+
+              if existing_issues:
+                  print(f"  [skip] Issue already exists for fp={fp}: #{existing_issues[0]['number']} {existing_issues[0]['title']}")
+                  skipped += 1
+                  continue
+
+              # File a new GitHub issue
+              severity = finding.get('severity', 'medium')
+              title = f"[QA Dogfood] {finding.get('title', 'Untitled issue')}"
+              body = f"""{marker}
+
+          **Severity**: {severity}
+          **Page**: {finding.get('page_url', 'unknown')}
+          **Classification**: Pre-existing (not caused by the triggering PR)
+
+          ## Description
+
+          {finding.get('description', 'No description provided.')}
+
+          ---
+          *Filed automatically by the QA dogfood pipeline (PR #{pr_number}).*
+          *Fingerprint: `{fp}`*
+          """
+
+              cmd = ['gh', 'issue', 'create',
+                     '--repo', repo,
+                     '--title', title,
+                     '--body', body,
+                     '--label', 'bug']
+              try:
+                  result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                  print(f"  [filed] {title} -> {result.stdout.strip()}")
+                  filed += 1
+              except subprocess.CalledProcessError as e:
+                  print(f"  [error] Failed to file issue: {e.stderr}")
+
+          # Write aggregated summary for verdict job
+          critical_count = sum(1 for f in pr_caused if f.get('severity') == 'critical')
+          high_count = sum(1 for f in pr_caused if f.get('severity') == 'high')
+          summary = {
+              'total': len(all_findings),
+              'critical': critical_count,
+              'high': high_count,
+              'medium': sum(1 for f in pr_caused if f.get('severity') == 'medium'),
+              'low': sum(1 for f in pr_caused if f.get('severity') == 'low'),
+              'preexisting': len(preexisting),
+              'preexisting_filed': filed,
+              'preexisting_skipped': skipped,
+              'blocking': critical_count > 0 or high_count > 0,
+          }
+          with open('dogfood-results.json', 'w') as f:
+              json.dump(summary, f, indent=2)
+          print(f"\nSummary: {json.dumps(summary)}")
+          PYEOF
+
+      - name: Upload aggregated dogfood results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: dogfood-results
+          path: dogfood-results.json
+          retention-days: 7
+          if-no-files-found: ignore
+
   verdict:
-    needs: [gate-check, qa-execution, dogfood]
+    needs: [gate-check, qa-execution, dogfood-plan, dogfood-aggregate]
     if: always() && needs.gate-check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -660,7 +940,7 @@ jobs:
           merge-multiple: true
         continue-on-error: true
 
-      - name: Download dogfood results
+      - name: Download dogfood aggregated results
         uses: actions/download-artifact@v7
         with:
           name: dogfood-results
@@ -673,7 +953,8 @@ jobs:
           PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
           RUN_ID: ${{ github.run_id }}
           QA_EXEC_RESULT: ${{ needs.qa-execution.result }}
-          DOGFOOD_RESULT: ${{ needs.dogfood.result }}
+          DOGFOOD_RESULT: ${{ needs.dogfood-aggregate.result }}
+          DOGFOOD_SKIPPED: ${{ needs.dogfood-plan.outputs.should_run != 'true' }}
         with:
           script: |
             const fs = require('fs');
@@ -682,8 +963,12 @@ jobs:
             const sha = process.env.HEAD_SHA;
             const execResult = process.env.QA_EXEC_RESULT;
             const dogfoodResult = process.env.DOGFOOD_RESULT;
+            const dogfoodSkipped = process.env.DOGFOOD_SKIPPED === 'true';
 
-            const jobsFailed = execResult === 'failure' || dogfoodResult === 'failure';
+            // dogfood-aggregate is 'skipped' when dogfood-plan emitted should_run=false
+            // (CI-only PR with no changed UI pages). That is not a failure.
+            const dogfoodFailed = !dogfoodSkipped && dogfoodResult === 'failure';
+            const jobsFailed = execResult === 'failure' || dogfoodFailed;
 
             let criticalCount = 0;
             let highCount = 0;
@@ -716,6 +1001,7 @@ jobs:
               console.log('Could not enumerate qa-results-*.json: ' + e.message);
             }
 
+            // Read aggregated dogfood results (produced by dogfood-aggregate job)
             try {
               const dogfoodResults = JSON.parse(fs.readFileSync('dogfood-results.json', 'utf8'));
               criticalCount += (dogfoodResults.critical || 0);
@@ -730,7 +1016,7 @@ jobs:
             if (jobsFailed) {
               const failed = [
                 execResult === 'failure' ? 'QA Execution' : null,
-                dogfoodResult === 'failure' ? 'Dogfood' : null
+                dogfoodFailed ? 'Dogfood' : null
               ].filter(Boolean).join(', ');
               description = `${failed} failed — check workflow logs`;
             } else if (criticalCount > 0 || highCount > 0) {
@@ -751,7 +1037,10 @@ jobs:
 
             // Update the single consolidated pipeline comment with final verdict
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const icon = (r) => r === 'success' ? '✅ Done' : r === 'skipped' ? '⏭️ Skipped' : '❌ Failed';
+            const icon = (r, skipped) => {
+              if (skipped) return '⏭️ Skipped (no UI changes)';
+              return r === 'success' ? '✅ Done' : r === 'skipped' ? '⏭️ Skipped' : '❌ Failed';
+            };
             const verdictIcon = hasBlockingIssues ? '❌' : '✅';
             const verdictText = hasBlockingIssues ? `FAIL — ${description}` : 'PASS — no blocking issues';
             const marker = '<!-- qa-pipeline-status -->';
@@ -771,8 +1060,8 @@ jobs:
                   '|-------|--------|',
                   '| QA Plan | ✅ Done |',
                   '| Build | ✅ Done |',
-                  `| QA Execution | ${icon(execResult)} |`,
-                  `| Dogfood | ${icon(dogfoodResult)} |`,
+                  `| QA Execution | ${icon(execResult, false)} |`,
+                  `| Dogfood | ${icon(dogfoodResult, dogfoodSkipped)} |`,
                   `| **Verdict** | **${verdictIcon} ${verdictText}** |`,
                   '',
                   `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${process.env.RUN_ID})`

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -275,11 +275,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: qa-build
+          # Glob form (`**`) is required for `actions/upload-artifact@v4`
+          # to honor the negation pattern; the directory shorthand `.next/`
+          # silently misses files and the negation never applies.
           path: |
-            .next/
-            !.next/cache
+            .next/**
+            !.next/cache/**
           retention-days: 1
           if-no-files-found: error
+          include-hidden-files: true
 
   # qa-execution and dogfood run IN PARALLEL after the shared build,
   # each downloading the prebuilt .next/ artifact instead of rebuilding.

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -205,24 +205,18 @@ jobs:
                 ].join('\n') });
             }
 
-  # qa-execution and dogfood run IN PARALLEL after qa-plan
-  # Each builds the app independently (Next.js cache makes this fast)
-
-  qa-execution:
+  # Build the app ONCE and share with both qa-execution and dogfood via artifact.
+  # Saves ~2m 30s of duplicated build work compared to building in each job.
+  build:
     needs: [gate-check, qa-plan]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
-
-      - name: Download QA plan
-        uses: actions/download-artifact@v4
-        with:
-          name: qa-plan
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -251,6 +245,55 @@ jobs:
         run: pnpm run build
         env:
           NODE_ENV: production
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-build
+          path: |
+            .next/
+            !.next/cache
+          retention-days: 1
+          if-no-files-found: error
+
+  # qa-execution and dogfood run IN PARALLEL after the shared build,
+  # each downloading the prebuilt .next/ artifact instead of rebuilding.
+
+  qa-execution:
+    needs: [gate-check, qa-plan, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-check.outputs.head_sha }}
+
+      - name: Download QA plan
+        uses: actions/download-artifact@v4
+        with:
+          name: qa-plan
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download prebuilt .next
+        uses: actions/download-artifact@v4
+        with:
+          name: qa-build
+          path: .next/
 
       - name: Start local server
         run: pnpm start &
@@ -300,7 +343,7 @@ jobs:
           if-no-files-found: ignore
 
   dogfood:
-    needs: [gate-check, qa-plan]
+    needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -330,19 +373,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Next.js build
-        uses: actions/cache@v4
+      - name: Download prebuilt .next
+        uses: actions/download-artifact@v4
         with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-qa-${{ needs.gate-check.outputs.head_sha }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-qa-
-            ${{ runner.os }}-nextjs-
-
-      - name: Build application
-        run: pnpm run build
-        env:
-          NODE_ENV: production
+          name: qa-build
+          path: .next/
 
       - name: Start local server
         run: pnpm start &

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -187,21 +187,28 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.gate-check.outputs.head_sha }}
 
-      - name: Compute changed-file list for cache key
+      - name: Compute diff fingerprint for cache key
         id: changed-files
-        # Write inside $GITHUB_WORKSPACE so hashFiles() can read it — hashFiles
-        # only sees workspace-relative paths, not /tmp.
+        # Hash the actual diff CONTENT (not just file names) so two
+        # commits that touch the same files but with different changes
+        # don't collide. Same diff = same plan, regardless of SHA — wins
+        # on rebases and force-pushes that re-apply identical changes.
+        # Files written into $GITHUB_WORKSPACE so hashFiles() can read them.
         run: |
           git diff --name-only origin/main...HEAD | sort > .qa-plan-changed-files.txt
+          git diff origin/main...HEAD > .qa-plan-diff-content.txt
           echo "Changed files:"
           cat .qa-plan-changed-files.txt
+          echo "Diff size: $(wc -c < .qa-plan-diff-content.txt) bytes"
 
       - name: Cache QA plan output
         id: qa-plan-cache
         uses: actions/cache@v5
         with:
           path: qa-plan.md
-          key: qa-plan-${{ hashFiles('.qa-plan-changed-files.txt') }}
+          # No restore-keys: a stale plan from a different PR is worse
+          # than re-generating. Only exact diff matches reuse the cache.
+          key: qa-plan-${{ hashFiles('.qa-plan-diff-content.txt') }}
 
       - name: Generate GitHub App token
         if: steps.qa-plan-cache.outputs.cache-hit != 'true'
@@ -296,7 +303,10 @@ jobs:
   build:
     needs: [gate-check]
     if: needs.gate-check.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    # 4-core runner cuts SWC compile time roughly in half (~5m → ~2.5m).
+    # Cost-neutral vs ubuntu-latest (2× per minute, half the minutes).
+    # Falls back automatically if plan does not allow 4-core.
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -333,12 +343,23 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Pack .next into tarball
+      - name: Assemble standalone bundle
+        # Next.js standalone output is self-contained (server.js + traced
+        # node_modules) but doesn't auto-copy public/ or .next/static/ —
+        # we stage them into the standalone tree so consumers boot with a
+        # single `node .next/standalone/server.js` and no extra setup.
+        run: |
+          cp -r public .next/standalone/
+          mkdir -p .next/standalone/.next
+          cp -r .next/static .next/standalone/.next/static
+
+      - name: Pack standalone bundle into tarball
         # actions/upload-artifact@v5 rejects filenames containing `:` (NTFS
         # incompatibility). Next.js + Turbopack emits chunks like
-        # `[externals]_node:inspector_*.js`, so uploading raw `.next/` fails.
-        # Packaging into a single tarball sidesteps the per-file validator.
-        run: tar --exclude='.next/cache' -czf next-build.tar.gz .next
+        # `[externals]_node:inspector_*.js`, so uploading raw paths fails.
+        # Packaging into a tarball sidesteps the per-file validator and
+        # also keeps the artifact ~3-5× smaller than packing all of .next/.
+        run: tar -czf next-build.tar.gz .next/standalone
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v5
@@ -426,13 +447,18 @@ jobs:
         with:
           name: qa-build
 
-      - name: Unpack .next tarball
+      - name: Unpack standalone bundle
         run: tar -xzf next-build.tar.gz
 
       - name: Start local server
-        run: pnpm start &
+        # Standalone server.js boots in ~2s and embeds its own pruned
+        # node_modules — no `pnpm start` / `next start` needed. HOSTNAME
+        # must be 0.0.0.0 so curl on localhost can reach it.
+        run: node .next/standalone/server.js &
         env:
           PORT: 3000
+          HOSTNAME: 0.0.0.0
+          NODE_ENV: production
 
       - name: Wait for server
         run: |
@@ -678,13 +704,18 @@ jobs:
         with:
           name: qa-build
 
-      - name: Unpack .next tarball
+      - name: Unpack standalone bundle
         run: tar -xzf next-build.tar.gz
 
       - name: Start local server
-        run: pnpm start &
+        # Standalone server.js boots in ~2s and embeds its own pruned
+        # node_modules — no `pnpm start` / `next start` needed. HOSTNAME
+        # must be 0.0.0.0 so curl on localhost can reach it.
+        run: node .next/standalone/server.js &
         env:
           PORT: 3000
+          HOSTNAME: 0.0.0.0
+          NODE_ENV: production
 
       - name: Wait for server
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload smoke test report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: smoke-test-report
           path: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,20 +46,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Next.js build
-        uses: actions/cache@v4
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-smoke-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-smoke-
-            ${{ runner.os }}-nextjs-
-
-      - name: Build application
-        run: pnpm run build
-        env:
-          NODE_ENV: production
-
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/__tests__/unit/hooks/useDonationTransfer.test.ts
+++ b/__tests__/unit/hooks/useDonationTransfer.test.ts
@@ -125,11 +125,17 @@ describe("useDonationTransfer", () => {
     readContract: vi.fn(),
   };
 
-  const mockWalletClient = {
+  const mockWalletClient: any = {
     account: { address: mockAddress },
     chain: { id: 10 },
     signTypedData: vi.fn(),
+    writeContract: vi.fn().mockResolvedValue("0xtxhash"),
   };
+  mockWalletClient.getChainId = vi.fn(() => Promise.resolve(mockWalletClient.chain.id));
+  mockWalletClient.switchChain = vi.fn(({ id }: { id: number }) => {
+    mockWalletClient.chain = { id };
+    return Promise.resolve();
+  });
 
   const mockWriteContractAsync = vi.fn();
 
@@ -164,7 +170,9 @@ describe("useDonationTransfer", () => {
     vi.mocked(isWalletClientGoodEnough).mockReturnValue(true);
     vi.mocked(validateChainSync).mockResolvedValue(undefined);
 
+    mockWalletClient.chain = { id: 10 };
     mockWalletClient.signTypedData.mockResolvedValue("0xsignature");
+    mockWalletClient.writeContract.mockResolvedValue("0xtxhash");
     mockWriteContractAsync.mockResolvedValue("0xtxhash");
     mockPublicClient.waitForTransactionReceipt.mockResolvedValue({
       status: "success",
@@ -180,7 +188,9 @@ describe("useDonationTransfer", () => {
     vi.clearAllMocks();
 
     // Reset mock implementations to defaults
+    mockWalletClient.chain = { id: 10 };
     mockWalletClient.signTypedData.mockResolvedValue("0xsignature");
+    mockWalletClient.writeContract.mockResolvedValue("0xtxhash");
     mockWriteContractAsync.mockResolvedValue("0xtxhash");
     mockPublicClient.waitForTransactionReceipt.mockResolvedValue({
       status: "success",
@@ -292,7 +302,7 @@ describe("useDonationTransfer", () => {
         await result.current.executeDonations([mockNativePayment], getRecipientAddress);
       });
 
-      expect(mockWriteContractAsync).toHaveBeenCalled();
+      expect(mockWalletClient.writeContract).toHaveBeenCalled();
       expect(result.current.transfers).toHaveLength(1);
       // Transaction completes immediately in test due to mocks
       expect(result.current.transfers[0].status).toBe("success");
@@ -313,7 +323,7 @@ describe("useDonationTransfer", () => {
         await result.current.executeDonations([mockPayment], getRecipientAddress);
       });
 
-      expect(mockWriteContractAsync).toHaveBeenCalled();
+      expect(mockWalletClient.writeContract).toHaveBeenCalled();
       expect(mockWalletClient.signTypedData).toHaveBeenCalled(); // Permit signature
     });
 
@@ -343,7 +353,7 @@ describe("useDonationTransfer", () => {
       });
 
       expect(executeApprovals).toHaveBeenCalled();
-      expect(mockWriteContractAsync).toHaveBeenCalled();
+      expect(mockWalletClient.writeContract).toHaveBeenCalled();
     });
 
     it("should validate recipient addresses before execution", async () => {
@@ -406,7 +416,7 @@ describe("useDonationTransfer", () => {
     it("should handle user rejection error", async () => {
       const { result } = renderHook(() => useDonationTransfer());
 
-      mockWriteContractAsync.mockRejectedValue(new Error("User rejected the request"));
+      mockWalletClient.writeContract.mockRejectedValue(new Error("User rejected the request"));
 
       // User rejection should throw an error
       await expect(
@@ -441,7 +451,7 @@ describe("useDonationTransfer", () => {
         );
       });
 
-      expect(mockWriteContractAsync).toHaveBeenCalled();
+      expect(mockWalletClient.writeContract).toHaveBeenCalled();
       expect(result.current.transfers).toHaveLength(2);
     });
 
@@ -458,7 +468,7 @@ describe("useDonationTransfer", () => {
       });
 
       // Should be called twice (once per chain)
-      expect(mockWriteContractAsync).toHaveBeenCalledTimes(2);
+      expect(mockWalletClient.writeContract).toHaveBeenCalledTimes(2);
     });
 
     it("should validate chain ID is supported", async () => {
@@ -768,8 +778,11 @@ describe("useDonationTransfer", () => {
       vi.mocked(validateChainSync).mockResolvedValue(undefined);
 
       // Reset mock implementations on shared objects
+      mockWalletClient.chain = { id: 10 };
       mockWalletClient.signTypedData.mockReset();
       mockWalletClient.signTypedData.mockResolvedValue("0xsignature");
+      mockWalletClient.writeContract.mockReset();
+      mockWalletClient.writeContract.mockResolvedValue("0xtxhash");
       mockWriteContractAsync.mockReset();
       mockWriteContractAsync.mockResolvedValue("0xtxhash");
       mockPublicClient.waitForTransactionReceipt.mockReset();
@@ -798,7 +811,7 @@ describe("useDonationTransfer", () => {
     it("should reset isExecuting to false on error", async () => {
       const { result } = renderHook(() => useDonationTransfer());
 
-      mockWriteContractAsync.mockRejectedValue(new Error("Test error"));
+      mockWalletClient.writeContract.mockRejectedValue(new Error("Test error"));
 
       try {
         await act(async () => {
@@ -846,17 +859,8 @@ describe("useDonationTransfer", () => {
       expect(result.current.isExecuting).toBe(false);
     });
 
-    it("should retry chain sync validation with fresh wallet client", async () => {
+    it("should verify chain via getChainId before executing", async () => {
       const { result } = renderHook(() => useDonationTransfer());
-      const freshWalletClient = { ...mockWalletClient, chain: { id: 10 } };
-
-      // First validation fails, triggering retry
-      vi.mocked(validateChainSync).mockRejectedValueOnce(new Error("Chain mismatch"));
-      // Second validation succeeds
-      vi.mocked(validateChainSync).mockResolvedValueOnce(undefined);
-
-      // getWalletClientWithFallback returns fresh wallet client
-      vi.mocked(getWalletClientWithFallback).mockResolvedValue(freshWalletClient);
 
       await act(async () => {
         await result.current.executeDonations(
@@ -865,8 +869,11 @@ describe("useDonationTransfer", () => {
         );
       });
 
-      // Should have retried validation
-      expect(validateChainSync).toHaveBeenCalledTimes(2);
+      // Hook now calls walletClient.getChainId() to verify the provider's
+      // chain matches the target before executing — replaces the older
+      // validateChainSync utility path.
+      expect(mockWalletClient.getChainId).toHaveBeenCalled();
+      expect(mockWalletClient.writeContract).toHaveBeenCalled();
     });
 
     it("should handle chain mismatch detection", async () => {
@@ -920,7 +927,7 @@ describe("useDonationTransfer", () => {
       const { result } = renderHook(() => useDonationTransfer());
 
       // Set up the writeContractAsync to fail
-      mockWriteContractAsync.mockRejectedValueOnce(
+      mockWalletClient.writeContract.mockRejectedValueOnce(
         new Error("Transaction failed: gas estimation error")
       );
 

--- a/components/Pages/Communities/Impact/__tests__/ProjectDiscovery.test.tsx
+++ b/components/Pages/Communities/Impact/__tests__/ProjectDiscovery.test.tsx
@@ -46,7 +46,10 @@ vi.mock("@/utilities/indexer", () => ({
   },
 }));
 
+import fetchData from "@/utilities/fetchData";
 import { ProjectDiscovery } from "../ProjectDiscovery";
+
+const mockedFetchData = vi.mocked(fetchData);
 
 /**
  * Helper: collects all className strings from the rendered container.
@@ -156,8 +159,8 @@ describe("ProjectDiscovery dark mode support", () => {
 
   it("should have dark: class on the loading spinner text", async () => {
     // Force loading state by making fetchData never resolve
-    const fetchData = require("@/utilities/fetchData").default;
-    fetchData.mockReturnValue(new Promise(() => {}));
+
+    mockedFetchData.mockReturnValue(new Promise(() => {}));
 
     const { container } = render(<ProjectDiscovery />);
 
@@ -167,8 +170,8 @@ describe("ProjectDiscovery dark mode support", () => {
 
   it("should not have any bg-white without a corresponding dark:bg- class", async () => {
     // Reset mock to resolve
-    const fetchData = require("@/utilities/fetchData").default;
-    fetchData.mockResolvedValue([[], null]);
+
+    mockedFetchData.mockResolvedValue([[], null]);
 
     const { container } = render(<ProjectDiscovery />);
 
@@ -184,8 +187,7 @@ describe("ProjectDiscovery dark mode support", () => {
   });
 
   it("should not have any text-gray-900 without a corresponding dark:text- class", async () => {
-    const fetchData = require("@/utilities/fetchData").default;
-    fetchData.mockResolvedValue([[], null]);
+    mockedFetchData.mockResolvedValue([[], null]);
 
     const { container } = render(<ProjectDiscovery />);
 
@@ -201,8 +203,7 @@ describe("ProjectDiscovery dark mode support", () => {
   });
 
   it("should not have any text-gray-700 without a corresponding dark:text- class", async () => {
-    const fetchData = require("@/utilities/fetchData").default;
-    fetchData.mockResolvedValue([[], null]);
+    mockedFetchData.mockResolvedValue([[], null]);
 
     const { container } = render(<ProjectDiscovery />);
 
@@ -218,8 +219,7 @@ describe("ProjectDiscovery dark mode support", () => {
   });
 
   it("should not have any border-gray-200 without a corresponding dark:border- class", async () => {
-    const fetchData = require("@/utilities/fetchData").default;
-    fetchData.mockResolvedValue([[], null]);
+    mockedFetchData.mockResolvedValue([[], null]);
 
     const { container } = render(<ProjectDiscovery />);
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,7 +12,17 @@ const STORAGE_STATE_PATH = path.join(__dirname, ".auth", "user.json");
 // boot a local webServer — there's nothing to serve, and `pnpm start` would
 // fail without a `.next/` build anyway.
 const baseURL = process.env.BASE_URL || "http://localhost:3000";
-const isRemoteTarget = !baseURL.startsWith("http://localhost");
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+const isRemoteTarget = (() => {
+  try {
+    const { hostname } = new URL(baseURL);
+    if (LOCAL_HOSTNAMES.has(hostname)) return false;
+    if (/^127\.\d+\.\d+\.\d+$/.test(hostname)) return false;
+    return true;
+  } catch {
+    return true;
+  }
+})();
 
 export default defineConfig({
   testDir: "./tests",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,12 @@ import path from "node:path";
 
 const STORAGE_STATE_PATH = path.join(__dirname, ".auth", "user.json");
 
+// Tests targeting a remote URL (e.g. smoke tests against staging) shouldn't
+// boot a local webServer — there's nothing to serve, and `pnpm start` would
+// fail without a `.next/` build anyway.
+const baseURL = process.env.BASE_URL || "http://localhost:3000";
+const isRemoteTarget = !baseURL.startsWith("http://localhost");
+
 export default defineConfig({
   testDir: "./tests",
   testIgnore: isAnvil ? undefined : ["**/*.anvil.spec.ts", "**/_experimental/**"],
@@ -19,7 +25,7 @@ export default defineConfig({
   outputDir: "./test-results",
 
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     // Use domcontentloaded instead of load to avoid timeouts caused by
@@ -51,10 +57,12 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    command: isCI ? "pnpm start" : "cross-env NEXT_PUBLIC_E2E_AUTH_BYPASS=true pnpm run dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !isCI,
-    timeout: 120_000,
-  },
+  webServer: isRemoteTarget
+    ? undefined
+    : {
+        command: isCI ? "pnpm start" : "cross-env NEXT_PUBLIC_E2E_AUTH_BYPASS=true pnpm run dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: !isCI,
+        timeout: 120_000,
+      },
 });

--- a/e2e/tests/smoke/health.smoke.spec.ts
+++ b/e2e/tests/smoke/health.smoke.spec.ts
@@ -133,8 +133,10 @@ test.describe("Smoke Tests — Health", () => {
   test("T35-06: API health endpoint responds", async ({ page, withApiMocks }) => {
     await withApiMocks();
 
-    // The health endpoint is mocked by default in setupApiMocks
-    const response = await page.request.get("http://localhost:3000/api/health", {
+    // The health endpoint is mocked by default in setupApiMocks.
+    // Use a relative path so the test works against any BASE_URL (local dev,
+    // staging, etc.) rather than a hardcoded localhost.
+    const response = await page.request.get("/api/health", {
       failOnStatusCode: false,
     });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,11 @@ const removeImports = require("next-remove-imports")();
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   staticPageGenerationTimeout: 10000,
+  // Standalone output produces a self-contained server.js bundle in
+  // .next/standalone with traced node_modules. Cuts CI artifact size
+  // from ~200MB to ~30-50MB and boots in ~2s vs ~25s for `pnpm start`.
+  // Vercel ignores this setting (it uses its own Lambda format).
+  output: "standalone",
   turbopack: {
     resolveAlias: {
       // Force CJS to work around Turbopack ESM bundling bug with markdown-it's isSpace export

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,10 @@
+// Set TZ before any imports so that worker threads created by vitest's thread
+// pool inherit UTC from the parent process environment at startup.  Without
+// this, date-fns' format() resolves the local OS timezone (V8 caches the ICU
+// timezone at thread creation time, so process.env.TZ mutations inside setup
+// files are a no-op for threads).
+process.env.TZ = "UTC";
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
@@ -68,7 +75,11 @@ export default defineConfig({
           name: "unit",
           environment: "jsdom",
           globals: true,
-          pool: "forks",
+          pool: "threads",
+          isolate: true,
+          // Ensure TZ is set at thread startup (threads inherit the parent process
+          // env, so process.env.TZ in setup.ts was a no-op for V8's tz resolution)
+          env: { TZ: "UTC" },
           setupFiles: ["./__tests__/setup.ts", "./__tests__/setup-mocks.ts"],
           include: ["**/*.{test,spec}.{ts,tsx}"],
           exclude: [


### PR DESCRIPTION
## Summary

End-to-end PR pipeline rewrite. Cuts the gate critical path from ~6m to ~2m 30s, the QA pipeline from ~30-45m to ~6-8m, and removes the last Blacksmith runner reference. Adds path filters so doc-only PRs skip the gate entirely, and concurrency groups so stale runs cancel themselves on rapid pushes.

## Changes (14 of 18 from the audit)

### Gate pipeline

| # | File | Change |
|---|------|--------|
| #1 | `smoke-tests.yml` | Dropped local `pnpm run build` — smoke runs against `https://staging.karmahq.xyz`, the build was wasted (~2m 30s) |
| #2 | `pr-tests.yml` | 4× vitest shard matrix + `--reporter=dot` (was verbose) |
| #3 | `pr-tests.yml` | `paths-ignore` for docs/markdown/images |
| #4 | `pr-checklist.yml` | `paths-ignore` for docs/markdown/images |
| #5 | `pr-tests.yml` | Removed `continue-on-error: true` — was masking real test failures (correctness bug) |
| #6 | `claude.yml` | Vercel-deploy poll 10 min → 3 min cap (Vercel preview is typically ready in 90-120s; falls back gracefully if not) |
| #7 | `claude.yml` | `timeout_minutes: '45'` → `'15'` |
| #8 | `claude.yml`, `pr-tests.yml`, `pr-checklist.yml` | Concurrency group keyed on PR number with `cancel-in-progress: true` — kills stale runs on rapid pushes |
| #9 | `pr-checklist.yml` | Shallow checkout (`fetch-depth: 1`) + explicit base ref fetch; two-dot diff avoids merge-base requirement |
| #18 | `pr-demo-video.yml` | Trigger moved from `workflow_run: E2E Tests` to `push: branches: [main]`; resolves PR from merge commit and posts demo on the closed PR |
| — | `e2e-tests.yml` | `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-latest`; dropped `pull_request` trigger (kept `schedule` + `workflow_dispatch`) |

### QA pipeline

| # | File | Change |
|---|------|--------|
| #10 | `qa-pipeline.yml` | `build` now runs in PARALLEL with `qa-plan` (qa-plan only reads source, doesn't need `.next/`) |
| #11 | `qa-pipeline.yml` | Verdict poll in `gate-check`: 12 × 15s = 3 min → 5 × 10s = 50s |
| #12 | `qa-pipeline.yml` | `npx wait-on` → tight `curl --silent --fail --max-time 2` loop |
| #13 | `qa-pipeline.yml` | Cache global Claude Code install with weekly-rotating key; install only runs on cache miss |
| #14 | `qa-pipeline.yml` | New `build` job uploads `.next/` artifact; `qa-execution` + `dogfood` download it instead of each rebuilding (saves ~2m 30s) |
| #15 | `qa-pipeline.yml` | Collapsed duplicated "target URL" phrasing in qa-execution and dogfood prompts (semantic-preserving) |
| #16 | `qa-pipeline.yml` | Lower per-job timeout caps (qa-plan 30 → 20, qa-execution 60 → 30, dogfood 45 → 25, claude steps 40 → 20, qa-plan claude step 25 → 15) |

### Intentionally deferred

| # | Why |
|---|-----|
| #17 | Make `verdict` job non-blocking — this is a **policy** change, not perf. Right now if QA finds a critical issue, merge is blocked; non-blocking flips that to advisory. Out of scope for a perf PR. |

## Estimated impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Gate critical path | ~6 min | ~2m 30s | −60% |
| QA pipeline | ~30-45 min | ~6-8 min | −80% |
| Doc-only PR cost | ~6 min | 0 (skipped) | −100% |
| GHA $/mo | ~$46 | ~$22 | −$24 |
| Anthropic $/mo | ~$30-90 | ~$9-27 | −$21-63 |
| Blacksmith | yes | none | eliminated |

## Heads-up

- **Coverage display on PRs is gone.** The previous `coverage/coverage-summary.json` comment relied on a single non-sharded run. If you want it back, we can add a separate `coverage` job that runs `pnpm test:coverage` in parallel — adds ~3m on a non-blocking job.
- **Demos now post post-merge** instead of on PR. Recorded against staging.
- **E2E off PRs.** Still runs nightly at 4 AM UTC and on `workflow_dispatch`. Previous PR runs were broken anyway (test step finished in 3s).
- **`cancel-in-progress: true`** on pr-tests, pr-checklist, claude. Push twice in quick succession → first run cancels.
- **pr-checklist shallow checkout** assumes most PRs share recent history with their base. If a stale PR with deep divergence breaks the diff, bump the base fetch depth from 1 to 50.

## Test plan

- [ ] `PR Tests` runs as a 4-shard matrix and all shards pass on this PR
- [ ] `Smoke Tests` runs without the build step and still passes against staging
- [ ] `E2E Tests` no longer triggers on this PR (only nightly + manual)
- [ ] Push a follow-up commit and verify the previous `Claude Code` and `PR Tests` runs cancel
- [ ] Open a docs-only PR and verify both `PR Tests` and `PR Quality Checklist` are skipped
- [ ] Once merged, verify QA Pipeline `gate-check` → (`qa-plan` ‖ `build`) → (`qa-execution` ‖ `dogfood`) → `verdict` flow on the next eligible PR
- [ ] Verify Claude Code install hits cache on the second QA run (look for `cache-hit: true` in logs)
- [ ] Trigger `pr-demo-video` manually via `workflow_dispatch` against a recent merged PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows now cancel redundant per-PR runs, shorten time budgets and polling windows, tighten triggers to skip doc/media-only changes, and upgrade core actions and runners.
  * Build/artifact steps and caching were streamlined; some long-running steps and uploads were removed or reduced.

* **Tests**
  * Test jobs run sharded with centralized reporting; coverage parsing/reporting removed.
  * Playwright honors env-driven base URLs; smoke tests use relative health checks.

* **Documentation**
  * QA guidance adds a new "BLOCKED" outcome with reporting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->