### PR TITLE
fix(portfolio-reports): bump axios timeout to 5m for report generation

### DIFF
--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -9,7 +9,7 @@ import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
 import { envVars } from "@/utilities/enviromentVars";
 
 const API_URL = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
-const apiClient = createAuthenticatedApiClient(API_URL, 60000);
+const apiClient = createAuthenticatedApiClient(API_URL, 300000);
 
 // unauthenticated fetcher for public endpoints
 async function fetchPublic<T>(url: string): Promise<T> {


### PR DESCRIPTION
## Summary

- Portfolio report generate/regenerate were failing in the UI with `timeout exceeded` after 60s, even though the backend kept running and the report appeared on the next page refresh.
- The backend `commit_generate_portfolio_report` tool runs a synchronous agentic LLM loop (up to 12 turns of tool calls + completions) which routinely exceeds 60s for real configs.
- Bump the axios client timeout in `services/portfolio-reports.service.ts` from `60000` to `300000` (5 min) so the FE no longer aborts before the backend finishes.

## Why a stopgap

Generation is still synchronous over the wire — if the user closes the tab the FE never sees the result. A proper async refactor (return `202` with a pending row, FE polls `GET /reports/:id` until status flips to `draft`/`failed`) is the right long-term fix and will be tracked separately.

## Scope

- Only affects the `apiClient` used by portfolio-reports endpoints. Read endpoints (configs, list, get, published) stay fast regardless of the higher ceiling.
- No backend changes, no schema changes.

## Test plan

- [ ] Open `/community/<slug>/manage/portfolio-reports`, click **Generate** with a config that takes >60s — toast no longer shows `timeout exceeded`; the new draft appears in the list once the backend completes.
- [ ] Click **Regenerate** on an existing report — same outcome, success toast fires.
- [ ] Verify other portfolio-reports actions (publish, unpublish, edit markdown, delete config) still complete without regression.