### PR TITLE
fix(adapter): use exact completed milestone count from API

### DIFF
--- a/__tests__/contracts/contracts/__tests__/schemas.test.ts
+++ b/__tests__/contracts/contracts/__tests__/schemas.test.ts
@@ -346,6 +346,7 @@ describe("community schemas", () => {
       endorsements: [],
       contractAddresses: [],
       numMilestones: 5,
+      numCompletedMilestones: 3,
       numUpdates: 10,
       percentCompleted: 60,
       numTransactions: 25,

--- a/__tests__/contracts/contracts/schemas/community.schema.ts
+++ b/__tests__/contracts/contracts/schemas/community.schema.ts
@@ -65,6 +65,7 @@ export const communityProjectSchema = z.object({
   contractAddresses: z.array(z.string()),
   chainPayoutAddress: z.record(z.string(), z.string()).optional(),
   numMilestones: z.number(),
+  numCompletedMilestones: z.number(),
   numUpdates: z.number(),
   percentCompleted: z.number(),
   numTransactions: z.number(),

--- a/__tests__/unit/utilities/adapters/v2/projectToGrant.test.ts
+++ b/__tests__/unit/utilities/adapters/v2/projectToGrant.test.ts
@@ -1,0 +1,87 @@
+import type { CommunityProject } from "@/types/v2/community";
+import { projectToGrant } from "@/utilities/adapters/v2/projectToGrant";
+
+const baseProject: CommunityProject = {
+  uid: "project-uid",
+  details: {
+    title: "Test Project",
+    description: "",
+    logoUrl: "",
+    slug: "test-project",
+  },
+  grantNames: ["Grant"],
+  funding: [],
+  categories: [],
+  regions: [],
+  members: [],
+  links: [],
+  endorsements: [],
+  contractAddresses: [],
+  numMilestones: 0,
+  numCompletedMilestones: 0,
+  numUpdates: 0,
+  percentCompleted: 0,
+  numTransactions: 0,
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+describe("projectToGrant", () => {
+  it("should_mark_first_n_milestones_as_completed_when_numCompletedMilestones_is_set", () => {
+    const grant = projectToGrant({
+      ...baseProject,
+      numMilestones: 7,
+      numCompletedMilestones: 4,
+      percentCompleted: 57,
+    });
+
+    const completedCount = grant.milestones.filter((m) => m.completed).length;
+    expect(grant.milestones).toHaveLength(7);
+    expect(completedCount).toBe(4);
+  });
+
+  it("should_not_lose_count_when_ratio_rounds_to_imprecise_percent", () => {
+    // Regression: 4/7 = 57.14% which previously round-tripped through
+    // Math.floor(percentCompleted/100 * total) and yielded 3.
+    const grant = projectToGrant({
+      ...baseProject,
+      numMilestones: 7,
+      numCompletedMilestones: 4,
+      percentCompleted: 57,
+    });
+
+    expect(grant.milestones.filter((m) => m.completed).length).toBe(4);
+  });
+
+  it("should_return_zero_completed_when_numCompletedMilestones_is_zero", () => {
+    const grant = projectToGrant({
+      ...baseProject,
+      numMilestones: 5,
+      numCompletedMilestones: 0,
+      percentCompleted: 0,
+    });
+
+    expect(grant.milestones.filter((m) => m.completed).length).toBe(0);
+  });
+
+  it("should_return_all_completed_when_numCompletedMilestones_equals_total", () => {
+    const grant = projectToGrant({
+      ...baseProject,
+      numMilestones: 3,
+      numCompletedMilestones: 3,
+      percentCompleted: 100,
+    });
+
+    expect(grant.milestones.filter((m) => m.completed).length).toBe(3);
+  });
+
+  it("should_return_empty_milestones_when_numMilestones_is_zero", () => {
+    const grant = projectToGrant({
+      ...baseProject,
+      numMilestones: 0,
+      numCompletedMilestones: 0,
+      percentCompleted: 0,
+    });
+
+    expect(grant.milestones).toHaveLength(0);
+  });
+});

--- a/types/v2/community.ts
+++ b/types/v2/community.ts
@@ -60,6 +60,7 @@ export interface CommunityProject {
   /** Chain-specific payout addresses keyed by chain ID (e.g., { "10": "0x...", "42161": "0x..." }) */
   chainPayoutAddress?: Record<string, string>;
   numMilestones: number;
+  numCompletedMilestones: number;
   numUpdates: number;
   percentCompleted: number;
   numTransactions: number;

--- a/utilities/adapters/v2/projectToGrant.ts
+++ b/utilities/adapters/v2/projectToGrant.ts
@@ -42,7 +42,7 @@ export const projectToGrant = (project: CommunityProject): Grant => {
     })),
     milestones: Array.from({ length: project.numMilestones }, (_, index) => ({
       uid: `milestone-${index}`,
-      completed: index < Math.floor((project.percentCompleted / 100) * project.numMilestones),
+      completed: index < project.numCompletedMilestones,
       createdAt: project.createdAt,
       title: `Milestone ${index + 1}`,
       description: "",


### PR DESCRIPTION
## Summary

`projectToGrant()` rebuilt each milestone's `completed` flag from the rounded `percentCompleted` integer with `Math.floor((percent/100) * numMilestones)`. That round-trip is lossy: for **4 of 7** milestones it produced `3`, so the program-page card (`/projects?programId=...`) showed `3/7` while the project-page milestone tab (`/project/[slug]?filter=milestones&milestoneStatus=completed`) showed `4`.

This PR consumes the new `numCompletedMilestones` field from the indexer API and uses it directly — no more re-quantizing on the client.

### Depends on
- show-karma/gap-indexer#1529 — must merge and deploy first; this PR's contract test asserts the new field is present.

### Changes
- `types/v2/community.ts` — add `numCompletedMilestones: number` to `CommunityProject`
- `utilities/adapters/v2/projectToGrant.ts` — replace `Math.floor((percentCompleted/100) * numMilestones)` with `index < project.numCompletedMilestones`
- `__tests__/contracts/contracts/schemas/community.schema.ts` + matching test fixture — extend contract schema with the new field
- `__tests__/unit/utilities/adapters/v2/projectToGrant.test.ts` — new test file with 5 cases including the 4/7 regression

### Test plan
- [x] `pnpm test:unit __tests__/unit/utilities/adapters/v2/projectToGrant.test.ts` — 5 new tests pass
- [x] Contract schema test passes with the new field
- [x] `pnpm exec biome check` clean on all touched files
- [ ] After backend deploy: visit `/projects?programId=1013` and confirm CIDGravity Filecoin Gateway shows `4/7`
- [ ] Confirm `/project/cidgravity-filecoin-gateway?filter=milestones&milestoneStatus=completed` still shows `4`

### Backend companion PR
- show-karma/gap-indexer#1529