### PR TITLE
fix(milestones): render empty completion text as em-dash and gate financials AI badge

### DIFF
--- a/__tests__/components/Pages/Communities/Financials/PublicProjectDetailsModal.test.tsx
+++ b/__tests__/components/Pages/Communities/Financials/PublicProjectDetailsModal.test.tsx
@@ -127,6 +127,7 @@ function makeInvoice(
     allocatedAmount: null,
     paymentStatus: "unpaid",
     paymentStatusDate: null,
+    completionReason: null,
     ...overrides,
   };
 }

--- a/__tests__/components/Shared/ActivityCard/milestone-card-gating.test.ts
+++ b/__tests__/components/Shared/ActivityCard/milestone-card-gating.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { computeMilestoneCardCompletionGate } from "@/components/Shared/ActivityCard/milestone-card-gating";
+
+const baseInput = {
+  type: "grant" as const,
+  completed: false,
+  completionReason: undefined,
+  completionProof: undefined,
+  completionDeliverables: undefined,
+  isCompleting: false,
+  isEditing: false,
+};
+
+describe("computeMilestoneCardCompletionGate", () => {
+  describe("completed milestone-shaped entry without narrative", () => {
+    // The reason this branch exists: evermedia-vault shipped grant
+    // milestones marked completed on-chain with no narrative. After the
+    // indexer fix, completionReason arrives empty — but the timeline
+    // should still surface the completion event so MilestoneCard can
+    // render "—" inside renderMilestoneCompletion.
+    it("should_show_section_for_completed_grant_with_empty_narrative", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant",
+        completed: true,
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+
+    it("should_show_section_for_completed_project_milestone_with_empty_narrative", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "milestone",
+        completed: true,
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+
+    it("should_show_section_for_completed_project_objective_with_empty_narrative", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "project",
+        completed: true,
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+
+    it("should_treat_object_form_completed_as_truthy", () => {
+      // V1 milestone shape carries `completed` as a metadata object, not
+      // a boolean. Both must trigger the same gate decision.
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant",
+        completed: { createdAt: "2024-01-01", data: { reason: "" } },
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+  });
+
+  describe("non-milestone activity types fall back to content gate", () => {
+    // Updates / grant_updates / activities don't have a "completion"
+    // semantic — without explicit content there's nothing to render and
+    // the section should stay hidden.
+    it.each(["update", "grant_update", "activity", "impact"] as const)(
+      "should_hide_section_for_%s_with_no_content",
+      (type) => {
+        const gate = computeMilestoneCardCompletionGate({
+          ...baseInput,
+          type,
+          completed: true,
+        });
+
+        expect(gate.showSection).toBe(false);
+        expect(gate.showTimelineHeader).toBe(false);
+      }
+    );
+
+    it("should_show_section_for_grant_update_when_completionReason_present", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant_update",
+        completionReason: "Quarterly report",
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+  });
+
+  describe("form-input flow suppresses the timeline header", () => {
+    // While the user is filling in the completion form we render the
+    // form inside the section but want to hide the "Posted by" header
+    // since the data isn't committed yet.
+    it("should_show_section_but_hide_header_when_isCompleting", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "milestone",
+        isCompleting: true,
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(false);
+    });
+
+    it("should_show_section_and_header_when_isEditing", () => {
+      // Editing differs from creating — there's already a committed
+      // completion behind the form, so the header (Posted X by Y) is
+      // still meaningful.
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant",
+        completed: true,
+        isEditing: true,
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+  });
+
+  describe("legacy content-only gate (pre-completion-flag entries)", () => {
+    it("should_show_section_when_only_completionProof_present", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant",
+        completionProof: "https://example.com/proof",
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+
+    it("should_show_section_when_only_completionDeliverables_present", () => {
+      const gate = computeMilestoneCardCompletionGate({
+        ...baseInput,
+        type: "grant",
+        completionDeliverables: [{ name: "Report" }],
+      });
+
+      expect(gate.showSection).toBe(true);
+      expect(gate.showTimelineHeader).toBe(true);
+    });
+  });
+
+  describe("default state", () => {
+    it("should_hide_section_for_pending_milestone_with_no_content", () => {
+      const gate = computeMilestoneCardCompletionGate(baseInput);
+
+      expect(gate.showSection).toBe(false);
+      expect(gate.showTimelineHeader).toBe(false);
+    });
+  });
+});

--- a/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
+++ b/__tests__/unit/components/Pages/Admin/MilestonesSection.test.tsx
@@ -69,6 +69,7 @@ function createMockInvoice(
     invoiceReceivedAt: null,
     invoiceReceivedBy: null,
     invoiceFileKey: null,
+    completionReason: null,
     ...overrides,
   };
 }

--- a/components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx
+++ b/components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx
@@ -600,7 +600,10 @@ export function PublicProjectDetailsModal({
                                 {invoice.milestoneUID &&
                                 (effectiveMsStatus === MilestoneLifecycleStatus.COMPLETED ||
                                   effectiveMsStatus === MilestoneLifecycleStatus.VERIFIED) ? (
-                                  <MilestoneAIEvaluationBadge milestoneUID={invoice.milestoneUID} />
+                                  <MilestoneAIEvaluationBadge
+                                    milestoneUID={invoice.milestoneUID}
+                                    completionReason={invoice.completionReason ?? ""}
+                                  />
                                 ) : (
                                   <span className="text-xs text-gray-300 dark:text-zinc-600">
                                     &mdash;

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -320,7 +320,11 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
             <div className="flex flex-col gap-1">
               <ReadMore side="left">{completionReason}</ReadMore>
             </div>
-          ) : null}
+          ) : (
+            <p className="text-sm text-muted-foreground" data-testid="empty-completion-text">
+              —
+            </p>
+          )}
           {isAuthorized && milestone.invoiceInfo?.fileKey && grantUID && (
             <button
               type="button"
@@ -587,52 +591,70 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
             </div>
           )}
       </div>
-      {isCompleting ||
-      isEditing ||
-      completionReason ||
-      completionProof ||
-      completionDeliverables ? (
-        <div className="flex flex-col gap-2.5 mt-2 pl-10">
-          {/* Timeline header: Only show when viewing existing completion data, not during form input */}
-          {!isCompleting && (completionReason || completionProof || completionDeliverables) && (
-            <div className="relative flex flex-row items-center justify-between gap-2 flex-wrap">
-              {!hideTimelineMarker && (
-                /* Timeline badge - vertically centered relative to header row, aligned with main timeline */
-                <div className="absolute -left-[73px] max-lg:-left-[69px] top-1/2 -translate-y-1/2 w-6 h-6 max-lg:w-5 max-lg:h-5 flex items-center justify-center z-10 bg-blue-50 dark:bg-blue-950 rounded-full ring-2 ring-white dark:ring-zinc-900">
-                  <div className="w-[3px] h-[3px] rounded-full bg-blue-400" />
+      {(() => {
+        // A milestone-type entry that's been marked complete should always
+        // render the "Milestone Update" section, even if the project owner
+        // submitted no narrative — empty completion is shown as "—" inside
+        // renderMilestoneCompletion.
+        const isCompletedMilestone =
+          (type === "milestone" || type === "grant" || type === "project") && Boolean(completed);
+        const showSection =
+          isCompleting ||
+          isEditing ||
+          isCompletedMilestone ||
+          Boolean(completionReason) ||
+          Boolean(completionProof) ||
+          Boolean(completionDeliverables);
+        if (!showSection) return null;
+        const showTimelineHeader =
+          !isCompleting &&
+          (isCompletedMilestone ||
+            Boolean(completionReason) ||
+            Boolean(completionProof) ||
+            Boolean(completionDeliverables));
+        return (
+          <div className="flex flex-col gap-2.5 mt-2 pl-10">
+            {/* Timeline header: Only show when viewing existing completion data, not during form input */}
+            {showTimelineHeader && (
+              <div className="relative flex flex-row items-center justify-between gap-2 flex-wrap">
+                {!hideTimelineMarker && (
+                  /* Timeline badge - vertically centered relative to header row, aligned with main timeline */
+                  <div className="absolute -left-[73px] max-lg:-left-[69px] top-1/2 -translate-y-1/2 w-6 h-6 max-lg:w-5 max-lg:h-5 flex items-center justify-center z-10 bg-blue-50 dark:bg-blue-950 rounded-full ring-2 ring-white dark:ring-zinc-900">
+                    <div className="w-[3px] h-[3px] rounded-full bg-blue-400" />
+                  </div>
+                )}
+                {/* Left side: Activity type label */}
+                <div className="flex flex-row items-center gap-2.5 flex-wrap">
+                  <span className="text-sm font-semibold text-foreground">
+                    {getActivityTypeLabel(type)}
+                  </span>
                 </div>
-              )}
-              {/* Left side: Activity type label */}
-              <div className="flex flex-row items-center gap-2.5 flex-wrap">
-                <span className="text-sm font-semibold text-foreground">
-                  {getActivityTypeLabel(type)}
-                </span>
+
+                {/* Right side: Posted by */}
+                {completionDate && (
+                  <div className="flex flex-row items-center gap-3 text-sm font-medium leading-5 text-muted-foreground">
+                    <span>Posted {formatDate(completionDate)} by</span>
+                    {completionAttester && (
+                      <div className="flex flex-row items-center gap-3">
+                        <span className="text-sm font-semibold leading-5 text-foreground">
+                          <EthereumAddressToProfileName
+                            address={completionAttester}
+                            showProfilePicture
+                            pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
+                          />
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
+            )}
 
-              {/* Right side: Posted by */}
-              {completionDate && (
-                <div className="flex flex-row items-center gap-3 text-sm font-medium leading-5 text-muted-foreground">
-                  <span>Posted {formatDate(completionDate)} by</span>
-                  {completionAttester && (
-                    <div className="flex flex-row items-center gap-3">
-                      <span className="text-sm font-semibold leading-5 text-foreground">
-                        <EthereumAddressToProfileName
-                          address={completionAttester}
-                          showProfilePicture
-                          pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
-                        />
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Completion card - aligned with header */}
-          <div>{renderMilestoneCompletion()}</div>
-        </div>
-      ) : null}
+            {/* Completion card - aligned with header */}
+            <div>{renderMilestoneCompletion()}</div>
+          </div>
+        );
+      })()}
     </div>
   );
 };

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -35,6 +35,7 @@ import { ActivityActionsWrapper } from "./ActivityActionsWrapper";
 import { ActivityAttribution } from "./ActivityAttribution";
 import { ActivityStatusHeader } from "./ActivityStatusHeader";
 import { GrantAssociation } from "./GrantAssociation";
+import { computeMilestoneCardCompletionGate } from "./milestone-card-gating";
 import { containerClassName } from "./styles";
 
 const ProjectObjectiveCompletion = dynamic(
@@ -214,6 +215,21 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
   const completionDeliverables =
     (projectMilestone?.completed?.data as any)?.deliverables ||
     (grantMilestone?.milestone.completed?.data as any)?.deliverables;
+
+  // See computeMilestoneCardCompletionGate for the full rule. Briefly: a
+  // completed milestone-shaped entry always renders the "Milestone Update"
+  // section, even with no narrative, so the timeline keeps surfacing the
+  // completion event and renderMilestoneCompletion can show "—".
+  const { showSection: showCompletionSection, showTimelineHeader: showCompletionTimelineHeader } =
+    computeMilestoneCardCompletionGate({
+      type,
+      completed,
+      completionReason,
+      completionProof,
+      completionDeliverables,
+      isCompleting,
+      isEditing,
+    });
 
   // Function to render project milestone completion form or details
   const renderMilestoneCompletion = () => {
@@ -591,70 +607,48 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
             </div>
           )}
       </div>
-      {(() => {
-        // A milestone-type entry that's been marked complete should always
-        // render the "Milestone Update" section, even if the project owner
-        // submitted no narrative — empty completion is shown as "—" inside
-        // renderMilestoneCompletion.
-        const isCompletedMilestone =
-          (type === "milestone" || type === "grant" || type === "project") && Boolean(completed);
-        const showSection =
-          isCompleting ||
-          isEditing ||
-          isCompletedMilestone ||
-          Boolean(completionReason) ||
-          Boolean(completionProof) ||
-          Boolean(completionDeliverables);
-        if (!showSection) return null;
-        const showTimelineHeader =
-          !isCompleting &&
-          (isCompletedMilestone ||
-            Boolean(completionReason) ||
-            Boolean(completionProof) ||
-            Boolean(completionDeliverables));
-        return (
-          <div className="flex flex-col gap-2.5 mt-2 pl-10">
-            {/* Timeline header: Only show when viewing existing completion data, not during form input */}
-            {showTimelineHeader && (
-              <div className="relative flex flex-row items-center justify-between gap-2 flex-wrap">
-                {!hideTimelineMarker && (
-                  /* Timeline badge - vertically centered relative to header row, aligned with main timeline */
-                  <div className="absolute -left-[73px] max-lg:-left-[69px] top-1/2 -translate-y-1/2 w-6 h-6 max-lg:w-5 max-lg:h-5 flex items-center justify-center z-10 bg-blue-50 dark:bg-blue-950 rounded-full ring-2 ring-white dark:ring-zinc-900">
-                    <div className="w-[3px] h-[3px] rounded-full bg-blue-400" />
-                  </div>
-                )}
-                {/* Left side: Activity type label */}
-                <div className="flex flex-row items-center gap-2.5 flex-wrap">
-                  <span className="text-sm font-semibold text-foreground">
-                    {getActivityTypeLabel(type)}
-                  </span>
+      {showCompletionSection && (
+        <div className="flex flex-col gap-2.5 mt-2 pl-10">
+          {/* Timeline header: Only show when viewing existing completion data, not during form input */}
+          {showCompletionTimelineHeader && (
+            <div className="relative flex flex-row items-center justify-between gap-2 flex-wrap">
+              {!hideTimelineMarker && (
+                /* Timeline badge - vertically centered relative to header row, aligned with main timeline */
+                <div className="absolute -left-[73px] max-lg:-left-[69px] top-1/2 -translate-y-1/2 w-6 h-6 max-lg:w-5 max-lg:h-5 flex items-center justify-center z-10 bg-blue-50 dark:bg-blue-950 rounded-full ring-2 ring-white dark:ring-zinc-900">
+                  <div className="w-[3px] h-[3px] rounded-full bg-blue-400" />
                 </div>
-
-                {/* Right side: Posted by */}
-                {completionDate && (
-                  <div className="flex flex-row items-center gap-3 text-sm font-medium leading-5 text-muted-foreground">
-                    <span>Posted {formatDate(completionDate)} by</span>
-                    {completionAttester && (
-                      <div className="flex flex-row items-center gap-3">
-                        <span className="text-sm font-semibold leading-5 text-foreground">
-                          <EthereumAddressToProfileName
-                            address={completionAttester}
-                            showProfilePicture
-                            pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
-                          />
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
+              )}
+              {/* Left side: Activity type label */}
+              <div className="flex flex-row items-center gap-2.5 flex-wrap">
+                <span className="text-sm font-semibold text-foreground">
+                  {getActivityTypeLabel(type)}
+                </span>
               </div>
-            )}
 
-            {/* Completion card - aligned with header */}
-            <div>{renderMilestoneCompletion()}</div>
-          </div>
-        );
-      })()}
+              {/* Right side: Posted by */}
+              {completionDate && (
+                <div className="flex flex-row items-center gap-3 text-sm font-medium leading-5 text-muted-foreground">
+                  <span>Posted {formatDate(completionDate)} by</span>
+                  {completionAttester && (
+                    <div className="flex flex-row items-center gap-3">
+                      <span className="text-sm font-semibold leading-5 text-foreground">
+                        <EthereumAddressToProfileName
+                          address={completionAttester}
+                          showProfilePicture
+                          pictureClassName="h-5 w-5 lg:h-6 lg:w-6 min-h-5 min-w-5 lg:min-h-6 lg:min-w-6 rounded-full"
+                        />
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Completion card - aligned with header */}
+          <div>{renderMilestoneCompletion()}</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/Shared/ActivityCard/milestone-card-gating.ts
+++ b/components/Shared/ActivityCard/milestone-card-gating.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure visibility logic for the "Milestone Update" section inside
+ * `MilestoneCard`. Lives outside the component so it can be unit-tested
+ * without a full render + mock harness.
+ *
+ * The rule we encode:
+ *   - A milestone-shaped entry (project / grant / project-milestone) that
+ *     is marked completed always renders the section, even when there's
+ *     no completion narrative — the inner renderer shows "—" so the
+ *     timeline still surfaces the completion event.
+ *   - Other activity-card types (update / grant_update / activity / impact)
+ *     keep the legacy "render only when there's content" gate, since they
+ *     don't have a "completed" state in the milestone sense.
+ */
+
+export type MilestoneCardActivityType =
+  | "milestone"
+  | "grant"
+  | "project"
+  | "update"
+  | "impact"
+  | "activity"
+  | "grant_update"
+  | "grant_received"
+  | "endorsement";
+
+export interface MilestoneCardCompletionGateInput {
+  type: MilestoneCardActivityType | string;
+  /** From `milestone.completed` — boolean for fresh shapes, object for v1 */
+  completed: unknown;
+  completionReason: unknown;
+  completionProof: unknown;
+  completionDeliverables: unknown;
+  isCompleting: boolean;
+  isEditing: boolean;
+}
+
+export interface MilestoneCardCompletionGate {
+  /** Whether the whole "Milestone Update" section renders. */
+  showSection: boolean;
+  /**
+   * Whether the timeline header (badge dot + "Posted X by Y") renders
+   * inside the section. Suppressed during the completion form input flow.
+   */
+  showTimelineHeader: boolean;
+}
+
+const MILESTONE_LIKE_TYPES = new Set<string>(["milestone", "grant", "project"]);
+
+export function computeMilestoneCardCompletionGate(
+  input: MilestoneCardCompletionGateInput
+): MilestoneCardCompletionGate {
+  const isCompletedMilestoneEntry =
+    MILESTONE_LIKE_TYPES.has(input.type) && Boolean(input.completed);
+  const hasCompletionContent = Boolean(
+    input.completionReason || input.completionProof || input.completionDeliverables
+  );
+  const showSection =
+    input.isCompleting || input.isEditing || isCompletedMilestoneEntry || hasCompletionContent;
+  const showTimelineHeader =
+    !input.isCompleting && (isCompletedMilestoneEntry || hasCompletionContent);
+  return { showSection, showTimelineHeader };
+}

--- a/src/features/payout-disbursement/types/payout-disbursement.ts
+++ b/src/features/payout-disbursement/types/payout-disbursement.ts
@@ -261,6 +261,10 @@ export interface CommunityPayoutInvoiceInfo {
   allocatedAmount: string | null;
   paymentStatus: MilestonePaymentStatus;
   paymentStatusDate: string | null;
+  /** Project-owner-supplied completion text. Null when the milestone has no
+   * on-chain completion or its completion carries no reason — in which case
+   * the AI evaluation badge is suppressed even if a stale evaluation exists. */
+  completionReason: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Pairs with show-karma/gap-indexer#1537, which stops the indexer from echoing the milestone's own description back as a fake completion narrative. With the indexer fix, `completionDetails.description` is now `''` when a milestone is marked complete on-chain without a narrative — this PR handles that empty state on the frontend and extends the same gating to the financials modal.

- `components/Shared/ActivityCard/MilestoneCard.tsx`: the "Milestone Update" section now renders for any completed milestone (`type ∈ {milestone, grant, project} && completed`), not only when there's completion text. When `completionReason` is empty, render an em-dash (`—`) inside the completion card. Extracted the gating into a small IIFE with named flags (`isCompletedMilestone`, `showSection`, `showTimelineHeader`) for readability.
- `components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx`: pass `completionReason={invoice.completionReason ?? ""}` to `<MilestoneAIEvaluationBadge>` so the gate added in #1343 also suppresses the AI score column when there's no real completion text. Field is sourced from the new `completionReason` on `CommunityPayoutInvoiceInfo`.
- `src/features/payout-disbursement/types/payout-disbursement.ts`: added `completionReason: string | null` to match the indexer payload.
- Mock factories in two test files updated for the new field.

## Why

For `evermedia-vault` Phase 1 / 3 / 4, the indexer was returning `completionDetails.description` byte-identical to the milestone's own definition. The on-chain AI evaluator scored those copies at 2/10 (correctly — there's no real evidence) and the public-facing project Updates tab + financials modal then displayed the score next to a "Completed" pill, reading as real assessment of the project rather than "no narrative supplied."

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec biome check` on changed files (no errors)
- [x] `pnpm exec vitest run __tests__/components/Pages/Communities/Financials/PublicProjectDetailsModal.test.tsx` — 20/20
- [x] `pnpm run build` succeeds
- [ ] Visit project Updates tab for `evermedia-vault` on a deploy targeting the indexer branch — verify Phase 1 / 3 / 4 cards still render with the "Milestone Update" section and show "—" instead of the milestone description echo, and the 2/10 AI badge is gone
- [ ] Visit Phase 2 (which has a real completion narrative) — verify it still renders its text and the 6/10 AI badge
- [ ] Open the financials modal (gear icon) for the same project — AI Score column reads "—" for milestones without narrative, and shows a real score for milestones with one