### PR TITLE
feat(knowledge-base): edit dialog for knowledge sources (DEV-202)

### DIFF
--- a/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import toast from "react-hot-toast";
@@ -186,12 +186,15 @@ describe("EditSourceDialog", () => {
       await user.type(goalInput, "different");
       await user.click(screen.getByRole("button", { name: /save changes/i }));
 
-      // Confirmation modal renders both a Cancel and an Apply button.
-      // Click Cancel within the confirmation context — match the one
-      // sitting alongside "Apply changes" using getAllByRole and the
-      // last index (the confirmation modal is layered on top).
-      const cancelButtons = screen.getAllByRole("button", { name: /cancel/i });
-      await cancelButtons[cancelButtons.length - 1].click();
+      // Scope the Cancel click to the confirmation modal. The edit
+      // dialog also has a Cancel button, so an unscoped `getByRole`
+      // would be ambiguous — `within` walks down from the confirmation
+      // modal's root via its title, and we route through `userEvent` so
+      // act-wrapping and pointer simulation match the rest of the suite.
+      const confirmModal = screen
+        .getByText(/apply re-sync changes/i)
+        .closest('[role="dialog"]') as HTMLElement;
+      await user.click(within(confirmModal).getByRole("button", { name: /cancel/i }));
 
       expect(mutateAsync).not.toHaveBeenCalled();
     });

--- a/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
@@ -1,0 +1,298 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import toast from "react-hot-toast";
+import { EditSourceDialog } from "@/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog";
+import { useEditKnowledgeSource } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
+import type { KnowledgeSource } from "@/types/v2/knowledge-base";
+import "@testing-library/jest-dom";
+
+// DEV-202: tests for the edit dialog's content-affecting gating, dup
+// collision toast, and content-projection of the form into the patch.
+// The hook is mocked — we assert what `mutateAsync` receives, not the
+// network call. Hydration is covered in SourceRow.test.tsx.
+
+vi.mock("@/hooks/knowledge-base/useKnowledgeSourceMutations", () => ({
+  useEditKnowledgeSource: vi.fn(),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockEdit = useEditKnowledgeSource as ReturnType<typeof vi.fn>;
+const toastMock = toast as unknown as { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const createSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource => ({
+  id: "src-1",
+  communityId: "comm-1",
+  programId: null,
+  kind: "url",
+  externalId: "https://example.com/old",
+  title: "Old title",
+  isActive: true,
+  paused: false,
+  goal: "old purpose",
+  syncIntervalMin: 1440,
+  followLinks: false,
+  lastSyncedAt: "2026-04-26T00:00:00.000Z",
+  lastSyncStatus: "success",
+  lastSyncError: null,
+  lastSyncStats: {},
+  createdAt: "2026-04-26T00:00:00.000Z",
+  updatedAt: "2026-04-26T00:00:00.000Z",
+  ...overrides,
+});
+
+function renderDialog(source: KnowledgeSource) {
+  return render(
+    <EditSourceDialog
+      communityIdOrSlug="filecoin"
+      source={source}
+      open
+      onOpenChange={() => undefined}
+    />,
+    { wrapper: Wrapper }
+  );
+}
+
+describe("EditSourceDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("save gating", () => {
+    it("disables Save when no fields have changed", () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(createSource());
+
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+    });
+
+    it("enables Save when title is edited", async () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const titleInput = screen.getByDisplayValue("Old title");
+      await user.clear(titleInput);
+      await user.type(titleInput, "New title");
+
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled();
+    });
+  });
+
+  describe("title-only edit (no confirmation)", () => {
+    it("commits a title-only change directly without showing the confirmation modal", async () => {
+      // Display-only edits must bypass the confirmation step — burning a
+      // re-sync on every typo fix would punish curators for low-stakes
+      // changes. Backend's change-detection independently guarantees
+      // markPendingSync isn't called.
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const titleInput = screen.getByDisplayValue("Old title");
+      await user.clear(titleInput);
+      await user.type(titleInput, "Renamed");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /apply re-sync changes/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { title: "Renamed" },
+        });
+      });
+    });
+  });
+
+  describe("content-affecting edits (confirmation gates)", () => {
+    it("shows the confirmation modal before saving when goal changes", async () => {
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const goalInput = screen.getByDisplayValue("old purpose");
+      await user.clear(goalInput);
+      await user.type(goalInput, "fresh purpose");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      // Confirmation appears; mutation has NOT fired yet.
+      expect(
+        screen.getByText(/apply re-sync changes/i)
+      ).toBeInTheDocument();
+      expect(mutateAsync).not.toHaveBeenCalled();
+
+      // Confirm — mutation fires with the goal in the patch.
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { goal: "fresh purpose" },
+        });
+      });
+    });
+
+    it("shows the confirmation modal before saving when externalId changes", async () => {
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const linkInput = screen.getByDisplayValue("https://example.com/old");
+      await user.clear(linkInput);
+      await user.type(linkInput, "https://example.com/new");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      expect(screen.getByText(/apply re-sync changes/i)).toBeInTheDocument();
+      expect(mutateAsync).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { externalId: "https://example.com/new" },
+        });
+      });
+    });
+
+    it("does NOT save when the user cancels the confirmation", async () => {
+      // Confirm-then-cancel must abort the patch entirely. Otherwise the
+      // mutation could fire after the curator backed out, which is the
+      // worst possible outcome for a content-affecting edit.
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const goalInput = screen.getByDisplayValue("old purpose");
+      await user.clear(goalInput);
+      await user.type(goalInput, "different");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      // Confirmation modal renders both a Cancel and an Apply button.
+      // Click Cancel within the confirmation context — match the one
+      // sitting alongside "Apply changes" using getAllByRole and the
+      // last index (the confirmation modal is layered on top).
+      const cancelButtons = screen.getAllByRole("button", { name: /cancel/i });
+      await cancelButtons[cancelButtons.length - 1].click();
+
+      expect(mutateAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("duplicate externalId error", () => {
+    it("shows a duplicate-specific toast when the backend returns AlreadyExists", async () => {
+      // Backend's `KnowledgeSourceAlreadyExistsException` surfaces via
+      // fetchData's error string ("Knowledge source already registered
+      // for community=…"). The dialog must convert that into specific
+      // copy so the curator immediately sees it's a collision, not a
+      // transport error or generic 500.
+      const mutateAsync = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "Knowledge source already registered for community=filecoin, kind=url, externalId=https://example.com/taken"
+          )
+        );
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const linkInput = screen.getByDisplayValue("https://example.com/old");
+      await user.clear(linkInput);
+      await user.type(linkInput, "https://example.com/taken");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(toastMock.error).toHaveBeenCalledWith(
+          expect.stringMatching(/already registered/i)
+        );
+      });
+      // Generic fallback must not have fired.
+      expect(toastMock.error).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^failed to update/i)
+      );
+    });
+
+    it("falls back to the server message for non-duplicate errors", async () => {
+      const mutateAsync = vi
+        .fn()
+        .mockRejectedValue(new Error("Connection lost"));
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const titleInput = screen.getByDisplayValue("Old title");
+      await user.clear(titleInput);
+      await user.type(titleInput, "Renamed");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(toastMock.error).toHaveBeenCalledWith("Connection lost");
+      });
+    });
+  });
+
+  describe("goal tri-state", () => {
+    it("clears goal to null when the field is emptied", async () => {
+      // Curator wipes the textarea — the patch must contain `goal: null`
+      // (key present), not omit the key. Otherwise the backend leaves
+      // the old goal in place.
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource({ goal: "delete me" }));
+
+      const user = userEvent.setup();
+      await user.clear(screen.getByDisplayValue("delete me"));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { goal: null },
+        });
+      });
+    });
+  });
+
+  describe("followLinks toggle (gdrive_file only)", () => {
+    it("does NOT show the follow-links toggle for url kind", () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(createSource({ kind: "url" }));
+
+      expect(
+        screen.queryByLabelText(/follow links to other google docs/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the follow-links toggle for gdrive_file kind", () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(
+        createSource({ kind: "gdrive_file", externalId: "doc-1234" })
+      );
+
+      expect(
+        screen.getByLabelText(/follow links to other google docs/i, {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import toast from "react-hot-toast";
 import { EditSourceDialog } from "@/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog";
 import { useEditKnowledgeSource } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
+import { KnowledgeBaseApiError } from "@/services/knowledge-base.service";
 import type { KnowledgeSource } from "@/types/v2/knowledge-base";
 import "@testing-library/jest-dom";
 
@@ -22,7 +23,10 @@ vi.mock("react-hot-toast", () => ({
 }));
 
 const mockEdit = useEditKnowledgeSource as ReturnType<typeof vi.fn>;
-const toastMock = toast as unknown as { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
+const toastMock = toast as unknown as {
+  error: ReturnType<typeof vi.fn>;
+  success: ReturnType<typeof vi.fn>;
+};
 
 function Wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -130,9 +134,7 @@ describe("EditSourceDialog", () => {
       await user.click(screen.getByRole("button", { name: /save changes/i }));
 
       // Confirmation appears; mutation has NOT fired yet.
-      expect(
-        screen.getByText(/apply re-sync changes/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/apply re-sync changes/i)).toBeInTheDocument();
       expect(mutateAsync).not.toHaveBeenCalled();
 
       // Confirm — mutation fires with the goal in the patch.
@@ -196,12 +198,35 @@ describe("EditSourceDialog", () => {
   });
 
   describe("duplicate externalId error", () => {
-    it("shows a duplicate-specific toast when the backend returns AlreadyExists", async () => {
-      // Backend's `KnowledgeSourceAlreadyExistsException` surfaces via
-      // fetchData's error string ("Knowledge source already registered
-      // for community=…"). The dialog must convert that into specific
-      // copy so the curator immediately sees it's a collision, not a
-      // transport error or generic 500.
+    it("shows a duplicate-specific toast when the service throws KnowledgeBaseApiError with status 409", async () => {
+      // Primary detection path: structured error with HTTP status. The
+      // service is responsible for preserving fetchData's status code
+      // on the thrown error so callers don't have to parse the server
+      // message — that decoupling is the whole point of the class.
+      const mutateAsync = vi
+        .fn()
+        .mockRejectedValue(new KnowledgeBaseApiError("anything the server says", 409));
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const linkInput = screen.getByDisplayValue("https://example.com/old");
+      await user.clear(linkInput);
+      await user.type(linkInput, "https://example.com/taken");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(toastMock.error).toHaveBeenCalledWith(expect.stringMatching(/already registered/i));
+      });
+    });
+
+    it("falls back to message substring when status is unavailable (defensive)", async () => {
+      // Defensive fallback: if some future code path strips the status
+      // (e.g., re-throws as a plain Error) but keeps the server message
+      // intact, we still detect the conflict so the curator sees the
+      // specific copy. Drops to generic "Failed" toast only as a last
+      // resort.
       const mutateAsync = vi
         .fn()
         .mockRejectedValue(
@@ -220,20 +245,37 @@ describe("EditSourceDialog", () => {
       await user.click(screen.getByRole("button", { name: /apply changes/i }));
 
       await waitFor(() => {
-        expect(toastMock.error).toHaveBeenCalledWith(
-          expect.stringMatching(/already registered/i)
-        );
+        expect(toastMock.error).toHaveBeenCalledWith(expect.stringMatching(/already registered/i));
       });
-      // Generic fallback must not have fired.
+      expect(toastMock.error).not.toHaveBeenCalledWith(expect.stringMatching(/^failed to update/i));
+    });
+
+    it("does NOT fire the duplicate toast when status is a non-conflict (e.g., 500)", async () => {
+      // A 500 with an unrelated message must fall through to the
+      // generic toast. Previous text-only matcher could have matched
+      // "already" inside a transport error message.
+      const mutateAsync = vi
+        .fn()
+        .mockRejectedValue(new KnowledgeBaseApiError("Database connection lost", 500));
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource());
+
+      const user = userEvent.setup();
+      const titleInput = screen.getByDisplayValue("Old title");
+      await user.clear(titleInput);
+      await user.type(titleInput, "Renamed");
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(toastMock.error).toHaveBeenCalledWith("Database connection lost");
+      });
       expect(toastMock.error).not.toHaveBeenCalledWith(
-        expect.stringMatching(/^failed to update/i)
+        expect.stringMatching(/already registered/i)
       );
     });
 
     it("falls back to the server message for non-duplicate errors", async () => {
-      const mutateAsync = vi
-        .fn()
-        .mockRejectedValue(new Error("Connection lost"));
+      const mutateAsync = vi.fn().mockRejectedValue(new Error("Connection lost"));
       mockEdit.mockReturnValue({ mutateAsync, isPending: false });
       renderDialog(createSource());
 
@@ -277,16 +319,12 @@ describe("EditSourceDialog", () => {
       mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
       renderDialog(createSource({ kind: "url" }));
 
-      expect(
-        screen.queryByLabelText(/follow links to other google docs/i)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/follow links to other google docs/i)).not.toBeInTheDocument();
     });
 
     it("shows the follow-links toggle for gdrive_file kind", () => {
       mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
-      renderDialog(
-        createSource({ kind: "gdrive_file", externalId: "doc-1234" })
-      );
+      renderDialog(createSource({ kind: "gdrive_file", externalId: "doc-1234" }));
 
       expect(
         screen.getByLabelText(/follow links to other google docs/i, {

--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -1,9 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { SourceRow } from "@/components/Pages/Admin/KnowledgeBasePage/SourceRow";
 import {
   useDeleteKnowledgeSource,
+  useEditKnowledgeSource,
   useResyncKnowledgeSource,
   useUpdateKnowledgeSource,
 } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
@@ -20,6 +22,7 @@ vi.mock("@/hooks/knowledge-base/useKnowledgeSourceMutations", () => ({
   useUpdateKnowledgeSource: vi.fn(),
   useResyncKnowledgeSource: vi.fn(),
   useDeleteKnowledgeSource: vi.fn(),
+  useEditKnowledgeSource: vi.fn(),
 }));
 
 vi.mock("@/components/DeleteDialog", () => ({
@@ -30,6 +33,7 @@ vi.mock("@/components/DeleteDialog", () => ({
 const mockUpdate = useUpdateKnowledgeSource as ReturnType<typeof vi.fn>;
 const mockResync = useResyncKnowledgeSource as ReturnType<typeof vi.fn>;
 const mockDelete = useDeleteKnowledgeSource as ReturnType<typeof vi.fn>;
+const mockEdit = useEditKnowledgeSource as ReturnType<typeof vi.fn>;
 
 // ── Helpers ──
 
@@ -75,6 +79,7 @@ describe("SourceRow", () => {
     mockUpdate.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
     mockResync.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
     mockDelete.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
   });
 
   describe("status pill", () => {
@@ -339,6 +344,64 @@ describe("SourceRow", () => {
       const classes = getTileAndContentOpacityClasses();
       expect(classes).not.toContain(tileOpacityClass);
       expect(classes).not.toContain(contentOpacityClass);
+    });
+  });
+
+  // DEV-202: edit action — verify the button renders, click opens the
+  // dialog, and the dialog hydrates from the source. The dialog's own
+  // change-detection logic (confirmation gating, dup-error toast) lives
+  // in EditSourceDialog.test.tsx.
+  describe("edit action", () => {
+    it("renders an Edit button between Pause and Delete", () => {
+      renderRow(createSource());
+      expect(
+        screen.getByRole("button", { name: /edit source/i })
+      ).toBeInTheDocument();
+    });
+
+    it("opens the Edit dialog populated with the current source values when clicked", async () => {
+      renderRow(
+        createSource({
+          title: "Existing title",
+          externalId: "https://docs.google.com/document/d/abc/edit",
+          goal: "old purpose",
+        })
+      );
+
+      // Pre-condition: the dialog is closed; its hydrated form fields
+      // shouldn't be in the DOM yet.
+      expect(screen.queryByDisplayValue("Existing title")).not.toBeInTheDocument();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /edit source/i }));
+
+      // After click, the Radix dialog renders into a portal but is still
+      // queryable from screen. The form fields hydrate from the source.
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Existing title")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByDisplayValue("https://docs.google.com/document/d/abc/edit")
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue("old purpose")).toBeInTheDocument();
+    });
+
+    it("shows the kind as read-only in the edit dialog (kind change is not editable in v1)", async () => {
+      // Per ticket §"Not editable in v1": switching kind is conceptually
+      // a different source. The dialog must not expose a kind picker.
+      renderRow(createSource({ kind: "gdrive_file" }));
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /edit source/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Source type:/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+      // The "Source type" radiogroup from AddSourceDialog must not appear
+      // in the edit flow.
+      expect(
+        screen.queryByRole("radiogroup", { name: /source type/i })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/Utilities/Button";
 import { useEditKnowledgeSource } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
+import { KnowledgeBaseApiError } from "@/services/knowledge-base.service";
 import {
   KNOWLEDGE_SOURCE_KIND_HINTS,
   KNOWLEDGE_SOURCE_KIND_LABELS,
@@ -135,7 +136,7 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
       onOpenChange(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : "";
-      if (isDuplicateExternalIdError(message)) {
+      if (isDuplicateExternalIdError(err)) {
         // Backend's `KnowledgeSourceAlreadyExistsException` (409) — show
         // a specific message so the curator immediately understands it's
         // a collision, not a transport failure. Leave the dialog open
@@ -487,19 +488,21 @@ function FormField({
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Detect the backend's KnowledgeSourceAlreadyExistsException by message.
- * fetchData surfaces the API's `response.data.message` as the error
- * string; for this exception that's "Knowledge source already
- * registered for community=…". The substring "already" is unique to
- * this path in the knowledge-base API so the match is robust enough
- * without coupling to the full English phrasing.
+ * Detect the backend's KnowledgeSourceAlreadyExistsException. Primary
+ * signal is the HTTP status (409) carried on `KnowledgeBaseApiError`;
+ * the message-substring fallback is defensive — if some intermediary
+ * (e.g., a future `Error` re-throw) strips the structured class but
+ * preserves the server's wording, we still detect the conflict and
+ * show specific copy. Without the fallback a stripped status would
+ * fall through to the generic "Failed to update" toast.
  */
-function isDuplicateExternalIdError(message: string): boolean {
-  if (!message) return false;
-  // Sentinel needs to identify the Already-Exists path while excluding
-  // unrelated matches. The backend exception always includes the word
-  // "registered" alongside "already", which the schema-validation
-  // messages (400) and the not-found message (404) don't share.
-  const lower = message.toLowerCase();
-  return lower.includes("already") && lower.includes("registered");
+function isDuplicateExternalIdError(err: unknown): boolean {
+  if (err instanceof KnowledgeBaseApiError && err.status === 409) {
+    return true;
+  }
+  if (err instanceof Error && err.message) {
+    const lower = err.message.toLowerCase();
+    return lower.includes("already") && lower.includes("registered");
+  }
+  return false;
 }

--- a/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
@@ -41,9 +41,14 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
 
   const edit = useEditKnowledgeSource(communityIdOrSlug);
 
-  // Hydrate from `source` whenever it changes or the dialog re-opens.
-  // We don't gate on `open` alone — a row that swaps `source` underneath
-  // a still-open dialog would otherwise display stale values.
+  // Hydrate from `source` only when the dialog opens or the row identity
+  // changes (different sourceId). Depending on the source object reference
+  // would re-fire on every cache update — including the optimistic patch
+  // from `useEditKnowledgeSource.onMutate` — and on a 409 rollback the
+  // effect would run twice and overwrite anything the curator typed
+  // during the round-trip. Keying on `source?.id` keeps hydration tied
+  // to "this is a different row" without coupling to identity churn.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hydration is intentionally driven by row identity, not source-object reference; see comment above
   useEffect(() => {
     if (open && source) {
       setTitle(source.title);
@@ -57,7 +62,7 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
       // confirm step that was waiting on the previous edit.
       setConfirmOpen(false);
     }
-  }, [open, source]);
+  }, [open, source?.id]);
 
   const trimmedTitle = title.trim();
   const trimmedExternalId = externalId.trim();
@@ -109,7 +114,10 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
     const patch: UpdateKnowledgeSourceInput = {};
     if (changes.titleChanged) patch.title = trimmedTitle;
     if (changes.goalChanged) {
-      patch.goal = goalForPatch === "unchanged" ? source.goal : goalForPatch;
+      // `changes.goalChanged` is defined as `goalForPatch !== "unchanged"`,
+      // so by the time we're inside this branch goalForPatch is always
+      // `string | null` — narrow it for the assignment.
+      patch.goal = goalForPatch as string | null;
     }
     if (changes.externalIdChanged) patch.externalId = trimmedExternalId;
     if (changes.followLinksTurnedOn || changes.followLinksTurnedOff) {

--- a/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { GitBranch, Lock, RefreshCw, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/Utilities/Button";
+import { useEditKnowledgeSource } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
+import {
+  KNOWLEDGE_SOURCE_KIND_HINTS,
+  KNOWLEDGE_SOURCE_KIND_LABELS,
+  type KnowledgeSource,
+  type UpdateKnowledgeSourceInput,
+} from "@/types/v2/knowledge-base";
+
+/**
+ * DEV-202: edit-mode dialog for an existing knowledge source. Distinct
+ * from `AddSourceDialog` — kind is locked (changing kind is conceptually
+ * a different source per ticket §"Not editable in v1"), and saves that
+ * touch content-affecting fields (`goal`, `externalId`, follow-links
+ * turn-on) prompt a confirmation describing the side effects before the
+ * patch is sent. Display-only saves (title) commit directly.
+ */
+
+interface Props {
+  communityIdOrSlug: string;
+  source: KnowledgeSource | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const GOAL_MAX = 500;
+
+export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange }: Props) {
+  const [title, setTitle] = useState("");
+  const [externalId, setExternalId] = useState("");
+  const [goal, setGoal] = useState("");
+  const [followLinks, setFollowLinks] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const edit = useEditKnowledgeSource(communityIdOrSlug);
+
+  // Hydrate from `source` whenever it changes or the dialog re-opens.
+  // We don't gate on `open` alone — a row that swaps `source` underneath
+  // a still-open dialog would otherwise display stale values.
+  useEffect(() => {
+    if (open && source) {
+      setTitle(source.title);
+      setExternalId(source.externalId);
+      setGoal(source.goal ?? "");
+      setFollowLinks(source.followLinks);
+    }
+    if (!open) {
+      // Clear any in-flight confirmation modal when the parent closes —
+      // otherwise re-opening on a different row could land on a stale
+      // confirm step that was waiting on the previous edit.
+      setConfirmOpen(false);
+    }
+  }, [open, source]);
+
+  const trimmedTitle = title.trim();
+  const trimmedExternalId = externalId.trim();
+  const trimmedGoal = goal.trim();
+
+  // Tri-state goal: original null + empty string → no change, original
+  // string + empty string → clear (null), original string + new string
+  // → change. The patch matches this. Same logic mirrored on the
+  // backend's `Object.prototype.hasOwnProperty.call(body, 'goal')` path.
+  const goalForPatch: string | null | "unchanged" = useMemo(() => {
+    if (!source) return "unchanged";
+    const original = source.goal ?? "";
+    if (trimmedGoal === original) return "unchanged";
+    return trimmedGoal.length > 0 ? trimmedGoal : null;
+  }, [source, trimmedGoal]);
+
+  const changes = useMemo<EditChanges | null>(() => {
+    if (!source) return null;
+    return {
+      titleChanged: trimmedTitle !== source.title && trimmedTitle.length > 0,
+      goalChanged: goalForPatch !== "unchanged",
+      externalIdChanged: trimmedExternalId !== source.externalId && trimmedExternalId.length > 0,
+      followLinksTurnedOn: followLinks && !source.followLinks,
+      followLinksTurnedOff: !followLinks && source.followLinks,
+    };
+  }, [source, trimmedTitle, goalForPatch, trimmedExternalId, followLinks]);
+
+  const hasAnyChange = changes
+    ? changes.titleChanged ||
+      changes.goalChanged ||
+      changes.externalIdChanged ||
+      changes.followLinksTurnedOn ||
+      changes.followLinksTurnedOff
+    : false;
+
+  const requiresConfirmation = changes
+    ? changes.goalChanged || changes.externalIdChanged || changes.followLinksTurnedOn
+    : false;
+
+  const canSubmit =
+    !!source &&
+    hasAnyChange &&
+    trimmedTitle.length > 0 &&
+    trimmedExternalId.length > 0 &&
+    !edit.isPending;
+
+  const buildPatch = (): UpdateKnowledgeSourceInput | null => {
+    if (!source || !changes) return null;
+    const patch: UpdateKnowledgeSourceInput = {};
+    if (changes.titleChanged) patch.title = trimmedTitle;
+    if (changes.goalChanged) {
+      patch.goal = goalForPatch === "unchanged" ? source.goal : goalForPatch;
+    }
+    if (changes.externalIdChanged) patch.externalId = trimmedExternalId;
+    if (changes.followLinksTurnedOn || changes.followLinksTurnedOff) {
+      patch.followLinks = followLinks;
+    }
+    return patch;
+  };
+
+  const persist = async () => {
+    if (!source) return;
+    const patch = buildPatch();
+    if (!patch || Object.keys(patch).length === 0) {
+      onOpenChange(false);
+      return;
+    }
+    try {
+      await edit.mutateAsync({ sourceId: source.id, patch });
+      toast.success(
+        requiresConfirmation
+          ? "Source updated. Re-sync queued — runs on the next worker tick."
+          : "Source updated."
+      );
+      setConfirmOpen(false);
+      onOpenChange(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "";
+      if (isDuplicateExternalIdError(message)) {
+        // Backend's `KnowledgeSourceAlreadyExistsException` (409) — show
+        // a specific message so the curator immediately understands it's
+        // a collision, not a transport failure. Leave the dialog open
+        // so they can correct the URL in place.
+        toast.error("That URL or ID is already registered for another source in this community.");
+      } else {
+        toast.error(message || "Failed to update source.");
+      }
+      setConfirmOpen(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    if (requiresConfirmation) {
+      setConfirmOpen(true);
+      return;
+    }
+    void persist();
+  };
+
+  if (!source) return null;
+
+  return (
+    <>
+      <Dialog.Root open={open} onOpenChange={onOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-stone-950/40 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=open]:fade-in-0 dark:bg-black/60" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[92vh] w-[min(560px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-2xl outline-none dark:border-zinc-800 dark:bg-zinc-950 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
+            <div className="flex items-center gap-3 border-b border-stone-200 px-5 py-4 dark:border-zinc-800">
+              <Dialog.Title className="text-[15px] font-semibold tracking-[-0.01em] text-stone-900 dark:text-zinc-100">
+                Edit knowledge source
+              </Dialog.Title>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  aria-label="Close"
+                  className="ml-auto rounded-md p-1.5 text-stone-500 transition hover:bg-stone-100 hover:text-stone-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </Dialog.Close>
+            </div>
+            <Dialog.Description className="sr-only">
+              Update this knowledge source. Changes that affect ingestion will trigger a re-sync on
+              the next worker tick.
+            </Dialog.Description>
+
+            <form
+              className="contents"
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleSubmit();
+              }}
+            >
+              <div className="flex-1 overflow-y-auto px-5 py-[18px]">
+                <KindLockedBadge kind={source.kind} />
+
+                <div className="mt-4 space-y-3.5">
+                  <FormField
+                    label="Title"
+                    hint="Shown in the admin list and as the citation label in chat replies."
+                    htmlFor="kb-edit-title"
+                  >
+                    <input
+                      id="kb-edit-title"
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      maxLength={200}
+                      className="h-9 w-full rounded-md border border-stone-300 bg-white px-3 text-[13px] text-stone-900 placeholder-stone-400 transition focus:border-sky-500 focus:outline-none focus:ring-[3px] focus:ring-sky-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/20"
+                    />
+                  </FormField>
+
+                  <FormField
+                    label={
+                      source.kind === "gdrive_file"
+                        ? "Google Doc URL or ID"
+                        : source.kind === "pdf_url"
+                          ? "PDF URL"
+                          : "Web page URL"
+                    }
+                    hint={
+                      KNOWLEDGE_SOURCE_KIND_HINTS[source.kind] ??
+                      "Provide a publicly-accessible URL."
+                    }
+                    htmlFor="kb-edit-external"
+                  >
+                    <input
+                      id="kb-edit-external"
+                      type="text"
+                      value={externalId}
+                      onChange={(e) => setExternalId(e.target.value)}
+                      maxLength={2048}
+                      spellCheck={false}
+                      className="h-9 w-full rounded-md border border-stone-300 bg-white px-3 font-mono text-[12.5px] text-stone-900 placeholder-stone-400 transition focus:border-sky-500 focus:outline-none focus:ring-[3px] focus:ring-sky-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-600 dark:focus:border-sky-400 dark:focus:ring-sky-400/20"
+                    />
+                  </FormField>
+
+                  <FormField
+                    label="Purpose (optional)"
+                    hint="One sentence on what this source is for. Prepended to each chunk at embed time so the chatbot ranks it higher when a question matches the intent. Editing this re-embeds every chunk under this source on the next sync."
+                    htmlFor="kb-edit-goal"
+                  >
+                    <div className="relative">
+                      <textarea
+                        id="kb-edit-goal"
+                        value={goal}
+                        onChange={(e) => setGoal(e.target.value.slice(0, GOAL_MAX))}
+                        maxLength={GOAL_MAX}
+                        rows={3}
+                        className="block w-full resize-y rounded-md border border-stone-300 bg-white px-3 py-2 pb-5 text-[13px] leading-relaxed text-stone-900 placeholder-stone-400 transition focus:border-sky-500 focus:outline-none focus:ring-[3px] focus:ring-sky-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:border-sky-400 dark:focus:ring-sky-400/20"
+                      />
+                      <span
+                        aria-live="polite"
+                        className="pointer-events-none absolute bottom-1.5 right-2 font-mono text-[10.5px] tabular-nums text-stone-400 dark:text-zinc-600"
+                      >
+                        {goal.length}/{GOAL_MAX}
+                      </span>
+                    </div>
+                  </FormField>
+
+                  {source.kind === "gdrive_file" && (
+                    <FollowLinksToggle checked={followLinks} onChange={setFollowLinks} />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex items-center justify-end gap-2 border-t border-stone-200 px-5 py-3 dark:border-zinc-800">
+                <Button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+                  className="bg-transparent text-stone-700 hover:bg-stone-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={!canSubmit}>
+                  {edit.isPending ? "Saving…" : "Save changes"}
+                </Button>
+              </div>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <ConfirmEditDialog
+        open={confirmOpen}
+        changes={changes}
+        loading={edit.isPending}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void persist()}
+      />
+    </>
+  );
+}
+
+interface EditChanges {
+  titleChanged: boolean;
+  goalChanged: boolean;
+  externalIdChanged: boolean;
+  followLinksTurnedOn: boolean;
+  followLinksTurnedOff: boolean;
+}
+
+// ── Locked kind badge ───────────────────────────────────────────────────────
+//
+// Kind is intentionally not editable in v1 — switching from URL to gdrive_file
+// is a different source. We surface the current kind so curators can confirm
+// they opened the right row, and a small lock icon explains why it's read-only.
+
+function KindLockedBadge({ kind }: { kind: KnowledgeSource["kind"] }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-[12px] text-stone-600 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-400">
+      <Lock className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span className="flex-1">
+        Source type: <strong className="font-semibold">{KNOWLEDGE_SOURCE_KIND_LABELS[kind]}</strong>
+      </span>
+      <span className="font-mono text-[10.5px] uppercase tracking-wider text-stone-500 dark:text-zinc-500">
+        Read-only
+      </span>
+    </div>
+  );
+}
+
+// ── Confirmation modal ──────────────────────────────────────────────────────
+//
+// Renders a bullet list of the side effects the curator is about to commit to.
+// Lives in this file because its copy and structure are tightly coupled to
+// the edit-flow change taxonomy — pulling it into a generic primitive would
+// require parameterizing the messaging anyway.
+
+function ConfirmEditDialog({
+  open,
+  changes,
+  loading,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  changes: EditChanges | null;
+  loading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const effects = useMemo(() => {
+    if (!changes) return [] as string[];
+    const items: string[] = [];
+    if (changes.goalChanged) {
+      items.push(
+        "Re-embed every chunk under this source. The new purpose will be prepended to each chunk at embed time."
+      );
+    }
+    if (changes.externalIdChanged) {
+      items.push(
+        "Re-fetch and re-index documents under the new URL/ID. For folder-style sources, documents that no longer match are soft-deleted on the next sync."
+      );
+    }
+    if (changes.followLinksTurnedOn) {
+      items.push(
+        "Discover and ingest Google Docs linked from this one (one level deep) on the next sync."
+      );
+    }
+    return items;
+  }, [changes]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => !next && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[60] bg-stone-950/50 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=open]:fade-in-0 dark:bg-black/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] flex w-[min(440px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-2xl outline-none dark:border-zinc-800 dark:bg-zinc-950 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
+          <div className="px-5 py-4">
+            <div className="flex items-start gap-3">
+              <div
+                aria-hidden="true"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sky-50 text-sky-600 dark:bg-sky-950/40 dark:text-sky-400"
+              >
+                <RefreshCw className="h-4 w-4" strokeWidth={2} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <Dialog.Title className="text-[14px] font-semibold tracking-[-0.01em] text-stone-900 dark:text-zinc-100">
+                  Apply re-sync changes?
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-[12.5px] leading-relaxed text-stone-600 dark:text-zinc-400">
+                  This edit changes how Karma ingests this source. The following will happen on the
+                  next worker tick:
+                </Dialog.Description>
+                <ul className="mt-3 space-y-1.5 text-[12.5px] leading-relaxed text-stone-700 dark:text-zinc-300">
+                  {effects.map((item) => (
+                    <li key={item} className="flex gap-2">
+                      <span
+                        aria-hidden="true"
+                        className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-stone-400 dark:bg-zinc-600"
+                      />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2 border-t border-stone-200 px-5 py-3 dark:border-zinc-800">
+            <Button
+              type="button"
+              onClick={onCancel}
+              disabled={loading}
+              className="bg-transparent text-stone-700 hover:bg-stone-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={onConfirm} disabled={loading}>
+              {loading ? "Applying…" : "Apply changes"}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+// ── Follow-links toggle ─────────────────────────────────────────────────────
+//
+// Mirror of AddSourceDialog's toggle; duplicated rather than exported so the
+// add/edit dialogs can diverge their hint copy if needed (edit's hint can
+// reasonably warn that turning the flag on triggers discovery).
+
+function FollowLinksToggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2.5 dark:border-zinc-800 dark:bg-zinc-900/60">
+      <label className="flex cursor-pointer items-start gap-2.5">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="mt-[2px] h-3.5 w-3.5 shrink-0 cursor-pointer rounded border-stone-300 text-sky-600 focus:ring-2 focus:ring-sky-500/40 dark:border-zinc-700 dark:bg-zinc-800 dark:focus:ring-sky-400/40"
+        />
+        <div className="min-w-0">
+          <p className="flex items-center gap-1.5 text-[12.5px] font-medium text-stone-800 dark:text-zinc-200">
+            <GitBranch
+              aria-hidden="true"
+              className="h-3.5 w-3.5 text-stone-500 dark:text-zinc-500"
+              strokeWidth={1.75}
+            />
+            Follow links to other Google Docs
+          </p>
+          <p className="mt-1 text-[11.5px] leading-relaxed text-stone-500 dark:text-zinc-500">
+            Karma also ingests Google Docs linked from this one (one level deep). Turning this on
+            triggers a discovery pass on the next sync. Turning it off leaves already-discovered
+            docs in place.
+          </p>
+        </div>
+      </label>
+    </div>
+  );
+}
+
+// ── Form field ──────────────────────────────────────────────────────────────
+
+function FormField({
+  label,
+  hint,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  hint: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1.5 block text-xs font-medium text-stone-600 dark:text-zinc-400"
+      >
+        {label}
+      </label>
+      {children}
+      <p className="mt-1.5 text-xs leading-relaxed text-stone-500 dark:text-zinc-500">{hint}</p>
+    </div>
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Detect the backend's KnowledgeSourceAlreadyExistsException by message.
+ * fetchData surfaces the API's `response.data.message` as the error
+ * string; for this exception that's "Knowledge source already
+ * registered for community=…". The substring "already" is unique to
+ * this path in the knowledge-base API so the match is robust enough
+ * without coupling to the full English phrasing.
+ */
+function isDuplicateExternalIdError(message: string): boolean {
+  if (!message) return false;
+  // Sentinel needs to identify the Already-Exists path while excluding
+  // unrelated matches. The backend exception always includes the word
+  // "registered" alongside "already", which the schema-validation
+  // messages (400) and the not-found message (404) don't share.
+  const lower = message.toLowerCase();
+  return lower.includes("already") && lower.includes("registered");
+}

--- a/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx
@@ -9,6 +9,7 @@ import {
   Globe,
   Network,
   Pause,
+  Pencil,
   Play,
   RefreshCw,
   Target,
@@ -28,6 +29,7 @@ import {
   type KnowledgeSource,
   type KnowledgeSourceKind,
 } from "@/types/v2/knowledge-base";
+import { EditSourceDialog } from "./EditSourceDialog";
 
 interface Props {
   source: KnowledgeSource;
@@ -223,6 +225,10 @@ function diffParts(source: KnowledgeSource): DiffPart[] {
 
 function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // DEV-202: edit dialog open state. The dialog hydrates from the
+  // `source` prop on each open, so toggling here is enough — we don't
+  // need to copy the source into local state.
+  const [editOpen, setEditOpen] = useState(false);
   const update = useUpdateKnowledgeSource(communityIdOrSlug);
   const resync = useResyncKnowledgeSource(communityIdOrSlug);
   const del = useDeleteKnowledgeSource(communityIdOrSlug);
@@ -483,6 +489,10 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
           disabled={update.isPending}
           Icon={source.paused ? Play : Pause}
         />
+        {/* DEV-202: Edit slots between Pause and Delete. Edits that
+            change content-affecting fields (goal, link, follow-links
+            on) prompt a confirmation modal before saving. */}
+        <RowAction label="Edit source" onClick={() => setEditOpen(true)} Icon={Pencil} />
         <RowAction
           label="Delete source"
           onClick={() => setConfirmDelete(true)}
@@ -499,6 +509,13 @@ function SourceRowImpl({ source, communityIdOrSlug, isFirst }: Props) {
         title="Delete this source? This will remove its documents and chunks."
         deleteFunction={handleDelete}
         buttonElement={null}
+      />
+
+      <EditSourceDialog
+        communityIdOrSlug={communityIdOrSlug}
+        source={editOpen ? source : null}
+        open={editOpen}
+        onOpenChange={setEditOpen}
       />
     </li>
   );

--- a/hooks/knowledge-base/useKnowledgeSourceMutations.ts
+++ b/hooks/knowledge-base/useKnowledgeSourceMutations.ts
@@ -7,6 +7,7 @@ import {
 } from "@/services/knowledge-base.service";
 import type {
   CreateKnowledgeSourceInput,
+  KnowledgeSource,
   UpdateKnowledgeSourceInput,
 } from "@/types/v2/knowledge-base";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
@@ -61,6 +62,76 @@ export function useDeleteKnowledgeSource(communityIdOrSlug: string | undefined) 
     },
     onSuccess: invalidate,
   });
+}
+
+/**
+ * DEV-202: edit-flow variant of useUpdateKnowledgeSource. Uses the same
+ * service call but adds optimistic-update-with-rollback for the source
+ * list cache so the dialog feels instant. Lives as a separate hook so
+ * the existing pause/resume call sites (which rely on the non-optimistic
+ * `useUpdateKnowledgeSource` semantics) keep their current behavior —
+ * onMutate cancels in-flight queries which can race with the rapid
+ * pause/unpause toggling pattern those callers use.
+ */
+export function useEditKnowledgeSource(communityIdOrSlug: string | undefined) {
+  const qc = useQueryClient();
+  const invalidate = useInvalidateSources(communityIdOrSlug);
+  return useMutation<
+    KnowledgeSource,
+    Error,
+    { sourceId: string; patch: UpdateKnowledgeSourceInput },
+    { previous: KnowledgeSource[] | undefined }
+  >({
+    mutationFn: ({ sourceId, patch }) => {
+      if (!communityIdOrSlug) throw new Error("Community required");
+      return updateKnowledgeSource(communityIdOrSlug, sourceId, patch);
+    },
+    // Optimistic patch: cancel in-flight refetches so they don't clobber
+    // our local change, snapshot the list for rollback, then mutate the
+    // cached row in place. We patch only the form-projected fields —
+    // server-derived fields like `lastSyncedAt` and `lastSyncStatus`
+    // refresh on settle when the backend re-syncs as a side effect.
+    onMutate: async ({ sourceId, patch }) => {
+      if (!communityIdOrSlug) return { previous: undefined };
+      const key = QUERY_KEYS.KNOWLEDGE_BASE.SOURCES(communityIdOrSlug);
+      await qc.cancelQueries({ queryKey: key });
+      const previous = qc.getQueryData<KnowledgeSource[]>(key);
+      qc.setQueryData<KnowledgeSource[]>(key, (old) =>
+        (old ?? []).map((s) => (s.id === sourceId ? applyPatch(s, patch) : s))
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (!communityIdOrSlug || !ctx?.previous) return;
+      qc.setQueryData(QUERY_KEYS.KNOWLEDGE_BASE.SOURCES(communityIdOrSlug), ctx.previous);
+    },
+    // Always invalidate at the end so server-side derived fields
+    // (lastSyncedAt cleared by markPendingSync, etc.) reach the cache.
+    onSettled: invalidate,
+  });
+}
+
+/**
+ * Project an UpdateKnowledgeSourceInput onto a KnowledgeSource for
+ * cache-level optimistic updates. Distinguishes "key absent → leave
+ * alone" from "key present → apply (including null)" to match the
+ * backend's tri-state handling of `goal`.
+ */
+function applyPatch(source: KnowledgeSource, patch: UpdateKnowledgeSourceInput): KnowledgeSource {
+  return {
+    ...source,
+    ...(patch.title !== undefined && { title: patch.title }),
+    ...(Object.hasOwn(patch, "goal") && {
+      goal: patch.goal ?? null,
+    }),
+    ...(patch.externalId !== undefined && { externalId: patch.externalId }),
+    ...(patch.isActive !== undefined && { isActive: patch.isActive }),
+    ...(patch.paused !== undefined && { paused: patch.paused }),
+    ...(patch.syncIntervalMin !== undefined && {
+      syncIntervalMin: patch.syncIntervalMin,
+    }),
+    ...(patch.followLinks !== undefined && { followLinks: patch.followLinks }),
+  };
 }
 
 export function useResyncKnowledgeSource(communityIdOrSlug: string | undefined) {

--- a/services/knowledge-base.service.ts
+++ b/services/knowledge-base.service.ts
@@ -15,6 +15,25 @@ interface SingleSourceResponse {
 }
 
 /**
+ * DEV-202: structured error thrown by the knowledge-base service so
+ * callers can branch on HTTP status (e.g., 409 → duplicate externalId)
+ * rather than text-matching the server message. fetchData returns the
+ * status code as the 4th tuple element; we preserve it on this class so
+ * dialogs can handle the conflict path without parsing English copy.
+ */
+export class KnowledgeBaseApiError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "KnowledgeBaseApiError";
+    this.status = status;
+    // Restore the prototype chain in case this is constructed in a
+    // bundled / down-leveled context where `super(...)` strips it.
+    Object.setPrototypeOf(this, KnowledgeBaseApiError.prototype);
+  }
+}
+
+/**
  * Knowledge-base API client. All hooks consume this module — the React
  * Query hooks supply caching/invalidation/optimistic-update plumbing,
  * the service supplies the network calls. Mirrors the convention used
@@ -62,7 +81,10 @@ export async function updateKnowledgeSource(
   sourceId: string,
   patch: UpdateKnowledgeSourceInput
 ): Promise<KnowledgeSource> {
-  const [data, error] = await fetchData<SingleSourceResponse>(
+  // The 4th tuple element is the HTTP status — preserve it on the
+  // thrown error so callers (e.g., EditSourceDialog) can branch on
+  // 409 → duplicate externalId without parsing the server's message.
+  const [data, error, , status] = await fetchData<SingleSourceResponse>(
     INDEXER.KNOWLEDGE_BASE.UPDATE_SOURCE(communityIdOrSlug, sourceId),
     "PATCH",
     patch,
@@ -70,7 +92,7 @@ export async function updateKnowledgeSource(
     {},
     true
   );
-  if (error) throw new Error(error);
+  if (error) throw new KnowledgeBaseApiError(error, status);
   if (!data?.data) throw new Error("Empty response from server");
   return data.data;
 }

--- a/types/v2/knowledge-base.ts
+++ b/types/v2/knowledge-base.ts
@@ -72,6 +72,10 @@ export interface UpdateKnowledgeSourceInput {
   title?: string;
   // `null` clears the goal; omitting the key leaves it unchanged.
   goal?: string | null;
+  // DEV-202: edit the link / Drive ID this source points at. Backend
+  // canonicalizes per-kind (matching create) and returns 409 if the
+  // target collides with another source in the same (community, kind).
+  externalId?: string;
   isActive?: boolean;
   // DEV-194: pause toggle — skips sync AND excludes chunks from
   // retrieval while true. Distinct from isActive.


### PR DESCRIPTION
## Summary

- Adds an Edit action to `SourceRow` between Pause and Delete that opens a pre-populated dialog
- Edits touching content-affecting fields (`goal`, `externalId`, follow-links → true) prompt a confirmation modal describing the side effect before dispatching the patch; display-only edits (title) commit directly
- New `useEditKnowledgeSource` hook with optimistic-with-rollback on the source list cache. The existing `useUpdateKnowledgeSource` hook is untouched — pause toggle's behavior is provably unchanged
- Duplicate `externalId` 409 from the backend surfaces as a curator-specific toast: "That URL or ID is already registered for another source in this community."

Linear: [DEV-202](https://linear.app/showkarma/issue/DEV-202)
Backend PR: show-karma/gap-indexer#1535

## Architecture

**Why a separate `useEditKnowledgeSource` hook instead of upgrading `useUpdateKnowledgeSource`?** The pause toggle calls `useUpdateKnowledgeSource` with `mutateAsync` and a simple invalidate-on-success path. Adding `onMutate` cancels in-flight queries, which can race with the rapid pause/unpause toggling pattern. Keeping the hooks separate is provably zero-blast-radius: pause toggle keeps its current behavior bit-for-bit, the edit flow gets the optimistic feedback it needs.

**Why a fresh `EditSourceDialog` instead of dual-mode `AddSourceDialog`?** `AddSourceDialog` resets on `[open]` (incompatible with hydrate-from-source), hardcodes `useCreateKnowledgeSource`, and its sub-components are file-private. Dual-mode would have invasive branching across 6+ touchpoints. New file is cleaner; some duplication is acceptable.

**Kind shown read-only.** Per ticket §"Not editable in v1" — switching kind is conceptually a different source (URL → gdrive_file means re-fetching from a different protocol).

**`externalId` is editable for all kinds.** Backend canonicalizes per-kind, so URL reformatting alone is a no-op. The frontend mirrors this via the `goalForPatch === "unchanged"` and `externalIdChanged` checks before flipping the confirmation modal.

## Test plan

- [x] `pnpm test:unit __tests__/components/Admin/KnowledgeBasePage` — 37 / 37 passing
- [x] `pnpm run build` — succeeded
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm exec biome check` on changed files — 0 errors

### Coverage added
- **3 SourceRow tests**: Edit button renders, click opens dialog with hydrated `title` / `externalId` / `goal`, kind picker absent and lock badge present
- **11 EditSourceDialog tests**:
  - Save gating (disabled when no changes, enabled after title edit)
  - Title-only commits directly without confirmation
  - Goal change shows confirmation, then sends `{ goal }` patch
  - externalId change shows confirmation, then sends `{ externalId }` patch
  - Cancel inside confirmation aborts the mutation
  - Backend 409 surfaces as duplicate-specific toast
  - Generic transport error falls back to server message
  - Goal cleared to empty string sends `{ goal: null }` (tri-state preserved)
  - Follow-links toggle hidden for `url` kind, shown for `gdrive_file`

### Manual checks done
- [x] Build artifact: 67 static pages generate cleanly
- [x] Pre-existing failures in `milestone-reviewers.service.test.ts` / `program-reviewers.service.test.ts` confirmed on `origin/main` (unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added edit functionality for knowledge sources via new Edit button on source rows
  * Edit dialog allows modifying title, goal, external ID, and follow-links toggle
  * Confirmation modal displays for changes affecting sync/indexing operations
  * Duplicate external ID detection with targeted error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->