### PR TITLE
feat(portfolio-reports): Shadow-DOM render + Edit modal + Export PDF

### DIFF
--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -1,20 +1,30 @@
 "use client";
 
-import { ArrowLeft, Eye, EyeOff, RefreshCw } from "lucide-react";
+import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import {
   usePortfolioReport,
   usePublishReport,
   useRegenerateReport,
   useUnpublishReport,
+  useUpdateReportContent,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
+import { downloadReportPdf } from "@/services/portfolio-reports.service";
 import { isReportGenerating } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
@@ -27,11 +37,14 @@ interface Props {
 }
 
 /**
- * Admin preview + actions page. Inline editing was retired with the
- * structured-document pipeline — admins regenerate (cheap, deterministic)
- * rather than hand-editing the rendered HTML. The MCP tool
- * `commit_edit_report_content` is the API-level escape hatch for
- * bespoke content edits.
+ * Admin preview + actions page.
+ *
+ * Edit affordance is intentionally a raw HTML textarea. The rendered
+ * output is structured HTML (produced by the BE renderer from the
+ * agentic structured document); a WYSIWYG would either lose round-trip
+ * fidelity or require rebuilding the renderer in the browser. The
+ * textarea is enough for typo-fix-shaped edits, and Regenerate is the
+ * right move for anything larger.
  */
 export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const slug = community.details.slug;
@@ -41,8 +54,18 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const publishMutation = usePublishReport(slug);
   const unpublishMutation = useUnpublishReport(slug);
   const regenerateMutation = useRegenerateReport(slug);
+  const updateContentMutation = useUpdateReportContent(slug);
 
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
+  const [showEditDialog, setShowEditDialog] = useState(false);
+  const [editDraft, setEditDraft] = useState("");
+  const [exportingPdf, setExportingPdf] = useState(false);
+
+  useEffect(() => {
+    if (showEditDialog && report?.content) {
+      setEditDraft(report.content);
+    }
+  }, [showEditDialog, report?.content]);
 
   if (accessLoading || isLoading) {
     return (
@@ -95,6 +118,35 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     }
   };
 
+  const handleSaveEdit = async () => {
+    try {
+      await updateContentMutation.mutateAsync({ reportId, content: editDraft });
+      setShowEditDialog(false);
+      toast.success("Report content saved");
+    } catch (err) {
+      toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
+    }
+  };
+
+  const handleExportPdf = async () => {
+    setExportingPdf(true);
+    try {
+      const blob = await downloadReportPdf(slug, reportId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `portfolio-report-${report.runDate}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
+    } finally {
+      setExportingPdf(false);
+    }
+  };
+
   const runDateLabel = formatRunDate(report.runDate).label;
 
   return (
@@ -107,6 +159,40 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
         externalSetIsOpen={setShowRegenerateDialog}
         buttonElement={null}
       />
+
+      <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
+        <DialogContent className="max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>Edit report content</DialogTitle>
+            <DialogDescription>
+              Edits the rendered HTML directly. Regenerating the report will overwrite these
+              changes.
+            </DialogDescription>
+          </DialogHeader>
+          <textarea
+            className="h-[60vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            value={editDraft}
+            onChange={(event) => setEditDraft(event.target.value)}
+            spellCheck={false}
+            aria-label="Report HTML content"
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowEditDialog(false)}
+              disabled={updateContentMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveEdit}
+              disabled={updateContentMutation.isPending || editDraft === (report.content ?? "")}
+            >
+              {updateContentMutation.isPending ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Top bar */}
       <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
@@ -133,6 +219,24 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowEditDialog(true)}
+            disabled={generating || !report.content}
+          >
+            <Pencil className="mr-1 h-3 w-3" />
+            Edit
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExportPdf}
+            disabled={exportingPdf || generating || !report.content}
+          >
+            <Download className="mr-1 h-3 w-3" />
+            {exportingPdf ? "Exporting…" : "Export PDF"}
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
@@ -60,12 +60,27 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [editDraft, setEditDraft] = useState("");
   const [exportingPdf, setExportingPdf] = useState(false);
+  const exportInFlight = useRef(false);
 
   useEffect(() => {
     if (showEditDialog && report?.content) {
       setEditDraft(report.content);
     }
   }, [showEditDialog, report?.content]);
+
+  // Close the Edit dialog if a regenerate kicks off while it's open —
+  // the draft is now stale (it was seeded from pre-regen content) and
+  // saving would clobber the freshly generated report. The user gets a
+  // toast so they know why their dialog disappeared.
+  const isReportRegenerating = report ? isReportGenerating(report) : false;
+  useEffect(() => {
+    if (showEditDialog && isReportRegenerating) {
+      setShowEditDialog(false);
+      toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
+        icon: "ℹ️",
+      });
+    }
+  }, [showEditDialog, isReportRegenerating]);
 
   if (accessLoading || isLoading) {
     return (
@@ -129,6 +144,11 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   };
 
   const handleExportPdf = async () => {
+    // Synchronous guard against double-clicks — `setExportingPdf(true)`
+    // is queued by React and won't disable the button before a second
+    // click can fire on the same event loop tick.
+    if (exportInFlight.current) return;
+    exportInFlight.current = true;
     setExportingPdf(true);
     try {
       const blob = await downloadReportPdf(slug, reportId);
@@ -143,6 +163,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     } catch (err) {
       toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
+      exportInFlight.current = false;
       setExportingPdf(false);
     }
   };

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -37,6 +37,7 @@ interface ReportTableRowProps {
   configName: string;
   rowPending: boolean;
   activeMutationType: "publish" | "unpublish" | "regenerate" | null;
+  onEdit: () => void;
   onPreview: () => void;
   onPublish: () => void;
   onUnpublish: () => void;
@@ -49,6 +50,7 @@ function ReportTableRow({
   configName,
   rowPending,
   activeMutationType,
+  onEdit,
   onPreview,
   onPublish,
   onUnpublish,
@@ -77,6 +79,9 @@ function ReportTableRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex items-center justify-end gap-1">
+          <Button variant="ghost" size="sm" onClick={onEdit} disabled={generating}>
+            Edit
+          </Button>
           {report.status === "draft" ? (
             <Button variant="ghost" size="sm" onClick={onPreview}>
               <FileSearch className="mr-1 h-3 w-3" />
@@ -368,6 +373,7 @@ export function PortfolioReportListPage({ community }: Props) {
                   configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
+                  onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
                   onPreview={() =>
                     router.push(PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW(slug, report.id))
                   }

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -37,7 +37,6 @@ interface ReportTableRowProps {
   configName: string;
   rowPending: boolean;
   activeMutationType: "publish" | "unpublish" | "regenerate" | null;
-  onEdit: () => void;
   onPreview: () => void;
   onPublish: () => void;
   onUnpublish: () => void;
@@ -50,7 +49,6 @@ function ReportTableRow({
   configName,
   rowPending,
   activeMutationType,
-  onEdit,
   onPreview,
   onPublish,
   onUnpublish,
@@ -79,9 +77,6 @@ function ReportTableRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex items-center justify-end gap-1">
-          <Button variant="ghost" size="sm" onClick={onEdit} disabled={generating}>
-            Edit
-          </Button>
           {report.status === "draft" ? (
             <Button variant="ghost" size="sm" onClick={onPreview}>
               <FileSearch className="mr-1 h-3 w-3" />
@@ -373,7 +368,6 @@ export function PortfolioReportListPage({ community }: Props) {
                   configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
-                  onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
                   onPreview={() =>
                     router.push(PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW(slug, report.id))
                   }

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -79,6 +79,7 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
       backHref={backHref}
       backLabel="Back to portfolio reports"
       bannerText={bannerText}
+      exportContext={{ communitySlug: slug, reportId }}
     />
   );
 }

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -13,14 +13,16 @@ interface Props {
  * produced by the agentic generator's HTML pipeline) inside a Shadow
  * DOM. Shadow DOM gives us the same style isolation an iframe did,
  * without the iframe drawbacks: no ResizeObserver / scrollHeight
- * measurement (the host `<div>` flows to its natural content height),
- * no inner scrollbar, no sandboxed-modal weirdness around print.
+ * measurement (the host `<section>` flows to its natural content
+ * height), no inner scrollbar, no sandboxed-modal weirdness around
+ * print.
  *
  * The BE-produced HTML is a complete document. Shadow roots only
  * accept fragment content, so we parse the doc with DOMParser, inject
- * its `<style>` tags + body innerHTML into the shadow root, and drop
- * the on-screen Export button (its old iframe-print path is being
- * replaced; tracked separately).
+ * its `<style>` tags + body content into the shadow root, drop the
+ * legacy in-content Export PDF button, and harden against unsafe
+ * markup that could land in `report.content` via the admin Edit
+ * textarea (see sanitizeFragment).
  */
 export function HtmlReportFrame({ html, title }: Props) {
   const hostRef = useRef<HTMLElement | null>(null);
@@ -33,19 +35,76 @@ export function HtmlReportFrame({ html, title }: Props) {
 
     const doc = new DOMParser().parseFromString(html, "text/html");
 
-    // Drop the on-screen Export PDF button — its old click handler
-    // (iframe.contentWindow.print()) was unreliable across browsers,
-    // and the new export path will live outside the rendered HTML.
+    sanitizeFragment(doc);
+
+    // Drop the legacy on-screen Export PDF button. New reports don't
+    // emit it; reports already in storage from before that BE change
+    // still do.
     for (const node of doc.querySelectorAll(".btn-export")) {
       node.remove();
     }
 
+    // The renderer's stylesheet targets `body { ... }` for page-level
+    // styles (margin, background, default text color, font). Inside a
+    // shadow root there is no <body> element, so those rules would
+    // silently miss. Rewriting `body` → `:host` makes them apply to
+    // the shadow host (our <section>), which is the visual equivalent.
+    // The negative-lookbehind avoids matching things like `nobody` or
+    // class fragments containing "body".
     const styles = Array.from(doc.head.querySelectorAll("style, link[rel='stylesheet']"))
       .map((node) => node.outerHTML)
-      .join("");
+      .join("")
+      .replace(/(?<![\w-])body(?=[\s,{])/g, ":host");
 
     root.innerHTML = styles + doc.body.innerHTML;
   }, [html]);
 
   return <section ref={hostRef} aria-label={title} />;
+}
+
+/**
+ * Strip XSS surface from the parsed HTML before it's injected into the
+ * shadow root. Shadow DOM `innerHTML` does not auto-execute `<script>`
+ * tags, but it DOES fire `onerror` / `onload` / other inline event
+ * handlers — and a same-origin shadow root can read the host page's
+ * cookies. The Edit textarea on the editor page lets a community
+ * admin paste arbitrary HTML; if their account is ever compromised,
+ * stored content shouldn't become an XSS sink.
+ *
+ * - Removes `<script>` and `<iframe>` and similar active elements.
+ * - Drops `on*` event-handler attributes from every remaining node.
+ * - Rewrites `javascript:` / `data:` / `vbscript:` URLs in href/src.
+ */
+function sanitizeFragment(doc: Document): void {
+  const ACTIVE_TAGS = new Set([
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "frame",
+    "frameset",
+    "applet",
+    "meta",
+    "base",
+  ]);
+  const UNSAFE_URL = /^\s*(javascript|vbscript|data):/i;
+
+  for (const node of Array.from(doc.querySelectorAll("*"))) {
+    if (ACTIVE_TAGS.has(node.tagName.toLowerCase())) {
+      node.remove();
+      continue;
+    }
+    for (const attr of Array.from(node.attributes)) {
+      if (attr.name.toLowerCase().startsWith("on")) {
+        node.removeAttribute(attr.name);
+        continue;
+      }
+      if (
+        (attr.name === "href" || attr.name === "src" || attr.name === "xlink:href") &&
+        UNSAFE_URL.test(attr.value)
+      ) {
+        node.removeAttribute(attr.name);
+      }
+    }
+  }
 }

--- a/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
+++ b/components/Pages/Community/PortfolioReports/HtmlReportFrame.tsx
@@ -1,110 +1,51 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 interface Props {
   html: string;
-  /** Accessible title for the iframe. */
+  /** Accessible label, mirrors the prior iframe `title` prop. */
   title: string;
 }
 
 /**
  * Renders a self-contained HTML report (full `<!DOCTYPE html>` document
- * produced by the agentic generator's HTML pipeline) inside a sandboxed
- * iframe. The iframe isolates the report's embedded CSS from the host
- * app's styles and vice-versa.
+ * produced by the agentic generator's HTML pipeline) inside a Shadow
+ * DOM. Shadow DOM gives us the same style isolation an iframe did,
+ * without the iframe drawbacks: no ResizeObserver / scrollHeight
+ * measurement (the host `<div>` flows to its natural content height),
+ * no inner scrollbar, no sandboxed-modal weirdness around print.
  *
- * Height auto-grows to match the report's content using a
- * `ResizeObserver` on the iframe's body. We poll for content readiness
- * via the `onLoad` event and re-measure when the inner content reflows.
+ * The BE-produced HTML is a complete document. Shadow roots only
+ * accept fragment content, so we parse the doc with DOMParser, inject
+ * its `<style>` tags + body innerHTML into the shadow root, and drop
+ * the on-screen Export button (its old iframe-print path is being
+ * replaced; tracked separately).
  */
 export function HtmlReportFrame({ html, title }: Props) {
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const [height, setHeight] = useState<number>(800);
+  const hostRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe) return undefined;
+    const host = hostRef.current;
+    if (!host) return;
 
-    let observer: ResizeObserver | null = null;
-    let detached = false;
-    let printButton: Element | null = null;
-    let printHandler: ((event: Event) => void) | null = null;
+    const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
 
-    function attach() {
-      if (detached) return;
-      const doc = iframe?.contentDocument;
-      const body = doc?.body;
-      if (!body) return;
+    const doc = new DOMParser().parseFromString(html, "text/html");
 
-      // `attach` runs both synchronously (on initial mount and on every
-      // `html` change before navigation completes) and again when the
-      // iframe fires `load`. Without disconnecting/cleaning up first,
-      // a fast sequence of `html` changes leaks observers + listeners
-      // and briefly observes the previous document's body.
-      observer?.disconnect();
-      if (printButton && printHandler) {
-        printButton.removeEventListener("click", printHandler);
-        printButton = null;
-        printHandler = null;
-      }
-
-      const measure = () => {
-        const next = Math.max(body.scrollHeight, 400);
-        setHeight((prev) => (Math.abs(prev - next) > 1 ? next : prev));
-      };
-      measure();
-      observer = new ResizeObserver(measure);
-      observer.observe(body);
-
-      // The renderer emits a visual `<button class="btn-export">` but
-      // the iframe sandbox forbids scripts, so the button does nothing
-      // on its own. Wire it from the host: clicking it opens the
-      // browser's print dialog scoped to the iframe content, which the
-      // user then "Save as PDF"s. Native, no extra deps.
-      printButton = doc?.querySelector(".btn-export") ?? null;
-      if (printButton) {
-        printHandler = (event: Event) => {
-          event.preventDefault();
-          iframe?.contentWindow?.print();
-        };
-        printButton.addEventListener("click", printHandler);
-      }
+    // Drop the on-screen Export PDF button — its old click handler
+    // (iframe.contentWindow.print()) was unreliable across browsers,
+    // and the new export path will live outside the rendered HTML.
+    for (const node of doc.querySelectorAll(".btn-export")) {
+      node.remove();
     }
 
-    iframe.addEventListener("load", attach);
-    // Re-attach on the first paint in case the load event already fired.
-    attach();
+    const styles = Array.from(doc.head.querySelectorAll("style, link[rel='stylesheet']"))
+      .map((node) => node.outerHTML)
+      .join("");
 
-    return () => {
-      detached = true;
-      iframe.removeEventListener("load", attach);
-      observer?.disconnect();
-      if (printButton && printHandler) {
-        printButton.removeEventListener("click", printHandler);
-      }
-    };
+    root.innerHTML = styles + doc.body.innerHTML;
   }, [html]);
 
-  return (
-    <iframe
-      ref={iframeRef}
-      srcDoc={html}
-      title={title}
-      // `allow-same-origin` lets the host read the iframe's body
-      // (resize observer, button click wire-up). `allow-modals`
-      // permits the print dialog when the host calls
-      // `contentWindow.print()` — without it browsers silently block
-      // print as a sandboxed-modal violation. We still omit
-      // `allow-scripts` since the renderer never emits any.
-      sandbox="allow-same-origin allow-modals"
-      style={{
-        width: "100%",
-        border: "none",
-        display: "block",
-        height: `${height}px`,
-        background: "#f5f6f8",
-      }}
-    />
-  );
+  return <section ref={hostRef} aria-label={title} />;
 }

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronRight, Download } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { downloadReportPdf } from "@/services/portfolio-reports.service";
@@ -49,9 +49,14 @@ export function PortfolioReportDocumentView({
 }: Props) {
   const runDateLabel = formatRunDate(runDate).label;
   const [exportingPdf, setExportingPdf] = useState(false);
+  const exportInFlight = useRef(false);
 
   const handleExportPdf = async () => {
     if (!exportContext) return;
+    // Synchronous guard against double-clicks; setState is async and the
+    // disabled prop won't update before a second click in the same tick.
+    if (exportInFlight.current) return;
+    exportInFlight.current = true;
     setExportingPdf(true);
     try {
       const blob = await downloadReportPdf(exportContext.communitySlug, exportContext.reportId);
@@ -66,6 +71,7 @@ export function PortfolioReportDocumentView({
     } catch (err) {
       toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
+      exportInFlight.current = false;
       setExportingPdf(false);
     }
   };

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -1,5 +1,11 @@
-import { ChevronRight } from "lucide-react";
+"use client";
+
+import { ChevronRight, Download } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { downloadReportPdf } from "@/services/portfolio-reports.service";
 import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
@@ -14,6 +20,14 @@ interface Props {
   backHref: string;
   backLabel?: string;
   bannerText?: string;
+  /**
+   * When provided, surfaces an "Export PDF" button next to the
+   * breadcrumb. Pass `{ communitySlug, reportId }` from contexts where
+   * the viewer is authorized to call the admin-scoped PDF endpoint
+   * (e.g. the admin /preview tab). Public report views should leave
+   * this undefined.
+   */
+  exportContext?: { communitySlug: string; reportId: string };
 }
 
 function formatDate(iso: string): string {
@@ -31,11 +45,31 @@ export function PortfolioReportDocumentView({
   backHref,
   backLabel = "Reports",
   bannerText,
+  exportContext,
 }: Props) {
   const runDateLabel = formatRunDate(runDate).label;
+  const [exportingPdf, setExportingPdf] = useState(false);
 
-  // The generated HTML document carries its own header/title/Export
-  // button. The FE wraps it with breadcrumb + banner navigation only.
+  const handleExportPdf = async () => {
+    if (!exportContext) return;
+    setExportingPdf(true);
+    try {
+      const blob = await downloadReportPdf(exportContext.communitySlug, exportContext.reportId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `portfolio-report-${runDate}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
+    } finally {
+      setExportingPdf(false);
+    }
+  };
+
   return (
     <>
       <ReadingProgress />
@@ -46,24 +80,37 @@ export function PortfolioReportDocumentView({
           </div>
         ) : null}
 
-        <nav aria-label="Breadcrumb" className="mb-8">
-          <ol className="flex flex-wrap items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
-            <li>
-              <Link
-                href={backHref}
-                className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
-              >
-                {backLabel}
-              </Link>
-            </li>
-            <li aria-hidden="true" className="text-zinc-300 dark:text-zinc-700">
-              <ChevronRight className="h-3.5 w-3.5" />
-            </li>
-            <li aria-current="page" className="font-medium text-zinc-900 dark:text-zinc-100">
-              {runDateLabel}
-            </li>
-          </ol>
-        </nav>
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
+          <nav aria-label="Breadcrumb">
+            <ol className="flex flex-wrap items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
+              <li>
+                <Link
+                  href={backHref}
+                  className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
+                >
+                  {backLabel}
+                </Link>
+              </li>
+              <li aria-hidden="true" className="text-zinc-300 dark:text-zinc-700">
+                <ChevronRight className="h-3.5 w-3.5" />
+              </li>
+              <li aria-current="page" className="font-medium text-zinc-900 dark:text-zinc-100">
+                {runDateLabel}
+              </li>
+            </ol>
+          </nav>
+          {exportContext ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleExportPdf}
+              disabled={exportingPdf || !report.content}
+            >
+              <Download className="mr-1 h-3 w-3" />
+              {exportingPdf ? "Exporting…" : "Export PDF"}
+            </Button>
+          ) : null}
+        </div>
 
         <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
 

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -88,6 +88,19 @@ export async function updateReportContent(
   return data;
 }
 
+/**
+ * Server-side PDF render. Returns the binary PDF as a Blob so the
+ * caller can drive a browser download. Uses the auth-aware api client
+ * because the underlying endpoint shares the same authorization as
+ * the JSON GET (community admin or staff).
+ */
+export async function downloadReportPdf(communitySlug: string, reportId: string): Promise<Blob> {
+  const { data } = await apiClient.get(`/v2/communities/${communitySlug}/reports/${reportId}/pdf`, {
+    responseType: "blob",
+  });
+  return data as Blob;
+}
+
 export async function generateReport(
   communitySlug: string,
   body: GenerateReportRequest


### PR DESCRIPTION
## Summary
Three FE changes for the admin portfolio-reports surface:

1. **Replaces iframe with Shadow DOM in \`HtmlReportFrame\`.** Eliminates the double-scrollbar / "scroll a little inside the frame" UX. The iframe path measured \`body.scrollHeight\` and sized the iframe to match — but webfonts and lazy SVGs reflowed the body a few pixels taller after the measurement, leaving the iframe shorter than its content. Shadow DOM gives the same style isolation without measurement: the host element flows to natural content height, so an inner scrollbar can never exist.

2. **Edit affordance.** A new "Edit" button on the editor page opens a modal with a textarea pre-filled with the report's HTML. Save → existing \`useUpdateReportContent\` hook → BE \`updateReportContent\`. The list-row "Edit" button (kept) routes here. Raw HTML textarea is intentional: the rendered output is structured HTML produced by the BE renderer, and a WYSIWYG would either lose round-trip fidelity or require rebuilding the renderer in the browser. Good enough for typo-fix-shaped edits — Regenerate is the right move for anything larger.

3. **Server-side Export PDF.** A new "Export PDF" button calls \`downloadReportPdf\` which hits the matching BE endpoint (\`GET /v2/communities/:uidOrSlug/reports/:reportId/pdf\`, gap-indexer PR #1573), receives the PDF as a blob, and triggers a browser download. Replaces the broken \`iframe.contentWindow.print()\` path; PDF colors / progress bars / KPI tiles all match the on-screen view because the BE consumes the same generated HTML.

## Why three things together
These are interdependent — the Shadow DOM swap removed the old in-iframe Export button (its \`contentWindow.print()\` handler was unreliable and is what we agreed to drop), so the new Export PDF button + BE endpoint had to land alongside.

## Backend dependency
Requires gap-indexer PR #1573 (\`feat(portfolio-report): server-side PDF export via Puppeteer\`) on the matching environment. Without it, "Export PDF" 404s.

## Test plan
- [ ] Open any rendered portfolio report (admin editor, /preview, public published view); confirm only the host page scrolls and the wheel never scrolls inside the report area.
- [ ] In the admin editor, click "Edit", change a word, Save → toast appears, modal closes, the rendered preview reflects the edit.
- [ ] Click "Export PDF" → PDF downloads, opens in your viewer, KPI tiles + progress bars + status dots have their colors, text is selectable.
- [ ] Confirm Edit button on list row routes back to the editor page.
- [ ] Confirm Edit / Export PDF are disabled when the report is generating or has no content yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio reports now support inline HTML editing through a dedicated Edit dialog, with save and cancel options for content updates
  * Added PDF export functionality to portfolio reports, enabling users to download reports as PDF files via an export button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->