### PR TITLE
fix(markdown-editor): coerce null/undefined value to empty string

### DIFF
--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -89,7 +89,7 @@ function validateMarkdownContent(content: string): { isValid: boolean; warnings:
 }
 
 export const MarkdownEditor: FC<MarkdownEditorProps> = ({
-  value = "",
+  value,
   onChange,
   onBlur,
   label,
@@ -111,6 +111,12 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   showCharacterCount = false,
   enablePreviewToggle = true,
 }) => {
+  // md-editor-rt accesses `modelValue.length` synchronously inside its
+  // CodeMirror input/paste/setValue handlers — if a caller (or RHF default)
+  // passes `null`/`undefined` we hit `Cannot read properties of null` and a
+  // setValue→onChange→re-render cycle that trips React's max-update-depth.
+  const safeValue = value ?? "";
+
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
@@ -141,15 +147,15 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
 
   // Calculate character count info
   const characterInfo = useMemo(() => {
-    const length = value?.length || 0;
+    const length = safeValue.length;
     const percentage = length / maxLength;
     const isNearLimit = percentage >= WARNING_THRESHOLD;
     const isAtLimit = length >= maxLength;
     return { length, percentage, isNearLimit, isAtLimit };
-  }, [value, maxLength]);
+  }, [safeValue, maxLength]);
 
   // Validate content
-  const contentValidation = useMemo(() => validateMarkdownContent(value || ""), [value]);
+  const contentValidation = useMemo(() => validateMarkdownContent(safeValue), [safeValue]);
 
   // Handle onChange with length limit
   const handleChange = useCallback(
@@ -238,7 +244,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
       >
         {showPreview ? (
           <div className="px-4 py-2" style={{ minHeight }}>
-            <MarkdownPreview source={value} />
+            <MarkdownPreview source={safeValue} />
           </div>
         ) : (
           <MdEditor
@@ -249,7 +255,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
               isEditorDisabled && "opacity-50 cursor-not-allowed",
               className
             )}
-            value={value}
+            value={safeValue}
             onChange={handleChange}
             onBlur={onBlur}
             theme={resolvedTheme === "dark" ? "dark" : "light"}


### PR DESCRIPTION
## Summary

Fixes a markdown editor crash + infinite-loop on the `/programs/[id]/apply` page (and any other form using `MarkdownEditor`).

`md-editor-rt@6.4.1` accesses `modelValue.length` directly inside its CodeMirror `input` event handler, paste handler, and `setValue` path — with **no null guard**:

```js
// node_modules/md-editor-rt/lib/es/chunks/Editor.mjs:2727
input: (_) => {
  e.onInput && e.onInput(_);
  const { data: F } = _;
  e.maxLength && e.modelValue.length + F.length > e.maxLength && f.emit(...)
}
```

The previous `value = ""` default parameter on `MarkdownEditor` only fired for `undefined`, so `null` (from RHF resets, restored sessionStorage on Privy OAuth callback, or `(field.value as string) || ""` casts where `field.value` is a falsy non-string) slipped through.

Two failure modes triggered by the same null path:

1. **`TypeError: Cannot read properties of null (reading 'length')`** — every keystroke throws inside `Object.input`. (Sentry: `GAP-FRONTEND-1YX`, `GAP-FRONTEND-1YY`)
2. **`Maximum update depth exceeded`** — `setValue(null)` throws inside md-editor-rt's `useEffect`, React error-recovers, re-renders, the effect runs again with the same `null`, loops. Stack matches: `MutationObserver → s8.flush → nt.dispatch → nt.dispatchTransactions → nt.update → Object.onChange`. (Sentry: `GAP-FRONTEND-1YW`)

All three were captured in the same Sentry session/replay (`0aa18789f13b4be5bba2b038abaad805`) for one user typing into the markdown editor on `/programs/1045/apply` after a Privy Google OAuth round-trip.

## Fix

Coerce with `??` once at the top of `MarkdownEditor` and forward `safeValue` everywhere `value` was used (`MdEditor`, `MarkdownPreview` in preview mode, `validateMarkdownContent`, character-count memo). This protects every call site (`ApplicationFormField`, `MilestoneItem`, `CommentMarkdownInput`) without each one needing its own guard.

Confidence: 100% on issues 1YX/1YY (mechanical match with the throw site). High (~90%) on 1YW — strongly correlated (same session, same replay, same null path), and the `setValue(null) → throw → recover` cycle is the most plausible source of the React update-depth trip. Will monitor Sentry to confirm 1YW does not recur on the next release.

## Test plan

- [x] `pnpm test __tests__/components/Utilities/MarkdownEditor.test.tsx` — 26/28 pass; the 2 failures (`should call onChange when typing`, `should enforce maxLength on change`) are pre-existing on `main` and unrelated (verified with `git stash`).
- [x] Biome clean on the changed file.
- [ ] Manually verify on a draft preview: open `/programs/[id]/apply`, type into a textarea (markdown) field, ensure no console errors and value persists.
- [ ] Manually verify the OAuth roundtrip restore path: start typing, click "Login to submit", complete Privy Google login, confirm form is restored without the editor crashing.

Fixes GAP-FRONTEND-1YX
Fixes GAP-FRONTEND-1YY
Fixes GAP-FRONTEND-1YW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the MarkdownEditor to more reliably handle cases where the value input may be missing or undefined, ensuring stable editor behavior in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->