### PR TITLE
feat(milestones-review): mention chips + progress bar redesign

### DIFF
--- a/__tests__/unit/components/AgentChat/AgentChatBubble.test.tsx
+++ b/__tests__/unit/components/AgentChat/AgentChatBubble.test.tsx
@@ -354,9 +354,9 @@ describe("AgentChatBubble", () => {
     useAgentChatStore.setState({ isOpen: true });
     render(<AgentChatBubble />);
 
-    const textarea = screen.getByTestId("prompt-textarea");
-    await user.clear(textarea);
-    await user.type(textarea, "Test message{Enter}");
+    const editor = screen.getByRole("textbox", { name: /chat message/i });
+    editor.focus();
+    await user.type(editor, "Test message{Enter}");
 
     expect(mockSendMessage).toHaveBeenCalledWith("Test message");
   });

--- a/components/AgentChat/AgentChatBubble.tsx
+++ b/components/AgentChat/AgentChatBubble.tsx
@@ -25,8 +25,17 @@ function contextLabel(ctx: Record<string, string | undefined> | null): string | 
 
 export function AgentChatBubble() {
   const { authenticated } = useAuth();
-  const { isOpen, toggleOpen, messages, isStreaming, error, clearMessages, agentContext } =
-    useAgentChatStore();
+  const {
+    isOpen,
+    toggleOpen,
+    messages,
+    isStreaming,
+    error,
+    clearMessages,
+    agentContext,
+    pendingMentions,
+    clearMentions,
+  } = useAgentChatStore();
   const { sendMessage, sendConfirmation, abort } = useAgentStream();
 
   // Sync page context (project/program/application) to agent store
@@ -49,6 +58,7 @@ export function AgentChatBubble() {
       onClear={() => {
         abort();
         clearMessages();
+        clearMentions();
       }}
       title="Karma Assistant"
       badge={badge ? <Badge variant="secondary">{badge}</Badge> : undefined}
@@ -67,6 +77,8 @@ export function AgentChatBubble() {
           isStreaming={isStreaming}
           onStop={abort}
           placeholder={authenticated ? "Ask about your project..." : "Ask about a project..."}
+          mentions={pendingMentions}
+          onMentionsConsumed={clearMentions}
         />
       )}
       renderAfterMessage={(msg) =>

--- a/components/AgentChat/ChatBubbleShell.tsx
+++ b/components/AgentChat/ChatBubbleShell.tsx
@@ -13,7 +13,6 @@ import { useEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import {
   Conversation,
   ConversationContent,
@@ -79,7 +78,6 @@ export function ChatBubbleShell({
   wrapper,
   renderHeaderActions,
 }: ChatBubbleShellProps) {
-  const [, copyToClipboard] = useCopyToClipboard();
   const content = (
     <>
       {/* Floating toggle button */}
@@ -192,7 +190,10 @@ export function ChatBubbleShell({
                                   variant="ghost"
                                   size="icon-sm"
                                   onClick={() => {
-                                    copyToClipboard(msg.content, "Copied");
+                                    // Raw navigator.clipboard here — this component is reused in
+                                    // the widget bundle, which forbids Next.js-coupled imports
+                                    // (useCopyToClipboard → errorManager → @sentry/nextjs).
+                                    navigator.clipboard.writeText(msg.content).catch(() => {});
                                   }}
                                   title="Copy"
                                 >

--- a/components/AgentChat/ChatBubbleShell.tsx
+++ b/components/AgentChat/ChatBubbleShell.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import {
   Conversation,
   ConversationContent,
@@ -78,6 +79,7 @@ export function ChatBubbleShell({
   wrapper,
   renderHeaderActions,
 }: ChatBubbleShellProps) {
+  const [, copyToClipboard] = useCopyToClipboard();
   const content = (
     <>
       {/* Floating toggle button */}
@@ -190,7 +192,7 @@ export function ChatBubbleShell({
                                   variant="ghost"
                                   size="icon-sm"
                                   onClick={() => {
-                                    navigator.clipboard.writeText(msg.content).catch(() => {});
+                                    copyToClipboard(msg.content, "Copied");
                                   }}
                                   title="Copy"
                                 >

--- a/components/AgentChat/ChatBubbleShell.tsx
+++ b/components/AgentChat/ChatBubbleShell.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/src/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/src/components/ai-elements/message";
 import type { ChatMessage } from "@/store/agentChat";
+import { renderWithMentionPills } from "@/widget/mention-token";
 
 function ScrollOnNewMessage({ lastMessageContent }: { lastMessageContent: string | undefined }) {
   const { scrollToBottom } = useStickToBottomContext();
@@ -178,7 +179,11 @@ export function ChatBubbleShell({
                         </Avatar>
                         <div className="max-w-[calc(100%-2.5rem)] group">
                           <Message from={msg.role}>
-                            <MessageContent>{renderMarkdown(msg.content)}</MessageContent>
+                            <MessageContent>
+                              {msg.role === "user"
+                                ? renderWithMentionPills(msg.content)
+                                : renderMarkdown(msg.content)}
+                            </MessageContent>
                             {msg.role === "assistant" && msg.content && !msg.isStreaming && (
                               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
                                 <Button

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import {
+  AtSymbolIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   EllipsisVerticalIcon,
+  LinkIcon,
   SparklesIcon,
   TrashIcon,
 } from "@heroicons/react/20/solid";
@@ -15,7 +17,9 @@ import { DeleteDialog } from "@/components/DeleteDialog";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
 import { toEditableUnifiedMilestone } from "@/utilities/milestoneTransforms";
 import { cn } from "@/utilities/tailwind";
@@ -57,6 +61,81 @@ function AIEvaluationButton({ onClick, className = "" }: AIEvaluationButtonProps
   );
 }
 
+function CopyMilestoneLinkButton({
+  milestoneUid,
+  milestoneTitle,
+}: {
+  milestoneUid: string;
+  milestoneTitle: string;
+}) {
+  const [, copyToClipboard] = useCopyToClipboard();
+  const handleClick = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const url = `${window.location.origin}${window.location.pathname}#milestone-${milestoneUid}`;
+    copyToClipboard(url, "Milestone link copied");
+  }, [milestoneUid, copyToClipboard]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="p-1 rounded hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors"
+      aria-label={`Copy link to milestone ${milestoneTitle}`}
+      title="Copy link to this milestone"
+    >
+      <LinkIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+    </button>
+  );
+}
+
+function MentionInChatButton({
+  milestoneUid,
+  milestoneTitle,
+  projectTitle,
+  projectSlug,
+}: {
+  milestoneUid: string;
+  milestoneTitle: string;
+  projectTitle?: string;
+  projectSlug?: string;
+}) {
+  const setOpen = useAgentChatStore((s) => s.setOpen);
+  const addMention = useAgentChatStore((s) => s.addMention);
+
+  const handleClick = useCallback(() => {
+    setOpen(true);
+    const label = projectTitle ? `${milestoneTitle} from ${projectTitle}` : milestoneTitle;
+    // refText uses the project slug (stable id `get_project_details` accepts directly)
+    // plus the milestone uid; agent doesn't have to disambiguate by free-text title.
+    const projectRef = projectSlug
+      ? `project ${projectSlug}`
+      : projectTitle
+        ? `project "${projectTitle}"`
+        : null;
+    const refText = projectRef
+      ? `milestone "${milestoneTitle}" (uid: ${milestoneUid}) in ${projectRef}`
+      : `milestone "${milestoneTitle}" (uid: ${milestoneUid})`;
+    addMention({
+      id: `milestone-${milestoneUid}`,
+      kind: "milestone",
+      label,
+      refText,
+    });
+  }, [setOpen, addMention, milestoneUid, milestoneTitle, projectTitle, projectSlug]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="p-1 rounded hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors"
+      aria-label={`Mention milestone ${milestoneTitle} in the assistant chat`}
+      title="Mention this milestone in the assistant chat"
+    >
+      <AtSymbolIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+    </button>
+  );
+}
+
 interface MilestoneCardProps {
   milestone: GrantMilestoneWithCompletion;
   index: number;
@@ -70,6 +149,7 @@ interface MilestoneCardProps {
   grantChainID?: number;
   projectUid?: string;
   projectSlug?: string;
+  projectTitle?: string;
   programId?: string;
   onVerifyClick: (uid: string) => void;
   onCancelVerification: () => void;
@@ -93,6 +173,7 @@ export function MilestoneCard({
   grantChainID,
   projectUid,
   projectSlug,
+  projectTitle,
   programId,
   onVerifyClick,
   onCancelVerification,
@@ -103,6 +184,7 @@ export function MilestoneCard({
   allocationAmount,
 }: MilestoneCardProps) {
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const anchorId = `milestone-${milestone.uid}`;
 
   const unifiedMilestone = useMemo(
     () =>
@@ -252,7 +334,8 @@ export function MilestoneCard({
   return (
     <div
       key={milestone.uid || index}
-      className="border border-gray-200 dark:border-zinc-700 rounded-lg p-4 hover:border-blue-500 dark:hover:border-blue-400 transition-colors"
+      id={anchorId}
+      className="border border-gray-200 dark:border-zinc-700 rounded-lg p-4 hover:border-blue-500 dark:hover:border-blue-400 transition-colors scroll-mt-24 target:ring-2 target:ring-blue-400 target:border-blue-500"
     >
       {/* Header row: title + status badge + actions */}
       <div className="flex items-start justify-between gap-2 mb-2">
@@ -273,8 +356,15 @@ export function MilestoneCard({
           </span>
         </div>
 
-        {/* Actions: edit + overflow menu */}
+        {/* Actions: copy link + edit + overflow menu */}
         <div className="flex items-center gap-1 flex-shrink-0">
+          <CopyMilestoneLinkButton milestoneUid={milestone.uid} milestoneTitle={milestone.title} />
+          <MentionInChatButton
+            milestoneUid={milestone.uid}
+            milestoneTitle={milestone.title}
+            projectTitle={projectTitle}
+            projectSlug={projectSlug}
+          />
           {unifiedMilestone && !isVerified && !hasCompletion && (
             <Button
               onClick={handleEditOpen}
@@ -386,21 +476,9 @@ export function MilestoneCard({
           {/* Completion Details Box - collapsible */}
           <div className="mb-3 p-3 bg-blue-50 dark:bg-blue-900/10 border border-blue-200 dark:border-blue-800 rounded-md">
             <div className="flex items-center justify-between gap-2 mb-1">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
-                  Completion Details
-                </p>
-                <span
-                  className={cn(
-                    "text-[0.65rem] font-semibold px-1.5 py-0.5 rounded",
-                    useOnChainData
-                      ? "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300"
-                      : "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300"
-                  )}
-                >
-                  {useOnChainData ? "On-chain" : "Self-reported"}
-                </span>
-              </div>
+              <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                Completion Details
+              </p>
               {hasLongCompletion && (
                 <button
                   type="button"

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -105,21 +105,12 @@ function MentionInChatButton({
   const handleClick = useCallback(() => {
     setOpen(true);
     const label = projectTitle ? `${milestoneTitle} from ${projectTitle}` : milestoneTitle;
-    // refText uses the project slug (stable id `get_project_details` accepts directly)
-    // plus the milestone uid; agent doesn't have to disambiguate by free-text title.
-    const projectRef = projectSlug
-      ? `project ${projectSlug}`
-      : projectTitle
-        ? `project "${projectTitle}"`
-        : null;
-    const refText = projectRef
-      ? `milestone "${milestoneTitle}" (uid: ${milestoneUid}) in ${projectRef}`
-      : `milestone "${milestoneTitle}" (uid: ${milestoneUid})`;
     addMention({
       id: `milestone-${milestoneUid}`,
       kind: "milestone",
       label,
-      refText,
+      primaryId: milestoneUid,
+      parentSlug: projectSlug,
     });
   }, [setOpen, addMention, milestoneUid, milestoneTitle, projectTitle, projectSlug]);
 

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -3,12 +3,13 @@
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
+  AtSymbolIcon,
   CheckCircleIcon,
   ChevronLeftIcon,
   ClockIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/20/solid";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
 import { Button } from "@/components/Utilities/Button";
 import { Badge } from "@/components/ui/badge";
@@ -27,6 +28,7 @@ import {
   usePermissionContext,
 } from "@/src/core/rbac/context/permission-context";
 import { ReviewerType } from "@/src/core/rbac/types";
+import { useAgentChatStore } from "@/store/agentChat";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { CommentsAndActivity } from "./CommentsAndActivity";
@@ -35,7 +37,6 @@ import { MilestoneCard } from "./MilestoneCard";
 import {
   FILTER_TABS,
   getMilestoneStatus,
-  MILESTONE_STATUS_CONFIG,
   type MilestoneFilterKey,
   MilestoneReviewStatus,
   type StatusIconName,
@@ -75,68 +76,82 @@ function StatusIcon({ icon, className }: { icon: StatusIconName | null; classNam
   }
 }
 
-// Order in which legend chips render — keeps Verified first for at-a-glance scanning.
-const LEGEND_STATUS_ORDER: MilestoneReviewStatus[] = [
-  MilestoneReviewStatus.Verified,
-  MilestoneReviewStatus.PendingVerification,
-  MilestoneReviewStatus.PendingCompletion,
-  MilestoneReviewStatus.NotStarted,
-];
+// Reviewers care about three buckets at a glance: done, in-progress, not yet started.
+// Pending Verification and Pending Completion are collapsed into a single "Pending"
+// segment to keep the bar legible and match the filter chip vocabulary.
+type ProgressBucket = "verified" | "pending" | "not_started";
 
-/** Visual progress stepper showing milestone states at a glance */
+const PROGRESS_BUCKET_CONFIG: Record<
+  ProgressBucket,
+  { label: string; barColor: string; legendColor: string }
+> = {
+  verified: { label: "Verified", barColor: "bg-green-500", legendColor: "bg-green-500" },
+  pending: { label: "Pending", barColor: "bg-yellow-500", legendColor: "bg-yellow-500" },
+  not_started: {
+    label: "Not Started",
+    barColor: "bg-gray-300 dark:bg-gray-600",
+    legendColor: "bg-gray-300 dark:bg-gray-600",
+  },
+};
+
+const PROGRESS_BUCKET_ORDER: ProgressBucket[] = ["verified", "pending", "not_started"];
+
+function statusToBucket(status: MilestoneReviewStatus): ProgressBucket {
+  if (status === MilestoneReviewStatus.Verified) return "verified";
+  if (status === MilestoneReviewStatus.NotStarted) return "not_started";
+  return "pending";
+}
+
+/** Single segmented progress bar: green/yellow/gray fill proportional to bucket counts. */
 function MilestoneProgressStepper({ milestones }: { milestones: GrantMilestoneWithCompletion[] }) {
-  const { entries, countsByStatus, verifiedCount } = useMemo(() => {
-    const entries = milestones.map((m) => ({ uid: m.uid, status: getMilestoneStatus(m) }));
-    const countsByStatus = {
-      [MilestoneReviewStatus.Verified]: 0,
-      [MilestoneReviewStatus.PendingVerification]: 0,
-      [MilestoneReviewStatus.PendingCompletion]: 0,
-      [MilestoneReviewStatus.NotStarted]: 0,
-    } as Record<MilestoneReviewStatus, number>;
-    for (const { status } of entries) {
-      countsByStatus[status]++;
-    }
-    return {
-      entries,
-      countsByStatus,
-      verifiedCount: countsByStatus[MilestoneReviewStatus.Verified],
-    };
+  const { total, counts } = useMemo(() => {
+    const counts: Record<ProgressBucket, number> = { verified: 0, pending: 0, not_started: 0 };
+    for (const m of milestones) counts[statusToBucket(getMilestoneStatus(m))]++;
+    return { total: milestones.length, counts };
   }, [milestones]);
 
-  if (entries.length === 0) return null;
+  if (total === 0) return null;
 
   return (
     <div className="mb-4">
       <div className="flex items-center gap-3 mb-1.5 flex-wrap text-xs text-gray-600 dark:text-gray-400">
-        {LEGEND_STATUS_ORDER.map((status) => {
-          const count = countsByStatus[status];
+        {PROGRESS_BUCKET_ORDER.map((bucket) => {
+          const count = counts[bucket];
           if (count === 0) return null;
-          const config = MILESTONE_STATUS_CONFIG[status];
+          const config = PROGRESS_BUCKET_CONFIG[bucket];
           return (
-            <span key={status} className="flex items-center gap-1">
-              <span className={cn("w-2 h-2 rounded-full", config.stepperColor)} />
-              {count} {config.filterLabel}
+            <span key={bucket} className="flex items-center gap-1.5">
+              <span className={cn("w-2 h-2 rounded-full", config.legendColor)} />
+              <span>
+                {count} {config.label}
+              </span>
             </span>
           );
         })}
       </div>
-      <ul
-        aria-label={`Milestone progress: ${verifiedCount} of ${entries.length} verified`}
-        className="flex items-center gap-0.5 list-none p-0 m-0"
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={counts.verified}
+        aria-label={`Milestone progress: ${counts.verified} of ${total} verified`}
+        className="flex h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-700"
       >
-        {entries.map(({ uid, status }, i) => {
-          const config = MILESTONE_STATUS_CONFIG[status];
-          const label = `Milestone ${i + 1}: ${config.label}`;
+        {PROGRESS_BUCKET_ORDER.map((bucket) => {
+          const count = counts[bucket];
+          if (count === 0) return null;
+          const config = PROGRESS_BUCKET_CONFIG[bucket];
+          const pct = (count / total) * 100;
           return (
-            <li
-              key={uid || `milestone-${i}`}
-              aria-label={label}
-              className={cn("h-2 rounded-full flex-1 transition-colors", config.stepperColor)}
-              title={label}
+            <div
+              key={bucket}
+              className={cn("h-full transition-all", config.barColor)}
+              style={{ width: `${pct}%` }}
+              title={`${count} ${config.label}`}
             />
           );
         })}
-      </ul>
+      </div>
     </div>
   );
 }
@@ -146,6 +161,44 @@ interface MilestonesReviewPageProps {
   projectId: string;
   programId: string;
   referrer?: string;
+}
+
+function ProjectAskButton({
+  projectUid,
+  projectTitle,
+  projectSlug,
+}: {
+  projectUid: string;
+  projectTitle: string;
+  projectSlug?: string;
+}) {
+  const setOpen = useAgentChatStore((s) => s.setOpen);
+  const addMention = useAgentChatStore((s) => s.addMention);
+
+  const handleClick = useCallback(() => {
+    setOpen(true);
+    // Prefer the slug — `get_project_details` accepts UID or slug, and the slug
+    // is the stable handle the agent can resolve without a search hop.
+    const refText = projectSlug ? `project ${projectSlug}` : `project "${projectTitle}"`;
+    addMention({
+      id: `project-${projectUid}`,
+      kind: "project",
+      label: projectTitle,
+      refText,
+    });
+  }, [setOpen, addMention, projectUid, projectTitle, projectSlug]);
+
+  return (
+    <Button
+      variant="secondary"
+      onClick={handleClick}
+      className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-zinc-600 bg-transparent hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-gray-300"
+      aria-label={`Ask about project ${projectTitle} in the assistant chat`}
+    >
+      <AtSymbolIcon className="w-4 h-4" />
+      Mention to AI
+    </Button>
+  );
 }
 
 export function MilestonesReviewPage({
@@ -358,15 +411,40 @@ function MilestonesReviewPageContent({
 
   const milestones = data?.grantMilestones ?? EMPTY_MILESTONES;
 
+  // When the URL points at a specific milestone (e.g. #milestone-<uid> from
+  // an email/Telegram deep-link), the targeted card must always render —
+  // otherwise the default PendingVerification filter could hide a verified
+  // or in-progress milestone the reviewer was sent to.
+  const targetedMilestoneUid = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    const hash = window.location.hash;
+    return hash.startsWith("#milestone-") ? hash.slice("#milestone-".length) : null;
+  }, []);
+
   // Compute the effective filter: default to PendingVerification if any exist, else "all".
   // Once the user explicitly picks a tab, their choice is locked in.
+  // If the URL targets a specific milestone, force "all" so it's always visible.
   const activeFilter = useMemo<MilestoneFilterKey>(() => {
     if (statusFilter !== null) return statusFilter;
+    if (targetedMilestoneUid) return "all";
     const hasPending = milestones.some(
       (m) => getMilestoneStatus(m) === MilestoneReviewStatus.PendingVerification
     );
     return hasPending ? MilestoneReviewStatus.PendingVerification : "all";
-  }, [statusFilter, milestones]);
+  }, [statusFilter, milestones, targetedMilestoneUid]);
+
+  // Scroll the targeted milestone into view once it has rendered. We can't rely
+  // on the browser's native hash-jump because milestones load asynchronously
+  // and the card doesn't exist on the initial paint. Runs once after the
+  // matching milestone enters the DOM.
+  useEffect(() => {
+    if (!targetedMilestoneUid || milestones.length === 0) return;
+    const exists = milestones.some((m) => m.uid === targetedMilestoneUid);
+    if (!exists) return;
+    const el = document.getElementById(`milestone-${targetedMilestoneUid}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [targetedMilestoneUid, milestones]);
 
   // Single-pass: group milestones by status, derive counts, filter, and sort.
   // Sort: non-verified by due date asc first, verified by due date asc last.
@@ -479,16 +557,23 @@ function MilestonesReviewPageContent({
                 {backButtonConfig.label}
               </Button>
             </Link>
-            {milestoneReviewUrl && (
-              <Link href={milestoneReviewUrl}>
-                <Button
-                  variant="secondary"
-                  className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-zinc-600 bg-transparent hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-gray-300"
-                >
-                  View Application
-                </Button>
-              </Link>
-            )}
+            <div className="flex items-center gap-2">
+              <ProjectAskButton
+                projectUid={project.uid}
+                projectTitle={project.details.title}
+                projectSlug={project.details?.slug}
+              />
+              {milestoneReviewUrl && (
+                <Link href={milestoneReviewUrl}>
+                  <Button
+                    variant="secondary"
+                    className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-zinc-600 bg-transparent hover:bg-gray-50 dark:hover:bg-zinc-700 text-gray-700 dark:text-gray-300"
+                  >
+                    View Application
+                  </Button>
+                </Link>
+              )}
+            </div>
           </div>
           {/* Title */}
           <div className="flex flex-col gap-0.5">
@@ -583,6 +668,7 @@ function MilestonesReviewPageContent({
                       grantChainID={grant?.chainID}
                       projectUid={project.uid}
                       projectSlug={project.details?.slug}
+                      projectTitle={project.details.title}
                       programId={parsedProgramId}
                       onVerifyClick={handleVerifyClick}
                       onCancelVerification={handleCancelVerification}

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@heroicons/react/20/solid";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
+import { OutputsAndOutcomes } from "@/components/Pages/Project/Impact/OutputsAndOutcomes";
 import { Button } from "@/components/Utilities/Button";
 import { Badge } from "@/components/ui/badge";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
@@ -177,14 +178,11 @@ function ProjectAskButton({
 
   const handleClick = useCallback(() => {
     setOpen(true);
-    // Prefer the slug — `get_project_details` accepts UID or slug, and the slug
-    // is the stable handle the agent can resolve without a search hop.
-    const refText = projectSlug ? `project ${projectSlug}` : `project "${projectTitle}"`;
     addMention({
       id: `project-${projectUid}`,
       kind: "project",
       label: projectTitle,
-      refText,
+      primaryId: projectSlug ?? projectUid,
     });
   }, [setOpen, addMention, projectUid, projectTitle, projectSlug]);
 
@@ -589,6 +587,13 @@ function MilestonesReviewPageContent({
 
       {/* Content Area */}
       <div className="px-4 sm:px-6 lg:px-8 py-6">
+        {/* Project Impact Metrics — collapsed by default. Reviewers see a
+            one-line summary (count + last updated) without losing milestones
+            below the fold; expanding shows the same charts/tables as /impact. */}
+        <div className="mb-6">
+          <OutputsAndOutcomes projectUid={project.uid} columns={2} collapsible />
+        </div>
+
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Main Content - Milestones */}
           <div className="flex flex-col gap-6 min-w-0">

--- a/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
+++ b/components/Pages/Project/Impact/OutputsAndOutcomes.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Dialog, Transition } from "@headlessui/react";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import { ChevronRightIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { Card, Title } from "@tremor/react";
 import dynamic from "next/dynamic";
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, type ReactNode, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { Button } from "@/components/Utilities/Button";
@@ -33,7 +33,86 @@ const AreaChart = dynamic(() => import("@tremor/react").then((mod) => mod.AreaCh
   loading: () => <ChartSkeleton height="h-52" />,
 });
 
-export const OutputsAndOutcomes = () => {
+interface OutputsAndOutcomesProps {
+  /**
+   * Optional project UID. When provided, overrides the store-resolved project
+   * (e.g. on pages like the admin milestone review where the project is not
+   * loaded into useProjectStore). Authorization (edit controls) still uses
+   * the store-derived ownership flags — passing a UID does not grant edits.
+   */
+  projectUid?: string;
+  /**
+   * Number of indicator cards per row at xl+ widths. Defaults to 1 (the
+   * project /impact page layout). Set to 2 for embedded views like the
+   * milestone review page where the section shares the page with other
+   * content. Below xl the layout always stacks to 1 column.
+   */
+  columns?: 1 | 2;
+  /**
+   * Render inside a closed-by-default <details> disclosure with a header
+   * showing indicator count + most recent update. When the project has
+   * no metrics, the component renders nothing — collapsible mode is meant
+   * for secondary context (e.g. milestone review) where empty state would
+   * be noise.
+   */
+  collapsible?: boolean;
+}
+
+// Animated disclosure used by the collapsible variant. Native <details> can't
+// transition height; the grid-template-rows 0fr → 1fr trick gives a smooth
+// open/close without measuring content.
+function CollapsibleMetricsPanel({
+  summary,
+  children,
+}: {
+  summary: ReactNode;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-zinc-900 shadow-sm">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="w-full cursor-pointer flex items-center justify-between gap-4 p-6 text-left rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <ChevronRightIcon
+            className={cn(
+              "w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform shrink-0",
+              open && "rotate-90"
+            )}
+            aria-hidden="true"
+          />
+          <h2 className="text-xl font-semibold text-black dark:text-white">
+            Project Impact Metrics
+          </h2>
+        </div>
+        {summary}
+      </button>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-300 ease-out",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        )}
+        // inert keeps tab/screen-reader focus out of the closed panel
+        // without the display:none flicker that would break the animation.
+        inert={!open}
+      >
+        <div className="overflow-hidden">
+          <div className="px-6 pb-6">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const OutputsAndOutcomes = ({
+  projectUid,
+  columns = 1,
+  collapsible = false,
+}: OutputsAndOutcomesProps = {}) => {
   const { project, isProjectOwner } = useProjectStore();
 
   const isContractOwner = useOwnerStore((state) => state.isOwner);
@@ -49,6 +128,8 @@ export const OutputsAndOutcomes = () => {
     data: SelectedPointData;
   } | null>(null);
 
+  const effectiveProjectUid = projectUid ?? (project?.uid as string | undefined);
+
   // Use our custom hook for fetching impact answers
   const {
     data: impactAnswers = [],
@@ -56,8 +137,8 @@ export const OutputsAndOutcomes = () => {
     submitImpactAnswer,
     refetch,
   } = useImpactAnswers({
-    projectIdentifier: project?.uid as string,
-    enabled: !!project?.uid,
+    projectIdentifier: effectiveProjectUid as string,
+    enabled: !!effectiveProjectUid,
   });
 
   // Fetch auto-synced indicators from API
@@ -237,7 +318,40 @@ export const OutputsAndOutcomes = () => {
     );
   };
 
-  if (!project || isLoading) return <GrantsOutputsLoading />;
+  if (!effectiveProjectUid || isLoading) {
+    if (collapsible) {
+      return (
+        <div
+          className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-zinc-900 p-4 animate-pulse"
+          aria-busy="true"
+        >
+          <div className="h-5 w-1/3 bg-gray-200 dark:bg-zinc-700 rounded" />
+        </div>
+      );
+    }
+    return <GrantsOutputsLoading />;
+  }
+
+  // Hide the section entirely in collapsible mode when there's nothing to show —
+  // an empty disclosure at the top of the milestone review page is just noise.
+  if (collapsible && filteredOutputs.length === 0) return null;
+
+  const summaryMeta = (() => {
+    if (filteredOutputs.length === 0) return null;
+    let latest: number | null = null;
+    for (const item of filteredOutputs) {
+      const candidate =
+        item.lastUpdatedAt ??
+        item.datapoints
+          ?.map((dp) => dp.endDate)
+          .filter(Boolean)
+          .sort((a, b) => new Date(b as string).getTime() - new Date(a as string).getTime())[0];
+      if (!candidate) continue;
+      const t = new Date(candidate).getTime();
+      if (Number.isFinite(t) && (latest === null || t > latest)) latest = t;
+    }
+    return { count: filteredOutputs.length, lastUpdated: latest };
+  })();
 
   const isInvalidValue = (value: number, unitOfMeasure: "int" | "float") => {
     if (value === undefined || value === null) return true;
@@ -302,10 +416,22 @@ export const OutputsAndOutcomes = () => {
       return false;
     });
 
-  return (
-    <div className="w-full max-w-[100rem]">
+  const collapsibleSummary =
+    collapsible && summaryMeta?.lastUpdated ? (
+      <span className="text-sm text-gray-500 dark:text-gray-400">
+        Last updated {formatDate(new Date(summaryMeta.lastUpdated), "UTC")}
+      </span>
+    ) : null;
+
+  const innerContent = (
+    <>
       {filteredOutputs.length > 0 ? (
-        <div className="flex flex-col gap-8">
+        <div
+          className={cn(
+            "gap-8",
+            columns === 2 ? "grid grid-cols-1 xl:grid-cols-2" : "flex flex-col"
+          )}
+        >
           {sortedOutputs.map((item) => {
             const form = forms.find((f) => f.id === item.id);
             // Prefer the server-computed lastUpdatedAt (when the sync job last
@@ -403,7 +529,15 @@ export const OutputsAndOutcomes = () => {
                     />
                   )}
 
-                <div className="flex flex-row gap-4 max-md:flex-col-reverse">
+                <div
+                  className={cn(
+                    "flex gap-4 max-md:flex-col-reverse",
+                    // When two cards share a row, the inner chart + breakdown
+                    // need to stack — at half-width there isn't enough room
+                    // for both a 4-column table and a chart side-by-side.
+                    columns === 2 ? "flex-col" : "flex-row"
+                  )}
+                >
                   <div className="flex flex-1 flex-col gap-5">
                     {/* Raw Historical Values Chart */}
                     {(item.datapoints?.length ?? 0) >= 1 ? (
@@ -960,6 +1094,14 @@ export const OutputsAndOutcomes = () => {
           </div>
         </Dialog>
       </Transition>
-    </div>
+    </>
   );
+
+  if (collapsible) {
+    return (
+      <CollapsibleMetricsPanel summary={collapsibleSummary}>{innerContent}</CollapsibleMetricsPanel>
+    );
+  }
+
+  return <div className="w-full max-w-[100rem]">{innerContent}</div>;
 };

--- a/store/agentChat.ts
+++ b/store/agentChat.ts
@@ -19,17 +19,26 @@ export interface ChatMessage {
 
 /**
  * A pre-seeded reference (milestone, project, etc.) rendered as a chip in the
- * input. The user still has to press Send — chips are not auto-submitted.
+ * input AND in the sent message bubble. The user still has to press Send —
+ * chips are not auto-submitted.
  *
  * - `label` is what shows in the pill ("Milestone 1 from Fund#2")
- * - `refText` is what gets prepended to the message sent to the LLM
- *   ("milestone \"Milestone 1\" in project \"Fund#2\"")
+ * - `primaryId` is the agent-resolvable handle (slug for project, uid for
+ *   milestone) — `get_project_details` accepts UID or slug directly.
+ * - `parentSlug` is an optional project slug carried alongside a milestone
+ *   so the agent has unambiguous project context.
+ *
+ * On submit, each chip is serialized as a markdown-link-shaped token:
+ *   `@[<label>](mention:<kind>:<primaryId>[?project=<parentSlug>])`
+ * The chat shell detects this token in user messages and renders it as a pill
+ * matching the input chip styling.
  */
 export interface ChatMention {
   id: string;
   kind: "milestone" | "project" | "application";
   label: string;
-  refText: string;
+  primaryId: string;
+  parentSlug?: string;
 }
 
 interface AgentChatStore {

--- a/store/agentChat.ts
+++ b/store/agentChat.ts
@@ -17,6 +17,21 @@ export interface ChatMessage {
   isStreaming?: boolean;
 }
 
+/**
+ * A pre-seeded reference (milestone, project, etc.) rendered as a chip in the
+ * input. The user still has to press Send — chips are not auto-submitted.
+ *
+ * - `label` is what shows in the pill ("Milestone 1 from Fund#2")
+ * - `refText` is what gets prepended to the message sent to the LLM
+ *   ("milestone \"Milestone 1\" in project \"Fund#2\"")
+ */
+export interface ChatMention {
+  id: string;
+  kind: "milestone" | "project" | "application";
+  label: string;
+  refText: string;
+}
+
 interface AgentChatStore {
   messages: ChatMessage[];
   isOpen: boolean;
@@ -31,6 +46,12 @@ interface AgentChatStore {
     communityId?: string;
   } | null;
 
+  // Reference chips seeded into the chat input (via "@mention" buttons on
+  // milestone cards, etc.). Rendered as pills inside the input; on submit
+  // their `refText` is prepended to the message. Chips persist until removed
+  // or until the message is sent.
+  pendingMentions: ChatMention[];
+
   setOpen: (open: boolean) => void;
   toggleOpen: () => void;
   addMessage: (message: ChatMessage) => void;
@@ -41,6 +62,9 @@ interface AgentChatStore {
   setStreaming: (streaming: boolean) => void;
   setError: (error: string | null) => void;
   setAgentContext: (ctx: AgentChatStore["agentContext"]) => void;
+  addMention: (mention: ChatMention) => void;
+  removeMention: (id: string) => void;
+  clearMentions: () => void;
   clearMessages: () => void;
 }
 
@@ -50,6 +74,7 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
   isStreaming: false,
   error: null,
   agentContext: null,
+  pendingMentions: [],
 
   setOpen: (open) => set({ isOpen: open }),
   toggleOpen: () => set((state) => ({ isOpen: !state.isOpen })),
@@ -98,5 +123,14 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
   setStreaming: (streaming) => set({ isStreaming: streaming }),
   setError: (error) => set({ error }),
   setAgentContext: (agentContext) => set({ agentContext }),
+  addMention: (mention) =>
+    set((state) =>
+      state.pendingMentions.some((m) => m.id === mention.id)
+        ? state
+        : { pendingMentions: [...state.pendingMentions, mention] }
+    ),
+  removeMention: (id) =>
+    set((state) => ({ pendingMentions: state.pendingMentions.filter((m) => m.id !== id) })),
+  clearMentions: () => set({ pendingMentions: [] }),
   clearMessages: () => set({ messages: [], error: null, isStreaming: false }),
 }));

--- a/widget/WidgetInput.tsx
+++ b/widget/WidgetInput.tsx
@@ -137,10 +137,12 @@ export const WidgetInput = memo(function WidgetInput({
   onMentionsConsumed,
 }: WidgetInputProps) {
   const editorRef = useRef<HTMLDivElement | null>(null);
-  // Re-renders are cheap; a single `version` tick lets the send button reflect
-  // emptiness without making the contenteditable a controlled component.
-  const [, setVersion] = useState(0);
-  const bump = useCallback(() => setVersion((v) => v + 1), []);
+  // Drives the send button's disabled state without making the contenteditable
+  // a controlled component. Synced from the live editor on input/insert/submit.
+  const [isEmpty, setIsEmpty] = useState(true);
+  const syncEmpty = useCallback(() => {
+    setIsEmpty(isEditorEmpty(editorRef.current));
+  }, []);
 
   // Drain queued mentions: insert each one inline, then notify the host.
   useEffect(() => {
@@ -148,8 +150,8 @@ export const WidgetInput = memo(function WidgetInput({
     if (!editor || !mentions || mentions.length === 0) return;
     for (const m of mentions) insertMentionAtCaret(editor, m);
     onMentionsConsumed?.();
-    bump();
-  }, [mentions, onMentionsConsumed, bump]);
+    syncEmpty();
+  }, [mentions, onMentionsConsumed, syncEmpty]);
 
   const submit = useCallback(() => {
     const editor = editorRef.current;
@@ -157,9 +159,9 @@ export const WidgetInput = memo(function WidgetInput({
     const body = serializeEditor(editor);
     if (body.length === 0) return;
     onSubmit(body);
-    editor.innerHTML = "";
-    bump();
-  }, [isStreaming, onSubmit, bump]);
+    editor.replaceChildren();
+    setIsEmpty(true);
+  }, [isStreaming, onSubmit]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
@@ -185,7 +187,7 @@ export const WidgetInput = memo(function WidgetInput({
     placeCaretAfter(node);
   }, []);
 
-  const canSend = !isStreaming && !isEditorEmpty(editorRef.current);
+  const canSend = !isStreaming && !isEmpty;
 
   return (
     <div className="border-t border-border p-3">
@@ -208,7 +210,7 @@ export const WidgetInput = memo(function WidgetInput({
           suppressContentEditableWarning
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          onInput={bump}
+          onInput={syncEmpty}
           data-placeholder={placeholder}
           className={cn(
             "flex-1 min-h-6 max-h-24 overflow-y-auto py-1.5 text-sm leading-6 outline-none",

--- a/widget/WidgetInput.tsx
+++ b/widget/WidgetInput.tsx
@@ -1,17 +1,113 @@
+"use client";
+
 import { CornerDownLeftIcon, SquareIcon } from "lucide-react";
-import { type KeyboardEvent, memo, useCallback, useState } from "react";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupTextarea,
-} from "@/components/ui/input-group";
+import { type KeyboardEvent, memo, useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { ChatMention } from "@/store/agentChat";
+import { cn } from "@/utilities/tailwind";
 
 interface WidgetInputProps {
   onSubmit: (text: string) => void;
   isStreaming: boolean;
   onStop?: () => void;
   placeholder?: string;
+  /**
+   * Mentions queued by external triggers (e.g. a "@-mention" button on a
+   * milestone card). When this prop changes to a non-empty array, each
+   * mention is inserted as an atomic inline pill at the current caret
+   * position in the editor, then `onMentionsConsumed` fires so the host
+   * can clear its queue. Chip data lives in the DOM after that.
+   */
+  mentions?: ChatMention[];
+  onMentionsConsumed?: () => void;
+}
+
+const MENTION_DATA_ATTR = "data-mention";
+const MENTION_REF_TEXT_ATTR = "data-mention-ref-text";
+const NBSP = " ";
+
+function buildMentionChip(mention: ChatMention): HTMLSpanElement {
+  const span = document.createElement("span");
+  span.contentEditable = "false";
+  span.setAttribute(MENTION_DATA_ATTR, mention.id);
+  span.setAttribute(MENTION_REF_TEXT_ATTR, mention.refText);
+  span.className =
+    "inline-flex items-center align-baseline rounded-full bg-brand-blue/10 text-brand-blue px-1.5 py-0.5 mx-0.5 text-xs font-medium select-none cursor-default";
+  span.textContent = `@${mention.label}`;
+  return span;
+}
+
+function placeCaretAfter(node: Node) {
+  const range = document.createRange();
+  range.setStartAfter(node);
+  range.collapse(true);
+  const sel = window.getSelection();
+  if (!sel) return;
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+/** Insert a chip at the current caret if the caret is inside `editor`,
+ * otherwise append it to the end of `editor`. Always followed by a single
+ * trailing space so the user can keep typing immediately. */
+function insertMentionAtCaret(editor: HTMLDivElement, mention: ChatMention) {
+  const sel = window.getSelection();
+  const chip = buildMentionChip(mention);
+  const space = document.createTextNode(" ");
+
+  const rangeIsInside =
+    sel && sel.rangeCount > 0 && editor.contains(sel.getRangeAt(0).startContainer as Node);
+
+  if (rangeIsInside && sel) {
+    const range = sel.getRangeAt(0);
+    range.deleteContents();
+    range.insertNode(chip);
+    chip.after(space);
+    placeCaretAfter(space);
+  } else {
+    editor.appendChild(chip);
+    editor.appendChild(space);
+    editor.focus();
+    placeCaretAfter(space);
+  }
+}
+
+/** Recursively walk the editor and produce the message body to send.
+ * Mention chips emit their `refText` and their visible @label children are
+ * skipped; everything else becomes plain text. <br>/block boundaries become
+ * newlines. */
+function serializeEditor(editor: HTMLDivElement): string {
+  let out = "";
+  const visit = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += (node.nodeValue ?? "").replace(new RegExp(NBSP, "g"), " ");
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const el = node as HTMLElement;
+    if (el.hasAttribute(MENTION_DATA_ATTR)) {
+      out += el.getAttribute(MENTION_REF_TEXT_ATTR) ?? "";
+      return;
+    }
+    if (el.tagName === "BR") {
+      out += "\n";
+      return;
+    }
+    const isBlock = el.tagName === "DIV" || el.tagName === "P";
+    if (isBlock && out && !out.endsWith("\n")) out += "\n";
+    el.childNodes.forEach(visit);
+  };
+  editor.childNodes.forEach(visit);
+  return out
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function isEditorEmpty(editor: HTMLDivElement | null): boolean {
+  if (!editor) return true;
+  if (editor.querySelector(`[${MENTION_DATA_ATTR}]`)) return false;
+  return editor.textContent?.trim().length === 0;
 }
 
 export const WidgetInput = memo(function WidgetInput({
@@ -19,18 +115,36 @@ export const WidgetInput = memo(function WidgetInput({
   isStreaming,
   onStop,
   placeholder = "Ask me anything...",
+  mentions,
+  onMentionsConsumed,
 }: WidgetInputProps) {
-  const [value, setValue] = useState("");
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  // Re-renders are cheap; a single `version` tick lets the send button reflect
+  // emptiness without making the contenteditable a controlled component.
+  const [, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  // Drain queued mentions: insert each one inline, then notify the host.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || !mentions || mentions.length === 0) return;
+    for (const m of mentions) insertMentionAtCaret(editor, m);
+    onMentionsConsumed?.();
+    bump();
+  }, [mentions, onMentionsConsumed, bump]);
 
   const submit = useCallback(() => {
-    const trimmed = value.trim();
-    if (!trimmed || isStreaming) return;
-    onSubmit(trimmed);
-    setValue("");
-  }, [value, isStreaming, onSubmit]);
+    const editor = editorRef.current;
+    if (!editor || isStreaming) return;
+    const body = serializeEditor(editor);
+    if (body.length === 0) return;
+    onSubmit(body);
+    editor.innerHTML = "";
+    bump();
+  }, [isStreaming, onSubmit, bump]);
 
   const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         submit();
@@ -39,43 +153,76 @@ export const WidgetInput = memo(function WidgetInput({
     [submit]
   );
 
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
+    // Strip formatting on paste — only plain text reaches the editor.
+    e.preventDefault();
+    const text = e.clipboardData.getData("text/plain");
+    if (!text) return;
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+    const range = sel.getRangeAt(0);
+    range.deleteContents();
+    const node = document.createTextNode(text);
+    range.insertNode(node);
+    placeCaretAfter(node);
+  }, []);
+
+  const canSend = !isStreaming && !isEditorEmpty(editorRef.current);
+
   return (
     <div className="border-t border-border p-3">
-      <InputGroup>
-        <InputGroupTextarea
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          disabled={isStreaming}
-          className="min-h-10 max-h-24 text-sm"
+      <div
+        className={cn(
+          "group/input flex w-full items-end gap-2 rounded-md border border-input bg-background px-2 py-1.5 shadow-xs",
+          "transition-[color,box-shadow] focus-within:ring-1 focus-within:ring-ring",
+          isStreaming && "opacity-60"
+        )}
+      >
+        {/* biome-ignore lint/a11y/useSemanticElements: contenteditable required for inline mention chips, which textarea cannot render */}
+        <div
+          ref={editorRef}
+          role="textbox"
+          tabIndex={0}
+          aria-multiline="true"
           aria-label="Chat message"
-        />
-        <InputGroupAddon align="block-end" className="justify-between gap-1">
-          <div />
-          {isStreaming ? (
-            <InputGroupButton
-              variant="outline"
-              size="icon-sm"
-              onClick={onStop}
-              aria-label="Stop generating"
-            >
-              <SquareIcon className="size-4" />
-            </InputGroupButton>
-          ) : (
-            <InputGroupButton
-              variant="default"
-              size="icon-sm"
-              onClick={submit}
-              disabled={!value.trim()}
-              aria-label="Send message"
-              type="submit"
-            >
-              <CornerDownLeftIcon className="size-4" />
-            </InputGroupButton>
+          aria-disabled={isStreaming}
+          contentEditable={!isStreaming}
+          suppressContentEditableWarning
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onInput={bump}
+          data-placeholder={placeholder}
+          className={cn(
+            "flex-1 min-h-6 max-h-24 overflow-y-auto py-1.5 text-sm leading-6 outline-none",
+            "[&:empty]:before:content-[attr(data-placeholder)] [&:empty]:before:text-muted-foreground",
+            "[&:empty]:before:pointer-events-none whitespace-pre-wrap break-words"
           )}
-        </InputGroupAddon>
-      </InputGroup>
+        />
+        {isStreaming ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            onClick={onStop}
+            aria-label="Stop generating"
+          >
+            <SquareIcon className="size-4" />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="default"
+            size="icon-sm"
+            onClick={submit}
+            disabled={!canSend}
+            aria-label="Send message"
+          >
+            <CornerDownLeftIcon className="size-4" />
+          </Button>
+        )}
+      </div>
     </div>
   );
 });
+
+export const __test = { serializeEditor, buildMentionChip, insertMentionAtCaret, isEditorEmpty };

--- a/widget/WidgetInput.tsx
+++ b/widget/WidgetInput.tsx
@@ -28,7 +28,10 @@ const MENTION_KIND_ATTR = "data-mention-kind";
 const MENTION_PRIMARY_ID_ATTR = "data-mention-primary-id";
 const MENTION_PARENT_SLUG_ATTR = "data-mention-parent-slug";
 const MENTION_LABEL_ATTR = "data-mention-label";
-const NBSP = " ";
+// U+00A0 — the browser inserts real non-breaking spaces in contenteditable
+// (trailing spaces, multi-space runs); strip them so the AI backend receives
+// regular ASCII spaces.
+const NBSP = "\u00A0";
 
 function buildMentionChip(mention: ChatMention): HTMLSpanElement {
   const span = document.createElement("span");
@@ -141,14 +144,34 @@ export const WidgetInput = memo(function WidgetInput({
   // a controlled component. Synced from the live editor on input/insert/submit.
   const [isEmpty, setIsEmpty] = useState(true);
   const syncEmpty = useCallback(() => {
-    setIsEmpty(isEditorEmpty(editorRef.current));
+    const editor = editorRef.current;
+    const empty = isEditorEmpty(editor);
+    // contenteditable leaves stray <br>s after the user deletes all text,
+    // which keeps `:empty` from matching and hides the placeholder. Clearing
+    // the children when we know the editor is logically empty restores it.
+    if (empty && editor && editor.childNodes.length > 0) {
+      editor.replaceChildren();
+    }
+    setIsEmpty(empty);
   }, []);
 
   // Drain queued mentions: insert each one inline, then notify the host.
+  // Skip mentions whose chip is already in the editor — once the host clears
+  // its `pendingMentions` queue, a second click on the same trigger button
+  // would otherwise re-insert a duplicate chip with the same id.
   useEffect(() => {
     const editor = editorRef.current;
     if (!editor || !mentions || mentions.length === 0) return;
-    for (const m of mentions) insertMentionAtCaret(editor, m);
+    const existingIds = new Set(
+      Array.from(editor.querySelectorAll(`[${MENTION_DATA_ATTR}]`))
+        .map((el) => el.getAttribute(MENTION_DATA_ATTR))
+        .filter((id): id is string => !!id)
+    );
+    for (const m of mentions) {
+      if (existingIds.has(m.id)) continue;
+      insertMentionAtCaret(editor, m);
+      existingIds.add(m.id);
+    }
     onMentionsConsumed?.();
     syncEmpty();
   }, [mentions, onMentionsConsumed, syncEmpty]);

--- a/widget/WidgetInput.tsx
+++ b/widget/WidgetInput.tsx
@@ -5,6 +5,7 @@ import { type KeyboardEvent, memo, useCallback, useEffect, useRef, useState } fr
 import { Button } from "@/components/ui/button";
 import type { ChatMention } from "@/store/agentChat";
 import { cn } from "@/utilities/tailwind";
+import { mentionToToken } from "./mention-token";
 
 interface WidgetInputProps {
   onSubmit: (text: string) => void;
@@ -23,18 +24,34 @@ interface WidgetInputProps {
 }
 
 const MENTION_DATA_ATTR = "data-mention";
-const MENTION_REF_TEXT_ATTR = "data-mention-ref-text";
-const NBSP = " ";
+const MENTION_KIND_ATTR = "data-mention-kind";
+const MENTION_PRIMARY_ID_ATTR = "data-mention-primary-id";
+const MENTION_PARENT_SLUG_ATTR = "data-mention-parent-slug";
+const MENTION_LABEL_ATTR = "data-mention-label";
+const NBSP = " ";
 
 function buildMentionChip(mention: ChatMention): HTMLSpanElement {
   const span = document.createElement("span");
   span.contentEditable = "false";
   span.setAttribute(MENTION_DATA_ATTR, mention.id);
-  span.setAttribute(MENTION_REF_TEXT_ATTR, mention.refText);
+  span.setAttribute(MENTION_KIND_ATTR, mention.kind);
+  span.setAttribute(MENTION_PRIMARY_ID_ATTR, mention.primaryId);
+  if (mention.parentSlug) span.setAttribute(MENTION_PARENT_SLUG_ATTR, mention.parentSlug);
+  span.setAttribute(MENTION_LABEL_ATTR, mention.label);
   span.className =
     "inline-flex items-center align-baseline rounded-full bg-brand-blue/10 text-brand-blue px-1.5 py-0.5 mx-0.5 text-xs font-medium select-none cursor-default";
   span.textContent = `@${mention.label}`;
   return span;
+}
+
+function chipToMention(el: HTMLElement): ChatMention | null {
+  const id = el.getAttribute(MENTION_DATA_ATTR);
+  const kind = el.getAttribute(MENTION_KIND_ATTR) as ChatMention["kind"] | null;
+  const primaryId = el.getAttribute(MENTION_PRIMARY_ID_ATTR);
+  const label = el.getAttribute(MENTION_LABEL_ATTR);
+  if (!id || !kind || !primaryId || !label) return null;
+  const parentSlug = el.getAttribute(MENTION_PARENT_SLUG_ATTR) ?? undefined;
+  return { id, kind, primaryId, label, parentSlug };
 }
 
 function placeCaretAfter(node: Node) {
@@ -73,8 +90,8 @@ function insertMentionAtCaret(editor: HTMLDivElement, mention: ChatMention) {
 }
 
 /** Recursively walk the editor and produce the message body to send.
- * Mention chips emit their `refText` and their visible @label children are
- * skipped; everything else becomes plain text. <br>/block boundaries become
+ * Mention chips emit their structured token (visible label + agent handle);
+ * their visible @label children are skipped. <br>/block boundaries become
  * newlines. */
 function serializeEditor(editor: HTMLDivElement): string {
   let out = "";
@@ -86,7 +103,8 @@ function serializeEditor(editor: HTMLDivElement): string {
     if (node.nodeType !== Node.ELEMENT_NODE) return;
     const el = node as HTMLElement;
     if (el.hasAttribute(MENTION_DATA_ATTR)) {
-      out += el.getAttribute(MENTION_REF_TEXT_ATTR) ?? "";
+      const mention = chipToMention(el);
+      if (mention) out += mentionToToken(mention);
       return;
     }
     if (el.tagName === "BR") {

--- a/widget/WidgetInput.tsx
+++ b/widget/WidgetInput.tsx
@@ -196,19 +196,25 @@ export const WidgetInput = memo(function WidgetInput({
     [submit]
   );
 
-  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
-    // Strip formatting on paste — only plain text reaches the editor.
-    e.preventDefault();
-    const text = e.clipboardData.getData("text/plain");
-    if (!text) return;
-    const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-    const range = sel.getRangeAt(0);
-    range.deleteContents();
-    const node = document.createTextNode(text);
-    range.insertNode(node);
-    placeCaretAfter(node);
-  }, []);
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      // Strip formatting on paste — only plain text reaches the editor.
+      e.preventDefault();
+      const text = e.clipboardData.getData("text/plain");
+      if (!text) return;
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const range = sel.getRangeAt(0);
+      range.deleteContents();
+      const node = document.createTextNode(text);
+      range.insertNode(node);
+      placeCaretAfter(node);
+      // Paste fires before `input`, so update isEmpty here too — otherwise
+      // the send button stays disabled until the next keystroke.
+      syncEmpty();
+    },
+    [syncEmpty]
+  );
 
   const canSend = !isStreaming && !isEmpty;
 

--- a/widget/__tests__/WidgetInput.test.tsx
+++ b/widget/__tests__/WidgetInput.test.tsx
@@ -284,6 +284,25 @@ describe("WidgetInput", () => {
     });
   });
 
+  it("enables the send button after a paste into an empty editor", () => {
+    const onSubmit = vi.fn();
+    render(<WidgetInput onSubmit={onSubmit} isStreaming={false} />);
+    const editor = getEditor();
+    expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
+
+    // Simulate the contenteditable's paste handler effect: range insert +
+    // the paste event (the handler calls syncEmpty after inserting).
+    editor.focus();
+    placeCaretAtEnd(editor);
+    // jsdom lacks DataTransfer — fake a clipboardData with the getData shape
+    // the handler reads.
+    fireEvent.paste(editor, {
+      clipboardData: { getData: (type: string) => (type === "text/plain" ? "pasted text" : "") },
+    });
+
+    expect(screen.getByRole("button", { name: /send/i })).not.toBeDisabled();
+  });
+
   it("clears stray <br>s left by contenteditable so the placeholder reappears", () => {
     render(<WidgetInput onSubmit={vi.fn()} isStreaming={false} />);
     const editor = getEditor();

--- a/widget/__tests__/WidgetInput.test.tsx
+++ b/widget/__tests__/WidgetInput.test.tsx
@@ -148,6 +148,14 @@ describe("WidgetInput helpers", () => {
       editor.textContent = "   hi   ";
       expect(serializeEditor(editor)).toBe("hi");
     });
+
+    it("replaces non-breaking spaces (U+00A0) with regular spaces", () => {
+      // contenteditable browsers insert real NBSP characters for trailing
+      // spaces and multi-space runs; the AI backend should receive plain ASCII.
+      const editor = makeEditor();
+      editor.textContent = "hello\u00A0world\u00A0\u00A0!";
+      expect(serializeEditor(editor)).toBe("hello world  !");
+    });
   });
 });
 
@@ -246,5 +254,47 @@ describe("WidgetInput", () => {
       await userEvent.click(screen.getByRole("button", { name: /send/i }));
       expect(onSubmit).toHaveBeenCalledWith(milestoneToken);
     });
+
+    it("skips chips whose id already exists in the editor on a re-push", () => {
+      // Repro for the "click the @-mention button twice" bug: after the host
+      // clears its queue via onMentionsConsumed and re-pushes the same
+      // mention, we must NOT add a second chip with the same id.
+      const onMentionsConsumed = vi.fn();
+      const { rerender } = render(
+        <WidgetInput
+          onSubmit={vi.fn()}
+          isStreaming={false}
+          mentions={[milestoneMention]}
+          onMentionsConsumed={onMentionsConsumed}
+        />
+      );
+      const firstCount = document.querySelectorAll('[data-mention="milestone-abc"]').length;
+      expect(firstCount).toBeGreaterThanOrEqual(1);
+
+      rerender(
+        <WidgetInput
+          onSubmit={vi.fn()}
+          isStreaming={false}
+          mentions={[milestoneMention]}
+          onMentionsConsumed={onMentionsConsumed}
+        />
+      );
+
+      expect(document.querySelectorAll('[data-mention="milestone-abc"]').length).toBe(firstCount);
+    });
+  });
+
+  it("clears stray <br>s left by contenteditable so the placeholder reappears", () => {
+    render(<WidgetInput onSubmit={vi.fn()} isStreaming={false} />);
+    const editor = getEditor();
+
+    // Mimic what browsers leave after the user types a char and deletes it.
+    editor.appendChild(document.createElement("br"));
+    expect(editor.childNodes.length).toBe(1);
+
+    fireEvent.input(editor);
+
+    expect(editor.childNodes.length).toBe(0);
+    expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
   });
 });

--- a/widget/__tests__/WidgetInput.test.tsx
+++ b/widget/__tests__/WidgetInput.test.tsx
@@ -9,15 +9,21 @@ const milestoneMention: ChatMention = {
   id: "milestone-abc",
   kind: "milestone",
   label: "Milestone 1 from Fund#2",
-  refText: 'milestone "Milestone 1" in project "Fund#2"',
+  primaryId: "0xmilestone-uid",
+  parentSlug: "fund-2",
 };
+
+const milestoneToken =
+  "@[Milestone 1 from Fund#2](mention:milestone:0xmilestone-uid?project=fund-2)";
 
 const secondMention: ChatMention = {
   id: "milestone-def",
   kind: "milestone",
   label: "Milestone 2",
-  refText: 'milestone "Milestone 2"',
+  primaryId: "0xmilestone-uid-2",
 };
+
+const secondToken = "@[Milestone 2](mention:milestone:0xmilestone-uid-2)";
 
 function makeEditor(): HTMLDivElement {
   const editor = document.createElement("div");
@@ -37,12 +43,20 @@ function placeCaretAtEnd(editor: HTMLElement) {
 
 describe("WidgetInput helpers", () => {
   describe("buildMentionChip", () => {
-    it("creates a contenteditable=false span with @-prefixed label", () => {
+    it("creates a contenteditable=false span with @-prefixed label and stamped attrs", () => {
       const chip = buildMentionChip(milestoneMention);
       expect(chip.contentEditable).toBe("false");
       expect(chip.textContent).toBe("@Milestone 1 from Fund#2");
       expect(chip.getAttribute("data-mention")).toBe("milestone-abc");
-      expect(chip.getAttribute("data-mention-ref-text")).toBe(milestoneMention.refText);
+      expect(chip.getAttribute("data-mention-kind")).toBe("milestone");
+      expect(chip.getAttribute("data-mention-primary-id")).toBe("0xmilestone-uid");
+      expect(chip.getAttribute("data-mention-parent-slug")).toBe("fund-2");
+      expect(chip.getAttribute("data-mention-label")).toBe("Milestone 1 from Fund#2");
+    });
+
+    it("omits parent-slug attr when not provided", () => {
+      const chip = buildMentionChip(secondMention);
+      expect(chip.hasAttribute("data-mention-parent-slug")).toBe(false);
     });
   });
 
@@ -99,19 +113,17 @@ describe("WidgetInput helpers", () => {
       expect(serializeEditor(editor)).toBe("Hello agent");
     });
 
-    it("substitutes chip refText for chip nodes", () => {
+    it("substitutes mention token for chip nodes", () => {
       const editor = makeEditor();
       editor.appendChild(buildMentionChip(milestoneMention));
       editor.appendChild(document.createTextNode(" what's the status?"));
-      expect(serializeEditor(editor)).toBe(
-        'milestone "Milestone 1" in project "Fund#2" what\'s the status?'
-      );
+      expect(serializeEditor(editor)).toBe(`${milestoneToken} what's the status?`);
     });
 
-    it("returns refText only when no typed text follows", () => {
+    it("returns token only when no typed text follows", () => {
       const editor = makeEditor();
       editor.appendChild(buildMentionChip(milestoneMention));
-      expect(serializeEditor(editor)).toBe('milestone "Milestone 1" in project "Fund#2"');
+      expect(serializeEditor(editor)).toBe(milestoneToken);
     });
 
     it("preserves multiple chips in order", () => {
@@ -120,9 +132,7 @@ describe("WidgetInput helpers", () => {
       editor.appendChild(document.createTextNode(" and "));
       editor.appendChild(buildMentionChip(secondMention));
       editor.appendChild(document.createTextNode(" — compare"));
-      expect(serializeEditor(editor)).toBe(
-        'milestone "Milestone 1" in project "Fund#2" and milestone "Milestone 2" — compare'
-      );
+      expect(serializeEditor(editor)).toBe(`${milestoneToken} and ${secondToken} — compare`);
     });
 
     it("converts <br> to newline", () => {
@@ -208,7 +218,7 @@ describe("WidgetInput", () => {
       expect(onMentionsConsumed).toHaveBeenCalled();
     });
 
-    it("submits message with chip refText substituted inline", async () => {
+    it("submits message with chip token substituted inline", async () => {
       const onSubmit = vi.fn();
       const onMentionsConsumed = vi.fn();
       render(
@@ -226,7 +236,7 @@ describe("WidgetInput", () => {
       await userEvent.click(screen.getByRole("button", { name: /send/i }));
       expect(onSubmit).toHaveBeenCalledTimes(1);
       const sent = onSubmit.mock.calls[0][0] as string;
-      expect(sent).toContain('milestone "Milestone 1" in project "Fund#2"');
+      expect(sent).toContain(milestoneToken);
       expect(sent).toContain("what's the status?");
     });
 
@@ -234,7 +244,7 @@ describe("WidgetInput", () => {
       const onSubmit = vi.fn();
       render(<WidgetInput onSubmit={onSubmit} isStreaming={false} mentions={[milestoneMention]} />);
       await userEvent.click(screen.getByRole("button", { name: /send/i }));
-      expect(onSubmit).toHaveBeenCalledWith('milestone "Milestone 1" in project "Fund#2"');
+      expect(onSubmit).toHaveBeenCalledWith(milestoneToken);
     });
   });
 });

--- a/widget/__tests__/WidgetInput.test.tsx
+++ b/widget/__tests__/WidgetInput.test.tsx
@@ -1,57 +1,240 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { WidgetInput } from "../WidgetInput";
+import type { ChatMention } from "@/store/agentChat";
+import { __test, WidgetInput } from "../WidgetInput";
 
-describe("WidgetInput", () => {
-  it("calls onSubmit with trimmed text and clears input", async () => {
-    const onSubmit = vi.fn();
-    render(<WidgetInput onSubmit={onSubmit} isStreaming={false} />);
+const { serializeEditor, buildMentionChip, insertMentionAtCaret, isEditorEmpty } = __test;
 
-    const textarea = screen.getByPlaceholderText(/ask/i);
-    await userEvent.type(textarea, "Hello agent");
+const milestoneMention: ChatMention = {
+  id: "milestone-abc",
+  kind: "milestone",
+  label: "Milestone 1 from Fund#2",
+  refText: 'milestone "Milestone 1" in project "Fund#2"',
+};
 
-    const submitBtn = screen.getByRole("button", { name: /send/i });
-    await userEvent.click(submitBtn);
+const secondMention: ChatMention = {
+  id: "milestone-def",
+  kind: "milestone",
+  label: "Milestone 2",
+  refText: 'milestone "Milestone 2"',
+};
 
-    expect(onSubmit).toHaveBeenCalledWith("Hello agent");
-    expect(textarea).toHaveValue("");
+function makeEditor(): HTMLDivElement {
+  const editor = document.createElement("div");
+  editor.contentEditable = "true";
+  document.body.appendChild(editor);
+  return editor;
+}
+
+function placeCaretAtEnd(editor: HTMLElement) {
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+}
+
+describe("WidgetInput helpers", () => {
+  describe("buildMentionChip", () => {
+    it("creates a contenteditable=false span with @-prefixed label", () => {
+      const chip = buildMentionChip(milestoneMention);
+      expect(chip.contentEditable).toBe("false");
+      expect(chip.textContent).toBe("@Milestone 1 from Fund#2");
+      expect(chip.getAttribute("data-mention")).toBe("milestone-abc");
+      expect(chip.getAttribute("data-mention-ref-text")).toBe(milestoneMention.refText);
+    });
   });
 
-  it("does not submit empty input", async () => {
+  describe("isEditorEmpty", () => {
+    it("returns true for null editor", () => {
+      expect(isEditorEmpty(null)).toBe(true);
+    });
+
+    it("returns true for empty editor", () => {
+      const editor = makeEditor();
+      expect(isEditorEmpty(editor)).toBe(true);
+    });
+
+    it("returns false when editor has text", () => {
+      const editor = makeEditor();
+      editor.textContent = "hi";
+      expect(isEditorEmpty(editor)).toBe(false);
+    });
+
+    it("returns false when editor has only a mention chip", () => {
+      const editor = makeEditor();
+      editor.appendChild(buildMentionChip(milestoneMention));
+      expect(isEditorEmpty(editor)).toBe(false);
+    });
+  });
+
+  describe("insertMentionAtCaret", () => {
+    it("appends a chip when caret is not inside the editor", () => {
+      const editor = makeEditor();
+      window.getSelection()?.removeAllRanges();
+      insertMentionAtCaret(editor, milestoneMention);
+      expect(editor.querySelector("[data-mention]")?.textContent).toBe("@Milestone 1 from Fund#2");
+    });
+
+    it("inserts at caret when caret is inside the editor", () => {
+      const editor = makeEditor();
+      editor.textContent = "hello world";
+      const range = document.createRange();
+      range.setStart(editor.firstChild as Node, 5);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      insertMentionAtCaret(editor, milestoneMention);
+      const chip = editor.querySelector("[data-mention]");
+      expect(chip).not.toBeNull();
+    });
+  });
+
+  describe("serializeEditor", () => {
+    it("returns plain text", () => {
+      const editor = makeEditor();
+      editor.textContent = "Hello agent";
+      expect(serializeEditor(editor)).toBe("Hello agent");
+    });
+
+    it("substitutes chip refText for chip nodes", () => {
+      const editor = makeEditor();
+      editor.appendChild(buildMentionChip(milestoneMention));
+      editor.appendChild(document.createTextNode(" what's the status?"));
+      expect(serializeEditor(editor)).toBe(
+        'milestone "Milestone 1" in project "Fund#2" what\'s the status?'
+      );
+    });
+
+    it("returns refText only when no typed text follows", () => {
+      const editor = makeEditor();
+      editor.appendChild(buildMentionChip(milestoneMention));
+      expect(serializeEditor(editor)).toBe('milestone "Milestone 1" in project "Fund#2"');
+    });
+
+    it("preserves multiple chips in order", () => {
+      const editor = makeEditor();
+      editor.appendChild(buildMentionChip(milestoneMention));
+      editor.appendChild(document.createTextNode(" and "));
+      editor.appendChild(buildMentionChip(secondMention));
+      editor.appendChild(document.createTextNode(" — compare"));
+      expect(serializeEditor(editor)).toBe(
+        'milestone "Milestone 1" in project "Fund#2" and milestone "Milestone 2" — compare'
+      );
+    });
+
+    it("converts <br> to newline", () => {
+      const editor = makeEditor();
+      editor.appendChild(document.createTextNode("line one"));
+      editor.appendChild(document.createElement("br"));
+      editor.appendChild(document.createTextNode("line two"));
+      expect(serializeEditor(editor)).toBe("line one\nline two");
+    });
+
+    it("trims surrounding whitespace", () => {
+      const editor = makeEditor();
+      editor.textContent = "   hi   ";
+      expect(serializeEditor(editor)).toBe("hi");
+    });
+  });
+});
+
+describe("WidgetInput", () => {
+  function getEditor() {
+    return screen.getByRole("textbox", { name: /chat message/i });
+  }
+
+  it("calls onSubmit with typed text and clears the editor", async () => {
     const onSubmit = vi.fn();
     render(<WidgetInput onSubmit={onSubmit} isStreaming={false} />);
+    const editor = getEditor();
+    editor.focus();
+    placeCaretAtEnd(editor);
+    await userEvent.type(editor, "Hello agent");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(onSubmit).toHaveBeenCalledWith("Hello agent");
+    expect(editor.textContent).toBe("");
+  });
 
-    const submitBtn = screen.getByRole("button", { name: /send/i });
-    expect(submitBtn).toBeDisabled();
-
+  it("disables send button when editor is empty", () => {
+    const onSubmit = vi.fn();
+    render(<WidgetInput onSubmit={onSubmit} isStreaming={false} />);
+    expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("disables input while streaming", () => {
+  it("marks editor non-editable while streaming", () => {
     render(<WidgetInput onSubmit={vi.fn()} isStreaming={true} onStop={vi.fn()} />);
-
-    const textarea = screen.getByPlaceholderText(/ask/i);
-    expect(textarea).toBeDisabled();
+    const editor = getEditor();
+    expect(editor.getAttribute("contenteditable")).toBe("false");
+    expect(editor).toHaveAttribute("aria-disabled", "true");
   });
 
   it("shows stop button while streaming", async () => {
     const onStop = vi.fn();
     render(<WidgetInput onSubmit={vi.fn()} isStreaming={true} onStop={onStop} />);
-
-    const stopBtn = screen.getByRole("button", { name: /stop/i });
-    await userEvent.click(stopBtn);
-
+    await userEvent.click(screen.getByRole("button", { name: /stop/i }));
     expect(onStop).toHaveBeenCalled();
   });
 
   it("submits on Enter (without Shift)", async () => {
     const onSubmit = vi.fn();
     render(<WidgetInput onSubmit={onSubmit} isStreaming={false} />);
-
-    const textarea = screen.getByPlaceholderText(/ask/i);
-    await userEvent.type(textarea, "Hello");
-    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
-
+    const editor = getEditor();
+    editor.focus();
+    placeCaretAtEnd(editor);
+    await userEvent.type(editor, "Hello");
+    fireEvent.keyDown(editor, { key: "Enter", shiftKey: false });
     expect(onSubmit).toHaveBeenCalledWith("Hello");
+  });
+
+  describe("mention chips", () => {
+    it("renders an inline @-prefixed chip for each mention", () => {
+      const onMentionsConsumed = vi.fn();
+      render(
+        <WidgetInput
+          onSubmit={vi.fn()}
+          isStreaming={false}
+          mentions={[milestoneMention]}
+          onMentionsConsumed={onMentionsConsumed}
+        />
+      );
+      // StrictMode may fire the drain effect twice; both insert chips with the
+      // same label. The host clears the queue in response to onMentionsConsumed
+      // so the steady-state UI shows however many chips the producer pushed.
+      expect(screen.getAllByText("@Milestone 1 from Fund#2").length).toBeGreaterThanOrEqual(1);
+      expect(onMentionsConsumed).toHaveBeenCalled();
+    });
+
+    it("submits message with chip refText substituted inline", async () => {
+      const onSubmit = vi.fn();
+      const onMentionsConsumed = vi.fn();
+      render(
+        <WidgetInput
+          onSubmit={onSubmit}
+          isStreaming={false}
+          mentions={[milestoneMention]}
+          onMentionsConsumed={onMentionsConsumed}
+        />
+      );
+      const editor = getEditor();
+      editor.focus();
+      placeCaretAtEnd(editor);
+      await userEvent.type(editor, "what's the status?");
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const sent = onSubmit.mock.calls[0][0] as string;
+      expect(sent).toContain('milestone "Milestone 1" in project "Fund#2"');
+      expect(sent).toContain("what's the status?");
+    });
+
+    it("can submit with only a mention and no typed text", async () => {
+      const onSubmit = vi.fn();
+      render(<WidgetInput onSubmit={onSubmit} isStreaming={false} mentions={[milestoneMention]} />);
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+      expect(onSubmit).toHaveBeenCalledWith('milestone "Milestone 1" in project "Fund#2"');
+    });
   });
 });

--- a/widget/__tests__/mention-token.test.tsx
+++ b/widget/__tests__/mention-token.test.tsx
@@ -1,0 +1,62 @@
+import { render } from "@testing-library/react";
+import type { ChatMention } from "@/store/agentChat";
+import { mentionToToken, renderWithMentionPills } from "../mention-token";
+
+describe("mentionToToken", () => {
+  it("emits @[label](mention:kind:id?project=parent) when parentSlug present", () => {
+    const m: ChatMention = {
+      id: "milestone-1",
+      kind: "milestone",
+      label: "Milestone 1",
+      primaryId: "0xabc",
+      parentSlug: "fund-2",
+    };
+    expect(mentionToToken(m)).toBe("@[Milestone 1](mention:milestone:0xabc?project=fund-2)");
+  });
+
+  it("omits the project tail when no parentSlug", () => {
+    const m: ChatMention = {
+      id: "project-1",
+      kind: "project",
+      label: "Fund#2",
+      primaryId: "fund-2",
+    };
+    expect(mentionToToken(m)).toBe("@[Fund#2](mention:project:fund-2)");
+  });
+
+  it("strips ] from labels (would terminate the link text)", () => {
+    const m: ChatMention = {
+      id: "x",
+      kind: "milestone",
+      label: "Phase [1] Goals]",
+      primaryId: "0x1",
+    };
+    expect(mentionToToken(m)).toBe("@[Phase [1) Goals)](mention:milestone:0x1)");
+  });
+});
+
+describe("renderWithMentionPills", () => {
+  it("renders plain text unchanged when no tokens are present", () => {
+    const { container } = render(<>{renderWithMentionPills("just some text")}</>);
+    expect(container.textContent).toBe("just some text");
+  });
+
+  it("renders a pill for an embedded mention token", () => {
+    const { container } = render(
+      <>{renderWithMentionPills("@[Fund#2](mention:project:fund-2) what is the status?")}</>
+    );
+    const pill = container.querySelector("span");
+    expect(pill?.textContent).toBe("@Fund#2");
+    expect(container.textContent).toBe("@Fund#2 what is the status?");
+  });
+
+  it("renders multiple pills in order interleaved with text", () => {
+    const text = "compare @[A](mention:milestone:0xa?project=p1) and @[B](mention:milestone:0xb)";
+    const { container } = render(<>{renderWithMentionPills(text)}</>);
+    const pills = container.querySelectorAll("span");
+    expect(pills.length).toBe(2);
+    expect(pills[0].textContent).toBe("@A");
+    expect(pills[1].textContent).toBe("@B");
+    expect(container.textContent).toBe("compare @A and @B");
+  });
+});

--- a/widget/mention-token.tsx
+++ b/widget/mention-token.tsx
@@ -1,0 +1,58 @@
+import { Fragment, type ReactNode } from "react";
+import type { ChatMention } from "@/store/agentChat";
+
+/**
+ * Wire format for a mention reference inside a chat message body.
+ *
+ *   @[<label>](mention:<kind>:<primaryId>[?project=<parentSlug>])
+ *
+ * The visible "@<label>" is what the user (and the LLM) reads as a friendly
+ * name; the structured tail is the agent-resolvable handle (slug for project,
+ * uid for milestone — both accepted by `get_project_details`). The chat
+ * shell parses this token to render a pill in the message bubble matching
+ * the chip styling in the input editor.
+ *
+ * Labels are user-controlled. We strip `]` (would terminate the link text)
+ * and `\n` (would break parsing across lines) before emission.
+ */
+export const MENTION_TOKEN_PATTERN =
+  /@\[([^\]\n]+)\]\(mention:(milestone|project|application):([^)?\s]+)(?:\?project=([^)\s]+))?\)/g;
+
+export function mentionToToken(m: ChatMention): string {
+  const safeLabel = m.label.replace(/]/g, ")").replace(/\n/g, " ");
+  const tail = m.parentSlug ? `?project=${m.parentSlug}` : "";
+  return `@[${safeLabel}](mention:${m.kind}:${m.primaryId}${tail})`;
+}
+
+const PILL_CLASSES =
+  "inline-flex items-center align-baseline rounded-full bg-brand-blue/10 text-brand-blue px-1.5 py-0.5 mx-0.5 text-xs font-medium select-none";
+
+/**
+ * Split a message body into plain-text chunks and inline pill nodes for
+ * any embedded mention tokens. Used to render user-authored bubbles that
+ * still carry their @-mentions visually.
+ */
+export function renderWithMentionPills(content: string): ReactNode {
+  const parts: ReactNode[] = [];
+  let lastIdx = 0;
+  const re = new RegExp(MENTION_TOKEN_PATTERN.source, "g");
+  let match: RegExpExecArray | null = re.exec(content);
+  let i = 0;
+  while (match !== null) {
+    if (match.index > lastIdx) {
+      parts.push(<Fragment key={`t-${i}`}>{content.slice(lastIdx, match.index)}</Fragment>);
+    }
+    parts.push(
+      <span key={`m-${i}-${match[3]}`} className={PILL_CLASSES}>
+        @{match[1]}
+      </span>
+    );
+    lastIdx = match.index + match[0].length;
+    i += 1;
+    match = re.exec(content);
+  }
+  if (lastIdx < content.length) {
+    parts.push(<Fragment key={`t-${i}`}>{content.slice(lastIdx)}</Fragment>);
+  }
+  return <>{parts}</>;
+}

--- a/widget/mention-token.tsx
+++ b/widget/mention-token.tsx
@@ -35,21 +35,19 @@ const PILL_CLASSES =
 export function renderWithMentionPills(content: string): ReactNode {
   const parts: ReactNode[] = [];
   let lastIdx = 0;
-  const re = new RegExp(MENTION_TOKEN_PATTERN.source, "g");
-  let match: RegExpExecArray | null = re.exec(content);
   let i = 0;
-  while (match !== null) {
-    if (match.index > lastIdx) {
-      parts.push(<Fragment key={`t-${i}`}>{content.slice(lastIdx, match.index)}</Fragment>);
+  for (const match of content.matchAll(MENTION_TOKEN_PATTERN)) {
+    const idx = match.index ?? 0;
+    if (idx > lastIdx) {
+      parts.push(<Fragment key={`t-${i}`}>{content.slice(lastIdx, idx)}</Fragment>);
     }
     parts.push(
       <span key={`m-${i}-${match[3]}`} className={PILL_CLASSES}>
         @{match[1]}
       </span>
     );
-    lastIdx = match.index + match[0].length;
+    lastIdx = idx + match[0].length;
     i += 1;
-    match = re.exec(content);
   }
   if (lastIdx < content.length) {
     parts.push(<Fragment key={`t-${i}`}>{content.slice(lastIdx)}</Fragment>);


### PR DESCRIPTION
## Summary

- **Inline @-mentions in the assistant chat.** Replaced the textarea with a `contentEditable` editor that supports atomic mention pills (WhatsApp/Slack-style). Chips carry a stable `refText` (project slug, milestone uid) so the agent can resolve them with `get_project_details` directly — no title-search hop.
- **\"Mention to AI\" buttons on the milestone review page.** One next to *View Application* seeds a project chip; one on each `MilestoneCard` (next to copy-link + overflow) seeds a milestone chip. Click → chat opens with the chip pre-seeded; user types and sends.
- **Progress bar redesign.** `MilestoneProgressStepper` is now a single continuous bar split into three buckets (Verified / Pending / Not Started) with a small legend. Removed the per-milestone segment pills and the redundant \"X/Y verified (Z%)\" badge.

## Files

- `widget/WidgetInput.tsx` — contenteditable rewrite, helpers (`buildMentionChip`, `insertMentionAtCaret`, `serializeEditor`, `isEditorEmpty`); paste-as-plain-text; `__test` export for unit tests
- `widget/__tests__/WidgetInput.test.tsx` — 21 tests covering helpers + component behavior
- `store/agentChat.ts` — `pendingInput` → `pendingMentions[]` with `addMention` / `removeMention` / `clearMentions`
- `components/AgentChat/AgentChatBubble.tsx` — wires the new mentions API
- `components/Pages/Admin/MilestonesReview/MilestoneCard.tsx` — `MentionInChatButton` (uses slug + uid in refText)
- `components/Pages/Admin/MilestonesReview/index.tsx` — `ProjectAskButton` + new progress bar

## Test plan

- [x] \`pnpm test widget/__tests__/WidgetInput.test.tsx\` — 21 passing
- [x] \`pnpm lint\` clean on touched files
- [x] Visual: mention button on milestone cards opens chat with inline pill; typing works; send forwards `milestone "X" (uid: …) in project <slug>` to backend
- [x] Visual: \"Mention to AI\" beside View Application opens chat with `project <slug>` pill
- [ ] Visual: backspace deletes the chip atomically; paste strips formatting
- [ ] Visual: progress bar reflects bucket counts proportionally; legend hides empty buckets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mention milestones and projects directly in chat from the Milestones Review page
  * Copy milestone links to clipboard and share deep links via URL anchors
  * View inline mention pills in chat messages showing referenced milestones and projects
  * Collapsible Outputs and Outcomes section with flexible layout options

* **Improvements**
  * Reorganized milestone progress visualization into three simpler buckets: Verified, Pending, Not Started
  * Enhanced chat input with native mention chip support
  * Improved accessibility of chat messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->