### PR TITLE
fix(updates): drop completed default and re-prioritise feed sort

### DIFF
--- a/__tests__/components/UpdatesContentMilestoneStatus.test.tsx
+++ b/__tests__/components/UpdatesContentMilestoneStatus.test.tsx
@@ -107,7 +107,7 @@ describe("UpdatesContent - milestone status filter URL sync", () => {
     expect(screen.getByTestId("milestone-status-value")).toHaveTextContent("all");
   });
 
-  it("adds completed milestoneStatus when milestones filter is enabled from the default view", async () => {
+  it("does not auto-apply a milestoneStatus when milestones filter is enabled from the default view", async () => {
     mockSearchParams = new URLSearchParams();
 
     const { UpdatesContent } = await import("@/components/Pages/Project/v2/Content/UpdatesContent");
@@ -115,7 +115,7 @@ describe("UpdatesContent - milestone status filter URL sync", () => {
 
     await userEvent.click(screen.getByTestId("trigger-milestones-filter"));
 
-    expect(mockReplace).toHaveBeenCalledWith("?filter=milestones&milestoneStatus=completed", {
+    expect(mockReplace).toHaveBeenCalledWith("?filter=milestones", {
       scroll: false,
     });
   });

--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -19,13 +19,13 @@ interface ProjectRoadmapProps {
 }
 
 // Pure utility function for sorting - uses seconds for consistency
+// Priority: completed.createdAt -> endsAt (dueDate) -> createdAt
 const getSortTimestamp = (item: UnifiedMilestone): number => {
-  // endsAt is already in seconds (Unix timestamp)
-  if (item.endsAt) return item.endsAt;
-  // Convert other dates to seconds for consistent comparison
   if (item.completed && typeof item.completed === "object" && "createdAt" in item.completed) {
     return Math.floor(new Date(item.completed.createdAt).getTime() / 1000);
   }
+  // endsAt is already in seconds (Unix timestamp)
+  if (item.endsAt) return item.endsAt;
   return Math.floor(new Date(item.createdAt).getTime() / 1000);
 };
 

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -109,12 +109,9 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
       }
       params.delete("sort");
 
-      // Default milestones to completed when no explicit status is present.
-      if (newFilters.includes("milestones")) {
-        if (!isMilestoneStatusFilter(params.get("milestoneStatus"))) {
-          params.set("milestoneStatus", "completed");
-        }
-      } else {
+      // Clear milestone status when milestones pill is toggled off; otherwise leave
+      // whatever the user has already chosen (defaults to "all" when absent).
+      if (!newFilters.includes("milestones")) {
         params.delete("milestoneStatus");
       }
 

--- a/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
@@ -220,14 +220,13 @@ export function ActivityFeed({
   };
 
   // Pure utility function for sorting - uses seconds for consistency
-  // Matches production sorting logic: endsAt (dueDate) -> completed.createdAt -> createdAt
+  // Priority: completed.createdAt -> endsAt (dueDate) -> createdAt
   const getSortTimestamp = (item: UnifiedMilestone): number => {
-    // endsAt is already in seconds (Unix timestamp)
-    if (item.endsAt) return item.endsAt;
-    // Convert other dates to seconds for consistent comparison
     if (item.completed && typeof item.completed === "object" && "createdAt" in item.completed) {
       return Math.floor(new Date(item.completed.createdAt).getTime() / 1000);
     }
+    // endsAt is already in seconds (Unix timestamp)
+    if (item.endsAt) return item.endsAt;
     return Math.floor(new Date(item.createdAt).getTime() / 1000);
   };
 


### PR DESCRIPTION
## Summary
- The Milestones filter pill auto-set `milestoneStatus=completed` on toggle, so opening a project landed users on a completed-only view by default. The auto-default is removed; the status now falls back to `all` unless the user explicitly picks one.
- Re-prioritised the activity feed sort from `endsAt → completed.createdAt → createdAt` to `completed.createdAt → endsAt → createdAt`, so recently-completed milestones rise to the top instead of being pinned by their original due date. Applied to both `ActivityFeed.tsx` (main profile page) and the legacy `Roadmap/index.tsx` for consistency.
- Updated the existing `UpdatesContentMilestoneStatus` test that asserted the old auto-default.

## Test plan
- [ ] Open a project (e.g. `/project/filecoin-infrastructure-services`), toggle the **Milestones** pill, confirm the status dropdown shows **All statuses** (not Completed) and both pending and completed milestones are visible.
- [ ] Confirm a milestone marked complete today appears above a still-pending milestone whose `endsAt` is in the future.
- [ ] Visit `/project/[id]/updates` (legacy Roadmap route) and verify the same ordering.
- [ ] `pnpm test __tests__/components/UpdatesContentMilestoneStatus.test.tsx` passes (8/8).