### PR TITLE
feat(projects): add milestones progress card to /projects landing page

### DIFF
--- a/__tests__/components/Pages/Projects/StatsSection.msw.test.tsx
+++ b/__tests__/components/Pages/Projects/StatsSection.msw.test.tsx
@@ -1,14 +1,16 @@
 /**
  * ProjectsStatsSection component tests using MSW for data fetching.
  *
- * Verifies loading, success, and error states for the global stats
- * displayed on the projects explorer page.
+ * Verifies loading, success, and error states for the stats displayed
+ * on the projects explorer page, including the milestones progress card.
+ * Covers both global mode and whitelabel (community-scoped) mode.
  */
 import { screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { installMswLifecycle, server } from "@/__tests__/msw/server";
 import { renderWithProviders } from "@/__tests__/utils/render";
 import { ProjectsStatsSection } from "@/components/Pages/Projects/StatsSection";
+import { WhitelabelProvider } from "@/utilities/whitelabel-context";
 
 vi.mock("next/image", () => ({
   __esModule: true,
@@ -20,6 +22,14 @@ vi.mock("next/image", () => ({
 
 const BASE = "http://localhost:4000";
 const GLOBAL_STATS_URL = `${BASE}/v2/communities/stats`;
+const COMMUNITY_STATS_URL = (slug: string) => `${BASE}/v2/communities/${slug}/stats`;
+
+const renderInWhitelabel = (slug: string) =>
+  renderWithProviders(
+    <WhitelabelProvider isWhitelabel={true} communitySlug={slug} config={null} tenantConfig={null}>
+      <ProjectsStatsSection />
+    </WhitelabelProvider>
+  );
 
 installMswLifecycle();
 
@@ -36,18 +46,16 @@ describe("ProjectsStatsSection", () => {
 
       const { container } = renderWithProviders(<ProjectsStatsSection />);
 
-      // While loading, stat values are "..."
       const dots = screen.getAllByText("...");
-      expect(dots.length).toBeGreaterThanOrEqual(4);
+      expect(dots.length).toBeGreaterThanOrEqual(5);
 
-      // Pulsing animation should be present
       const pulsing = container.querySelectorAll(".animate-pulse");
       expect(pulsing.length).toBeGreaterThan(0);
     });
   });
 
-  describe("success state", () => {
-    it("renders all four stat cards with formatted numbers", async () => {
+  describe("success state (global)", () => {
+    it("renders all five stat cards with formatted numbers", async () => {
       server.use(
         http.get(GLOBAL_STATS_URL, () => {
           return HttpResponse.json({
@@ -56,6 +64,8 @@ describe("ProjectsStatsSection", () => {
             activeCommunities: 45,
             activeBuilders: 2100,
             totalProjectUpdates: 5000,
+            totalMilestones: 137,
+            totalCompletedMilestones: 55,
           });
         })
       );
@@ -66,16 +76,40 @@ describe("ProjectsStatsSection", () => {
         expect(screen.getByText("1.5k+")).toBeInTheDocument();
       });
 
-      // Check all stat labels
       expect(screen.getByText("Total Projects")).toBeInTheDocument();
       expect(screen.getByText("Grants Tracked")).toBeInTheDocument();
       expect(screen.getByText("Active Communities")).toBeInTheDocument();
       expect(screen.getByText("Active Builders")).toBeInTheDocument();
+      expect(screen.getByText("Completed / Total Milestones")).toBeInTheDocument();
 
-      // Check formatted values
       expect(screen.getByText("320+")).toBeInTheDocument();
       expect(screen.getByText("45")).toBeInTheDocument();
       expect(screen.getByText("2.1k+")).toBeInTheDocument();
+      expect(screen.getByText("55 / 137")).toBeInTheDocument();
+      expect(screen.getByText("40.1%")).toBeInTheDocument();
+      expect(screen.getByText("59.9%")).toBeInTheDocument();
+    });
+
+    it("renders the progress bar with the correct accessible value", async () => {
+      server.use(
+        http.get(GLOBAL_STATS_URL, () => {
+          return HttpResponse.json({
+            totalProjects: 1,
+            totalGrants: 1,
+            activeCommunities: 1,
+            activeBuilders: 1,
+            totalProjectUpdates: 1,
+            totalMilestones: 200,
+            totalCompletedMilestones: 50,
+          });
+        })
+      );
+
+      renderWithProviders(<ProjectsStatsSection />);
+
+      await screen.findByText("50 / 200");
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAttribute("aria-valuenow", "25");
     });
 
     it("formats millions correctly", async () => {
@@ -87,6 +121,8 @@ describe("ProjectsStatsSection", () => {
             activeCommunities: 500,
             activeBuilders: 10000,
             totalProjectUpdates: 100,
+            totalMilestones: 0,
+            totalCompletedMilestones: 0,
           });
         })
       );
@@ -100,28 +136,68 @@ describe("ProjectsStatsSection", () => {
       expect(screen.getByText("1.0M+")).toBeInTheDocument();
     });
 
-    it("shows numbers under 1000 as-is", async () => {
+    it("shows zero milestones without dividing by zero", async () => {
       server.use(
         http.get(GLOBAL_STATS_URL, () => {
           return HttpResponse.json({
-            totalProjects: 42,
-            totalGrants: 10,
-            activeCommunities: 3,
-            activeBuilders: 99,
-            totalProjectUpdates: 50,
+            totalProjects: 1,
+            totalGrants: 1,
+            activeCommunities: 1,
+            activeBuilders: 1,
+            totalProjectUpdates: 1,
+            totalMilestones: 0,
+            totalCompletedMilestones: 0,
           });
         })
       );
 
       renderWithProviders(<ProjectsStatsSection />);
 
-      await waitFor(() => {
-        expect(screen.getByText("42+")).toBeInTheDocument();
-      });
+      expect(await screen.findByText("0 / 0")).toBeInTheDocument();
+      const percents = screen.getAllByText("0.0%");
+      expect(percents.length).toBe(2);
+    });
+  });
 
-      expect(screen.getByText("10+")).toBeInTheDocument();
-      expect(screen.getByText("3")).toBeInTheDocument();
-      expect(screen.getByText("99+")).toBeInTheDocument();
+  describe("success state (whitelabel)", () => {
+    it("uses community-scoped stats for milestones when on a whitelabel domain", async () => {
+      server.use(
+        http.get(GLOBAL_STATS_URL, () => {
+          return HttpResponse.json({
+            totalProjects: 1500,
+            totalGrants: 320,
+            activeCommunities: 45,
+            activeBuilders: 2100,
+            totalProjectUpdates: 5000,
+            totalMilestones: 9999,
+            totalCompletedMilestones: 9999,
+          });
+        }),
+        http.get(COMMUNITY_STATS_URL("filecoin"), () => {
+          return HttpResponse.json({
+            totalProjects: 50,
+            totalGrants: 25,
+            totalMilestones: 137,
+            projectUpdates: 200,
+            projectUpdatesBreakdown: {
+              projectMilestones: 80,
+              projectCompletedMilestones: 30,
+              projectUpdates: 40,
+              grantMilestones: 57,
+              grantCompletedMilestones: 25,
+              grantUpdates: 60,
+            },
+            totalTransactions: 0,
+            averageCompletion: 0,
+          });
+        })
+      );
+
+      renderInWhitelabel("filecoin");
+
+      expect(await screen.findByText("55 / 137")).toBeInTheDocument();
+      expect(screen.getByText("40.1%")).toBeInTheDocument();
+      expect(screen.getByText("59.9%")).toBeInTheDocument();
     });
   });
 
@@ -135,15 +211,10 @@ describe("ProjectsStatsSection", () => {
 
       renderWithProviders(<ProjectsStatsSection />);
 
-      // On error, stats stay undefined so we see "..." placeholders
-      // The component does not show an explicit error message;
-      // it just never replaces the "..." placeholders.
-      // We wait briefly and verify no real numbers appear.
       await waitFor(
         () => {
-          // Should still show dots (stats never populated)
           const dots = screen.getAllByText("...");
-          expect(dots.length).toBeGreaterThanOrEqual(4);
+          expect(dots.length).toBeGreaterThanOrEqual(5);
         },
         { timeout: 3000 }
       );
@@ -160,6 +231,8 @@ describe("ProjectsStatsSection", () => {
             activeCommunities: 1,
             activeBuilders: 1,
             totalProjectUpdates: 1,
+            totalMilestones: 1,
+            totalCompletedMilestones: 1,
           });
         })
       );

--- a/components/Pages/Projects/StatsSection.tsx
+++ b/components/Pages/Projects/StatsSection.tsx
@@ -4,13 +4,38 @@ import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
+import { useWhitelabel } from "@/utilities/whitelabel-context";
 
 interface GlobalStats {
   activeCommunities: number;
   totalProjectUpdates: number;
   totalProjects: number;
   totalGrants: number;
+  totalMilestones: number;
+  totalCompletedMilestones: number;
   activeBuilders: number;
+}
+
+interface CommunityStatsResponse {
+  totalProjects: number;
+  totalGrants: number;
+  totalMilestones: number;
+  projectUpdates: number;
+  projectUpdatesBreakdown: {
+    projectMilestones: number;
+    projectCompletedMilestones: number;
+    projectUpdates: number;
+    grantMilestones: number;
+    grantCompletedMilestones: number;
+    grantUpdates: number;
+  };
+  totalTransactions: number;
+  averageCompletion: number;
+}
+
+interface MilestoneTotals {
+  total: number;
+  completed: number;
 }
 
 const formatNumber = (num: number | undefined): string => {
@@ -20,43 +45,130 @@ const formatNumber = (num: number | undefined): string => {
   return num.toLocaleString();
 };
 
+const fetchGlobalStats = async (): Promise<GlobalStats> => {
+  const [response, error] = await fetchData(
+    INDEXER.COMMUNITY.GLOBAL_STATS(),
+    "GET",
+    {},
+    {},
+    {},
+    false
+  );
+  if (error || !response) {
+    throw new Error(error || "Failed to fetch stats");
+  }
+  return response as GlobalStats;
+};
+
+const fetchCommunityStats = async (slug: string): Promise<CommunityStatsResponse> => {
+  const [response, error] = await fetchData(
+    INDEXER.COMMUNITY.V2.STATS(slug),
+    "GET",
+    {},
+    {},
+    {},
+    false
+  );
+  if (error || !response) {
+    throw new Error(error || "Failed to fetch community stats");
+  }
+  return response as CommunityStatsResponse;
+};
+
+const MilestonesProgressCard = ({
+  milestones,
+  isLoading,
+}: {
+  milestones: MilestoneTotals | undefined;
+  isLoading: boolean;
+}) => {
+  const total = milestones?.total ?? 0;
+  const completed = milestones?.completed ?? 0;
+  const completedPct = total > 0 ? (completed / total) * 100 : 0;
+  const pendingPct = total > 0 ? 100 - completedPct : 0;
+
+  const valueLabel = milestones === undefined ? "..." : `${completed} / ${total}`;
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      <span
+        className={`text-4xl md:text-5xl font-bold text-teal-500 dark:text-teal-400 ${
+          isLoading ? "animate-pulse" : ""
+        }`}
+      >
+        {valueLabel}
+      </span>
+      <span className="text-gray-600 dark:text-gray-400 mt-2">Completed / Total Milestones</span>
+      <div
+        className="w-full max-w-[180px] mt-3 h-2 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-700 flex"
+        role="progressbar"
+        aria-valuenow={completedPct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${completedPct.toFixed(1)}% of milestones completed`}
+      >
+        <div
+          className="h-full bg-emerald-500 dark:bg-emerald-400 transition-all"
+          style={{ width: `${completedPct}%` }}
+        />
+      </div>
+      <div className="flex justify-between w-full max-w-[180px] mt-1.5 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+        <span>{completedPct.toFixed(1)}%</span>
+        <span>{pendingPct.toFixed(1)}%</span>
+      </div>
+    </div>
+  );
+};
+
 export const ProjectsStatsSection = () => {
-  const { data: stats, isLoading } = useQuery<GlobalStats>({
+  const { isWhitelabel, communitySlug } = useWhitelabel();
+
+  const { data: globalStats, isLoading: isLoadingGlobal } = useQuery<GlobalStats>({
     queryKey: ["projects-global-stats"],
-    queryFn: async () => {
-      const [response, error] = await fetchData(
-        INDEXER.COMMUNITY.GLOBAL_STATS(),
-        "GET",
-        {},
-        {},
-        {},
-        false
-      );
-
-      if (error || !response) {
-        throw new Error(error || "Failed to fetch stats");
-      }
-
-      return response as GlobalStats;
-    },
+    queryFn: fetchGlobalStats,
     staleTime: 5 * 60 * 1000,
   });
 
+  const { data: communityStats, isLoading: isLoadingCommunity } = useQuery<CommunityStatsResponse>({
+    queryKey: ["projects-community-stats", communitySlug],
+    queryFn: () => fetchCommunityStats(communitySlug as string),
+    enabled: Boolean(isWhitelabel && communitySlug),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const milestones: MilestoneTotals | undefined = (() => {
+    if (isWhitelabel && communitySlug) {
+      if (!communityStats) return undefined;
+      const breakdown = communityStats.projectUpdatesBreakdown;
+      return {
+        total: communityStats.totalMilestones,
+        completed: breakdown.projectCompletedMilestones + breakdown.grantCompletedMilestones,
+      };
+    }
+    if (!globalStats) return undefined;
+    return {
+      total: globalStats.totalMilestones,
+      completed: globalStats.totalCompletedMilestones,
+    };
+  })();
+
+  const isLoadingMilestones = isWhitelabel && communitySlug ? isLoadingCommunity : isLoadingGlobal;
+
   const displayStats = [
     {
-      value: stats ? `${formatNumber(stats.totalProjects)}+` : "...",
+      value: globalStats ? `${formatNumber(globalStats.totalProjects)}+` : "...",
       label: "Total Projects",
     },
     {
-      value: stats ? `${formatNumber(stats.totalGrants)}+` : "...",
+      value: globalStats ? `${formatNumber(globalStats.totalGrants)}+` : "...",
       label: "Grants Tracked",
     },
     {
-      value: stats ? formatNumber(stats.activeCommunities) : "...",
+      value: globalStats ? formatNumber(globalStats.activeCommunities) : "...",
       label: "Active Communities",
     },
     {
-      value: stats ? `${formatNumber(stats.activeBuilders)}+` : "...",
+      value: globalStats ? `${formatNumber(globalStats.activeBuilders)}+` : "...",
       label: "Active Builders",
     },
   ];
@@ -64,7 +176,6 @@ export const ProjectsStatsSection = () => {
   return (
     <section className="w-full py-16 px-4 bg-gradient-to-br from-teal-50/50 via-white to-blue-50/50 dark:from-zinc-900 dark:via-zinc-900 dark:to-zinc-900">
       <div className="max-w-7xl mx-auto text-center">
-        {/* Logo */}
         <div className="flex justify-center mb-4">
           <Image
             src="/logo/karma-logo.svg"
@@ -75,18 +186,16 @@ export const ProjectsStatsSection = () => {
           />
         </div>
 
-        {/* Title */}
         <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-12">
           Karma by the Numbers
         </h2>
 
-        {/* Stats Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-          {displayStats.map((stat, index) => (
-            <div key={index} className="flex flex-col items-center">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8">
+          {displayStats.map((stat) => (
+            <div key={stat.label} className="flex flex-col items-center">
               <span
                 className={`text-4xl md:text-5xl font-bold text-teal-500 dark:text-teal-400 ${
-                  isLoading ? "animate-pulse" : ""
+                  isLoadingGlobal ? "animate-pulse" : ""
                 }`}
               >
                 {stat.value}
@@ -94,6 +203,7 @@ export const ProjectsStatsSection = () => {
               <span className="text-gray-600 dark:text-gray-400 mt-2">{stat.label}</span>
             </div>
           ))}
+          <MilestonesProgressCard milestones={milestones} isLoading={isLoadingMilestones} />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Adds a fifth stat card to `/projects` showing completed/total milestones with a two-segment progress bar (green completed, gray pending) and percentage labels
- On whitelabel domains the card uses community-scoped `/v2/communities/:slug/stats` so each tenant sees its own milestone totals; the marketing site uses the global stats endpoint
- Accessible progressbar with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and a descriptive `aria-label`

## Test plan
- [x] `pnpm test __tests__/components/Pages/Projects/StatsSection.msw.test.tsx` — 8/8 passing (loading, global success, a11y, formatting, zero edge case, whitelabel scoping, error, structure)
- [x] Biome lint clean
- [ ] Verify rendering on `app.filpgf.io/projects` after backend PR merges and deploys

Depends on backend PR: show-karma/gap-indexer#1505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added milestones progress card displaying completion percentage and totals in the project stats section
  * Enhanced community-specific metrics visibility in whitelabel mode

* **Improvements**
  * Optimized stats grid layout for better content organization
  * Refined loading and error state handling for milestone data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->