### PR TITLE
feat(funding-platform): use indexer-resolved Karma project name as title fallback

### DIFF
--- a/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
+++ b/components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts
@@ -76,6 +76,22 @@ describe("getProjectTitle", () => {
     });
     expect(getProjectTitle(app)).toBe("Fallback Pod");
   });
+
+  it("prefers server-resolved project name over form-data and referenceNumber", () => {
+    const app = {
+      ...makeApplication({ "Some Field": "value" }),
+      resolvedProjectName: "Titan Network",
+    };
+    expect(getProjectTitle(app)).toBe("Titan Network");
+  });
+
+  it("falls back to form-data when resolvedProjectName is whitespace-only", () => {
+    const app = {
+      ...makeApplication({ "Project Title": "Form Title" }),
+      resolvedProjectName: "   ",
+    };
+    expect(getProjectTitle(app)).toBe("Form Title");
+  });
 });
 
 describe("findProjectTitleInData", () => {

--- a/components/FundingPlatform/helper/getProjectTitle.ts
+++ b/components/FundingPlatform/helper/getProjectTitle.ts
@@ -1,6 +1,7 @@
 interface ApplicationWithData {
   applicationData: Record<string, unknown>;
   referenceNumber: string;
+  resolvedProjectName?: string;
 }
 
 // Title/name fields are short labels (e.g. "Project Title", "Pod Name"),
@@ -57,5 +58,7 @@ export const findProjectTitleInData = (
 };
 
 export const getProjectTitle = (application: ApplicationWithData): string => {
+  const resolved = application.resolvedProjectName?.trim();
+  if (resolved) return resolved;
   return findProjectTitleInData(application.applicationData) ?? application.referenceNumber;
 };

--- a/types/whitelabel-entities.ts
+++ b/types/whitelabel-entities.ts
@@ -250,6 +250,7 @@ export interface Application {
   communitySlug?: string;
   communityName?: string;
   communityImage?: string;
+  resolvedProjectName?: string;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary

- Adds `resolvedProjectName?: string` to the `Application` type (mirrors the field already enriched by the indexer in `getByProgramWithOptionalAuth`).
- Updates `getProjectTitle` to prefer `resolvedProjectName` over form-data lookups before falling back to the reference number.
- New tests cover the precedence and a whitespace-only fallthrough.

## Why

On `/browse-applications?programId=1013` we were exposing reference numbers like `APP-XWN3ROD8-Z5CL09` when the form schema lacked a project-title field. Many of those applications are already linked to Karma projects (e.g. "Titan Network") and the indexer batches that lookup server-side via `attachResolvedProjectNames` — we just weren't consuming it on the FE.

## Title resolution order (after this PR)

1. `application.resolvedProjectName` (server-side enrichment from linked Karma project)
2. Form-data title field via `findProjectTitleInData`
3. `application.referenceNumber`

## Architecture note

Per project guidelines, no business logic was added on the FE — the resolution logic stays in the indexer (`application-project-name.service.ts`). This PR is a pure consumer hookup.

## Test plan

- [x] `pnpm vitest run components/FundingPlatform/helper/__tests__/getProjectTitle.test.ts` — 18/18 pass
- [ ] Smoke test `/browse-applications?programId=1013` post-deploy: verify cards now show "Titan Network" instead of `APP-…`