### PR TITLE
feat(portfolio-reports): poll async generation instead of blocking

### DIFF
--- a/__tests__/utilities/portfolio-reports/poll-interval.test.ts
+++ b/__tests__/utilities/portfolio-reports/poll-interval.test.ts
@@ -2,7 +2,6 @@ import {
   GENERATING_POLL_INTERVAL_MS,
   isReportGenerating,
   type PortfolioReport,
-  reportListPollIntervalMs,
   reportPollIntervalMs,
 } from "@/types/portfolio-report";
 
@@ -51,29 +50,5 @@ describe("reportPollIntervalMs", () => {
 
   it("returns false when report is undefined", () => {
     expect(reportPollIntervalMs(undefined)).toBe(false);
-  });
-});
-
-describe("reportListPollIntervalMs", () => {
-  it("returns the poll interval when any row is generating", () => {
-    const reports = [
-      makeReport({ id: "r-1", status: "draft" }),
-      makeReport({ id: "r-2", status: "generating" }),
-    ];
-    expect(reportListPollIntervalMs(reports)).toBe(GENERATING_POLL_INTERVAL_MS);
-  });
-
-  it("returns false when all rows are terminal", () => {
-    const reports = [
-      makeReport({ id: "r-1", status: "draft" }),
-      makeReport({ id: "r-2", status: "published" }),
-      makeReport({ id: "r-3", status: "failed" }),
-    ];
-    expect(reportListPollIntervalMs(reports)).toBe(false);
-  });
-
-  it("returns false for empty or undefined input", () => {
-    expect(reportListPollIntervalMs([])).toBe(false);
-    expect(reportListPollIntervalMs(undefined)).toBe(false);
   });
 });

--- a/__tests__/utilities/portfolio-reports/poll-interval.test.ts
+++ b/__tests__/utilities/portfolio-reports/poll-interval.test.ts
@@ -1,0 +1,79 @@
+import {
+  GENERATING_POLL_INTERVAL_MS,
+  isReportGenerating,
+  type PortfolioReport,
+  reportListPollIntervalMs,
+  reportPollIntervalMs,
+} from "@/types/portfolio-report";
+
+function makeReport(overrides: Partial<PortfolioReport> = {}): PortfolioReport {
+  return {
+    id: "r-1",
+    reportConfigId: "cfg-1",
+    communityId: "0xcomm",
+    runDate: "2026-04-30",
+    status: "draft",
+    markdown: "# md",
+    dataSnapshot: {},
+    modelId: "gpt-5.2",
+    tokenUsage: null,
+    generatedAt: "2026-04-30T10:00:00.000Z",
+    generationError: null,
+    publishedAt: null,
+    publishedBy: null,
+    createdAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isReportGenerating", () => {
+  it("returns true only for generating status", () => {
+    expect(isReportGenerating(makeReport({ status: "generating" }))).toBe(true);
+    expect(isReportGenerating(makeReport({ status: "draft" }))).toBe(false);
+    expect(isReportGenerating(makeReport({ status: "failed" }))).toBe(false);
+    expect(isReportGenerating(makeReport({ status: "published" }))).toBe(false);
+  });
+});
+
+describe("reportPollIntervalMs", () => {
+  it("returns the poll interval when status is generating", () => {
+    expect(reportPollIntervalMs(makeReport({ status: "generating" }))).toBe(
+      GENERATING_POLL_INTERVAL_MS
+    );
+  });
+
+  it("returns false for terminal statuses", () => {
+    expect(reportPollIntervalMs(makeReport({ status: "draft" }))).toBe(false);
+    expect(reportPollIntervalMs(makeReport({ status: "failed" }))).toBe(false);
+    expect(reportPollIntervalMs(makeReport({ status: "published" }))).toBe(false);
+  });
+
+  it("returns false when report is undefined", () => {
+    expect(reportPollIntervalMs(undefined)).toBe(false);
+  });
+});
+
+describe("reportListPollIntervalMs", () => {
+  it("returns the poll interval when any row is generating", () => {
+    const reports = [
+      makeReport({ id: "r-1", status: "draft" }),
+      makeReport({ id: "r-2", status: "generating" }),
+    ];
+    expect(reportListPollIntervalMs(reports)).toBe(GENERATING_POLL_INTERVAL_MS);
+  });
+
+  it("returns false when all rows are terminal", () => {
+    const reports = [
+      makeReport({ id: "r-1", status: "draft" }),
+      makeReport({ id: "r-2", status: "published" }),
+      makeReport({ id: "r-3", status: "failed" }),
+    ];
+    expect(reportListPollIntervalMs(reports)).toBe(false);
+  });
+
+  it("returns false for empty or undefined input", () => {
+    expect(reportListPollIntervalMs([])).toBe(false);
+    expect(reportListPollIntervalMs(undefined)).toBe(false);
+  });
+});

--- a/components/Pages/Admin/PortfolioReports/GenerationStatusBadge.tsx
+++ b/components/Pages/Admin/PortfolioReports/GenerationStatusBadge.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import type { PortfolioReportStatus } from "@/types/portfolio-report";
+
+const STATUS_LABEL: Record<PortfolioReportStatus, string> = {
+  generating: "Generating",
+  draft: "draft",
+  failed: "Failed",
+  published: "published",
+};
+
+const STATUS_CLASSES: Record<PortfolioReportStatus, string> = {
+  generating: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  draft: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  failed: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  published: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+};
+
+interface Props {
+  status: PortfolioReportStatus;
+}
+
+export function GenerationStatusBadge({ status }: Props) {
+  const label = STATUS_LABEL[status];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
+    >
+      {status === "generating" ? (
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+      ) : null}
+      {label}
+    </span>
+  );
+}

--- a/components/Pages/Admin/PortfolioReports/GenerationStatusBadge.tsx
+++ b/components/Pages/Admin/PortfolioReports/GenerationStatusBadge.tsx
@@ -2,12 +2,13 @@
 
 import { Loader2 } from "lucide-react";
 import type { PortfolioReportStatus } from "@/types/portfolio-report";
+import { cn } from "@/utilities/tailwind";
 
 const STATUS_LABEL: Record<PortfolioReportStatus, string> = {
   generating: "Generating",
-  draft: "draft",
+  draft: "Draft",
   failed: "Failed",
-  published: "published",
+  published: "Published",
 };
 
 const STATUS_CLASSES: Record<PortfolioReportStatus, string> = {
@@ -25,7 +26,10 @@ export function GenerationStatusBadge({ status }: Props) {
   const label = STATUS_LABEL[status];
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        STATUS_CLASSES[status]
+      )}
     >
       {status === "generating" ? (
         <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -170,7 +170,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     try {
       await regenerateMutation.mutateAsync(reportId);
       setMarkdown(null);
-      toast.success("Regeneration started — this can take a few minutes.");
+      toast.success("Regeneration started, this can take a few minutes.");
     } catch (error) {
       toast.error(
         `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -16,9 +16,11 @@ import {
   useUnpublishReport,
   useUpdateReportMarkdown,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
+import { isReportGenerating } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
+import { GenerationStatusBadge } from "./GenerationStatusBadge";
 
 interface Props {
   community: Community;
@@ -117,6 +119,9 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     );
   }
 
+  const generating = isReportGenerating(report);
+  const failed = report.status === "failed";
+
   const navigateBack = () => {
     router.push(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
   };
@@ -163,11 +168,13 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const handleRegenerate = async () => {
     try {
-      const result = await regenerateMutation.mutateAsync(reportId);
-      setMarkdown(result.markdown);
-      toast.success("Report regenerated");
-    } catch {
-      toast.error("Failed to regenerate report");
+      await regenerateMutation.mutateAsync(reportId);
+      setMarkdown(null);
+      toast.success("Regeneration started — this can take a few minutes.");
+    } catch (error) {
+      toast.error(
+        `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
     }
   };
 
@@ -225,15 +232,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
               {isDirty && <span className="ml-2 text-sm font-normal text-zinc-400">(unsaved)</span>}
             </h1>
             <div className="flex items-center gap-2 text-xs text-zinc-500">
-              <span
-                className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium ${
-                  report.status === "published"
-                    ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                    : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
-                }`}
-              >
-                {report.status}
-              </span>
+              <GenerationStatusBadge status={report.status} />
               <span>Model: {report.modelId}</span>
               {report.tokenUsage && (
                 <span>{report.tokenUsage.totalTokens.toLocaleString()} tokens</span>
@@ -246,16 +245,22 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
             variant="outline"
             size="sm"
             onClick={() => setShowRegenerateDialog(true)}
-            disabled={regenerateMutation.isPending}
+            disabled={regenerateMutation.isPending || generating}
           >
             <RefreshCw className="mr-1 h-3 w-3" />
-            {regenerateMutation.isPending ? "Regenerating..." : "Regenerate"}
+            {regenerateMutation.isPending
+              ? "Starting…"
+              : generating
+                ? "Generating…"
+                : failed
+                  ? "Retry"
+                  : "Regenerate"}
           </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={handleSave}
-            disabled={updateMarkdownMutation.isPending}
+            disabled={updateMarkdownMutation.isPending || generating}
           >
             <Save className="mr-1 h-3 w-3" />
             {updateMarkdownMutation.isPending ? "Saving..." : "Save"}
@@ -265,7 +270,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
               <Eye className="mr-1 h-3 w-3" />
               Publish
             </Button>
-          ) : (
+          ) : report.status === "published" ? (
             <Button
               variant="outline"
               size="sm"
@@ -275,9 +280,28 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
               <EyeOff className="mr-1 h-3 w-3" />
               Unpublish
             </Button>
-          )}
+          ) : null}
         </div>
       </div>
+
+      {generating ? (
+        <output className="flex items-center gap-2 border-b border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-300">
+          <Spinner className="h-4 w-4" />
+          <span>
+            Generation in progress. This page will refresh automatically when the report is ready.
+          </span>
+        </output>
+      ) : null}
+
+      {failed && report.generationError ? (
+        <div
+          role="alert"
+          className="border-b border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-300"
+        >
+          <p className="font-medium">Generation failed</p>
+          <p className="text-xs opacity-90">{report.generationError}</p>
+        </div>
+      ) : null}
 
       {/* Editor */}
       <div className="flex-1 p-4">

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -176,7 +176,7 @@ export function PortfolioReportListPage({ community }: Props) {
     setGeneratingConfigId(configId);
     try {
       await generateMutation.mutateAsync({ configId });
-      toast.success("Generation started — this can take a few minutes.");
+      toast.success("Generation started, this can take a few minutes.");
     } catch (error) {
       toast.error(
         `Failed to start generation: ${error instanceof Error ? error.message : "Unknown error"}`
@@ -221,7 +221,7 @@ export function PortfolioReportListPage({ community }: Props) {
     setActiveMutationType("regenerate");
     try {
       await regenerateMutation.mutateAsync(reportId);
-      toast.success("Regeneration started — this can take a few minutes.");
+      toast.success("Regeneration started, this can take a few minutes.");
     } catch (error) {
       toast.error(
         `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -16,13 +16,15 @@ import {
   useReportConfigs,
   useUnpublishReport,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
-import type { PortfolioReport, ReportConfig } from "@/types/portfolio-report";
+import {
+  isReportGenerating,
+  type PortfolioReport,
+  type ReportConfig,
+} from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
-import {
-  formatRunDate,
-  formatScheduleLabel,
-} from "@/utilities/portfolio-reports/period";
+import { formatRunDate, formatScheduleLabel } from "@/utilities/portfolio-reports/period";
+import { GenerationStatusBadge } from "./GenerationStatusBadge";
 
 interface Props {
   community: Community;
@@ -52,23 +54,20 @@ function ReportTableRow({
   onRegenerate,
 }: ReportTableRowProps) {
   const fmt = formatRunDate(report.runDate);
+  const generating = isReportGenerating(report);
+  const failed = report.status === "failed";
+  const actionsDisabled = rowPending || generating;
   return (
     <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-      <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-100">
-        {configName}
-      </td>
+      <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-100">{configName}</td>
       <td className="px-4 py-3 text-zinc-500">{fmt.shortLabel}</td>
       <td className="px-4 py-3">
-        <span
-          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-            report.status === "published"
-              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-              : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
-          }`}
-        >
-          {report.status}
-        </span>
-        {report.generationError && <span className="ml-2 text-xs text-red-500">Error</span>}
+        <GenerationStatusBadge status={report.status} />
+        {failed && report.generationError ? (
+          <p className="mt-1 max-w-md truncate text-xs text-red-500" title={report.generationError}>
+            {report.generationError}
+          </p>
+        ) : null}
       </td>
       <td className="px-4 py-3 text-zinc-500">{report.modelId}</td>
       <td className="px-4 py-3 text-zinc-500">
@@ -76,7 +75,7 @@ function ReportTableRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex items-center justify-end gap-1">
-          <Button variant="ghost" size="sm" onClick={onEdit}>
+          <Button variant="ghost" size="sm" onClick={onEdit} disabled={generating}>
             Edit
           </Button>
           {report.status === "draft" ? (
@@ -86,19 +85,25 @@ function ReportTableRow({
             </Button>
           ) : null}
           {report.status === "draft" ? (
-            <Button variant="ghost" size="sm" onClick={onPublish} disabled={rowPending}>
+            <Button variant="ghost" size="sm" onClick={onPublish} disabled={actionsDisabled}>
               <Eye className="mr-1 h-3 w-3" />
               {rowPending && activeMutationType === "publish" ? "Publishing..." : "Publish"}
             </Button>
-          ) : (
-            <Button variant="ghost" size="sm" onClick={onUnpublish} disabled={rowPending}>
+          ) : report.status === "published" ? (
+            <Button variant="ghost" size="sm" onClick={onUnpublish} disabled={actionsDisabled}>
               <EyeOff className="mr-1 h-3 w-3" />
               {rowPending && activeMutationType === "unpublish" ? "Unpublishing..." : "Unpublish"}
             </Button>
-          )}
-          <Button variant="ghost" size="sm" onClick={onRegenerate} disabled={rowPending}>
+          ) : null}
+          <Button variant="ghost" size="sm" onClick={onRegenerate} disabled={actionsDisabled}>
             <RefreshCw className="mr-1 h-3 w-3" />
-            {rowPending && activeMutationType === "regenerate" ? "Regenerating..." : "Regen"}
+            {rowPending && activeMutationType === "regenerate"
+              ? "Regenerating..."
+              : generating
+                ? "Generating…"
+                : failed
+                  ? "Retry"
+                  : "Regen"}
           </Button>
         </div>
       </td>
@@ -129,10 +134,15 @@ export function PortfolioReportListPage({ community }: Props) {
     return map;
   }, [configs]);
 
-  const activeConfigs = useMemo(
-    () => (configs ?? []).filter((c) => c.isActive),
-    [configs]
-  );
+  const activeConfigs = useMemo(() => (configs ?? []).filter((c) => c.isActive), [configs]);
+
+  const generatingConfigIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const r of reports ?? []) {
+      if (isReportGenerating(r)) ids.add(r.reportConfigId);
+    }
+    return ids;
+  }, [reports]);
 
   // Per-row pending state: track which report is being mutated and what action
   const [activeReportId, setActiveReportId] = useState<string | null>(null);
@@ -162,10 +172,10 @@ export function PortfolioReportListPage({ community }: Props) {
     setGeneratingConfigId(configId);
     try {
       await generateMutation.mutateAsync({ configId });
-      toast.success("Report generated successfully");
+      toast.success("Generation started — this can take a few minutes.");
     } catch (error) {
       toast.error(
-        `Failed to generate report: ${error instanceof Error ? error.message : "Unknown error"}`
+        `Failed to start generation: ${error instanceof Error ? error.message : "Unknown error"}`
       );
     } finally {
       setGeneratingConfigId(null);
@@ -207,12 +217,15 @@ export function PortfolioReportListPage({ community }: Props) {
     setActiveMutationType("regenerate");
     try {
       await regenerateMutation.mutateAsync(reportId);
-      toast.success("Report regenerated");
-    } catch {
-      toast.error("Failed to regenerate report");
+      toast.success("Regeneration started — this can take a few minutes.");
+    } catch (error) {
+      toast.error(
+        `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
     } finally {
       setActiveReportId(null);
       setActiveMutationType(null);
+      setRegenerateTargetId(null);
     }
   };
 
@@ -220,9 +233,7 @@ export function PortfolioReportListPage({ community }: Props) {
     activeReportId === reportId &&
     (publishMutation.isPending || unpublishMutation.isPending || regenerateMutation.isPending);
 
-  const sortedReports = (reports ?? [])
-    .slice()
-    .sort((a, b) => b.runDate.localeCompare(a.runDate));
+  const sortedReports = (reports ?? []).slice().sort((a, b) => b.runDate.localeCompare(a.runDate));
 
   return (
     <div className="space-y-6">
@@ -244,11 +255,7 @@ export function PortfolioReportListPage({ community }: Props) {
             Reports generated from your configured prompts.
           </p>
         </div>
-        <Button
-          onClick={() =>
-            router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?new=1`)
-          }
-        >
+        <Button onClick={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?new=1`)}>
           <Plus className="mr-2 h-4 w-4" />
           Configure New Report
         </Button>
@@ -256,9 +263,7 @@ export function PortfolioReportListPage({ community }: Props) {
 
       {/* Per-config generate row */}
       <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-        <h2 className="mb-3 text-sm font-medium text-zinc-700 dark:text-zinc-300">
-          Generate now
-        </h2>
+        <h2 className="mb-3 text-sm font-medium text-zinc-700 dark:text-zinc-300">Generate now</h2>
         {configsLoading ? (
           <div className="flex items-center gap-2 text-sm text-zinc-500">
             <Spinner className="h-4 w-4" />
@@ -272,9 +277,7 @@ export function PortfolioReportListPage({ community }: Props) {
             <button
               type="button"
               className="text-blue-600 underline dark:text-blue-400"
-              onClick={() =>
-                router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?new=1`)
-              }
+              onClick={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?new=1`)}
             >
               Configure your first report
             </button>{" "}
@@ -302,9 +305,7 @@ export function PortfolioReportListPage({ community }: Props) {
                     size="sm"
                     onClick={() =>
                       cfg.id &&
-                      router.push(
-                        `${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?editId=${cfg.id}`
-                      )
+                      router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS_CONFIG(slug)}?editId=${cfg.id}`)
                     }
                   >
                     <Settings className="mr-1 h-3 w-3" />
@@ -313,9 +314,13 @@ export function PortfolioReportListPage({ community }: Props) {
                   <Button
                     size="sm"
                     onClick={() => cfg.id && handleGenerate(cfg.id)}
-                    disabled={generatingConfigId !== null}
+                    disabled={
+                      generatingConfigId !== null ||
+                      (cfg.id ? generatingConfigIds.has(cfg.id) : false)
+                    }
                   >
-                    {generatingConfigId === cfg.id ? (
+                    {generatingConfigId === cfg.id ||
+                    (cfg.id && generatingConfigIds.has(cfg.id)) ? (
                       <>
                         <Spinner className="mr-2 h-3 w-3" />
                         Generating…
@@ -360,9 +365,7 @@ export function PortfolioReportListPage({ community }: Props) {
                 <ReportTableRow
                   key={report.id}
                   report={report}
-                  configName={
-                    configById.get(report.reportConfigId)?.name ?? "(deleted config)"
-                  }
+                  configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
                   onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -14,6 +14,7 @@ import {
   usePublishReport,
   useRegenerateReport,
   useReportConfigs,
+  useReportRowSync,
   useUnpublishReport,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
 import {
@@ -31,6 +32,7 @@ interface Props {
 }
 
 interface ReportTableRowProps {
+  slug: string;
   report: PortfolioReport;
   configName: string;
   rowPending: boolean;
@@ -43,7 +45,8 @@ interface ReportTableRowProps {
 }
 
 function ReportTableRow({
-  report,
+  slug,
+  report: initialReport,
   configName,
   rowPending,
   activeMutationType,
@@ -53,6 +56,7 @@ function ReportTableRow({
   onUnpublish,
   onRegenerate,
 }: ReportTableRowProps) {
+  const report = useReportRowSync(slug, initialReport);
   const fmt = formatRunDate(report.runDate);
   const generating = isReportGenerating(report);
   const failed = report.status === "failed";
@@ -364,6 +368,7 @@ export function PortfolioReportListPage({ community }: Props) {
               {sortedReports.map((report: PortfolioReport) => (
                 <ReportTableRow
                   key={report.id}
+                  slug={slug}
                   report={report}
                   configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
                   rowPending={isRowPending(report.id)}

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -1,13 +1,13 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 import * as portfolioService from "@/services/portfolio-reports.service";
 import {
   type CreateReportConfigRequest,
   type GenerateReportRequest,
   type PortfolioReport,
   type ReportConfig,
-  reportListPollIntervalMs,
   reportPollIntervalMs,
   type UpdateReportConfigRequest,
 } from "@/types/portfolio-report";
@@ -84,8 +84,6 @@ export function usePortfolioReports(communitySlug: string, status?: string) {
     queryKey: [...QUERY_KEYS.reports(communitySlug), status],
     queryFn: () => portfolioService.listReports(communitySlug, status),
     enabled: Boolean(communitySlug),
-    refetchInterval: (query) =>
-      reportListPollIntervalMs(query.state.data as PortfolioReport[] | undefined),
   });
 }
 
@@ -97,6 +95,53 @@ export function usePortfolioReport(communitySlug: string, reportId: string) {
     refetchInterval: (query) =>
       reportPollIntervalMs(query.state.data as PortfolioReport | undefined),
   });
+}
+
+/**
+ * Per-row polling for the list page: while the row is `generating`, polls
+ * `GET /reports/:id` and mirrors the result back into the list cache so
+ * the badge updates without a separate list refetch.
+ */
+export function useReportRowSync(
+  communitySlug: string,
+  initialReport: PortfolioReport
+): PortfolioReport {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: QUERY_KEYS.report(communitySlug, initialReport.id),
+    queryFn: () => portfolioService.getReport(communitySlug, initialReport.id),
+    enabled: Boolean(communitySlug && initialReport.id),
+    initialData: initialReport,
+    refetchInterval: (query) =>
+      reportPollIntervalMs(query.state.data as PortfolioReport | undefined),
+  });
+
+  useEffect(() => {
+    if (!data) return;
+    queryClient.setQueriesData<PortfolioReport[] | undefined>(
+      { queryKey: QUERY_KEYS.reports(communitySlug) },
+      (old) => {
+        if (!old) return old;
+        let changed = false;
+        const next = old.map((r) => {
+          if (r.id !== data.id || r === data) return r;
+          if (
+            r.status === data.status &&
+            r.markdown === data.markdown &&
+            r.generationError === data.generationError &&
+            r.updatedAt === data.updatedAt
+          ) {
+            return r;
+          }
+          changed = true;
+          return data;
+        });
+        return changed ? next : old;
+      }
+    );
+  }, [data, communitySlug, queryClient]);
+
+  return data ?? initialReport;
 }
 
 // ── Mutations ────────────────────────────────────────────────

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -2,12 +2,14 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as portfolioService from "@/services/portfolio-reports.service";
-import type {
-  CreateReportConfigRequest,
-  GenerateReportRequest,
-  PortfolioReport,
-  ReportConfig,
-  UpdateReportConfigRequest,
+import {
+  type CreateReportConfigRequest,
+  type GenerateReportRequest,
+  type PortfolioReport,
+  type ReportConfig,
+  reportListPollIntervalMs,
+  reportPollIntervalMs,
+  type UpdateReportConfigRequest,
 } from "@/types/portfolio-report";
 
 const QUERY_KEYS = {
@@ -82,6 +84,8 @@ export function usePortfolioReports(communitySlug: string, status?: string) {
     queryKey: [...QUERY_KEYS.reports(communitySlug), status],
     queryFn: () => portfolioService.listReports(communitySlug, status),
     enabled: Boolean(communitySlug),
+    refetchInterval: (query) =>
+      reportListPollIntervalMs(query.state.data as PortfolioReport[] | undefined),
   });
 }
 
@@ -90,6 +94,8 @@ export function usePortfolioReport(communitySlug: string, reportId: string) {
     queryKey: QUERY_KEYS.report(communitySlug, reportId),
     queryFn: () => portfolioService.getReport(communitySlug, reportId),
     enabled: Boolean(communitySlug && reportId),
+    refetchInterval: (query) =>
+      reportPollIntervalMs(query.state.data as PortfolioReport | undefined),
   });
 }
 
@@ -100,7 +106,8 @@ export function useGenerateReport(communitySlug: string) {
   return useMutation({
     mutationFn: (body: GenerateReportRequest) =>
       portfolioService.generateReport(communitySlug, body),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.reports(communitySlug),
       });
@@ -113,10 +120,10 @@ export function useRegenerateReport(communitySlug: string) {
   return useMutation({
     mutationFn: (reportId: string) => portfolioService.regenerateReport(communitySlug, reportId),
     onSuccess: (data) => {
+      queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
       queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.reports(communitySlug),
       });
-      queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
     },
   });
 }

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -60,10 +60,6 @@ export function reportPollIntervalMs(report: PortfolioReport | undefined): numbe
   return report && isReportGenerating(report) ? GENERATING_POLL_INTERVAL_MS : false;
 }
 
-export function reportListPollIntervalMs(reports: PortfolioReport[] | undefined): number | false {
-  return reports?.some(isReportGenerating) ? GENERATING_POLL_INTERVAL_MS : false;
-}
-
 export interface CreateReportConfigRequest {
   name: string;
   programIds: string[];

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -1,8 +1,6 @@
 export type ScheduleIntervalUnit = "days" | "weeks" | "months";
 
-export type ScheduleEnds =
-  | { kind: "never" }
-  | { kind: "on_date"; date: string };
+export type ScheduleEnds = { kind: "never" } | { kind: "on_date"; date: string };
 
 export interface ReportSchedule {
   intervalUnit: ScheduleIntervalUnit;
@@ -32,12 +30,14 @@ export interface TokenUsage {
   totalTokens: number;
 }
 
+export type PortfolioReportStatus = "generating" | "draft" | "failed" | "published";
+
 export interface PortfolioReport {
   id: string;
   reportConfigId: string;
   communityId: string;
   runDate: string;
-  status: "draft" | "published";
+  status: PortfolioReportStatus;
   markdown: string;
   dataSnapshot: Record<string, unknown>;
   modelId: string;
@@ -48,6 +48,20 @@ export interface PortfolioReport {
   publishedBy: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export function isReportGenerating(report: PortfolioReport): boolean {
+  return report.status === "generating";
+}
+
+export const GENERATING_POLL_INTERVAL_MS = 3000;
+
+export function reportPollIntervalMs(report: PortfolioReport | undefined): number | false {
+  return report && isReportGenerating(report) ? GENERATING_POLL_INTERVAL_MS : false;
+}
+
+export function reportListPollIntervalMs(reports: PortfolioReport[] | undefined): number | false {
+  return reports?.some(isReportGenerating) ? GENERATING_POLL_INTERVAL_MS : false;
 }
 
 export interface CreateReportConfigRequest {


### PR DESCRIPTION
## Summary

The portfolio-reports backend now persists a `generating` row, runs the LLM in the background, and transitions the row to `draft` or `failed` when finished (see [show-karma/gap-indexer#1551](https://github.com/show-karma/gap-indexer/pull/1551)). This PR makes the FE poll the backend instead of holding open a long-running mutation:

- The Generate / Regenerate mutations succeed immediately with a `generating` row, no more 60s axios timeouts producing false-negative errors while the backend keeps working.
- React Query refetches the report (or the list of reports) every 3s while any tracked row is `generating`, and stops on a terminal status.
- The UI shows a per-row badge / banner so the user sees progress and any backend `generationError` if the run fails.

## What changed

### Types (`types/portfolio-report/index.ts`)
- `PortfolioReportStatus` now `"generating" | "draft" | "failed" | "published"`.
- New helpers: `isReportGenerating`, `reportPollIntervalMs`, `reportListPollIntervalMs`, `GENERATING_POLL_INTERVAL_MS`.

### Hooks (`hooks/portfolio-reports/usePortfolioReports.ts`)
- `usePortfolioReport(slug, id)`: `refetchInterval = 3000` while data is `generating`, `false` otherwise.
- `usePortfolioReports(slug)`: same predicate over the list.
- `useGenerateReport` / `useRegenerateReport` now seed the report cache with the pending row and invalidate the list — polling starts immediately without waiting on a list refetch.

### Components
- New `GenerationStatusBadge` renders all four states with a spinner on `generating`.
- `PortfolioReportListPage`:
  - Status column uses the badge; failed rows surface `generationError` inline.
  - Per-config Generate button is disabled while a generating row exists for that config (server-side defense in depth: dispatcher already short-circuits).
  - Per-row Edit / Publish / Regenerate disabled while generating; Regenerate label becomes "Retry" on failed rows.
  - Toast copy reflects async dispatch.
- `PortfolioReportEditorPage`:
  - Header status uses the badge.
  - Banner above the editor when the current report is `generating`; alert banner with `generationError` when `failed`.
  - Save / Regenerate disabled while generating; Regenerate becomes "Retry" on failed.

### Tests
- New `__tests__/utilities/portfolio-reports/poll-interval.test.ts` covering the polling predicates (generating → 3000, terminal → false, undefined → false, list with mixed statuses).

## Risks / behaviour notes

- This PR depends on the backend PR being deployed first. Without the BE change the endpoint still returns 200 with a fully-generated report, in which case status will be `draft` immediately and the polling predicate returns `false` — i.e. it gracefully no-ops, so this PR is safe to merge in either order. (The user-visible behaviour without the BE PR is unchanged from today.)
- Polling at 3s is per-tab; React Query pauses on tab blur by default.

## Test plan

- [ ] Open `/community/<slug>/manage/portfolio-reports`, click **Generate** on an active config — toast says "Generation started", row appears with the `Generating` badge + spinner, and the row flips to `draft` automatically when the backend finishes (no manual refresh).
- [ ] Click **Regen** on a draft report — same async flow.
- [ ] Open the editor for a `generating` report — status banner is visible, Save / Regenerate are disabled until terminal status arrives.
- [ ] Force a failure (e.g. invalid model id on the config) — row transitions to `Failed` with the error message visible in the list and as a banner in the editor; the **Retry** button is enabled.
- [ ] With a generated draft, confirm Publish / Unpublish still work normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live generation status badge with animated spinner and a new "Failed" state.
  * Automatic per-report polling while generating (short polling interval) and per-row sync so lists reflect live status.
  * Regenerate flow now starts asynchronously with "started" toasts and updated button labels/disabled states.

* **Bug Fixes**
  * Improved error messaging and disabled controls during in-progress generation to prevent conflicting actions.

* **Tests**
  * Added unit tests covering generation-state helpers and polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->