### PR TITLE
fix(updates): bucket completed milestones above pending in feed sort

### DIFF
--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -18,8 +18,12 @@ interface ProjectRoadmapProps {
   project?: ProjectResponse;
 }
 
-// Pure utility function for sorting - uses seconds for consistency
-// Priority: completed.createdAt -> endsAt (dueDate) -> createdAt
+// Completed items go in their own bucket so a completed milestone never sinks below
+// a pending one whose endsAt is in the future. Within a bucket we order by date.
+const isItemCompleted = (item: UnifiedMilestone): boolean =>
+  item.completed === true ||
+  (typeof item.completed === "object" && item.completed !== null && "createdAt" in item.completed);
+
 const getSortTimestamp = (item: UnifiedMilestone): number => {
   if (item.completed && typeof item.completed === "object" && "createdAt" in item.completed) {
     return Math.floor(new Date(item.completed.createdAt).getTime() / 1000);
@@ -27,6 +31,13 @@ const getSortTimestamp = (item: UnifiedMilestone): number => {
   // endsAt is already in seconds (Unix timestamp)
   if (item.endsAt) return item.endsAt;
   return Math.floor(new Date(item.createdAt).getTime() / 1000);
+};
+
+const compareMilestonesNewestFirst = (a: UnifiedMilestone, b: UnifiedMilestone): number => {
+  const aCompleted = isItemCompleted(a);
+  const bCompleted = isItemCompleted(b);
+  if (aCompleted !== bCompleted) return aCompleted ? -1 : 1;
+  return getSortTimestamp(b) - getSortTimestamp(a);
 };
 
 export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) => {
@@ -63,14 +74,7 @@ export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) =>
 
     const allItems = [...apiMilestones, ...impactItems];
 
-    const allSortedItems = [...allItems].sort((a, b) => {
-      const timestampA = getSortTimestamp(a);
-      const timestampB = getSortTimestamp(b);
-
-      return timestampB - timestampA;
-    });
-
-    return allSortedItems;
+    return [...allItems].sort(compareMilestonesNewestFirst);
   }, [impacts, apiMilestones]);
 
   // Filter items based on active filters

--- a/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
@@ -219,8 +219,14 @@ export function ActivityFeed({
     return filters.flatMap((filter) => typeMap[filter]);
   };
 
-  // Pure utility function for sorting - uses seconds for consistency
-  // Priority: completed.createdAt -> endsAt (dueDate) -> createdAt
+  // Completed items go in their own bucket so a completed milestone never sinks below
+  // a pending one whose endsAt is in the future. Within a bucket we order by date.
+  const isItemCompleted = (item: UnifiedMilestone): boolean =>
+    item.completed === true ||
+    (typeof item.completed === "object" &&
+      item.completed !== null &&
+      "createdAt" in item.completed);
+
   const getSortTimestamp = (item: UnifiedMilestone): number => {
     if (item.completed && typeof item.completed === "object" && "createdAt" in item.completed) {
       return Math.floor(new Date(item.completed.createdAt).getTime() / 1000);
@@ -242,8 +248,14 @@ export function ActivityFeed({
 
     // Milestone status filtering is now done server-side via API query param
 
-    // Sort by date using same logic as production (ProjectRoadmap)
+    // Bucket: completed first (newest), last (oldest). Then by timestamp within bucket.
     filtered.sort((a, b) => {
+      const aCompleted = isItemCompleted(a);
+      const bCompleted = isItemCompleted(b);
+      if (aCompleted !== bCompleted) {
+        if (sortBy === "newest") return aCompleted ? -1 : 1;
+        return aCompleted ? 1 : -1;
+      }
       const timestampA = getSortTimestamp(a);
       const timestampB = getSortTimestamp(b);
       return sortBy === "newest" ? timestampB - timestampA : timestampA - timestampB;

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
@@ -331,3 +331,73 @@ describe("ActivityFeed - renders pre-filtered items from server", () => {
     expect(screen.getByTestId("activity-feed-empty")).toBeInTheDocument();
   });
 });
+
+describe("ActivityFeed - completed-first ordering", () => {
+  const createMilestone = (
+    type: UnifiedMilestone["type"],
+    overrides: Partial<UnifiedMilestone> = {}
+  ): UnifiedMilestone => ({
+    uid: `test-${type}-${Math.random()}`,
+    type,
+    title: `Test ${type}`,
+    description: "Test description",
+    completed: false,
+    createdAt: new Date().toISOString(),
+    chainID: 1,
+    refUID: "0xref1",
+    source: {},
+    ...overrides,
+  });
+
+  // Repro for the bug seen on /project/filecoin-infrastructure-services: a completed
+  // milestone whose completed.createdAt is in the past was sinking below pending
+  // milestones whose endsAt is in the future, because the previous single-key sort
+  // compared those two values directly.
+  it("places a completed milestone above pending ones with future endsAt (newest sort)", () => {
+    const completed = createMilestone("grant", {
+      uid: "completed-ms",
+      title: "Completed Milestone",
+      completed: { createdAt: "2026-04-28T00:00:00.000Z", data: { reason: "Done" } },
+      endsAt: 1777334400, // 2026-04-28
+    });
+    const pendingFutureA = createMilestone("grant", {
+      uid: "pending-future-a",
+      title: "Pending A",
+      completed: false,
+      endsAt: 1788220800, // 2026-06-27
+    });
+    const pendingFutureB = createMilestone("grant", {
+      uid: "pending-future-b",
+      title: "Pending B",
+      completed: false,
+      endsAt: 1803859200, // 2026-12-25
+    });
+
+    render(
+      <ActivityFeed milestones={[pendingFutureA, completed, pendingFutureB]} sortBy="newest" />
+    );
+
+    const cards = screen.getAllByTestId("activity-card");
+    expect(cards[0]).toHaveTextContent("Completed Milestone");
+  });
+
+  it("places a completed milestone below pending ones when sortBy is oldest", () => {
+    const completed = createMilestone("grant", {
+      uid: "completed-ms",
+      title: "Completed Milestone",
+      completed: { createdAt: "2026-04-28T00:00:00.000Z", data: { reason: "Done" } },
+    });
+    const pending = createMilestone("grant", {
+      uid: "pending-ms",
+      title: "Pending Milestone",
+      completed: false,
+      endsAt: 1803859200,
+    });
+
+    render(<ActivityFeed milestones={[completed, pending]} sortBy="oldest" />);
+
+    const cards = screen.getAllByTestId("activity-card");
+    expect(cards[0]).toHaveTextContent("Pending Milestone");
+    expect(cards[1]).toHaveTextContent("Completed Milestone");
+  });
+});


### PR DESCRIPTION
## Summary

Reported on https://www.karmahq.xyz/project/filecoin-infrastructure-services: a recently-completed milestone was rendering at the *bottom* of the Updates feed instead of the top, even though the intended order is "completed first, then pending by `endsAt`, then by `createdAt`".

The previous fix (#1363) restructured `getSortTimestamp` as a fallback chain: `completed.createdAt -> endsAt -> createdAt`. That works when a pending milestone has only `createdAt`, but it breaks when the pending milestone has a future `endsAt`: those raw seconds values (e.g. `1788220800` for Jun 2026) are *larger* than the completion timestamp (e.g. `1777334400` for Apr 28 2026), so under `newest`-first sort the future-deadline pending items leapfrog the completed one.

The fix replaces the single-key sort with a **categorical comparator**:

1. Completed items form one bucket; pending another. Bucket ordering: completed first under `newest`, last under `oldest`.
2. Within each bucket, items are ordered by the same `completed.createdAt → endsAt → createdAt` priority as before.

Applied to both `ActivityFeed` (Updates tab) and `Roadmap/index.tsx` (which uses the same logic).

### Repro data (from the live API)

The completed milestone has `completed.createdAt = 2026-04-28` (≈ 1777334400 s). All 9 pending milestones have `endsAt` ≥ 1777593600 s. With the old single-key sort, all 9 pending milestones sort above the completed one.

## Test plan

- [x] New unit test: completed milestone sorts above pending with future `endsAt` under `sortBy=newest`
- [x] New unit test: completed milestone sorts below pending under `sortBy=oldest`
- [x] Pre-existing tests still pass (3 unrelated failures exist on `main` already)
- [ ] Manual verify: visit `/project/filecoin-infrastructure-services` and confirm the completed milestone appears at the top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Completed milestones now appear first in roadmap and activity feed, with sorting preferences (newest/oldest) applied within each completion group.

* **Tests**
  * Added test coverage for completion-based milestone ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->