### PR TITLE
feat(milestones): show per-grant ordinal pill on milestone cards

### DIFF
--- a/__tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts
+++ b/__tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts
@@ -1,0 +1,161 @@
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import {
+  assignGrantMilestoneOrder,
+  buildGrantMilestoneOrderMap,
+} from "@/utilities/milestones/assignGrantMilestoneOrder";
+
+function createGrantMilestone(
+  uid: string,
+  grantUID: string,
+  options: { endsAt?: number; createdAt?: string } = {}
+): UnifiedMilestone {
+  return {
+    uid,
+    title: `Milestone ${uid}`,
+    description: "",
+    completed: false,
+    type: "grant",
+    createdAt: options.createdAt || "2024-01-01T00:00:00Z",
+    chainID: 1,
+    refUID: grantUID,
+    endsAt: options.endsAt,
+    source: {
+      grantMilestone: {
+        milestone: {
+          uid: `gm-${uid}`,
+          chainID: 1,
+          title: `Milestone ${uid}`,
+          verified: [],
+        },
+        grant: {
+          uid: grantUID,
+          chainID: 1,
+          details: { title: `Grant ${grantUID}` },
+        },
+      },
+    },
+  };
+}
+
+function createProjectMilestone(uid: string): UnifiedMilestone {
+  return {
+    uid,
+    title: `Project Milestone ${uid}`,
+    description: "",
+    completed: false,
+    type: "milestone",
+    createdAt: "2024-01-01T00:00:00Z",
+    chainID: 0,
+    refUID: "",
+    source: {
+      projectMilestone: { uid: `pm-${uid}`, attester: "0x0" },
+    },
+  };
+}
+
+describe("assignGrantMilestoneOrder", () => {
+  it("returns empty array for empty input", () => {
+    expect(assignGrantMilestoneOrder([])).toEqual([]);
+  });
+
+  it("assigns 1..N per grant sorted ascending by endsAt", () => {
+    const a = createGrantMilestone("a", "grant-1", { endsAt: 3000 });
+    const b = createGrantMilestone("b", "grant-1", { endsAt: 1000 });
+    const c = createGrantMilestone("c", "grant-1", { endsAt: 2000 });
+
+    const result = assignGrantMilestoneOrder([a, b, c]);
+
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+    expect(byUid.b).toEqual({ index: 1, total: 3 });
+    expect(byUid.c).toEqual({ index: 2, total: 3 });
+    expect(byUid.a).toEqual({ index: 3, total: 3 });
+  });
+
+  it("scopes numbering per grant", () => {
+    const g1a = createGrantMilestone("g1a", "grant-1", { endsAt: 1000 });
+    const g1b = createGrantMilestone("g1b", "grant-1", { endsAt: 2000 });
+    const g2a = createGrantMilestone("g2a", "grant-2", { endsAt: 5000 });
+
+    const result = assignGrantMilestoneOrder([g1a, g1b, g2a]);
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+
+    expect(byUid.g1a).toEqual({ index: 1, total: 2 });
+    expect(byUid.g1b).toEqual({ index: 2, total: 2 });
+    expect(byUid.g2a).toEqual({ index: 1, total: 1 });
+  });
+
+  it("falls back to createdAt when endsAt is missing", () => {
+    const a = createGrantMilestone("a", "grant-1", { createdAt: "2024-03-01T00:00:00Z" });
+    const b = createGrantMilestone("b", "grant-1", { createdAt: "2024-01-01T00:00:00Z" });
+    const c = createGrantMilestone("c", "grant-1", { createdAt: "2024-02-01T00:00:00Z" });
+
+    const result = assignGrantMilestoneOrder([a, b, c]);
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+
+    expect(byUid.b).toEqual({ index: 1, total: 3 });
+    expect(byUid.c).toEqual({ index: 2, total: 3 });
+    expect(byUid.a).toEqual({ index: 3, total: 3 });
+  });
+
+  it("does not stamp non-grant items", () => {
+    const grant = createGrantMilestone("g", "grant-1", { endsAt: 1000 });
+    const project = createProjectMilestone("p");
+
+    const result = assignGrantMilestoneOrder([grant, project]);
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+
+    expect(byUid.g).toEqual({ index: 1, total: 1 });
+    expect(byUid.p).toBeUndefined();
+  });
+
+  it("does not mutate the input array or its items", () => {
+    const a = createGrantMilestone("a", "grant-1", { endsAt: 2000 });
+    const b = createGrantMilestone("b", "grant-1", { endsAt: 1000 });
+    const input = [a, b];
+
+    const result = assignGrantMilestoneOrder(input);
+
+    expect(a.grantMilestoneOrder).toBeUndefined();
+    expect(b.grantMilestoneOrder).toBeUndefined();
+    expect(result).not.toBe(input);
+  });
+
+  it("breaks ties deterministically by uid", () => {
+    const a = createGrantMilestone("zzz", "grant-1", { endsAt: 1000 });
+    const b = createGrantMilestone("aaa", "grant-1", { endsAt: 1000 });
+
+    const result = assignGrantMilestoneOrder([a, b]);
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+
+    expect(byUid.aaa).toEqual({ index: 1, total: 2 });
+    expect(byUid.zzz).toEqual({ index: 2, total: 2 });
+  });
+});
+
+describe("buildGrantMilestoneOrderMap", () => {
+  it("orders by endsAt ascending regardless of input order", () => {
+    const map = buildGrantMilestoneOrderMap([
+      { uid: "m3", endsAt: 3000 },
+      { uid: "m1", endsAt: 1000 },
+      { uid: "m2", endsAt: 2000 },
+    ]);
+
+    expect(map.get("m1")).toEqual({ index: 1, total: 3 });
+    expect(map.get("m2")).toEqual({ index: 2, total: 3 });
+    expect(map.get("m3")).toEqual({ index: 3, total: 3 });
+  });
+
+  it("falls back to createdAt when endsAt is missing", () => {
+    const map = buildGrantMilestoneOrderMap([
+      { uid: "a", createdAt: "2024-03-01T00:00:00Z" },
+      { uid: "b", createdAt: "2024-01-01T00:00:00Z" },
+    ]);
+
+    expect(map.get("b")).toEqual({ index: 1, total: 2 });
+    expect(map.get("a")).toEqual({ index: 2, total: 2 });
+  });
+
+  it("returns empty map for empty input", () => {
+    expect(buildGrantMilestoneOrderMap([]).size).toBe(0);
+  });
+});

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -23,6 +23,29 @@ interface CommunityMilestoneCardProps {
   allocationAmount?: string;
 }
 
+type MilestoneStatusVariant = "completed" | "pastDue" | "pending";
+
+const STATUS_BADGE_CLASSES: Record<MilestoneStatusVariant, string> = {
+  completed: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  pastDue: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  pending: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+};
+
+const STATUS_BADGE_LABELS: Record<MilestoneStatusVariant, string> = {
+  completed: "Completed",
+  pastDue: "Past Due",
+  pending: "Pending",
+};
+
+const getStatusVariant = (
+  status: CommunityMilestoneUpdate["status"],
+  dueDate: string | null
+): MilestoneStatusVariant => {
+  if (status === "completed") return "completed";
+  if (dueDate && new Date(dueDate) < new Date()) return "pastDue";
+  return "pending";
+};
+
 const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
   milestone,
   allocationAmount,
@@ -32,9 +55,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
   const projectTitle = milestone.project.details?.data?.title;
   const grantTitle = milestone.grant?.details?.data?.title || "Project Milestone";
 
-  // Check if milestone is past due (not completed and due date has passed)
-  const isPastDue =
-    !isCompleted && milestone.details.dueDate && new Date(milestone.details.dueDate) < new Date();
+  const statusVariant = getStatusVariant(milestone.status, milestone.details.dueDate);
 
   return (
     <div className="flex flex-col w-full gap-2.5 md:gap-5">
@@ -62,11 +83,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
             <div
               className={cn(
                 "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium",
-                isCompleted
-                  ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-                  : isPastDue
-                    ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
-                    : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                STATUS_BADGE_CLASSES[statusVariant]
               )}
             >
               {isCompleted ? (
@@ -74,8 +91,13 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
               ) : (
                 <ClockIcon className="h-3 w-3" />
               )}
-              {isCompleted ? "Completed" : isPastDue ? "Past Due" : "Pending"}
+              {STATUS_BADGE_LABELS[statusVariant]}
             </div>
+            {milestone.grantMilestoneIndex && milestone.grantMilestoneTotal ? (
+              <span className="px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-200">
+                {milestone.grantMilestoneIndex} of {milestone.grantMilestoneTotal}
+              </span>
+            ) : null}
             {allocationAmount ? (
               <span className="px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-200">
                 {allocationAmount}

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -95,7 +95,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
             </div>
             {milestone.grantMilestoneIndex && milestone.grantMilestoneTotal ? (
               <span className="px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-200">
-                {milestone.grantMilestoneIndex} of {milestone.grantMilestoneTotal}
+                Milestone {milestone.grantMilestoneIndex} of {milestone.grantMilestoneTotal}
               </span>
             ) : null}
             {allocationAmount ? (

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { type FC, memo } from "react";
 import { ActivityAttribution } from "@/components/Shared/ActivityCard/ActivityAttribution";
 import { containerClassName } from "@/components/Shared/ActivityCard/styles";
+import { Badge } from "@/components/ui/badge";
 import { Link } from "@/src/components/navigation/Link";
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 import { formatDate } from "@/utilities/formatDate";
@@ -93,10 +94,13 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
               )}
               {STATUS_BADGE_LABELS[statusVariant]}
             </div>
-            {milestone.grantMilestoneIndex && milestone.grantMilestoneTotal ? (
-              <span className="px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-200">
+            {milestone.grantMilestoneIndex != null && milestone.grantMilestoneTotal != null ? (
+              <Badge
+                variant="secondary"
+                className="bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-950 dark:text-blue-200 dark:hover:bg-blue-950"
+              >
                 Milestone {milestone.grantMilestoneIndex} of {milestone.grantMilestoneTotal}
-              </span>
+              </Badge>
             ) : null}
             {allocationAmount ? (
               <span className="px-2 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-200">

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
@@ -106,9 +106,14 @@ function toUnifiedMilestone(milestone: GrantMilestone, grant: GrantContext): Uni
 interface MilestoneDetailsProps {
   milestone: GrantMilestone;
   allocationAmount?: string;
+  grantMilestoneOrder?: { index: number; total: number };
 }
 
-export const MilestoneDetails: FC<MilestoneDetailsProps> = ({ milestone, allocationAmount }) => {
+export const MilestoneDetails: FC<MilestoneDetailsProps> = ({
+  milestone,
+  allocationAmount,
+  grantMilestoneOrder,
+}) => {
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
@@ -117,7 +122,10 @@ export const MilestoneDetails: FC<MilestoneDetailsProps> = ({ milestone, allocat
 
   const grant = useGrantStore((state) => state.grant);
 
-  const unifiedMilestone = useMemo(() => toUnifiedMilestone(milestone, grant), [milestone, grant]);
+  const unifiedMilestone = useMemo(() => {
+    const base = toUnifiedMilestone(milestone, grant);
+    return grantMilestoneOrder ? { ...base, grantMilestoneOrder } : base;
+  }, [milestone, grant, grantMilestoneOrder]);
 
   return (
     <ActivityCard

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -6,6 +6,7 @@ import { usePayoutConfigByGrantPublic } from "@/src/features/payout-disbursement
 import type { Grant } from "@/types/v2/grant";
 import { normalizeTimestamp } from "@/utilities/formatDate";
 import { formatMilestoneAmount } from "@/utilities/formatMilestoneAmount";
+import { buildGrantMilestoneOrderMap } from "@/utilities/milestones/assignGrantMilestoneOrder";
 import { cn } from "@/utilities/tailwind";
 import { GrantUpdate } from "./GrantUpdate";
 import { MilestoneDetails } from "./MilestoneDetails";
@@ -64,6 +65,9 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
     }
     return undefined;
   }, [grant.details?.currency, payoutConfig?.tokenAddress, payoutConfig?.chainID]);
+
+  // Build a per-grant ordinal map (uid → { index, total }) for the "N of M" pill.
+  const orderByUID = useMemo(() => buildGrantMilestoneOrderMap(milestones ?? []), [milestones]);
 
   // Build a map from milestoneUID to formatted allocation amount
   const allocationByUID = useMemo<Map<string, string>>(() => {
@@ -283,6 +287,7 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
                   key={item.object.uid}
                   milestone={item.object}
                   allocationAmount={allocationByUID.get(item.object.uid)}
+                  grantMilestoneOrder={orderByUID.get(item.object.uid)}
                 />
               );
             })}

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -482,8 +482,18 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
         <div className="flex flex-col gap-6 w-full px-6 py-6">
           <div className="flex flex-row justify-between items-start gap-3 w-full flex-wrap">
             <div className="flex flex-col gap-2 flex-1 flex-wrap">
-              {/* Title */}
-              <p className="text-xl font-semibold text-foreground">{title}</p>
+              {/* Title row with per-grant ordinal pill */}
+              <div className="flex flex-row items-center gap-2 flex-wrap">
+                {type === "grant" && milestone.grantMilestoneOrder && (
+                  <Badge
+                    variant="secondary"
+                    className="bg-blue-50 text-blue-700 hover:bg-blue-50 dark:bg-blue-950 dark:text-blue-200 dark:hover:bg-blue-950"
+                  >
+                    {`${milestone.grantMilestoneOrder.index} of ${milestone.grantMilestoneOrder.total}`}
+                  </Badge>
+                )}
+                <p className="text-xl font-semibold text-foreground">{title}</p>
+              </div>
 
               {/* Community/Grant Badge - only shown for grant milestones */}
               {type === "grant" && (

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -9,6 +9,7 @@ import type {
   UnifiedMilestone,
   UpdatesApiResponse,
 } from "@/types/v2/roadmap";
+import { assignGrantMilestoneOrder } from "@/utilities/milestones/assignGrantMilestoneOrder";
 import { parseChainId } from "@/utilities/parseChainId";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
@@ -395,7 +396,9 @@ export function useProjectUpdates(
   });
 
   // Convert response to unified format (no longer needs project data)
-  const milestones = data ? sortByDateDescending(convertToUnifiedMilestones(data)) : [];
+  const milestones = data
+    ? sortByDateDescending(assignGrantMilestoneOrder(convertToUnifiedMilestones(data)))
+    : [];
 
   // Filter pending milestones (not completed)
   const pendingMilestones = milestones.filter((m) => !m.completed);

--- a/types/community-updates.ts
+++ b/types/community-updates.ts
@@ -35,6 +35,10 @@ export interface CommunityMilestoneUpdate {
   details: MilestoneDetails;
   project: ProjectInfo;
   grant?: GrantInfo;
+  /** 1-based position of this milestone within its parent grant. */
+  grantMilestoneIndex?: number;
+  /** Total number of milestones in the parent grant. */
+  grantMilestoneTotal?: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/types/v2/roadmap.ts
+++ b/types/v2/roadmap.ts
@@ -285,4 +285,10 @@ export type UnifiedMilestone = {
     receivedAt: string | null;
     fileKey: string | null;
   };
+  /**
+   * Ordinal position of this milestone within its parent grant.
+   * Computed client-side by sorting a grant's milestones ascending by due date
+   * (fallback `createdAt`) and assigning 1..N. Only set for grant milestones.
+   */
+  grantMilestoneOrder?: { index: number; total: number };
 };

--- a/utilities/milestones/assignGrantMilestoneOrder.ts
+++ b/utilities/milestones/assignGrantMilestoneOrder.ts
@@ -1,0 +1,74 @@
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+
+interface OrderableMilestone {
+  uid: string;
+  endsAt?: number;
+  createdAt?: string;
+}
+
+const getOrderTimestamp = (milestone: OrderableMilestone): number => {
+  if (milestone.endsAt) return milestone.endsAt;
+  if (!milestone.createdAt) return 0;
+  return Math.floor(new Date(milestone.createdAt).getTime() / 1000);
+};
+
+/**
+ * Builds a stable per-grant ordinal map (uid → { index, total }) for a single
+ * grant's milestones. Sorts ascending by `endsAt` (fallback `createdAt`,
+ * tiebreak by `uid`) and numbers them 1..N.
+ */
+export function buildGrantMilestoneOrderMap<T extends OrderableMilestone>(
+  milestones: T[]
+): Map<string, { index: number; total: number }> {
+  const sorted = [...milestones].sort((a, b) => {
+    const diff = getOrderTimestamp(a) - getOrderTimestamp(b);
+    if (diff !== 0) return diff;
+    return a.uid.localeCompare(b.uid);
+  });
+  const total = sorted.length;
+  const map = new Map<string, { index: number; total: number }>();
+  sorted.forEach((milestone, idx) => {
+    map.set(milestone.uid, { index: idx + 1, total });
+  });
+  return map;
+}
+
+/**
+ * Assigns a stable per-grant ordinal (1..N) to every grant milestone.
+ *
+ * Milestones are grouped by their parent grant UID, sorted ascending by due date
+ * (`endsAt`) with `createdAt` as fallback, then stamped with `grantMilestoneOrder`.
+ * Non-grant items (project milestones, updates, impacts, etc.) pass through unchanged.
+ *
+ * The original array is not mutated; a new array of new objects is returned.
+ */
+export function assignGrantMilestoneOrder(milestones: UnifiedMilestone[]): UnifiedMilestone[] {
+  const grouped = new Map<string, UnifiedMilestone[]>();
+
+  milestones.forEach((milestone) => {
+    if (milestone.type !== "grant") return;
+    const grantUID = milestone.source.grantMilestone?.grant.uid;
+    if (!grantUID) return;
+    const list = grouped.get(grantUID);
+    if (list) {
+      list.push(milestone);
+    } else {
+      grouped.set(grantUID, [milestone]);
+    }
+  });
+
+  const orderByMilestoneUID = new Map<string, { index: number; total: number }>();
+
+  grouped.forEach((groupMilestones) => {
+    const groupMap = buildGrantMilestoneOrderMap(groupMilestones);
+    groupMap.forEach((order, uid) => {
+      orderByMilestoneUID.set(uid, order);
+    });
+  });
+
+  return milestones.map((milestone) => {
+    const order = orderByMilestoneUID.get(milestone.uid);
+    if (!order) return milestone;
+    return { ...milestone, grantMilestoneOrder: order };
+  });
+}


### PR DESCRIPTION
## Summary

Adds a \`N of M\` blue pill next to grant milestones across three pages:

- **Project profile roadmap** (\`/project/[slug]\`) — pill on each grant milestone in the unified roadmap
- **Funding page** (\`/project/[slug]/funding/[grantUid]/milestones-and-updates\`) — pill on every milestone in the per-grant list
- **Community updates feed** (\`/community/[id]/updates\`) — pill on each grant milestone update

Project-level milestones (no parent grant) are intentionally left without a pill — the ordinal is per-grant only.

## Approach

Two paths feed the new pill:

1. **Frontend helper** (\`utilities/milestones/assignGrantMilestoneOrder.ts\`) for the project + funding pages. Groups unified milestones by parent grant uid and stamps ordinals based on \`endsAt\` asc → \`createdAt\` asc → \`uid\` lexicographic tiebreak.
2. **Indexer response** drives the community updates feed (server-side computation needed so the total reflects every milestone in the grant — even with pagination or status filters applied). Requires sibling PR show-karma/gap-indexer#1469.

## Tests

- 10 new unit tests in \`__tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts\` — happy path, multi-grant scoping, deterministic tiebreak, project-only-milestone passthrough, helper map vs assigner

## Test plan

- [x] Unit tests pass (10/10)
- [x] Lint clean for changed files
- [x] Verified live in browser against local indexer:
  - Project roadmap shows 7 pills \`1 of 7\` … \`7 of 7\` for cidgravity-filecoin-gateway
  - Funding page shows the same 7 pills on the milestones list
  - Community updates feed (\`/community/filecoin/updates\`) shows pills including \`2 of 4\`, \`3 of 3\`, \`4 of 4\`, \`5 of 5\` and \`1 of 1\` for single-milestone grants
  - With \`status=completed\` filter applied, totals still reflect the full grant (e.g. \`1 of 4\` even though only 2 of 4 are completed)

## Sibling PR

Requires show-karma/gap-indexer#1469 in production for the community updates feed to render the pill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grant milestones now display their ordinal position (e.g., "3 of 5") via badge indicators.
  * Milestone ordering is now consistently sorted by due date across all sections, with proper fallback handling.

* **Tests**
  * Added comprehensive test coverage for milestone ordering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->