### PR TITLE
ci: switch QA Pipeline build to ubuntu-latest

### DIFF
--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -359,10 +359,7 @@ jobs:
   build:
     needs: [gate-check]
     if: needs.gate-check.outputs.should_run == 'true'
-    # 4-core runner cuts SWC compile time roughly in half (~5m → ~2.5m).
-    # Cost-neutral vs ubuntu-latest (2× per minute, half the minutes).
-    # Falls back automatically if plan does not allow 4-core.
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

The `build` job in `qa-pipeline.yml` was set to `ubuntu-latest-4-cores`. Larger GitHub-hosted runners require a **Team or Enterprise plan**; the org is on **free**, so this label is unreachable.

GitHub does NOT fall back automatically — the job sits queued until workflow timeout. Evidence:

- 3 QA Pipeline runs currently queued, oldest from over 12 hours ago, all stuck on `ubuntu-latest-4-cores` with `runner_name: null` and `runner_id: 0`
- The last 5 "successful" QA Pipeline runs all had `build` skipped (the pipeline only succeeded because earlier jobs short-circuited it before reaching `build`)
- PR #1355 attempt 1 queued 89 minutes with no runner assigned before being cancelled
- PR #1323 currently stuck the same way

## Change

- `runs-on: ubuntu-latest-4-cores` → `runs-on: ubuntu-latest`
- Removed the stale comment claiming automatic fallback

If the org upgrades to Team/Enterprise later, the line can be reverted.

## Test plan

- [ ] CI for this PR's `build` job actually executes (not skipped, not stuck queued)
- [ ] Build completes within `timeout-minutes: 15`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to use standard environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->