### PR TITLE
feat(reports): display resolved team name in milestones-report and control center

### DIFF
--- a/__tests__/components/Pages/Admin/ControlCenter/useControlCenterData.test.tsx
+++ b/__tests__/components/Pages/Admin/ControlCenter/useControlCenterData.test.tsx
@@ -1,0 +1,133 @@
+import { renderHookWithProviders } from "@/__tests__/utils/render";
+import { useControlCenterData } from "@/components/Pages/Admin/ControlCenter/useControlCenterData";
+
+vi.mock("@/hooks/communities/useCommunityDetails", () => ({
+  useCommunityDetails: () => ({
+    data: { uid: "0xCommunity", details: { slug: "test" } },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/communities/useCommunityAdminAccess", () => ({
+  useCommunityAdminAccess: () => ({ hasAccess: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useKycStatus", () => ({
+  useKycConfig: () => ({ isEnabled: false }),
+  useKycBatchStatuses: () => ({ statuses: new Map(), isLoading: false }),
+}));
+
+const mockUseCommunityPayouts = vi.fn();
+vi.mock("@/src/features/payout-disbursement", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/src/features/payout-disbursement")
+  >("@/src/features/payout-disbursement");
+  return {
+    ...actual,
+    useCommunityPayouts: (...args: unknown[]) => mockUseCommunityPayouts(...args),
+    usePayoutConfigsByCommunity: () => ({ data: [] }),
+  };
+});
+
+function makePayoutPayload(
+  resolvedProjectName: string | undefined,
+  title: string
+) {
+  return {
+    payload: [
+      {
+        project: {
+          uid: "0xProject",
+          title,
+          slug: "project-slug",
+          chainID: 10,
+          payoutAddress: null,
+          chainPayoutAddress: null,
+          adminPayoutAddress: "0xAdmin",
+          resolvedProjectName,
+        },
+        grant: {
+          uid: "0xGrant",
+          title: "Grant",
+          chainID: 10,
+          payoutAmount: "1000",
+          currency: "USDC",
+          payoutAddress: null,
+          programId: "100",
+          adminPayoutAmount: "1000",
+          invoiceRequired: false,
+        },
+        disbursements: { totalDisbursed: "0", totalsByToken: [], status: "NOT_STARTED", history: [] },
+        agreement: null,
+        milestoneInvoices: [],
+        paidMilestoneCount: 0,
+      },
+    ],
+    pagination: { totalCount: 1 },
+  };
+}
+
+const baseFilters = {
+  programId: null,
+  agreementFilter: undefined,
+  invoiceFilter: undefined,
+  disbursementFilter: undefined,
+  kycFilter: undefined,
+  searchQuery: "",
+  sortBy: undefined,
+  sortOrder: undefined,
+  currentPage: 1,
+  itemsPerPage: 10,
+} as const;
+
+describe("useControlCenterData - team name resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_use_resolvedProjectName_when_provided_by_payouts_response", () => {
+    mockUseCommunityPayouts.mockReturnValue({
+      data: makePayoutPayload("Awesome Team", "Karma Title"),
+      isLoading: false,
+      error: null,
+      invalidate: vi.fn(),
+    });
+
+    const { result } = renderHookWithProviders(() =>
+      useControlCenterData("test", true, baseFilters)
+    );
+
+    expect(result.current.tableData[0].projectName).toBe("Awesome Team");
+  });
+
+  it("should_fallback_to_project_title_when_resolvedProjectName_is_missing", () => {
+    mockUseCommunityPayouts.mockReturnValue({
+      data: makePayoutPayload(undefined, "Karma Title"),
+      isLoading: false,
+      error: null,
+      invalidate: vi.fn(),
+    });
+
+    const { result } = renderHookWithProviders(() =>
+      useControlCenterData("test", true, baseFilters)
+    );
+
+    expect(result.current.tableData[0].projectName).toBe("Karma Title");
+  });
+
+  it("should_fallback_to_project_title_when_resolvedProjectName_is_empty_string", () => {
+    mockUseCommunityPayouts.mockReturnValue({
+      data: makePayoutPayload("", "Karma Title"),
+      isLoading: false,
+      error: null,
+      invalidate: vi.fn(),
+    });
+
+    const { result } = renderHookWithProviders(() =>
+      useControlCenterData("test", true, baseFilters)
+    );
+
+    expect(result.current.tableData[0].projectName).toBe("Karma Title");
+  });
+});

--- a/__tests__/services/milestone-report.service.test.ts
+++ b/__tests__/services/milestone-report.service.test.ts
@@ -1,0 +1,106 @@
+import type { Mock } from "vitest";
+import { milestoneReportService } from "@/services/milestone-report.service";
+import fetchData from "@/utilities/fetchData";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+const mockedFetch = fetchData as unknown as Mock;
+
+describe("milestoneReportService.getReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFetch.mockResolvedValue([
+      {
+        data: [],
+        pageInfo: { totalItems: 0, page: 1, pageLimit: 50 },
+        uniqueProjectCount: 0,
+        stats: {
+          totalGrants: 0,
+          totalProjectsWithMilestones: 0,
+          totalMilestones: 0,
+          totalCompletedMilestones: 0,
+          totalPendingMilestones: 0,
+          totalProjects: 0,
+          percentageProjectsWithMilestones: 0,
+          percentageCompletedMilestones: 0,
+          percentagePendingMilestones: 0,
+        },
+      },
+      null,
+    ]);
+  });
+
+  it("should_call_v2_endpoint_with_pageLimit_and_sortField_query_params", async () => {
+    await milestoneReportService.getReport(
+      "filecoin",
+      2,
+      50,
+      "totalMilestones",
+      "desc"
+    );
+
+    const url = mockedFetch.mock.calls[0][0] as string;
+
+    expect(url).toContain("/v2/communities/filecoin/milestones/report");
+    expect(url).toContain("pageLimit=50");
+    expect(url).toContain("page=2");
+    expect(url).toContain("sortField=totalMilestones");
+    expect(url).toContain("sortOrder=desc");
+    expect(url).not.toContain("limit=50");
+    expect(url).not.toContain("sort=totalMilestones");
+  });
+
+  it("should_normalize_and_pass_program_ids_when_provided", async () => {
+    await milestoneReportService.getReport(
+      "filecoin",
+      1,
+      50,
+      "totalMilestones",
+      "desc",
+      ["100_42161", "200"]
+    );
+
+    const url = mockedFetch.mock.calls[0][0] as string;
+
+    expect(url).toContain("programIds=");
+  });
+
+  it("should_pass_reviewerAddress_when_provided", async () => {
+    await milestoneReportService.getReport(
+      "filecoin",
+      1,
+      50,
+      "totalMilestones",
+      "desc",
+      [],
+      "0x1234567890abcdef1234567890abcdef12345678"
+    );
+
+    const url = mockedFetch.mock.calls[0][0] as string;
+
+    expect(url).toContain(
+      "reviewerAddress=0x1234567890abcdef1234567890abcdef12345678"
+    );
+  });
+
+  it("should_throw_when_fetchData_returns_an_error", async () => {
+    mockedFetch.mockResolvedValueOnce([null, new Error("network down")]);
+
+    await expect(
+      milestoneReportService.getReport("filecoin", 1, 50)
+    ).rejects.toThrow();
+  });
+
+  it("should_return_empty_response_when_fetchData_returns_null_data", async () => {
+    mockedFetch.mockResolvedValueOnce([null, null]);
+
+    const result = await milestoneReportService.getReport("filecoin", 1, 50);
+
+    expect(result.data).toEqual([]);
+    expect(result.pageInfo).toEqual({ totalItems: 0, page: 1, pageLimit: 50 });
+    expect(result.uniqueProjectCount).toBe(0);
+  });
+});

--- a/components/Pages/Admin/ControlCenter/useControlCenterData.ts
+++ b/components/Pages/Admin/ControlCenter/useControlCenterData.ts
@@ -144,7 +144,10 @@ export function useControlCenterData(
     return dedupedPayouts.map((payout) => ({
       grantUid: payout.grant.uid,
       projectUid: payout.project.uid,
-      projectName: payout.project.title,
+      // Prefer the team name resolved from the approved application data
+      // (Team Name / Project Name / Organization Name in the form) and fall
+      // back to the on-chain Karma project title when no application is found.
+      projectName: payout.project.resolvedProjectName || payout.project.title,
       projectSlug: payout.project.slug,
       grantName: payout.grant.title,
       grantProgramId: payout.grant.programId || "",

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -13,28 +13,31 @@ import { validateProgramIdentifiers } from "@/utilities/validators";
 type TabId = "pending-verification" | "stats";
 
 interface Report {
-  _id: {
-    $oid: string;
-  };
   grantUid: string;
   grantTitle: string;
+  /** ChainID of the grant (V2 only — used for cross-chain links). */
+  grantChainID?: number;
   projectUid: string;
+  /**
+   * On-chain Karma project title. The V2 endpoint pre-substitutes this with
+   * the resolved team name (Team Name / Project Name / Organization Name)
+   * from approved funding-application data when available, so the column
+   * already shows the team name without further work on the consumer side.
+   */
   projectTitle: string;
-  programId?: string;
+  /**
+   * Team name resolved from approved application data, exposed separately so
+   * sort/search can target the same value the column displays.
+   */
+  resolvedProjectName?: string;
+  programId?: string | null;
   totalMilestones: number;
   pendingMilestones: number;
   pastDueMilestones?: number;
   completedMilestones: number;
   isGrantCompleted?: boolean;
-  proofOfWorkLinks: string[];
-  evaluations: Evaluation[] | null | undefined;
+  proofOfWorkLinks?: string[];
   projectSlug: string;
-}
-
-interface Evaluation {
-  _id: string;
-  rating: number;
-  reasons: string[];
 }
 
 export type MilestoneCompletion = Pick<
@@ -56,10 +59,11 @@ interface ReportAPIResponse {
     totalMilestones: number;
     totalCompletedMilestones: number;
     totalPendingMilestones: number;
+    /** Total project count across the community (V2 stats addition). */
+    totalProjects?: number;
     percentageProjectsWithMilestones: number;
     percentageCompletedMilestones: number;
     percentagePendingMilestones: number;
-    proofOfWorkLinks: string[];
   };
 }
 

--- a/services/milestone-report.service.ts
+++ b/services/milestone-report.service.ts
@@ -17,7 +17,6 @@ const EMPTY_REPORT_RESPONSE: ReportAPIResponse = {
     percentageProjectsWithMilestones: 0,
     percentageCompletedMilestones: 0,
     percentagePendingMilestones: 0,
-    proofOfWorkLinks: [],
   },
 };
 
@@ -34,7 +33,12 @@ export const milestoneReportService = {
     const normalizedProgramIds = selectedProgramIds.map(normalizeProgramId);
     const queryProgramIds = normalizedProgramIds.join(",");
     const encodedProgramIds = encodeURIComponent(queryProgramIds);
-    let url = `${INDEXER.COMMUNITY.REPORT.GET(communityId)}?limit=${pageLimit}&page=${page}&sort=${sortBy}&sortOrder=${sortOrder}${
+    // The V2 endpoint uses `pageLimit` and `sortField` (instead of V1's
+    // `limit`/`sort`). Keep the same input contract for callers but adapt
+    // the wire format here.
+    let url = `${INDEXER.COMMUNITY.REPORT.GET(
+      communityId
+    )}?pageLimit=${pageLimit}&page=${page}&sortField=${sortBy}&sortOrder=${sortOrder}${
       queryProgramIds ? `&programIds=${encodedProgramIds}` : ""
     }`;
     if (reviewerAddress) {

--- a/src/features/payout-disbursement/types/payout-disbursement.ts
+++ b/src/features/payout-disbursement/types/payout-disbursement.ts
@@ -175,6 +175,12 @@ export interface CommunityPayoutProjectInfo {
   chainPayoutAddress: Record<string, string> | null;
   /** Admin-set payout address for this community (from attestation.payoutAddress[communityUID]) */
   adminPayoutAddress: string | null;
+  /**
+   * Team/project name resolved from approved funding-application data for the
+   * matching (projectUID, programId) pair. Falls back to `title` (the on-chain
+   * Karma project title) when no application data is available.
+   */
+  resolvedProjectName?: string;
 }
 
 /**

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -646,7 +646,8 @@ export const INDEXER = {
       BULK: `/bulk-subscription/subscribe`,
     },
     REPORT: {
-      GET: (communityIdOrSlug: string) => `/communities/${communityIdOrSlug}/report`,
+      GET: (communityIdOrSlug: string) =>
+        `/v2/communities/${communityIdOrSlug}/milestones/report`,
       PENDING_VERIFICATION: (communityIdOrSlug: string) =>
         `/v2/communities/${communityIdOrSlug}/milestones/pending-verification`,
     },


### PR DESCRIPTION
## Summary

- Switch milestones-report stats tab to the V2 endpoint (`/v2/communities/:slug/milestones/report`) — the V2 mapper pre-substitutes `projectTitle` with the resolved team name from approved funding-application data, so the existing column now shows the team name with no consumer changes.
- Wire `resolvedProjectName` into the Control Center table (with on-chain Karma project title fallback when no application data is available).
- Service URL contract updated to V2 query params (`pageLimit` / `sortField`).
- Drop unused V1-only fields from the report types (`_id`, `evaluations`, `stats.proofOfWorkLinks`).

Pairs with the gap-indexer PR that resolves and exposes the team name across reporting endpoints.

## Test plan

- [ ] `pnpm lint:fix && pnpm test`
- [ ] `/manage/milestones-report` — Pending Verification tab shows team name
- [ ] `/manage/milestones-report` — Stats tab shows team name and sorts/searches against it
- [ ] `/manage/control-center` — Team name column populated; falls back to project title where no application data
- [ ] Verify across at least 2 communities (one with application data, one without)