### PR TITLE
feat(portfolio-reports): always-HTML rendering, drop markdown fallback

### DIFF
--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { ArrowLeft, Eye, EyeOff, RefreshCw, Save } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
-import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
+import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
@@ -14,7 +14,6 @@ import {
   usePublishReport,
   useRegenerateReport,
   useUnpublishReport,
-  useUpdateReportMarkdown,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
 import { isReportGenerating } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
@@ -27,81 +26,23 @@ interface Props {
   reportId: string;
 }
 
-// Extracts the in-app navigation target from an anchor click, or null if the
-// click should be ignored (external link, new tab, same-page anchor, etc.).
-function getInAppNavTarget(e: MouseEvent): string | null {
-  if (e.defaultPrevented) return null;
-  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return null;
-  const anchor = (e.target as Element | null)?.closest?.("a[href]") as HTMLAnchorElement | null;
-  if (!anchor) return null;
-  const href = anchor.getAttribute("href");
-  if (!href) return null;
-  if (href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) return null;
-  let url: URL;
-  try {
-    url = new URL(href, window.location.href);
-  } catch {
-    return null;
-  }
-  if (url.origin !== window.location.origin) return null;
-  if (url.pathname === window.location.pathname && url.search === window.location.search) {
-    return null;
-  }
-  return url.pathname + url.search + url.hash;
-}
-
+/**
+ * Admin preview + actions page. Inline editing was retired with the
+ * structured-document pipeline — admins regenerate (cheap, deterministic)
+ * rather than hand-editing the rendered HTML. The MCP tool
+ * `commit_edit_report_content` is the API-level escape hatch for
+ * bespoke content edits.
+ */
 export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const slug = community.details.slug;
   const router = useRouter();
   const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
   const { data: report, isLoading } = usePortfolioReport(slug, reportId);
-  const updateMarkdownMutation = useUpdateReportMarkdown(slug);
   const publishMutation = usePublishReport(slug);
   const unpublishMutation = useUnpublishReport(slug);
   const regenerateMutation = useRegenerateReport(slug);
 
-  const [markdown, setMarkdown] = useState<string | null>(null);
-  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
-  const [pendingHref, setPendingHref] = useState<string | null>(null);
-  const isDirtyRef = useRef(false);
-
-  // Initialize local markdown from fetched report
-  const currentMarkdown = markdown ?? report?.markdown ?? "";
-
-  // Dirty flag: local edits differ from the saved value
-  const isDirty = markdown !== null && markdown !== (report?.markdown ?? "");
-
-  // Keep a ref so event handlers always see the latest value without re-binding.
-  useEffect(() => {
-    isDirtyRef.current = isDirty;
-  }, [isDirty]);
-
-  // Browser refresh/close/external nav — show the native confirm.
-  useEffect(() => {
-    if (!isDirty) return;
-    const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = "";
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [isDirty]);
-
-  // In-app nav — intercept anchor clicks on capture phase so they can't slip past.
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (!isDirtyRef.current) return;
-      const target = getInAppNavTarget(e);
-      if (!target) return;
-      e.preventDefault();
-      e.stopPropagation();
-      setPendingHref(target);
-      setShowUnsavedDialog(true);
-    };
-    document.addEventListener("click", handler, true);
-    return () => document.removeEventListener("click", handler, true);
-  }, []);
 
   if (accessLoading || isLoading) {
     return (
@@ -126,28 +67,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     router.push(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
   };
 
-  const handleBackClick = () => {
-    if (isDirty) {
-      setShowUnsavedDialog(true);
-    } else {
-      navigateBack();
-    }
-  };
-
-  const handleSave = async () => {
-    try {
-      await updateMarkdownMutation.mutateAsync({
-        reportId,
-        markdown: currentMarkdown,
-      });
-      // Sync dirty state away after successful save
-      setMarkdown(null);
-      toast.success("Report saved");
-    } catch {
-      toast.error("Failed to save report");
-    }
-  };
-
   const handlePublish = async () => {
     try {
       await publishMutation.mutateAsync(reportId);
@@ -169,45 +88,19 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const handleRegenerate = async () => {
     try {
       await regenerateMutation.mutateAsync(reportId);
-      setMarkdown(null);
-      toast.success("Regeneration started, this can take a few minutes.");
-    } catch (error) {
-      toast.error(
-        `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`
-      );
+      setShowRegenerateDialog(false);
+      toast.success("Regeneration started");
+    } catch {
+      toast.error("Failed to start regeneration");
     }
   };
 
+  const runDateLabel = formatRunDate(report.runDate).label;
+
   return (
     <div className="flex h-full flex-col">
-      {/* Unsaved changes confirmation dialog */}
       <DeleteDialog
-        title="You have unsaved changes. Leave without saving?"
-        deleteFunction={async () => {
-          const href = pendingHref;
-          // Discard local edits so the beforeunload + click guards don't re-fire
-          setMarkdown(null);
-          setPendingHref(null);
-          // Let state flush before navigating
-          await Promise.resolve();
-          if (href) {
-            router.push(href);
-          } else {
-            navigateBack();
-          }
-        }}
-        isLoading={false}
-        externalIsOpen={showUnsavedDialog}
-        externalSetIsOpen={(open) => {
-          setShowUnsavedDialog(open);
-          if (!open) setPendingHref(null);
-        }}
-        buttonElement={null}
-      />
-
-      {/* Regenerate confirmation dialog */}
-      <DeleteDialog
-        title="This will overwrite the current draft. Any edits will be lost. Continue?"
+        title="This re-runs the agentic generator with the current config and overwrites the existing content. Spends LLM tokens. Continue?"
         deleteFunction={handleRegenerate}
         isLoading={regenerateMutation.isPending}
         externalIsOpen={showRegenerateDialog}
@@ -221,15 +114,14 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           <Button
             variant="ghost"
             size="sm"
-            onClick={handleBackClick}
+            onClick={navigateBack}
             aria-label="Back to portfolio reports"
           >
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
             <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              {formatRunDate(report.runDate).label}
-              {isDirty && <span className="ml-2 text-sm font-normal text-zinc-400">(unsaved)</span>}
+              {runDateLabel}
             </h1>
             <div className="flex items-center gap-2 text-xs text-zinc-500">
               <GenerationStatusBadge status={report.status} />
@@ -255,15 +147,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
                 : failed
                   ? "Retry"
                   : "Regenerate"}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleSave}
-            disabled={updateMarkdownMutation.isPending || generating}
-          >
-            <Save className="mr-1 h-3 w-3" />
-            {updateMarkdownMutation.isPending ? "Saving..." : "Save"}
           </Button>
           {report.status === "draft" ? (
             <Button size="sm" onClick={handlePublish} disabled={publishMutation.isPending}>
@@ -303,14 +186,15 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
         </div>
       ) : null}
 
-      {/* Editor */}
+      {/* Preview */}
       <div className="flex-1 p-4">
-        <MarkdownEditor
-          value={currentMarkdown}
-          onChange={(val) => setMarkdown(val)}
-          maxLength={500000}
-          height={700}
-        />
+        {report.content ? (
+          <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
+        ) : (
+          <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-400">
+            No content yet. Regenerate to produce the report body.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -28,12 +28,15 @@ export function HtmlReportFrame({ html, title }: Props) {
 
     let observer: ResizeObserver | null = null;
     let detached = false;
+    let printButton: Element | null = null;
+    let printHandler: ((event: Event) => void) | null = null;
 
-    function attachObserver() {
+    function attach() {
       if (detached) return;
       const doc = iframe?.contentDocument;
       const body = doc?.body;
       if (!body) return;
+
       const measure = () => {
         const next = Math.max(body.scrollHeight, 400);
         setHeight((prev) => (Math.abs(prev - next) > 1 ? next : prev));
@@ -41,16 +44,33 @@ export function HtmlReportFrame({ html, title }: Props) {
       measure();
       observer = new ResizeObserver(measure);
       observer.observe(body);
+
+      // The renderer emits a visual `<button class="btn-export">` but
+      // the iframe sandbox forbids scripts, so the button does nothing
+      // on its own. Wire it from the host: clicking it opens the
+      // browser's print dialog scoped to the iframe content, which the
+      // user then "Save as PDF"s. Native, no extra deps.
+      printButton = doc?.querySelector(".btn-export") ?? null;
+      if (printButton) {
+        printHandler = (event: Event) => {
+          event.preventDefault();
+          iframe?.contentWindow?.print();
+        };
+        printButton.addEventListener("click", printHandler);
+      }
     }
 
-    iframe.addEventListener("load", attachObserver);
+    iframe.addEventListener("load", attach);
     // Re-attach on the first paint in case the load event already fired.
-    attachObserver();
+    attach();
 
     return () => {
       detached = true;
-      iframe.removeEventListener("load", attachObserver);
+      iframe.removeEventListener("load", attach);
       observer?.disconnect();
+      if (printButton && printHandler) {
+        printButton.removeEventListener("click", printHandler);
+      }
     };
   }, [html]);
 

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  html: string;
+  /** Accessible title for the iframe. */
+  title: string;
+}
+
+/**
+ * Renders a self-contained HTML report (full `<!DOCTYPE html>` document
+ * produced by the agentic generator's HTML pipeline) inside a sandboxed
+ * iframe. The iframe isolates the report's embedded CSS from the host
+ * app's styles and vice-versa.
+ *
+ * Height auto-grows to match the report's content using a
+ * `ResizeObserver` on the iframe's body. We poll for content readiness
+ * via the `onLoad` event and re-measure when the inner content reflows.
+ */
+export function HtmlReportFrame({ html, title }: Props) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [height, setHeight] = useState<number>(800);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return undefined;
+
+    let observer: ResizeObserver | null = null;
+    let detached = false;
+
+    function attachObserver() {
+      if (detached) return;
+      const doc = iframe?.contentDocument;
+      const body = doc?.body;
+      if (!body) return;
+      const measure = () => {
+        const next = Math.max(body.scrollHeight, 400);
+        setHeight((prev) => (Math.abs(prev - next) > 1 ? next : prev));
+      };
+      measure();
+      observer = new ResizeObserver(measure);
+      observer.observe(body);
+    }
+
+    iframe.addEventListener("load", attachObserver);
+    // Re-attach on the first paint in case the load event already fired.
+    attachObserver();
+
+    return () => {
+      detached = true;
+      iframe.removeEventListener("load", attachObserver);
+      observer?.disconnect();
+    };
+  }, [html]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={html}
+      title={title}
+      // `allow-same-origin` is required for the resize observer to read
+      // the iframe's body. We deliberately omit `allow-scripts` since
+      // the renderer never emits any.
+      sandbox="allow-same-origin"
+      style={{
+        width: "100%",
+        border: "none",
+        display: "block",
+        height: `${height}px`,
+        background: "#f5f6f8",
+      }}
+    />
+  );
+}

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -79,10 +79,13 @@ export function HtmlReportFrame({ html, title }: Props) {
       ref={iframeRef}
       srcDoc={html}
       title={title}
-      // `allow-same-origin` is required for the resize observer to read
-      // the iframe's body. We deliberately omit `allow-scripts` since
-      // the renderer never emits any.
-      sandbox="allow-same-origin"
+      // `allow-same-origin` lets the host read the iframe's body
+      // (resize observer, button click wire-up). `allow-modals`
+      // permits the print dialog when the host calls
+      // `contentWindow.print()` — without it browsers silently block
+      // print as a sandboxed-modal violation. We still omit
+      // `allow-scripts` since the renderer never emits any.
+      sandbox="allow-same-origin allow-modals"
       style={{
         width: "100%",
         border: "none",

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -37,6 +37,18 @@ export function HtmlReportFrame({ html, title }: Props) {
       const body = doc?.body;
       if (!body) return;
 
+      // `attach` runs both synchronously (on initial mount and on every
+      // `html` change before navigation completes) and again when the
+      // iframe fires `load`. Without disconnecting/cleaning up first,
+      // a fast sequence of `html` changes leaks observers + listeners
+      // and briefly observes the previous document's body.
+      observer?.disconnect();
+      if (printButton && printHandler) {
+        printButton.removeEventListener("click", printHandler);
+        printButton = null;
+        printHandler = null;
+      }
+
       const measure = () => {
         const next = Math.max(body.scrollHeight, 400);
         setHeight((prev) => (Math.abs(prev - next) > 1 ? next : prev));

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -1,10 +1,10 @@
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
-import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { BackToTop } from "./BackToTop";
+import { HtmlReportFrame } from "./HtmlReportFrame";
 import { ReadingProgress } from "./ReadingProgress";
 
 interface Props {
@@ -25,16 +25,17 @@ function formatDate(iso: string): string {
 }
 
 export function PortfolioReportDocumentView({
-  community,
+  community: _community,
   runDate,
   report,
   backHref,
   backLabel = "Reports",
   bannerText,
 }: Props) {
-  const slug = community.details.slug;
   const runDateLabel = formatRunDate(runDate).label;
 
+  // The generated HTML document carries its own header/title/Export
+  // button. The FE wraps it with breadcrumb + banner navigation only.
   return (
     <>
       <ReadingProgress />
@@ -64,21 +65,7 @@ export function PortfolioReportDocumentView({
           </ol>
         </nav>
 
-        <header className="mb-8 border-b border-zinc-200 pb-8 dark:border-zinc-800">
-          <p className="mb-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-            {community.details.name ?? slug} · Portfolio report
-          </p>
-          <h1 className="text-4xl font-bold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100">
-            {runDateLabel}
-          </h1>
-          <p className="mt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400">
-            {report.publishedAt ? `Published ${formatDate(report.publishedAt)}` : "Draft"}
-          </p>
-        </header>
-
-        <article className="report-article prose prose-zinc max-w-none dark:prose-invert">
-          <MarkdownPreview source={report.markdown} />
-        </article>
+        <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
 
         <footer className="mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
           <span>Generated {formatDate(report.generatedAt)}</span>

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
+import { reportExcerpt } from "@/utilities/portfolio-reports/excerpt";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { ReportTimelineScrubber, type TimelineEntry } from "./ReportTimelineScrubber";
 
@@ -20,37 +21,6 @@ function formatPublished(iso: string): string {
     month: "short",
     day: "2-digit",
   });
-}
-
-function toExcerpt(markdown: string, maxLength = 240): string {
-  let text = markdown;
-  text = text.replace(/```[\s\S]*?```/g, " ");
-  text = text.replace(/`([^`]+)`/g, "$1");
-  text = text.replace(/!\[[^\]]*\]\([^)]+\)/g, "");
-  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
-  text = text
-    .split("\n")
-    .filter((line) => {
-      const trimmed = line.trim();
-      if (/^\|.*\|$/.test(trimmed)) return false;
-      if (/^[\s|:-]+$/.test(trimmed) && trimmed.includes("-")) return false;
-      return true;
-    })
-    .join("\n");
-  text = text.replace(/^#{1,6}\s+/gm, "");
-  text = text.replace(/^>\s?/gm, "");
-  text = text.replace(/^[\s]*[-*+]\s+/gm, "");
-  text = text.replace(/^[\s]*\d+\.\s+/gm, "");
-  text = text.replace(/(\*\*|__)(.+?)\1/g, "$2");
-  text = text.replace(/(\*|_)(.+?)\1/g, "$2");
-  text = text.replace(/~~(.+?)~~/g, "$1");
-  text = text.replace(/^[-*_]{3,}$/gm, "");
-  text = text.replace(/\s+/g, " ").trim();
-  if (text.length <= maxLength) return text;
-  const truncated = text.slice(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(" ");
-  const cut = lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated;
-  return `${cut}…`;
 }
 
 const MONTH_ABBR = [
@@ -74,9 +44,7 @@ const MONTH_ABBR = [
  * `runDate`s (any day, any cadence) so gap-fill no longer makes sense; we
  * just render what we have.
  */
-function deriveTimeline(
-  sortedReports: Array<{ id: string; runDate: string }>
-): TimelineEntry[] {
+function deriveTimeline(sortedReports: Array<{ id: string; runDate: string }>): TimelineEntry[] {
   return sortedReports.map((r) => {
     const [yearStr, monthStr, dayStr] = r.runDate.split("-");
     const monthIdx = Number(monthStr) - 1;
@@ -98,10 +66,7 @@ export function PublicReportListPage({ community }: Props) {
   const seededRef = useRef(false);
 
   const sortedReports = useMemo(
-    () =>
-      reports
-        ? [...reports].sort((a, b) => b.runDate.localeCompare(a.runDate))
-        : [],
+    () => (reports ? [...reports].sort((a, b) => b.runDate.localeCompare(a.runDate)) : []),
     [reports]
   );
 
@@ -210,7 +175,7 @@ export function PublicReportListPage({ community }: Props) {
 
         <div ref={sectionsRef} className="min-w-0">
           {sortedReports.map((report, index) => {
-            const excerpt = toExcerpt(report.markdown, 280);
+            const excerpt = reportExcerpt(report, 280);
             const fmt = formatRunDate(report.runDate);
             return (
               <article

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -127,7 +127,7 @@ export function useReportRowSync(
           if (r.id !== data.id || r === data) return r;
           if (
             r.status === data.status &&
-            r.markdown === data.markdown &&
+            r.content === data.content &&
             r.generationError === data.generationError &&
             r.updatedAt === data.updatedAt
           ) {
@@ -211,11 +211,11 @@ export function useUnpublishReport(communitySlug: string) {
   });
 }
 
-export function useUpdateReportMarkdown(communitySlug: string) {
+export function useUpdateReportContent(communitySlug: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ reportId, markdown }: { reportId: string; markdown: string }) =>
-      portfolioService.updateReportMarkdown(communitySlug, reportId, markdown),
+    mutationFn: ({ reportId, content }: { reportId: string; content: string }) =>
+      portfolioService.updateReportContent(communitySlug, reportId, content),
     onSuccess: (data: PortfolioReport) => {
       queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
       if (data.status === "published") {

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -77,13 +77,13 @@ export async function getReport(communitySlug: string, reportId: string): Promis
   return data;
 }
 
-export async function updateReportMarkdown(
+export async function updateReportContent(
   communitySlug: string,
   reportId: string,
-  markdown: string
+  content: string
 ): Promise<PortfolioReport> {
   const { data } = await apiClient.put(`/v2/communities/${communitySlug}/reports/${reportId}`, {
-    markdown,
+    content,
   });
   return data;
 }

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -38,7 +38,14 @@ export interface PortfolioReport {
   communityId: string;
   runDate: string;
   status: PortfolioReportStatus;
-  markdown: string;
+  /**
+   * Rendered report body. New reports are full `<!DOCTYPE html>`
+   * documents emitted by the agentic generator's structured-document
+   * pipeline. Pre-migration rows carry markdown text (one-time
+   * backfill converts them to HTML). The FE always renders this
+   * inside a sandboxed frame, format-agnostic by design.
+   */
+  content: string;
   dataSnapshot: Record<string, unknown>;
   modelId: string;
   tokenUsage: TokenUsage | null;

--- a/utilities/portfolio-reports/excerpt.ts
+++ b/utilities/portfolio-reports/excerpt.ts
@@ -1,0 +1,52 @@
+import type { PortfolioReport } from "@/types/portfolio-report";
+
+const DEFAULT_LENGTH = 240;
+
+/**
+ * Plain-text excerpt for a report card. The report's `content` field
+ * is HTML for new reports and markdown for any pre-migration rows; the
+ * stripper below tolerates both shapes (markdown that doesn't contain
+ * tags passes through with its punctuation cleaned up; HTML loses tags
+ * + named entities). Used by the public list page card preview only —
+ * never feed the output back into HTML rendering.
+ */
+export function reportExcerpt(report: PortfolioReport, maxLength: number = DEFAULT_LENGTH): string {
+  if (!report.content) return "";
+  return excerptFromBody(report.content, maxLength);
+}
+
+function excerptFromBody(input: string, maxLength: number): string {
+  let text = input;
+  // Drop scripts / styles / heads if this is HTML.
+  text = text.replace(/<script[\s\S]*?<\/script>/gi, " ");
+  text = text.replace(/<style[\s\S]*?<\/style>/gi, " ");
+  text = text.replace(/<head[\s\S]*?<\/head>/gi, " ");
+  text = text.replace(/<[^>]+>/g, " ");
+  // Decode the named entities the renderer actually emits.
+  text = text
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_m, code) => String.fromCharCode(Number(code)));
+  // Light markdown cleanup so legacy markdown rows look reasonable.
+  text = text.replace(/```[\s\S]*?```/g, " ");
+  text = text.replace(/`([^`]+)`/g, "$1");
+  text = text.replace(/!\[[^\]]*\]\([^)]+\)/g, "");
+  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  text = text.replace(/^#{1,6}\s+/gm, "");
+  text = text.replace(/^>\s?/gm, "");
+  text = text.replace(/^[\s]*[-*+]\s+/gm, "");
+  text = text.replace(/^[\s]*\d+\.\s+/gm, "");
+  text = text.replace(/(\*\*|__)(.+?)\1/g, "$2");
+  text = text.replace(/(\*|_)(.+?)\1/g, "$2");
+  text = text.replace(/~~(.+?)~~/g, "$1");
+  text = text.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) return text;
+  const truncated = text.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  const cut = lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated;
+  return `${cut}…`;
+}


### PR DESCRIPTION
## Summary

- Cuts the FE over to the always-HTML rendering pipeline shipped in [show-karma/gap-indexer#1560](https://github.com/show-karma/gap-indexer/pull/1560). One render path, no format detection, no \`html?\` flag.
- Renames \`PortfolioReport.markdown\` → \`content\` to match the BE rename. Field is format-agnostic by design.
- Adds \`HtmlReportFrame\` — sandboxed iframe with auto-resizing height (\`ResizeObserver\` on the iframe body). \`sandbox=\"allow-same-origin\"\` only; the BE renderer never emits scripts.
- Drops the inline \`MarkdownEditor\` from the admin editor page. Admins regenerate (cheap, deterministic) or use the MCP tool \`commit_edit_report_content\` for bespoke edits.
- Service rename: \`updateReportMarkdown\` → \`updateReportContent\`. Hook rename: \`useUpdateReportMarkdown\` → \`useUpdateReportContent\`.

## Files changed

| File | Change |
|---|---|
| \`types/portfolio-report/index.ts\` | \`markdown\` → \`content: string\` (required); dropped \`html?\` field + \`reportHasHtml\` helper |
| \`components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx\` | New — sandboxed iframe component |
| \`components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx\` | Single render path, FE header chrome dropped (generated HTML doc carries its own) |
| \`components/Pages/Community/PortfolioReports/PublicReportListPage.tsx\` | Uses shared \`reportExcerpt\` helper |
| \`utilities/portfolio-reports/excerpt.ts\` | New — single body stripper that tolerates HTML and legacy markdown |
| \`components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx\` | Drops the inline editor + dirty-tracking + unsaved-dialog plumbing. Preview iframe + publish/unpublish/regenerate actions remain. |
| \`hooks/portfolio-reports/usePortfolioReports.ts\` | \`useUpdateReportContent\` rename + report cache-equality on \`content\` instead of \`markdown\` |
| \`services/portfolio-reports.service.ts\` | \`updateReportContent\` rename |

## Deploy coordination

This PR depends on the BE migration in [show-karma/gap-indexer#1560](https://github.com/show-karma/gap-indexer/pull/1560):

1. Apply the BE \`markdown\` → \`content\` Prisma rename (the BE PR includes it).
2. \`mongosh\` against prod: \`db.portfolio_reports.updateMany({}, { \$rename: { markdown: 'content' } })\`.
3. For the single existing report: convert its (now-\`content\`) markdown text to HTML locally and update the row via Prisma Studio / mongosh.
4. Deploy BE.
5. Deploy this PR.

Old reports keep working — their pre-migration markdown lives in the renamed \`content\` field after the conversion. The FE renders both inside the same sandboxed iframe.

## Test plan

- [ ] Manual: open a published report's public page; iframe renders the HTML at the correct height, no horizontal scroll, app styles isolated.
- [ ] Manual: open the admin preview page; same iframe + publish/unpublish/regenerate buttons work.
- [ ] Manual: trigger Regenerate; status badge shows \"Generating…\" then refreshes to the new content.
- [ ] Manual: portfolio reports list page shows excerpt text from HTML body (not raw tag output).
- [ ] Manual: a community without published reports shows the empty state, not a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio reports now display as rendered HTML content for enhanced formatting and presentation

* **Improvements**
  * Admin portfolio report editor is now a read-only preview with regeneration workflow
  * Report list excerpts automatically generated from report content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->