### PR TITLE
fix(milestones): show application completion criteria in review workspace

### DIFF
--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -155,6 +155,7 @@ interface MilestoneCardProps {
   allocationAmount?: string;
   showAIEvaluationButton?: boolean;
   quietSurface?: boolean;
+  completionCriteria?: string;
 }
 
 export function MilestoneCard({
@@ -182,6 +183,7 @@ export function MilestoneCard({
   allocationAmount,
   showAIEvaluationButton = true,
   quietSurface = false,
+  completionCriteria,
 }: MilestoneCardProps) {
   const [isEditOpen, setIsEditOpen] = useState(false);
   const anchorId = `milestone-${milestone.uid}`;
@@ -314,7 +316,7 @@ export function MilestoneCard({
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     return () => observer.disconnect();
-  }, [milestone.description]);
+  }, [milestone.description, completionCriteria]);
 
   useIsomorphicLayoutEffect(() => {
     const node = completionRef.current;
@@ -448,6 +450,11 @@ export function MilestoneCard({
             )}
           >
             <MarkdownPreview source={milestone.description} />
+            {completionCriteria && (
+              <div className="mt-2">
+                <MarkdownPreview source={completionCriteria} />
+              </div>
+            )}
           </div>
           {hasLongDescription && !isDescriptionExpanded && (
             <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white dark:from-zinc-900 to-transparent pointer-events-none" />

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -59,6 +59,10 @@ const MarkdownPreview = dynamic(
   { ssr: false }
 );
 
+function normalizeMilestoneTitleKey(title: string): string {
+  return title.trim().toLowerCase();
+}
+
 function extractCompletionCriteriaByTitle(
   applicationData: Record<string, unknown> | undefined
 ): Map<string, string> {
@@ -74,8 +78,11 @@ function extractCompletionCriteriaByTitle(
         completionCriteria?: unknown;
       };
       if (typeof title !== "string" || typeof completionCriteria !== "string") continue;
-      const trimmed = completionCriteria.trim();
-      if (trimmed && !map.has(title)) map.set(title, trimmed);
+      const trimmedCriteria = completionCriteria.trim();
+      if (!trimmedCriteria) continue;
+      const key = normalizeMilestoneTitleKey(title);
+      if (!key || map.has(key)) continue;
+      map.set(key, trimmedCriteria);
     }
   }
   return map;
@@ -989,7 +996,9 @@ function MilestonesReviewPageContent({
                       }
                       showAIEvaluationButton={false}
                       quietSurface
-                      completionCriteria={completionCriteriaByTitle.get(selectedMilestone.title)}
+                      completionCriteria={completionCriteriaByTitle.get(
+                        normalizeMilestoneTitleKey(selectedMilestone.title)
+                      )}
                     />
                     <InlineAIEvaluation milestone={selectedMilestone} />
                   </div>

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -59,6 +59,28 @@ const MarkdownPreview = dynamic(
   { ssr: false }
 );
 
+function extractCompletionCriteriaByTitle(
+  applicationData: Record<string, unknown> | undefined
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!applicationData) return map;
+
+  for (const value of Object.values(applicationData)) {
+    if (!Array.isArray(value)) continue;
+    for (const item of value) {
+      if (!item || typeof item !== "object") continue;
+      const { title, completionCriteria } = item as {
+        title?: unknown;
+        completionCriteria?: unknown;
+      };
+      if (typeof title !== "string" || typeof completionCriteria !== "string") continue;
+      const trimmed = completionCriteria.trim();
+      if (trimmed && !map.has(title)) map.set(title, trimmed);
+    }
+  }
+  return map;
+}
+
 // Strip the optional chainId suffix from program IDs (e.g. "959_42161" -> "959").
 function parseProgramId(programId: string): string {
   if (programId.includes("_")) {
@@ -487,6 +509,13 @@ function MilestonesReviewPageContent({
     error: fundingApplicationError,
     refetch: refetchFundingApplication,
   } = useFundingApplicationByProjectUID(projectUID || "");
+
+  // On-chain milestone attestations don't carry completion criteria, so we look
+  // it up from the application data (where the grantee originally entered it).
+  const completionCriteriaByTitle = useMemo(
+    () => extractCompletionCriteriaByTitle(fundingApplication?.applicationData),
+    [fundingApplication?.applicationData]
+  );
 
   // Memoize reference number: prefer funding application, fallback to milestone completion data
   const referenceNumber = useMemo(() => {
@@ -960,6 +989,7 @@ function MilestonesReviewPageContent({
                       }
                       showAIEvaluationButton={false}
                       quietSurface
+                      completionCriteria={completionCriteriaByTitle.get(selectedMilestone.title)}
                     />
                     <InlineAIEvaluation milestone={selectedMilestone} />
                   </div>


### PR DESCRIPTION
## Summary
- Milestone review workspace was missing the **Completion Criteria** that grantees enter in their funding application — on-chain milestone attestations don't carry that text, so it only showed on the application page.
- Pull the criteria from `fundingApplication.applicationData` (matched by milestone title) and render it inline below the milestone description, no separate section and no label, so it reads as part of the milestone content.
- The "Show more" clamp/toggle covers description + criteria together since they share the same container.

## Test plan
- [ ] Open a Filecoin (or any) funding-platform application that defined milestones with completion criteria, e.g. `community/filecoin/manage/funding-platform/992/milestones/<grant>?from=application#milestone-<uid>`.
- [ ] Verify the milestone card shows: description first, then criteria below it, with no "Completion Criteria" heading.
- [ ] Confirm long combined content still collapses behind a "Show more" / "Show less" toggle.
- [ ] Confirm milestones whose application has no `completionCriteria` render unchanged.
- [ ] Confirm projects without a linked funding application (no `applicationData`) render unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone cards now display completion criteria alongside milestone descriptions.
  * Completion criteria are automatically extracted from funding application data and integrated into the milestone review interface.
  * Card layout adjusts to accommodate the additional completion criteria section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->