### PR TITLE
fix: hide milestone AI badge without evaluation

### DIFF
--- a/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
+++ b/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   ApplicationMilestoneAIEvaluationBadge,
   MilestoneAIEvaluationBadge,
@@ -67,6 +68,42 @@ describe("MilestoneAIEvaluationBadge", () => {
 
     expect(screen.getByRole("button")).toHaveTextContent("8/10");
   });
+
+  it("modal filters out invalid evaluations and renders only valid ones", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 9,
+            reasoning: "Comprehensive evidence supporting completion.",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+          {
+            milestoneUID: "milestone-1",
+            rating: 4,
+            reasoning: "",
+            model: "claude",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(<MilestoneAIEvaluationBadge milestoneUID="milestone-1" />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("9")).toBeInTheDocument();
+    expect(screen.queryByText("4")).not.toBeInTheDocument();
+    expect(screen.queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
+  });
 });
 
 describe("ApplicationMilestoneAIEvaluationBadge", () => {
@@ -127,5 +164,46 @@ describe("ApplicationMilestoneAIEvaluationBadge", () => {
     );
 
     expect(screen.getByRole("button")).toHaveTextContent("7/10");
+  });
+
+  it("modal filters out invalid evaluations and renders only valid ones", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useApplicationMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 6,
+            reasoning: "The submission demonstrates measurable progress.",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+          {
+            milestoneUID: "milestone-1",
+            rating: 3,
+            reasoning: "   ",
+            model: "claude",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useApplicationMilestoneEvaluation>);
+
+    render(
+      <ApplicationMilestoneAIEvaluationBadge
+        referenceNumber="APP-123"
+        milestoneTitle="Milestone 1"
+      />
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.queryByText("3")).not.toBeInTheDocument();
+    expect(screen.queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
+++ b/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
@@ -69,6 +69,60 @@ describe("MilestoneAIEvaluationBadge", () => {
     expect(screen.getByRole("button")).toHaveTextContent("8/10");
   });
 
+  it("renders nothing and skips fetching when completionReason is empty", () => {
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(<MilestoneAIEvaluationBadge milestoneUID="milestone-1" completionReason="" />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(useMilestoneEvaluation).toHaveBeenCalledWith("milestone-1", false);
+  });
+
+  it("renders nothing and skips fetching when completionReason is whitespace-only", () => {
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(<MilestoneAIEvaluationBadge milestoneUID="milestone-1" completionReason={"   \n  "} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(useMilestoneEvaluation).toHaveBeenCalledWith("milestone-1", false);
+  });
+
+  it("fetches and renders when completionReason has content", () => {
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 6,
+            reasoning: "Solid evidence of completion.",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(
+      <MilestoneAIEvaluationBadge
+        milestoneUID="milestone-1"
+        completionReason="Built and shipped feature X"
+      />
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("6/10");
+    expect(useMilestoneEvaluation).toHaveBeenCalledWith("milestone-1", true);
+  });
+
   it("modal filters out invalid evaluations and renders only valid ones", async () => {
     const user = userEvent.setup();
     vi.mocked(useMilestoneEvaluation).mockReturnValue({
@@ -164,6 +218,25 @@ describe("ApplicationMilestoneAIEvaluationBadge", () => {
     );
 
     expect(screen.getByRole("button")).toHaveTextContent("7/10");
+  });
+
+  it("renders nothing and skips fetching when completionReason is empty", () => {
+    vi.mocked(useApplicationMilestoneEvaluation).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useApplicationMilestoneEvaluation>);
+
+    render(
+      <ApplicationMilestoneAIEvaluationBadge
+        referenceNumber="APP-123"
+        milestoneTitle="Milestone 1"
+        completionReason=""
+      />
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(useApplicationMilestoneEvaluation).toHaveBeenCalledWith("APP-123", "Milestone 1", false);
   });
 
   it("modal filters out invalid evaluations and renders only valid ones", async () => {

--- a/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
+++ b/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import {
+  ApplicationMilestoneAIEvaluationBadge,
+  MilestoneAIEvaluationBadge,
+} from "@/components/Milestone/MilestoneAIEvaluationBadge";
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+vi.mock("@/hooks/useMilestoneEvaluation", () => ({
+  useMilestoneEvaluation: vi.fn(),
+  useApplicationMilestoneEvaluation: vi.fn(),
+}));
+
+const { useApplicationMilestoneEvaluation, useMilestoneEvaluation } = await import(
+  "@/hooks/useMilestoneEvaluation"
+);
+
+describe("MilestoneAIEvaluationBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides the badge when milestone evaluations are missing AI evaluation data", () => {
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 2,
+            reasoning: "",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(<MilestoneAIEvaluationBadge milestoneUID="milestone-1" />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText("2/10")).not.toBeInTheDocument();
+  });
+
+  it("renders the badge when milestone evaluations include valid AI evaluation data", () => {
+    vi.mocked(useMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 8,
+            reasoning: "Strong evidence and clear completion details.",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useMilestoneEvaluation>);
+
+    render(<MilestoneAIEvaluationBadge milestoneUID="milestone-1" />);
+
+    expect(screen.getByRole("button")).toHaveTextContent("8/10");
+  });
+});
+
+describe("ApplicationMilestoneAIEvaluationBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides the badge when application milestone evaluations are missing AI evaluation data", () => {
+    vi.mocked(useApplicationMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 2,
+            reasoning: "   ",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useApplicationMilestoneEvaluation>);
+
+    render(
+      <ApplicationMilestoneAIEvaluationBadge
+        referenceNumber="APP-123"
+        milestoneTitle="Milestone 1"
+      />
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText("2/10")).not.toBeInTheDocument();
+  });
+
+  it("renders the badge when application milestone evaluations include valid AI evaluation data", () => {
+    vi.mocked(useApplicationMilestoneEvaluation).mockReturnValue({
+      data: {
+        evaluations: [
+          {
+            milestoneUID: "milestone-1",
+            rating: 7,
+            reasoning: "The completion includes concrete proof of work.",
+            model: "gpt",
+            createdAt: "2026-04-30T00:00:00.000Z",
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useApplicationMilestoneEvaluation>);
+
+    render(
+      <ApplicationMilestoneAIEvaluationBadge
+        referenceNumber="APP-123"
+        milestoneTitle="Milestone 1"
+      />
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("7/10");
+  });
+});

--- a/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
+++ b/__tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   ApplicationMilestoneAIEvaluationBadge,
   MilestoneAIEvaluationBadge,
 } from "@/components/Milestone/MilestoneAIEvaluationBadge";
+import {
+  useApplicationMilestoneEvaluation,
+  useMilestoneEvaluation,
+} from "@/hooks/useMilestoneEvaluation";
 
 vi.mock("next/dynamic", () => ({
   __esModule: true,
@@ -14,10 +18,6 @@ vi.mock("@/hooks/useMilestoneEvaluation", () => ({
   useMilestoneEvaluation: vi.fn(),
   useApplicationMilestoneEvaluation: vi.fn(),
 }));
-
-const { useApplicationMilestoneEvaluation, useMilestoneEvaluation } = await import(
-  "@/hooks/useMilestoneEvaluation"
-);
 
 describe("MilestoneAIEvaluationBadge", () => {
   beforeEach(() => {
@@ -153,10 +153,11 @@ describe("MilestoneAIEvaluationBadge", () => {
 
     await user.click(screen.getByRole("button"));
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("9")).toBeInTheDocument();
-    expect(screen.queryByText("4")).not.toBeInTheDocument();
-    expect(screen.queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText("9")).toBeInTheDocument();
+    expect(within(dialog).queryByText("4")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
   });
 });
 
@@ -274,9 +275,10 @@ describe("ApplicationMilestoneAIEvaluationBadge", () => {
 
     await user.click(screen.getByRole("button"));
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("6")).toBeInTheDocument();
-    expect(screen.queryByText("3")).not.toBeInTheDocument();
-    expect(screen.queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText("6")).toBeInTheDocument();
+    expect(within(dialog).queryByText("3")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("No AI evaluation available yet.")).not.toBeInTheDocument();
   });
 });

--- a/components/Milestone/MilestoneAIEvaluationBadge.tsx
+++ b/components/Milestone/MilestoneAIEvaluationBadge.tsx
@@ -417,7 +417,7 @@ function AIEvaluationApplicationModal({
           <div className="space-y-4 max-h-96 overflow-y-auto">
             {evaluations.map((evaluation) => (
               <div
-                key={`${evaluation.milestoneUID}-${evaluation.createdAt}`}
+                key={`${evaluation.milestoneUID}-${evaluation.model}-${evaluation.createdAt}`}
                 className="border border-gray-200 dark:border-zinc-700 rounded-lg p-4"
               >
                 <div className="flex items-center mb-3">

--- a/components/Milestone/MilestoneAIEvaluationBadge.tsx
+++ b/components/Milestone/MilestoneAIEvaluationBadge.tsx
@@ -47,9 +47,9 @@ function formatReasoning(text: string): string {
   );
 }
 
-function isValidEvaluation(
-  evaluation: { rating?: number; reasoning?: string } | null | undefined
-): evaluation is { rating: number; reasoning: string } {
+function isValidEvaluation<T extends { rating?: number; reasoning?: string }>(
+  evaluation: T | null | undefined
+): evaluation is T & { rating: number; reasoning: string } {
   return (
     typeof evaluation?.rating === "number" &&
     Number.isFinite(evaluation.rating) &&
@@ -88,7 +88,10 @@ export function MilestoneAIEvaluationBadge({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const hasCompletionContent = completionReason === undefined || completionReason.trim().length > 0;
   const { data, isLoading, error } = useMilestoneEvaluation(milestoneUID, hasCompletionContent);
-  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
+  const evaluations = useMemo(
+    () => (data?.evaluations ?? []).filter(isValidEvaluation),
+    [data?.evaluations]
+  );
 
   const avgScore = useMemo(() => {
     if (evaluations.length === 0) return null;
@@ -188,7 +191,10 @@ interface AIEvaluationInlineModalProps {
 
 function AIEvaluationInlineModal({ milestoneUID, isOpen, onClose }: AIEvaluationInlineModalProps) {
   const { data, isLoading, error, refetch } = useMilestoneEvaluation(milestoneUID, isOpen);
-  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
+  const evaluations = useMemo(
+    () => (data?.evaluations ?? []).filter(isValidEvaluation),
+    [data?.evaluations]
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -292,7 +298,10 @@ export function ApplicationMilestoneAIEvaluationBadge({
     milestoneTitle,
     hasCompletionContent
   );
-  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
+  const evaluations = useMemo(
+    () => (data?.evaluations ?? []).filter(isValidEvaluation),
+    [data?.evaluations]
+  );
 
   const avgScore = useMemo(() => {
     if (evaluations.length === 0) return null;
@@ -403,7 +412,10 @@ function AIEvaluationApplicationModal({
     milestoneTitle,
     isOpen
   );
-  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
+  const evaluations = useMemo(
+    () => (data?.evaluations ?? []).filter(isValidEvaluation),
+    [data?.evaluations]
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/components/Milestone/MilestoneAIEvaluationBadge.tsx
+++ b/components/Milestone/MilestoneAIEvaluationBadge.tsx
@@ -47,6 +47,19 @@ function formatReasoning(text: string): string {
   );
 }
 
+function isValidEvaluation(
+  evaluation: { rating?: number; reasoning?: string } | null | undefined
+): evaluation is { rating: number; reasoning: string } {
+  return (
+    typeof evaluation?.rating === "number" &&
+    Number.isFinite(evaluation.rating) &&
+    evaluation.rating >= 0 &&
+    evaluation.rating <= 10 &&
+    typeof evaluation.reasoning === "string" &&
+    evaluation.reasoning.trim().length > 0
+  );
+}
+
 // ─── Inline Badge ────────────────────────────────────────────────────────────
 
 interface MilestoneAIEvaluationBadgeProps {
@@ -66,7 +79,7 @@ export function MilestoneAIEvaluationBadge({
 }: MilestoneAIEvaluationBadgeProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data, isLoading, error } = useMilestoneEvaluation(milestoneUID, true);
-  const evaluations = data?.evaluations ?? [];
+  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
   const avgScore = useMemo(() => {
     if (evaluations.length === 0) return null;
@@ -123,9 +136,9 @@ export function MilestoneAIEvaluationBadge({
               ) : (
                 <>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-                    {evaluations.map((evaluation, idx) => (
+                    {evaluations.map((evaluation) => (
                       <span
-                        key={idx}
+                        key={`${evaluation.milestoneUID}-${evaluation.model}-${evaluation.createdAt}`}
                         className={`text-xs font-semibold ${getScoreColor(evaluation.rating)}`}
                       >
                         {evaluation.rating}/10
@@ -162,7 +175,7 @@ interface AIEvaluationInlineModalProps {
 
 function AIEvaluationInlineModal({ milestoneUID, isOpen, onClose }: AIEvaluationInlineModalProps) {
   const { data, isLoading, error, refetch } = useMilestoneEvaluation(milestoneUID, isOpen);
-  const evaluations = data?.evaluations ?? [];
+  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -259,7 +272,7 @@ export function ApplicationMilestoneAIEvaluationBadge({
     milestoneTitle,
     true
   );
-  const evaluations = data?.evaluations ?? [];
+  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
   const avgScore = useMemo(() => {
     if (evaluations.length === 0) return null;
@@ -316,9 +329,9 @@ export function ApplicationMilestoneAIEvaluationBadge({
               ) : (
                 <>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-                    {evaluations.map((evaluation, idx) => (
+                    {evaluations.map((evaluation) => (
                       <span
-                        key={idx}
+                        key={`${evaluation.milestoneUID}-${evaluation.model}-${evaluation.createdAt}`}
                         className={`text-xs font-semibold ${getScoreColor(evaluation.rating)}`}
                       >
                         {evaluation.rating}/10
@@ -366,7 +379,7 @@ function AIEvaluationApplicationModal({
     milestoneTitle,
     isOpen
   );
-  const evaluations = data?.evaluations ?? [];
+  const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/components/Milestone/MilestoneAIEvaluationBadge.tsx
+++ b/components/Milestone/MilestoneAIEvaluationBadge.tsx
@@ -65,6 +65,13 @@ function isValidEvaluation(
 interface MilestoneAIEvaluationBadgeProps {
   milestoneUID: string;
   className?: string;
+  /**
+   * The milestone completion's reason text. When provided and empty/whitespace,
+   * the badge skips fetching and renders nothing — there's nothing for the AI to
+   * have evaluated. Leaving this undefined preserves the legacy behavior of
+   * always fetching.
+   */
+  completionReason?: string;
 }
 
 /**
@@ -76,9 +83,11 @@ interface MilestoneAIEvaluationBadgeProps {
 export function MilestoneAIEvaluationBadge({
   milestoneUID,
   className = "",
+  completionReason,
 }: MilestoneAIEvaluationBadgeProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { data, isLoading, error } = useMilestoneEvaluation(milestoneUID, true);
+  const hasCompletionContent = completionReason === undefined || completionReason.trim().length > 0;
+  const { data, isLoading, error } = useMilestoneEvaluation(milestoneUID, hasCompletionContent);
   const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
   const avgScore = useMemo(() => {
@@ -87,6 +96,10 @@ export function MilestoneAIEvaluationBadge({
       Math.round((evaluations.reduce((sum, e) => sum + e.rating, 0) / evaluations.length) * 10) / 10
     );
   }, [evaluations]);
+
+  if (!hasCompletionContent) {
+    return null;
+  }
 
   if (isLoading) {
     return (
@@ -255,6 +268,11 @@ interface ApplicationMilestoneAIEvaluationBadgeProps {
   referenceNumber: string;
   milestoneTitle: string;
   className?: string;
+  /**
+   * The application milestone completion's text. When provided and
+   * empty/whitespace, the badge skips fetching and renders nothing.
+   */
+  completionReason?: string;
 }
 
 /**
@@ -265,12 +283,14 @@ export function ApplicationMilestoneAIEvaluationBadge({
   referenceNumber,
   milestoneTitle,
   className = "",
+  completionReason,
 }: ApplicationMilestoneAIEvaluationBadgeProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const hasCompletionContent = completionReason === undefined || completionReason.trim().length > 0;
   const { data, isLoading, error } = useApplicationMilestoneEvaluation(
     referenceNumber,
     milestoneTitle,
-    true
+    hasCompletionContent
   );
   const evaluations = (data?.evaluations ?? []).filter(isValidEvaluation);
 
@@ -280,6 +300,10 @@ export function ApplicationMilestoneAIEvaluationBadge({
       Math.round((evaluations.reduce((sum, e) => sum + e.rating, 0) / evaluations.length) * 10) / 10
     );
   }, [evaluations]);
+
+  if (!hasCompletionContent) {
+    return null;
+  }
 
   if (isLoading) {
     return (

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -113,7 +113,10 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
               </span>
             )}
             {isCompleted && milestone.uid ? (
-              <MilestoneAIEvaluationBadge milestoneUID={milestone.uid} />
+              <MilestoneAIEvaluationBadge
+                milestoneUID={milestone.uid}
+                completionReason={milestone.details.completionReason}
+              />
             ) : null}
           </div>
 

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -112,7 +112,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
                 Due {formatDate(milestone.details.dueDate)}
               </span>
             )}
-            {isCompleted && milestone.uid ? (
+            {isCompleted && milestone.uid && milestone.details.completionReason ? (
               <MilestoneAIEvaluationBadge
                 milestoneUID={milestone.uid}
                 completionReason={milestone.details.completionReason}

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -536,7 +536,7 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
                   {completed ? "Completed" : "Pending"}
                 </Badge>
               )}
-              {completed && milestone.uid && (
+              {completed && milestone.uid && completionReason && (
                 <MilestoneAIEvaluationBadge
                   milestoneUID={milestone.uid}
                   completionReason={completionReason}

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -537,7 +537,10 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
                 </Badge>
               )}
               {completed && milestone.uid && (
-                <MilestoneAIEvaluationBadge milestoneUID={milestone.uid} />
+                <MilestoneAIEvaluationBadge
+                  milestoneUID={milestone.uid}
+                  completionReason={completionReason}
+                />
               )}
             </div>
           </div>

--- a/src/features/applications/components/MilestoneCompletionEditor.tsx
+++ b/src/features/applications/components/MilestoneCompletionEditor.tsx
@@ -421,11 +421,13 @@ export function MilestoneCompletionEditor({
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                           <p className="text-xs font-semibold">Completion Update</p>
-                          <ApplicationMilestoneAIEvaluationBadge
-                            referenceNumber={referenceNumber}
-                            milestoneTitle={milestone.title}
-                            completionReason={completion.completionText}
-                          />
+                          {completion.completionText ? (
+                            <ApplicationMilestoneAIEvaluationBadge
+                              referenceNumber={referenceNumber}
+                              milestoneTitle={milestone.title}
+                              completionReason={completion.completionText}
+                            />
+                          ) : null}
                         </div>
                         {canEdit && (
                           <Button size="icon-sm" onClick={() => handleStartEdit(milestone.title)}>

--- a/src/features/applications/components/MilestoneCompletionEditor.tsx
+++ b/src/features/applications/components/MilestoneCompletionEditor.tsx
@@ -424,6 +424,7 @@ export function MilestoneCompletionEditor({
                           <ApplicationMilestoneAIEvaluationBadge
                             referenceNumber={referenceNumber}
                             milestoneTitle={milestone.title}
+                            completionReason={completion.completionText}
                           />
                         </div>
                         {canEdit && (


### PR DESCRIPTION
## Summary
- hide milestone AI evaluation badges when the returned evaluation payload has no usable AI evaluation content
- keep badges visible only for evaluations with a numeric rating and non-empty reasoning
- add badge tests for both milestone and application milestone variants

## Testing
- pnpm exec biome check components/Milestone/MilestoneAIEvaluationBadge.tsx __tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
- CACHE_DIR=/tmp/storybook-cache STORYBOOK_DISABLE_TELEMETRY=1 pnpm exec vitest run --project unit __tests__/components/Milestone/MilestoneAIEvaluationBadge.test.tsx
- CACHE_DIR=/tmp/storybook-cache STORYBOOK_DISABLE_TELEMETRY=1 pnpm run test *(fails on existing unrelated repo-wide issues, including __tests__/navbar/integration/navigation-flow.test.tsx and many other pre-existing suite failures)*

Refs DEV-213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for AI evaluation badge components, including validation and rendering scenarios.

* **Bug Fixes**
  * Added validation to ensure AI evaluations contain valid ratings and reasoning before display.
  * Fixed conditional rendering of AI evaluation badges to require completion context and prevent invalid data display.
  * Improved component stability with more robust key management for list rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->