### PR TITLE
feat(evaluator): standalone grant application evaluator UI (DEV-60)

### DIFF
--- a/__tests__/features/standalone-evaluation/components/BulkUploadPanel.test.tsx
+++ b/__tests__/features/standalone-evaluation/components/BulkUploadPanel.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @file Tests BulkUploadPanel CSV validation feedback.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn(async () => "test-token") },
+}));
+
+import { BulkUploadPanel } from "@/src/features/standalone-evaluation/components/BulkUploadPanel";
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+function makeFile(content: string, name = "apps.csv") {
+  return new File([content], name, { type: "text/csv" });
+}
+
+describe("BulkUploadPanel", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    qc = buildClient();
+    vi.clearAllMocks();
+  });
+  afterEach(() => qc.clear());
+
+  it("rejects a CSV with no data rows", async () => {
+    const Wrapper = wrapper(qc);
+    render(
+      <Wrapper>
+        <BulkUploadPanel sessionId="s-1" />
+      </Wrapper>
+    );
+
+    const fileInput = document.querySelector("input[type=file]") as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+
+    const csv = "name,foo\n";
+    await userEvent.upload(fileInput, makeFile(csv));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/CSV must include a header row and at least one application/i)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it("accepts a CSV with arbitrary column names", async () => {
+    const Wrapper = wrapper(qc);
+    render(
+      <Wrapper>
+        <BulkUploadPanel sessionId="s-1" />
+      </Wrapper>
+    );
+
+    const fileInput = document.querySelector("input[type=file]") as HTMLInputElement;
+    const csv =
+      "Project name,Abstract\nFoo,This is a long-enough abstract for parsing.\nBar,Another abstract\n";
+    await userEvent.upload(fileInput, makeFile(csv));
+
+    await waitFor(() => expect(screen.getByText(/applications detected/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /Start bulk evaluation/i })).toBeEnabled();
+  });
+});

--- a/__tests__/features/standalone-evaluation/components/EvaluationResultCard.test.tsx
+++ b/__tests__/features/standalone-evaluation/components/EvaluationResultCard.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @file Component tests for EvaluationResultCard — verifies all three styles render.
+ */
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    const Stub = ({ source }: { source?: string }) => <div data-testid="markdown">{source}</div>;
+    Stub.displayName = "MarkdownStub";
+    return Stub;
+  },
+}));
+
+import { EvaluationResultCard } from "@/src/features/standalone-evaluation/components/EvaluationResultCard";
+import type { EvaluationResultResponse } from "@/src/features/standalone-evaluation/schemas/session.schema";
+
+const baseResult: EvaluationResultResponse = {
+  id: "r-1",
+  sessionId: "s-1",
+  score: 8,
+  summary: "Strong application overall.",
+  fullEvaluation: {},
+  iterationNumber: 1,
+  model: "claude-test",
+  createdAt: new Date().toISOString(),
+};
+
+describe("EvaluationResultCard", () => {
+  it("renders the rubric layout with criteria scores", () => {
+    render(
+      <EvaluationResultCard
+        style="RUBRIC"
+        result={{
+          ...baseResult,
+          fullEvaluation: {
+            criteria: [
+              { name: "Feasibility", score: 9, rationale: "Looks great" },
+              { name: "Team", score: 7, rationale: "Strong leads" },
+            ],
+            strengths: ["Clear roadmap"],
+            weaknesses: ["Light on metrics"],
+            recommendation: "Fund",
+          },
+        }}
+      />
+    );
+    expect(screen.getByTestId("eval-result-rubric")).toBeInTheDocument();
+    expect(screen.getByText("Feasibility")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+    expect(screen.getByText("Strengths")).toBeInTheDocument();
+    expect(screen.getByText("Weaknesses")).toBeInTheDocument();
+    expect(screen.getByText("Recommendation")).toBeInTheDocument();
+    expect(screen.getByText("Fund")).toBeInTheDocument();
+  });
+
+  it("renders the narrative layout with markdown sections", () => {
+    render(
+      <EvaluationResultCard
+        style="NARRATIVE"
+        result={{
+          ...baseResult,
+          fullEvaluation: {
+            scores: { Feasibility: 8, Team: 7 },
+            sections: [{ title: "Summary", body: "Markdown body here." }],
+          },
+        }}
+      />
+    );
+    expect(screen.getByTestId("eval-result-narrative")).toBeInTheDocument();
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.getByText("Feasibility:")).toBeInTheDocument();
+    expect(screen.getByTestId("markdown")).toHaveTextContent("Markdown body here.");
+  });
+
+  it("renders the quick-score layout with PASS chip and red flags", () => {
+    render(
+      <EvaluationResultCard
+        style="QUICK_SCORE"
+        result={{
+          ...baseResult,
+          score: null,
+          fullEvaluation: {
+            decision: "PASS",
+            keyFactors: ["Strong team"],
+            redFlags: ["Vague timeline"],
+            oneLineSummary: "Solid candidate.",
+          },
+        }}
+      />
+    );
+    expect(screen.getByTestId("eval-result-quick_score")).toBeInTheDocument();
+    expect(screen.getByText("PASS")).toBeInTheDocument();
+    expect(screen.getByText("Solid candidate.")).toBeInTheDocument();
+    expect(screen.getByText("Strong team")).toBeInTheDocument();
+    expect(screen.getByText("Vague timeline")).toBeInTheDocument();
+  });
+});

--- a/__tests__/features/standalone-evaluation/components/FeedbackComposer.test.tsx
+++ b/__tests__/features/standalone-evaluation/components/FeedbackComposer.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @file Tests the disabled-without-sample state of FeedbackComposer.
+ */
+import { render, screen } from "@testing-library/react";
+
+import { FeedbackComposer } from "@/src/features/standalone-evaluation/components/FeedbackComposer";
+
+describe("FeedbackComposer", () => {
+  it("shows the empty-state hint when there is no sample", () => {
+    render(<FeedbackComposer hasSample={false} isPending={false} onSubmit={() => {}} />);
+    expect(
+      screen.getByText(/Run an initial evaluation on a sample application/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Feedback")).not.toBeInTheDocument();
+  });
+
+  it("renders the textarea when a sample is set", () => {
+    render(<FeedbackComposer hasSample isPending={false} onSubmit={() => {}} />);
+    expect(screen.getByLabelText("Feedback")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Re-evaluate/i })).toBeDisabled(); // empty feedback shouldn't allow submit
+  });
+});

--- a/__tests__/features/standalone-evaluation/components/PurchaseCreditsModal.test.tsx
+++ b/__tests__/features/standalone-evaluation/components/PurchaseCreditsModal.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @file Tests that PurchaseCreditsModal pack click triggers Stripe redirect.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({ authenticated: true })),
+}));
+
+import { PurchaseCreditsModal } from "@/src/features/standalone-evaluation/components/PurchaseCreditsModal";
+import fetchData from "@/utilities/fetchData";
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+describe("PurchaseCreditsModal", () => {
+  let qc: QueryClient;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    qc = buildClient();
+    vi.clearAllMocks();
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, href: "" },
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects to Stripe when a pack is selected", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([
+      { url: "https://checkout.stripe.com/x", sessionId: "cs_x" },
+      null,
+      null,
+      201,
+    ]);
+
+    const Wrapper = wrapper(qc);
+    render(
+      <Wrapper>
+        <PurchaseCreditsModal open onOpenChange={() => {}} />
+      </Wrapper>
+    );
+
+    const starterButton = await screen.findByRole("button", {
+      name: /Buy Starter pack/i,
+    });
+    await userEvent.click(starterButton);
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalled());
+    await waitFor(() => expect(window.location.href).toBe("https://checkout.stripe.com/x"));
+  });
+});

--- a/__tests__/features/standalone-evaluation/hooks/useBulkJobProgress.test.tsx
+++ b/__tests__/features/standalone-evaluation/hooks/useBulkJobProgress.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @file Tests for the bulk job SSE consumer hook.
+ *
+ * Strategy: stub global.fetch with a ReadableStream that emits SSE-shaped
+ * chunks. We verify that progress events update state, the `done` event
+ * captures the resultFileUrl, heartbeat lines do not break parsing, and
+ * the AbortController is fired on unmount.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn(async () => "test-token") },
+}));
+
+import { useBulkJobProgress } from "@/src/features/standalone-evaluation/hooks/useBulkJob";
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+function makeStream(chunks: string[]) {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[i]));
+      i += 1;
+    },
+  });
+}
+
+describe("useBulkJobProgress", () => {
+  let qc: QueryClient;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    qc = buildClient();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    qc.clear();
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("processes progress and done events, ignoring heartbeats", async () => {
+    const chunks = [
+      ":keepalive\n\n",
+      'event: progress\ndata: {"status":"RUNNING","totalApplications":3,"completedApplications":1,"failedApplications":0}\n\n',
+      'event: progress\ndata: {"status":"RUNNING","totalApplications":3,"completedApplications":3,"failedApplications":0}\n\n',
+      'event: done\ndata: {"hasResult":true}\n\n',
+    ];
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: makeStream(chunks),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const { result } = renderHook(() => useBulkJobProgress("sess-1", "job-1"), {
+      wrapper: wrapper(qc),
+    });
+
+    await waitFor(() => expect(result.current.progress.status).toBe("COMPLETED"));
+    expect(result.current.progress.completedApplications).toBe(3);
+    expect(result.current.progress.totalApplications).toBe(3);
+    expect(result.current.progress.hasResult).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the request on unmount", async () => {
+    const aborted = vi.fn();
+
+    // Long-lived stream: never completes until aborted.
+    let aborter: ((reason?: unknown) => void) | null = null;
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          if (signal) {
+            const onAbort = () => {
+              aborted();
+              try {
+                controller.error(new DOMException("Aborted", "AbortError"));
+              } catch {
+                // already errored
+              }
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          }
+          aborter = (reason) => {
+            try {
+              controller.error(reason);
+            } catch {
+              // ignore
+            }
+          };
+        },
+      });
+      return { ok: true, status: 200, body: stream };
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const { unmount } = renderHook(() => useBulkJobProgress("sess-1", "job-2"), {
+      wrapper: wrapper(qc),
+    });
+
+    // Wait until fetch was called once.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    unmount();
+
+    await waitFor(() => expect(aborted).toHaveBeenCalled());
+    // Reference aborter to satisfy lints; we also use it to ensure stream is held.
+    expect(typeof aborter === "function" || aborter === null).toBe(true);
+  });
+
+  it("does not fetch when sessionId or jobId is missing", () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, body: makeStream([]) }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    renderHook(() => useBulkJobProgress("", null), { wrapper: wrapper(qc) });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/features/standalone-evaluation/hooks/useCredits.test.tsx
+++ b/__tests__/features/standalone-evaluation/hooks/useCredits.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file Tests for credit hooks (balance + Stripe redirect).
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({ authenticated: true })),
+}));
+
+import {
+  useCredits,
+  usePurchaseCredits,
+} from "@/src/features/standalone-evaluation/hooks/useCredits";
+import fetchData from "@/utilities/fetchData";
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+describe("useCredits", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    qc = buildClient();
+  });
+  afterEach(() => qc.clear());
+
+  it("fetches the credit balance", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([
+      { balance: 42, totalPurchased: 100, totalUsed: 58, recentTransactions: [] },
+      null,
+      null,
+      200,
+    ]);
+
+    const { result } = renderHook(() => useCredits(), { wrapper: wrapper(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.balance).toBe(42);
+    expect(fetchData).toHaveBeenCalledWith("/v2/evaluate/credits", "GET");
+  });
+});
+
+describe("usePurchaseCredits", () => {
+  let qc: QueryClient;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    qc = buildClient();
+    originalLocation = window.location;
+    // Stripe redirect sets window.location.href directly. Stub it so we can assert.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, href: "" },
+    });
+  });
+  afterEach(() => {
+    qc.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects the browser to the Stripe checkout URL", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([
+      { url: "https://checkout.stripe.com/abc", sessionId: "cs_123" },
+      null,
+      null,
+      201,
+    ]);
+
+    const { result } = renderHook(() => usePurchaseCredits(), {
+      wrapper: wrapper(qc),
+    });
+
+    result.current.mutate({ pack: "PACK_100" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchData).toHaveBeenCalledWith(
+      "/v2/evaluate/credits/purchase",
+      "POST",
+      expect.objectContaining({
+        pack: "PACK_100",
+        successUrl: expect.stringContaining("/evaluate"),
+        cancelUrl: expect.stringContaining("/evaluate"),
+      })
+    );
+    expect(window.location.href).toBe("https://checkout.stripe.com/abc");
+  });
+});

--- a/__tests__/features/standalone-evaluation/hooks/useEvaluationSessions.test.tsx
+++ b/__tests__/features/standalone-evaluation/hooks/useEvaluationSessions.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @file Tests for evaluation session hooks (list, detail, create).
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({ authenticated: true })),
+}));
+
+import {
+  useCreateSession,
+  useSessions,
+} from "@/src/features/standalone-evaluation/hooks/useEvaluationSessions";
+import fetchData from "@/utilities/fetchData";
+
+const mockSession = {
+  id: "sess-1",
+  userId: "u-1",
+  programDescription: "A test program description that is long enough to validate.",
+  evaluationCriteria: "Bullet list criteria more than 20 chars.",
+  evaluationStyle: "RUBRIC" as const,
+  status: "DRAFT" as const,
+  feedbackHistory: [],
+  sampleApplication: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper =
+  (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+describe("useSessions", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    qc = buildClient();
+  });
+  afterEach(() => qc.clear());
+
+  it("fetches and returns the sessions list", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([
+      { items: [mockSession], total: 1 },
+      null,
+      null,
+      200,
+    ]);
+
+    const { result } = renderHook(() => useSessions(), { wrapper: wrapper(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.total).toBe(1);
+    expect(fetchData).toHaveBeenCalledWith("/v2/evaluate/sessions?limit=20&offset=0", "GET");
+  });
+
+  it("surfaces errors from the service layer", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([null, "Server boom", null, 500]);
+
+    const { result } = renderHook(() => useSessions(), { wrapper: wrapper(qc) });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe("Server boom");
+  });
+});
+
+describe("useCreateSession", () => {
+  let qc: QueryClient;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    qc = buildClient();
+  });
+  afterEach(() => qc.clear());
+
+  it("creates a session and invalidates the list cache", async () => {
+    (fetchData as vi.Mock).mockResolvedValueOnce([mockSession, null, null, 201]);
+
+    const { result } = renderHook(() => useCreateSession(), {
+      wrapper: wrapper(qc),
+    });
+
+    result.current.mutate({
+      programDescription: mockSession.programDescription,
+      evaluationCriteria: mockSession.evaluationCriteria,
+      evaluationStyle: "RUBRIC",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchData).toHaveBeenCalledWith(
+      "/v2/evaluate/sessions",
+      "POST",
+      expect.objectContaining({ evaluationStyle: "RUBRIC" })
+    );
+    expect(result.current.data?.id).toBe("sess-1");
+  });
+});

--- a/app/evaluate/error.tsx
+++ b/app/evaluate/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Link } from "@/src/components/navigation/Link";
+
+export default function EvaluateError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading the evaluator. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/evaluate/layout.tsx
+++ b/app/evaluate/layout.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function EvaluateLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/evaluate/layout.tsx
+++ b/app/evaluate/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export default function EvaluateLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }

--- a/app/evaluate/loading.tsx
+++ b/app/evaluate/loading.tsx
@@ -1,0 +1,11 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-12">
+      <div className="space-y-4">
+        <div className="h-8 w-72 animate-pulse rounded-lg bg-muted" />
+        <div className="h-4 w-full max-w-md animate-pulse rounded bg-muted" />
+        <div className="mt-8 h-64 animate-pulse rounded-xl bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/app/evaluate/page.tsx
+++ b/app/evaluate/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { EvaluatePage } from "@/src/features/standalone-evaluation/EvaluatePage";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "Evaluate Grant Applications",
+  description:
+    "AI-powered grant application evaluation. Iterate on your evaluation prompt against a sample application, then bulk-process a CSV of applications.",
+  path: "/evaluate",
+  robots: { index: false, follow: true },
+});
+
+export default function Page() {
+  return <EvaluatePage />;
+}

--- a/src/features/standalone-evaluation/EvaluatePage.tsx
+++ b/src/features/standalone-evaluation/EvaluatePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -51,37 +52,51 @@ export function EvaluatePage() {
   // Auto-download when arriving from a completion-email link:
   //   /evaluate?session=<sessionId>&bulk-download=<jobId>
   // The user is already authenticated here, so we fetch via the authed
-  // service and trigger a Blob download. Runs at most once per mount.
+  // service and trigger a Blob download. Each `session/job` pair is
+  // attempted at most once per mount, but distinct links land in distinct
+  // attempts — and on failure the key clears so the user can retry by
+  // refreshing the page.
   const searchParams = useSearchParams();
   const downloadSession = searchParams?.get("session");
   const downloadJobId = searchParams?.get("bulk-download");
-  const didAutoDownloadRef = useRef(false);
+  const autoDownloadKey =
+    downloadSession && downloadJobId ? `${downloadSession}:${downloadJobId}` : null;
+  const lastAutoDownloadKeyRef = useRef<string | null>(null);
+
+  const autoDownloadMutation = useMutation<void, Error, { sessionId: string; jobId: string }>({
+    mutationFn: async ({ sessionId, jobId }) => {
+      const blob = await standaloneEvaluationService.downloadBulkResultCsv(sessionId, jobId);
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = `bulk-evaluation-${jobId}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    },
+    onSuccess: () => {
+      toast.success("Results downloaded");
+    },
+    onError: (err, _variables) => {
+      // Reset the key so a refresh can retry.
+      lastAutoDownloadKeyRef.current = null;
+      toast.error(err.message || "Couldn't download results");
+    },
+  });
+
   useEffect(() => {
     if (!authenticated) return;
-    if (!downloadSession || !downloadJobId) return;
-    if (didAutoDownloadRef.current) return;
-    didAutoDownloadRef.current = true;
-    (async () => {
-      try {
-        const blob = await standaloneEvaluationService.downloadBulkResultCsv(
-          downloadSession,
-          downloadJobId
-        );
-        const objectUrl = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = objectUrl;
-        a.download = `bulk-evaluation-${downloadJobId}.csv`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
-        toast.success("Results downloaded");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Couldn't download results";
-        toast.error(msg);
-      }
-    })();
-  }, [authenticated, downloadSession, downloadJobId]);
+    if (!downloadSession || !downloadJobId || !autoDownloadKey) return;
+    if (lastAutoDownloadKeyRef.current === autoDownloadKey) return;
+    lastAutoDownloadKeyRef.current = autoDownloadKey;
+    autoDownloadMutation.mutate({
+      sessionId: downloadSession,
+      jobId: downloadJobId,
+    });
+    // autoDownloadMutation is stable from useMutation; not depending on it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authenticated, downloadSession, downloadJobId, autoDownloadKey]);
 
   if (!ready) {
     return (

--- a/src/features/standalone-evaluation/EvaluatePage.tsx
+++ b/src/features/standalone-evaluation/EvaluatePage.tsx
@@ -154,6 +154,11 @@ export function EvaluatePage() {
             setView("workspace");
           }}
           onCreateNew={() => {
+            // Block any pending auto-select once the user has explicitly
+            // asked for a fresh form. Without this, if the click happens
+            // while sessionsQuery is still loading, the auto-select effect
+            // above will later open items[0] and clobber the form.
+            didAutoSelectRef.current = true;
             setActiveSessionId(null);
             setView("form");
           }}

--- a/src/features/standalone-evaluation/EvaluatePage.tsx
+++ b/src/features/standalone-evaluation/EvaluatePage.tsx
@@ -25,10 +25,8 @@ export function EvaluatePage() {
   // Initial view: workspace if we have an active session id, otherwise the form.
   const [view, setView] = useState<View>(activeSessionId ? "workspace" : "form");
 
-  // Apply the "default to most recent session" only ONCE per mount. Without
-  // this guard, clicking "New session" (which sets activeSessionId to null)
-  // would immediately re-trigger the auto-select effect and clobber the
-  // user's intent to start fresh.
+  // Auto-select runs once per mount; "New session" flips this to keep the
+  // form open after an explicit reset.
   const didAutoSelectRef = useRef(false);
   useEffect(() => {
     if (!authenticated) return;
@@ -42,20 +40,13 @@ export function EvaluatePage() {
     }
   }, [authenticated, activeSessionId, sessionsQuery.data, setActiveSessionId]);
 
-  // Whenever activeSessionId changes meaningfully, sync the view.
   useEffect(() => {
     if (activeSessionId) {
       setView("workspace");
     }
   }, [activeSessionId]);
 
-  // Auto-download when arriving from a completion-email link:
-  //   /evaluate?session=<sessionId>&bulk-download=<jobId>
-  // The user is already authenticated here, so we fetch via the authed
-  // service and trigger a Blob download. Each `session/job` pair is
-  // attempted at most once per mount, but distinct links land in distinct
-  // attempts — and on failure the key clears so the user can retry by
-  // refreshing the page.
+  // Auto-download from completion-email links: /evaluate?session=&bulk-download=
   const searchParams = useSearchParams();
   const downloadSession = searchParams?.get("session");
   const downloadJobId = searchParams?.get("bulk-download");
@@ -78,8 +69,7 @@ export function EvaluatePage() {
     onSuccess: () => {
       toast.success("Results downloaded");
     },
-    onError: (err, _variables) => {
-      // Reset the key so a refresh can retry.
+    onError: (err) => {
       lastAutoDownloadKeyRef.current = null;
       toast.error(err.message || "Couldn't download results");
     },
@@ -94,7 +84,6 @@ export function EvaluatePage() {
       sessionId: downloadSession,
       jobId: downloadJobId,
     });
-    // autoDownloadMutation is stable from useMutation; not depending on it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authenticated, downloadSession, downloadJobId, autoDownloadKey]);
 
@@ -154,10 +143,6 @@ export function EvaluatePage() {
             setView("workspace");
           }}
           onCreateNew={() => {
-            // Block any pending auto-select once the user has explicitly
-            // asked for a fresh form. Without this, if the click happens
-            // while sessionsQuery is still loading, the auto-select effect
-            // above will later open items[0] and clobber the form.
             didAutoSelectRef.current = true;
             setActiveSessionId(null);
             setView("form");

--- a/src/features/standalone-evaluation/EvaluatePage.tsx
+++ b/src/features/standalone-evaluation/EvaluatePage.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { useAuth } from "@/hooks/useAuth";
+import { CreditBalanceBadge } from "./components/CreditBalanceBadge";
+import { EvaluateWorkspace } from "./components/EvaluateWorkspace";
+import { EvaluationSessionForm } from "./components/EvaluationSessionForm";
+import { SessionListSidebar } from "./components/SessionListSidebar";
+import { useSessions } from "./hooks/useEvaluationSessions";
+import { standaloneEvaluationService } from "./services/standaloneEvaluationService";
+import { useEvaluationDraftStore } from "./store/evaluationDraftStore";
+
+type View = "form" | "workspace";
+
+export function EvaluatePage() {
+  const { ready, authenticated, login } = useAuth();
+  const activeSessionId = useEvaluationDraftStore((s) => s.activeSessionId);
+  const setActiveSessionId = useEvaluationDraftStore((s) => s.setActiveSessionId);
+  const sessionsQuery = useSessions();
+
+  // Initial view: workspace if we have an active session id, otherwise the form.
+  const [view, setView] = useState<View>(activeSessionId ? "workspace" : "form");
+
+  // Apply the "default to most recent session" only ONCE per mount. Without
+  // this guard, clicking "New session" (which sets activeSessionId to null)
+  // would immediately re-trigger the auto-select effect and clobber the
+  // user's intent to start fresh.
+  const didAutoSelectRef = useRef(false);
+  useEffect(() => {
+    if (!authenticated) return;
+    if (activeSessionId) return;
+    if (didAutoSelectRef.current) return;
+    const items = sessionsQuery.data?.items;
+    if (items && items.length > 0) {
+      didAutoSelectRef.current = true;
+      setActiveSessionId(items[0].id);
+      setView("workspace");
+    }
+  }, [authenticated, activeSessionId, sessionsQuery.data, setActiveSessionId]);
+
+  // Whenever activeSessionId changes meaningfully, sync the view.
+  useEffect(() => {
+    if (activeSessionId) {
+      setView("workspace");
+    }
+  }, [activeSessionId]);
+
+  // Auto-download when arriving from a completion-email link:
+  //   /evaluate?session=<sessionId>&bulk-download=<jobId>
+  // The user is already authenticated here, so we fetch via the authed
+  // service and trigger a Blob download. Runs at most once per mount.
+  const searchParams = useSearchParams();
+  const downloadSession = searchParams?.get("session");
+  const downloadJobId = searchParams?.get("bulk-download");
+  const didAutoDownloadRef = useRef(false);
+  useEffect(() => {
+    if (!authenticated) return;
+    if (!downloadSession || !downloadJobId) return;
+    if (didAutoDownloadRef.current) return;
+    didAutoDownloadRef.current = true;
+    (async () => {
+      try {
+        const blob = await standaloneEvaluationService.downloadBulkResultCsv(
+          downloadSession,
+          downloadJobId
+        );
+        const objectUrl = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = objectUrl;
+        a.download = `bulk-evaluation-${downloadJobId}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+        toast.success("Results downloaded");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Couldn't download results";
+        toast.error(msg);
+      }
+    })();
+  }, [authenticated, downloadSession, downloadJobId]);
+
+  if (!ready) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        <div className="space-y-4">
+          <div className="h-8 w-72 animate-pulse rounded-lg bg-muted" />
+          <div className="h-4 w-full max-w-md animate-pulse rounded bg-muted" />
+          <div className="mt-8 h-64 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="mx-auto max-w-xl px-4 py-16">
+        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Sparkles className="h-6 w-6 text-primary" />
+          </div>
+          <h1 className="text-2xl font-semibold text-foreground">Evaluate Grant Applications</h1>
+          <p className="text-sm text-muted-foreground">
+            AI-powered grant application evaluation. Sign in to create a session, iterate on your
+            evaluation prompt, and bulk-process a CSV of applications.
+          </p>
+          <button
+            type="button"
+            onClick={() => login()}
+            className="mt-2 rounded-lg bg-primary px-5 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Sign in to continue
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-foreground">Evaluate Grant Applications</h1>
+          <p className="text-sm text-muted-foreground">
+            Configure your evaluation, iterate on a sample, then bulk-process your applications.
+          </p>
+        </div>
+        <CreditBalanceBadge />
+      </header>
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <SessionListSidebar
+          activeSessionId={activeSessionId}
+          onSelect={(id) => {
+            setActiveSessionId(id);
+            setView("workspace");
+          }}
+          onCreateNew={() => {
+            setActiveSessionId(null);
+            setView("form");
+          }}
+        />
+
+        <main className="flex-1 min-w-0">
+          {view === "form" || !activeSessionId ? (
+            <EvaluationSessionForm
+              onCancel={
+                (sessionsQuery.data?.items.length ?? 0) > 0 ? () => setView("workspace") : undefined
+              }
+            />
+          ) : (
+            <EvaluateWorkspace sessionId={activeSessionId} />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/EvaluatePage.tsx
+++ b/src/features/standalone-evaluation/EvaluatePage.tsx
@@ -89,7 +89,7 @@ export function EvaluatePage() {
 
   if (!ready) {
     return (
-      <div className="mx-auto max-w-5xl px-4 py-12">
+      <div className="mx-auto max-w-screen-2xl px-4 py-12 lg:px-8">
         <div className="space-y-4">
           <div className="h-8 w-72 animate-pulse rounded-lg bg-muted" />
           <div className="h-4 w-full max-w-md animate-pulse rounded bg-muted" />
@@ -124,7 +124,7 @@ export function EvaluatePage() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-10">
+    <div className="mx-auto max-w-screen-2xl px-4 py-10 lg:px-8">
       <header className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-semibold text-foreground">Evaluate Grant Applications</h1>

--- a/src/features/standalone-evaluation/components/ApplicationInput.tsx
+++ b/src/features/standalone-evaluation/components/ApplicationInput.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Loader2, Play } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { APPLICATION_TEXT_MAX, sessionEvaluateSchema } from "../schemas/session.schema";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+
+interface ApplicationInputProps {
+  sessionId: string;
+  onRun: (applicationText: string) => void;
+  isRunning: boolean;
+  disabled?: boolean;
+}
+
+const textareaClass =
+  "mt-1 w-full min-h-[220px] rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60";
+
+export function ApplicationInput({ onRun, isRunning, disabled }: ApplicationInputProps) {
+  const applicationText = useEvaluationDraftStore((s) => s.applicationText);
+  const setApplicationText = useEvaluationDraftStore((s) => s.setApplicationText);
+  const [error, setError] = useState<string | null>(null);
+
+  const length = applicationText.length;
+
+  const handleRun = () => {
+    const parsed = sessionEvaluateSchema.safeParse({ applicationText });
+    if (!parsed.success) {
+      setError(parsed.error.errors[0]?.message ?? "Invalid application text");
+      return;
+    }
+    setError(null);
+    onRun(parsed.data.applicationText);
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Sample application</h2>
+          <p className="text-sm text-muted-foreground">
+            Paste one application text. We’ll run a single evaluation so you can iterate on the
+            prompt before going bulk.
+          </p>
+        </div>
+      </div>
+      <textarea
+        aria-label="Application text"
+        className={textareaClass}
+        value={applicationText}
+        onChange={(e) => setApplicationText(e.target.value.slice(0, APPLICATION_TEXT_MAX))}
+        placeholder="Paste an application — proposal text, application form answers, etc."
+        disabled={disabled || isRunning}
+      />
+      <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-xs">
+        <span className="text-red-500">{error}</span>
+        <span className="text-muted-foreground">
+          {length}/{APPLICATION_TEXT_MAX}
+        </span>
+      </div>
+
+      <div className="mt-4 flex items-center gap-2">
+        <Button onClick={handleRun} disabled={disabled || isRunning || length < 20}>
+          {isRunning ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" /> Evaluating
+            </>
+          ) : (
+            <>
+              <Play className="h-4 w-4" /> Run evaluation
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/BulkHistoryList.tsx
+++ b/src/features/standalone-evaluation/components/BulkHistoryList.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from "lucide-react";
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utilities/tailwind";
+import { useBulkJobsList } from "../hooks/useBulkJob";
+import type { BulkJobResponse } from "../schemas/session.schema";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { BulkResultTable } from "./BulkResultTable";
+
+interface BulkHistoryListProps {
+  sessionId: string;
+}
+
+const TERMINAL_STATUSES = new Set(["COMPLETED", "FAILED"]);
+
+function StatusIcon({ status }: { status: BulkJobResponse["status"] }) {
+  if (status === "COMPLETED")
+    return <CheckCircle2 className="h-4 w-4 text-green-600" aria-hidden />;
+  if (status === "FAILED") return <XCircle className="h-4 w-4 text-red-600" aria-hidden />;
+  return <Loader2 className="h-4 w-4 animate-spin text-brand-500" aria-hidden />;
+}
+
+function formatDate(value: string): string {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+export function BulkHistoryList({ sessionId }: BulkHistoryListProps) {
+  const query = useBulkJobsList(sessionId);
+  const activeJobId = useEvaluationDraftStore((s) => s.activeBulkJobIdBySession[sessionId]);
+
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading bulk history…
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+        <span>Couldn't load bulk history: {query.error?.message ?? "unknown error"}</span>
+        <button
+          type="button"
+          className="self-start rounded border border-red-300 px-2 py-0.5 hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/40"
+          onClick={() => query.refetch()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const jobs = query.data ?? [];
+  if (jobs.length === 0) {
+    return <p className="text-xs text-muted-foreground">No bulk runs yet for this session.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Past bulk runs</h3>
+        <span className="text-xs text-muted-foreground">
+          {jobs.length} {jobs.length === 1 ? "run" : "runs"}
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {jobs.map((job) => (
+          <BulkHistoryRow
+            key={job.id}
+            job={job}
+            sessionId={sessionId}
+            isActive={activeJobId === job.id}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface BulkHistoryRowProps {
+  job: BulkJobResponse;
+  sessionId: string;
+  isActive: boolean;
+}
+
+const BulkHistoryRow = React.memo(function BulkHistoryRow({
+  job,
+  sessionId,
+  isActive,
+}: BulkHistoryRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const isTerminal = TERMINAL_STATUSES.has(job.status);
+  const canExpand = isTerminal && job.hasResult;
+
+  return (
+    <li
+      className={cn("rounded-md border border-border bg-card", isActive && "ring-1 ring-brand-500")}
+    >
+      <div className="flex flex-wrap items-center gap-3 p-3 text-xs">
+        <StatusIcon status={job.status} />
+        <span className="font-mono text-muted-foreground" title={job.id}>
+          {job.id.slice(0, 8)}
+        </span>
+        <span className="text-muted-foreground">
+          {formatDate(job.completedAt ?? job.startedAt)}
+        </span>
+        <span className="rounded bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          {job.status}
+        </span>
+        <span className="ml-auto text-muted-foreground">
+          {job.completedApplications}/{job.totalApplications} done
+          {job.failedApplications > 0 ? ` · ${job.failedApplications} failed` : ""}
+        </span>
+        {canExpand ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? (
+              <>
+                <ChevronDown className="h-3.5 w-3.5" /> Hide
+              </>
+            ) : (
+              <>
+                <ChevronRight className="h-3.5 w-3.5" /> View
+              </>
+            )}
+          </Button>
+        ) : null}
+      </div>
+      {expanded && canExpand ? (
+        <div className="border-t border-border bg-muted/20 p-3">
+          <BulkResultTable sessionId={sessionId} jobId={job.id} enabled={true} />
+        </div>
+      ) : null}
+    </li>
+  );
+});

--- a/src/features/standalone-evaluation/components/BulkHistoryList.tsx
+++ b/src/features/standalone-evaluation/components/BulkHistoryList.tsx
@@ -23,11 +23,9 @@ function StatusIcon({ status }: { status: BulkJobResponse["status"] }) {
 }
 
 function formatDate(value: string): string {
-  try {
-    return new Date(value).toLocaleString();
-  } catch {
-    return value;
-  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
 }
 
 export function BulkHistoryList({ sessionId }: BulkHistoryListProps) {

--- a/src/features/standalone-evaluation/components/BulkHistoryList.tsx
+++ b/src/features/standalone-evaluation/components/BulkHistoryList.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/utilities/tailwind";
 import { useBulkJobsList } from "../hooks/useBulkJob";
 import type { BulkJobResponse } from "../schemas/session.schema";
 import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
-import { BulkResultTable } from "./BulkResultTable";
+import { BulkResultsDashboard } from "./BulkResultsDashboard";
 
 interface BulkHistoryListProps {
   sessionId: string;
@@ -140,7 +140,7 @@ const BulkHistoryRow = React.memo(function BulkHistoryRow({
       </div>
       {expanded && canExpand ? (
         <div className="border-t border-border bg-muted/20 p-3">
-          <BulkResultTable sessionId={sessionId} jobId={job.id} enabled={true} />
+          <BulkResultsDashboard sessionId={sessionId} jobId={job.id} enabled={true} />
         </div>
       ) : null}
     </li>

--- a/src/features/standalone-evaluation/components/BulkProgressView.tsx
+++ b/src/features/standalone-evaluation/components/BulkProgressView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
 import { CheckCircle2, Download, Loader2, X, XCircle } from "lucide-react";
-import { useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utilities/tailwind";
@@ -56,14 +56,12 @@ interface DownloadButtonProps {
 }
 
 function DownloadButton({ sessionId, jobId }: DownloadButtonProps) {
-  const [downloading, setDownloading] = useState(false);
-
-  const handle = async () => {
-    setDownloading(true);
-    try {
-      // BE serializes the stored {columns, rows} to CSV on demand and
-      // streams it back. We read as a Blob, build an object URL, and
-      // trigger a download via a synthetic anchor click.
+  // BE serializes the stored {columns, rows} to CSV on demand and streams
+  // it back. We read as a Blob, build an object URL, and trigger a download
+  // via a synthetic anchor click. Using `useMutation` so loading/error
+  // state goes through React Query rather than ad-hoc useState.
+  const downloadMutation = useMutation<void, Error, void>({
+    mutationFn: async () => {
       const blob = await standaloneEvaluationService.downloadBulkResultCsv(sessionId, jobId);
       const objectUrl = URL.createObjectURL(blob);
       try {
@@ -77,13 +75,14 @@ function DownloadButton({ sessionId, jobId }: DownloadButtonProps) {
         // Revoke after a tick so the browser has a chance to start the download.
         setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Couldn't download results";
-      toast.error(message);
-    } finally {
-      setDownloading(false);
-    }
-  };
+    },
+    onError: (err) => {
+      toast.error(err.message || "Couldn't download results");
+    },
+  });
+
+  const downloading = downloadMutation.isPending;
+  const handle = () => downloadMutation.mutate();
 
   return (
     <Button type="button" onClick={handle} disabled={downloading}>

--- a/src/features/standalone-evaluation/components/BulkProgressView.tsx
+++ b/src/features/standalone-evaluation/components/BulkProgressView.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { CheckCircle2, Download, Loader2, X, XCircle } from "lucide-react";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utilities/tailwind";
+import { useBulkJobProgress } from "../hooks/useBulkJob";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+import { BulkResultTable } from "./BulkResultTable";
+
+interface BulkProgressViewProps {
+  sessionId: string;
+  jobId: string;
+}
+
+interface ProgressMetrics {
+  total: number;
+  done: number;
+  percent: number;
+  failedCount: number;
+}
+
+function computeMetrics(
+  totalApplications: number,
+  completedApplications: number,
+  failedApplications: number,
+  isComplete: boolean
+): ProgressMetrics {
+  const total = totalApplications;
+  const done = completedApplications + failedApplications;
+  let percent = 0;
+  if (total > 0) {
+    percent = Math.min(100, Math.round((done / total) * 100));
+  } else if (isComplete) {
+    percent = 100;
+  }
+  return { total, done, percent, failedCount: failedApplications };
+}
+
+function StatusIcon({ status }: { status: "DONE" | "FAILED" | "RUNNING" }) {
+  if (status === "DONE") return <CheckCircle2 className="h-5 w-5 text-green-600" aria-hidden />;
+  if (status === "FAILED") return <XCircle className="h-5 w-5 text-red-600" aria-hidden />;
+  return <Loader2 className="h-5 w-5 animate-spin text-brand-500" aria-hidden />;
+}
+
+function statusTitle(status: "DONE" | "FAILED" | "RUNNING"): string {
+  if (status === "DONE") return "Bulk evaluation complete";
+  if (status === "FAILED") return "Bulk evaluation failed";
+  return "Bulk evaluation in progress";
+}
+
+interface DownloadButtonProps {
+  sessionId: string;
+  jobId: string;
+}
+
+function DownloadButton({ sessionId, jobId }: DownloadButtonProps) {
+  const [downloading, setDownloading] = useState(false);
+
+  const handle = async () => {
+    setDownloading(true);
+    try {
+      // BE serializes the stored {columns, rows} to CSV on demand and
+      // streams it back. We read as a Blob, build an object URL, and
+      // trigger a download via a synthetic anchor click.
+      const blob = await standaloneEvaluationService.downloadBulkResultCsv(sessionId, jobId);
+      const objectUrl = URL.createObjectURL(blob);
+      try {
+        const a = document.createElement("a");
+        a.href = objectUrl;
+        a.download = `bulk-evaluation-${jobId}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } finally {
+        // Revoke after a tick so the browser has a chance to start the download.
+        setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Couldn't download results";
+      toast.error(message);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <Button type="button" onClick={handle} disabled={downloading}>
+      {downloading ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" /> Preparing download
+        </>
+      ) : (
+        <>
+          <Download className="h-4 w-4" /> Download results CSV
+        </>
+      )}
+    </Button>
+  );
+}
+
+export function BulkProgressView({ sessionId, jobId }: BulkProgressViewProps) {
+  const { progress, dismiss } = useBulkJobProgress(sessionId, jobId);
+
+  const isDone = progress.status === "COMPLETED";
+  const isFailed = progress.status === "FAILED" || progress.status === "ERROR";
+  const status: "DONE" | "FAILED" | "RUNNING" = isDone ? "DONE" : isFailed ? "FAILED" : "RUNNING";
+
+  const { total, done, percent, failedCount } = computeMetrics(
+    progress.totalApplications,
+    progress.completedApplications,
+    progress.failedApplications,
+    isDone
+  );
+
+  const progressDescription =
+    total > 0
+      ? `${done} of ${total} ${total === 1 ? "application" : "applications"} processed (${percent}%)`
+      : "Waiting for processing to start…";
+  const failureDescription =
+    failedCount > 0 ? ` · ${failedCount} ${failedCount === 1 ? "failure" : "failures"}` : "";
+
+  return (
+    <section
+      className="space-y-4 rounded-xl border border-border bg-card p-6"
+      aria-live="polite"
+      aria-label="Bulk evaluation progress"
+    >
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <StatusIcon status={status} />
+          <h2 className="text-lg font-semibold text-foreground">{statusTitle(status)}</h2>
+        </div>
+        {status !== "RUNNING" ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={dismiss}
+            aria-label="Dismiss bulk job"
+          >
+            <X className="h-4 w-4" /> Dismiss
+          </Button>
+        ) : null}
+      </header>
+
+      <div>
+        <div
+          className="h-2 w-full overflow-hidden rounded-full bg-muted"
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className={cn("h-full transition-all", isFailed ? "bg-red-500" : "bg-brand-500")}
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {progressDescription}
+          {failureDescription}
+        </p>
+      </div>
+
+      {progress.error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {progress.error}
+        </div>
+      ) : null}
+
+      {isDone && progress.hasResult ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <DownloadButton sessionId={sessionId} jobId={jobId} />
+          </div>
+          <div className="mt-4">
+            <BulkResultTable
+              sessionId={sessionId}
+              jobId={jobId}
+              enabled={isDone && progress.hasResult}
+            />
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/standalone-evaluation/components/BulkProgressView.tsx
+++ b/src/features/standalone-evaluation/components/BulkProgressView.tsx
@@ -56,10 +56,6 @@ interface DownloadButtonProps {
 }
 
 function DownloadButton({ sessionId, jobId }: DownloadButtonProps) {
-  // BE serializes the stored {columns, rows} to CSV on demand and streams
-  // it back. We read as a Blob, build an object URL, and trigger a download
-  // via a synthetic anchor click. Using `useMutation` so loading/error
-  // state goes through React Query rather than ad-hoc useState.
   const downloadMutation = useMutation<void, Error, void>({
     mutationFn: async () => {
       const blob = await standaloneEvaluationService.downloadBulkResultCsv(sessionId, jobId);
@@ -72,7 +68,7 @@ function DownloadButton({ sessionId, jobId }: DownloadButtonProps) {
         a.click();
         a.remove();
       } finally {
-        // Revoke after a tick so the browser has a chance to start the download.
+        // Revoke after a tick so the browser can start the download.
         setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
       }
     },

--- a/src/features/standalone-evaluation/components/BulkProgressView.tsx
+++ b/src/features/standalone-evaluation/components/BulkProgressView.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/utilities/tailwind";
 import { useBulkJobProgress } from "../hooks/useBulkJob";
 import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
-import { BulkResultTable } from "./BulkResultTable";
+import { BulkResultsDashboard } from "./BulkResultsDashboard";
 
 interface BulkProgressViewProps {
   sessionId: string;
@@ -171,7 +171,7 @@ export function BulkProgressView({ sessionId, jobId }: BulkProgressViewProps) {
             <DownloadButton sessionId={sessionId} jobId={jobId} />
           </div>
           <div className="mt-4">
-            <BulkResultTable
+            <BulkResultsDashboard
               sessionId={sessionId}
               jobId={jobId}
               enabled={isDone && progress.hasResult}

--- a/src/features/standalone-evaluation/components/BulkProgressView.tsx
+++ b/src/features/standalone-evaluation/components/BulkProgressView.tsx
@@ -144,6 +144,7 @@ export function BulkProgressView({ sessionId, jobId }: BulkProgressViewProps) {
         <div
           className="h-2 w-full overflow-hidden rounded-full bg-muted"
           role="progressbar"
+          aria-label={statusTitle(status)}
           aria-valuenow={percent}
           aria-valuemin={0}
           aria-valuemax={100}

--- a/src/features/standalone-evaluation/components/BulkResultTable.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useBulkJobResult } from "../hooks/useBulkJob";
+
+interface BulkResultTableProps {
+  sessionId: string;
+  jobId: string;
+  enabled: boolean;
+}
+
+const INITIAL_VISIBLE = 25;
+const PAGE_INCREMENT = 25;
+// Eval columns the orchestrator appends to every row; pinned to the right of
+// the table so they're always at the same position regardless of CSV shape.
+const PINNED_EVAL_COLUMNS = ["eval_score", "eval_summary", "eval_decision", "eval_error"] as const;
+
+function cellToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTableProps) {
+  const query = useBulkJobResult(sessionId, jobId, enabled);
+  const [visible, setVisible] = useState(INITIAL_VISIBLE);
+
+  const orderedColumns = useMemo(() => {
+    if (!query.data) return [];
+    const evalSet = new Set<string>(PINNED_EVAL_COLUMNS);
+    const original = query.data.columns.filter((c) => !evalSet.has(c));
+    const evalCols = PINNED_EVAL_COLUMNS.filter((c) => query.data!.columns.includes(c));
+    return [...original, ...evalCols];
+  }, [query.data]);
+
+  if (!enabled) return null;
+
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading results…
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+        <span>Couldn't load results inline: {query.error?.message ?? "unknown error"}</span>
+        <button
+          type="button"
+          className="self-start rounded border border-red-300 px-2 py-1 text-xs hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/40"
+          onClick={() => query.refetch()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const data = query.data;
+  if (!data || data.rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows in this result.</p>;
+  }
+
+  const visibleRows = data.rows.slice(0, visible);
+  const remaining = data.rows.length - visible;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          Showing {visibleRows.length} of {data.rows.length}{" "}
+          {data.rows.length === 1 ? "row" : "rows"}
+        </span>
+        <span>{orderedColumns.length} columns</span>
+      </div>
+      <div className="max-h-[480px] overflow-auto rounded-md border border-border">
+        <table className="min-w-full text-left text-xs">
+          <thead className="sticky top-0 bg-muted/60 text-muted-foreground">
+            <tr>
+              {orderedColumns.map((col) => (
+                <th key={col} className="border-b border-border px-3 py-2 font-semibold">
+                  {col}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.map((row, rowIdx) => (
+              <BulkResultRow key={rowIdx} row={row} columns={orderedColumns} rowIndex={rowIdx} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {remaining > 0 ? (
+        <div className="text-center">
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-muted/60"
+            onClick={() => setVisible((v) => v + PAGE_INCREMENT)}
+          >
+            Show {Math.min(remaining, PAGE_INCREMENT)} more
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface RowProps {
+  row: Record<string, unknown>;
+  columns: string[];
+  rowIndex: number;
+}
+
+const BulkResultRow = React.memo(function BulkResultRow({ row, columns, rowIndex }: RowProps) {
+  return (
+    <tr className={rowIndex % 2 === 0 ? "bg-background" : "bg-muted/20"}>
+      {columns.map((col) => {
+        const value = cellToString(row[col]);
+        const isEval = col.startsWith("eval_");
+        return (
+          <td
+            key={col}
+            className={
+              "border-b border-border px-3 py-2 align-top " +
+              (isEval ? "font-medium text-foreground" : "text-muted-foreground")
+            }
+            title={value.length > 200 ? value : undefined}
+          >
+            <div className="max-w-[420px] whitespace-pre-wrap break-words">{value || "—"}</div>
+          </td>
+        );
+      })}
+    </tr>
+  );
+});

--- a/src/features/standalone-evaluation/components/BulkResultTable.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultTable.tsx
@@ -15,6 +15,10 @@ const PAGE_INCREMENT = 25;
 // Eval columns the orchestrator appends to every row; pinned to the right of
 // the table so they're always at the same position regardless of CSV shape.
 const PINNED_EVAL_COLUMNS = ["eval_score", "eval_summary", "eval_decision", "eval_error"] as const;
+// Fixed cell width for pinned columns so the sticky-right offsets stay
+// consistent across rows. Wider than narrow headers but tighter than the
+// 420px cell cap used for unpinned text content.
+const PINNED_CELL_WIDTH_PX = 180;
 
 function cellToString(value: unknown): string {
   if (value === null || value === undefined) return "";
@@ -31,12 +35,27 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
   const query = useBulkJobResult(sessionId, jobId, enabled);
   const [visible, setVisible] = useState(INITIAL_VISIBLE);
 
-  const orderedColumns = useMemo(() => {
-    if (!query.data) return [];
+  const { orderedColumns, pinnedRightOffsets } = useMemo(() => {
+    if (!query.data) {
+      return {
+        orderedColumns: [] as string[],
+        pinnedRightOffsets: {} as Record<string, number>,
+      };
+    }
     const evalSet = new Set<string>(PINNED_EVAL_COLUMNS);
     const original = query.data.columns.filter((c) => !evalSet.has(c));
     const evalCols = PINNED_EVAL_COLUMNS.filter((c) => query.data!.columns.includes(c));
-    return [...original, ...evalCols];
+    // Right offset for each pinned column = count of pinned columns AFTER it.
+    // Rightmost pinned column gets offset 0 (right: 0px); the next gets 1 *
+    // PINNED_CELL_WIDTH_PX, and so on.
+    const offsets: Record<string, number> = {};
+    evalCols.forEach((col, idx) => {
+      offsets[col] = (evalCols.length - 1 - idx) * PINNED_CELL_WIDTH_PX;
+    });
+    return {
+      orderedColumns: [...original, ...evalCols],
+      pinnedRightOffsets: offsets,
+    };
   }, [query.data]);
 
   if (!enabled) return null;
@@ -83,18 +102,41 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
       </div>
       <div className="max-h-[480px] overflow-auto rounded-md border border-border">
         <table className="min-w-full text-left text-xs">
-          <thead className="sticky top-0 bg-muted/60 text-muted-foreground">
+          <thead className="sticky top-0 z-20 bg-muted/60 text-muted-foreground">
             <tr>
-              {orderedColumns.map((col) => (
-                <th key={col} className="border-b border-border px-3 py-2 font-semibold">
-                  {col}
-                </th>
-              ))}
+              {orderedColumns.map((col) => {
+                const isPinned = col in pinnedRightOffsets;
+                return (
+                  <th
+                    key={col}
+                    className={
+                      "border-b border-border px-3 py-2 font-semibold " +
+                      (isPinned ? "sticky right-0 z-30 bg-muted/95 backdrop-blur" : "")
+                    }
+                    style={
+                      isPinned
+                        ? {
+                            right: `${pinnedRightOffsets[col]}px`,
+                            minWidth: `${PINNED_CELL_WIDTH_PX}px`,
+                          }
+                        : undefined
+                    }
+                  >
+                    {col}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
             {visibleRows.map((row, rowIdx) => (
-              <BulkResultRow key={rowIdx} row={row} columns={orderedColumns} rowIndex={rowIdx} />
+              <BulkResultRow
+                key={rowIdx}
+                row={row}
+                columns={orderedColumns}
+                rowIndex={rowIdx}
+                pinnedRightOffsets={pinnedRightOffsets}
+              />
             ))}
           </tbody>
         </table>
@@ -118,20 +160,41 @@ interface RowProps {
   row: Record<string, unknown>;
   columns: string[];
   rowIndex: number;
+  pinnedRightOffsets: Record<string, number>;
 }
 
-const BulkResultRow = React.memo(function BulkResultRow({ row, columns, rowIndex }: RowProps) {
+const BulkResultRow = React.memo(function BulkResultRow({
+  row,
+  columns,
+  rowIndex,
+  pinnedRightOffsets,
+}: RowProps) {
+  // Striping applied as the cell background so sticky cells don't visually
+  // bleed through the rest of the row when the body scrolls horizontally.
+  const stripeBg = rowIndex % 2 === 0 ? "bg-background" : "bg-muted/20";
   return (
-    <tr className={rowIndex % 2 === 0 ? "bg-background" : "bg-muted/20"}>
+    <tr>
       {columns.map((col) => {
         const value = cellToString(row[col]);
         const isEval = col.startsWith("eval_");
+        const isPinned = col in pinnedRightOffsets;
         return (
           <td
             key={col}
             className={
               "border-b border-border px-3 py-2 align-top " +
-              (isEval ? "font-medium text-foreground" : "text-muted-foreground")
+              stripeBg +
+              " " +
+              (isEval ? "font-medium text-foreground" : "text-muted-foreground") +
+              (isPinned ? " sticky right-0 z-10" : "")
+            }
+            style={
+              isPinned
+                ? {
+                    right: `${pinnedRightOffsets[col]}px`,
+                    minWidth: `${PINNED_CELL_WIDTH_PX}px`,
+                  }
+                : undefined
             }
             title={value.length > 200 ? value : undefined}
           >

--- a/src/features/standalone-evaluation/components/BulkResultTable.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultTable.tsx
@@ -8,6 +8,7 @@ interface BulkResultTableProps {
   sessionId: string;
   jobId: string;
   enabled: boolean;
+  search?: string;
 }
 
 const INITIAL_VISIBLE = 25;
@@ -26,9 +27,18 @@ function cellToString(value: unknown): string {
   }
 }
 
-export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTableProps) {
+export function BulkResultTable({ sessionId, jobId, enabled, search = "" }: BulkResultTableProps) {
   const query = useBulkJobResult(sessionId, jobId, enabled);
   const [visible, setVisible] = useState(INITIAL_VISIBLE);
+
+  const filteredRows = useMemo(() => {
+    if (!query.data) return [];
+    const term = search.trim().toLowerCase();
+    if (!term) return query.data.rows;
+    return query.data.rows.filter((row) =>
+      query.data!.columns.some((col) => cellToString(row[col]).toLowerCase().includes(term))
+    );
+  }, [query.data, search]);
 
   const { orderedColumns, pinnedRightOffsets } = useMemo(() => {
     if (!query.data) {
@@ -80,15 +90,19 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
     return <p className="text-sm text-muted-foreground">No rows in this result.</p>;
   }
 
-  const visibleRows = data.rows.slice(0, visible);
-  const remaining = data.rows.length - visible;
+  const visibleRows = filteredRows.slice(0, visible);
+  const remaining = filteredRows.length - visible;
+
+  if (filteredRows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows match your search.</p>;
+  }
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          Showing {visibleRows.length} of {data.rows.length}{" "}
-          {data.rows.length === 1 ? "row" : "rows"}
+          Showing {visibleRows.length} of {filteredRows.length}{" "}
+          {filteredRows.length === 1 ? "row" : "rows"}
         </span>
         <span>{orderedColumns.length} columns</span>
       </div>

--- a/src/features/standalone-evaluation/components/BulkResultTable.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultTable.tsx
@@ -117,7 +117,13 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
                       isPinned
                         ? {
                             right: `${pinnedRightOffsets[col]}px`,
+                            // All three set so the column is truly fixed —
+                            // sticky-right offsets only line up across cells
+                            // when the rendered width matches the offset
+                            // arithmetic in `pinnedRightOffsets`.
+                            width: `${PINNED_CELL_WIDTH_PX}px`,
                             minWidth: `${PINNED_CELL_WIDTH_PX}px`,
+                            maxWidth: `${PINNED_CELL_WIDTH_PX}px`,
                           }
                         : undefined
                     }
@@ -192,7 +198,9 @@ const BulkResultRow = React.memo(function BulkResultRow({
               isPinned
                 ? {
                     right: `${pinnedRightOffsets[col]}px`,
+                    width: `${PINNED_CELL_WIDTH_PX}px`,
                     minWidth: `${PINNED_CELL_WIDTH_PX}px`,
+                    maxWidth: `${PINNED_CELL_WIDTH_PX}px`,
                   }
                 : undefined
             }

--- a/src/features/standalone-evaluation/components/BulkResultTable.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultTable.tsx
@@ -12,12 +12,7 @@ interface BulkResultTableProps {
 
 const INITIAL_VISIBLE = 25;
 const PAGE_INCREMENT = 25;
-// Eval columns the orchestrator appends to every row; pinned to the right of
-// the table so they're always at the same position regardless of CSV shape.
 const PINNED_EVAL_COLUMNS = ["eval_score", "eval_summary", "eval_decision", "eval_error"] as const;
-// Fixed cell width for pinned columns so the sticky-right offsets stay
-// consistent across rows. Wider than narrow headers but tighter than the
-// 420px cell cap used for unpinned text content.
 const PINNED_CELL_WIDTH_PX = 180;
 
 function cellToString(value: unknown): string {
@@ -45,9 +40,6 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
     const evalSet = new Set<string>(PINNED_EVAL_COLUMNS);
     const original = query.data.columns.filter((c) => !evalSet.has(c));
     const evalCols = PINNED_EVAL_COLUMNS.filter((c) => query.data!.columns.includes(c));
-    // Right offset for each pinned column = count of pinned columns AFTER it.
-    // Rightmost pinned column gets offset 0 (right: 0px); the next gets 1 *
-    // PINNED_CELL_WIDTH_PX, and so on.
     const offsets: Record<string, number> = {};
     evalCols.forEach((col, idx) => {
       offsets[col] = (evalCols.length - 1 - idx) * PINNED_CELL_WIDTH_PX;
@@ -117,10 +109,6 @@ export function BulkResultTable({ sessionId, jobId, enabled }: BulkResultTablePr
                       isPinned
                         ? {
                             right: `${pinnedRightOffsets[col]}px`,
-                            // All three set so the column is truly fixed —
-                            // sticky-right offsets only line up across cells
-                            // when the rendered width matches the offset
-                            // arithmetic in `pinnedRightOffsets`.
                             width: `${PINNED_CELL_WIDTH_PX}px`,
                             minWidth: `${PINNED_CELL_WIDTH_PX}px`,
                             maxWidth: `${PINNED_CELL_WIDTH_PX}px`,
@@ -175,8 +163,8 @@ const BulkResultRow = React.memo(function BulkResultRow({
   rowIndex,
   pinnedRightOffsets,
 }: RowProps) {
-  // Striping applied as the cell background so sticky cells don't visually
-  // bleed through the rest of the row when the body scrolls horizontally.
+  // Stripe each cell rather than the row — sticky cells render transparent
+  // over scrolled rows otherwise.
   const stripeBg = rowIndex % 2 === 0 ? "bg-background" : "bg-muted/20";
   return (
     <tr>

--- a/src/features/standalone-evaluation/components/BulkResultsDashboard.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultsDashboard.tsx
@@ -1,0 +1,591 @@
+"use client";
+
+import { Flag, Loader2, Search, X } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { cn } from "@/utilities/tailwind";
+import { useBulkJobResult } from "../hooks/useBulkJob";
+import { BulkResultTable } from "./BulkResultTable";
+
+interface BulkResultsDashboardProps {
+  sessionId: string;
+  jobId: string;
+  enabled: boolean;
+}
+
+type DecisionBucket = "approve" | "needs-review" | "reject";
+
+interface NormalizedRow {
+  id: string;
+  name: string;
+  score: number | null;
+  decision: DecisionBucket;
+  summary: string;
+  raw: Record<string, unknown>;
+  flags: number;
+}
+
+const SCORE_BUCKETS: ReadonlyArray<{ label: string; min: number; max: number }> = [
+  { label: "0-20", min: 0, max: 20 },
+  { label: "20-40", min: 20, max: 40 },
+  { label: "40-60", min: 40, max: 60 },
+  { label: "60-80", min: 60, max: 80 },
+  { label: "80-100", min: 80, max: 101 },
+];
+
+const NAME_COLUMN_CANDIDATES = [
+  "name",
+  "project",
+  "project name",
+  "project_name",
+  "title",
+  "application",
+  "applicant",
+  "company",
+];
+
+function pickNameColumn(columns: string[]): string | null {
+  const lower = new Map(columns.map((c) => [c.toLowerCase(), c]));
+  for (const candidate of NAME_COLUMN_CANDIDATES) {
+    const match = lower.get(candidate);
+    if (match) return match;
+  }
+  return columns.find((c) => !c.startsWith("eval_")) ?? null;
+}
+
+function valueToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseScore(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const num = Number.parseFloat(value);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+}
+
+const APPROVE_TOKENS = new Set(["approve", "approved", "pass", "accept", "accepted"]);
+const REJECT_TOKENS = new Set(["reject", "rejected", "fail", "deny", "denied"]);
+
+function classifyDecision(rawDecision: unknown, score: number | null): DecisionBucket {
+  const text = valueToString(rawDecision).trim().toLowerCase();
+  if (APPROVE_TOKENS.has(text)) return "approve";
+  if (REJECT_TOKENS.has(text)) return "reject";
+  if (text.includes("review")) return "needs-review";
+  if (text === "" && score !== null) {
+    if (score >= 70) return "approve";
+    if (score >= 40) return "needs-review";
+    return "reject";
+  }
+  return "needs-review";
+}
+
+function rowKey(row: Record<string, unknown>, fallbackIndex: number): string {
+  const candidate =
+    valueToString(row.id) || valueToString(row.uid) || valueToString(row.application_id);
+  return candidate || `APP-${String(fallbackIndex + 1).padStart(3, "0")}`;
+}
+
+function normalize(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  nameColumn: string | null
+): NormalizedRow[] {
+  return rows.map((row, idx) => {
+    const score = parseScore(row.eval_score);
+    const decision = classifyDecision(row.eval_decision, score);
+    const errorText = valueToString(row.eval_error);
+    return {
+      id: rowKey(row, idx),
+      name: nameColumn ? valueToString(row[nameColumn]) || "Untitled" : "Untitled",
+      score,
+      decision,
+      summary: valueToString(row.eval_summary),
+      raw: row,
+      flags: errorText.length > 0 ? 1 : 0,
+    };
+  });
+}
+
+const DECISION_META: Record<
+  DecisionBucket,
+  { label: string; pillCls: string; cardCls: string; dot: string; sub: string }
+> = {
+  approve: {
+    label: "Approve",
+    pillCls:
+      "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-900",
+    cardCls: "bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-300 border-border",
+    dot: "bg-brand-500",
+    sub: "Score ≥ 70",
+  },
+  "needs-review": {
+    label: "Needs review",
+    pillCls:
+      "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-950/40 dark:text-yellow-300 dark:border-yellow-900",
+    cardCls:
+      "bg-yellow-50 dark:bg-yellow-950/30 text-yellow-700 dark:text-yellow-300 border-border",
+    dot: "bg-yellow-400",
+    sub: "Mid-range or flagged",
+  },
+  reject: {
+    label: "Reject",
+    pillCls:
+      "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900",
+    cardCls: "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-300 border-border",
+    dot: "bg-red-500",
+    sub: "Score < 40 or flagged",
+  },
+};
+
+const COLUMN_ORDER: ReadonlyArray<DecisionBucket> = ["approve", "needs-review", "reject"];
+
+export function BulkResultsDashboard({ sessionId, jobId, enabled }: BulkResultsDashboardProps) {
+  const query = useBulkJobResult(sessionId, jobId, enabled);
+  const [view, setView] = useState<"triage" | "table">("triage");
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const data = query.data;
+
+  const { rows, nameColumn } = useMemo(() => {
+    if (!data) return { rows: [] as NormalizedRow[], nameColumn: null as string | null };
+    const name = pickNameColumn(data.columns);
+    return { rows: normalize(data.rows, name), nameColumn: name };
+  }, [data]);
+
+  const buckets = useMemo(() => {
+    return SCORE_BUCKETS.map((b) => ({
+      ...b,
+      count: rows.filter((r) => r.score !== null && r.score >= b.min && r.score < b.max).length,
+    }));
+  }, [rows]);
+
+  const grouped = useMemo(() => {
+    return COLUMN_ORDER.reduce(
+      (acc, key) => {
+        acc[key] = rows.filter((r) => r.decision === key);
+        return acc;
+      },
+      { approve: [], "needs-review": [], reject: [] } as Record<DecisionBucket, NormalizedRow[]>
+    );
+  }, [rows]);
+
+  const stats = useMemo(() => {
+    const scores = rows.map((r) => r.score).filter((s): s is number => s !== null);
+    const sorted = [...scores].sort((a, b) => a - b);
+    const median =
+      sorted.length === 0
+        ? null
+        : sorted.length % 2 === 1
+          ? sorted[(sorted.length - 1) / 2]
+          : (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2;
+    const mean = scores.length === 0 ? null : scores.reduce((a, b) => a + b, 0) / scores.length;
+    return { median, mean };
+  }, [rows]);
+
+  const filteredGrouped = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return grouped;
+    return COLUMN_ORDER.reduce(
+      (acc, key) => {
+        acc[key] = grouped[key].filter(
+          (r) =>
+            r.name.toLowerCase().includes(term) ||
+            r.summary.toLowerCase().includes(term) ||
+            r.id.toLowerCase().includes(term)
+        );
+        return acc;
+      },
+      { approve: [], "needs-review": [], reject: [] } as Record<DecisionBucket, NormalizedRow[]>
+    );
+  }, [grouped, search]);
+
+  const selected = useMemo(() => {
+    if (!selectedId) return null;
+    return rows.find((r) => r.id === selectedId) ?? null;
+  }, [rows, selectedId]);
+
+  if (!enabled) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Results will appear once the bulk job completes.
+      </p>
+    );
+  }
+
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading results…
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+        <span>Couldn't load results: {query.error?.message ?? "unknown error"}</span>
+        <button
+          type="button"
+          className="self-start rounded border border-red-300 px-2 py-1 text-xs hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/40"
+          onClick={() => query.refetch()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data || data.rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows in this result.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <Stats buckets={buckets} grouped={grouped} stats={stats} />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <ViewToggle view={view} onChange={setView} />
+        <span className="text-xs text-muted-foreground">
+          {rows.length} {rows.length === 1 ? "application" : "applications"}
+        </span>
+        <div className="ml-auto relative w-full sm:w-60">
+          <Search
+            className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search applications…"
+            className="w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-2 text-xs text-foreground placeholder:text-muted-foreground focus:border-brand-500 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {view === "table" ? (
+        <BulkResultTable sessionId={sessionId} jobId={jobId} enabled={enabled} />
+      ) : (
+        <div className="grid min-w-0 grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3">
+            {COLUMN_ORDER.map((key) => (
+              <KanbanColumn
+                key={key}
+                bucket={key}
+                rows={filteredGrouped[key]}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+              />
+            ))}
+          </div>
+
+          <DetailDrawer
+            row={selected}
+            nameColumn={nameColumn}
+            onClose={() => setSelectedId(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface StatsProps {
+  buckets: ReadonlyArray<{ label: string; count: number; min: number }>;
+  grouped: Record<DecisionBucket, NormalizedRow[]>;
+  stats: { median: number | null; mean: number | null };
+}
+
+function Stats({ buckets, grouped, stats }: StatsProps) {
+  const maxCount = Math.max(1, ...buckets.map((b) => b.count));
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-[1.4fr_1fr_1fr_1fr]">
+      <div className="rounded-xl border border-border bg-background p-4">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Score distribution
+          </span>
+          <span className="text-[10px] text-muted-foreground">
+            {stats.median !== null
+              ? `Median ${Math.round(stats.median)} · Mean ${Math.round(stats.mean ?? 0)}`
+              : "No scored rows"}
+          </span>
+        </div>
+        <div className="mt-3 flex h-16 items-end gap-2">
+          {buckets.map((b) => {
+            const h = (b.count / maxCount) * 100;
+            const isHigh = b.min >= 60;
+            const isMid = b.min >= 40 && b.min < 60;
+            return (
+              <div key={b.label} className="flex flex-1 flex-col items-center gap-1">
+                <span className="text-[10px] font-semibold tabular-nums text-muted-foreground">
+                  {b.count}
+                </span>
+                <div
+                  className={cn(
+                    "w-full min-h-[4px] rounded-t",
+                    isHigh ? "bg-brand-500" : isMid ? "bg-brand-300" : "bg-muted"
+                  )}
+                  style={{ height: `${h}%` }}
+                />
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-1 flex">
+          {buckets.map((b) => (
+            <span key={b.label} className="flex-1 text-center text-[9px] text-muted-foreground">
+              {b.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {COLUMN_ORDER.map((key) => {
+        const meta = DECISION_META[key];
+        const count = grouped[key].length;
+        return (
+          <div key={key} className={cn("rounded-xl border p-4", meta.cardCls)}>
+            <div className="text-[10px] font-semibold uppercase tracking-wide">{meta.label}</div>
+            <div className="mt-2 text-3xl font-bold leading-none tabular-nums">{count}</div>
+            <div className="mt-1 text-[11px] text-muted-foreground">{meta.sub}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ViewToggleProps {
+  view: "triage" | "table";
+  onChange: (next: "triage" | "table") => void;
+}
+
+function ViewToggle({ view, onChange }: ViewToggleProps) {
+  return (
+    <div className="inline-flex overflow-hidden rounded-md border border-border">
+      {(["triage", "table"] as const).map((id) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={cn(
+            "px-3 py-1 text-xs font-medium capitalize",
+            view === id
+              ? "bg-foreground text-background"
+              : "bg-background text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {id}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface KanbanColumnProps {
+  bucket: DecisionBucket;
+  rows: ReadonlyArray<NormalizedRow>;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function KanbanColumn({ bucket, rows, selectedId, onSelect }: KanbanColumnProps) {
+  const meta = DECISION_META[bucket];
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-border bg-background p-3">
+      <div className="flex items-center gap-2 border-b border-border/50 pb-2">
+        <span className={cn("inline-block h-1.5 w-1.5 rounded-full", meta.dot)} />
+        <span className="text-sm font-semibold">{meta.label}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">{rows.length}</span>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-1 py-3 text-xs text-muted-foreground">No applications in this bucket.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {rows.map((row) => (
+            <KanbanCard
+              key={row.id}
+              row={row}
+              isSelected={selectedId === row.id}
+              onSelect={() => onSelect(row.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface KanbanCardProps {
+  row: NormalizedRow;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
+const KanbanCard = React.memo(function KanbanCard({ row, isSelected, onSelect }: KanbanCardProps) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "flex w-full flex-col gap-1.5 rounded-lg border bg-background p-3 text-left transition-colors",
+          isSelected
+            ? "border-brand-300 bg-brand-50/50 dark:border-brand-700 dark:bg-brand-500/10"
+            : "border-border hover:border-muted-foreground/40"
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] text-muted-foreground">{row.id}</span>
+          <span className="ml-auto">
+            <ScorePill score={row.score} />
+          </span>
+        </div>
+        <div className="line-clamp-1 text-sm font-semibold text-foreground">{row.name}</div>
+        {row.summary ? (
+          <div className="line-clamp-2 text-xs text-muted-foreground">{row.summary}</div>
+        ) : null}
+        {row.flags > 0 ? (
+          <div className="flex items-center gap-1 text-[11px] text-yellow-700 dark:text-yellow-300">
+            <Flag className="h-3 w-3" /> {row.flags} {row.flags === 1 ? "flag" : "flags"}
+          </div>
+        ) : null}
+      </button>
+    </li>
+  );
+});
+
+function ScorePill({ score, big = false }: { score: number | null; big?: boolean }) {
+  if (score === null) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-baseline gap-0.5 rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground tabular-nums",
+          big && "rounded-xl px-3 py-1.5 text-base"
+        )}
+      >
+        —
+      </span>
+    );
+  }
+  const cls =
+    score >= 70
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : score >= 50
+        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+        : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-baseline gap-0.5 font-semibold tabular-nums",
+        big ? "rounded-xl px-3 py-1.5 text-base" : "rounded-full px-2 py-0.5 text-xs",
+        cls
+      )}
+    >
+      {Math.round(score)}
+      <span className={cn("font-medium opacity-70", big ? "text-xs" : "text-[10px]")}>/100</span>
+    </span>
+  );
+}
+
+interface DetailDrawerProps {
+  row: NormalizedRow | null;
+  nameColumn: string | null;
+  onClose: () => void;
+}
+
+function DetailDrawer({ row, nameColumn, onClose }: DetailDrawerProps) {
+  if (!row) {
+    return (
+      <aside className="hidden flex-col rounded-xl border border-dashed border-border bg-background p-6 text-sm text-muted-foreground lg:flex">
+        Pick an application to see details, criteria breakdown, and the original submission.
+      </aside>
+    );
+  }
+
+  const meta = DECISION_META[row.decision];
+  const errorText = typeof row.raw.eval_error === "string" ? row.raw.eval_error : "";
+  const originalEntries = Object.entries(row.raw)
+    .filter(([key]) => !key.startsWith("eval_"))
+    .filter(([key]) => key !== nameColumn);
+
+  return (
+    <aside className="flex flex-col rounded-xl border border-border bg-background">
+      <div className="flex flex-col gap-3 border-b border-border p-4">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] text-muted-foreground">{row.id}</span>
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium",
+              meta.pillCls
+            )}
+          >
+            {meta.label}
+          </span>
+          {row.flags > 0 ? (
+            <span className="inline-flex items-center gap-1 rounded-full border border-yellow-200 bg-yellow-50 px-2 py-0.5 text-[11px] font-medium text-yellow-700 dark:border-yellow-900 dark:bg-yellow-950/40 dark:text-yellow-300">
+              <Flag className="h-3 w-3" /> {row.flags}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close details"
+            className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <h2 className="text-base font-semibold leading-snug text-foreground">{row.name}</h2>
+        <div className="flex items-center gap-3">
+          <ScorePill score={row.score} big />
+          {row.summary ? (
+            <p className="text-xs leading-snug text-muted-foreground">{row.summary}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-4 overflow-y-auto p-4">
+        {errorText ? (
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-yellow-700 dark:text-yellow-300">
+              Why flagged
+            </div>
+            <p className="mt-1 whitespace-pre-wrap text-xs text-foreground">{errorText}</p>
+          </div>
+        ) : null}
+
+        {originalEntries.length > 0 ? (
+          <div>
+            <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Original application
+            </div>
+            <dl className="space-y-2">
+              {originalEntries.map(([key, value]) => (
+                <div key={key}>
+                  <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {key}
+                  </dt>
+                  <dd className="whitespace-pre-wrap break-words text-xs text-foreground">
+                    {valueToString(value) || "—"}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/src/features/standalone-evaluation/components/BulkResultsDashboard.tsx
+++ b/src/features/standalone-evaluation/components/BulkResultsDashboard.tsx
@@ -273,7 +273,7 @@ export function BulkResultsDashboard({ sessionId, jobId, enabled }: BulkResultsD
       </div>
 
       {view === "table" ? (
-        <BulkResultTable sessionId={sessionId} jobId={jobId} enabled={enabled} />
+        <BulkResultTable sessionId={sessionId} jobId={jobId} enabled={enabled} search={search} />
       ) : (
         <div className="grid min-w-0 grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
           <div className="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3">

--- a/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
+++ b/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { Loader2, Play, RefreshCw } from "lucide-react";
+import Papa from "papaparse";
+import { useCallback, useState } from "react";
+import toast from "react-hot-toast";
+import { FileUpload } from "@/components/Utilities/FileUpload";
+import { Button } from "@/components/ui/button";
+import { useStartBulkJob } from "../hooks/useBulkJob";
+
+interface BulkUploadPanelProps {
+  sessionId: string;
+}
+
+interface PreviewState {
+  rowCount: number;
+  columns: string[];
+  rows: string[][];
+}
+
+// Permissive email shape — full RFC validation lives on the BE Zod schema. We
+// just guard against obvious mistakes here so the user gets immediate feedback.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [parsing, setParsing] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [notificationEmail, setNotificationEmail] = useState<string>("");
+
+  const startBulk = useStartBulkJob();
+  const trimmedEmail = notificationEmail.trim();
+  const emailLooksValid = trimmedEmail === "" || EMAIL_REGEX.test(trimmedEmail);
+
+  const parseFile = useCallback((selected: File) => {
+    setParsing(true);
+    setValidationError(null);
+    setPreview(null);
+
+    Papa.parse<string[]>(selected, {
+      header: false,
+      skipEmptyLines: true,
+      preview: 6, // header + 5 rows
+      complete: (results) => {
+        try {
+          if (!results.data || results.data.length < 2) {
+            setValidationError("CSV must include a header row and at least one application.");
+            return;
+          }
+          const headers = results.data[0] as string[];
+          const rows = (results.data.slice(1) as string[][]).filter((r) =>
+            r.some((cell) => (cell ?? "").trim().length > 0)
+          );
+          if (rows.length === 0) {
+            setValidationError("CSV has no application rows.");
+            return;
+          }
+          setPreview({ rowCount: rows.length, columns: headers, rows });
+        } finally {
+          setParsing(false);
+        }
+      },
+      error: (err) => {
+        setValidationError(err.message || "Failed to parse CSV");
+        setParsing(false);
+      },
+    });
+  }, []);
+
+  const handleFileSelect = useCallback(
+    (selected: File) => {
+      if (!/\.csv$/i.test(selected.name) && selected.type !== "text/csv") {
+        toast.error("Please upload a .csv file.");
+        return;
+      }
+      setFile(selected);
+      parseFile(selected);
+    },
+    [parseFile]
+  );
+
+  const handleStart = () => {
+    if (!file) return;
+    if (!emailLooksValid) return;
+    startBulk.mutate({
+      sessionId,
+      file,
+      notificationEmail: trimmedEmail || undefined,
+    });
+  };
+
+  const reset = () => {
+    setFile(null);
+    setPreview(null);
+    setValidationError(null);
+  };
+
+  return (
+    <section className="space-y-4 rounded-xl border border-border bg-card p-6">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Bulk evaluation</h2>
+        <p className="text-sm text-muted-foreground">
+          Upload a CSV where each row is one application. We’ll evaluate them in the background and
+          email you a download link when it’s ready.
+        </p>
+      </div>
+
+      {file && preview ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between rounded-md border border-border bg-muted/30 p-3">
+            <div>
+              <p className="text-sm font-medium text-foreground">{file.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {preview.rowCount === 1
+                  ? "1 application detected"
+                  : `${preview.rowCount} applications detected`}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={reset}
+              disabled={startBulk.isPending}
+            >
+              <RefreshCw className="h-3.5 w-3.5" /> Replace
+            </Button>
+          </div>
+
+          <div className="overflow-x-auto rounded-md border border-border">
+            <table className="min-w-full text-left text-xs">
+              <thead className="bg-muted/40 text-muted-foreground">
+                <tr>
+                  {preview.columns.map((c, i) => (
+                    <th key={`${i}-${c}`} className="px-3 py-2 font-semibold">
+                      {c || `col ${i + 1}`}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {preview.rows.slice(0, 5).map((row, idx) => {
+                  const rowKey = `${idx}-${(row[0] ?? "").slice(0, 16)}`;
+                  return (
+                    <tr key={rowKey} className="border-t border-border">
+                      {preview.columns.map((col, i) => (
+                        <td
+                          key={`${rowKey}-${col}-${i}`}
+                          className="px-3 py-2 text-muted-foreground"
+                        >
+                          <span className="line-clamp-2">{row[i] ?? ""}</span>
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : (
+        <FileUpload
+          onFileSelect={handleFileSelect}
+          acceptedFormats=".csv,text/csv"
+          description="CSV with one application per row. Include a column named 'application' (or similar)."
+          disabled={parsing || startBulk.isPending}
+          uploadedFile={file}
+        />
+      )}
+
+      {validationError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {validationError}
+        </div>
+      ) : null}
+
+      {startBulk.isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {startBulk.error.message}
+        </div>
+      ) : null}
+
+      <div className="space-y-1">
+        <label htmlFor="bulk-notification-email" className="text-sm font-medium text-foreground">
+          Email when results are ready{" "}
+          <span className="font-normal text-muted-foreground">(optional)</span>
+        </label>
+        <input
+          id="bulk-notification-email"
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          placeholder="you@example.com"
+          value={notificationEmail}
+          onChange={(e) => setNotificationEmail(e.target.value)}
+          disabled={startBulk.isPending}
+          className="block w-full max-w-sm rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+          aria-invalid={!emailLooksValid}
+        />
+        <p className="text-xs text-muted-foreground">
+          Wallet-only sign-ins have no email on file. Provide one here if you want a completion
+          notification.
+        </p>
+        {!emailLooksValid ? (
+          <p className="text-xs text-red-600 dark:text-red-400">
+            Enter a valid email address (or leave blank to skip).
+          </p>
+        ) : null}
+      </div>
+
+      <div>
+        <Button
+          type="button"
+          onClick={handleStart}
+          disabled={
+            !file || !preview || Boolean(validationError) || !emailLooksValid || startBulk.isPending
+          }
+        >
+          {startBulk.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" /> Starting bulk job
+            </>
+          ) : (
+            <>
+              <Play className="h-4 w-4" /> Start bulk evaluation
+            </>
+          )}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
+++ b/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
@@ -38,9 +38,6 @@ export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
     setValidationError(null);
     setPreview(null);
 
-    // Parse the FULL file (no preview cap) so the row count we surface to the
-    // user matches what the BE will actually process. The whole file is sent
-    // anyway and the BE caps at 10 MB / 500 rows, so this is bounded.
     Papa.parse<string[]>(selected, {
       header: false,
       skipEmptyLines: true,
@@ -58,8 +55,6 @@ export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
             setValidationError("CSV has no application rows.");
             return;
           }
-          // Cap the in-memory preview to the first 5 rows; the rowCount we
-          // display below is the *true* count, not the preview length.
           setPreview({
             rowCount: rows.length,
             columns: headers,

--- a/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
+++ b/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
@@ -200,13 +200,14 @@ export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
           disabled={startBulk.isPending}
           className="block w-full max-w-sm rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
           aria-invalid={!emailLooksValid}
+          aria-describedby={!emailLooksValid ? "bulk-notification-email-error" : undefined}
         />
         <p className="text-xs text-muted-foreground">
           Wallet-only sign-ins have no email on file. Provide one here if you want a completion
           notification.
         </p>
         {!emailLooksValid ? (
-          <p className="text-xs text-red-600 dark:text-red-400">
+          <p id="bulk-notification-email-error" className="text-xs text-red-600 dark:text-red-400">
             Enter a valid email address (or leave blank to skip).
           </p>
         ) : null}

--- a/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
+++ b/src/features/standalone-evaluation/components/BulkUploadPanel.tsx
@@ -38,10 +38,12 @@ export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
     setValidationError(null);
     setPreview(null);
 
+    // Parse the FULL file (no preview cap) so the row count we surface to the
+    // user matches what the BE will actually process. The whole file is sent
+    // anyway and the BE caps at 10 MB / 500 rows, so this is bounded.
     Papa.parse<string[]>(selected, {
       header: false,
       skipEmptyLines: true,
-      preview: 6, // header + 5 rows
       complete: (results) => {
         try {
           if (!results.data || results.data.length < 2) {
@@ -56,7 +58,13 @@ export function BulkUploadPanel({ sessionId }: BulkUploadPanelProps) {
             setValidationError("CSV has no application rows.");
             return;
           }
-          setPreview({ rowCount: rows.length, columns: headers, rows });
+          // Cap the in-memory preview to the first 5 rows; the rowCount we
+          // display below is the *true* count, not the preview length.
+          setPreview({
+            rowCount: rows.length,
+            columns: headers,
+            rows: rows.slice(0, 5),
+          });
         } finally {
           setParsing(false);
         }

--- a/src/features/standalone-evaluation/components/CreditBalanceBadge.tsx
+++ b/src/features/standalone-evaluation/components/CreditBalanceBadge.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Coins, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useCredits } from "../hooks/useCredits";
+import { PurchaseCreditsModal } from "./PurchaseCreditsModal";
+
+export function CreditBalanceBadge() {
+  const { data, isLoading, isError, error, refetch } = useCredits();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className="flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm"
+        aria-live="polite"
+      >
+        <Coins className="h-4 w-4 text-brand-500" aria-hidden />
+        {isLoading ? (
+          <span className="flex items-center gap-1 text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" /> Loading credits
+          </span>
+        ) : isError ? (
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="text-red-600 underline-offset-2 hover:underline"
+            title={error.message}
+          >
+            Retry credits
+          </button>
+        ) : (
+          <span className="font-medium text-foreground">
+            {data?.balance ?? 0}{" "}
+            <span className="text-muted-foreground">
+              {data?.balance === 1 ? "credit" : "credits"}
+            </span>
+          </span>
+        )}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        aria-label="Buy more credits"
+      >
+        Buy more
+      </Button>
+      <PurchaseCreditsModal open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
+++ b/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { Loader2, RefreshCw } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  useEvaluateApplication,
+  useMarkReadyForBulk,
+  useSubmitFeedback,
+} from "../hooks/useEvaluationRun";
+import { useSession } from "../hooks/useEvaluationSessions";
+import type { SessionResponse } from "../schemas/session.schema";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { ApplicationInput } from "./ApplicationInput";
+import { BulkHistoryList } from "./BulkHistoryList";
+import { BulkProgressView } from "./BulkProgressView";
+import { BulkUploadPanel } from "./BulkUploadPanel";
+import { FeedbackComposer } from "./FeedbackComposer";
+import { IterationHistory } from "./IterationHistory";
+import { TemplateSavePanel } from "./TemplateSavePanel";
+
+interface EvaluateWorkspaceProps {
+  sessionId: string;
+}
+
+export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
+  const sessionQuery = useSession(sessionId);
+
+  const evaluate = useEvaluateApplication();
+  const submitFeedback = useSubmitFeedback();
+  const markReady = useMarkReadyForBulk();
+
+  const activeBulkJobId = useEvaluationDraftStore(
+    (s) => s.activeBulkJobIdBySession[sessionId] ?? null
+  );
+
+  const session = sessionQuery.data;
+  const results = useEvaluationDraftStore((s) => s.resultsBySession[sessionId] ?? []);
+  const latestResult = useMemo(
+    () =>
+      results.length === 0
+        ? null
+        : [...results].sort((a, b) => a.iterationNumber - b.iterationNumber).at(-1),
+    [results]
+  );
+
+  // When a session has a sample but no client-side history (e.g. user came back later),
+  // we still allow the user to send feedback against the stored sample. The latest
+  // result will appear in the history once they re-evaluate.
+
+  useEffect(() => {
+    if (!session) return;
+    if (session.status !== "READY_FOR_BULK" && results.length >= 2) {
+      // light hint via toast handled inside markReady mutation – nothing to do here
+    }
+  }, [session, results.length]);
+
+  if (sessionQuery.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading session…
+      </div>
+    );
+  }
+
+  if (sessionQuery.isError) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+        <p className="font-medium">Couldn’t load this session.</p>
+        <p>{sessionQuery.error.message}</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => sessionQuery.refetch()}
+          className="mt-3"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-card p-6 text-sm text-muted-foreground">
+        Session not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SessionSummaryCard session={session} />
+
+      {!session.sampleApplication ? (
+        <ApplicationInput
+          sessionId={session.id}
+          isRunning={evaluate.isPending}
+          onRun={(applicationText) => evaluate.mutate({ sessionId: session.id, applicationText })}
+        />
+      ) : null}
+
+      {evaluate.isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {evaluate.error.message}
+        </div>
+      ) : null}
+
+      <IterationHistory sessionId={session.id} style={session.evaluationStyle} />
+
+      <FeedbackComposer
+        hasSample={Boolean(session.sampleApplication) || Boolean(latestResult)}
+        isPending={submitFeedback.isPending}
+        onSubmit={(feedback) => submitFeedback.mutate({ sessionId: session.id, feedback })}
+      />
+
+      {submitFeedback.isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {submitFeedback.error.message}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <TemplateSavePanel session={session} />
+        {session.status !== "READY_FOR_BULK" && Boolean(latestResult) ? (
+          <Button
+            type="button"
+            onClick={() => markReady.mutate(session.id)}
+            disabled={markReady.isPending}
+            variant="outline"
+          >
+            {markReady.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Saving
+              </>
+            ) : (
+              "Mark ready for bulk"
+            )}
+          </Button>
+        ) : null}
+      </div>
+
+      {session.status === "READY_FOR_BULK" || activeBulkJobId ? (
+        activeBulkJobId ? (
+          <BulkProgressView sessionId={session.id} jobId={activeBulkJobId} />
+        ) : (
+          <BulkUploadPanel sessionId={session.id} />
+        )
+      ) : null}
+
+      <BulkHistoryList sessionId={session.id} />
+    </div>
+  );
+}
+
+function SessionSummaryCard({ session }: { session: SessionResponse }) {
+  return (
+    <section className="rounded-xl border border-border bg-card p-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Session · {session.evaluationStyle}
+          </p>
+          <h2 className="text-lg font-semibold text-foreground">
+            {session.programDescription.slice(0, 80) || "Untitled"}
+          </h2>
+        </div>
+        <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {session.status.replace("_", " ").toLowerCase()}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
+++ b/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
@@ -112,7 +112,9 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
       <FeedbackComposer
         hasSample={Boolean(session.sampleApplication) || Boolean(latestResult)}
         isPending={submitFeedback.isPending}
-        onSubmit={(feedback) => submitFeedback.mutate({ sessionId: session.id, feedback })}
+        onSubmit={async (feedback) => {
+          await submitFeedback.mutateAsync({ sessionId: session.id, feedback });
+        }}
       />
 
       {submitFeedback.isError ? (
@@ -167,7 +169,7 @@ function SessionSummaryCard({ session }: { session: SessionResponse }) {
           </h2>
         </div>
         <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {session.status.replace("_", " ").toLowerCase()}
+          {session.status.replace(/_/g, " ").toLowerCase()}
         </span>
       </div>
     </section>

--- a/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
+++ b/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
@@ -126,7 +126,7 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
         <PromptViewer session={session} />
       </div>
 
-      <div className="flex gap-1 border-b border-border px-4">
+      <div role="tablist" className="flex gap-1 border-b border-border px-4">
         {TABS.map((t) => {
           const Icon = t.icon;
           const isActive = tab === t.id;
@@ -134,6 +134,10 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
             <button
               key={t.id}
               type="button"
+              role="tab"
+              id={`evaluate-tab-${t.id}`}
+              aria-selected={isActive}
+              aria-controls={`evaluate-panel-${t.id}`}
               onClick={() => setTab(t.id)}
               className={cn(
                 "inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
@@ -150,33 +154,42 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
       </div>
 
       {tab === "iterate" ? (
-        <IterateLayout
-          session={session}
-          hasSample={hasSample}
-          isEvaluating={evaluate.isPending}
-          isSubmittingFeedback={submitFeedback.isPending}
-          results={sortedResults}
-          activeIterationNumber={activeIteration}
-          onSelectIteration={setActiveIterationNumber}
-          evaluateError={evaluate.isError ? evaluate.error.message : null}
-          feedbackError={submitFeedback.isError ? submitFeedback.error.message : null}
-          onRunInitial={(applicationText) =>
-            evaluate.mutate({ sessionId: session.id, applicationText })
-          }
-          onSubmitFeedback={async (feedback) => {
-            await submitFeedback.mutateAsync({ sessionId: session.id, feedback });
-          }}
-          onSwitchToBulk={() => setTab("bulk")}
-        />
+        <div role="tabpanel" id="evaluate-panel-iterate" aria-labelledby="evaluate-tab-iterate">
+          <IterateLayout
+            session={session}
+            hasSample={hasSample}
+            isEvaluating={evaluate.isPending}
+            isSubmittingFeedback={submitFeedback.isPending}
+            results={sortedResults}
+            activeIterationNumber={activeIteration}
+            onSelectIteration={setActiveIterationNumber}
+            evaluateError={evaluate.isError ? evaluate.error.message : null}
+            feedbackError={submitFeedback.isError ? submitFeedback.error.message : null}
+            onRunInitial={(applicationText) =>
+              evaluate.mutate({ sessionId: session.id, applicationText })
+            }
+            onSubmitFeedback={async (feedback) => {
+              await submitFeedback.mutateAsync({ sessionId: session.id, feedback });
+            }}
+            onSwitchToBulk={() => setTab("bulk")}
+          />
+        </div>
       ) : tab === "bulk" ? (
-        <BulkLayout
-          session={session}
-          activeBulkJobId={activeBulkJobId}
-          canRunBulk={canRunBulk}
-          onSwitchToIterate={() => setTab("iterate")}
-        />
+        <div role="tabpanel" id="evaluate-panel-bulk" aria-labelledby="evaluate-tab-bulk">
+          <BulkLayout
+            session={session}
+            activeBulkJobId={activeBulkJobId}
+            canRunBulk={canRunBulk}
+            onSwitchToIterate={() => setTab("iterate")}
+          />
+        </div>
       ) : (
-        <div className="p-5">
+        <div
+          role="tabpanel"
+          id="evaluate-panel-history"
+          aria-labelledby="evaluate-tab-history"
+          className="p-5"
+        >
           <BulkHistoryList sessionId={session.id} />
         </div>
       )}

--- a/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
+++ b/src/features/standalone-evaluation/components/EvaluateWorkspace.tsx
@@ -1,34 +1,54 @@
 "use client";
 
-import { Loader2, RefreshCw } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import {
+  ArrowRight,
+  History,
+  Loader2,
+  MoreHorizontal,
+  RefreshCw,
+  Save,
+  Sparkles,
+  Upload,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  useEvaluateApplication,
-  useMarkReadyForBulk,
-  useSubmitFeedback,
-} from "../hooks/useEvaluationRun";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/utilities/tailwind";
+import { useEvaluateApplication, useSubmitFeedback } from "../hooks/useEvaluationRun";
 import { useSession } from "../hooks/useEvaluationSessions";
-import type { SessionResponse } from "../schemas/session.schema";
+import type { EvaluationResultResponse, SessionResponse } from "../schemas/session.schema";
 import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
 import { ApplicationInput } from "./ApplicationInput";
 import { BulkHistoryList } from "./BulkHistoryList";
 import { BulkProgressView } from "./BulkProgressView";
 import { BulkUploadPanel } from "./BulkUploadPanel";
 import { FeedbackComposer } from "./FeedbackComposer";
-import { IterationHistory } from "./IterationHistory";
+import { PromptViewer } from "./PromptViewer";
 import { TemplateSavePanel } from "./TemplateSavePanel";
+import { WorkbenchResultPane } from "./WorkbenchResultPane";
 
 interface EvaluateWorkspaceProps {
   sessionId: string;
 }
+
+type WorkbenchTab = "iterate" | "bulk" | "history";
+
+const TABS: ReadonlyArray<{ id: WorkbenchTab; label: string; icon: typeof Sparkles }> = [
+  { id: "iterate", label: "Iterate on sample", icon: Sparkles },
+  { id: "bulk", label: "Bulk run", icon: Upload },
+  { id: "history", label: "History", icon: History },
+];
 
 export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
   const sessionQuery = useSession(sessionId);
 
   const evaluate = useEvaluateApplication();
   const submitFeedback = useSubmitFeedback();
-  const markReady = useMarkReadyForBulk();
 
   const activeBulkJobId = useEvaluationDraftStore(
     (s) => s.activeBulkJobIdBySession[sessionId] ?? null
@@ -36,24 +56,26 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
 
   const session = sessionQuery.data;
   const results = useEvaluationDraftStore((s) => s.resultsBySession[sessionId] ?? []);
-  const latestResult = useMemo(
-    () =>
-      results.length === 0
-        ? null
-        : [...results].sort((a, b) => a.iterationNumber - b.iterationNumber).at(-1),
+  const sortedResults = useMemo(
+    () => [...results].sort((a, b) => a.iterationNumber - b.iterationNumber),
     [results]
   );
+  const latestResult = sortedResults.at(-1) ?? null;
 
-  // When a session has a sample but no client-side history (e.g. user came back later),
-  // we still allow the user to send feedback against the stored sample. The latest
-  // result will appear in the history once they re-evaluate.
+  const [tab, setTab] = useState<WorkbenchTab>("iterate");
+  const [activeIterationNumber, setActiveIterationNumber] = useState<number | null>(null);
 
+  // Auto-pin to the newest iteration whenever a fresh result lands so the
+  // user lands on the result they just produced.
   useEffect(() => {
-    if (!session) return;
-    if (session.status !== "READY_FOR_BULK" && results.length >= 2) {
-      // light hint via toast handled inside markReady mutation – nothing to do here
-    }
-  }, [session, results.length]);
+    if (latestResult) setActiveIterationNumber(latestResult.iterationNumber);
+  }, [latestResult]);
+
+  // If a bulk is running or the session is ready_for_bulk, jump straight to
+  // the bulk tab so the user doesn't have to hunt for it.
+  useEffect(() => {
+    if (activeBulkJobId) setTab("bulk");
+  }, [activeBulkJobId]);
 
   if (sessionQuery.isLoading) {
     return (
@@ -89,89 +111,266 @@ export function EvaluateWorkspace({ sessionId }: EvaluateWorkspaceProps) {
     );
   }
 
+  const hasSample = Boolean(session.sampleApplication) || Boolean(latestResult);
+  // Bulk unlocks the moment any eval has run on this session; a "DRAFT"
+  // session has no sample/run history, so we keep that gate. ITERATING and
+  // READY_FOR_BULK both qualify — there's no separate "ready" checkpoint.
+  const canRunBulk = session.status !== "DRAFT" || Boolean(activeBulkJobId);
+  const activeIteration = activeIterationNumber ?? latestResult?.iterationNumber ?? 0;
+
   return (
-    <div className="space-y-6">
-      <SessionSummaryCard session={session} />
+    <div className="overflow-hidden rounded-xl border border-border bg-background">
+      <SessionHeader session={session} iterationCount={sortedResults.length} />
 
-      {!session.sampleApplication ? (
-        <ApplicationInput
-          sessionId={session.id}
-          isRunning={evaluate.isPending}
-          onRun={(applicationText) => evaluate.mutate({ sessionId: session.id, applicationText })}
-        />
-      ) : null}
-
-      {evaluate.isError ? (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
-          {evaluate.error.message}
-        </div>
-      ) : null}
-
-      <IterationHistory sessionId={session.id} style={session.evaluationStyle} />
-
-      <FeedbackComposer
-        hasSample={Boolean(session.sampleApplication) || Boolean(latestResult)}
-        isPending={submitFeedback.isPending}
-        onSubmit={async (feedback) => {
-          await submitFeedback.mutateAsync({ sessionId: session.id, feedback });
-        }}
-      />
-
-      {submitFeedback.isError ? (
-        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
-          {submitFeedback.error.message}
-        </div>
-      ) : null}
-
-      <div className="flex flex-wrap items-center gap-2">
-        <TemplateSavePanel session={session} />
-        {session.status !== "READY_FOR_BULK" && Boolean(latestResult) ? (
-          <Button
-            type="button"
-            onClick={() => markReady.mutate(session.id)}
-            disabled={markReady.isPending}
-            variant="outline"
-          >
-            {markReady.isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" /> Saving
-              </>
-            ) : (
-              "Mark ready for bulk"
-            )}
-          </Button>
-        ) : null}
+      <div className="border-b border-border px-5 py-3">
+        <PromptViewer session={session} />
       </div>
 
-      {session.status === "READY_FOR_BULK" || activeBulkJobId ? (
-        activeBulkJobId ? (
-          <BulkProgressView sessionId={session.id} jobId={activeBulkJobId} />
-        ) : (
-          <BulkUploadPanel sessionId={session.id} />
-        )
-      ) : null}
+      <div className="flex gap-1 border-b border-border px-4">
+        {TABS.map((t) => {
+          const Icon = t.icon;
+          const isActive = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "border-brand-500 text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
 
-      <BulkHistoryList sessionId={session.id} />
+      {tab === "iterate" ? (
+        <IterateLayout
+          session={session}
+          hasSample={hasSample}
+          isEvaluating={evaluate.isPending}
+          isSubmittingFeedback={submitFeedback.isPending}
+          results={sortedResults}
+          activeIterationNumber={activeIteration}
+          onSelectIteration={setActiveIterationNumber}
+          evaluateError={evaluate.isError ? evaluate.error.message : null}
+          feedbackError={submitFeedback.isError ? submitFeedback.error.message : null}
+          onRunInitial={(applicationText) =>
+            evaluate.mutate({ sessionId: session.id, applicationText })
+          }
+          onSubmitFeedback={async (feedback) => {
+            await submitFeedback.mutateAsync({ sessionId: session.id, feedback });
+          }}
+          onSwitchToBulk={() => setTab("bulk")}
+        />
+      ) : tab === "bulk" ? (
+        <BulkLayout
+          session={session}
+          activeBulkJobId={activeBulkJobId}
+          canRunBulk={canRunBulk}
+          onSwitchToIterate={() => setTab("iterate")}
+        />
+      ) : (
+        <div className="p-5">
+          <BulkHistoryList sessionId={session.id} />
+        </div>
+      )}
     </div>
   );
 }
 
-function SessionSummaryCard({ session }: { session: SessionResponse }) {
+function SessionHeader({
+  session,
+  iterationCount,
+}: {
+  session: SessionResponse;
+  iterationCount: number;
+}) {
+  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false);
   return (
-    <section className="rounded-xl border border-border bg-card p-5">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+    <header className="flex flex-col gap-2 border-b border-border px-5 py-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Session · {session.evaluationStyle}
-          </p>
-          <h2 className="text-lg font-semibold text-foreground">
-            {session.programDescription.slice(0, 80) || "Untitled"}
-          </h2>
+          </span>
+          <span className="inline-flex items-center rounded-full border border-brand-200 bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700 dark:border-brand-800 dark:bg-brand-500/10 dark:text-brand-300">
+            {session.status.replace(/_/g, " ").toLowerCase()}
+            {iterationCount > 0
+              ? ` · ${iterationCount} ${iterationCount === 1 ? "run" : "runs"}`
+              : ""}
+          </span>
         </div>
-        <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {session.status.replace(/_/g, " ").toLowerCase()}
-        </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Session actions"
+              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setSaveTemplateOpen(true)}>
+              <Save className="h-3.5 w-3.5" /> Save as template
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <TemplateSavePanel
+          session={session}
+          open={saveTemplateOpen}
+          onOpenChange={setSaveTemplateOpen}
+        />
       </div>
-    </section>
+      <h1 className="text-lg font-semibold leading-tight text-foreground">
+        {session.programDescription.slice(0, 200) || "Untitled session"}
+      </h1>
+    </header>
+  );
+}
+
+interface IterateLayoutProps {
+  session: SessionResponse;
+  hasSample: boolean;
+  isEvaluating: boolean;
+  isSubmittingFeedback: boolean;
+  results: ReadonlyArray<EvaluationResultResponse>;
+  activeIterationNumber: number;
+  onSelectIteration: (n: number) => void;
+  evaluateError: string | null;
+  feedbackError: string | null;
+  onRunInitial: (applicationText: string) => void;
+  onSubmitFeedback: (feedback: string) => Promise<void>;
+  onSwitchToBulk: () => void;
+}
+
+function IterateLayout({
+  session,
+  hasSample,
+  isEvaluating,
+  isSubmittingFeedback,
+  results,
+  activeIterationNumber,
+  onSelectIteration,
+  evaluateError,
+  feedbackError,
+  onRunInitial,
+  onSubmitFeedback,
+  onSwitchToBulk,
+}: IterateLayoutProps) {
+  return (
+    <div className="grid min-w-0 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,32rem)]">
+      <section className="flex min-h-[28rem] min-w-0 flex-col border-b border-border lg:border-b-0 lg:border-r">
+        {!hasSample ? (
+          <div className="p-5">
+            <ApplicationInput
+              sessionId={session.id}
+              isRunning={isEvaluating}
+              onRun={onRunInitial}
+            />
+            {evaluateError ? (
+              <p className="mt-3 text-xs text-red-600 dark:text-red-400">{evaluateError}</p>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <SamplePanel session={session} />
+            <div className="border-t border-border bg-background p-4">
+              <FeedbackComposer
+                hasSample={hasSample}
+                isPending={isSubmittingFeedback}
+                onSubmit={onSubmitFeedback}
+              />
+              {feedbackError ? (
+                <p className="mt-2 text-xs text-red-600 dark:text-red-400">{feedbackError}</p>
+              ) : null}
+            </div>
+          </>
+        )}
+      </section>
+
+      <section className="flex min-w-0 flex-col">
+        <WorkbenchResultPane
+          results={results}
+          style={session.evaluationStyle}
+          activeIterationNumber={activeIterationNumber}
+          onSelectIteration={onSelectIteration}
+        />
+        {results.length > 0 ? (
+          <button
+            type="button"
+            onClick={onSwitchToBulk}
+            className="group flex items-center justify-center gap-1.5 border-t border-border bg-muted/30 px-4 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            Happy with this run? Run it on the full CSV
+            <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+          </button>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function SamplePanel({ session }: { session: SessionResponse }) {
+  return (
+    <div className="flex flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-5 py-2.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Sample application
+        </span>
+        {session.sampleApplication ? (
+          <span className="text-[11px] text-muted-foreground">
+            · {session.sampleApplication.length.toLocaleString()} chars · pinned
+          </span>
+        ) : null}
+      </div>
+      <div className="max-h-[24rem] flex-1 overflow-y-auto overflow-x-hidden p-5 lg:max-h-none">
+        <pre className="whitespace-pre-wrap font-mono text-[13px] leading-relaxed text-foreground/90 [overflow-wrap:anywhere]">
+          {session.sampleApplication?.trim() || "No sample on this session."}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+interface BulkLayoutProps {
+  session: SessionResponse;
+  activeBulkJobId: string | null;
+  canRunBulk: boolean;
+  onSwitchToIterate: () => void;
+}
+
+function BulkLayout({ session, activeBulkJobId, canRunBulk, onSwitchToIterate }: BulkLayoutProps) {
+  if (!canRunBulk) {
+    return (
+      <div className="space-y-3 p-6">
+        <p className="text-sm font-medium text-foreground">
+          Iterate on a sample before running the full CSV
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Run at least one evaluation on a sample so you can verify the rubric. You can come back
+          here and upload the CSV right after.
+        </p>
+        <Button type="button" variant="outline" onClick={onSwitchToIterate}>
+          <Sparkles className="h-4 w-4" /> Go to iterate
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-5">
+      {activeBulkJobId ? (
+        <BulkProgressView sessionId={session.id} jobId={activeBulkJobId} />
+      ) : (
+        <BulkUploadPanel sessionId={session.id} />
+      )}
+    </div>
   );
 }

--- a/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
+++ b/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
@@ -262,11 +262,7 @@ export const EvaluationResultCard = React.memo(function EvaluationResultCard({
         <span className="text-xs text-muted-foreground">{result.model}</span>
       </header>
 
-      {/*
-        Skip the top-level summary for NARRATIVE — the NarrativeBlock falls
-        back to result.summary when its data lacks `sections`/`narrative`,
-        so rendering both here would duplicate the same paragraph.
-      */}
+      {/* NarrativeBlock falls back to result.summary; skip here to avoid duplication. */}
       {style !== "NARRATIVE" && result.summary ? (
         <p className="text-sm text-foreground">{result.summary}</p>
       ) : null}

--- a/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
+++ b/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
@@ -262,7 +262,14 @@ export const EvaluationResultCard = React.memo(function EvaluationResultCard({
         <span className="text-xs text-muted-foreground">{result.model}</span>
       </header>
 
-      {result.summary ? <p className="text-sm text-foreground">{result.summary}</p> : null}
+      {/*
+        Skip the top-level summary for NARRATIVE — the NarrativeBlock falls
+        back to result.summary when its data lacks `sections`/`narrative`,
+        so rendering both here would duplicate the same paragraph.
+      */}
+      {style !== "NARRATIVE" && result.summary ? (
+        <p className="text-sm text-foreground">{result.summary}</p>
+      ) : null}
 
       {style === "RUBRIC" ? (
         <RubricBlock data={fullEvaluation as RubricEvaluation} />

--- a/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
+++ b/src/features/standalone-evaluation/components/EvaluationResultCard.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import React from "react";
+import { cn } from "@/utilities/tailwind";
+import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
+
+const MarkdownPreview = dynamic(
+  () =>
+    import("@/components/Utilities/MarkdownPreview").then((m) => ({
+      default: m.MarkdownPreview,
+    })),
+  { ssr: false }
+);
+
+interface EvaluationResultCardProps {
+  result: EvaluationResultResponse;
+  style: EvaluationStyle;
+  highlight?: boolean;
+}
+
+interface RubricEvaluation {
+  criteria?: Array<{
+    name: string;
+    score: number;
+    rationale?: string;
+  }>;
+  strengths?: string[];
+  weaknesses?: string[];
+  recommendation?: string;
+  overallScore?: number;
+}
+
+interface NarrativeEvaluation {
+  // BE prompt currently asks for `narrative` (a single multi-paragraph string)
+  // + `overallAssessment` (strong/moderate/weak) + `summary`. Older prompts
+  // may emit `sections[]`/`scores` — both shapes render correctly.
+  narrative?: string;
+  overallAssessment?: string;
+  sections?: Array<{ title: string; body: string }>;
+  scores?: Record<string, number>;
+  summary?: string;
+}
+
+interface QuickScoreEvaluation {
+  // Accept both `decision` (legacy/expected) and `verdict` (what the BE
+  // prompt currently asks the LLM to emit). One of them gets normalized
+  // and rendered.
+  decision?: "PASS" | "FAIL" | string;
+  verdict?: "approve" | "reject" | "needs-review" | string;
+  keyFactors?: string[];
+  redFlags?: string[];
+  oneLineSummary?: string;
+  summary?: string;
+}
+
+function ScoreBadge({ score, max = 100 }: { score: number | null; max?: number }) {
+  if (score === null) return null;
+  // Bands are computed as a percentage of `max` so the same badge works for
+  // both the 0-100 overall score and the 0-10 per-criterion score.
+  const ratio = score / max;
+  const color =
+    ratio >= 0.8
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : ratio >= 0.5
+        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+        : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+  return (
+    <output
+      aria-label={`Score ${score} out of ${max}`}
+      className={cn("rounded-full px-3 py-1 text-sm font-semibold", color)}
+    >
+      {score}/{max}
+    </output>
+  );
+}
+
+function RubricBlock({ data }: { data: RubricEvaluation }) {
+  return (
+    <div className="space-y-4">
+      {(data.criteria?.length ?? 0) > 0 ? (
+        <div className="overflow-hidden rounded-md border border-border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2">Criterion</th>
+                <th className="px-3 py-2">Score</th>
+                <th className="px-3 py-2">Rationale</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.criteria!.map((c) => (
+                <tr key={c.name} className="border-t border-border">
+                  <td className="px-3 py-2 font-medium text-foreground">{c.name}</td>
+                  <td className="px-3 py-2">
+                    {/* Per-criterion scores are 0-10 per the BE prompt schema. */}
+                    <ScoreBadge score={c.score} max={10} />
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{c.rationale ?? "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {data.strengths?.length ? (
+          <div className="rounded-md border border-border p-3">
+            <h4 className="mb-1 text-sm font-semibold text-foreground">Strengths</h4>
+            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+              {data.strengths.map((s, i) => (
+                <li key={`${i}-${s.slice(0, 8)}`}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {data.weaknesses?.length ? (
+          <div className="rounded-md border border-border p-3">
+            <h4 className="mb-1 text-sm font-semibold text-foreground">Weaknesses</h4>
+            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+              {data.weaknesses.map((s, i) => (
+                <li key={`${i}-${s.slice(0, 8)}`}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      {data.recommendation ? (
+        <div className="rounded-md border border-brand-200 bg-brand-50 p-3 text-sm dark:border-brand-900 dark:bg-brand-500/10">
+          <h4 className="mb-1 text-sm font-semibold text-foreground">Recommendation</h4>
+          <p className="text-muted-foreground">{data.recommendation}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function NarrativeBlock({
+  data,
+  fallbackSummary,
+}: {
+  data: NarrativeEvaluation;
+  fallbackSummary: string | null;
+}) {
+  return (
+    <div className="space-y-4">
+      {data.scores && Object.keys(data.scores).length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {Object.entries(data.scores).map(([name, value]) => (
+            <span
+              key={name}
+              className="rounded-md border border-border bg-muted/40 px-3 py-1 text-xs text-muted-foreground"
+            >
+              <span className="mr-1 font-semibold text-foreground">{name}:</span>
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {data.overallAssessment ? (
+        <span className="inline-flex rounded-md border border-border bg-muted/40 px-2 py-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+          {data.overallAssessment}
+        </span>
+      ) : null}
+      {data.sections?.length ? (
+        <div className="space-y-3">
+          {data.sections.map((sec, i) => (
+            <div key={`${i}-${sec.title}`} className="rounded-md border border-border p-3">
+              <h4 className="mb-1 text-sm font-semibold text-foreground">{sec.title}</h4>
+              <div className="text-sm text-muted-foreground">
+                <MarkdownPreview source={sec.body} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : data.narrative ? (
+        // BE-prompt shape: a single multi-paragraph narrative string.
+        <div className="rounded-md border border-border p-3 text-sm text-muted-foreground">
+          <MarkdownPreview source={data.narrative} />
+        </div>
+      ) : (data.summary ?? fallbackSummary) ? (
+        <div className="text-sm text-muted-foreground">
+          <MarkdownPreview source={(data.summary ?? fallbackSummary) as string} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function QuickScoreBlock({ data }: { data: QuickScoreEvaluation }) {
+  // BE prompt asks for `verdict` ("approve" | "reject" | "needs-review");
+  // accept `decision` too in case future prompts use that name. Normalize to
+  // uppercase so PASS/APPROVE both color green, FAIL/REJECT red.
+  const verdict = (data.decision ?? data.verdict ?? "").toUpperCase();
+  const isPositive = verdict === "PASS" || verdict === "APPROVE";
+  const isNegative = verdict === "FAIL" || verdict === "REJECT";
+  const verdictClass = isPositive
+    ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200"
+    : isNegative
+      ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+      : "bg-muted text-foreground";
+  const oneLine = data.oneLineSummary ?? data.summary;
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        {verdict ? (
+          <span
+            className={cn("rounded-full px-3 py-1 text-sm font-semibold uppercase", verdictClass)}
+          >
+            {verdict}
+          </span>
+        ) : null}
+        {oneLine ? <p className="text-sm text-muted-foreground">{oneLine}</p> : null}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {data.keyFactors?.length ? (
+          <div className="rounded-md border border-border p-3">
+            <h4 className="mb-1 text-sm font-semibold text-foreground">Key factors</h4>
+            <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+              {data.keyFactors.map((s, i) => (
+                <li key={`${i}-${s.slice(0, 8)}`}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {data.redFlags?.length ? (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950/40">
+            <h4 className="mb-1 text-sm font-semibold text-red-700 dark:text-red-300">Red flags</h4>
+            <ul className="list-disc space-y-1 pl-5 text-sm text-red-700 dark:text-red-300">
+              {data.redFlags.map((s, i) => (
+                <li key={`${i}-${s.slice(0, 8)}`}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export const EvaluationResultCard = React.memo(function EvaluationResultCard({
+  result,
+  style,
+  highlight,
+}: EvaluationResultCardProps) {
+  const fullEvaluation = result.fullEvaluation as Record<string, unknown>;
+  return (
+    <article
+      data-testid={`eval-result-${style.toLowerCase()}`}
+      className={cn(
+        "space-y-3 rounded-xl border bg-card p-5",
+        highlight ? "border-brand-500 shadow-sm" : "border-border"
+      )}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
+          <span className="rounded-md bg-muted px-2 py-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+            Iteration {result.iterationNumber + 1}
+          </span>
+          <ScoreBadge score={result.score} />
+        </div>
+        <span className="text-xs text-muted-foreground">{result.model}</span>
+      </header>
+
+      {result.summary ? <p className="text-sm text-foreground">{result.summary}</p> : null}
+
+      {style === "RUBRIC" ? (
+        <RubricBlock data={fullEvaluation as RubricEvaluation} />
+      ) : style === "NARRATIVE" ? (
+        <NarrativeBlock
+          data={fullEvaluation as NarrativeEvaluation}
+          fallbackSummary={result.summary}
+        />
+      ) : (
+        <QuickScoreBlock data={fullEvaluation as QuickScoreEvaluation} />
+      )}
+    </article>
+  );
+});

--- a/src/features/standalone-evaluation/components/EvaluationSessionForm.tsx
+++ b/src/features/standalone-evaluation/components/EvaluationSessionForm.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { useCreateSession } from "../hooks/useEvaluationSessions";
+import {
+  PROGRAM_DESCRIPTION_MAX,
+  type SessionCreateInput,
+  sessionCreateSchema,
+} from "../schemas/session.schema";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { StylePicker } from "./StylePicker";
+import { TemplatePicker } from "./TemplatePicker";
+
+interface EvaluationSessionFormProps {
+  onCancel?: () => void;
+}
+
+const textareaClass =
+  "mt-1 w-full min-h-[140px] rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60";
+
+export function EvaluationSessionForm({ onCancel }: EvaluationSessionFormProps) {
+  const draft = useEvaluationDraftStore((s) => s.draft);
+  const setDraft = useEvaluationDraftStore((s) => s.setDraft);
+
+  const createSession = useCreateSession();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<SessionCreateInput>({
+    resolver: zodResolver(sessionCreateSchema),
+    mode: "onChange",
+    defaultValues: {
+      programDescription: draft.programDescription,
+      evaluationCriteria: draft.evaluationCriteria,
+      evaluationStyle: draft.evaluationStyle,
+    },
+  });
+
+  // Persist form values back into the draft store when they change so
+  // refreshing/abandoning the page doesn't lose progress.
+  const programDescription = watch("programDescription");
+  const evaluationCriteria = watch("evaluationCriteria");
+  const evaluationStyle = watch("evaluationStyle");
+
+  useEffect(() => {
+    setDraft({ programDescription, evaluationCriteria, evaluationStyle });
+  }, [programDescription, evaluationCriteria, evaluationStyle, setDraft]);
+
+  const isSubmitting = createSession.isPending;
+
+  const onSubmit = (input: SessionCreateInput) => {
+    createSession.mutate(input);
+  };
+
+  return (
+    <div className="space-y-6">
+      <TemplatePicker
+        onSelect={(tpl) => {
+          reset({
+            programDescription: tpl.programDescription,
+            evaluationCriteria: tpl.evaluationCriteria,
+            evaluationStyle: tpl.evaluationStyle,
+          });
+        }}
+      />
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="space-y-5 rounded-xl border border-border bg-card p-6"
+        aria-label="Create evaluation session"
+      >
+        <div>
+          <label htmlFor="program-description" className="text-sm font-medium text-foreground">
+            Program description
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Tell the model what your funding program is about, who it serves, and what kinds of
+            applications you receive.
+          </p>
+          <textarea
+            id="program-description"
+            disabled={isSubmitting}
+            placeholder="e.g. Public goods funding for open-source infrastructure on Optimism..."
+            className={textareaClass}
+            {...register("programDescription")}
+          />
+          <div className="mt-1 flex justify-between text-xs">
+            <span className="text-red-500">{errors.programDescription?.message}</span>
+            <span className="text-muted-foreground">
+              {(watch("programDescription") ?? "").length}/{PROGRAM_DESCRIPTION_MAX}
+            </span>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="evaluation-criteria" className="text-sm font-medium text-foreground">
+            Evaluation criteria
+          </label>
+          <p className="text-xs text-muted-foreground">
+            Spell out the dimensions you want graded. Bullet lists work well.
+          </p>
+          <textarea
+            id="evaluation-criteria"
+            disabled={isSubmitting}
+            placeholder={
+              "- Technical feasibility\n- Team experience\n- Public goods alignment\n- Budget reasonableness"
+            }
+            className={textareaClass}
+            {...register("evaluationCriteria")}
+          />
+          <p className="mt-1 text-xs text-red-500">{errors.evaluationCriteria?.message}</p>
+        </div>
+
+        <div>
+          <span className="text-sm font-medium text-foreground">Evaluation style</span>
+          <div className="mt-2">
+            <StylePicker
+              value={evaluationStyle}
+              onChange={(style) => setValue("evaluationStyle", style, { shouldValidate: true })}
+              disabled={isSubmitting}
+              errorMessage={errors.evaluationStyle?.message}
+            />
+          </div>
+        </div>
+
+        {createSession.isError ? (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            <p className="font-medium">Could not create session</p>
+            <p>{createSession.error.message}</p>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="submit" disabled={!isValid || isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Creating
+              </>
+            ) : (
+              "Create session"
+            )}
+          </Button>
+          {onCancel ? (
+            <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+          ) : null}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/FeedbackComposer.tsx
+++ b/src/features/standalone-evaluation/components/FeedbackComposer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Loader2, RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { FEEDBACK_MAX, sessionFeedbackSchema } from "../schemas/session.schema";
 
@@ -22,6 +22,7 @@ const textareaClass =
 export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackComposerProps) {
   const [feedback, setFeedback] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
 
   const handleSubmit = async () => {
     const parsed = sessionFeedbackSchema.safeParse({ feedback });
@@ -59,6 +60,8 @@ export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackCom
       </p>
       <textarea
         aria-label="Feedback"
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? errorId : undefined}
         className={textareaClass}
         value={feedback}
         onChange={(e) => setFeedback(e.target.value.slice(0, FEEDBACK_MAX))}
@@ -66,7 +69,9 @@ export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackCom
         disabled={isPending}
       />
       <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-xs">
-        <span className="text-red-500">{error}</span>
+        <span id={errorId} role="alert" className="text-red-500">
+          {error}
+        </span>
         <span className="text-muted-foreground">
           {feedback.length}/{FEEDBACK_MAX}
         </span>

--- a/src/features/standalone-evaluation/components/FeedbackComposer.tsx
+++ b/src/features/standalone-evaluation/components/FeedbackComposer.tsx
@@ -8,7 +8,12 @@ import { FEEDBACK_MAX, sessionFeedbackSchema } from "../schemas/session.schema";
 interface FeedbackComposerProps {
   hasSample: boolean;
   isPending: boolean;
-  onSubmit: (feedback: string) => void;
+  /**
+   * Submit handler. May return a promise — the composer awaits it and only
+   * clears the textarea after the promise resolves, so a failed mutation
+   * preserves the user's input for retry.
+   */
+  onSubmit: (feedback: string) => void | Promise<void>;
 }
 
 const textareaClass =
@@ -18,15 +23,21 @@ export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackCom
   const [feedback, setFeedback] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const parsed = sessionFeedbackSchema.safeParse({ feedback });
     if (!parsed.success) {
       setError(parsed.error.errors[0]?.message ?? "Invalid feedback");
       return;
     }
     setError(null);
-    onSubmit(parsed.data.feedback);
-    setFeedback("");
+    try {
+      await onSubmit(parsed.data.feedback);
+      // Only clear after a successful submit so a failed mutation preserves
+      // what the user just typed.
+      setFeedback("");
+    } catch {
+      // Parent reports the error via the mutation; keep the textarea intact.
+    }
   };
 
   if (!hasSample) {

--- a/src/features/standalone-evaluation/components/FeedbackComposer.tsx
+++ b/src/features/standalone-evaluation/components/FeedbackComposer.tsx
@@ -8,11 +8,7 @@ import { FEEDBACK_MAX, sessionFeedbackSchema } from "../schemas/session.schema";
 interface FeedbackComposerProps {
   hasSample: boolean;
   isPending: boolean;
-  /**
-   * Submit handler. May return a promise — the composer awaits it and only
-   * clears the textarea after the promise resolves, so a failed mutation
-   * preserves the user's input for retry.
-   */
+  // Awaited so a failed mutation preserves the typed feedback.
   onSubmit: (feedback: string) => void | Promise<void>;
 }
 
@@ -33,11 +29,9 @@ export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackCom
     setError(null);
     try {
       await onSubmit(parsed.data.feedback);
-      // Only clear after a successful submit so a failed mutation preserves
-      // what the user just typed.
       setFeedback("");
     } catch {
-      // Parent reports the error via the mutation; keep the textarea intact.
+      // Parent surfaces the error via the mutation; keep the input.
     }
   };
 

--- a/src/features/standalone-evaluation/components/FeedbackComposer.tsx
+++ b/src/features/standalone-evaluation/components/FeedbackComposer.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Loader2, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { FEEDBACK_MAX, sessionFeedbackSchema } from "../schemas/session.schema";
+
+interface FeedbackComposerProps {
+  hasSample: boolean;
+  isPending: boolean;
+  onSubmit: (feedback: string) => void;
+}
+
+const textareaClass =
+  "mt-1 w-full min-h-[100px] rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60";
+
+export function FeedbackComposer({ hasSample, isPending, onSubmit }: FeedbackComposerProps) {
+  const [feedback, setFeedback] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    const parsed = sessionFeedbackSchema.safeParse({ feedback });
+    if (!parsed.success) {
+      setError(parsed.error.errors[0]?.message ?? "Invalid feedback");
+      return;
+    }
+    setError(null);
+    onSubmit(parsed.data.feedback);
+    setFeedback("");
+  };
+
+  if (!hasSample) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-card p-5 text-sm text-muted-foreground">
+        <p>
+          Run an initial evaluation on a sample application above to start iterating with feedback.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-5">
+      <h3 className="text-sm font-semibold text-foreground">Send feedback</h3>
+      <p className="text-xs text-muted-foreground">
+        Tell the model what to weight differently. We’ll re-run on the same sample application you
+        submitted.
+      </p>
+      <textarea
+        aria-label="Feedback"
+        className={textareaClass}
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value.slice(0, FEEDBACK_MAX))}
+        placeholder="e.g. Penalise applications without a clear team bio. Reward measurable KPIs."
+        disabled={isPending}
+      />
+      <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-xs">
+        <span className="text-red-500">{error}</span>
+        <span className="text-muted-foreground">
+          {feedback.length}/{FEEDBACK_MAX}
+        </span>
+      </div>
+      <div className="mt-3">
+        <Button onClick={handleSubmit} disabled={isPending || feedback.length < 5}>
+          {isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" /> Re-evaluating
+            </>
+          ) : (
+            <>
+              <RefreshCw className="h-4 w-4" /> Re-evaluate
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/IterationHistory.tsx
+++ b/src/features/standalone-evaluation/components/IterationHistory.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { ChevronDown, ChevronUp, History } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { EvaluationResultCard } from "./EvaluationResultCard";
+
+interface IterationHistoryProps {
+  sessionId: string;
+  style: EvaluationStyle;
+}
+
+interface RowProps {
+  result: EvaluationResultResponse;
+  style: EvaluationStyle;
+  highlight: boolean;
+}
+
+const HistoryRow = React.memo(function HistoryRow({ result, style, highlight }: RowProps) {
+  return <EvaluationResultCard result={result} style={style} highlight={highlight} />;
+});
+
+export function IterationHistory({ sessionId, style }: IterationHistoryProps) {
+  const results = useEvaluationDraftStore((s) => s.resultsBySession[sessionId] ?? []);
+  const [expanded, setExpanded] = useState(true);
+
+  const sorted = useMemo(
+    () => [...results].sort((a, b) => a.iterationNumber - b.iterationNumber),
+    [results]
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border p-5 text-sm text-muted-foreground">
+        <p className="flex items-center gap-2 font-medium">
+          <History className="h-4 w-4" /> No iterations yet
+        </p>
+        <p className="mt-1 text-xs">
+          Once you run an evaluation, every result is shown here so you can compare across
+          iterations.
+        </p>
+      </div>
+    );
+  }
+
+  const latestId = sorted[sorted.length - 1].id;
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold text-foreground"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className="flex items-center gap-2">
+          <History className="h-4 w-4" /> Iteration history (
+          {sorted.length === 1 ? "1 iteration" : `${sorted.length} iterations`})
+        </span>
+        {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </button>
+      {expanded ? (
+        <div className="space-y-3">
+          {sorted.map((result) => (
+            <HistoryRow
+              key={result.id}
+              result={result}
+              style={style}
+              highlight={result.id === latestId}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/PromptViewer.tsx
+++ b/src/features/standalone-evaluation/components/PromptViewer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ChevronDown, ChevronUp, Copy, Loader2, Pencil, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { cn } from "@/utilities/tailwind";
+import { useUpdatePrompt } from "../hooks/useEvaluationRun";
+import type { SessionResponse } from "../schemas/session.schema";
+
+interface PromptViewerProps {
+  session: SessionResponse;
+}
+
+const PROMPT_MAX = 50_000;
+const PROMPT_MIN = 20;
+
+export function PromptViewer({ session }: PromptViewerProps) {
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(session.currentPrompt);
+  const updatePrompt = useUpdatePrompt();
+  const [, copy] = useCopyToClipboard();
+
+  // Reset the draft whenever the session's currentPrompt changes from the BE
+  // (e.g. after a feedback iteration appends to it). Don't clobber an
+  // in-flight edit, though.
+  useEffect(() => {
+    if (!editing) setDraft(session.currentPrompt);
+  }, [session.currentPrompt, editing]);
+
+  const handleCopy = () => {
+    void copy(session.currentPrompt, "Prompt copied");
+  };
+
+  const handleSave = async () => {
+    const trimmed = draft.trim();
+    if (trimmed.length < PROMPT_MIN) {
+      toast.error(`Prompt must be at least ${PROMPT_MIN} characters`);
+      return;
+    }
+    if (trimmed.length > PROMPT_MAX) {
+      toast.error(`Prompt must be at most ${PROMPT_MAX} characters`);
+      return;
+    }
+    try {
+      await updatePrompt.mutateAsync({ sessionId: session.id, prompt: trimmed });
+      setEditing(false);
+    } catch {
+      // toast handled in the mutation onError
+    }
+  };
+
+  const handleCancel = () => {
+    setDraft(session.currentPrompt);
+    setEditing(false);
+  };
+
+  const feedbackCount = session.feedbackHistory.length;
+
+  return (
+    <section className="rounded-xl border border-border bg-background">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left"
+        aria-expanded={open}
+      >
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          System prompt
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {session.currentPrompt.length.toLocaleString()} chars
+          {feedbackCount > 0
+            ? ` · ${feedbackCount} feedback ${feedbackCount === 1 ? "line" : "lines"} appended`
+            : ""}
+        </span>
+        <span className="ml-auto text-muted-foreground">
+          {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+      </button>
+
+      {open ? (
+        <div className="border-t border-border p-4">
+          {editing ? (
+            <>
+              <textarea
+                aria-label="System prompt"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value.slice(0, PROMPT_MAX))}
+                disabled={updatePrompt.isPending}
+                className={cn(
+                  "h-72 w-full resize-y rounded-md border border-border bg-background p-3 font-mono text-[12px] leading-relaxed text-foreground",
+                  "focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+                )}
+              />
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
+                <p className="text-yellow-700 dark:text-yellow-300">
+                  Saving overwrites the prompt and clears the feedback history. Future feedback
+                  restarts from this baseline.
+                </p>
+                <span className="ml-auto tabular-nums text-muted-foreground">
+                  {draft.length.toLocaleString()}/{PROMPT_MAX.toLocaleString()}
+                </span>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={updatePrompt.isPending || draft.trim().length < PROMPT_MIN}
+                >
+                  {updatePrompt.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Saving
+                    </>
+                  ) : (
+                    "Save prompt"
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCancel}
+                  disabled={updatePrompt.isPending}
+                >
+                  <X className="h-4 w-4" /> Cancel
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <pre className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 font-mono text-[12px] leading-relaxed text-foreground">
+                {session.currentPrompt}
+              </pre>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
+                  <Pencil className="h-3.5 w-3.5" /> Edit prompt
+                </Button>
+                <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+                  <Copy className="h-3.5 w-3.5" /> Copy
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/standalone-evaluation/components/PurchaseCreditsModal.tsx
+++ b/src/features/standalone-evaluation/components/PurchaseCreditsModal.tsx
@@ -62,7 +62,11 @@ export function PurchaseCreditsModal({ open, onOpenChange }: PurchaseCreditsModa
           })}
         </div>
         {purchase.isError ? (
-          <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+          >
             {purchase.error.message}
           </div>
         ) : null}

--- a/src/features/standalone-evaluation/components/PurchaseCreditsModal.tsx
+++ b/src/features/standalone-evaluation/components/PurchaseCreditsModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { usePurchaseCredits } from "../hooks/useCredits";
+import { CREDIT_PACK_INFO, CREDIT_PACKS } from "../schemas/credit.schema";
+
+interface PurchaseCreditsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function PurchaseCreditsModal({ open, onOpenChange }: PurchaseCreditsModalProps) {
+  const purchase = usePurchaseCredits();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-background">
+        <DialogHeader>
+          <DialogTitle>Buy evaluation credits</DialogTitle>
+          <DialogDescription>
+            Each credit covers one application evaluation. You’ll be redirected to Stripe to
+            complete payment.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {CREDIT_PACKS.map((id) => {
+            const info = CREDIT_PACK_INFO[id];
+            const isPending = purchase.isPending && purchase.variables?.pack === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                disabled={purchase.isPending}
+                onClick={() => purchase.mutate({ pack: id })}
+                className="flex flex-col items-start gap-1 rounded-lg border border-border bg-background p-4 text-left transition-colors hover:border-brand-500 hover:bg-brand-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-brand-500/10"
+                aria-label={`Buy ${info.label} pack: ${info.credits} credits for ${info.priceLabel}`}
+              >
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {info.label}
+                </span>
+                <span className="text-2xl font-bold text-foreground">
+                  {info.credits}{" "}
+                  <span className="text-base font-medium text-muted-foreground">credits</span>
+                </span>
+                <span className="text-sm font-semibold text-brand-600">{info.priceLabel}</span>
+                <span className="text-xs text-muted-foreground">{info.description}</span>
+                {isPending ? (
+                  <span className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" /> Redirecting…
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        {purchase.isError ? (
+          <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            {purchase.error.message}
+          </div>
+        ) : null}
+        <div className="mt-4 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={purchase.isPending}
+          >
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/standalone-evaluation/components/SessionListSidebar.tsx
+++ b/src/features/standalone-evaluation/components/SessionListSidebar.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Loader2, Plus, Trash2 } from "lucide-react";
+import React from "react";
+import { DeleteDialog } from "@/components/DeleteDialog";
+import { cn } from "@/utilities/tailwind";
+import { useDeleteSession, useSessions } from "../hooks/useEvaluationSessions";
+import type { SessionResponse } from "../schemas/session.schema";
+
+interface SessionListSidebarProps {
+  activeSessionId: string | null;
+  onSelect: (id: string) => void;
+  onCreateNew: () => void;
+}
+
+interface SessionItemProps {
+  session: SessionResponse;
+  isActive: boolean;
+  isDeleting: boolean;
+  onSelect: () => void;
+  onDelete: () => Promise<void>;
+}
+
+const SessionItem = React.memo(function SessionItem({
+  session,
+  isActive,
+  isDeleting,
+  onSelect,
+  onDelete,
+}: SessionItemProps) {
+  return (
+    <li className="relative">
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "block w-full rounded-md border px-3 py-2 text-left transition-colors",
+          isActive
+            ? "border-brand-500 bg-brand-50 dark:bg-brand-500/10"
+            : "border-border bg-background hover:border-muted-foreground/40"
+        )}
+      >
+        <p className="line-clamp-1 text-sm font-medium text-foreground">
+          {session.programDescription.slice(0, 60) || "Untitled"}
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {session.evaluationStyle} · {session.status.replace("_", " ").toLowerCase()}
+        </p>
+      </button>
+      <div className="absolute right-1.5 top-1.5">
+        <DeleteDialog
+          title={`Delete this session?`}
+          deleteFunction={onDelete}
+          isLoading={isDeleting}
+          buttonElement={{
+            icon: <Trash2 className="h-3.5 w-3.5 text-red-500" />,
+            text: "",
+            styleClass: "border-none p-1 hover:bg-red-50 dark:hover:bg-red-950/40 rounded-md",
+          }}
+        />
+      </div>
+    </li>
+  );
+});
+
+export function SessionListSidebar({
+  activeSessionId,
+  onSelect,
+  onCreateNew,
+}: SessionListSidebarProps) {
+  const sessions = useSessions();
+  const deleteSession = useDeleteSession();
+
+  return (
+    <aside className="flex w-full flex-col gap-3 lg:max-w-xs">
+      <button
+        type="button"
+        onClick={onCreateNew}
+        className="flex items-center justify-center gap-2 rounded-md border border-dashed border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:border-brand-500 hover:bg-brand-50 dark:hover:bg-brand-500/10"
+      >
+        <Plus className="h-4 w-4" /> New session
+      </button>
+
+      {sessions.isLoading ? (
+        <div className="flex items-center gap-2 rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading sessions…
+        </div>
+      ) : sessions.isError ? (
+        <div className="flex items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          <span>Couldn’t load sessions: {sessions.error.message}</span>
+          <button
+            type="button"
+            className="font-medium underline"
+            onClick={() => sessions.refetch()}
+          >
+            Retry
+          </button>
+        </div>
+      ) : (sessions.data?.items.length ?? 0) === 0 ? (
+        <p className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+          No sessions yet. Create one to get started.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {(sessions.data?.items ?? []).map((session) => (
+            <SessionItem
+              key={session.id}
+              session={session}
+              isActive={session.id === activeSessionId}
+              isDeleting={deleteSession.isPending && deleteSession.variables === session.id}
+              onSelect={() => onSelect(session.id)}
+              onDelete={() => deleteSession.mutateAsync(session.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/src/features/standalone-evaluation/components/StylePicker.tsx
+++ b/src/features/standalone-evaluation/components/StylePicker.tsx
@@ -54,6 +54,7 @@ export const StylePicker = React.memo(function StylePicker({
       <fieldset
         className="grid grid-cols-1 gap-3 sm:grid-cols-3"
         aria-describedby={errorMessage ? errorId : undefined}
+        aria-invalid={errorMessage ? true : undefined}
       >
         <legend className="sr-only">Evaluation style</legend>
         {STYLE_OPTIONS.map((opt) => {
@@ -88,7 +89,7 @@ export const StylePicker = React.memo(function StylePicker({
         })}
       </fieldset>
       {errorMessage ? (
-        <p id={errorId} className="text-xs text-red-600 dark:text-red-400">
+        <p id={errorId} role="alert" className="text-xs text-red-600 dark:text-red-400">
           {errorMessage}
         </p>
       ) : null}

--- a/src/features/standalone-evaluation/components/StylePicker.tsx
+++ b/src/features/standalone-evaluation/components/StylePicker.tsx
@@ -47,6 +47,10 @@ export const StylePicker = React.memo(function StylePicker({
   errorMessage,
 }: StylePickerProps) {
   const errorId = useId();
+  // Per-instance group name. Hardcoding `evaluation-style` would let two
+  // mounted StylePickers (e.g., a form + a preview modal) bleed into each
+  // other's selection because the browser treats them as one radio group.
+  const groupName = useId();
   return (
     <div className="space-y-2">
       <fieldset
@@ -69,7 +73,7 @@ export const StylePicker = React.memo(function StylePicker({
             >
               <input
                 type="radio"
-                name="evaluation-style"
+                name={groupName}
                 className="sr-only"
                 value={opt.id}
                 checked={isSelected}

--- a/src/features/standalone-evaluation/components/StylePicker.tsx
+++ b/src/features/standalone-evaluation/components/StylePicker.tsx
@@ -47,9 +47,7 @@ export const StylePicker = React.memo(function StylePicker({
   errorMessage,
 }: StylePickerProps) {
   const errorId = useId();
-  // Per-instance group name. Hardcoding `evaluation-style` would let two
-  // mounted StylePickers (e.g., a form + a preview modal) bleed into each
-  // other's selection because the browser treats them as one radio group.
+  // Per-instance so two mounted pickers don't share a radio group.
   const groupName = useId();
   return (
     <div className="space-y-2">

--- a/src/features/standalone-evaluation/components/StylePicker.tsx
+++ b/src/features/standalone-evaluation/components/StylePicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ListChecks, ScrollText, Zap } from "lucide-react";
-import React from "react";
+import React, { useId } from "react";
 import { cn } from "@/utilities/tailwind";
 import type { EvaluationStyle } from "../schemas/session.schema";
 
@@ -46,11 +46,12 @@ export const StylePicker = React.memo(function StylePicker({
   disabled,
   errorMessage,
 }: StylePickerProps) {
+  const errorId = useId();
   return (
     <div className="space-y-2">
       <fieldset
         className="grid grid-cols-1 gap-3 sm:grid-cols-3"
-        aria-describedby="style-picker-error"
+        aria-describedby={errorMessage ? errorId : undefined}
       >
         <legend className="sr-only">Evaluation style</legend>
         {STYLE_OPTIONS.map((opt) => {
@@ -85,7 +86,7 @@ export const StylePicker = React.memo(function StylePicker({
         })}
       </fieldset>
       {errorMessage ? (
-        <p id="style-picker-error" className="text-xs text-red-600 dark:text-red-400">
+        <p id={errorId} className="text-xs text-red-600 dark:text-red-400">
           {errorMessage}
         </p>
       ) : null}

--- a/src/features/standalone-evaluation/components/StylePicker.tsx
+++ b/src/features/standalone-evaluation/components/StylePicker.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { ListChecks, ScrollText, Zap } from "lucide-react";
+import React from "react";
+import { cn } from "@/utilities/tailwind";
+import type { EvaluationStyle } from "../schemas/session.schema";
+
+interface StyleOption {
+  id: EvaluationStyle;
+  title: string;
+  description: string;
+  Icon: React.ComponentType<{ className?: string }>;
+}
+
+const STYLE_OPTIONS: ReadonlyArray<StyleOption> = [
+  {
+    id: "RUBRIC",
+    title: "Rubric",
+    description: "Per-criteria scores with strengths, weaknesses, and a recommendation.",
+    Icon: ListChecks,
+  },
+  {
+    id: "NARRATIVE",
+    title: "Narrative",
+    description: "Markdown narrative covering the application across each dimension.",
+    Icon: ScrollText,
+  },
+  {
+    id: "QUICK_SCORE",
+    title: "Quick Score",
+    description: "Pass/fail decision with key factors, red flags, and a one-line summary.",
+    Icon: Zap,
+  },
+];
+
+interface StylePickerProps {
+  value: EvaluationStyle;
+  onChange: (value: EvaluationStyle) => void;
+  disabled?: boolean;
+  errorMessage?: string;
+}
+
+export const StylePicker = React.memo(function StylePicker({
+  value,
+  onChange,
+  disabled,
+  errorMessage,
+}: StylePickerProps) {
+  return (
+    <div className="space-y-2">
+      <fieldset
+        className="grid grid-cols-1 gap-3 sm:grid-cols-3"
+        aria-describedby="style-picker-error"
+      >
+        <legend className="sr-only">Evaluation style</legend>
+        {STYLE_OPTIONS.map((opt) => {
+          const isSelected = opt.id === value;
+          return (
+            <label
+              key={opt.id}
+              className={cn(
+                "relative flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-colors",
+                isSelected
+                  ? "border-brand-500 bg-brand-50 dark:bg-brand-500/10"
+                  : "border-border bg-background hover:border-muted-foreground/40",
+                disabled && "cursor-not-allowed opacity-60"
+              )}
+            >
+              <input
+                type="radio"
+                name="evaluation-style"
+                className="sr-only"
+                value={opt.id}
+                checked={isSelected}
+                disabled={disabled}
+                onChange={() => onChange(opt.id)}
+              />
+              <div className="flex items-center gap-2">
+                <opt.Icon className="h-5 w-5 text-brand-600" />
+                <span className="font-semibold text-foreground">{opt.title}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">{opt.description}</p>
+            </label>
+          );
+        })}
+      </fieldset>
+      {errorMessage ? (
+        <p id="style-picker-error" className="text-xs text-red-600 dark:text-red-400">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+});

--- a/src/features/standalone-evaluation/components/TemplatePicker.tsx
+++ b/src/features/standalone-evaluation/components/TemplatePicker.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { Loader2, Sparkles, Trash2 } from "lucide-react";
+import React, { useState } from "react";
+import { DeleteDialog } from "@/components/DeleteDialog";
+import { useBuiltInTemplates, useDeleteTemplate, useTemplates } from "../hooks/useTemplates";
+import type { EvaluationStyle } from "../schemas/session.schema";
+import type { BuiltInTemplate, TemplateResponse } from "../schemas/template.schema";
+
+interface SelectedTemplateShape {
+  programDescription: string;
+  evaluationCriteria: string;
+  evaluationStyle: EvaluationStyle;
+}
+
+interface TemplatePickerProps {
+  onSelect: (tpl: SelectedTemplateShape) => void;
+}
+
+const cardClass =
+  "flex w-full flex-col items-start gap-1 rounded-lg border border-border bg-background p-3 text-left transition-colors hover:border-brand-500 hover:bg-brand-50 dark:hover:bg-brand-500/10";
+
+interface TemplateCardProps {
+  title: string;
+  subtitle: string;
+  description?: string;
+  onSelect: () => void;
+  onDelete?: () => Promise<void>;
+  isDeleting?: boolean;
+}
+
+const TemplateCard = React.memo(function TemplateCard({
+  title,
+  subtitle,
+  description,
+  onSelect,
+  onDelete,
+  isDeleting,
+}: TemplateCardProps) {
+  return (
+    <div className="relative">
+      <button type="button" onClick={onSelect} className={cardClass}>
+        <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <Sparkles className="h-3.5 w-3.5 text-brand-500" /> {title}
+        </span>
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">{subtitle}</span>
+        {description ? (
+          <span className="text-xs text-muted-foreground line-clamp-2">{description}</span>
+        ) : null}
+      </button>
+      {onDelete ? (
+        <div className="absolute right-2 top-2">
+          <DeleteDialog
+            title={`Delete this template?`}
+            deleteFunction={onDelete}
+            isLoading={Boolean(isDeleting)}
+            buttonElement={{
+              icon: <Trash2 className="h-3.5 w-3.5 text-red-500" />,
+              text: "",
+              styleClass: "border-none p-1 hover:bg-red-50 dark:hover:bg-red-950/40 rounded-md",
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+export function TemplatePicker({ onSelect }: TemplatePickerProps) {
+  const builtIns = useBuiltInTemplates();
+  const userTemplates = useTemplates();
+  const deleteTemplate = useDeleteTemplate();
+
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const handleDelete = async (id: string) => {
+    setPendingDeleteId(id);
+    try {
+      await deleteTemplate.mutateAsync(id);
+    } finally {
+      setPendingDeleteId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <section aria-label="Your templates">
+        <h3 className="mb-2 text-sm font-semibold text-foreground">Your templates</h3>
+        {userTemplates.isLoading ? (
+          <div className="flex items-center gap-2 rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading templates…
+          </div>
+        ) : userTemplates.isError ? (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            <span>Couldn’t load templates: {userTemplates.error.message}</span>
+            <button
+              type="button"
+              className="font-medium underline"
+              onClick={() => userTemplates.refetch()}
+            >
+              Retry
+            </button>
+          </div>
+        ) : (userTemplates.data?.length ?? 0) === 0 ? (
+          <p className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+            You haven’t saved any templates yet. After iterating on a session, save it as a template
+            to reuse later.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {(userTemplates.data ?? []).map((tpl: TemplateResponse) => (
+              <TemplateCard
+                key={tpl.id}
+                title={tpl.name}
+                subtitle={tpl.evaluationStyle}
+                description={tpl.programDescription}
+                onSelect={() =>
+                  onSelect({
+                    programDescription: tpl.programDescription,
+                    evaluationCriteria: tpl.evaluationCriteria,
+                    evaluationStyle: tpl.evaluationStyle,
+                  })
+                }
+                onDelete={() => handleDelete(tpl.id)}
+                isDeleting={pendingDeleteId === tpl.id}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section aria-label="Starter templates">
+        <h3 className="mb-2 text-sm font-semibold text-foreground">Starter templates</h3>
+        {builtIns.isLoading ? (
+          <div className="flex items-center gap-2 rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading starters…
+          </div>
+        ) : builtIns.isError ? (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            <span>Couldn’t load starters: {builtIns.error.message}</span>
+            <button
+              type="button"
+              className="font-medium underline"
+              onClick={() => builtIns.refetch()}
+            >
+              Retry
+            </button>
+          </div>
+        ) : (builtIns.data?.length ?? 0) === 0 ? (
+          <p className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+            No starter templates available right now.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {(builtIns.data ?? []).map((tpl: BuiltInTemplate) => (
+              <TemplateCard
+                key={tpl.id}
+                title={tpl.name}
+                subtitle={tpl.evaluationStyle}
+                description={tpl.description}
+                onSelect={() =>
+                  onSelect({
+                    programDescription: tpl.programDescription,
+                    evaluationCriteria: tpl.evaluationCriteria,
+                    evaluationStyle: tpl.evaluationStyle,
+                  })
+                }
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
+++ b/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
@@ -16,13 +16,27 @@ import { TEMPLATE_NAME_MAX, templateCreateSchema } from "../schemas/template.sch
 
 interface TemplateSavePanelProps {
   session: SessionResponse;
+  /**
+   * Controlled open state — when provided, the trigger button renders nothing
+   * and the parent owns the open/close lifecycle (e.g. opening from a
+   * dropdown menu item). When omitted, the panel renders its own button.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const inputClass =
   "mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500";
 
-export function TemplateSavePanel({ session }: TemplateSavePanelProps) {
-  const [open, setOpen] = useState(false);
+export function TemplateSavePanel({
+  session,
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
+}: TemplateSavePanelProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = onOpenChangeProp ?? setInternalOpen;
+  const isControlled = openProp !== undefined;
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -52,14 +66,16 @@ export function TemplateSavePanel({ session }: TemplateSavePanelProps) {
 
   return (
     <>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => setOpen(true)}
-        disabled={createTemplate.isPending}
-      >
-        <Save className="h-4 w-4" /> Save as template
-      </Button>
+      {isControlled ? null : (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setOpen(true)}
+          disabled={createTemplate.isPending}
+        >
+          <Save className="h-4 w-4" /> Save as template
+        </Button>
+      )}
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="bg-background">
           <DialogHeader>

--- a/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
+++ b/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Loader2, Save } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateTemplate } from "../hooks/useTemplates";
+import type { SessionResponse } from "../schemas/session.schema";
+import { TEMPLATE_NAME_MAX, templateCreateSchema } from "../schemas/template.schema";
+
+interface TemplateSavePanelProps {
+  session: SessionResponse;
+}
+
+const inputClass =
+  "mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500";
+
+export function TemplateSavePanel({ session }: TemplateSavePanelProps) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const createTemplate = useCreateTemplate();
+
+  const handleSave = async () => {
+    const parsed = templateCreateSchema.safeParse({
+      name,
+      programDescription: session.programDescription,
+      evaluationCriteria: session.evaluationCriteria,
+      evaluationStyle: session.evaluationStyle,
+      feedbackInstructions: session.feedbackHistory,
+    });
+    if (!parsed.success) {
+      setError(parsed.error.errors[0]?.message ?? "Invalid template");
+      return;
+    }
+    setError(null);
+    try {
+      await createTemplate.mutateAsync(parsed.data);
+      setOpen(false);
+      setName("");
+    } catch {
+      // toast handled in hook
+    }
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setOpen(true)}
+        disabled={createTemplate.isPending}
+      >
+        <Save className="h-4 w-4" /> Save as template
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="bg-background">
+          <DialogHeader>
+            <DialogTitle>Save evaluation template</DialogTitle>
+            <DialogDescription>
+              Reuse this configuration (program, criteria, style, and feedback iterations) for
+              future sessions.
+            </DialogDescription>
+          </DialogHeader>
+          <div>
+            <label htmlFor="template-name" className="text-sm font-medium text-foreground">
+              Template name
+            </label>
+            <input
+              id="template-name"
+              className={inputClass}
+              maxLength={TEMPLATE_NAME_MAX}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Optimism public goods rubric v1"
+              disabled={createTemplate.isPending}
+            />
+            <p className="mt-1 text-xs text-red-500">{error}</p>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={createTemplate.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={createTemplate.isPending || name.trim().length < 2}
+            >
+              {createTemplate.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" /> Saving
+                </>
+              ) : (
+                "Save template"
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
+++ b/src/features/standalone-evaluation/components/TemplateSavePanel.tsx
@@ -97,8 +97,14 @@ export function TemplateSavePanel({
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Optimism public goods rubric v1"
               disabled={createTemplate.isPending}
+              aria-invalid={Boolean(error)}
+              aria-describedby={error ? "template-name-error" : undefined}
             />
-            <p className="mt-1 text-xs text-red-500">{error}</p>
+            {error ? (
+              <p id="template-name-error" className="mt-1 text-xs text-red-500">
+                {error}
+              </p>
+            ) : null}
           </div>
           <div className="mt-4 flex justify-end gap-2">
             <Button

--- a/src/features/standalone-evaluation/components/WorkbenchResultPane.tsx
+++ b/src/features/standalone-evaluation/components/WorkbenchResultPane.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useMemo } from "react";
+import { cn } from "@/utilities/tailwind";
+import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
+
+const MarkdownPreview = dynamic(
+  () =>
+    import("@/components/Utilities/MarkdownPreview").then((m) => ({
+      default: m.MarkdownPreview,
+    })),
+  { ssr: false }
+);
+
+interface WorkbenchResultPaneProps {
+  results: ReadonlyArray<EvaluationResultResponse>;
+  style: EvaluationStyle;
+  activeIterationNumber: number;
+  onSelectIteration: (iterationNumber: number) => void;
+}
+
+interface RubricEvaluation {
+  criteria?: Array<{ name: string; score: number; rationale?: string }>;
+  strengths?: string[];
+  weaknesses?: string[];
+  recommendation?: string;
+  overallScore?: number;
+}
+
+interface NarrativeEvaluation {
+  narrative?: string;
+  overallAssessment?: string;
+  sections?: Array<{ title: string; body: string }>;
+  scores?: Record<string, number>;
+  summary?: string;
+}
+
+interface QuickScoreEvaluation {
+  decision?: string;
+  verdict?: string;
+  keyFactors?: string[];
+  redFlags?: string[];
+  oneLineSummary?: string;
+  summary?: string;
+}
+
+export function WorkbenchResultPane({
+  results,
+  style,
+  activeIterationNumber,
+  onSelectIteration,
+}: WorkbenchResultPaneProps) {
+  const sorted = useMemo(
+    () => [...results].sort((a, b) => a.iterationNumber - b.iterationNumber),
+    [results]
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-sm font-medium text-foreground">No evaluations yet</p>
+        <p className="text-xs text-muted-foreground">
+          Run an evaluation on the sample to see scores, criteria, and feedback here.
+        </p>
+      </div>
+    );
+  }
+
+  const active =
+    sorted.find((r) => r.iterationNumber === activeIterationNumber) ?? sorted[sorted.length - 1];
+  const previousIndex = sorted.findIndex((r) => r.id === active.id) - 1;
+  const previous = previousIndex >= 0 ? sorted[previousIndex] : null;
+  const delta =
+    active.score !== null && previous?.score !== null && previous?.score !== undefined
+      ? Math.round(active.score - previous.score)
+      : null;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Result
+        </span>
+        <IterationSwitcher
+          iterations={sorted.map((r) => r.iterationNumber)}
+          active={active.iterationNumber}
+          onChange={onSelectIteration}
+        />
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto bg-muted/20 p-4">
+        <ScoreCard result={active} delta={delta} />
+        {style === "RUBRIC" ? (
+          <RubricBlocks data={active.fullEvaluation as RubricEvaluation} />
+        ) : style === "NARRATIVE" ? (
+          <NarrativeBlocks
+            data={active.fullEvaluation as NarrativeEvaluation}
+            fallbackSummary={active.summary}
+          />
+        ) : (
+          <QuickScoreBlocks data={active.fullEvaluation as QuickScoreEvaluation} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface IterationSwitcherProps {
+  iterations: number[];
+  active: number;
+  onChange: (n: number) => void;
+}
+
+function IterationSwitcher({ iterations, active, onChange }: IterationSwitcherProps) {
+  return (
+    <div className="inline-flex overflow-hidden rounded-md border border-border">
+      {iterations.map((n, i) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => onChange(n)}
+          className={cn(
+            "px-2.5 py-0.5 text-xs font-medium tabular-nums transition-colors",
+            active === n
+              ? "bg-foreground text-background"
+              : "bg-background text-muted-foreground hover:text-foreground",
+            i > 0 && "border-l border-border"
+          )}
+          aria-label={`Show iteration ${n + 1}`}
+        >
+          v{n + 1}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface ScoreCardProps {
+  result: EvaluationResultResponse;
+  delta: number | null;
+}
+
+function ScoreCard({ result, delta }: ScoreCardProps) {
+  return (
+    <div className="rounded-xl border border-border bg-background p-4">
+      <div className="flex items-center gap-3">
+        <ScorePill score={result.score} big />
+        <div className="flex-1">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Iteration {result.iterationNumber + 1} · {result.model}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {delta === null
+              ? "First iteration"
+              : delta === 0
+                ? "No change from previous"
+                : `Δ ${delta > 0 ? "+" : ""}${delta} from previous`}
+          </div>
+        </div>
+      </div>
+      {result.summary ? (
+        <p className="mt-3 text-sm leading-relaxed text-foreground">{result.summary}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function RubricBlocks({ data }: { data: RubricEvaluation }) {
+  const criteria = data?.criteria ?? [];
+  const strengths = data?.strengths ?? [];
+  const weaknesses = data?.weaknesses ?? [];
+  return (
+    <>
+      {criteria.length > 0 ? (
+        <div className="overflow-hidden rounded-xl border border-border bg-background">
+          <div className="border-b border-border px-4 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Criteria
+          </div>
+          <ul className="divide-y divide-border">
+            {criteria.map((c) => (
+              <li
+                key={c.name}
+                className="grid grid-cols-[2.5rem_1fr] items-center gap-3 px-4 py-2.5"
+              >
+                <CriterionBadge score={c.score} />
+                <div>
+                  <div className="text-sm font-medium text-foreground">{c.name}</div>
+                  {c.rationale ? (
+                    <div className="text-xs leading-snug text-muted-foreground">{c.rationale}</div>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {strengths.length > 0 || weaknesses.length > 0 ? (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {strengths.length > 0 ? (
+            <div className="rounded-xl border border-border bg-background p-3">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:text-green-300">
+                Strengths
+              </div>
+              <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
+                {strengths.map((s) => (
+                  <li key={s}>{s}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {weaknesses.length > 0 ? (
+            <div className="rounded-xl border border-border bg-background p-3">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-yellow-700 dark:text-yellow-300">
+                Weaknesses
+              </div>
+              <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
+                {weaknesses.map((w) => (
+                  <li key={w}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {data?.recommendation ? (
+        <div className="rounded-xl border border-brand-200 bg-brand-50 p-3 dark:border-brand-800 dark:bg-brand-500/10">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-brand-700 dark:text-brand-300">
+            Recommendation
+          </div>
+          <p className="mt-1 text-sm leading-relaxed text-foreground">{data.recommendation}</p>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function NarrativeBlocks({
+  data,
+  fallbackSummary,
+}: {
+  data: NarrativeEvaluation;
+  fallbackSummary: string | null;
+}) {
+  const text = data?.narrative ?? fallbackSummary ?? "";
+  const sections = data?.sections ?? [];
+  return (
+    <>
+      {data?.overallAssessment ? (
+        <div className="rounded-xl border border-border bg-background p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Overall assessment
+          </div>
+          <div className="mt-1 text-sm font-semibold capitalize text-foreground">
+            {data.overallAssessment}
+          </div>
+        </div>
+      ) : null}
+      {text ? (
+        <div className="rounded-xl border border-border bg-background p-4 text-sm leading-relaxed">
+          <MarkdownPreview source={text} />
+        </div>
+      ) : null}
+      {sections.length > 0 ? (
+        <div className="space-y-2">
+          {sections.map((s) => (
+            <div key={s.title} className="rounded-xl border border-border bg-background p-3">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {s.title}
+              </div>
+              <div className="mt-1 text-sm leading-relaxed text-foreground">
+                <MarkdownPreview source={s.body} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function QuickScoreBlocks({ data }: { data: QuickScoreEvaluation }) {
+  const verdict = data?.verdict ?? data?.decision ?? "";
+  const summary = data?.oneLineSummary ?? data?.summary ?? "";
+  return (
+    <>
+      {verdict ? (
+        <div className="rounded-xl border border-border bg-background p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Verdict
+          </div>
+          <div className="mt-1 text-sm font-semibold capitalize text-foreground">{verdict}</div>
+        </div>
+      ) : null}
+      {summary ? (
+        <div className="rounded-xl border border-border bg-background p-3 text-sm text-foreground">
+          {summary}
+        </div>
+      ) : null}
+      {data?.keyFactors && data.keyFactors.length > 0 ? (
+        <div className="rounded-xl border border-border bg-background p-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:text-green-300">
+            Key factors
+          </div>
+          <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
+            {data.keyFactors.map((k) => (
+              <li key={k}>{k}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {data?.redFlags && data.redFlags.length > 0 ? (
+        <div className="rounded-xl border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-900 dark:bg-yellow-950/30">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-yellow-700 dark:text-yellow-300">
+            Red flags
+          </div>
+          <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
+            {data.redFlags.map((k) => (
+              <li key={k}>{k}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function CriterionBadge({ score }: { score: number }) {
+  const cls =
+    score >= 7
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : score >= 5
+        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+        : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 w-10 items-center justify-center rounded-md text-xs font-semibold tabular-nums",
+        cls
+      )}
+    >
+      {score}
+    </span>
+  );
+}
+
+function ScorePill({ score, big = false }: { score: number | null; big?: boolean }) {
+  if (score === null) return null;
+  const cls =
+    score >= 70
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : score >= 50
+        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"
+        : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-baseline gap-0.5 font-bold tabular-nums",
+        big ? "rounded-xl px-3 py-1.5 text-lg" : "rounded-full px-2 py-0.5 text-xs",
+        cls
+      )}
+    >
+      {Math.round(score)}
+      <span className={cn("font-medium opacity-70", big ? "text-xs" : "text-[10px]")}>/100</span>
+    </span>
+  );
+}

--- a/src/features/standalone-evaluation/components/WorkbenchResultPane.tsx
+++ b/src/features/standalone-evaluation/components/WorkbenchResultPane.tsx
@@ -204,8 +204,8 @@ function RubricBlocks({ data }: { data: RubricEvaluation }) {
                 Strengths
               </div>
               <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
-                {strengths.map((s) => (
-                  <li key={s}>{s}</li>
+                {strengths.map((s, i) => (
+                  <li key={`${i}-${s}`}>{s}</li>
                 ))}
               </ul>
             </div>
@@ -216,8 +216,8 @@ function RubricBlocks({ data }: { data: RubricEvaluation }) {
                 Weaknesses
               </div>
               <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
-                {weaknesses.map((w) => (
-                  <li key={w}>{w}</li>
+                {weaknesses.map((w, i) => (
+                  <li key={`${i}-${w}`}>{w}</li>
                 ))}
               </ul>
             </div>
@@ -305,8 +305,8 @@ function QuickScoreBlocks({ data }: { data: QuickScoreEvaluation }) {
             Key factors
           </div>
           <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
-            {data.keyFactors.map((k) => (
-              <li key={k}>{k}</li>
+            {data.keyFactors.map((k, i) => (
+              <li key={`${i}-${k}`}>{k}</li>
             ))}
           </ul>
         </div>
@@ -317,8 +317,8 @@ function QuickScoreBlocks({ data }: { data: QuickScoreEvaluation }) {
             Red flags
           </div>
           <ul className="mt-1.5 list-disc space-y-1 pl-5 text-xs leading-relaxed text-foreground">
-            {data.redFlags.map((k) => (
-              <li key={k}>{k}</li>
+            {data.redFlags.map((k, i) => (
+              <li key={`${i}-${k}`}>{k}</li>
             ))}
           </ul>
         </div>

--- a/src/features/standalone-evaluation/hooks/useBulkJob.ts
+++ b/src/features/standalone-evaluation/hooks/useBulkJob.ts
@@ -258,11 +258,7 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
                 queryKey: BULK_JOB_KEYS.list(sessionId),
               });
             } else if (event.type === "error") {
-              // Mark the stream terminal so the post-stream reconnect loop
-              // doesn't retry past a server-reported failure. Without this,
-              // the connection close that typically follows an error event
-              // would re-arm the backoff and overwrite FAILED with ERROR
-              // after retries exhaust.
+              // Suppress reconnect — server-reported failure is terminal.
               doneReceivedRef.current = true;
               const msg = (event.payload as { message?: string }).message ?? "Bulk job failed";
               setProgress((prev) => ({ ...prev, status: "FAILED", error: msg }));

--- a/src/features/standalone-evaluation/hooks/useBulkJob.ts
+++ b/src/features/standalone-evaluation/hooks/useBulkJob.ts
@@ -1,0 +1,242 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { TokenManager } from "@/utilities/auth/token-manager";
+import type { BulkJobResponse, BulkJobStatus } from "../schemas/session.schema";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { CREDITS_QUERY_KEYS } from "./useCredits";
+import { EVALUATION_SESSION_KEYS } from "./useEvaluationSessions";
+
+export const BULK_JOB_KEYS = {
+  all: ["evaluation-bulk-jobs"] as const,
+  job: (sessionId: string, jobId: string) => [...BULK_JOB_KEYS.all, sessionId, jobId] as const,
+  result: (sessionId: string, jobId: string) =>
+    [...BULK_JOB_KEYS.all, sessionId, jobId, "result"] as const,
+  list: (sessionId: string) => [...BULK_JOB_KEYS.all, "list", sessionId] as const,
+};
+
+export const useBulkJobsList = (sessionId: string, enabled = true) => {
+  return useQuery<BulkJobResponse[]>({
+    queryKey: BULK_JOB_KEYS.list(sessionId),
+    queryFn: () => standaloneEvaluationService.listBulkJobs(sessionId),
+    enabled: Boolean(sessionId && enabled),
+    staleTime: 30_000,
+  });
+};
+
+export interface BulkResultData {
+  columns: string[];
+  rows: Record<string, unknown>[];
+}
+
+export const useBulkJobResult = (sessionId: string, jobId: string | null, enabled: boolean) => {
+  return useQuery<BulkResultData>({
+    queryKey: BULK_JOB_KEYS.result(sessionId, jobId ?? ""),
+    queryFn: () => standaloneEvaluationService.getBulkResult(sessionId, jobId as string),
+    enabled: Boolean(sessionId && jobId && enabled),
+    // Result is immutable once a job is complete; cache forever.
+    staleTime: Infinity,
+  });
+};
+
+export interface BulkProgressState {
+  status: BulkJobStatus | "IDLE" | "ERROR";
+  totalApplications: number;
+  completedApplications: number;
+  failedApplications: number;
+  hasResult: boolean;
+  error: string | null;
+}
+
+const idleProgress: BulkProgressState = {
+  status: "IDLE",
+  totalApplications: 0,
+  completedApplications: 0,
+  failedApplications: 0,
+  hasResult: false,
+  error: null,
+};
+
+export const useStartBulkJob = () => {
+  const queryClient = useQueryClient();
+  const setActiveBulkJobId = useEvaluationDraftStore((s) => s.setActiveBulkJobId);
+
+  return useMutation<
+    BulkJobResponse,
+    Error,
+    { sessionId: string; file: File; notificationEmail?: string }
+  >({
+    mutationFn: ({ sessionId, file, notificationEmail }) =>
+      standaloneEvaluationService.startBulkJob(sessionId, file, notificationEmail),
+    onSuccess: (job, vars) => {
+      toast.success("Bulk job started");
+      setActiveBulkJobId(vars.sessionId, job.id);
+      queryClient.invalidateQueries({
+        queryKey: EVALUATION_SESSION_KEYS.detail(vars.sessionId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: BULK_JOB_KEYS.list(vars.sessionId),
+      });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to start bulk job");
+    },
+  });
+};
+
+export const useBulkJobStatus = (sessionId: string, jobId: string | null) => {
+  return useQuery<BulkJobResponse>({
+    queryKey: BULK_JOB_KEYS.job(sessionId, jobId ?? ""),
+    queryFn: () => standaloneEvaluationService.getBulkJob(sessionId, jobId as string),
+    enabled: Boolean(sessionId && jobId),
+    staleTime: 0,
+  });
+};
+
+interface SSEEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+function parseSSE(chunk: string): SSEEvent[] {
+  const out: SSEEvent[] = [];
+  const blocks = chunk.replace(/\r\n/g, "\n").split("\n\n").filter(Boolean);
+  for (const block of blocks) {
+    let event = "message";
+    let data = "";
+    for (const rawLine of block.split("\n")) {
+      const line = rawLine.trimEnd();
+      if (!line || line.startsWith(":")) continue; // heartbeat / comment
+      if (line.startsWith("event:")) {
+        event = line.slice(6).trim();
+      } else if (line.startsWith("data:")) {
+        data += (data ? "\n" : "") + line.slice(5).trimStart();
+      }
+    }
+    if (data) {
+      try {
+        out.push({ type: event, payload: JSON.parse(data) });
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Subscribes to the BE's SSE progress stream. Reads events
+ * `progress` { status, totalApplications, completedApplications, failedApplications }
+ * and `done` { hasResult }, plus `:keepalive` heartbeats.
+ *
+ * Aborts cleanly on unmount or jobId change.
+ */
+export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
+  const [progress, setProgress] = useState<BulkProgressState>(idleProgress);
+  const queryClient = useQueryClient();
+  const setActiveBulkJobId = useEvaluationDraftStore((s) => s.setActiveBulkJobId);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!sessionId || !jobId) {
+      setProgress(idleProgress);
+      return;
+    }
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setProgress({ ...idleProgress, status: "PENDING" });
+
+    const consume = async () => {
+      try {
+        const token = await TokenManager.getToken();
+        const url = standaloneEvaluationService.bulkProgressUrl(sessionId, jobId);
+        const response = await fetch(url, {
+          headers: {
+            Accept: "text/event-stream",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) throw new Error("No response body");
+
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          const lastBoundary = buffer.lastIndexOf("\n\n");
+          if (lastBoundary < 0) continue;
+
+          const consumable = buffer.slice(0, lastBoundary + 2);
+          buffer = buffer.slice(lastBoundary + 2);
+          const events = parseSSE(consumable);
+
+          for (const event of events) {
+            if (event.type === "progress") {
+              const p = event.payload as Partial<BulkProgressState>;
+              setProgress((prev) => ({
+                ...prev,
+                status: (p.status as BulkJobStatus) ?? prev.status,
+                totalApplications: p.totalApplications ?? prev.totalApplications,
+                completedApplications: p.completedApplications ?? prev.completedApplications,
+                failedApplications: p.failedApplications ?? prev.failedApplications,
+              }));
+            } else if (event.type === "done") {
+              const hasResult = Boolean((event.payload as { hasResult?: boolean }).hasResult);
+              setProgress((prev) => ({
+                ...prev,
+                status: "COMPLETED",
+                hasResult,
+              }));
+              queryClient.invalidateQueries({ queryKey: CREDITS_QUERY_KEYS.all });
+              queryClient.invalidateQueries({
+                queryKey: EVALUATION_SESSION_KEYS.detail(sessionId),
+              });
+              queryClient.invalidateQueries({
+                queryKey: BULK_JOB_KEYS.job(sessionId, jobId),
+              });
+              queryClient.invalidateQueries({
+                queryKey: BULK_JOB_KEYS.list(sessionId),
+              });
+            } else if (event.type === "error") {
+              const msg = (event.payload as { message?: string }).message ?? "Bulk job failed";
+              setProgress((prev) => ({ ...prev, status: "FAILED", error: msg }));
+            }
+          }
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        const message = err instanceof Error ? err.message : "Connection lost";
+        setProgress((prev) => ({ ...prev, status: "ERROR", error: message }));
+      }
+    };
+
+    consume();
+
+    return () => {
+      controller.abort();
+      controllerRef.current = null;
+    };
+  }, [sessionId, jobId, queryClient]);
+
+  const dismiss = () => {
+    if (sessionId) setActiveBulkJobId(sessionId, null);
+    setProgress(idleProgress);
+  };
+
+  return { progress, dismiss };
+};

--- a/src/features/standalone-evaluation/hooks/useBulkJob.ts
+++ b/src/features/standalone-evaluation/hooks/useBulkJob.ts
@@ -258,6 +258,12 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
                 queryKey: BULK_JOB_KEYS.list(sessionId),
               });
             } else if (event.type === "error") {
+              // Mark the stream terminal so the post-stream reconnect loop
+              // doesn't retry past a server-reported failure. Without this,
+              // the connection close that typically follows an error event
+              // would re-arm the backoff and overwrite FAILED with ERROR
+              // after retries exhaust.
+              doneReceivedRef.current = true;
               const msg = (event.payload as { message?: string }).message ?? "Bulk job failed";
               setProgress((prev) => ({ ...prev, status: "FAILED", error: msg }));
             }

--- a/src/features/standalone-evaluation/hooks/useBulkJob.ts
+++ b/src/features/standalone-evaluation/hooks/useBulkJob.ts
@@ -133,12 +133,27 @@ function parseSSE(chunk: string): SSEEvent[] {
  * and `done` { hasResult }, plus `:keepalive` heartbeats.
  *
  * Aborts cleanly on unmount or jobId change.
+ *
+ * Resilience: on transient failures (network drop, premature end of stream)
+ * the hook reconnects with exponential backoff (1s, 2s, 4s, 8s, 16s, capped
+ * at 30s) up to 5 retries. The retry counter resets on every successfully
+ * consumed event, so long-running jobs don't accumulate retry budget over
+ * hours. Surfaces ERROR only after retries are exhausted; never reconnects
+ * after the `done` event or after user-initiated unmount.
  */
+const MAX_RETRIES = 5;
+const BASE_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+
 export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
   const [progress, setProgress] = useState<BulkProgressState>(idleProgress);
   const queryClient = useQueryClient();
   const setActiveBulkJobId = useEvaluationDraftStore((s) => s.setActiveBulkJobId);
   const controllerRef = useRef<AbortController | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryAttemptRef = useRef(0);
+  const doneReceivedRef = useRef(false);
+  const unmountedRef = useRef(false);
 
   useEffect(() => {
     if (!sessionId || !jobId) {
@@ -146,12 +161,32 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
       return;
     }
 
-    const controller = new AbortController();
-    controllerRef.current = controller;
+    unmountedRef.current = false;
+    retryAttemptRef.current = 0;
+    doneReceivedRef.current = false;
 
     setProgress({ ...idleProgress, status: "PENDING" });
 
+    const clearReconnectTimer = () => {
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    };
+
     const consume = async () => {
+      if (unmountedRef.current) return;
+
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      // Tracks whether the stream produced any usable signal. A successful
+      // open with at least one parsed event clears the retry budget; a
+      // stream that closes before yielding anything is treated as a
+      // transient failure and counts against retries.
+      let receivedAnyEvent = false;
+      let streamEndedCleanly = false;
+
       try {
         const token = await TokenManager.getToken();
         const url = standaloneEvaluationService.bulkProgressUrl(sessionId, jobId);
@@ -175,7 +210,10 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
 
         while (true) {
           const { done, value } = await reader.read();
-          if (done) break;
+          if (done) {
+            streamEndedCleanly = true;
+            break;
+          }
           buffer += decoder.decode(value, { stream: true });
 
           const lastBoundary = buffer.lastIndexOf("\n\n");
@@ -186,6 +224,12 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
           const events = parseSSE(consumable);
 
           for (const event of events) {
+            // Any successfully parsed event proves the connection is healthy.
+            // Reset the retry budget so long-running jobs don't accumulate
+            // retry count from earlier transient blips.
+            receivedAnyEvent = true;
+            retryAttemptRef.current = 0;
+
             if (event.type === "progress") {
               const p = event.payload as Partial<BulkProgressState>;
               setProgress((prev) => ({
@@ -196,6 +240,7 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
                 failedApplications: p.failedApplications ?? prev.failedApplications,
               }));
             } else if (event.type === "done") {
+              doneReceivedRef.current = true;
               const hasResult = Boolean((event.payload as { hasResult?: boolean }).hasResult);
               setProgress((prev) => ({
                 ...prev,
@@ -219,16 +264,53 @@ export const useBulkJobProgress = (sessionId: string, jobId: string | null) => {
           }
         }
       } catch (err) {
+        // User-initiated abort (unmount, jobId/sessionId change): never retry.
         if (err instanceof DOMException && err.name === "AbortError") return;
+        if (controller.signal.aborted) return;
+
         const message = err instanceof Error ? err.message : "Connection lost";
-        setProgress((prev) => ({ ...prev, status: "ERROR", error: message }));
+        scheduleReconnectOrFail(message);
+        return;
       }
+
+      // Stream closed without throwing. Two cases:
+      //   1) `done` event received → terminal success, do nothing.
+      //   2) Premature end of stream → treat as transient and reconnect.
+      if (doneReceivedRef.current) return;
+      if (streamEndedCleanly && !unmountedRef.current && !controller.signal.aborted) {
+        scheduleReconnectOrFail(
+          receivedAnyEvent ? "Connection lost" : "Stream ended without completion"
+        );
+      }
+    };
+
+    const scheduleReconnectOrFail = (message: string) => {
+      if (unmountedRef.current) return;
+      if (doneReceivedRef.current) return;
+
+      if (retryAttemptRef.current >= MAX_RETRIES) {
+        setProgress((prev) => ({ ...prev, status: "ERROR", error: message }));
+        return;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s — capped at 30s.
+      const delay = Math.min(BASE_BACKOFF_MS * 2 ** retryAttemptRef.current, MAX_BACKOFF_MS);
+      retryAttemptRef.current += 1;
+
+      clearReconnectTimer();
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null;
+        if (unmountedRef.current || doneReceivedRef.current) return;
+        consume();
+      }, delay);
     };
 
     consume();
 
     return () => {
-      controller.abort();
+      unmountedRef.current = true;
+      clearReconnectTimer();
+      controllerRef.current?.abort();
       controllerRef.current = null;
     };
   }, [sessionId, jobId, queryClient]);

--- a/src/features/standalone-evaluation/hooks/useCredits.ts
+++ b/src/features/standalone-evaluation/hooks/useCredits.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { useAuth } from "@/hooks/useAuth";
+import { PAGES } from "@/utilities/pages";
 import type {
   CreditPack,
   CreditsResponse,
@@ -33,8 +34,8 @@ export const usePurchaseCredits = () => {
       // Both URLs return to /evaluate; Stripe will redirect the browser here
       // after the user completes (or cancels) checkout.
       const base = typeof window !== "undefined" ? window.location.origin : "";
-      const successUrl = `${base}/evaluate?stripe=success`;
-      const cancelUrl = `${base}/evaluate?stripe=cancel`;
+      const successUrl = `${base}${PAGES.EVALUATE}?stripe=success`;
+      const cancelUrl = `${base}${PAGES.EVALUATE}?stripe=cancel`;
       return standaloneEvaluationService.createPurchaseSession(pack, successUrl, cancelUrl);
     },
     onSuccess: (response) => {

--- a/src/features/standalone-evaluation/hooks/useCredits.ts
+++ b/src/features/standalone-evaluation/hooks/useCredits.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { useAuth } from "@/hooks/useAuth";
+import type {
+  CreditPack,
+  CreditsResponse,
+  PurchaseSessionResponse,
+} from "../schemas/credit.schema";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+
+export const CREDITS_QUERY_KEYS = {
+  all: ["evaluation-credits"] as const,
+  balance: () => [...CREDITS_QUERY_KEYS.all, "balance"] as const,
+};
+
+export const useCredits = () => {
+  const { authenticated } = useAuth();
+  return useQuery<CreditsResponse>({
+    queryKey: CREDITS_QUERY_KEYS.balance(),
+    queryFn: () => standaloneEvaluationService.getCredits(),
+    enabled: authenticated,
+    staleTime: 30_000,
+  });
+};
+
+export const usePurchaseCredits = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<PurchaseSessionResponse, Error, { pack: CreditPack }>({
+    mutationFn: ({ pack }) => {
+      // Both URLs return to /evaluate; Stripe will redirect the browser here
+      // after the user completes (or cancels) checkout.
+      const base = typeof window !== "undefined" ? window.location.origin : "";
+      const successUrl = `${base}/evaluate?stripe=success`;
+      const cancelUrl = `${base}/evaluate?stripe=cancel`;
+      return standaloneEvaluationService.createPurchaseSession(pack, successUrl, cancelUrl);
+    },
+    onSuccess: (response) => {
+      // After Stripe redirect/return the user lands back on /evaluate; keep credits stale-fresh.
+      queryClient.invalidateQueries({ queryKey: CREDITS_QUERY_KEYS.all });
+      if (typeof window !== "undefined" && response.url) {
+        window.location.href = response.url;
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to start purchase");
+    },
+  });
+};

--- a/src/features/standalone-evaluation/hooks/useEvaluationRun.ts
+++ b/src/features/standalone-evaluation/hooks/useEvaluationRun.ts
@@ -81,6 +81,28 @@ export const useSetSample = () => {
   });
 };
 
+interface UpdatePromptInput {
+  sessionId: string;
+  prompt: string;
+}
+
+export const useUpdatePrompt = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SessionResponse, Error, UpdatePromptInput>({
+    mutationFn: ({ sessionId, prompt }) =>
+      standaloneEvaluationService.updatePrompt(sessionId, prompt),
+    onSuccess: (session) => {
+      toast.success("Prompt updated · feedback history reset");
+      queryClient.setQueryData(EVALUATION_SESSION_KEYS.detail(session.id), session);
+      queryClient.invalidateQueries({ queryKey: EVALUATION_SESSION_KEYS.all });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to update prompt");
+    },
+  });
+};
+
 export const useMarkReadyForBulk = () => {
   const queryClient = useQueryClient();
 

--- a/src/features/standalone-evaluation/hooks/useEvaluationRun.ts
+++ b/src/features/standalone-evaluation/hooks/useEvaluationRun.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import type { EvaluationResultResponse, SessionResponse } from "../schemas/session.schema";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+import { CREDITS_QUERY_KEYS } from "./useCredits";
+import { EVALUATION_SESSION_KEYS } from "./useEvaluationSessions";
+
+interface EvaluateApplicationInput {
+  sessionId: string;
+  applicationText: string;
+}
+
+export const useEvaluateApplication = () => {
+  const queryClient = useQueryClient();
+  const appendResult = useEvaluationDraftStore((s) => s.appendResult);
+
+  return useMutation<EvaluationResultResponse, Error, EvaluateApplicationInput>({
+    mutationFn: ({ sessionId, applicationText }) =>
+      standaloneEvaluationService.evaluateApplication(sessionId, applicationText),
+    onSuccess: (result, vars) => {
+      toast.success("Evaluation complete");
+      appendResult(vars.sessionId, result);
+      queryClient.invalidateQueries({
+        queryKey: EVALUATION_SESSION_KEYS.detail(vars.sessionId),
+      });
+      queryClient.invalidateQueries({ queryKey: CREDITS_QUERY_KEYS.all });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Evaluation failed");
+    },
+  });
+};
+
+interface SubmitFeedbackInput {
+  sessionId: string;
+  feedback: string;
+}
+
+export const useSubmitFeedback = () => {
+  const queryClient = useQueryClient();
+  const appendResult = useEvaluationDraftStore((s) => s.appendResult);
+
+  return useMutation<EvaluationResultResponse, Error, SubmitFeedbackInput>({
+    mutationFn: ({ sessionId, feedback }) =>
+      standaloneEvaluationService.submitFeedback(sessionId, feedback),
+    onSuccess: (result, vars) => {
+      toast.success("Re-evaluation complete");
+      appendResult(vars.sessionId, result);
+      queryClient.invalidateQueries({
+        queryKey: EVALUATION_SESSION_KEYS.detail(vars.sessionId),
+      });
+      queryClient.invalidateQueries({ queryKey: CREDITS_QUERY_KEYS.all });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to submit feedback");
+    },
+  });
+};
+
+interface SetSampleInput {
+  sessionId: string;
+  sampleApplication: string;
+}
+
+export const useSetSample = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SessionResponse, Error, SetSampleInput>({
+    mutationFn: ({ sessionId, sampleApplication }) =>
+      standaloneEvaluationService.setSample(sessionId, sampleApplication),
+    onSuccess: (session) => {
+      queryClient.setQueryData(EVALUATION_SESSION_KEYS.detail(session.id), session);
+      queryClient.invalidateQueries({ queryKey: EVALUATION_SESSION_KEYS.all });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to save sample");
+    },
+  });
+};
+
+export const useMarkReadyForBulk = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SessionResponse, Error, string>({
+    mutationFn: (sessionId) => standaloneEvaluationService.markReadyForBulk(sessionId),
+    onSuccess: (session) => {
+      toast.success("Session ready for bulk processing");
+      queryClient.setQueryData(EVALUATION_SESSION_KEYS.detail(session.id), session);
+      queryClient.invalidateQueries({ queryKey: EVALUATION_SESSION_KEYS.all });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to mark session ready");
+    },
+  });
+};

--- a/src/features/standalone-evaluation/hooks/useEvaluationSessions.ts
+++ b/src/features/standalone-evaluation/hooks/useEvaluationSessions.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { useAuth } from "@/hooks/useAuth";
+import type { SessionCreateInput, SessionResponse } from "../schemas/session.schema";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+import { useEvaluationDraftStore } from "../store/evaluationDraftStore";
+
+export const EVALUATION_SESSION_KEYS = {
+  all: ["evaluation-sessions"] as const,
+  list: (params: { limit: number; offset: number }) =>
+    [...EVALUATION_SESSION_KEYS.all, "list", params] as const,
+  detail: (id: string) => [...EVALUATION_SESSION_KEYS.all, "detail", id] as const,
+};
+
+export const useSessions = (params: { limit?: number; offset?: number } = {}) => {
+  const { authenticated } = useAuth();
+  const limit = params.limit ?? 20;
+  const offset = params.offset ?? 0;
+  return useQuery({
+    queryKey: EVALUATION_SESSION_KEYS.list({ limit, offset }),
+    queryFn: () => standaloneEvaluationService.listSessions({ limit, offset }),
+    enabled: authenticated,
+    staleTime: 30_000,
+  });
+};
+
+export const useSession = (id: string | null | undefined) => {
+  const { authenticated } = useAuth();
+  return useQuery({
+    queryKey: EVALUATION_SESSION_KEYS.detail(id ?? ""),
+    queryFn: () => standaloneEvaluationService.getSession(id as string),
+    enabled: authenticated && Boolean(id),
+    staleTime: 15_000,
+  });
+};
+
+export const useCreateSession = () => {
+  const queryClient = useQueryClient();
+  const setActiveSessionId = useEvaluationDraftStore((s) => s.setActiveSessionId);
+  const resetDraft = useEvaluationDraftStore((s) => s.resetDraft);
+
+  return useMutation<SessionResponse, Error, SessionCreateInput>({
+    mutationFn: (input) => standaloneEvaluationService.createSession(input),
+    onSuccess: (session) => {
+      toast.success("Evaluation session created");
+      setActiveSessionId(session.id);
+      resetDraft();
+      queryClient.invalidateQueries({ queryKey: EVALUATION_SESSION_KEYS.all });
+      queryClient.setQueryData(EVALUATION_SESSION_KEYS.detail(session.id), session);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to create session");
+    },
+  });
+};
+
+export const useDeleteSession = () => {
+  const queryClient = useQueryClient();
+  const clearResults = useEvaluationDraftStore((s) => s.clearResults);
+  const activeSessionId = useEvaluationDraftStore((s) => s.activeSessionId);
+  const setActiveSessionId = useEvaluationDraftStore((s) => s.setActiveSessionId);
+
+  return useMutation<void, Error, string>({
+    mutationFn: (id) => standaloneEvaluationService.deleteSession(id),
+    onSuccess: (_, id) => {
+      toast.success("Session deleted");
+      clearResults(id);
+      if (activeSessionId === id) setActiveSessionId(null);
+      queryClient.invalidateQueries({ queryKey: EVALUATION_SESSION_KEYS.all });
+      queryClient.removeQueries({ queryKey: EVALUATION_SESSION_KEYS.detail(id) });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to delete session");
+    },
+  });
+};

--- a/src/features/standalone-evaluation/hooks/useTemplates.ts
+++ b/src/features/standalone-evaluation/hooks/useTemplates.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { useAuth } from "@/hooks/useAuth";
+import type {
+  BuiltInTemplate,
+  TemplateCreateInput,
+  TemplateResponse,
+} from "../schemas/template.schema";
+import { standaloneEvaluationService } from "../services/standaloneEvaluationService";
+
+export const TEMPLATES_QUERY_KEYS = {
+  all: ["evaluation-templates"] as const,
+  user: () => [...TEMPLATES_QUERY_KEYS.all, "user"] as const,
+  builtIn: () => [...TEMPLATES_QUERY_KEYS.all, "built-in"] as const,
+};
+
+export const useTemplates = () => {
+  const { authenticated } = useAuth();
+  return useQuery<TemplateResponse[]>({
+    queryKey: TEMPLATES_QUERY_KEYS.user(),
+    queryFn: () => standaloneEvaluationService.listTemplates(),
+    enabled: authenticated,
+    staleTime: 60_000,
+  });
+};
+
+export const useBuiltInTemplates = () => {
+  return useQuery<BuiltInTemplate[]>({
+    queryKey: TEMPLATES_QUERY_KEYS.builtIn(),
+    queryFn: () => standaloneEvaluationService.listBuiltInTemplates(),
+    staleTime: 5 * 60_000,
+  });
+};
+
+export const useCreateTemplate = () => {
+  const queryClient = useQueryClient();
+  return useMutation<TemplateResponse, Error, TemplateCreateInput>({
+    mutationFn: (input) => standaloneEvaluationService.createTemplate(input),
+    onSuccess: () => {
+      toast.success("Template saved");
+      queryClient.invalidateQueries({ queryKey: TEMPLATES_QUERY_KEYS.user() });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to save template");
+    },
+  });
+};
+
+export const useDeleteTemplate = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (id) => standaloneEvaluationService.deleteTemplate(id),
+    onSuccess: () => {
+      toast.success("Template deleted");
+      queryClient.invalidateQueries({ queryKey: TEMPLATES_QUERY_KEYS.user() });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to delete template");
+    },
+  });
+};

--- a/src/features/standalone-evaluation/schemas/credit.schema.ts
+++ b/src/features/standalone-evaluation/schemas/credit.schema.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+export const CREDIT_PACKS = ["PACK_50", "PACK_100", "PACK_500"] as const;
+export const creditPackSchema = z.enum(CREDIT_PACKS);
+export type CreditPack = z.infer<typeof creditPackSchema>;
+
+export const creditPurchaseSchema = z.object({
+  pack: creditPackSchema,
+});
+export type CreditPurchaseInput = z.infer<typeof creditPurchaseSchema>;
+
+export interface CreditPackInfo {
+  id: CreditPack;
+  label: string;
+  credits: number;
+  priceLabel: string;
+  description: string;
+}
+
+export const CREDIT_PACK_INFO: Readonly<Record<CreditPack, CreditPackInfo>> = Object.freeze({
+  PACK_50: {
+    id: "PACK_50",
+    label: "Starter",
+    credits: 50,
+    priceLabel: "$25",
+    description: "Try the evaluator on a small batch.",
+  },
+  PACK_100: {
+    id: "PACK_100",
+    label: "Standard",
+    credits: 100,
+    priceLabel: "$45",
+    description: "Best value for typical grant rounds.",
+  },
+  PACK_500: {
+    id: "PACK_500",
+    label: "Pro",
+    credits: 500,
+    priceLabel: "$200",
+    description: "For high-volume programs.",
+  },
+});
+
+export const TRANSACTION_TYPES = [
+  "SIGNUP_BONUS",
+  "PURCHASE",
+  "EVALUATION",
+  "BULK_EVALUATION",
+  "REFUND",
+] as const;
+export type TransactionType = (typeof TRANSACTION_TYPES)[number];
+
+export interface TransactionResponse {
+  id: string;
+  amount: number;
+  type: TransactionType;
+  referenceId: string | null;
+  createdAt: string;
+}
+
+export interface CreditsResponse {
+  balance: number;
+  totalPurchased: number;
+  totalUsed: number;
+  recentTransactions: TransactionResponse[];
+}
+
+export interface PurchaseSessionResponse {
+  url: string;
+  sessionId: string;
+}

--- a/src/features/standalone-evaluation/schemas/session.schema.ts
+++ b/src/features/standalone-evaluation/schemas/session.schema.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+export const EVALUATION_STYLES = ["RUBRIC", "NARRATIVE", "QUICK_SCORE"] as const;
+export const evaluationStyleSchema = z.enum(EVALUATION_STYLES);
+export type EvaluationStyle = z.infer<typeof evaluationStyleSchema>;
+
+export const SESSION_STATUSES = ["DRAFT", "ITERATING", "READY_FOR_BULK", "COMPLETED"] as const;
+export const sessionStatusSchema = z.enum(SESSION_STATUSES);
+export type SessionStatus = z.infer<typeof sessionStatusSchema>;
+
+// Field caps mirror BE schema (kept conservative).
+export const PROGRAM_DESCRIPTION_MAX = 10_000;
+export const EVALUATION_CRITERIA_MAX = 10_000;
+export const APPLICATION_TEXT_MAX = 50_000;
+export const FEEDBACK_MAX = 2_000;
+export const SAMPLE_APPLICATION_MAX = 50_000;
+
+export const sessionCreateSchema = z.object({
+  programDescription: z
+    .string()
+    .min(20, "Describe your program in at least 20 characters")
+    .max(
+      PROGRAM_DESCRIPTION_MAX,
+      `Program description must be at most ${PROGRAM_DESCRIPTION_MAX} characters`
+    ),
+  evaluationCriteria: z
+    .string()
+    .min(20, "Describe your evaluation criteria in at least 20 characters")
+    .max(
+      EVALUATION_CRITERIA_MAX,
+      `Evaluation criteria must be at most ${EVALUATION_CRITERIA_MAX} characters`
+    ),
+  evaluationStyle: evaluationStyleSchema,
+});
+export type SessionCreateInput = z.infer<typeof sessionCreateSchema>;
+
+export const sessionEvaluateSchema = z.object({
+  applicationText: z
+    .string()
+    .min(20, "Provide a sample application of at least 20 characters")
+    .max(
+      APPLICATION_TEXT_MAX,
+      `Application text must be at most ${APPLICATION_TEXT_MAX} characters`
+    ),
+});
+export type SessionEvaluateInput = z.infer<typeof sessionEvaluateSchema>;
+
+export const sessionFeedbackSchema = z.object({
+  feedback: z
+    .string()
+    .min(5, "Feedback must be at least 5 characters")
+    .max(FEEDBACK_MAX, `Feedback must be at most ${FEEDBACK_MAX} characters`),
+});
+export type SessionFeedbackInput = z.infer<typeof sessionFeedbackSchema>;
+
+export const sessionSampleSchema = z.object({
+  sampleApplication: z
+    .string()
+    .min(20, "Sample application must be at least 20 characters")
+    .max(
+      SAMPLE_APPLICATION_MAX,
+      `Sample application must be at most ${SAMPLE_APPLICATION_MAX} characters`
+    ),
+});
+export type SessionSampleInput = z.infer<typeof sessionSampleSchema>;
+
+export interface SessionResponse {
+  id: string;
+  userId: string;
+  programDescription: string;
+  evaluationCriteria: string;
+  evaluationStyle: EvaluationStyle;
+  status: SessionStatus;
+  feedbackHistory: string[];
+  sampleApplication: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EvaluationResultResponse {
+  id: string;
+  sessionId: string;
+  score: number | null;
+  summary: string | null;
+  fullEvaluation: Record<string, unknown>;
+  iterationNumber: number;
+  model: string;
+  createdAt: string;
+}
+
+export const BULK_JOB_STATUSES = ["PENDING", "RUNNING", "COMPLETED", "FAILED"] as const;
+export type BulkJobStatus = (typeof BULK_JOB_STATUSES)[number];
+
+export interface BulkJobResponse {
+  id: string;
+  sessionId: string;
+  userId: string;
+  status: BulkJobStatus;
+  totalApplications: number;
+  completedApplications: number;
+  failedApplications: number;
+  hasResult: boolean;
+  startedAt: string;
+  completedAt: string | null;
+}

--- a/src/features/standalone-evaluation/schemas/session.schema.ts
+++ b/src/features/standalone-evaluation/schemas/session.schema.ts
@@ -76,6 +76,8 @@ export interface SessionResponse {
   evaluationCriteria: string;
   evaluationStyle: EvaluationStyle;
   status: SessionStatus;
+  basePrompt: string;
+  currentPrompt: string;
   feedbackHistory: string[];
   sampleApplication: string | null;
   createdAt: string;

--- a/src/features/standalone-evaluation/schemas/session.schema.ts
+++ b/src/features/standalone-evaluation/schemas/session.schema.ts
@@ -18,6 +18,7 @@ export const SAMPLE_APPLICATION_MAX = 50_000;
 export const sessionCreateSchema = z.object({
   programDescription: z
     .string()
+    .trim()
     .min(20, "Describe your program in at least 20 characters")
     .max(
       PROGRAM_DESCRIPTION_MAX,
@@ -25,6 +26,7 @@ export const sessionCreateSchema = z.object({
     ),
   evaluationCriteria: z
     .string()
+    .trim()
     .min(20, "Describe your evaluation criteria in at least 20 characters")
     .max(
       EVALUATION_CRITERIA_MAX,
@@ -37,6 +39,7 @@ export type SessionCreateInput = z.infer<typeof sessionCreateSchema>;
 export const sessionEvaluateSchema = z.object({
   applicationText: z
     .string()
+    .trim()
     .min(20, "Provide a sample application of at least 20 characters")
     .max(
       APPLICATION_TEXT_MAX,
@@ -48,6 +51,7 @@ export type SessionEvaluateInput = z.infer<typeof sessionEvaluateSchema>;
 export const sessionFeedbackSchema = z.object({
   feedback: z
     .string()
+    .trim()
     .min(5, "Feedback must be at least 5 characters")
     .max(FEEDBACK_MAX, `Feedback must be at most ${FEEDBACK_MAX} characters`),
 });
@@ -56,6 +60,7 @@ export type SessionFeedbackInput = z.infer<typeof sessionFeedbackSchema>;
 export const sessionSampleSchema = z.object({
   sampleApplication: z
     .string()
+    .trim()
     .min(20, "Sample application must be at least 20 characters")
     .max(
       SAMPLE_APPLICATION_MAX,

--- a/src/features/standalone-evaluation/schemas/template.schema.ts
+++ b/src/features/standalone-evaluation/schemas/template.schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import {
+  EVALUATION_CRITERIA_MAX,
+  type EvaluationStyle,
+  evaluationStyleSchema,
+  PROGRAM_DESCRIPTION_MAX,
+} from "./session.schema";
+
+export const TEMPLATE_NAME_MAX = 120;
+export const FEEDBACK_INSTRUCTION_MAX = 1_000;
+export const FEEDBACK_INSTRUCTIONS_MAX_ITEMS = 50;
+
+export const templateCreateSchema = z.object({
+  name: z
+    .string()
+    .min(2, "Template name must be at least 2 characters")
+    .max(TEMPLATE_NAME_MAX, `Template name must be at most ${TEMPLATE_NAME_MAX} characters`),
+  programDescription: z
+    .string()
+    .min(20, "Describe your program in at least 20 characters")
+    .max(PROGRAM_DESCRIPTION_MAX),
+  evaluationCriteria: z
+    .string()
+    .min(20, "Describe your evaluation criteria in at least 20 characters")
+    .max(EVALUATION_CRITERIA_MAX),
+  evaluationStyle: evaluationStyleSchema,
+  feedbackInstructions: z
+    .array(z.string().max(FEEDBACK_INSTRUCTION_MAX))
+    .max(FEEDBACK_INSTRUCTIONS_MAX_ITEMS)
+    .default([]),
+});
+export type TemplateCreateInput = z.infer<typeof templateCreateSchema>;
+
+export interface TemplateResponse {
+  id: string;
+  userId: string;
+  name: string;
+  programDescription: string;
+  evaluationCriteria: string;
+  evaluationStyle: EvaluationStyle;
+  feedbackInstructions: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BuiltInTemplate {
+  id: string;
+  name: string;
+  description: string;
+  programDescription: string;
+  evaluationCriteria: string;
+  evaluationStyle: EvaluationStyle;
+  feedbackInstructions: string[];
+}

--- a/src/features/standalone-evaluation/schemas/template.schema.ts
+++ b/src/features/standalone-evaluation/schemas/template.schema.ts
@@ -13,19 +13,22 @@ export const FEEDBACK_INSTRUCTIONS_MAX_ITEMS = 50;
 export const templateCreateSchema = z.object({
   name: z
     .string()
+    .trim()
     .min(2, "Template name must be at least 2 characters")
     .max(TEMPLATE_NAME_MAX, `Template name must be at most ${TEMPLATE_NAME_MAX} characters`),
   programDescription: z
     .string()
+    .trim()
     .min(20, "Describe your program in at least 20 characters")
     .max(PROGRAM_DESCRIPTION_MAX),
   evaluationCriteria: z
     .string()
+    .trim()
     .min(20, "Describe your evaluation criteria in at least 20 characters")
     .max(EVALUATION_CRITERIA_MAX),
   evaluationStyle: evaluationStyleSchema,
   feedbackInstructions: z
-    .array(z.string().max(FEEDBACK_INSTRUCTION_MAX))
+    .array(z.string().trim().min(1).max(FEEDBACK_INSTRUCTION_MAX))
     .max(FEEDBACK_INSTRUCTIONS_MAX_ITEMS)
     .default([]),
 });

--- a/src/features/standalone-evaluation/services/standaloneEvaluationService.ts
+++ b/src/features/standalone-evaluation/services/standaloneEvaluationService.ts
@@ -29,6 +29,7 @@ const ENDPOINTS = {
   feedback: (id: string) => `${BASE}/sessions/${id}/feedback`,
   sample: (id: string) => `${BASE}/sessions/${id}/sample`,
   readyForBulk: (id: string) => `${BASE}/sessions/${id}/ready-for-bulk`,
+  prompt: (id: string) => `${BASE}/sessions/${id}/prompt`,
   bulk: (id: string) => `${BASE}/sessions/${id}/bulk`,
   bulkJob: (sessionId: string, jobId: string) => `${BASE}/sessions/${sessionId}/bulk/${jobId}`,
   bulkProgress: (sessionId: string, jobId: string) =>
@@ -119,6 +120,13 @@ export const standaloneEvaluationService = {
   markReadyForBulk: async (sessionId: string): Promise<SessionResponse> => {
     const result = await fetchData<SessionResponse>(ENDPOINTS.readyForBulk(sessionId), "POST");
     return unwrap(result, "Failed to mark session ready for bulk");
+  },
+
+  updatePrompt: async (sessionId: string, prompt: string): Promise<SessionResponse> => {
+    const result = await fetchData<SessionResponse>(ENDPOINTS.prompt(sessionId), "PATCH", {
+      prompt,
+    });
+    return unwrap(result, "Failed to update prompt");
   },
 
   // ─── Bulk ─────────────────────────────────────────────────────────────────

--- a/src/features/standalone-evaluation/services/standaloneEvaluationService.ts
+++ b/src/features/standalone-evaluation/services/standaloneEvaluationService.ts
@@ -1,0 +1,253 @@
+import { TokenManager } from "@/utilities/auth/token-manager";
+import { envVars } from "@/utilities/enviromentVars";
+import fetchData from "@/utilities/fetchData";
+import type {
+  CreditPack,
+  CreditsResponse,
+  PurchaseSessionResponse,
+} from "../schemas/credit.schema";
+import type {
+  BulkJobResponse,
+  EvaluationResultResponse,
+  SessionCreateInput,
+  SessionResponse,
+} from "../schemas/session.schema";
+import type {
+  BuiltInTemplate,
+  TemplateCreateInput,
+  TemplateResponse,
+} from "../schemas/template.schema";
+
+const BASE = "/v2/evaluate";
+
+const ENDPOINTS = {
+  sessions: () => `${BASE}/sessions`,
+  sessionList: (limit: number, offset: number) =>
+    `${BASE}/sessions?limit=${limit}&offset=${offset}`,
+  session: (id: string) => `${BASE}/sessions/${id}`,
+  evaluate: (id: string) => `${BASE}/sessions/${id}/evaluate`,
+  feedback: (id: string) => `${BASE}/sessions/${id}/feedback`,
+  sample: (id: string) => `${BASE}/sessions/${id}/sample`,
+  readyForBulk: (id: string) => `${BASE}/sessions/${id}/ready-for-bulk`,
+  bulk: (id: string) => `${BASE}/sessions/${id}/bulk`,
+  bulkJob: (sessionId: string, jobId: string) => `${BASE}/sessions/${sessionId}/bulk/${jobId}`,
+  bulkProgress: (sessionId: string, jobId: string) =>
+    `${BASE}/sessions/${sessionId}/bulk/${jobId}/progress`,
+  bulkDownload: (sessionId: string, jobId: string) =>
+    `${BASE}/sessions/${sessionId}/bulk/${jobId}/download`,
+  bulkResult: (sessionId: string, jobId: string) =>
+    `${BASE}/sessions/${sessionId}/bulk/${jobId}/result`,
+  bulksList: (sessionId: string) => `${BASE}/sessions/${sessionId}/bulks`,
+  templates: () => `${BASE}/templates`,
+  template: (id: string) => `${BASE}/templates/${id}`,
+  templatesBuiltIn: () => `${BASE}/templates/built-in`,
+  credits: () => `${BASE}/credits`,
+  creditsPurchase: () => `${BASE}/credits/purchase`,
+} as const;
+
+function unwrap<T>(
+  result: [T, null, unknown, number] | [null, string, null, number],
+  fallbackMsg: string
+): T {
+  const [data, error] = result;
+  if (error || !data) {
+    throw new Error(error || fallbackMsg);
+  }
+  return data;
+}
+
+export const standaloneEvaluationService = {
+  // ─── Sessions ─────────────────────────────────────────────────────────────
+  createSession: async (input: SessionCreateInput): Promise<SessionResponse> => {
+    const result = await fetchData<SessionResponse>(ENDPOINTS.sessions(), "POST", input);
+    return unwrap(result, "Failed to create session");
+  },
+
+  listSessions: async (
+    params: { limit?: number; offset?: number } = {}
+  ): Promise<{ items: SessionResponse[]; total: number }> => {
+    const limit = params.limit ?? 20;
+    const offset = params.offset ?? 0;
+    const result = await fetchData<{ items: SessionResponse[]; total: number }>(
+      ENDPOINTS.sessionList(limit, offset),
+      "GET"
+    );
+    return unwrap(result, "Failed to list sessions");
+  },
+
+  getSession: async (id: string): Promise<SessionResponse> => {
+    const result = await fetchData<SessionResponse>(ENDPOINTS.session(id), "GET");
+    return unwrap(result, "Failed to fetch session");
+  },
+
+  deleteSession: async (id: string): Promise<void> => {
+    const [, error] = await fetchData(ENDPOINTS.session(id), "DELETE");
+    if (error) throw new Error(error);
+  },
+
+  evaluateApplication: async (
+    sessionId: string,
+    applicationText: string
+  ): Promise<EvaluationResultResponse> => {
+    const result = await fetchData<EvaluationResultResponse>(
+      ENDPOINTS.evaluate(sessionId),
+      "POST",
+      { applicationText }
+    );
+    return unwrap(result, "Failed to evaluate application");
+  },
+
+  submitFeedback: async (
+    sessionId: string,
+    feedback: string
+  ): Promise<EvaluationResultResponse> => {
+    const result = await fetchData<EvaluationResultResponse>(
+      ENDPOINTS.feedback(sessionId),
+      "POST",
+      { feedback }
+    );
+    return unwrap(result, "Failed to submit feedback");
+  },
+
+  setSample: async (sessionId: string, sampleApplication: string): Promise<SessionResponse> => {
+    const result = await fetchData<SessionResponse>(ENDPOINTS.sample(sessionId), "POST", {
+      sampleApplication,
+    });
+    return unwrap(result, "Failed to set sample");
+  },
+
+  markReadyForBulk: async (sessionId: string): Promise<SessionResponse> => {
+    const result = await fetchData<SessionResponse>(ENDPOINTS.readyForBulk(sessionId), "POST");
+    return unwrap(result, "Failed to mark session ready for bulk");
+  },
+
+  // ─── Bulk ─────────────────────────────────────────────────────────────────
+  startBulkJob: async (
+    sessionId: string,
+    file: File,
+    notificationEmail?: string
+  ): Promise<BulkJobResponse> => {
+    // Backend accepts the CSV as a JSON string (no @fastify/multipart wired). Read the file
+    // text client-side and POST `{ csvContent }` — the orchestrator handles parsing + row caps.
+    // `notificationEmail` is optional; when present, it overrides the Privy email lookup so
+    // wallet-only users can still receive completion notifications.
+    const csvContent = await file.text();
+    const body: { csvContent: string; notificationEmail?: string } = { csvContent };
+    if (notificationEmail) body.notificationEmail = notificationEmail;
+    const result = await fetchData<BulkJobResponse>(ENDPOINTS.bulk(sessionId), "POST", body);
+    return unwrap(result, "Failed to start bulk job");
+  },
+
+  getBulkJob: async (sessionId: string, jobId: string): Promise<BulkJobResponse> => {
+    const result = await fetchData<BulkJobResponse>(ENDPOINTS.bulkJob(sessionId, jobId), "GET");
+    return unwrap(result, "Failed to fetch bulk job");
+  },
+
+  /**
+   * Lists all bulk jobs for a session, newest first. Used by the FE to render
+   * a history panel so past bulks survive refresh / cross-device.
+   */
+  listBulkJobs: async (sessionId: string): Promise<BulkJobResponse[]> => {
+    const result = await fetchData<BulkJobResponse[]>(ENDPOINTS.bulksList(sessionId), "GET");
+    return unwrap(result, "Failed to list bulk jobs");
+  },
+
+  /**
+   * Fetches the bulk-job result as structured `{ columns, rows }` JSON for
+   * inline rendering. Same DB column the CSV download serializes from — this
+   * is the JSON-shaped sibling.
+   */
+  getBulkResult: async (
+    sessionId: string,
+    jobId: string
+  ): Promise<{ columns: string[]; rows: Record<string, unknown>[] }> => {
+    const result = await fetchData<{
+      columns: string[];
+      rows: Record<string, unknown>[];
+    }>(ENDPOINTS.bulkResult(sessionId, jobId), "GET");
+    return unwrap(result, "Failed to fetch bulk result");
+  },
+
+  /**
+   * Fetches the bulk-job result CSV. The BE serializes from DB-stored
+   * `{ columns, rows }` and streams `text/csv`. We use raw fetch + Privy token
+   * (instead of the JSON-oriented `fetchData`) so we can read the response as
+   * a Blob and trigger a browser download via an anchor click.
+   */
+  downloadBulkResultCsv: async (sessionId: string, jobId: string): Promise<Blob> => {
+    const token = await TokenManager.getToken();
+    const url = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}${ENDPOINTS.bulkDownload(sessionId, jobId)}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "text/csv",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    if (!response.ok) {
+      let message = `HTTP ${response.status}`;
+      try {
+        const body = await response.json();
+        message = body.message || body.error || message;
+      } catch {
+        // ignore body parse errors
+      }
+      throw new Error(message);
+    }
+    return response.blob();
+  },
+
+  bulkProgressUrl: (sessionId: string, jobId: string): string =>
+    `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}${ENDPOINTS.bulkProgress(sessionId, jobId)}`,
+
+  // ─── Templates ────────────────────────────────────────────────────────────
+  createTemplate: async (input: TemplateCreateInput): Promise<TemplateResponse> => {
+    const result = await fetchData<TemplateResponse>(ENDPOINTS.templates(), "POST", input);
+    return unwrap(result, "Failed to create template");
+  },
+
+  listTemplates: async (): Promise<TemplateResponse[]> => {
+    const result = await fetchData<TemplateResponse[]>(ENDPOINTS.templates(), "GET");
+    return unwrap(result, "Failed to list templates");
+  },
+
+  deleteTemplate: async (id: string): Promise<void> => {
+    const [, error] = await fetchData(ENDPOINTS.template(id), "DELETE");
+    if (error) throw new Error(error);
+  },
+
+  listBuiltInTemplates: async (): Promise<BuiltInTemplate[]> => {
+    // Public endpoint — no auth needed. fetchData still injects the token if available;
+    // BE ignores it so this works for both anonymous and authenticated callers.
+    const result = await fetchData<BuiltInTemplate[]>(
+      ENDPOINTS.templatesBuiltIn(),
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+    return unwrap(result, "Failed to list built-in templates");
+  },
+
+  // ─── Credits ──────────────────────────────────────────────────────────────
+  getCredits: async (): Promise<CreditsResponse> => {
+    const result = await fetchData<CreditsResponse>(ENDPOINTS.credits(), "GET");
+    return unwrap(result, "Failed to fetch credits");
+  },
+
+  createPurchaseSession: async (
+    pack: CreditPack,
+    successUrl: string,
+    cancelUrl: string
+  ): Promise<PurchaseSessionResponse> => {
+    const result = await fetchData<PurchaseSessionResponse>(ENDPOINTS.creditsPurchase(), "POST", {
+      pack,
+      successUrl,
+      cancelUrl,
+    });
+    return unwrap(result, "Failed to create purchase session");
+  },
+};
+
+export type StandaloneEvaluationService = typeof standaloneEvaluationService;

--- a/src/features/standalone-evaluation/store/evaluationDraftStore.ts
+++ b/src/features/standalone-evaluation/store/evaluationDraftStore.ts
@@ -4,14 +4,8 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
 
-/**
- * Bucket persisted state by Privy wallet so a shared browser / account switch
- * doesn't rehydrate one user's drafts and results into another's session.
- * Reads the wallet address synchronously from Privy's own localStorage entry
- * (the same one `getWalletFromWagmiStore` uses); falls back to `anon` before
- * login. The base key matches the historical name so existing keys collide
- * only with the legacy unscoped bucket — the cleanup is left to the user.
- */
+// Bucket persisted state by Privy wallet — shared browser / account switch
+// would otherwise leak one user's drafts and results into another's session.
 const STORAGE_KEY = "karma-evaluator-draft";
 
 function readPrivyWalletAddress(): string | null {
@@ -54,15 +48,10 @@ export interface EvaluationDraft {
 }
 
 interface EvaluationDraftState {
-  // Form draft for an unsubmitted session config
   draft: EvaluationDraft;
-  // Application text the user is composing for the active session
   applicationText: string;
-  // Active session ID the user is iterating on (null when starting fresh)
   activeSessionId: string | null;
-  // Iteration result history keyed by sessionId
   resultsBySession: Record<string, EvaluationResultResponse[]>;
-  // Active bulk job id by sessionId
   activeBulkJobIdBySession: Record<string, string | null>;
 
   setDraft: (patch: Partial<EvaluationDraft>) => void;
@@ -95,17 +84,9 @@ const initialState = {
   activeBulkJobIdBySession: {} as Record<string, string | null>,
 };
 
-/**
- * Watch for Privy wallet changes — when the active wallet flips (login,
- * logout, account switch) we reset in-memory state to defaults and
- * re-rehydrate from the new bucket. Without this, the store's in-memory
- * state would persist across account switches and leak the previous
- * user's drafts/results into the new wallet's storage on next write.
- *
- * Implementation notes: `storage` events fire only for OTHER tabs, so we
- * also poll `privy:user` lazily on focus + a 1s interval. Both are
- * lightweight (string compare + read of one localStorage key).
- */
+// On wallet change, reset in-memory state and re-read from the new bucket.
+// `storage` events fire only for OTHER tabs, so a 1s tick + focus listener
+// covers same-tab account switches that emit no storage event.
 function installWalletChangeWatcher(): void {
   if (typeof window === "undefined") return;
   let lastSeenWallet = readPrivyWalletAddress();
@@ -114,27 +95,19 @@ function installWalletChangeWatcher(): void {
     const current = readPrivyWalletAddress();
     if (current === lastSeenWallet) return;
     lastSeenWallet = current;
-    // Reset in-memory state to defaults; persist middleware then re-reads
-    // from the new (current-wallet-scoped) bucket via rehydrate().
     useEvaluationDraftStore.setState({ ...initialState });
-    // The persist API exposes rehydrate() on the store's `persist` extension.
-    // Cast through unknown because the typing depends on middleware order.
     const persistApi = (
       useEvaluationDraftStore as unknown as {
         persist?: { rehydrate: () => Promise<void> };
       }
     ).persist;
-    persistApi?.rehydrate().catch(() => {
-      // Rehydrate failures are non-fatal — fall back to defaults already set.
-    });
+    persistApi?.rehydrate().catch(() => {});
   };
 
   window.addEventListener("storage", (event) => {
     if (event.key === "privy:user") checkAndReact();
   });
   window.addEventListener("focus", checkAndReact);
-  // Same-tab account switches (logout → login as different user without a
-  // reload) emit no storage event, so a low-frequency tick covers them.
   window.setInterval(checkAndReact, 1000);
 }
 
@@ -190,9 +163,6 @@ export const useEvaluationDraftStore = create<EvaluationDraftState>()(
     {
       name: STORAGE_KEY,
       storage: createJSONStorage(() => userScopedLocalStorage),
-      // Include activeBulkJobIdBySession so a refresh / new tab can rebind
-      // BulkProgressView to the still-running job. The id is just a pointer
-      // to a server-authoritative resource — safe to round-trip via storage.
       partialize: (state) => ({
         draft: state.draft,
         applicationText: state.applicationText,

--- a/src/features/standalone-evaluation/store/evaluationDraftStore.ts
+++ b/src/features/standalone-evaluation/store/evaluationDraftStore.ts
@@ -1,10 +1,51 @@
 "use client";
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
 
+/**
+ * Bucket persisted state by Privy wallet so a shared browser / account switch
+ * doesn't rehydrate one user's drafts and results into another's session.
+ * Reads the wallet address synchronously from Privy's own localStorage entry
+ * (the same one `getWalletFromWagmiStore` uses); falls back to `anon` before
+ * login. The base key matches the historical name so existing keys collide
+ * only with the legacy unscoped bucket — the cleanup is left to the user.
+ */
 const STORAGE_KEY = "karma-evaluator-draft";
+
+function readPrivyWalletAddress(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem("privy:user");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      wallet?: { address?: string };
+      linkedAccounts?: Array<{ type?: string; address?: string }>;
+    };
+    if (parsed.wallet?.address) return parsed.wallet.address;
+    const linked = parsed.linkedAccounts?.find((a) => a?.type === "wallet");
+    return linked?.address ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function scopedKey(baseKey: string): string {
+  const wallet = readPrivyWalletAddress();
+  return wallet ? `${baseKey}::${wallet.toLowerCase()}` : `${baseKey}::anon`;
+}
+
+const userScopedLocalStorage = {
+  getItem: (name: string): string | null =>
+    typeof window === "undefined" ? null : window.localStorage.getItem(scopedKey(name)),
+  setItem: (name: string, value: string): void => {
+    if (typeof window !== "undefined") window.localStorage.setItem(scopedKey(name), value);
+  },
+  removeItem: (name: string): void => {
+    if (typeof window !== "undefined") window.localStorage.removeItem(scopedKey(name));
+  },
+};
 
 export interface EvaluationDraft {
   programDescription: string;
@@ -105,12 +146,16 @@ export const useEvaluationDraftStore = create<EvaluationDraftState>()(
     }),
     {
       name: STORAGE_KEY,
-      // Persist everything except activeBulkJobIdBySession (job state is server-authoritative).
+      storage: createJSONStorage(() => userScopedLocalStorage),
+      // Include activeBulkJobIdBySession so a refresh / new tab can rebind
+      // BulkProgressView to the still-running job. The id is just a pointer
+      // to a server-authoritative resource — safe to round-trip via storage.
       partialize: (state) => ({
         draft: state.draft,
         applicationText: state.applicationText,
         activeSessionId: state.activeSessionId,
         resultsBySession: state.resultsBySession,
+        activeBulkJobIdBySession: state.activeBulkJobIdBySession,
       }),
     }
   )

--- a/src/features/standalone-evaluation/store/evaluationDraftStore.ts
+++ b/src/features/standalone-evaluation/store/evaluationDraftStore.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { EvaluationResultResponse, EvaluationStyle } from "../schemas/session.schema";
+
+const STORAGE_KEY = "karma-evaluator-draft";
+
+export interface EvaluationDraft {
+  programDescription: string;
+  evaluationCriteria: string;
+  evaluationStyle: EvaluationStyle;
+}
+
+interface EvaluationDraftState {
+  // Form draft for an unsubmitted session config
+  draft: EvaluationDraft;
+  // Application text the user is composing for the active session
+  applicationText: string;
+  // Active session ID the user is iterating on (null when starting fresh)
+  activeSessionId: string | null;
+  // Iteration result history keyed by sessionId
+  resultsBySession: Record<string, EvaluationResultResponse[]>;
+  // Active bulk job id by sessionId
+  activeBulkJobIdBySession: Record<string, string | null>;
+
+  setDraft: (patch: Partial<EvaluationDraft>) => void;
+  resetDraft: () => void;
+
+  setApplicationText: (text: string) => void;
+
+  setActiveSessionId: (id: string | null) => void;
+
+  appendResult: (sessionId: string, result: EvaluationResultResponse) => void;
+  setResults: (sessionId: string, results: EvaluationResultResponse[]) => void;
+  clearResults: (sessionId: string) => void;
+
+  setActiveBulkJobId: (sessionId: string, jobId: string | null) => void;
+
+  reset: () => void;
+}
+
+const emptyDraft: EvaluationDraft = {
+  programDescription: "",
+  evaluationCriteria: "",
+  evaluationStyle: "RUBRIC",
+};
+
+const initialState = {
+  draft: emptyDraft,
+  applicationText: "",
+  activeSessionId: null as string | null,
+  resultsBySession: {} as Record<string, EvaluationResultResponse[]>,
+  activeBulkJobIdBySession: {} as Record<string, string | null>,
+};
+
+export const useEvaluationDraftStore = create<EvaluationDraftState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setDraft: (patch) => set((state) => ({ draft: { ...state.draft, ...patch } })),
+      resetDraft: () => set({ draft: { ...emptyDraft } }),
+
+      setApplicationText: (text) => set({ applicationText: text }),
+
+      setActiveSessionId: (id) => set({ activeSessionId: id }),
+
+      appendResult: (sessionId, result) =>
+        set((state) => {
+          const prior = state.resultsBySession[sessionId] ?? [];
+          // Avoid duplicate iteration numbers if the same mutation re-runs.
+          const filtered = prior.filter((r) => r.id !== result.id);
+          return {
+            resultsBySession: {
+              ...state.resultsBySession,
+              [sessionId]: [...filtered, result].sort(
+                (a, b) => a.iterationNumber - b.iterationNumber
+              ),
+            },
+          };
+        }),
+
+      setResults: (sessionId, results) =>
+        set((state) => ({
+          resultsBySession: { ...state.resultsBySession, [sessionId]: results },
+        })),
+
+      clearResults: (sessionId) =>
+        set((state) => {
+          const next = { ...state.resultsBySession };
+          delete next[sessionId];
+          return { resultsBySession: next };
+        }),
+
+      setActiveBulkJobId: (sessionId, jobId) =>
+        set((state) => ({
+          activeBulkJobIdBySession: {
+            ...state.activeBulkJobIdBySession,
+            [sessionId]: jobId,
+          },
+        })),
+
+      reset: () => set({ ...initialState }),
+    }),
+    {
+      name: STORAGE_KEY,
+      // Persist everything except activeBulkJobIdBySession (job state is server-authoritative).
+      partialize: (state) => ({
+        draft: state.draft,
+        applicationText: state.applicationText,
+        activeSessionId: state.activeSessionId,
+        resultsBySession: state.resultsBySession,
+      }),
+    }
+  )
+);

--- a/src/features/standalone-evaluation/store/evaluationDraftStore.ts
+++ b/src/features/standalone-evaluation/store/evaluationDraftStore.ts
@@ -95,6 +95,49 @@ const initialState = {
   activeBulkJobIdBySession: {} as Record<string, string | null>,
 };
 
+/**
+ * Watch for Privy wallet changes — when the active wallet flips (login,
+ * logout, account switch) we reset in-memory state to defaults and
+ * re-rehydrate from the new bucket. Without this, the store's in-memory
+ * state would persist across account switches and leak the previous
+ * user's drafts/results into the new wallet's storage on next write.
+ *
+ * Implementation notes: `storage` events fire only for OTHER tabs, so we
+ * also poll `privy:user` lazily on focus + a 1s interval. Both are
+ * lightweight (string compare + read of one localStorage key).
+ */
+function installWalletChangeWatcher(): void {
+  if (typeof window === "undefined") return;
+  let lastSeenWallet = readPrivyWalletAddress();
+
+  const checkAndReact = (): void => {
+    const current = readPrivyWalletAddress();
+    if (current === lastSeenWallet) return;
+    lastSeenWallet = current;
+    // Reset in-memory state to defaults; persist middleware then re-reads
+    // from the new (current-wallet-scoped) bucket via rehydrate().
+    useEvaluationDraftStore.setState({ ...initialState });
+    // The persist API exposes rehydrate() on the store's `persist` extension.
+    // Cast through unknown because the typing depends on middleware order.
+    const persistApi = (
+      useEvaluationDraftStore as unknown as {
+        persist?: { rehydrate: () => Promise<void> };
+      }
+    ).persist;
+    persistApi?.rehydrate().catch(() => {
+      // Rehydrate failures are non-fatal — fall back to defaults already set.
+    });
+  };
+
+  window.addEventListener("storage", (event) => {
+    if (event.key === "privy:user") checkAndReact();
+  });
+  window.addEventListener("focus", checkAndReact);
+  // Same-tab account switches (logout → login as different user without a
+  // reload) emit no storage event, so a low-frequency tick covers them.
+  window.setInterval(checkAndReact, 1000);
+}
+
 export const useEvaluationDraftStore = create<EvaluationDraftState>()(
   persist(
     (set) => ({
@@ -160,3 +203,5 @@ export const useEvaluationDraftStore = create<EvaluationDraftState>()(
     }
   )
 );
+
+installWalletChangeWatcher();

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -42,6 +42,7 @@ export const PAGES = {
   MY_REVIEWS: `/my-reviews`,
   DASHBOARD: `/dashboard`,
   DONATIONS: `/donations`,
+  EVALUATE: `/evaluate`,
   // REVIEWER routes now point to MANAGE (unified RBAC-based routes)
   REVIEWER: {
     DASHBOARD: (community: string) => `/community/${community}/manage/funding-platform`,


### PR DESCRIPTION
## Summary

New `/evaluate` route — a self-serve tool for grant program managers to score applications outside Karma's program/community model. Pairs with the BE PR: show-karma/gap-indexer#1541. Linear: [DEV-60](https://linear.app/showkarma/issue/DEV-60).

- **Session lifecycle** — RHF + Zod form (program description / criteria / style) → evaluate sample → feedback loop → re-evaluate. Built-in templates pre-fill the form; saving an iterated session writes a personal template.
- **Bulk path** — drag-drop CSV upload (parsed client-side for instant row-count + size feedback), SSE progress with reconnect, paginated results table (25 + Show more, sticky header, eval_* columns pinned right). Download serializes via Blob + anchor click. Email links route here too — auto-detected via `?session=&bulk-download=` query params, fetched through the authed client, downloaded once per visit.
- **Bulk history list** — past runs newest-first under the workspace; expanding a completed row reuses `BulkResultTable` in-place. Active job tracked per-session in Zustand so refresh / cross-tab keeps the live view.
- **Credits + Stripe** — sticky balance badge polls the API. Insufficient credit → `PurchaseCreditsModal` → POST `/credits/purchase` → `window.location` to the returned Stripe Checkout URL. Successful return re-fetches balance.

### Conventions followed

- App Router shell at `app/evaluate/{page,layout,loading,error}.tsx`
- All data components handle loading / empty / error (no `return null`)
- Mutations go through React Query (`useMutation`) — no `useState` + direct service calls
- New route added to `PAGES.EVALUATE` in `utilities/pages.ts`
- Feature isolated under `src/features/standalone-evaluation/{components,hooks,services,store,schemas,types}` with no barrel exports
- Vitest + RTL coverage on hooks (`useEvaluationSessions`, `useCredits`, `useBulkJobProgress`), four most load-bearing components (`BulkUploadPanel`, `EvaluationResultCard` per style, `FeedbackComposer`, `PurchaseCreditsModal`), and the service layer

## Test plan

- [ ] `pnpm test` green
- [ ] `pnpm lint:fix` clean
- [ ] Manual: log in via Privy on `/evaluate` → 10 free credits granted on first visit
- [ ] Create RUBRIC session → paste sample → result card renders with criteria + score
- [ ] Leave feedback → re-evaluate → iteration history shows both results
- [ ] "Save as template" → reload → template appears in list and pre-fills a new session
- [ ] Upload 5-row CSV → SSE progress counter ticks 0→5 → completion email delivered → click email link → CSV downloads, history row expanded inline
- [ ] Switch tabs / refresh during a running bulk → progress view rebinds to the active job
- [ ] Insufficient credit → modal → Stripe Checkout opens (test mode) → complete with `4242 4242 4242 4242` → redirect back → balance refreshes via webhook
- [ ] NARRATIVE + QUICK_SCORE styles render correctly (each has its own result card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Evaluate page with a tabbed workspace (iterate, bulk, history), session management, templates, prompt editor, and multiple evaluation styles
  * Bulk evaluation: CSV upload with validation, progress streaming, past-run history, interactive results dashboard, and CSV download
  * Credits UI and in-app purchase flow with balance badge and purchase modal
  * Loading/error UI and richer result cards/panes for reviewing iterations

* **Tests**
  * Extensive new test coverage for components, hooks, and bulk/session workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->