### PR TITLE
chore: add Skills repo link to header and footer

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -22,6 +22,7 @@ const navigationLinks = [
   { label: "Blog", href: SOCIALS.PARAGRAPH },
   { label: "Guide", href: SOCIALS.DOCS },
   { label: "API Docs", href: karmaLinks.apiDocs },
+  { label: "Skills", href: karmaLinks.skills },
   { label: "Governance", href: karmaLinks.website },
   { label: "llms.txt", href: karmaLinks.llmsTxt },
 ];

--- a/src/components/navbar/menu-items.tsx
+++ b/src/components/navbar/menu-items.tsx
@@ -2,6 +2,7 @@ import {
   BanknoteArrowDown,
   BellDot,
   GalleryThumbnails,
+  Github,
   GoalIcon,
   LayoutGrid,
   LayoutList,
@@ -12,6 +13,7 @@ import {
   ScrollText,
   UserPlus,
 } from "lucide-react";
+import { karmaLinks } from "@/utilities/karma/karma";
 import { PAGES } from "@/utilities/pages";
 import { SOCIALS } from "@/utilities/socials";
 
@@ -124,6 +126,13 @@ export const resourcesItems: MenuItem[] = [
     href: SOCIALS.PARAGRAPH,
     icon: ScrollText,
     title: "Blog",
+    external: true,
+    showArrow: true,
+  },
+  {
+    href: karmaLinks.skills,
+    icon: Github,
+    title: "Skills",
     external: true,
     showArrow: true,
   },

--- a/utilities/karma/karma.ts
+++ b/utilities/karma/karma.ts
@@ -3,6 +3,7 @@ import { envVars } from "../enviromentVars";
 export const karmaLinks = {
   website: "https://gov.karmahq.xyz",
   githubSDK: "https://github.com/show-karma/karma-gap-sdk",
+  skills: "https://github.com/show-karma/skills",
   apiDocs: "https://gapapi.karmahq.xyz/v2/docs",
   llmsTxt: "https://www.karmahq.xyz/llms.txt",
 };


### PR DESCRIPTION
## Summary
- Adds a link to the Karma Skills repository (https://github.com/show-karma/skills) in the navbar Resources dropdown (desktop + mobile) with a GitHub icon
- Adds the same link to the footer navigation row, between "API Docs" and "Governance"
- Centralizes the URL in `karmaLinks.skills` so it can be reused elsewhere

## Test plan
- [ ] Open `/` while logged out — Resources dropdown shows "Skills" entry that opens the GitHub repo in a new tab
- [ ] Open the mobile menu — Resources section shows "Skills"
- [ ] Footer shows "Skills" link that opens the repo in a new tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Skills navigation link in the footer, positioned after API Docs
- Added Skills resource access in the navbar menu with a Github icon and external link indicator
- Navigation updates provide consistent access to the Skills resource across the application's header and footer sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->