### PR TITLE
fix(portfolio-reports): flatten nested table chrome

### DIFF
--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -1,11 +1,22 @@
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
+import type { ComponentPropsWithoutRef } from "react";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { BackToTop } from "./BackToTop";
 import { ReadingProgress } from "./ReadingProgress";
+
+const REPORT_MARKDOWN_COMPONENTS = {
+  // Wide tables should scroll horizontally rather than squeezing column widths
+  // (e.g. forcing the BATCH column to wrap one character per line).
+  table: ({ children, ...rest }: ComponentPropsWithoutRef<"table">) => (
+    <div className="overflow-x-auto">
+      <table {...rest}>{children}</table>
+    </div>
+  ),
+};
 
 interface Props {
   community: Community;
@@ -38,7 +49,7 @@ export function PortfolioReportDocumentView({
   return (
     <>
       <ReadingProgress />
-      <div className="mx-auto w-full max-w-6xl px-6 pt-6 pb-10 lg:px-8">
+      <div className="px-6 pt-6 pb-10 lg:px-10">
         {bannerText ? (
           <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200">
             {bannerText}
@@ -77,7 +88,7 @@ export function PortfolioReportDocumentView({
         </header>
 
         <article className="report-article prose prose-zinc max-w-none dark:prose-invert">
-          <MarkdownPreview source={report.markdown} />
+          <MarkdownPreview source={report.markdown} components={REPORT_MARKDOWN_COMPONENTS} />
         </article>
 
         <footer className="mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -38,7 +38,7 @@ export function PortfolioReportDocumentView({
   return (
     <>
       <ReadingProgress />
-      <div className="px-6 pt-6 pb-10 lg:px-10">
+      <div className="mx-auto w-full max-w-6xl px-6 pt-6 pb-10 lg:px-8">
         {bannerText ? (
           <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200">
             {bannerText}

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -1,22 +1,11 @@
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
-import type { ComponentPropsWithoutRef } from "react";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { BackToTop } from "./BackToTop";
 import { ReadingProgress } from "./ReadingProgress";
-
-const REPORT_MARKDOWN_COMPONENTS = {
-  // Wide tables should scroll horizontally rather than squeezing column widths
-  // (e.g. forcing the BATCH column to wrap one character per line).
-  table: ({ children, ...rest }: ComponentPropsWithoutRef<"table">) => (
-    <div className="overflow-x-auto">
-      <table {...rest}>{children}</table>
-    </div>
-  ),
-};
 
 interface Props {
   community: Community;
@@ -88,7 +77,7 @@ export function PortfolioReportDocumentView({
         </header>
 
         <article className="report-article prose prose-zinc max-w-none dark:prose-invert">
-          <MarkdownPreview source={report.markdown} components={REPORT_MARKDOWN_COMPONENTS} />
+          <MarkdownPreview source={report.markdown} />
         </article>
 
         <footer className="mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -682,12 +682,7 @@ article.report-article {
 article.report-article table {
   border-collapse: separate;
   border-spacing: 0;
-  border: 1px solid rgb(228 228 231);
-  border-radius: 8px;
-  overflow: hidden;
-}
-.dark article.report-article table {
-  border-color: rgb(39 39 42);
+  border: none;
 }
 article.report-article th,
 article.report-article td {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -689,6 +689,11 @@ article.report-article table {
 .dark article.report-article table {
   border-color: rgb(39 39 42);
 }
+article.report-article th,
+article.report-article td {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
 article.report-article th {
   background: rgb(250 250 250);
   font-weight: 600;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -684,6 +684,16 @@ article.report-article table {
   border-spacing: 0;
   border: none;
 }
+/* streamdown wraps tables in an outer card (with copy/download icons) AND an
+   inner div with its own border + bg — flatten the inner one so the table
+   sits directly inside the card instead of looking like a box-in-a-box. */
+article.report-article [data-streamdown="table-wrapper"] > div:has(> table),
+article.report-article [data-streamdown="table-wrapper"] > div:has(> [data-streamdown="table"]) {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
 article.report-article th,
 article.report-article td {
   padding-left: 1rem;


### PR DESCRIPTION
## Summary

Portfolio report tables rendered as a "box inside a box": our own outer border + radius on `<table>`, plus streamdown's two-layer chrome (outer card with copy/download icons + an inner div with its own border, radius, and background) all stacked. Result was visually noisy with empty cells hugging the card edges.

This PR keeps the streamdown card + icons (which we want) and flattens everything inside it so the table sits directly within the card.

## Changes (CSS only — `styles/globals.css`)

- Drop the inline border + radius on `article.report-article table` — that border duplicated the streamdown card's own border.
- Flatten streamdown's inner `<div>` wrapper inside `[data-streamdown="table-wrapper"]` (the one with `rounded-md border bg-background`): no border, no radius, no background, no padding. Table now sits directly in the card.
- Add `padding-left: 1rem; padding-right: 1rem` to `th`/`td` so row content doesn't hug the card edge.

No component / TS changes — the markdown renderer and document layout are unchanged.

## Before / after

- Before: outer streamdown card → inner streamdown div with its own border + bg → our `<table>` with another border. Three concentric containers.
- After: outer streamdown card → table cells flush. One card per table, icons in the corner, padded rows.

## Test plan

- [ ] Open any draft / published portfolio report (admin preview or public view) — each table renders as a single card with copy/download icons in the top-right and no nested border around the table itself.
- [ ] Tables with many columns (e.g. portfolio metrics with 8+ columns) keep streamdown's `overflow-x-auto` scroll behaviour — still applies because we left the outer card's wrapping div intact.
- [ ] Cell padding looks comfortable on both narrow and wide tables.
- [ ] No regressions in markdown rendered elsewhere — selectors are scoped to `article.report-article`.