### PR TITLE
feat(knowledge-base): paused toggle on SourceRow (DEV-194)

### DIFF
--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -295,4 +295,50 @@ describe("SourceRow", () => {
       });
     });
   });
+
+  describe("dimmed visual treatment", () => {
+    // The row dims (opacity-55 on the icon tile, opacity-70 on the title
+    // block) whenever it's "off" — either paused or legacy isActive=false.
+    // Pre-DEV-194 the trigger was just !isActive; the regression tests below
+    // pin the union so legacy inactive rows don't lose their dim treatment.
+    const tileOpacityClass = "opacity-55";
+    const contentOpacityClass = "opacity-70";
+
+    function getTileAndContentOpacityClasses(): string[] {
+      // The icon tile is the first descendant rendered with opacity-55,
+      // the content wrapper carries opacity-70. We collect classNames of
+      // every dimmed element to assert the row visually communicates the
+      // off state.
+      const dimmed = document.querySelectorAll(
+        `.${tileOpacityClass}, .${contentOpacityClass}`
+      );
+      return Array.from(dimmed).flatMap((el) =>
+        Array.from(el.classList)
+      );
+    }
+
+    it("dims the row when source is paused", () => {
+      renderRow(createSource({ paused: true }));
+      const classes = getTileAndContentOpacityClasses();
+      expect(classes).toContain(tileOpacityClass);
+      expect(classes).toContain(contentOpacityClass);
+    });
+
+    it("dims the row when source is inactive (legacy axis)", () => {
+      // Regression for the dogfood-agent finding: pre-DEV-194 the row
+      // dimmed on !isActive. The first cut moved dimming to source.paused
+      // only, so legacy isActive=false rows lost their dim treatment.
+      renderRow(createSource({ isActive: false, paused: false }));
+      const classes = getTileAndContentOpacityClasses();
+      expect(classes).toContain(tileOpacityClass);
+      expect(classes).toContain(contentOpacityClass);
+    });
+
+    it("does not dim a healthy active source", () => {
+      renderRow(createSource({ isActive: true, paused: false }));
+      const classes = getTileAndContentOpacityClasses();
+      expect(classes).not.toContain(tileOpacityClass);
+      expect(classes).not.toContain(contentOpacityClass);
+    });
+  });
 });

--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -41,8 +41,10 @@ const createSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource
   externalId: "https://docs.google.com/document/d/abc/edit",
   title: "Onboarding doc",
   isActive: true,
+  paused: false,
   goal: null,
   syncIntervalMin: 1440,
+  followLinks: false,
   lastSyncedAt: "2026-04-26T00:00:00.000Z",
   lastSyncStatus: "success",
   lastSyncError: null,
@@ -139,12 +141,29 @@ describe("SourceRow", () => {
       expect(screen.getByText("1 doc failed")).toBeInTheDocument();
     });
 
-    it("renders 'Sync paused' when the source is inactive (regardless of sync status)", () => {
-      // Specifically "Sync paused" rather than "Paused" — the source's
-      // existing chunks remain searchable while paused; only future
-      // syncs stop. The label communicates that distinction.
-      renderRow(createSource({ isActive: false, lastSyncStatus: "failed" }));
-      expect(screen.getByText("Sync paused")).toBeInTheDocument();
+    it("renders 'Paused' when source.paused=true (regardless of sync status)", () => {
+      // DEV-194: paused is the explicit "off" switch — it stops sync AND
+      // hides chunks from search. The label is just "Paused" (no qualifier)
+      // because both axes stop together.
+      renderRow(createSource({ paused: true, lastSyncStatus: "failed" }));
+      expect(screen.getByText("Paused")).toBeInTheDocument();
+    });
+
+    it("renders 'Inactive' when isActive=false and not paused (legacy disable axis)", () => {
+      // isActive is orthogonal to paused. Today no UI control flips it, but
+      // pre-existing rows might still be in this state — we surface a
+      // distinct "Inactive" label so admins can tell them apart.
+      renderRow(createSource({ isActive: false, paused: false }));
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
+    });
+
+    it("'Paused' wins over 'Inactive' when both flags are off", () => {
+      // Defense: a row with both flags off should read as "Paused" because
+      // paused is the active, intent-driven state — admins clicked it
+      // recently. Inactive is the dormant "we never enabled this" tone.
+      renderRow(createSource({ isActive: false, paused: true }));
+      expect(screen.getByText("Paused")).toBeInTheDocument();
+      expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
     });
   });
 
@@ -200,6 +219,68 @@ describe("SourceRow", () => {
       renderRow(createSource({ lastSyncStatus: "failed", lastSyncError: "fetch failed" }));
       const syncBtn = screen.getByRole("button", { name: /^sync now$/i });
       expect(syncBtn).toBeEnabled();
+    });
+
+    it("disables the sync trigger when source is paused", () => {
+      // DEV-194: claimDueForSync filters paused rows out, so a Sync click
+      // on a paused source would never make progress. Gate the button
+      // and explain why in the tooltip.
+      renderRow(createSource({ paused: true, lastSyncStatus: "success" }));
+      const syncBtn = screen.getByRole("button", {
+        name: /resume to sync — paused sources are skipped/i,
+      });
+      expect(syncBtn).toBeDisabled();
+    });
+  });
+
+  describe("pause toggle", () => {
+    it("renders Pause button label when source is not paused", () => {
+      renderRow(createSource({ paused: false }));
+      expect(
+        screen.getByRole("button", { name: /pause — skip sync and hide from search/i })
+      ).toBeInTheDocument();
+    });
+
+    it("renders Resume button label when source is paused", () => {
+      renderRow(createSource({ paused: true }));
+      expect(
+        screen.getByRole("button", { name: /resume — back in sync and search/i })
+      ).toBeInTheDocument();
+    });
+
+    it("calls update mutation with paused:true when pausing an active source", async () => {
+      // The button must drive the new `paused` field, not `isActive`. A
+      // regression that swapped the field would still render correctly
+      // (both are booleans) but the backend would never honor the pause.
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue({ mutateAsync, isPending: false });
+      renderRow(createSource({ paused: false }));
+
+      const btn = screen.getByRole("button", {
+        name: /pause — skip sync and hide from search/i,
+      });
+      btn.click();
+
+      expect(mutateAsync).toHaveBeenCalledWith({
+        sourceId: "src-1",
+        patch: { paused: true },
+      });
+    });
+
+    it("calls update mutation with paused:false when resuming a paused source", async () => {
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockUpdate.mockReturnValue({ mutateAsync, isPending: false });
+      renderRow(createSource({ paused: true }));
+
+      const btn = screen.getByRole("button", {
+        name: /resume — back in sync and search/i,
+      });
+      btn.click();
+
+      expect(mutateAsync).toHaveBeenCalledWith({
+        sourceId: "src-1",
+        patch: { paused: false },
+      });
     });
   });
 });

--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -231,6 +231,18 @@ describe("SourceRow", () => {
       });
       expect(syncBtn).toBeDisabled();
     });
+
+    it("disables the sync trigger when source is inactive (matches backend filter)", () => {
+      // Defense against UI/backend drift: claimDueForSync also filters
+      // is_active = FALSE, so the button must be disabled for the same
+      // reason as paused — otherwise the click looks like progress but
+      // the worker silently skips the row.
+      renderRow(createSource({ isActive: false, paused: false, lastSyncStatus: "success" }));
+      const syncBtn = screen.getByRole("button", {
+        name: /source is inactive — sync is disabled/i,
+      });
+      expect(syncBtn).toBeDisabled();
+    });
   });
 
   describe("pause toggle", () => {

--- a/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
@@ -231,9 +231,11 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
   const status = getStatusMeta(source);
   const KindIcon = kind.Icon;
   const parts = diffParts(source);
-  // DEV-194: paused now drives the row's dimmed treatment. isActive is
-  // an orthogonal long-term-disable axis that no UI control flips today.
-  const isPaused = source.paused;
+  // DEV-194: dim the row whenever it's "off" — either paused (the new
+  // explicit switch) or legacy isActive=false. The status badge still
+  // distinguishes the two states; this just keeps the visual treatment
+  // consistent with pre-DEV-194 behavior for inactive rows.
+  const isDimmed = source.paused || !source.isActive;
 
   const handleTogglePaused = async () => {
     try {
@@ -304,7 +306,7 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
           isFailed
             ? "border-rose-200 bg-rose-50 dark:border-rose-900/50 dark:bg-rose-950/40"
             : "border-stone-200 bg-stone-50 dark:border-zinc-800 dark:bg-zinc-900"
-        } ${isPaused ? "opacity-55" : ""}`}
+        } ${isDimmed ? "opacity-55" : ""}`}
         aria-hidden="true"
       >
         <KindIcon
@@ -314,7 +316,7 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
       </div>
 
       {/* Title / URL / meta */}
-      <div className={`min-w-0 ${isPaused ? "opacity-70" : ""}`}>
+      <div className={`min-w-0 ${isDimmed ? "opacity-70" : ""}`}>
         <div className="flex items-baseline gap-2.5">
           <p className="truncate text-sm font-semibold leading-tight text-stone-900 dark:text-zinc-100">
             {source.title}

--- a/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
@@ -280,9 +280,12 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
   // nothing for "force reprocess" to do until the worker finishes.
   // DEV-194: paused rows aren't "queued" — claimDueForSync skips them,
   // so a Sync click would have no effect; gate the button accordingly.
+  // Same reasoning applies to is_active=false: claimDueForSync filters
+  // those out too, so the button has to be disabled for the click to
+  // honestly reflect what the backend will do.
   const isQueued =
     source.isActive && !source.paused && !source.lastSyncedAt && status.tone === "idle";
-  const syncBlocked = isSyncingNow || isQueued || source.paused;
+  const syncBlocked = isSyncingNow || isQueued || source.paused || !source.isActive;
 
   return (
     <li
@@ -455,11 +458,13 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
           label={
             source.paused
               ? "Resume to sync — paused sources are skipped"
-              : isSyncingNow
-                ? "Sync in progress"
-                : isQueued
-                  ? "Already queued for sync"
-                  : "Sync now"
+              : !source.isActive
+                ? "Source is inactive — sync is disabled"
+                : isSyncingNow
+                  ? "Sync in progress"
+                  : isQueued
+                    ? "Already queued for sync"
+                    : "Sync now"
           }
           onClick={handleResync}
           disabled={resync.isPending || syncBlocked}

--- a/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
@@ -93,14 +93,24 @@ interface StatusMeta {
 }
 
 function getStatusMeta(source: KnowledgeSource): StatusMeta {
-  if (!source.isActive) {
-    // "Sync paused" rather than just "Paused" because pausing only stops
-    // future syncs — the source's existing chunks remain in the index
-    // and continue answering chatbot questions until the source is
-    // deleted. The Pause button's tooltip carries the same caveat.
+  // DEV-194: paused is explicit and authoritative — the backend skips
+  // sync AND excludes the source's chunks from retrieval. The label is
+  // just "Paused" (no "sync" qualifier) because both axes stop at once.
+  if (source.paused) {
     return {
       tone: "paused",
-      label: "Sync paused",
+      label: "Paused",
+      dot: "bg-stone-400 dark:bg-zinc-500",
+    };
+  }
+  if (!source.isActive) {
+    // Legacy `isActive=false` — the long-term disable axis. Today no UI
+    // control flips this, but pre-existing rows might already be in
+    // this state. Keep the badge so admins see "this is off" without
+    // conflating it with paused.
+    return {
+      tone: "paused",
+      label: "Inactive",
       dot: "bg-stone-400 dark:bg-zinc-500",
     };
   }
@@ -221,15 +231,17 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
   const status = getStatusMeta(source);
   const KindIcon = kind.Icon;
   const parts = diffParts(source);
-  const isPaused = !source.isActive;
+  // DEV-194: paused now drives the row's dimmed treatment. isActive is
+  // an orthogonal long-term-disable axis that no UI control flips today.
+  const isPaused = source.paused;
 
-  const handleToggleActive = async () => {
+  const handleTogglePaused = async () => {
     try {
       await update.mutateAsync({
         sourceId: source.id,
-        patch: { isActive: !source.isActive },
+        patch: { paused: !source.paused },
       });
-      toast.success(source.isActive ? "Source paused." : "Source resumed.");
+      toast.success(source.paused ? "Source resumed." : "Source paused.");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Update failed.");
     }
@@ -266,8 +278,11 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
   // cleared status + lastSyncedAt). The Sync button is gated for both
   // states so a double-click can't enqueue redundant work — there's
   // nothing for "force reprocess" to do until the worker finishes.
-  const isQueued = source.isActive && !source.lastSyncedAt && status.tone === "idle";
-  const syncBlocked = isSyncingNow || isQueued;
+  // DEV-194: paused rows aren't "queued" — claimDueForSync skips them,
+  // so a Sync click would have no effect; gate the button accordingly.
+  const isQueued =
+    source.isActive && !source.paused && !source.lastSyncedAt && status.tone === "idle";
+  const syncBlocked = isSyncingNow || isQueued || source.paused;
 
   return (
     <li
@@ -438,7 +453,13 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
         )}
         <RowAction
           label={
-            isSyncingNow ? "Sync in progress" : isQueued ? "Already queued for sync" : "Sync now"
+            source.paused
+              ? "Resume to sync — paused sources are skipped"
+              : isSyncingNow
+                ? "Sync in progress"
+                : isQueued
+                  ? "Already queued for sync"
+                  : "Sync now"
           }
           onClick={handleResync}
           disabled={resync.isPending || syncBlocked}
@@ -447,13 +468,13 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
         />
         <RowAction
           label={
-            source.isActive
-              ? "Pause syncing — existing chunks stay searchable"
-              : "Resume syncing on the regular schedule"
+            source.paused
+              ? "Resume — back in sync and search"
+              : "Pause — skip sync and hide from search"
           }
-          onClick={handleToggleActive}
+          onClick={handleTogglePaused}
           disabled={update.isPending}
-          Icon={source.isActive ? Pause : Play}
+          Icon={source.paused ? Play : Pause}
         />
         <RowAction
           label="Delete source"

--- a/types/v2/knowledge-base.ts
+++ b/types/v2/knowledge-base.ts
@@ -17,6 +17,12 @@ export interface KnowledgeSource {
   externalId: string;
   title: string;
   isActive: boolean;
+  // DEV-194: explicit pause flag, distinct from isActive. When true the
+  // sync worker skips this source AND retrieval excludes its chunks —
+  // chunks themselves are preserved so a resume is cheap. Use this for
+  // temporary "silence a noisy source" cases; isActive is the long-term
+  // enable/disable axis.
+  paused: boolean;
   // Optional editorial purpose. Prepended to each chunk at embed time so
   // retrieval picks up the curator's intent — never shown in citations or
   // the agent's excerpt path.
@@ -67,6 +73,9 @@ export interface UpdateKnowledgeSourceInput {
   // `null` clears the goal; omitting the key leaves it unchanged.
   goal?: string | null;
   isActive?: boolean;
+  // DEV-194: pause toggle — skips sync AND excludes chunks from
+  // retrieval while true. Distinct from isActive.
+  paused?: boolean;
   syncIntervalMin?: number;
   followLinks?: boolean;
 }


### PR DESCRIPTION
## Summary

Wires the new `paused` field (introduced in [gap-indexer #1487](https://github.com/show-karma/gap-indexer/pull/1487)) into the admin knowledge-base list. The Pause / Play button now drives `paused`, not `isActive`, and the row reflects the new semantics: paused sources are skipped by the sync worker **and** their chunks are excluded from retrieval.

## Why

The old Pause button toggled `isActive`. That was a misnomer — the backend only stopped sync; the chunks stayed searchable. With the indexer change, "Paused" is now a single decisive off-switch that hides the source from search too. The button label, tooltip, and status badge needed to follow.

## Behavior changes

- **Pause/Play button**: writes `{ paused: true | false }` (was `{ isActive: ... }`)
- **Status badge**: `paused = true` → "Paused"; `isActive = false && !paused` → "Inactive" (legacy axis surfaced separately)
- **Row dimming**: gated on `source.paused` (was `!source.isActive`)
- **Sync button**: disabled while `source.paused` (claimDueForSync skips paused rows — a Sync click would no-op). Tooltip explains: "Resume to sync — paused sources are skipped"
- **Tooltips**: "Pause — skip sync and hide from search" / "Resume — back in sync and search"

## Files

- `types/v2/knowledge-base.ts` — `paused` on `KnowledgeSource` and `UpdateKnowledgeSourceInput`
- `components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx` — toggle logic, status meta, sync gating, tooltip copy
- `__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx` — fixture updated, 5 new tests

## Tests

19/19 SourceRow tests pass. New tests cover:
- "Paused" badge renders when `paused = true` (regardless of sync status)
- "Inactive" badge renders when `isActive = false && !paused`
- "Paused" wins over "Inactive" when both flags are off (paused is the active intent-driven state)
- Sync button disabled when source is paused
- Pause click invokes the mutation with `{ paused: true }`; Resume click with `{ paused: false }` (regression guard against an `isActive` swap)

`pnpm run build` clean. `tsc --noEmit` clean.

## Test plan

- [ ] Backend PR ([gap-indexer #1487](https://github.com/show-karma/gap-indexer/pull/1487)) deployed first
- [ ] Visit a community admin → Knowledge Base
- [ ] Click Pause on a synced source — row dims, badge flips to "Paused", Sync button disables
- [ ] Run a chatbot/search query that previously hit the source's content — confirm it no longer surfaces
- [ ] Click Resume — badge flips back, search results return
- [ ] No re-embed required: a paused→resumed source returns instantly with the same answers (chunks were preserved)

## Depends on

- [gap-indexer #1487 — feat(knowledge-base): add paused state for sources (DEV-194)](https://github.com/show-karma/gap-indexer/pull/1487)

## Related

- Parent: DEV-187 (Knowledge Base RAG Improvements)
- Next: DEV-202 (Edit dialog) — will reuse this toggle inside the edit form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge sources now support a "Paused" state, displayed with a distinct label in the UI
  * Paused sources cannot trigger sync operations; the Sync button is disabled until the source is resumed
  * Added a pause/resume toggle button for convenient control of source synchronization behavior
  * Paused state operates independently of the source's active/inactive status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->