### PR TITLE
fix(project-updates): trust server-stamped grant milestone ordinal

### DIFF
--- a/__tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts
+++ b/__tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts
@@ -120,6 +120,31 @@ describe("assignGrantMilestoneOrder", () => {
     expect(result).not.toBe(input);
   });
 
+  it("preserves existing grantMilestoneOrder when already stamped (e.g. server-provided)", () => {
+    // Server stamps order before filtering; recomputing locally on a filtered
+    // subset would produce a wrong total (e.g. "1 of 1" instead of "2 of 4").
+    const filtered = createGrantMilestone("a", "grant-1", { endsAt: 2000 });
+    filtered.grantMilestoneOrder = { index: 2, total: 4 };
+
+    const result = assignGrantMilestoneOrder([filtered]);
+
+    expect(result[0].grantMilestoneOrder).toEqual({ index: 2, total: 4 });
+  });
+
+  it("only computes order for milestones missing it, leaving stamped ones alone", () => {
+    const stamped = createGrantMilestone("a", "grant-1", { endsAt: 1000 });
+    stamped.grantMilestoneOrder = { index: 3, total: 5 };
+    const unstamped1 = createGrantMilestone("b", "grant-2", { endsAt: 1000 });
+    const unstamped2 = createGrantMilestone("c", "grant-2", { endsAt: 2000 });
+
+    const result = assignGrantMilestoneOrder([stamped, unstamped1, unstamped2]);
+    const byUid = Object.fromEntries(result.map((m) => [m.uid, m.grantMilestoneOrder]));
+
+    expect(byUid.a).toEqual({ index: 3, total: 5 });
+    expect(byUid.b).toEqual({ index: 1, total: 2 });
+    expect(byUid.c).toEqual({ index: 2, total: 2 });
+  });
+
   it("breaks ties deterministically by uid", () => {
     const a = createGrantMilestone("zzz", "grant-1", { endsAt: 1000 });
     const b = createGrantMilestone("aaa", "grant-1", { endsAt: 1000 });

--- a/hooks/v2/__tests__/useProjectUpdates.test.tsx
+++ b/hooks/v2/__tests__/useProjectUpdates.test.tsx
@@ -252,6 +252,106 @@ describe("useProjectUpdates", () => {
     });
   });
 
+  it("uses server-provided grantMilestoneIndex/Total for the per-grant ordinal", async () => {
+    // Server stamps the per-grant ordinal BEFORE applying status/date/AI filters,
+    // so a single milestone returned under `?milestoneStatus=verified` still
+    // reports its true position within the FULL grant (e.g. "2 of 4"), not
+    // "1 of 1" as a client-side recompute on the filtered subset would yield.
+    const response: UpdatesApiResponse = {
+      projectUpdates: [],
+      projectMilestones: [],
+      grantMilestones: [
+        {
+          uid: "verified-only-milestone",
+          programId: "program-1",
+          chainId: "0xa",
+          title: "Virtual appliance",
+          description: "Verified milestone",
+          dueDate: null,
+          createdAt: "2025-01-01T00:00:00.000Z",
+          recipient: "0x123",
+          status: "verified",
+          grant: {
+            uid: "grant-1",
+            title: "Grant 1",
+            communityName: "Community",
+          },
+          completionDetails: {
+            description: "Done",
+            completedAt: "2025-01-02T00:00:00.000Z",
+            completedBy: "0x123",
+          },
+          verificationDetails: null,
+          fundingApplicationCompletion: null,
+          grantMilestoneIndex: 2,
+          grantMilestoneTotal: 4,
+        },
+      ],
+      grantUpdates: [],
+    };
+
+    mockGetProjectUpdates.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useProjectUpdates("test-project", "verified"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const milestone = result.current.milestones.find(
+      (item) => item.uid === "verified-only-milestone"
+    );
+
+    expect(milestone?.grantMilestoneOrder).toEqual({ index: 2, total: 4 });
+  });
+
+  it("falls back to client-computed ordinal when server omits grantMilestoneIndex/Total", async () => {
+    // Backwards compatibility: if the indexer hasn't shipped the new fields yet,
+    // the frontend still computes a per-grant ordinal locally.
+    const response: UpdatesApiResponse = {
+      projectUpdates: [],
+      projectMilestones: [],
+      grantMilestones: [
+        {
+          uid: "legacy-milestone",
+          programId: "program-1",
+          chainId: "0xa",
+          title: "Legacy milestone",
+          description: "No server ordinal",
+          dueDate: "2025-06-01T00:00:00.000Z",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          recipient: "0x123",
+          status: "completed",
+          grant: {
+            uid: "grant-legacy",
+            title: "Legacy Grant",
+            communityName: "Community",
+          },
+          completionDetails: null,
+          verificationDetails: null,
+          fundingApplicationCompletion: null,
+        },
+      ],
+      grantUpdates: [],
+    };
+
+    mockGetProjectUpdates.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useProjectUpdates("test-project"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const milestone = result.current.milestones.find((item) => item.uid === "legacy-milestone");
+
+    expect(milestone?.grantMilestoneOrder).toEqual({ index: 1, total: 1 });
+  });
+
   it("exposes isFetching as true during a filter transition and retains previous milestones", async () => {
     const firstResponse: UpdatesApiResponse = {
       projectUpdates: [],

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -150,6 +150,16 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
     // Use grant info directly from API response
     const grantInfo = milestone.grant;
 
+    // Use the per-grant ordinal computed server-side. The backend stamps these
+    // BEFORE applying any status/date/AI filter, so the badge reflects the
+    // milestone's position within the FULL grant — not within the filtered
+    // subset, which would otherwise produce misleading totals (e.g. "1 of 1"
+    // when filtering by verified instead of the true "2 of 4").
+    const serverOrder =
+      milestone.grantMilestoneIndex != null && milestone.grantMilestoneTotal != null
+        ? { index: milestone.grantMilestoneIndex, total: milestone.grantMilestoneTotal }
+        : undefined;
+
     unified.push({
       uid: milestone.uid,
       chainID,
@@ -157,6 +167,7 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
       type: "grant",
       title: milestone.title,
       description: milestone.description,
+      grantMilestoneOrder: serverOrder,
       completed: isCompleted
         ? {
             createdAt:

--- a/types/v2/roadmap.ts
+++ b/types/v2/roadmap.ts
@@ -125,6 +125,13 @@ export type GrantMilestoneWithDetails = {
     receivedAt: string | null;
     fileKey: string | null;
   } | null;
+  /**
+   * 1-based position of this milestone within its parent grant, computed by
+   * the backend across ALL of the grant's milestones (independent of any
+   * active status / date / AI filter). Paired with `grantMilestoneTotal`.
+   */
+  grantMilestoneIndex?: number;
+  grantMilestoneTotal?: number;
 };
 
 export type GrantUpdateWithDetails = {

--- a/utilities/milestones/assignGrantMilestoneOrder.ts
+++ b/utilities/milestones/assignGrantMilestoneOrder.ts
@@ -34,11 +34,16 @@ export function buildGrantMilestoneOrderMap<T extends OrderableMilestone>(
 }
 
 /**
- * Assigns a stable per-grant ordinal (1..N) to every grant milestone.
+ * Assigns a stable per-grant ordinal (1..N) to every grant milestone that does
+ * not already carry one.
  *
  * Milestones are grouped by their parent grant UID, sorted ascending by due date
  * (`endsAt`) with `createdAt` as fallback, then stamped with `grantMilestoneOrder`.
  * Non-grant items (project milestones, updates, impacts, etc.) pass through unchanged.
+ *
+ * Milestones that already have `grantMilestoneOrder` set (e.g. stamped by the
+ * server before status/date/AI filtering) are preserved as-is — recomputing
+ * locally on a filtered subset would yield an incorrect total.
  *
  * The original array is not mutated; a new array of new objects is returned.
  */
@@ -47,6 +52,7 @@ export function assignGrantMilestoneOrder(milestones: UnifiedMilestone[]): Unifi
 
   milestones.forEach((milestone) => {
     if (milestone.type !== "grant") return;
+    if (milestone.grantMilestoneOrder) return;
     const grantUID = milestone.source.grantMilestone?.grant.uid;
     if (!grantUID) return;
     const list = grouped.get(grantUID);
@@ -67,6 +73,7 @@ export function assignGrantMilestoneOrder(milestones: UnifiedMilestone[]): Unifi
   });
 
   return milestones.map((milestone) => {
+    if (milestone.grantMilestoneOrder) return milestone;
     const order = orderByMilestoneUID.get(milestone.uid);
     if (!order) return milestone;
     return { ...milestone, grantMilestoneOrder: order };


### PR DESCRIPTION
## Summary

Companion to show-karma/gap-indexer#1527. The per-grant "X of Y" badge on grant milestones was being recomputed client-side after the indexer had already filtered the response by `milestoneStatus` (or date / AI score), so a verified-only filter could show "1 of 1" instead of the true "1 of 4".

This PR makes the frontend prefer the server-stamped `grantMilestoneIndex`/`grantMilestoneTotal` (computed pre-filter) and only falls back to the existing client compute when those fields are absent — keeping graceful degradation during deployment skew.

## Changes

- `types/v2/roadmap.ts`: add `grantMilestoneIndex`/`grantMilestoneTotal` to `GrantMilestoneWithDetails`.
- `hooks/v2/useProjectUpdates.ts`: in `convertToUnifiedMilestones`, use the server-provided values for `grantMilestoneOrder` when both are non-null.
- `utilities/milestones/assignGrantMilestoneOrder.ts`: skip recompute for milestones that already carry `grantMilestoneOrder` (preserves server stamping; recomputing on a filtered subset would yield wrong totals).
- Tests: 2 hook-level cases (server values flow through; legacy fallback works) + 2 utility cases (preserves stamped order; mixes stamped/unstamped correctly).

## Test plan

- [x] `pnpm test hooks/v2/__tests__/useProjectUpdates.test.tsx` — 9 pass
- [x] `pnpm test __tests__/utilities/milestones/assignGrantMilestoneOrder.test.ts` — 12 pass
- [ ] After both PRs deploy: re-check https://app.filpgf.io/project/cidgravity-filecoin-gateway?filter=milestones&milestoneStatus=verified — "Virtual appliance" should show "1 of 4" (matching the `completed` filter view)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Milestone numbering now uses server-provided ordinal data, ensuring badge totals accurately reflect full grant context even when views are filtered.
  * Preserved pre-existing milestone order values to prevent recalculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->