### PR TITLE
Add comprehensive smoke tests for all page routes

### DIFF
--- a/__tests__/integration/pages/smoke/community-async-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-async-pages.test.tsx
@@ -1,0 +1,254 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Smoke tests for async server-rendered community pages. Pattern:
+ *  1. Mock the data-fetching helpers (getCommunityDetails etc.) so the page
+ *     can resolve without the network.
+ *  2. Mock the inner page-component import with a sentinel.
+ *  3. Invoke the page as `await Page({ params: Promise.resolve({...}) })`.
+ *  4. render() the returned element and check the sentinel is mounted.
+ */
+
+const mockCommunity = {
+  uid: "0x123",
+  details: { name: "Test Community", slug: "test-community" },
+};
+
+vi.mock("@/utilities/queries/v2/community", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue(mockCommunity),
+}));
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue(mockCommunity),
+  getCommunityProjects: vi.fn().mockResolvedValue({
+    data: [],
+    pagination: { currentPage: 1, totalPages: 1, totalItems: 0 },
+  }),
+  getCommunityCategories: vi.fn().mockResolvedValue([{ name: "DeFi" }, { name: "NFT" }]),
+  getCommunityStats: vi.fn().mockResolvedValue({ totalProjects: 0, totalGrants: 0 }),
+}));
+
+vi.mock("@/utilities/pagesOnRoot", () => ({ pagesOnRoot: [] }));
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn().mockResolvedValue([null, null]),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    COMMUNITY: {
+      PROGRAMS: (id: string) => `/communities/${id}/programs`,
+    },
+  },
+}));
+
+// Inner component mocks
+vi.mock("@/components/CommunityGrants", () => ({
+  CommunityGrants: () => <div data-testid="community-grants">CommunityGrants</div>,
+}));
+
+vi.mock("@/components/CommunityGrantsDonate", () => ({
+  CommunityGrantsDonate: () => <div data-testid="community-grants-donate">Donate</div>,
+}));
+
+vi.mock("@/components/Manage/DashboardOverview", () => ({
+  DashboardOverview: () => <div data-testid="dashboard-overview">DashboardOverview</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/KycSettingsPage", () => ({
+  KycSettingsPage: () => <div data-testid="kyc-settings-page">KycSettingsPage</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage", () => ({
+  KnowledgeBasePage: () => <div data-testid="knowledge-base-page">KnowledgeBase</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/NotificationSettingsPage", () => ({
+  NotificationSettingsPage: () => (
+    <div data-testid="notification-settings-page">NotificationSettings</div>
+  ),
+}));
+
+vi.mock("@/components/Pages/Admin/PortfolioReports/PortfolioReportListPage", () => ({
+  PortfolioReportListPage: () => (
+    <div data-testid="portfolio-report-list-page">PortfolioReportList</div>
+  ),
+}));
+
+vi.mock("@/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage", () => ({
+  PortfolioReportEditorPage: () => (
+    <div data-testid="portfolio-report-editor-page">PortfolioReportEditor</div>
+  ),
+}));
+
+vi.mock("@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage", () => ({
+  PortfolioReportPreviewPage: () => (
+    <div data-testid="portfolio-report-preview-page">PortfolioReportPreview</div>
+  ),
+}));
+
+vi.mock("@/components/Pages/Admin/PortfolioReports/ReportConfigPage", () => ({
+  ReportConfigPage: () => <div data-testid="report-config-page">ReportConfig</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/ReportMilestonePage", () => ({
+  ReportMilestonePage: () => <div data-testid="report-milestone-page">ReportMilestone</div>,
+}));
+
+vi.mock("@/components/Pages/Communities/TracksAdminPage", () => ({
+  TracksAdminPage: () => <div data-testid="tracks-admin-page">TracksAdmin</div>,
+}));
+
+vi.mock("@/components/Pages/Community/PortfolioReports/PublicReportListPage", () => ({
+  PublicReportListPage: () => <div data-testid="public-report-list-page">PublicReportList</div>,
+}));
+
+vi.mock("@/components/Pages/Community/PortfolioReports/PublicReportViewPage", () => ({
+  PublicReportViewPage: () => <div data-testid="public-report-view-page">PublicReportView</div>,
+}));
+
+const renderAsyncPage = async (
+  importer: () => Promise<{ default: (props: unknown) => Promise<React.ReactElement> }>,
+  props: unknown
+) => {
+  const { default: Page } = await importer();
+  const result = await Page(props);
+  return render(result);
+};
+
+describe("Community async server pages — happy path", () => {
+  it("/manage renders DashboardOverview", async () => {
+    await renderAsyncPage(() => import("@/app/community/[communityId]/manage/page"), {
+      params: Promise.resolve({ communityId: "c1" }),
+    });
+    expect(screen.getByTestId("dashboard-overview")).toBeInTheDocument();
+  });
+
+  it("/manage/knowledge-base renders KnowledgeBasePage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/knowledge-base/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("knowledge-base-page")).toBeInTheDocument();
+  });
+
+  it("/manage/kyc-settings renders KycSettingsPage", async () => {
+    await renderAsyncPage(() => import("@/app/community/[communityId]/manage/kyc-settings/page"), {
+      params: Promise.resolve({ communityId: "c1" }),
+    });
+    expect(screen.getByTestId("kyc-settings-page")).toBeInTheDocument();
+  });
+
+  it("/admin/kyc-settings renders KycSettingsPage", async () => {
+    await renderAsyncPage(() => import("@/app/community/[communityId]/admin/kyc-settings/page"), {
+      params: Promise.resolve({ communityId: "c1" }),
+    });
+    expect(screen.getByTestId("kyc-settings-page")).toBeInTheDocument();
+  });
+
+  it("/manage/notification-settings renders NotificationSettingsPage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/notification-settings/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("notification-settings-page")).toBeInTheDocument();
+  });
+
+  it("/manage/portfolio-reports renders PortfolioReportListPage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/portfolio-reports/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("portfolio-report-list-page")).toBeInTheDocument();
+  });
+
+  it("/manage/portfolio-reports/config renders ReportConfigPage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/portfolio-reports/config/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("report-config-page")).toBeInTheDocument();
+  });
+
+  it("/manage/portfolio-reports/[reportId] renders editor", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/portfolio-reports/[reportId]/page"),
+      { params: Promise.resolve({ communityId: "c1", reportId: "r1" }) }
+    );
+    expect(screen.getByTestId("portfolio-report-editor-page")).toBeInTheDocument();
+  });
+
+  it("/manage/portfolio-reports/[reportId]/preview renders preview", async () => {
+    await renderAsyncPage(
+      () =>
+        import("@/app/community/[communityId]/manage/portfolio-reports/[reportId]/preview/page"),
+      { params: Promise.resolve({ communityId: "c1", reportId: "r1" }) }
+    );
+    expect(screen.getByTestId("portfolio-report-preview-page")).toBeInTheDocument();
+  });
+
+  it("/manage/tracks renders TracksAdminPage", async () => {
+    await renderAsyncPage(() => import("@/app/community/[communityId]/manage/tracks/page"), {
+      params: Promise.resolve({ communityId: "c1" }),
+    });
+    expect(screen.getByTestId("tracks-admin-page")).toBeInTheDocument();
+  });
+
+  it("/manage/milestones-report renders ReportMilestonePage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/manage/milestones-report/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("report-milestone-page")).toBeInTheDocument();
+  });
+
+  it("/(with-header)/projects renders CommunityGrants", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/(with-header)/projects/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("community-grants")).toBeInTheDocument();
+  });
+
+  it("/(with-header)/reports renders PublicReportListPage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/(with-header)/reports/page"),
+      { params: Promise.resolve({ communityId: "c1" }) }
+    );
+    expect(screen.getByTestId("public-report-list-page")).toBeInTheDocument();
+  });
+
+  it("/(with-header)/reports/[month] renders PublicReportViewPage", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/(with-header)/reports/[month]/page"),
+      { params: Promise.resolve({ communityId: "c1", month: "2025-04" }) }
+    );
+    expect(screen.getByTestId("public-report-view-page")).toBeInTheDocument();
+  });
+
+  it("/donate/[programId] renders CommunityGrantsDonate", async () => {
+    await renderAsyncPage(() => import("@/app/community/[communityId]/donate/[programId]/page"), {
+      params: Promise.resolve({ communityId: "c1", programId: "p1" }),
+    });
+    expect(screen.getByTestId("community-grants-donate")).toBeInTheDocument();
+  });
+});
+
+describe("Community async server pages — month route validation", () => {
+  it("/(with-header)/reports/[month] calls notFound for invalid month", async () => {
+    const navigation = await import("next/navigation");
+    (navigation.notFound as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      const err = new Error("NEXT_NOT_FOUND") as Error & { digest: string };
+      err.digest = "NEXT_NOT_FOUND";
+      throw err;
+    });
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(with-header)/reports/[month]/page"
+    );
+    await expect(
+      Page({ params: Promise.resolve({ communityId: "c1", month: "not-a-month" }) })
+    ).rejects.toThrow(/NEXT_NOT_FOUND/);
+  });
+});

--- a/__tests__/integration/pages/smoke/community-async-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-async-pages.test.tsx
@@ -118,6 +118,10 @@ const renderAsyncPage = async (
   return render(result);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Community async server pages — happy path", () => {
   it("/manage renders DashboardOverview", async () => {
     await renderAsyncPage(() => import("@/app/community/[communityId]/manage/page"), {

--- a/__tests__/integration/pages/smoke/community-async-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-async-pages.test.tsx
@@ -239,7 +239,7 @@ describe("Community async server pages — happy path", () => {
 describe("Community async server pages — month route validation", () => {
   it("/(with-header)/reports/[month] calls notFound for invalid month", async () => {
     const navigation = await import("next/navigation");
-    (navigation.notFound as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+    vi.mocked(navigation.notFound).mockImplementationOnce(() => {
       const err = new Error("NEXT_NOT_FOUND") as Error & { digest: string };
       err.digest = "NEXT_NOT_FOUND";
       throw err;

--- a/__tests__/integration/pages/smoke/community-client-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-client-pages.test.tsx
@@ -269,6 +269,10 @@ const renderClientPage = async (importer: () => Promise<{ default: React.Compone
   return render(<Page />, { wrapper: Wrapper });
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Community client pages", () => {
   it("/(with-header)/browse-applications renders client", async () => {
     await renderClientPage(

--- a/__tests__/integration/pages/smoke/community-client-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-client-pages.test.tsx
@@ -1,0 +1,341 @@
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+
+/**
+ * Smoke tests for client-side community pages — those that "use client",
+ * read params via useParams, and call hooks directly. We mock the data
+ * hooks and the inner heavy components, then render the page in a
+ * QueryClientProvider.
+ */
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={buildClient()}>{children}</QueryClientProvider>
+);
+
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("next/navigation");
+  return {
+    ...actual,
+    useParams: () => ({ communityId: "c1", programId: "p1", projectId: "proj1" }),
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => "/community/c1",
+  };
+});
+
+// Inner-component mocks
+vi.mock(
+  "@/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient",
+  () => ({
+    BrowseApplicationsClient: () => (
+      <div data-testid="browse-applications-client">BrowseApplications</div>
+    ),
+  })
+);
+
+vi.mock("@/features/programs/components/program-list", () => ({
+  ProgramList: () => <div data-testid="program-list">ProgramList</div>,
+}));
+
+vi.mock("@/features/programs/components/program-filters", () => ({
+  ProgramFilters: () => <div data-testid="program-filters">ProgramFilters</div>,
+}));
+
+vi.mock("@/features/programs/hooks/use-programs", () => ({
+  usePrograms: () => ({
+    programs: [],
+    loading: false,
+    error: null,
+    filters: {},
+    setFilters: vi.fn(),
+    totalCount: 0,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/Pages/Admin/ProgramScoresUpload", () => ({
+  ProgramScoresUpload: () => <div data-testid="program-scores-upload">ProgramScores</div>,
+}));
+
+vi.mock("@/hooks/communities/useCommunityAdminAccess", () => ({
+  useCommunityAdminAccess: () => ({ hasAccess: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/communities/useCommunityDetails", () => ({
+  useCommunityDetails: () => ({
+    data: { uid: "c1", details: { name: "Test" } },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/usePrograms", () => ({
+  useCommunityPrograms: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+vi.mock("@/components/Pages/Admin/MilestonesReview", () => ({
+  MilestonesReviewPage: () => <div data-testid="milestones-review-page">MilestonesReview</div>,
+}));
+
+vi.mock("@/src/core/rbac", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@/src/core/rbac");
+  return {
+    ...actual,
+    FundingPlatformGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useIsFundingPlatformAdmin: () => true,
+  };
+});
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: () => ({ isLoading: false, can: () => true }),
+  PermissionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Utilities/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner">Spinner</div>,
+}));
+
+vi.mock("@/components/QuestionBuilder", () => ({
+  QuestionBuilder: () => <div data-testid="question-builder">QuestionBuilder</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/SetupWizard", () => ({
+  SetupWizard: () => <div data-testid="setup-wizard">SetupWizard</div>,
+}));
+
+vi.mock("@/components/ErrorBoundary/FormBuilderErrorBoundary", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useFundingPlatform", () => ({
+  useFundingPrograms: () => ({
+    programs: [{ programId: "p1", chainID: 1, metadata: { title: "Program" } }],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useApplication: () => ({ data: null, isLoading: false }),
+  useApplicationStatus: () => ({ status: "pending" }),
+  useFundingApplications: () => ({ data: [], isLoading: false }),
+  useProgramConfig: () => ({ data: null, isLoading: false }),
+  useApplicationComments: () => ({ data: [], isLoading: false }),
+  useApplicationVersions: () => ({ data: [], isLoading: false }),
+  useDeleteApplication: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/useProgramSetupProgress", () => ({
+  useProgramSetupProgress: () => ({ stepsCompleted: 0, totalSteps: 5 }),
+}));
+
+vi.mock("@/hooks/useProgramReviewers", () => ({
+  useProgramReviewers: () => ({ reviewers: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/useQuestionBuilder", () => ({
+  usePostApprovalSchema: () => ({ schema: null, isLoading: false }),
+  useQuestionBuilderSchema: () => ({ schema: null, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useKycStatus", () => ({
+  useKycConfig: () => ({ data: null, isLoading: false }),
+  useKycStatus: () => ({ status: null, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useBackNavigation", () => ({
+  useBackNavigation: () => ({ goBack: vi.fn(), backHref: "/" }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: true, ready: true, user: null }),
+}));
+
+vi.mock("@/components/FundingPlatform", () => ({
+  ApplicationListWithAPI: () => <div data-testid="application-list-with-api">Apps</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/CreateProgramModal", () => ({
+  CreateProgramModal: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/Dashboard/card", () => ({
+  FundingPlatformStatsCard: () => <div data-testid="funding-platform-stats-card">Stats</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/NoProgramsEmptyState", () => ({
+  NoProgramsEmptyState: () => <div data-testid="no-programs-empty">Empty</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/ProgramSetupStatus", () => ({
+  ProgramSetupStatus: () => null,
+  hasFormConfigured: () => true,
+}));
+
+vi.mock("@/services/fundingPlatformService", () => ({
+  fundingPlatformService: {},
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source?: string }) => (
+    <div data-testid="markdown-preview">{source ?? ""}</div>
+  ),
+}));
+
+vi.mock("@/components/Utilities/LoadingOverlay", () => ({
+  LoadingOverlay: () => null,
+}));
+
+vi.mock("@/components/Utilities/Button", () => ({
+  Button: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationHeader", () => ({
+  __esModule: true,
+  default: () => <div data-testid="application-header">ApplicationHeader</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationTab", () => ({
+  ApplicationTab: () => <div data-testid="application-tab">ApplicationTab</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationTabs", () => ({
+  ApplicationTabs: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TabIcons: {},
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/AIAnalysisTab", () => ({
+  AIAnalysisTab: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/DiscussionTab", () => ({
+  DiscussionTab: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/TabPanel", () => ({
+  TabPanel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/HeaderActions", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/MoreActionsDropdown", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/StatusChangeInline", () => ({
+  StatusChangeInline: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/EditApplicationModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/EditPostApprovalModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/ApplicationView/DeleteApplicationModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("./SendEmailComposer", () => ({
+  SendEmailComposer: () => <div data-testid="send-email-composer">SendEmail</div>,
+}));
+
+const renderClientPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const { default: Page } = await importer();
+  return render(<Page />, { wrapper: Wrapper });
+};
+
+describe("Community client pages", () => {
+  it("/(with-header)/browse-applications renders client", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/(with-header)/browse-applications/page")
+    );
+    expect(screen.getByTestId("browse-applications-client")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /browse applications/i, level: 1 })
+    ).toBeInTheDocument();
+  });
+
+  it("/(with-header)/funding-opportunities renders ProgramList", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/(with-header)/funding-opportunities/page")
+    );
+    expect(screen.getByTestId("program-list")).toBeInTheDocument();
+    expect(screen.getByTestId("program-filters")).toBeInTheDocument();
+  });
+
+  it("/manage/program-scores renders ProgramScoresUpload", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/manage/program-scores/page")
+    );
+    expect(screen.getByTestId("program-scores-upload")).toBeInTheDocument();
+  });
+
+  it("/manage/funding-platform/[programId]/milestones/[projectId] renders review", async () => {
+    await renderClientPage(
+      () =>
+        import(
+          "@/app/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]/page"
+        )
+    );
+    expect(screen.getByTestId("milestones-review-page")).toBeInTheDocument();
+  });
+
+  it("/manage/funding-platform/[programId]/setup renders SetupWizard", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/manage/funding-platform/[programId]/setup/page")
+    );
+    expect(screen.getByTestId("setup-wizard")).toBeInTheDocument();
+  });
+
+  it("/manage/funding-platform/[programId]/question-builder renders QuestionBuilder", async () => {
+    await renderClientPage(
+      () =>
+        import(
+          "@/app/community/[communityId]/manage/funding-platform/[programId]/question-builder/page"
+        )
+    );
+    expect(screen.getByTestId("question-builder")).toBeInTheDocument();
+  });
+
+  it("/manage/funding-platform/[programId]/applications renders ApplicationListWithAPI", async () => {
+    await renderClientPage(
+      () =>
+        import(
+          "@/app/community/[communityId]/manage/funding-platform/[programId]/applications/page"
+        )
+    );
+    expect(screen.getByTestId("application-list-with-api")).toBeInTheDocument();
+  });
+
+  it("/manage/send-email renders client section", async () => {
+    await renderClientPage(() => import("@/app/community/[communityId]/manage/send-email/page"));
+    // SendEmail page either renders the composer or an empty/error state — at
+    // minimum the heading must mount.
+    expect(screen.getByRole("heading", { name: /send email/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/pages/smoke/component-wrapper-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/component-wrapper-pages.test.tsx
@@ -115,6 +115,10 @@ const renderPage = async (importer: () => Promise<{ default: React.ComponentType
   return render(<Page />);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Admin pages", () => {
   it("/super-admin renders SuperAdminPage", async () => {
     await renderPage(() => import("@/app/super-admin/page"));

--- a/__tests__/integration/pages/smoke/component-wrapper-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/component-wrapper-pages.test.tsx
@@ -1,0 +1,237 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Smoke tests for pages that simply delegate to a single inner component.
+ * Each test mocks the inner component with a sentinel, then asserts the
+ * page renders that sentinel — proving the page module loads, its imports
+ * resolve, and the component is mounted.
+ */
+
+vi.mock("@/components/Pages/Admin/SuperAdmin", () => ({
+  __esModule: true,
+  default: () => <div data-testid="super-admin-page">SuperAdmin</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/CommunityAdmin", () => ({
+  __esModule: true,
+  default: () => <div data-testid="communities-to-admin-page">CommunityAdmin</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/AllProjects", () => ({
+  AllProjects: () => <div data-testid="all-projects">AllProjects</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/CommunityStats", () => ({
+  __esModule: true,
+  default: () => <div data-testid="community-stats">CommunityStats</div>,
+}));
+
+vi.mock("@/components/FaucetAdmin/Dashboard", () => ({
+  FaucetAdminDashboard: () => <div data-testid="faucet-admin-dashboard">FaucetDashboard</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/SumupAdmin", () => ({
+  __esModule: true,
+  default: () => <div data-testid="sumup-admin">SumupAdmin</div>,
+}));
+
+vi.mock("@/components/Pages/Dashboard/Dashboard", () => ({
+  Dashboard: () => <div data-testid="dashboard-component">Dashboard</div>,
+}));
+
+vi.mock("@/components/Pages/Communities/CommunitiesPage", () => ({
+  CommunitiesPage: () => <div data-testid="communities-page">CommunitiesPage</div>,
+}));
+
+vi.mock("@/components/Pages/ProgramRegistry/AddProgramWrapper", () => ({
+  AddProgramWrapper: () => <div data-testid="add-program-wrapper">AddProgramWrapper</div>,
+}));
+
+vi.mock("@/components/Pages/ProgramRegistry/ManageProgramsWrapper", () => ({
+  __esModule: true,
+  default: () => <div data-testid="manage-programs-wrapper">ManageProgramsWrapper</div>,
+}));
+
+vi.mock("@/components/Disbursement/DisbursementForm", () => ({
+  DisbursementForm: () => <div data-testid="disbursement-form">DisbursementForm</div>,
+}));
+
+vi.mock("@/components/Pages/Home/Communities", () => ({
+  Communities: () => <div data-testid="home-communities">Communities</div>,
+}));
+vi.mock("@/components/Pages/Home/Presentation", () => ({
+  Presentation: () => <div data-testid="home-presentation">Presentation</div>,
+}));
+vi.mock("@/components/Pages/Home/WhatIsSolving", () => ({
+  WhatIsSolving: () => <div data-testid="home-what-is-solving">WhatIsSolving</div>,
+}));
+
+vi.mock("@/components/DonationCheckout", () => ({
+  __esModule: true,
+  default: () => <div data-testid="donation-checkout">DonationCheckout</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/ControlCenter/ControlCenterPage", () => ({
+  ControlCenterPage: () => <div data-testid="control-center-page">ControlCenterPage</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/EditCategoriesPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="edit-categories-page">EditCategoriesPage</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/EditProjectsPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="edit-projects-page">EditProjectsPage</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/ImpactPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="manage-impact-page">ManageImpactPage</div>,
+}));
+
+vi.mock("@/components/Pages/Admin/ManageIndicatorsPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="manage-indicators-page">ManageIndicatorsPage</div>,
+}));
+
+vi.mock("@/components/Pages/Communities/Impact/ImpactCharts", () => ({
+  CommunityImpactCharts: () => <div data-testid="community-impact-charts">ImpactCharts</div>,
+}));
+
+vi.mock("@/components/Pages/Communities/Impact/ProjectDiscovery", () => ({
+  ProjectDiscovery: () => <div data-testid="project-discovery">ProjectDiscovery</div>,
+}));
+
+vi.mock("@/app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="claim-funds-client">ClaimFundsClient</div>,
+}));
+
+const renderPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const mod = await importer();
+  const Page = mod.default;
+  return render(<Page />);
+};
+
+describe("Admin pages", () => {
+  it("/super-admin renders SuperAdminPage", async () => {
+    await renderPage(() => import("@/app/super-admin/page"));
+    expect(screen.getByTestId("super-admin-page")).toBeInTheDocument();
+  });
+
+  it("/admin renders CommunitiesToAdmin", async () => {
+    await renderPage(() => import("@/app/admin/page"));
+    expect(screen.getByTestId("communities-to-admin-page")).toBeInTheDocument();
+  });
+
+  it("/admin/projects renders AllProjects", async () => {
+    await renderPage(() => import("@/app/admin/projects/page"));
+    expect(screen.getByTestId("all-projects")).toBeInTheDocument();
+  });
+
+  it("/admin/communities/stats renders CommunityStats", async () => {
+    await renderPage(() => import("@/app/admin/communities/stats/page"));
+    expect(screen.getByTestId("community-stats")).toBeInTheDocument();
+  });
+
+  it("/admin/faucet renders FaucetAdminDashboard", async () => {
+    await renderPage(() => import("@/app/admin/faucet/page"));
+    expect(screen.getByTestId("faucet-admin-dashboard")).toBeInTheDocument();
+  });
+
+  it("/admin/sumup renders SumupAdmin", async () => {
+    await renderPage(() => import("@/app/admin/sumup/page"));
+    expect(screen.getByTestId("sumup-admin")).toBeInTheDocument();
+  });
+});
+
+describe("Top-level component-wrapper pages", () => {
+  it("/dashboard renders Dashboard", async () => {
+    await renderPage(() => import("@/app/dashboard/page"));
+    expect(screen.getByTestId("dashboard-component")).toBeInTheDocument();
+  });
+
+  it("/communities renders CommunitiesPage", async () => {
+    await renderPage(() => import("@/app/communities/page"));
+    expect(screen.getByTestId("communities-page")).toBeInTheDocument();
+  });
+
+  it("/funding-map/add-program renders AddProgramWrapper", async () => {
+    await renderPage(() => import("@/app/funding-map/add-program/page"));
+    expect(screen.getByTestId("add-program-wrapper")).toBeInTheDocument();
+  });
+
+  it("/funding-map/manage-programs renders ManageProgramsWrapper", async () => {
+    await renderPage(() => import("@/app/funding-map/manage-programs/page"));
+    expect(screen.getByTestId("manage-programs-wrapper")).toBeInTheDocument();
+  });
+
+  it("/safe/disburse renders DisbursementForm", async () => {
+    await renderPage(() => import("@/app/safe/disburse/page"));
+    expect(screen.getByTestId("disbursement-form")).toBeInTheDocument();
+  });
+
+  it("/old-home renders all sections", async () => {
+    await renderPage(() => import("@/app/old-home/page"));
+    expect(screen.getByTestId("home-presentation")).toBeInTheDocument();
+    expect(screen.getByTestId("home-communities")).toBeInTheDocument();
+    expect(screen.getByTestId("home-what-is-solving")).toBeInTheDocument();
+  });
+});
+
+describe("Community manage component-wrapper pages", () => {
+  it("/manage/control-center renders ControlCenterPage", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/manage/control-center/page"));
+    expect(screen.getByTestId("control-center-page")).toBeInTheDocument();
+  });
+
+  it("/manage/edit-categories renders EditCategoriesPage", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/manage/edit-categories/page"));
+    expect(screen.getByTestId("edit-categories-page")).toBeInTheDocument();
+  });
+
+  it("/manage/edit-projects renders EditProjectsPage", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/manage/edit-projects/page"));
+    expect(screen.getByTestId("edit-projects-page")).toBeInTheDocument();
+  });
+
+  it("/manage/impact renders ImpactPage", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/manage/impact/page"));
+    expect(screen.getByTestId("manage-impact-page")).toBeInTheDocument();
+  });
+
+  it("/manage/manage-indicators renders ManageIndicatorsPage", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/manage/manage-indicators/page"));
+    expect(screen.getByTestId("manage-indicators-page")).toBeInTheDocument();
+  });
+});
+
+describe("Community with-header component-wrapper pages", () => {
+  it("/(with-header)/impact renders CommunityImpactCharts", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/(with-header)/impact/page"));
+    expect(screen.getByTestId("community-impact-charts")).toBeInTheDocument();
+  });
+
+  it("/(with-header)/impact/project-discovery renders ProjectDiscovery", async () => {
+    await renderPage(
+      () => import("@/app/community/[communityId]/(with-header)/impact/project-discovery/page")
+    );
+    expect(screen.getByTestId("project-discovery")).toBeInTheDocument();
+  });
+
+  it("/donate/[programId]/checkout renders DonationCheckout", async () => {
+    await renderPage(
+      () => import("@/app/community/[communityId]/donate/[programId]/checkout/page")
+    );
+    expect(screen.getByTestId("donation-checkout")).toBeInTheDocument();
+  });
+});
+
+describe("Whitelabel component-wrapper pages", () => {
+  it("/(whitelabel)/claim-funds renders ClaimFundsClient", async () => {
+    await renderPage(() => import("@/app/community/[communityId]/(whitelabel)/claim-funds/page"));
+    expect(screen.getByTestId("claim-funds-client")).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/pages/smoke/marketing-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/marketing-pages.test.tsx
@@ -1,0 +1,219 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Smoke tests for top-level marketing pages (landing pages composed of
+ * feature-section components). Each section component is mocked with a
+ * sentinel; we assert the page renders all expected sections.
+ */
+
+// /foundations sections
+vi.mock("@/src/features/foundations/components/cta-section", () => ({
+  CTASection: () => <div data-testid="foundations-cta" />,
+}));
+vi.mock("@/src/features/foundations/components/hero", () => ({
+  Hero: () => <div data-testid="foundations-hero" />,
+}));
+vi.mock("@/src/features/foundations/components/how-it-works-section", () => ({
+  HowItWorksSection: () => <div data-testid="foundations-how-it-works" />,
+}));
+vi.mock("@/src/features/foundations/components/objections-section", () => ({
+  ObjectionsSection: () => <div data-testid="foundations-objections" />,
+}));
+vi.mock("@/src/features/foundations/components/pain-points-section", () => ({
+  PainPointsSection: () => <div data-testid="foundations-pain-points" />,
+}));
+vi.mock("@/src/features/foundations/components/platform-section", () => ({
+  PlatformSection: () => <div data-testid="foundations-platform" />,
+}));
+vi.mock("@/src/features/foundations/components/why-karma-section", () => ({
+  WhyKarmaSection: () => <div data-testid="foundations-why-karma" />,
+}));
+
+// /funders sections
+vi.mock("@/src/features/funders/components/case-studies-section", () => ({
+  CaseStudiesSection: () => <div data-testid="funders-case-studies" />,
+}));
+vi.mock("@/src/features/funders/components/faq-section", () => ({
+  FAQSection: () => <div data-testid="funders-faq" />,
+}));
+vi.mock("@/src/features/funders/components/handle-the-vision-section", () => ({
+  HandleTheVisionSection: () => <div data-testid="funders-handle-vision" />,
+}));
+vi.mock("@/src/features/funders/components/hero", () => ({
+  Hero: () => <div data-testid="funders-hero" />,
+}));
+vi.mock("@/src/features/funders/components/how-it-works-section", () => ({
+  HowItWorksSection: () => <div data-testid="funders-how-it-works" />,
+}));
+vi.mock("@/src/features/funders/components/numbers-section", () => ({
+  NumbersSection: () => <div data-testid="funders-numbers" />,
+}));
+vi.mock("@/src/features/funders/components/offering-section", () => ({
+  OfferingSection: () => <div data-testid="funders-offering" />,
+}));
+vi.mock("@/src/features/funders/components/platform-section", () => ({
+  PlatformSection: () => <div data-testid="funders-platform" />,
+}));
+
+// /for-projects sections
+vi.mock("@/src/features/homepage/components/faq", () => ({
+  FAQ: () => <div data-testid="homepage-faq" />,
+}));
+vi.mock("@/src/features/homepage/components/hero", () => ({
+  Hero: () => <div data-testid="homepage-hero" />,
+}));
+vi.mock("@/src/features/homepage/components/how-it-works", () => ({
+  HowItWorks: () => <div data-testid="homepage-how-it-works" />,
+}));
+vi.mock("@/src/features/homepage/components/join-community", () => ({
+  JoinCommunity: () => <div data-testid="homepage-join-community" />,
+}));
+vi.mock("@/src/features/homepage/components/live-funding-opportunities", () => ({
+  LiveFundingOpportunities: () => <div data-testid="homepage-live-funding" />,
+}));
+vi.mock("@/src/features/homepage/components/live-funding-opportunities-skeleton", () => ({
+  LiveFundingOpportunitiesSkeleton: () => <div data-testid="homepage-live-funding-skeleton" />,
+}));
+vi.mock("@/src/features/homepage/components/platform-features", () => ({
+  PlatformFeatures: () => <div data-testid="homepage-platform-features" />,
+}));
+vi.mock("@/src/features/homepage/components/where-builders-grow", () => ({
+  WhereBuildersGrow: () => <div data-testid="homepage-where-builders-grow" />,
+}));
+
+// /seeds sections
+vi.mock("@/src/features/seeds/components/launch/launch-cta", () => ({
+  LaunchCTA: () => <div data-testid="seeds-launch-cta" />,
+}));
+vi.mock("@/src/features/seeds/components/launch/launch-faq", () => ({
+  LaunchFAQ: () => <div data-testid="seeds-launch-faq" />,
+}));
+vi.mock("@/src/features/seeds/components/launch/launch-hero", () => ({
+  LaunchHero: () => <div data-testid="seeds-launch-hero" />,
+}));
+vi.mock("@/src/features/seeds/components/launch/launch-how-to", () => ({
+  LaunchHowTo: () => <div data-testid="seeds-launch-how-to" />,
+}));
+vi.mock("@/src/features/seeds/components/launch/launch-problem", () => ({
+  LaunchProblem: () => <div data-testid="seeds-launch-problem" />,
+}));
+vi.mock("@/src/features/seeds/components/launch/launch-use-cases", () => ({
+  LaunchUseCases: () => <div data-testid="seeds-launch-use-cases" />,
+}));
+
+// /seeds/fund sections
+vi.mock("@/src/features/seeds/components/benefits-section", () => ({
+  SeedsBenefits: () => <div data-testid="seeds-benefits" />,
+}));
+vi.mock("@/src/features/seeds/components/cta-section", () => ({
+  SeedsCTA: () => <div data-testid="seeds-cta" />,
+}));
+vi.mock("@/src/features/seeds/components/faq-section", () => ({
+  SeedsFAQ: () => <div data-testid="seeds-faq" />,
+}));
+vi.mock("@/src/features/seeds/components/hero", () => ({
+  SeedsHero: () => <div data-testid="seeds-hero" />,
+}));
+vi.mock("@/src/features/seeds/components/how-it-works", () => ({
+  SeedsHowItWorks: () => <div data-testid="seeds-how-it-works" />,
+}));
+vi.mock("@/src/features/seeds/components/projects-section", () => ({
+  SeedsProjectsSection: () => <div data-testid="seeds-projects" />,
+}));
+
+// /projects sections
+vi.mock("@/components/Pages/Projects", () => ({
+  ProjectsExplorer: () => <div data-testid="projects-explorer" />,
+  ProjectsHeroSection: () => <div data-testid="projects-hero" />,
+  ProjectsLoading: () => <div data-testid="projects-loading" />,
+  ProjectsStatsSection: () => <div data-testid="projects-stats" />,
+}));
+
+const renderPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const { default: Page } = await importer();
+  return render(<Page />);
+};
+
+describe("/foundations marketing page", () => {
+  it("renders all foundation sections", async () => {
+    await renderPage(() => import("@/app/foundations/page"));
+    [
+      "foundations-hero",
+      "foundations-pain-points",
+      "foundations-platform",
+      "foundations-why-karma",
+      "foundations-how-it-works",
+      "foundations-objections",
+      "foundations-cta",
+    ].forEach((id) => {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("/funders marketing page", () => {
+  it("renders all funder sections", async () => {
+    await renderPage(() => import("@/app/funders/page"));
+    [
+      "funders-hero",
+      "funders-numbers",
+      "funders-platform",
+      "funders-handle-vision",
+      "funders-case-studies",
+      "funders-how-it-works",
+      "funders-offering",
+      "funders-faq",
+    ].forEach((id) => {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("/for-projects marketing page", () => {
+  it("renders core homepage feature sections", async () => {
+    await renderPage(() => import("@/app/for-projects/page"));
+    expect(screen.getByTestId("homepage-hero")).toBeInTheDocument();
+    expect(screen.getByTestId("homepage-platform-features")).toBeInTheDocument();
+    expect(screen.getByTestId("homepage-faq")).toBeInTheDocument();
+  });
+});
+
+describe("/seeds marketing pages", () => {
+  it("/seeds renders all launch sections", async () => {
+    await renderPage(() => import("@/app/seeds/page"));
+    [
+      "seeds-launch-hero",
+      "seeds-launch-problem",
+      "seeds-launch-how-to",
+      "seeds-launch-use-cases",
+      "seeds-launch-faq",
+      "seeds-launch-cta",
+    ].forEach((id) => {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    });
+  });
+
+  it("/seeds/fund renders all fund sections", async () => {
+    await renderPage(() => import("@/app/seeds/fund/page"));
+    [
+      "seeds-hero",
+      "seeds-how-it-works",
+      "seeds-benefits",
+      "seeds-projects",
+      "seeds-faq",
+      "seeds-cta",
+    ].forEach((id) => {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("/projects explorer page", () => {
+  it("renders hero, explorer, stats", async () => {
+    await renderPage(() => import("@/app/projects/page"));
+    expect(screen.getByTestId("projects-hero")).toBeInTheDocument();
+    expect(screen.getByTestId("projects-explorer")).toBeInTheDocument();
+    expect(screen.getByTestId("projects-stats")).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/pages/smoke/marketing-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/marketing-pages.test.tsx
@@ -135,6 +135,10 @@ const renderPage = async (importer: () => Promise<{ default: React.ComponentType
   return render(<Page />);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("/foundations marketing page", () => {
   it("renders all foundation sections", async () => {
     await renderPage(() => import("@/app/foundations/page"));

--- a/__tests__/integration/pages/smoke/project-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/project-pages.test.tsx
@@ -110,6 +110,10 @@ const renderAsyncPage = async (
   return render(result);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Project profile pages", () => {
   it("/project/[projectId]/(profile)/about renders AboutPageClient", async () => {
     await renderPageElement(() => import("@/app/project/[projectId]/(profile)/about/page"));

--- a/__tests__/integration/pages/smoke/project-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/project-pages.test.tsx
@@ -197,9 +197,7 @@ describe("Project /updates async page", () => {
 
   it("returns null when project data missing", async () => {
     const cached = await import("@/utilities/queries/getProjectCachedData");
-    (cached.getProjectCachedData as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      null
-    );
+    vi.mocked(cached.getProjectCachedData).mockResolvedValueOnce(null);
     const result = await renderAsyncPage(() => import("@/app/project/[projectId]/updates/page"), {
       params: Promise.resolve({ projectId: "p1" }),
     });

--- a/__tests__/integration/pages/smoke/project-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/project-pages.test.tsx
@@ -1,0 +1,208 @@
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Smoke tests for /project/[projectId] routes. Most routes are thin wrappers
+ * around colocated `*PageClient` components — we mock those clients with
+ * sentinels and assert the page renders them. The async /updates route is
+ * exercised end-to-end with mocked data layers.
+ */
+
+// next/dynamic — render the loading fallback (or, when no fallback, render
+// the dynamic module via its default export). We can't easily run the dynamic
+// importer synchronously, so always render a stub that proves dynamic() was
+// called with a real component.
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: (_loader: () => Promise<unknown>, options?: { loading?: () => React.ReactNode }) => {
+    return function DynamicComponent() {
+      return options?.loading ? options.loading() : <div data-testid="dynamic-stub" />;
+    };
+  },
+}));
+
+// Server-side data layer used by the /updates route
+vi.mock("@/utilities/queries/getProjectCachedData", () => ({
+  getProjectCachedData: vi.fn().mockResolvedValue({
+    uid: "0xproj",
+    details: { title: "Test Project", slug: "test-project" },
+  }),
+}));
+
+vi.mock("@/services/project-updates.service", () => ({
+  getProjectUpdates: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/utilities/queries/defaultOptions", () => ({
+  defaultQueryOptions: {},
+}));
+
+vi.mock("@/utilities/queryKeys", () => ({
+  QUERY_KEYS: {
+    PROJECT: {
+      UPDATES: (id: string) => ["project", id, "updates"],
+    },
+  },
+}));
+
+// Inner client mocks — colocated PageClient files
+vi.mock("@/app/project/[projectId]/(profile)/about/AboutPageClient", () => ({
+  AboutPageClient: () => <div data-testid="about-page-client">About</div>,
+}));
+
+vi.mock("@/app/project/[projectId]/(profile)/contact-info/ContactInfoPageClient", () => ({
+  ContactInfoPageClient: () => <div data-testid="contact-info-page-client">ContactInfo</div>,
+}));
+
+vi.mock("@/app/project/[projectId]/(profile)/team/TeamPageClient", () => ({
+  TeamPageClient: () => <div data-testid="team-page-client">Team</div>,
+}));
+
+vi.mock("@/app/project/[projectId]/(profile)/impact/ImpactPageClient", () => ({
+  ImpactPageClient: () => <div data-testid="impact-page-client">Impact</div>,
+}));
+
+vi.mock("@/app/project/[projectId]/(profile)/funding/new/NewGrantPageClient", () => ({
+  NewGrantPageClient: () => <div data-testid="new-grant-page-client">NewGrant</div>,
+}));
+
+vi.mock("@/app/project/[projectId]/(profile)/funding/[grantUid]/edit/EditGrantPageClient", () => ({
+  EditGrantPageClient: () => <div data-testid="edit-grant-page-client">EditGrant</div>,
+}));
+
+vi.mock(
+  "@/app/project/[projectId]/(profile)/funding/[grantUid]/complete-grant/CompleteGrantPageClient",
+  () => ({
+    CompleteGrantPageClient: () => (
+      <div data-testid="complete-grant-page-client">CompleteGrant</div>
+    ),
+  })
+);
+
+// Project Roadmap (server-rendered for /updates)
+vi.mock("@/components/Pages/Project/Roadmap", () => ({
+  ProjectRoadmap: ({ project }: { project: { uid: string } | null }) => (
+    <div data-testid="project-roadmap">{project ? project.uid : "no-project"}</div>
+  ),
+}));
+
+// UpdatesContent (the /(profile)/page.tsx default route renders this dynamically)
+vi.mock("@/components/Pages/Project/v2/Content/UpdatesContent", () => ({
+  UpdatesContent: () => <div data-testid="updates-content">UpdatesContent</div>,
+}));
+vi.mock("@/components/Pages/Project/v2/Skeletons", () => ({
+  UpdatesContentSkeleton: () => <div data-testid="updates-content-skeleton">Loading</div>,
+}));
+
+const renderPageElement = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const { default: Page } = await importer();
+  return render(<Page />);
+};
+
+const renderAsyncPage = async (
+  importer: () => Promise<{ default: (props: unknown) => Promise<React.ReactElement | null> }>,
+  props: unknown
+) => {
+  const { default: Page } = await importer();
+  const result = await Page(props);
+  if (result === null) return null;
+  return render(result);
+};
+
+describe("Project profile pages", () => {
+  it("/project/[projectId]/(profile)/about renders AboutPageClient", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/about/page"));
+    expect(screen.getByTestId("about-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/contact-info renders ContactInfoPageClient", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/contact-info/page"));
+    expect(screen.getByTestId("contact-info-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/team renders TeamPageClient", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/team/page"));
+    expect(screen.getByTestId("team-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/impact renders ImpactPageClient", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/impact/page"));
+    expect(screen.getByTestId("impact-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/new renders NewGrantPageClient", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/funding/new/page"));
+    expect(screen.getByTestId("new-grant-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/[grantUid]/edit renders EditGrantPageClient", async () => {
+    await renderPageElement(
+      () => import("@/app/project/[projectId]/(profile)/funding/[grantUid]/edit/page")
+    );
+    expect(screen.getByTestId("edit-grant-page-client")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/[grantUid]/complete-grant renders CompleteGrantPageClient", async () => {
+    await renderPageElement(
+      () => import("@/app/project/[projectId]/(profile)/funding/[grantUid]/complete-grant/page")
+    );
+    expect(screen.getByTestId("complete-grant-page-client")).toBeInTheDocument();
+  });
+});
+
+describe("Project profile pages — dynamic imports", () => {
+  it("/project/[projectId]/(profile)/funding renders dynamic stub", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/funding/page"));
+    // dynamic() returns a stub — proves dynamic was invoked with real loader
+    expect(screen.getByTestId("dynamic-stub")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/[grantUid] renders dynamic stub", async () => {
+    await renderPageElement(
+      () => import("@/app/project/[projectId]/(profile)/funding/[grantUid]/page")
+    );
+    expect(screen.getByTestId("dynamic-stub")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/[grantUid]/impact-criteria renders dynamic stub", async () => {
+    await renderPageElement(
+      () => import("@/app/project/[projectId]/(profile)/funding/[grantUid]/impact-criteria/page")
+    );
+    expect(screen.getByTestId("dynamic-stub")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile)/funding/[grantUid]/milestones-and-updates renders dynamic stub", async () => {
+    await renderPageElement(
+      () =>
+        import("@/app/project/[projectId]/(profile)/funding/[grantUid]/milestones-and-updates/page")
+    );
+    expect(screen.getByTestId("dynamic-stub")).toBeInTheDocument();
+  });
+
+  it("/project/[projectId]/(profile) (updates index) renders the loading skeleton", async () => {
+    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/page"));
+    expect(screen.getByTestId("updates-content-skeleton")).toBeInTheDocument();
+  });
+});
+
+describe("Project /updates async page", () => {
+  it("renders ProjectRoadmap when project data loads", async () => {
+    const { default: Page } = await import("@/app/project/[projectId]/updates/page");
+    const result = await Page({ params: Promise.resolve({ projectId: "p1" }) });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(<QueryClientProvider client={client}>{result}</QueryClientProvider>);
+    expect(screen.getByTestId("project-roadmap")).toBeInTheDocument();
+  });
+
+  it("returns null when project data missing", async () => {
+    const cached = await import("@/utilities/queries/getProjectCachedData");
+    (cached.getProjectCachedData as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      null
+    );
+    const result = await renderAsyncPage(() => import("@/app/project/[projectId]/updates/page"), {
+      params: Promise.resolve({ projectId: "p1" }),
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/integration/pages/smoke/redirect-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/redirect-pages.test.tsx
@@ -1,0 +1,119 @@
+import "@testing-library/jest-dom";
+
+/**
+ * Smoke tests for redirect-only pages. Each page invokes Next's redirect()
+ * or permanentRedirect() helpers — we mock them to throw a sentinel and
+ * assert the page invokes them with the expected target.
+ */
+
+const redirectMock = vi.fn((url: string) => {
+  const err = new Error(`NEXT_REDIRECT:${url}`) as Error & { digest: string };
+  err.digest = `NEXT_REDIRECT;${url}`;
+  throw err;
+});
+const permanentRedirectMock = vi.fn((url: string) => {
+  const err = new Error(`NEXT_PERMANENT_REDIRECT:${url}`) as Error & { digest: string };
+  err.digest = `NEXT_REDIRECT;${url};308`;
+  throw err;
+});
+const notFoundMock = vi.fn(() => {
+  const err = new Error("NEXT_NOT_FOUND") as Error & { digest: string };
+  err.digest = "NEXT_NOT_FOUND";
+  throw err;
+});
+
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("next/navigation");
+  return {
+    ...actual,
+    redirect: redirectMock,
+    permanentRedirect: permanentRedirectMock,
+    notFound: notFoundMock,
+  };
+});
+
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: vi.fn().mockResolvedValue({ isWhitelabel: false }),
+  buildWhitelabelRedirectPath: vi.fn((path: string) => path),
+}));
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  permanentRedirectMock.mockClear();
+  notFoundMock.mockClear();
+});
+
+describe("Redirect-only pages", () => {
+  it("/admin/communities redirects to /admin", async () => {
+    const { default: Page } = await import("@/app/admin/communities/page");
+    expect(() => Page()).toThrow(/NEXT_REDIRECT/);
+    expect(redirectMock).toHaveBeenCalledWith("/admin");
+  });
+
+  it("/(whitelabel)/applications redirects to /dashboard", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/page"
+    );
+    await expect(Page()).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("/(whitelabel)/programs redirects to community funding-opportunities", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/programs/page"
+    );
+    await expect(Page({ params: Promise.resolve({ communityId: "abc" }) })).rejects.toThrow(
+      /NEXT_REDIRECT/
+    );
+    expect(redirectMock).toHaveBeenCalledWith("/community/abc/funding-opportunities");
+  });
+
+  it("/manage/funding-platform/[programId] redirects to question-builder", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/manage/funding-platform/[programId]/page"
+    );
+    await expect(
+      Page({ params: Promise.resolve({ communityId: "c1", programId: "p1" }) })
+    ).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(redirectMock).toHaveBeenCalledTimes(1);
+    const target = redirectMock.mock.calls[0][0] as string;
+    expect(target).toContain("c1");
+    expect(target).toContain("p1");
+  });
+
+  it("/manage/funding-platform/[programId]/milestones redirects", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/manage/funding-platform/[programId]/milestones/page"
+    );
+    await expect(Page({ params: Promise.resolve({ communityId: "c1" }) })).rejects.toThrow(
+      /NEXT_REDIRECT/
+    );
+    expect(redirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("/manage/payouts permanent-redirects to control-center", async () => {
+    const { default: Page } = await import("@/app/community/[communityId]/manage/payouts/page");
+    await expect(
+      Page({
+        params: Promise.resolve({ communityId: "c1" }),
+        searchParams: Promise.resolve({ tab: "next" }),
+      })
+    ).rejects.toThrow(/NEXT_PERMANENT_REDIRECT/);
+    expect(permanentRedirectMock).toHaveBeenCalledTimes(1);
+    const target = permanentRedirectMock.mock.calls[0][0] as string;
+    expect(target).toContain("c1");
+    expect(target).toContain("tab=next");
+  });
+
+  it("/(with-header)/browse-applications/[referenceNumber] permanent-redirects", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(with-header)/browse-applications/[referenceNumber]/page"
+    );
+    await expect(
+      Page({ params: Promise.resolve({ communityId: "c1", referenceNumber: "AB123" }) })
+    ).rejects.toThrow(/NEXT_PERMANENT_REDIRECT/);
+    expect(permanentRedirectMock).toHaveBeenCalledTimes(1);
+    const target = permanentRedirectMock.mock.calls[0][0] as string;
+    expect(target).toContain("AB123");
+  });
+});

--- a/__tests__/integration/pages/smoke/remaining-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/remaining-pages.test.tsx
@@ -287,6 +287,10 @@ const renderClientPage = async (importer: () => Promise<{ default: React.Compone
   return render(<Page />, { wrapper: Wrapper });
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("/donations page", () => {
   it("renders empty-state when no donations", async () => {
     await renderClientPage(() => import("@/app/donations/page"));

--- a/__tests__/integration/pages/smoke/remaining-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/remaining-pages.test.tsx
@@ -1,0 +1,355 @@
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+
+/**
+ * Smoke tests for the remaining client-side pages that read params, call
+ * hooks, and render conditional UI. We mock the relevant data hooks to a
+ * stable state and assert the page renders one of its expected branches.
+ */
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={buildClient()}>{children}</QueryClientProvider>
+);
+
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("next/navigation");
+  return {
+    ...actual,
+    useParams: () => ({ communityId: "c1", programId: "p1", applicationId: "app-1" }),
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => "/test",
+  };
+});
+
+vi.mock("nuqs", () => ({
+  useQueryState: <T,>(_name: string, opts?: { defaultValue?: T }) => [
+    opts?.defaultValue ?? null,
+    vi.fn(),
+  ],
+}));
+
+// Donation history hook
+vi.mock("@/hooks/donation/useDonationHistory", () => ({
+  useDonationHistory: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+// Auth hooks
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: true, ready: true, user: null }),
+}));
+
+// Community programs hooks
+vi.mock("@/hooks/usePrograms", () => ({
+  useCommunityPrograms: () => ({
+    data: [{ programId: "p1", chainID: 1, metadata: { title: "Program One" } }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/useFundingPlatform", () => ({
+  useFundingPrograms: () => ({
+    programs: [{ programId: "p1", chainID: 1, metadata: { title: "Program One" } }],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useApplication: () => ({ data: null, isLoading: false }),
+  useApplicationStatus: () => ({ status: "pending" }),
+  useApplicationComments: () => ({ data: [], isLoading: false }),
+  useApplicationVersions: () => ({ data: [], isLoading: false }),
+  useDeleteApplication: () => ({ mutate: vi.fn(), isPending: false }),
+  useFundingApplications: () => ({ data: [], isLoading: false }),
+  useProgramConfig: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("@/hooks/usePermissions", () => ({
+  useReviewerPrograms: () => ({ programs: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/useCommunityProjects", () => ({
+  useCommunityProjects: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/useCommunityProjectUpdates", () => ({
+  useCommunityProjectUpdates: () => ({
+    data: { payload: [], pagination: { totalCount: 0, page: 1, pageSize: 25 } },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useCommunityMilestoneAllocations", () => ({
+  useCommunityMilestoneAllocations: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/useBackNavigation", () => ({
+  useBackNavigation: () => ({ goBack: vi.fn(), backHref: "/" }),
+}));
+
+vi.mock("@/hooks/useKycStatus", () => ({
+  useKycConfig: () => ({ data: null, isLoading: false }),
+  useKycStatus: () => ({ status: null, isLoading: false }),
+}));
+
+// Whitelabel context
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: () => ({ isWhitelabel: false, slug: null }),
+}));
+
+// React Query for /donate page.tsx
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue({
+    uid: "c1",
+    details: { name: "Test", slug: "test" },
+  }),
+}));
+
+// RBAC
+vi.mock("@/src/core/rbac", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@/src/core/rbac");
+  return {
+    ...actual,
+    FundingPlatformGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    AdminOnly: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useIsFundingPlatformAdmin: () => true,
+  };
+});
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: () => ({ isLoading: false, can: () => true }),
+  PermissionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Inner UI mocks
+vi.mock("@/components/Pages/Communities/CommunityProjectEvaluatorPage", () => ({
+  CommunityProjectEvaluatorPage: () => (
+    <div data-testid="karma-ai-evaluator">CommunityProjectEvaluator</div>
+  ),
+}));
+
+vi.mock("@/components/Utilities/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner">Spinner</div>,
+}));
+
+vi.mock("@/components/Pages/Communities/Impact/SearchWithValueDropdown", () => ({
+  SearchWithValueDropdown: () => null,
+}));
+
+vi.mock("@/components/Pages/Community/Updates/CommunityMilestoneCard", () => ({
+  CommunityMilestoneCard: () => null,
+}));
+
+vi.mock("@/components/Pages/Community/Updates/SimplePagination", () => ({
+  SimplePagination: () => null,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}));
+
+vi.mock("@/components/Utilities/Button", () => ({
+  Button: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: () => null,
+}));
+
+vi.mock("@/components/Utilities/LoadingOverlay", () => ({
+  LoadingOverlay: () => null,
+}));
+
+vi.mock("@/components/FundingPlatform/CreateProgramModal", () => ({
+  CreateProgramModal: () => null,
+}));
+vi.mock("@/components/FundingPlatform/Dashboard/card", () => ({
+  FundingPlatformStatsCard: () => <div data-testid="funding-platform-stats-card" />,
+}));
+vi.mock("@/components/FundingPlatform/NoProgramsEmptyState", () => ({
+  NoProgramsEmptyState: () => <div data-testid="no-programs-empty">Empty</div>,
+}));
+vi.mock("@/components/FundingPlatform/ProgramSetupStatus", () => ({
+  ProgramSetupStatus: () => null,
+  hasFormConfigured: () => true,
+}));
+
+vi.mock("@/services/fundingPlatformService", () => ({
+  fundingPlatformService: {
+    programs: {
+      toggleProgramStatus: vi.fn().mockResolvedValue(true),
+    },
+  },
+}));
+
+vi.mock("@/components/FundingPlatform", () => ({
+  ApplicationListWithAPI: () => <div data-testid="application-list-with-api" />,
+}));
+
+// Application view sub-components
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationHeader", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationTab", () => ({
+  ApplicationTab: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationTabs", () => ({
+  ApplicationTabs: () => null,
+  TabIcons: {},
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/AIAnalysisTab", () => ({
+  AIAnalysisTab: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/DiscussionTab", () => ({
+  DiscussionTab: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/TabPanel", () => ({
+  TabPanel: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/HeaderActions", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/MoreActionsDropdown", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/StatusChangeInline", () => ({
+  StatusChangeInline: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/EditApplicationModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/EditPostApprovalModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("@/components/FundingPlatform/ApplicationView/DeleteApplicationModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// /donations DonationHistoryList
+vi.mock("@/app/donations/components/DonationHistoryList", () => ({
+  DonationHistoryList: ({ donations }: { donations: unknown[] }) => (
+    <div data-testid="donation-history-list">count={donations.length}</div>
+  ),
+  DonationHistorySkeleton: () => <div data-testid="donation-history-skeleton">Loading</div>,
+}));
+
+// /utilities helpers
+vi.mock("@/utilities/project-lookup", () => ({
+  findProjectOptionBySlugOrUid: () => null,
+  projectsToOptions: () => [],
+}));
+
+vi.mock("@/utilities/sorting/communityMilestoneSort", () => ({
+  sortCommunityMilestones: (m: unknown[]) => m,
+}));
+
+vi.mock("@/utilities/fundingPlatformUrls", () => ({
+  getProgramApplyUrl: (cId: string, pId: string) => `/c/${cId}/p/${pId}`,
+}));
+
+vi.mock("@/utilities/formatCurrency", () => ({
+  __esModule: true,
+  default: (n: number) => `$${n}`,
+}));
+
+vi.mock("@/utilities/formatDate", () => ({
+  formatDate: (d: string) => d,
+}));
+
+const renderClientPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const { default: Page } = await importer();
+  return render(<Page />, { wrapper: Wrapper });
+};
+
+describe("/donations page", () => {
+  it("renders empty-state when no donations", async () => {
+    await renderClientPage(() => import("@/app/donations/page"));
+    expect(screen.getByRole("heading", { name: /my donations/i })).toBeInTheDocument();
+    expect(screen.getByText(/no donations yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("/community/[communityId]/donate program-select page", () => {
+  it("renders programs select when loaded", async () => {
+    await renderClientPage(() => import("@/app/community/[communityId]/donate/page"));
+    // Page either renders the loading state, redirect spinner, or the program
+    // selector — all acceptable proof that the module loads & mounts.
+    const heading = screen.queryByText(/select.*program/i);
+    const loadingSpinner = screen.queryByText(/loading programs/i);
+    expect(heading || loadingSpinner).not.toBeNull();
+  });
+});
+
+describe("/community/[communityId]/(with-header)/updates page", () => {
+  it("renders updates page with filter controls", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/(with-header)/updates/page")
+    );
+    // Loose: the page should at minimum mount without throwing — assert
+    // some text from one of its many states is present.
+    const possibleTexts = [/pending/i, /completed/i, /past due/i, /no updates/i, /loading/i];
+    const found = possibleTexts.some((re) => screen.queryByText(re));
+    expect(found).toBe(true);
+  });
+});
+
+describe("/community/[communityId]/karma-ai async page", () => {
+  it("renders CommunityProjectEvaluatorPage", async () => {
+    const { default: Page } = await import("@/app/community/[communityId]/karma-ai/page");
+    const result = await Page({ params: Promise.resolve({ communityId: "c1" }) });
+    render(result);
+    expect(screen.getByTestId("karma-ai-evaluator")).toBeInTheDocument();
+  });
+});
+
+describe("/community/[communityId]/manage/funding-platform list page", () => {
+  it("renders programs stats or empty state", async () => {
+    await renderClientPage(
+      () => import("@/app/community/[communityId]/manage/funding-platform/page")
+    );
+    const empty = screen.queryByTestId("no-programs-empty");
+    const cards = screen.queryAllByTestId("funding-platform-stats-card");
+    expect(empty !== null || cards.length > 0).toBe(true);
+  });
+});
+
+describe("/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]", () => {
+  it("renders the application detail client page", async () => {
+    await renderClientPage(
+      () =>
+        import(
+          "@/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page"
+        )
+    );
+    // Page mounts; with no application data it shows a spinner or back nav.
+    const spinner = screen.queryByTestId("spinner");
+    const back = screen.queryByText(/back/i);
+    expect(spinner || back).not.toBeNull();
+  });
+});

--- a/__tests__/integration/pages/smoke/static-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/static-pages.test.tsx
@@ -1,0 +1,150 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Smoke tests for static pages — those that render only static markup
+ * (legal text, knowledge-base articles, marketing copy). No data fetching,
+ * no client-only hooks. Each test asserts the page module loads and renders
+ * its top-level heading without throwing.
+ */
+
+const renderPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
+  const mod = await importer();
+  const Page = mod.default;
+  return render(<Page />);
+};
+
+describe("Static legal pages", () => {
+  it("Terms and Conditions renders", async () => {
+    await renderPage(() => import("@/app/terms-and-conditions/page"));
+    expect(
+      screen.getByRole("heading", { name: /terms and conditions/i, level: 1 })
+    ).toBeInTheDocument();
+  });
+
+  it("Privacy Policy renders", async () => {
+    await renderPage(() => import("@/app/privacy-policy/page"));
+    expect(screen.getByRole("heading", { name: /privacy policy/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it("Create Project Profile renders", async () => {
+    await renderPage(() => import("@/app/create-project-profile/page"));
+    expect(
+      screen.getByRole("heading", { name: /create your project profile/i, level: 1 })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Knowledge base pages", () => {
+  const knowledgePages: Array<[string, () => Promise<{ default: React.ComponentType }>, RegExp]> = [
+    ["index", () => import("@/app/knowledge/page"), /grant funding knowledge base/i],
+    [
+      "ai-grant-evaluation",
+      () => import("@/app/knowledge/ai-grant-evaluation/page"),
+      /AI[- ]Assisted Grant Evaluation/i,
+    ],
+    ["dao-grant-milestones", () => import("@/app/knowledge/dao-grant-milestones/page"), /DAO/i],
+    [
+      "funding-distribution-mechanisms",
+      () => import("@/app/knowledge/funding-distribution-mechanisms/page"),
+      /distribution mechanisms/i,
+    ],
+    [
+      "grant-accountability",
+      () => import("@/app/knowledge/grant-accountability/page"),
+      /grant accountability/i,
+    ],
+    [
+      "grant-document-signing",
+      () => import("@/app/knowledge/grant-document-signing/page"),
+      /document signing/i,
+    ],
+    [
+      "grant-fund-disbursement",
+      () => import("@/app/knowledge/grant-fund-disbursement/page"),
+      /disbursement/i,
+    ],
+    ["grant-kyc", () => import("@/app/knowledge/grant-kyc/page"), /kyc/i],
+    ["grant-lifecycle", () => import("@/app/knowledge/grant-lifecycle/page"), /grant lifecycle/i],
+    [
+      "how-funders-use-project-profiles",
+      () => import("@/app/knowledge/how-funders-use-project-profiles/page"),
+      /how funders/i,
+    ],
+    [
+      "impact-measurement",
+      () => import("@/app/knowledge/impact-measurement/page"),
+      /impact measurement/i,
+    ],
+    ["impact-verification", () => import("@/app/knowledge/impact-verification/page"), /impact/i],
+    [
+      "manual-vs-platform-grant-tracking",
+      () => import("@/app/knowledge/manual-vs-platform-grant-tracking/page"),
+      /manual vs platform/i,
+    ],
+    [
+      "milestones-vs-impact",
+      () => import("@/app/knowledge/milestones-vs-impact/page"),
+      /milestones vs impact/i,
+    ],
+    [
+      "onchain-project-profiles",
+      () => import("@/app/knowledge/onchain-project-profiles/page"),
+      /onchain project profiles/i,
+    ],
+    [
+      "onchain-reputation",
+      () => import("@/app/knowledge/onchain-reputation/page"),
+      /onchain reputation/i,
+    ],
+    [
+      "project-profiles-as-resumes",
+      () => import("@/app/knowledge/project-profiles-as-resumes/page"),
+      /project profiles/i,
+    ],
+    [
+      "project-profiles-software-vs-nonsoftware",
+      () => import("@/app/knowledge/project-profiles-software-vs-nonsoftware/page"),
+      /software/i,
+    ],
+    [
+      "project-profiles",
+      () => import("@/app/knowledge/project-profiles/page"),
+      /project profiles/i,
+    ],
+    ["project-registry", () => import("@/app/knowledge/project-registry/page"), /project registr/i],
+    ["project-reputation", () => import("@/app/knowledge/project-reputation/page"), /reputation/i],
+    [
+      "project-updates-and-reputation",
+      () => import("@/app/knowledge/project-updates-and-reputation/page"),
+      /reputation/i,
+    ],
+    [
+      "reputation-compounding",
+      () => import("@/app/knowledge/reputation-compounding/page"),
+      /reputation/i,
+    ],
+    [
+      "whitelabel-funding-platforms",
+      () => import("@/app/knowledge/whitelabel-funding-platforms/page"),
+      /whitelabel/i,
+    ],
+    [
+      "why-grant-programs-fail",
+      () => import("@/app/knowledge/why-grant-programs-fail/page"),
+      /grant programs fail/i,
+    ],
+    [
+      "why-grantees-need-project-profiles",
+      () => import("@/app/knowledge/why-grantees-need-project-profiles/page"),
+      /grantees/i,
+    ],
+  ];
+
+  it.each(knowledgePages)("/%s renders heading", async (_slug, importer, headingPattern) => {
+    await renderPage(importer);
+    const headings = screen.getAllByRole("heading", { level: 1 });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(headings.some((h) => headingPattern.test(h.textContent || ""))).toBe(true);
+  });
+});

--- a/__tests__/integration/pages/smoke/static-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/static-pages.test.tsx
@@ -14,6 +14,10 @@ const renderPage = async (importer: () => Promise<{ default: React.ComponentType
   return render(<Page />);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Static legal pages", () => {
   it("Terms and Conditions renders", async () => {
     await renderPage(() => import("@/app/terms-and-conditions/page"));

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -1,0 +1,303 @@
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+
+/**
+ * Smoke tests for whitelabel application/program routes. These pages are
+ * async server components that fetch from the indexer; we mock fetchData
+ * to return a sentinel application/program and assert the page renders.
+ */
+
+const mockApplication = {
+  uid: "app-1",
+  programId: "prog-1",
+  referenceNumber: "APP-001",
+  status: "submitted",
+  applicantEmail: "test@example.com",
+  applicationData: { name: "Alice" },
+  createdAt: "2025-01-15T00:00:00Z",
+};
+
+const mockProgram = {
+  programId: "prog-1",
+  name: "Test Program",
+  metadata: { title: "Test Program" },
+  applicationConfig: {
+    isEnabled: true,
+    formSchema: {
+      title: "App Form",
+      fields: [{ id: "f1", label: "Name", type: "text", required: true }],
+    },
+  },
+};
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn().mockImplementation(async (url: string) => {
+    if (url.includes("funding-applications/")) return [mockApplication, null];
+    if (url.includes("funding-program-configs/")) return [mockProgram, null];
+    return [null, null];
+  }),
+}));
+
+vi.mock("@/utilities/queries/v2/community", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue({
+    uid: "c1",
+    details: { name: "Test Community", slug: "test-community" },
+  }),
+}));
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue({
+    uid: "c1",
+    details: { name: "Test Community", slug: "test-community" },
+  }),
+}));
+
+vi.mock("@/utilities/funding-programs", () => ({
+  isProgramEnabled: () => true,
+}));
+
+vi.mock("@/utilities/community-flags", () => ({
+  FINANCIALS_ENABLED_COMMUNITIES: ["c1"],
+}));
+
+vi.mock("@/src/features/payout-disbursement/services/payout-disbursement.service", () => ({
+  getCommunityPayoutsPublic: vi.fn().mockResolvedValue({ data: [], pagination: {} }),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    COMMUNITY: {
+      PROGRAMS: (id: string) => `/communities/${id}/programs`,
+    },
+    KYC: {
+      GET_CONFIG: (id: string) => `/communities/${id}/kyc/config`,
+    },
+  },
+}));
+
+vi.mock("@/src/features/applications/lib/form-utils", () => ({
+  transformFormSchemaToQuestions: () => [],
+}));
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  PermissionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePermissionContext: () => ({ isLoading: false, can: () => true }),
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source?: string }) => (
+    <div data-testid="markdown-preview">{source ?? ""}</div>
+  ),
+}));
+
+vi.mock("@/src/components/ui/ApplicationStatusChip", () => ({
+  ApplicationStatusChip: ({ status }: { status: string }) => (
+    <span data-testid="application-status-chip">{status}</span>
+  ),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children, ...props }: { children: React.ReactNode } & Record<string, unknown>) => (
+    // biome-ignore lint/a11y/useValidAnchor: stub
+    <a {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>{children}</a>
+  ),
+}));
+
+vi.mock(
+  "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient",
+  () => ({
+    ApplicationPageClient: ({ communityId }: { communityId: string }) => (
+      <div data-testid="application-page-client">{communityId}</div>
+    ),
+  })
+);
+
+vi.mock(
+  "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/ApplicationEditClient",
+  () => ({
+    ApplicationEditClient: () => <div data-testid="application-edit-client">EditClient</div>,
+  })
+);
+
+vi.mock(
+  "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/success/WhatHappensNext",
+  () => ({
+    WhatHappensNext: () => <div data-testid="what-happens-next">WhatHappensNext</div>,
+    extractApplicantName: (d: Record<string, unknown> | undefined) =>
+      (d?.name as string) ?? "Applicant",
+  })
+);
+
+vi.mock(
+  "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/success/WhatHappensNextSkeleton",
+  () => ({
+    WhatHappensNextSkeleton: () => <div data-testid="what-happens-next-skeleton">Loading</div>,
+  })
+);
+
+vi.mock(
+  "@/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/ApplicationFormClient",
+  () => ({
+    ApplicationFormClient: () => <div data-testid="application-form-client">ApplicationForm</div>,
+  })
+);
+
+vi.mock("@/components/Pages/Communities/Financials/PublicControlCenter", () => ({
+  PublicControlCenter: () => <div data-testid="public-control-center">PublicControlCenter</div>,
+}));
+
+vi.mock("@/utilities/queries/defaultOptions", () => ({
+  defaultQueryOptions: {},
+}));
+
+const renderInQueryClient = (element: React.ReactElement) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{element}</QueryClientProvider>);
+};
+
+describe("Whitelabel application detail page", () => {
+  it("/applications/[applicationId] renders ApplicationPageClient", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", applicationId: "app-1" }),
+    });
+    render(result);
+    expect(screen.getByTestId("application-page-client")).toBeInTheDocument();
+  });
+
+  it("/applications/[applicationId] renders not-available when fetch fails", async () => {
+    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    fetchData.mockResolvedValueOnce([null, null]);
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", applicationId: "missing" }),
+    });
+    render(result);
+    expect(screen.getByRole("heading", { name: /application not available/i })).toBeInTheDocument();
+  });
+});
+
+describe("Whitelabel application edit page", () => {
+  it("/applications/[applicationId]/edit renders ApplicationEditClient", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", applicationId: "app-1" }),
+    });
+    render(result);
+    expect(screen.getByTestId("application-edit-client")).toBeInTheDocument();
+  });
+
+  it("/applications/[applicationId]/edit renders not-available when fetch fails", async () => {
+    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    fetchData.mockResolvedValueOnce([null, null]);
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", applicationId: "missing" }),
+    });
+    render(result);
+    expect(screen.getByRole("heading", { name: /application not available/i })).toBeInTheDocument();
+  });
+});
+
+describe("Whitelabel application success page", () => {
+  it("/applications/[applicationId]/success renders thanks message and reference", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/success/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", applicationId: "app-1" }),
+    });
+    render(result);
+    expect(screen.getByRole("heading", { name: /thanks for submitting/i })).toBeInTheDocument();
+    expect(screen.getByText(/APP-001/)).toBeInTheDocument();
+    expect(screen.getByTestId("application-status-chip")).toBeInTheDocument();
+  });
+});
+
+describe("Whitelabel programs/[programId]/apply page", () => {
+  it("renders ApplicationFormClient with full schema", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", programId: "prog-1" }),
+    });
+    render(result);
+    expect(screen.getByTestId("application-form-client")).toBeInTheDocument();
+  });
+
+  it("renders 'form not available' empty state when schema has no fields", async () => {
+    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    fetchData.mockResolvedValueOnce([
+      {
+        ...mockProgram,
+        applicationConfig: { ...mockProgram.applicationConfig, formSchema: { fields: [] } },
+      },
+      null,
+    ]);
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/page"
+    );
+    const result = await Page({
+      params: Promise.resolve({ communityId: "c1", programId: "prog-1" }),
+    });
+    render(result);
+    expect(
+      screen.getByRole("heading", { name: /application form not available yet/i })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Whitelabel programs/[programId] client page", () => {
+  it("/programs/[programId] renders loading state when useProgram is loading", async () => {
+    vi.doMock("@/features/programs/hooks/use-program", () => ({
+      useProgram: () => ({
+        program: null,
+        loading: true,
+        error: null,
+        refetch: vi.fn(),
+      }),
+    }));
+    vi.doMock("next/navigation", () => ({
+      useParams: () => ({ communityId: "c1", programId: "prog-1" }),
+    }));
+    vi.resetModules();
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(whitelabel)/programs/[programId]/page"
+    );
+    const { container } = renderInQueryClient(<Page />);
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    vi.doUnmock("@/features/programs/hooks/use-program");
+    vi.doUnmock("next/navigation");
+  });
+});
+
+describe("/(with-header)/financials page", () => {
+  it("renders PublicControlCenter for enabled community", async () => {
+    const { default: Page } = await import(
+      "@/app/community/[communityId]/(with-header)/financials/page"
+    );
+    const result = await Page({ params: Promise.resolve({ communityId: "c1" }) });
+    renderInQueryClient(result);
+    expect(screen.getByTestId("public-control-center")).toBeInTheDocument();
+  });
+});

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -160,6 +160,10 @@ const renderInQueryClient = (element: React.ReactElement) => {
   return render(<QueryClientProvider client={client}>{element}</QueryClientProvider>);
 };
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("Whitelabel application detail page", () => {
   it("/applications/[applicationId] renders ApplicationPageClient", async () => {
     const { default: Page } = await import(

--- a/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/whitelabel-pages.test.tsx
@@ -173,10 +173,8 @@ describe("Whitelabel application detail page", () => {
   });
 
   it("/applications/[applicationId] renders not-available when fetch fails", async () => {
-    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
-      typeof vi.fn
-    >;
-    fetchData.mockResolvedValueOnce([null, null]);
+    const fetchData = (await import("@/utilities/fetchData")).default;
+    vi.mocked(fetchData).mockResolvedValueOnce([null, null]);
     const { default: Page } = await import(
       "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/page"
     );
@@ -201,10 +199,8 @@ describe("Whitelabel application edit page", () => {
   });
 
   it("/applications/[applicationId]/edit renders not-available when fetch fails", async () => {
-    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
-      typeof vi.fn
-    >;
-    fetchData.mockResolvedValueOnce([null, null]);
+    const fetchData = (await import("@/utilities/fetchData")).default;
+    vi.mocked(fetchData).mockResolvedValueOnce([null, null]);
     const { default: Page } = await import(
       "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/page"
     );
@@ -244,10 +240,8 @@ describe("Whitelabel programs/[programId]/apply page", () => {
   });
 
   it("renders 'form not available' empty state when schema has no fields", async () => {
-    const fetchData = (await import("@/utilities/fetchData")).default as unknown as ReturnType<
-      typeof vi.fn
-    >;
-    fetchData.mockResolvedValueOnce([
+    const fetchData = (await import("@/utilities/fetchData")).default;
+    vi.mocked(fetchData).mockResolvedValueOnce([
       {
         ...mockProgram,
         applicationConfig: { ...mockProgram.applicationConfig, formSchema: { fields: [] } },


### PR DESCRIPTION
## Summary
This PR adds a comprehensive suite of smoke tests covering all major page routes in the application. These tests verify that pages load without errors, resolve their imports correctly, and render expected components.

## Key Changes

### Test Files Added
- **`community-async-pages.test.tsx`** – Tests async server-rendered community pages (manage, admin, knowledge-base, etc.) that fetch data via `getCommunityDetails` and similar helpers
- **`community-client-pages.test.tsx`** – Tests client-side community pages that use `useParams`, call hooks directly, and render conditional UI
- **`remaining-pages.test.tsx`** – Tests funding platform, application, and other client-side pages with complex hook dependencies
- **`whitelabel-pages.test.tsx`** – Tests whitelabel application/program routes that are async server components
- **`component-wrapper-pages.test.tsx`** – Tests pages that simply delegate to a single inner component (admin dashboards, etc.)
- **`marketing-pages.test.tsx`** – Tests top-level marketing/landing pages composed of feature-section components
- **`project-pages.test.tsx`** – Tests `/project/[projectId]` routes and their various profile sub-pages
- **`static-pages.test.tsx`** – Tests static pages (legal, knowledge-base articles) with no data fetching
- **`redirect-pages.test.tsx`** – Tests redirect-only pages that invoke Next's `redirect()` or `permanentRedirect()` helpers

### Testing Strategy
Each test file follows a consistent pattern:
1. Mock data-fetching helpers (hooks, services, queries) to return stable sentinel values
2. Mock inner heavy components with test IDs to verify they're mounted
3. Render the page and assert expected components are present
4. Verify pages load without throwing errors

### Coverage
The tests cover:
- ~50+ page routes across the application
- Async server components with data fetching
- Client-side pages with React Query and custom hooks
- Pages with RBAC guards and permission checks
- Whitelabel and multi-community routing
- Static content pages
- Redirect logic

## Implementation Details
- Uses `vi.mock()` to stub external dependencies (Next.js navigation, data hooks, inner components)
- Wraps client pages in `QueryClientProvider` with retry disabled for faster tests
- Tests async pages by awaiting the page function and rendering the result
- Uses data-testid attributes to verify component mounting without testing implementation details
- Mocks are scoped per test file to avoid cross-test pollution

https://claude.ai/code/session_01FiD9Y3cUaSyvVf2MDAgxp6