### PR TITLE
feat(community): add completed/total milestones stat card

### DIFF
--- a/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
+++ b/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
@@ -65,9 +65,16 @@ describe("CommunityStatCards", () => {
           return HttpResponse.json({
             totalProjects: 25,
             totalGrants: 50,
-            totalMilestones: 100,
+            totalMilestones: 137,
             projectUpdates: 75,
-            projectUpdatesBreakdown: null,
+            projectUpdatesBreakdown: {
+              projectMilestones: 80,
+              projectCompletedMilestones: 30,
+              projectUpdates: 40,
+              grantMilestones: 57,
+              grantCompletedMilestones: 25,
+              grantUpdates: 60,
+            },
           });
         })
       );
@@ -83,6 +90,42 @@ describe("CommunityStatCards", () => {
       expect(screen.getByText("Total Projects")).toBeInTheDocument();
       expect(screen.getByText("Project Updates")).toBeInTheDocument();
       expect(screen.getByText("75")).toBeInTheDocument();
+
+      // Milestones card: completed = 30 + 25 = 55, total = 137
+      expect(screen.getByText("55 / 137")).toBeInTheDocument();
+      expect(screen.getByText("Completed / Total Milestones")).toBeInTheDocument();
+      expect(screen.getByText("40.1%")).toBeInTheDocument();
+      expect(screen.getByText("59.9%")).toBeInTheDocument();
+
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAttribute("aria-valuenow", String((55 / 137) * 100));
+    });
+
+    it("renders 0 / 0 milestones without dividing by zero", async () => {
+      server.use(
+        http.get(`${BASE}/v2/communities/:slug/stats`, () => {
+          return HttpResponse.json({
+            totalProjects: 1,
+            totalGrants: 1,
+            totalMilestones: 0,
+            projectUpdates: 1,
+            projectUpdatesBreakdown: {
+              projectMilestones: 0,
+              projectCompletedMilestones: 0,
+              projectUpdates: 0,
+              grantMilestones: 0,
+              grantCompletedMilestones: 0,
+              grantUpdates: 0,
+            },
+          });
+        })
+      );
+
+      renderWithProviders(<CommunityStatCards />);
+
+      expect(await screen.findByText("0 / 0")).toBeInTheDocument();
+      const percents = screen.getAllByText("0.0%");
+      expect(percents.length).toBe(2);
     });
 
     it("renders dash when values are zero or falsy", async () => {

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -58,19 +58,19 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
       <div className="py-3 pl-3">
         <div className="w-1 h-full rounded-full bg-emerald-500" />
       </div>
-      <div className="flex flex-col items-start justify-center py-3 pl-2 pr-4 w-full min-w-[160px]">
+      <div className="flex flex-col items-start justify-center py-2 pl-2 pr-3 w-full min-w-[180px]">
         {isLoading ? (
-          <Skeleton className="w-20 h-8 mb-1" />
+          <Skeleton className="w-20 h-8" />
         ) : (
-          <p className="text-gray-900 dark:text-zinc-100 text-[30px] font-semibold leading-none tracking-tight tabular-nums">
+          <p className="text-gray-900 dark:text-zinc-100 text-[30px] font-semibold leading-none tracking-tight tabular-nums whitespace-nowrap">
             {completed} / {total}
           </p>
         )}
-        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-normal mt-1">
+        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-tight whitespace-nowrap">
           Completed / Total Milestones
         </span>
         <div
-          className="w-full mt-2 h-1.5 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-700"
+          className="w-full mt-1.5 h-1.5 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-700"
           role="progressbar"
           aria-valuenow={completedPct}
           aria-valuemin={0}
@@ -82,7 +82,7 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
             style={{ width: `${completedPct}%` }}
           />
         </div>
-        <div className="flex justify-between w-full mt-1 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+        <div className="flex justify-between w-full mt-0.5 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
           <span>{completedPct.toFixed(1)}%</span>
           <span>{pendingPct.toFixed(1)}%</span>
         </div>

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -48,7 +48,8 @@ interface MilestonesCardProps {
 }
 
 const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) => {
-  const completedPct = total > 0 ? (completed / total) * 100 : 0;
+  const safeCompleted = Math.max(0, Math.min(completed, total));
+  const completedPct = total > 0 ? (safeCompleted / total) * 100 : 0;
   const pendingPct = total > 0 ? 100 - completedPct : 0;
 
   return (

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -43,6 +43,54 @@ const StatCard = ({ title, value, color, isLoading, tooltip }: StatCardProps) =>
   </div>
 );
 
+interface MilestonesCardProps {
+  completed: number;
+  total: number;
+  isLoading?: boolean;
+}
+
+const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) => {
+  const completedPct = total > 0 ? (completed / total) * 100 : 0;
+  const pendingPct = total > 0 ? 100 - completedPct : 0;
+
+  return (
+    <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
+      <div className="py-3 pl-3">
+        <div className="w-1 h-full rounded-full bg-emerald-500" />
+      </div>
+      <div className="flex flex-col items-start justify-center py-3 pl-2 pr-4 w-full min-w-[160px]">
+        {isLoading ? (
+          <Skeleton className="w-20 h-8 mb-1" />
+        ) : (
+          <p className="text-gray-900 dark:text-zinc-100 text-[30px] font-semibold leading-none tracking-tight tabular-nums">
+            {completed} / {total}
+          </p>
+        )}
+        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-normal mt-1">
+          Completed / Total Milestones
+        </span>
+        <div
+          className="w-full mt-2 h-1.5 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-700"
+          role="progressbar"
+          aria-valuenow={completedPct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${completedPct.toFixed(1)}% of milestones completed`}
+        >
+          <div
+            className="h-full bg-emerald-500 dark:bg-emerald-400 transition-all"
+            style={{ width: `${completedPct}%` }}
+          />
+        </div>
+        <div className="flex justify-between w-full mt-1 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+          <span>{completedPct.toFixed(1)}%</span>
+          <span>{pendingPct.toFixed(1)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const ImpactStatCards = () => {
   const { data, isLoading } = useImpactMeasurement();
 
@@ -176,16 +224,31 @@ export const CommunityStatCards = () => {
     [programId, stats]
   );
 
-  return filteredStats.map((item) => (
-    <StatCard
-      key={item.title}
-      title={item.title}
-      value={item.displayValue}
-      color={item.color}
-      isLoading={isLoading || item.showLoading}
-      tooltip={item.tooltip}
-    />
-  ));
+  const breakdown = data?.projectUpdatesBreakdown;
+  const completedMilestones = breakdown
+    ? breakdown.projectCompletedMilestones + breakdown.grantCompletedMilestones
+    : 0;
+  const totalMilestones = data?.totalMilestones ?? 0;
+
+  return (
+    <>
+      {filteredStats.map((item) => (
+        <StatCard
+          key={item.title}
+          title={item.title}
+          value={item.displayValue}
+          color={item.color}
+          isLoading={isLoading || item.showLoading}
+          tooltip={item.tooltip}
+        />
+      ))}
+      <MilestonesCard
+        completed={completedMilestones}
+        total={totalMilestones}
+        isLoading={isLoading || isLoadingFilters}
+      />
+    </>
+  );
 };
 
 export const CommunityImpactStatCards = () => {

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -52,9 +52,9 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
   const pendingPct = total > 0 ? 100 - completedPct : 0;
 
   return (
-    <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
+    <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 max-sm:col-span-2 min-w-0">
       <div className="w-1 my-1.5 ml-3 rounded-full bg-emerald-500" />
-      <div className="flex flex-col items-start justify-center py-3 pl-2 pr-3 w-full min-w-[180px]">
+      <div className="flex flex-col items-start justify-center py-3 pl-2 pr-3 w-full min-w-0">
         {isLoading ? (
           <Skeleton className="w-20 h-8" />
         ) : (
@@ -62,7 +62,7 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
             {completed} / {total}
           </p>
         )}
-        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-tight whitespace-nowrap">
+        <span className="text-gray-900 dark:text-zinc-100 text-sm font-medium leading-tight">
           Completed / Total Milestones
         </span>
         <div

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -20,9 +20,7 @@ interface StatCardProps {
 
 const StatCard = ({ title, value, color, isLoading, tooltip }: StatCardProps) => (
   <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
-    <div className="py-1.5 pl-3">
-      <div className="w-1 h-full rounded-full" style={{ background: color }} />
-    </div>
+    <div className="w-1 my-1.5 ml-3 rounded-full" style={{ background: color }} />
     <div className="flex flex-col items-start justify-center py-3 pl-2 pr-4">
       {isLoading ? (
         <Skeleton className="w-12 h-8 mb-1" />
@@ -55,9 +53,7 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
 
   return (
     <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
-      <div className="py-1.5 pl-3">
-        <div className="w-1 h-full rounded-full bg-emerald-500" />
-      </div>
+      <div className="w-1 my-1.5 ml-3 rounded-full bg-emerald-500" />
       <div className="flex flex-col items-start justify-center py-3 pl-2 pr-3 w-full min-w-[180px]">
         {isLoading ? (
           <Skeleton className="w-20 h-8" />

--- a/components/Pages/Communities/Impact/StatCards.tsx
+++ b/components/Pages/Communities/Impact/StatCards.tsx
@@ -20,7 +20,7 @@ interface StatCardProps {
 
 const StatCard = ({ title, value, color, isLoading, tooltip }: StatCardProps) => (
   <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
-    <div className="py-3 pl-3">
+    <div className="py-1.5 pl-3">
       <div className="w-1 h-full rounded-full" style={{ background: color }} />
     </div>
     <div className="flex flex-col items-start justify-center py-3 pl-2 pr-4">
@@ -55,10 +55,10 @@ const MilestonesCard = ({ completed, total, isLoading }: MilestonesCardProps) =>
 
   return (
     <div className="flex flex-1 rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
-      <div className="py-3 pl-3">
+      <div className="py-1.5 pl-3">
         <div className="w-1 h-full rounded-full bg-emerald-500" />
       </div>
-      <div className="flex flex-col items-start justify-center py-2 pl-2 pr-3 w-full min-w-[180px]">
+      <div className="flex flex-col items-start justify-center py-3 pl-2 pr-3 w-full min-w-[180px]">
         {isLoading ? (
           <Skeleton className="w-20 h-8" />
         ) : (


### PR DESCRIPTION
## Summary
- Adds a fourth stat card to the community header (`/community/:communityId/projects` and other community pages) showing **Completed / Total Milestones** with a green progress bar and percentage labels (e.g. `26 / 197` → `13.2% / 86.8%`)
- Sources data from the existing `GET /v2/communities/:slug/stats` response — `totalMilestones` for the denominator and `projectUpdatesBreakdown.{project,grant}CompletedMilestones` summed for the numerator. **No backend change required**.
- Card matches the existing `StatCard` shell (border, colored bar, value + label) so it lays out alongside Total Projects / Total Grants / Project Updates without disrupting the row.

## Screenshots / numbers
QA against staging data on `filecoin`:
- API: `totalMilestones=197`, completed = `0 + 26 = 26`
- Card renders: `26 / 197`, progressbar `aria-valuenow=13.198`, `aria-label="13.2% of milestones completed"`, labels `13.2% / 86.8%`

## Test plan
- [x] `pnpm test __tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx` — 7/7 passing (success with breakdown, zero-state divide-by-zero guard, progressbar a11y, programId filter, error)
- [x] Browser QA: `/community/filecoin/projects` against staging data
- [ ] Verify on `app.filpgf.io/community/filecoin/projects` (whitelabel) after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Milestones Card to the Communities Impact view, displaying completed and total milestones with a progress bar and percentage breakdown.

* **Tests**
  * Enhanced milestone card tests to verify completed/total counts, percentage values, and progress bar attributes.
  * Added test coverage for the zero-milestones scenario to ensure proper UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->