### PR TITLE
feat(claim-funds): support proposing claims via Safe multisig

### DIFF
--- a/app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient.tsx
@@ -14,14 +14,18 @@ import { EmptyState } from "@/src/features/claim-funds/components/EmptyState";
 import { LoadingState } from "@/src/features/claim-funds/components/LoadingState";
 import { useCampaignNameMappings } from "@/src/features/claim-funds/hooks/use-campaign-name-mappings";
 import { useCampaigns } from "@/src/features/claim-funds/hooks/use-campaigns";
+import { useCheckSafeOwnership } from "@/src/features/claim-funds/hooks/use-check-safe-ownership";
 import { useClaimGrantsEnabled } from "@/src/features/claim-funds/hooks/use-claim-provider";
 import { useClaimTransaction } from "@/src/features/claim-funds/hooks/use-claim-transaction";
+import { useClaimViaASafe } from "@/src/features/claim-funds/hooks/use-claim-via-safe";
 import { useClaimedStatuses } from "@/src/features/claim-funds/hooks/use-claimed-status";
 import { useDelegatedClaim } from "@/src/features/claim-funds/hooks/use-delegated-claim";
 import { useEligibility } from "@/src/features/claim-funds/hooks/use-eligibility";
+import { getChainByName } from "@/src/features/claim-funds/lib/viem-clients";
 import type { ClaimCampaign } from "@/src/features/claim-funds/providers/types";
 import { getTenantConfig } from "@/src/infrastructure/config/tenant-config";
 import { isKnownTenant, type TenantId } from "@/src/infrastructure/types/tenant";
+import type { SupportedChainId } from "@/config/tokens";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 
 const truncateAddress = (address: string) => formatAddressForDisplay(address, 6, 4);
@@ -90,13 +94,40 @@ function ClaimFundsContent() {
     activeCampaignId: delegatedActiveCampaignId,
   } = useDelegatedClaim(tenantId, claimGrants);
 
+  // Resolve the campaign network's chainId from the tenant config
+  const campaignNetworkName =
+    claimGrants?.providerConfig?.type === "hedgey"
+      ? claimGrants.providerConfig.networkName
+      : "optimism";
+  const campaignChainId = getChainByName(campaignNetworkName).id as SupportedChainId;
+
+  // Check if alternate address is a Safe the user owns (on the campaign's chain)
+  const { isSafeYouOwn, isCheckingOwnership } = useCheckSafeOwnership(
+    alternateAddress as `0x${string}` | null,
+    campaignChainId,
+    isUsingAlternateAddress
+  );
+
+  // Claim via Safe (for Safe ownership claims)
+  const {
+    requestClaim: requestClaimViaSafe,
+    submitClaim: submitClaimViaSafe,
+    step: safeClaimStep,
+    activeCampaignId: safeActiveCampaignId,
+    reset: resetSafeClaim,
+  } = useClaimViaASafe(tenantId, campaignNetworkName);
+
   // Fetch campaign name mappings from database
   const { data: campaignNameMappings } = useCampaignNameMappings(communityId, claimFundsEnabled);
 
   const isClaiming = isClaimPending || isClaimConfirming;
   const isDelegatedClaimInProgress =
     delegatedClaimStep === "awaiting_signature" || delegatedClaimStep === "submitting";
-  const isAnyClaiming = isClaiming || isDelegatedClaimInProgress;
+  const isSafeClaimInProgress =
+    safeClaimStep === "preparing" ||
+    safeClaimStep === "awaiting_signature" ||
+    safeClaimStep === "submitting";
+  const isAnyClaiming = isClaiming || isDelegatedClaimInProgress || isSafeClaimInProgress;
 
   // Filter to only show eligible or claimed campaigns
   const displayCampaigns = useMemo(
@@ -146,6 +177,22 @@ function ClaimFundsContent() {
     void submitDelegatedClaim();
   }, [submitDelegatedClaim]);
 
+  const handleRequestClaimViaSafe = useCallback(
+    (campaign: ClaimCampaign) => {
+      if (!alternateAddress) return;
+      const eligibility = eligibilities.get(campaign.id);
+      if (!eligibility) return;
+      if (!isAddress(campaign.contractAddress)) return;
+      const contractAddress = campaign.contractAddress as `0x${string}`;
+      void requestClaimViaSafe(campaign.id, eligibility, contractAddress, alternateAddress);
+    },
+    [alternateAddress, eligibilities, requestClaimViaSafe]
+  );
+
+  const handleSubmitClaimViaSafe = useCallback(() => {
+    void submitClaimViaSafe();
+  }, [submitClaimViaSafe]);
+
   const handleCheckAlternateAddress = useCallback((address: `0x${string}`) => {
     setAlternateAddress(address);
   }, []);
@@ -153,7 +200,8 @@ function ClaimFundsContent() {
   const handleResetToConnectedWallet = useCallback(() => {
     setAlternateAddress(null);
     resetDelegatedClaim();
-  }, [resetDelegatedClaim]);
+    resetSafeClaim();
+  }, [resetDelegatedClaim, resetSafeClaim]);
 
   useEffect(() => {
     if (
@@ -163,8 +211,9 @@ function ClaimFundsContent() {
     ) {
       setAlternateAddress(null);
       resetDelegatedClaim();
+      resetSafeClaim();
     }
-  }, [alternateAddress, connectedAddress, resetDelegatedClaim]);
+  }, [alternateAddress, connectedAddress, resetDelegatedClaim, resetSafeClaim]);
 
   if (!claimFundsEnabled) {
     return (
@@ -294,6 +343,12 @@ function ClaimFundsContent() {
                   delegatedActiveCampaignId={delegatedActiveCampaignId}
                   isAnyClaiming={isAnyClaiming}
                   overrideDisplayName={campaignNameMappings?.get(campaign.id)}
+                  isSafeYouOwn={isSafeYouOwn}
+                  isCheckingOwnership={isCheckingOwnership}
+                  onRequestClaimViaSafe={() => handleRequestClaimViaSafe(campaign)}
+                  onSubmitClaimViaSafe={handleSubmitClaimViaSafe}
+                  safeClaimStep={safeClaimStep}
+                  safeActiveCampaignId={safeActiveCampaignId}
                 />
               );
             })}

--- a/app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { isAddress } from "viem";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import type { SupportedChainId } from "@/config/tokens";
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "@/src/components/navigation/Link";
 import { CampaignCard } from "@/src/features/claim-funds/components/CampaignCard";
@@ -25,7 +26,6 @@ import { getChainByName } from "@/src/features/claim-funds/lib/viem-clients";
 import type { ClaimCampaign } from "@/src/features/claim-funds/providers/types";
 import { getTenantConfig } from "@/src/infrastructure/config/tenant-config";
 import { isKnownTenant, type TenantId } from "@/src/infrastructure/types/tenant";
-import type { SupportedChainId } from "@/config/tokens";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 
 const truncateAddress = (address: string) => formatAddressForDisplay(address, 6, 4);
@@ -102,7 +102,7 @@ function ClaimFundsContent() {
   const campaignChainId = getChainByName(campaignNetworkName).id as SupportedChainId;
 
   // Check if alternate address is a Safe the user owns (on the campaign's chain)
-  const { isSafeYouOwn, isCheckingOwnership } = useCheckSafeOwnership(
+  const { canProposeViaSafe, isCheckingOwnership } = useCheckSafeOwnership(
     alternateAddress as `0x${string}` | null,
     campaignChainId,
     isUsingAlternateAddress
@@ -193,9 +193,16 @@ function ClaimFundsContent() {
     void submitClaimViaSafe();
   }, [submitClaimViaSafe]);
 
-  const handleCheckAlternateAddress = useCallback((address: `0x${string}`) => {
-    setAlternateAddress(address);
-  }, []);
+  const handleCheckAlternateAddress = useCallback(
+    (address: `0x${string}`) => {
+      // Clear any in-flight prepare/sign state from the previous wallet so that
+      // pending claims don't leak across address changes.
+      resetDelegatedClaim();
+      resetSafeClaim();
+      setAlternateAddress(address);
+    },
+    [resetDelegatedClaim, resetSafeClaim]
+  );
 
   const handleResetToConnectedWallet = useCallback(() => {
     setAlternateAddress(null);
@@ -343,7 +350,7 @@ function ClaimFundsContent() {
                   delegatedActiveCampaignId={delegatedActiveCampaignId}
                   isAnyClaiming={isAnyClaiming}
                   overrideDisplayName={campaignNameMappings?.get(campaign.id)}
-                  isSafeYouOwn={isSafeYouOwn}
+                  canProposeViaSafe={canProposeViaSafe}
                   isCheckingOwnership={isCheckingOwnership}
                   onRequestClaimViaSafe={() => handleRequestClaimViaSafe(campaign)}
                   onSubmitClaimViaSafe={handleSubmitClaimViaSafe}

--- a/src/features/claim-funds/components/CampaignCard.tsx
+++ b/src/features/claim-funds/components/CampaignCard.tsx
@@ -29,6 +29,12 @@ interface CampaignCardProps {
   delegatedActiveCampaignId?: string | null;
   isAnyClaiming?: boolean;
   overrideDisplayName?: string;
+  isSafeYouOwn?: boolean;
+  isCheckingOwnership?: boolean;
+  onRequestClaimViaSafe?: () => void;
+  onSubmitClaimViaSafe?: () => void;
+  safeClaimStep?: "idle" | "preparing" | "awaiting_signature" | "submitting";
+  safeActiveCampaignId?: string | null;
 }
 
 const truncateAddress = (address: string) => formatAddressForDisplay(address, 6, 4);
@@ -76,6 +82,12 @@ function CampaignCardComponent({
   delegatedActiveCampaignId,
   isAnyClaiming = false,
   overrideDisplayName,
+  isSafeYouOwn = false,
+  isCheckingOwnership = false,
+  onRequestClaimViaSafe,
+  onSubmitClaimViaSafe,
+  safeClaimStep = "idle",
+  safeActiveCampaignId,
 }: CampaignCardProps) {
   const displayName = useMemo(
     () => overrideDisplayName || eligibility?.title || campaign.token.name,
@@ -108,9 +120,52 @@ function CampaignCardComponent({
   const isThisCampaignRequesting =
     delegatedActiveCampaignId === campaign.id && delegatedClaimStep === "awaiting_signature";
   const isThisCampaignSubmitting = hasPendingSignature && delegatedClaimStep === "submitting";
+  const isThisCampaignSafePreparing =
+    safeActiveCampaignId === campaign.id && safeClaimStep === "preparing";
+  const isThisCampaignSafeAwaitingSignature =
+    safeActiveCampaignId === campaign.id && safeClaimStep === "awaiting_signature";
+  const isThisCampaignSafeSubmitting =
+    safeActiveCampaignId === campaign.id && safeClaimStep === "submitting";
+
+  const getSafeClaimButton = () => {
+    if (!canClaim || !isViewingAlternateAddress || !isSafeYouOwn) return null;
+
+    // After prepare succeeds, show the explicit "Sign & Propose" button so the user
+    // can trigger the wallet signature + Safe API submission.
+    if (isThisCampaignSafeAwaitingSignature || isThisCampaignSafeSubmitting) {
+      return (
+        <Button
+          className="w-full font-semibold"
+          onClick={onSubmitClaimViaSafe}
+          disabled={isAnyClaiming && !isThisCampaignSafeAwaitingSignature}
+          aria-label={`Sign and propose Safe transaction for ${displayName}`}
+          aria-busy={isThisCampaignSafeSubmitting}
+        >
+          {isThisCampaignSafeSubmitting ? "Submitting to Safe..." : "Sign & Propose"}
+        </Button>
+      );
+    }
+
+    return (
+      <Button
+        className="w-full font-semibold"
+        onClick={onRequestClaimViaSafe}
+        disabled={isAnyClaiming || isCheckingOwnership}
+        aria-label={`Propose claim to Safe for ${displayName}`}
+        aria-busy={isThisCampaignSafePreparing}
+      >
+        {isCheckingOwnership
+          ? "Checking ownership..."
+          : isThisCampaignSafePreparing
+            ? "Preparing Safe transaction..."
+            : "Propose Claim"}
+      </Button>
+    );
+  };
 
   const getDelegatedClaimButton = () => {
     if (!canClaim || !isViewingAlternateAddress) return null;
+    if (isSafeYouOwn) return null;
 
     if (hasPendingSignature && delegatedClaimStep !== "awaiting_signature") {
       return (
@@ -210,26 +265,56 @@ function CampaignCardComponent({
               {isLockupActive && formattedCliffDate && (
                 <LockupWarning cliffDate={formattedCliffDate} />
               )}
-              <div
-                role="alert"
-                className="mb-2 p-3 rounded-lg border bg-primary/5 border-primary/20"
-              >
-                <p className="text-sm text-primary">
-                  {hasPendingSignature ? (
-                    <>
-                      Signature obtained. Submit claim to send tokens to{" "}
-                      <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
-                    </>
-                  ) : (
-                    <>
-                      Funds belong to{" "}
-                      <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
-                      Authorize to claim on their behalf.
-                    </>
-                  )}
-                </p>
-              </div>
-              {getDelegatedClaimButton()}
+              {isSafeYouOwn ? (
+                <>
+                  <div
+                    role="alert"
+                    className="mb-2 p-3 rounded-lg border bg-blue-50 border-blue-200 dark:bg-blue-950/20 dark:border-blue-800"
+                  >
+                    <p className="text-sm text-blue-700 dark:text-blue-400">
+                      {isThisCampaignSafeAwaitingSignature ? (
+                        <>
+                          Ready to sign. Click <strong>Sign & Propose</strong> to submit this
+                          transaction to the Safe queue at{" "}
+                          <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
+                        </>
+                      ) : (
+                        <>
+                          Safe wallet{" "}
+                          <span title={alternateAddress}>
+                            {truncateAddress(alternateAddress)}
+                          </span>
+                          . Propose claim to Safe. Any signer can execute it.
+                        </>
+                      )}
+                    </p>
+                  </div>
+                  {getSafeClaimButton()}
+                </>
+              ) : (
+                <>
+                  <div
+                    role="alert"
+                    className="mb-2 p-3 rounded-lg border bg-primary/5 border-primary/20"
+                  >
+                    <p className="text-sm text-primary">
+                      {hasPendingSignature ? (
+                        <>
+                          Signature obtained. Submit claim to send tokens to{" "}
+                          <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
+                        </>
+                      ) : (
+                        <>
+                          Funds belong to{" "}
+                          <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
+                          Authorize to claim on their behalf.
+                        </>
+                      )}
+                    </p>
+                  </div>
+                  {getDelegatedClaimButton()}
+                </>
+              )}
             </>
           )}
           {isCampaignCompleted && !isClaimed && (

--- a/src/features/claim-funds/components/CampaignCard.tsx
+++ b/src/features/claim-funds/components/CampaignCard.tsx
@@ -29,7 +29,7 @@ interface CampaignCardProps {
   delegatedActiveCampaignId?: string | null;
   isAnyClaiming?: boolean;
   overrideDisplayName?: string;
-  isSafeYouOwn?: boolean;
+  canProposeViaSafe?: boolean;
   isCheckingOwnership?: boolean;
   onRequestClaimViaSafe?: () => void;
   onSubmitClaimViaSafe?: () => void;
@@ -82,7 +82,7 @@ function CampaignCardComponent({
   delegatedActiveCampaignId,
   isAnyClaiming = false,
   overrideDisplayName,
-  isSafeYouOwn = false,
+  canProposeViaSafe = false,
   isCheckingOwnership = false,
   onRequestClaimViaSafe,
   onSubmitClaimViaSafe,
@@ -128,7 +128,7 @@ function CampaignCardComponent({
     safeActiveCampaignId === campaign.id && safeClaimStep === "submitting";
 
   const getSafeClaimButton = () => {
-    if (!canClaim || !isViewingAlternateAddress || !isSafeYouOwn) return null;
+    if (!canClaim || !isViewingAlternateAddress || !canProposeViaSafe) return null;
 
     // After prepare succeeds, show the explicit "Sign & Propose" button so the user
     // can trigger the wallet signature + Safe API submission.
@@ -165,7 +165,24 @@ function CampaignCardComponent({
 
   const getDelegatedClaimButton = () => {
     if (!canClaim || !isViewingAlternateAddress) return null;
-    if (isSafeYouOwn) return null;
+    if (canProposeViaSafe) return null;
+
+    // While we don't yet know whether the alternate address is a Safe the user
+    // can propose for, render a disabled placeholder. Otherwise an owner could
+    // start the unsupported delegated-signature flow before the ownership check
+    // resolves and the Safe path appears.
+    if (isCheckingOwnership) {
+      return (
+        <Button
+          className="w-full font-semibold"
+          disabled
+          aria-label={`Checking wallet type for ${alternateAddress ? truncateAddress(alternateAddress) : "alternate wallet"}`}
+          aria-busy={true}
+        >
+          Checking wallet type...
+        </Button>
+      );
+    }
 
     if (hasPendingSignature && delegatedClaimStep !== "awaiting_signature") {
       return (
@@ -265,7 +282,15 @@ function CampaignCardComponent({
               {isLockupActive && formattedCliffDate && (
                 <LockupWarning cliffDate={formattedCliffDate} />
               )}
-              {isSafeYouOwn ? (
+              {isCheckingOwnership ? (
+                <div role="alert" className="mb-2 p-3 rounded-lg border bg-muted/50 border-muted">
+                  <p className="text-sm text-muted-foreground">
+                    Checking whether{" "}
+                    <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span> is a
+                    Safe you can propose to...
+                  </p>
+                </div>
+              ) : canProposeViaSafe ? (
                 <>
                   <div
                     role="alert"
@@ -281,10 +306,8 @@ function CampaignCardComponent({
                       ) : (
                         <>
                           Safe wallet{" "}
-                          <span title={alternateAddress}>
-                            {truncateAddress(alternateAddress)}
-                          </span>
-                          . Propose claim to Safe. Any signer can execute it.
+                          <span title={alternateAddress}>{truncateAddress(alternateAddress)}</span>.
+                          Propose claim to Safe. Any signer can execute it.
                         </>
                       )}
                     </p>

--- a/src/features/claim-funds/hooks/use-check-safe-ownership.ts
+++ b/src/features/claim-funds/hooks/use-check-safe-ownership.ts
@@ -3,8 +3,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 import type { SupportedChainId } from "@/config/tokens";
-import { isSafeOwner } from "@/utilities/safe";
+import { canProposeToSafe } from "@/utilities/safe";
 
+/**
+ * Detects whether the connected wallet can propose transactions to the
+ * given Safe — i.e. is an owner OR a delegate. The check runs on the
+ * campaign's chain, not the wallet's currently selected chain.
+ */
 export function useCheckSafeOwnership(
   alternateAddress: `0x${string}` | null,
   chainId: SupportedChainId,
@@ -12,16 +17,16 @@ export function useCheckSafeOwnership(
 ) {
   const { address: userAddress } = useAccount();
 
-  const { data: isSafeYouOwn, isLoading } = useQuery({
-    queryKey: ["safe-ownership", alternateAddress, userAddress, chainId],
+  const { data: canPropose, isLoading } = useQuery({
+    queryKey: ["safe-can-propose", alternateAddress, userAddress, chainId],
     queryFn: async () => {
       if (!alternateAddress || !userAddress) return false;
 
       try {
-        const result = await isSafeOwner(alternateAddress, userAddress, chainId);
-        return result;
-      } catch (error) {
-        // Not a Safe or error checking ownership - return false
+        const result = await canProposeToSafe(alternateAddress, userAddress, chainId);
+        return result.canPropose;
+      } catch {
+        // Not a Safe or error checking permissions - return false
         return false;
       }
     },
@@ -30,7 +35,7 @@ export function useCheckSafeOwnership(
   });
 
   return {
-    isSafeYouOwn: isSafeYouOwn ?? false,
+    canProposeViaSafe: canPropose ?? false,
     isCheckingOwnership: isLoading,
   };
 }

--- a/src/features/claim-funds/hooks/use-check-safe-ownership.ts
+++ b/src/features/claim-funds/hooks/use-check-safe-ownership.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAccount } from "wagmi";
+import type { SupportedChainId } from "@/config/tokens";
+import { isSafeOwner } from "@/utilities/safe";
+
+export function useCheckSafeOwnership(
+  alternateAddress: `0x${string}` | null,
+  chainId: SupportedChainId,
+  enabled: boolean = true
+) {
+  const { address: userAddress } = useAccount();
+
+  const { data: isSafeYouOwn, isLoading } = useQuery({
+    queryKey: ["safe-ownership", alternateAddress, userAddress, chainId],
+    queryFn: async () => {
+      if (!alternateAddress || !userAddress) return false;
+
+      try {
+        const result = await isSafeOwner(alternateAddress, userAddress, chainId);
+        return result;
+      } catch (error) {
+        // Not a Safe or error checking ownership - return false
+        return false;
+      }
+    },
+    enabled: enabled && !!alternateAddress && !!userAddress,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  return {
+    isSafeYouOwn: isSafeYouOwn ?? false,
+    isCheckingOwnership: isLoading,
+  };
+}

--- a/src/features/claim-funds/hooks/use-claim-via-safe.ts
+++ b/src/features/claim-funds/hooks/use-claim-via-safe.ts
@@ -1,0 +1,310 @@
+"use client";
+
+import Safe from "@safe-global/protocol-kit";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import toast from "react-hot-toast";
+import { encodeFunctionData, getAddress, isAddress } from "viem";
+import { useAccount, useChainId, useSwitchChain, useWalletClient } from "wagmi";
+import { NETWORKS, type SupportedChainId } from "@/config/tokens";
+import { formatAddressForDisplay } from "@/utilities/donations/helpers";
+import {
+  canProposeToSafe,
+  createEthereumProvider,
+  getSafeNetworkId,
+  getSafeServiceUrl,
+  isSafeDeployed,
+} from "@/utilities/safe";
+import { sanitizeErrorMessage } from "../lib/error-messages";
+import { CLAIM_CAMPAIGNS_ABI, uuidToBytes16 } from "../lib/hedgey-contract";
+import { getChainByName } from "../lib/viem-clients";
+import type { ClaimEligibility } from "../types";
+
+interface PendingClaimViaASafe {
+  campaignId: string;
+  eligibility: ClaimEligibility;
+  contractAddress: `0x${string}`;
+  claimerAddress: `0x${string}`;
+  claimAmount: bigint;
+}
+
+export interface UseClaimViaASafeReturn {
+  requestClaim: (
+    campaignId: string,
+    eligibility: ClaimEligibility,
+    contractAddress: `0x${string}`,
+    claimerAddress: `0x${string}`
+  ) => void;
+  submitClaim: () => void;
+  step: "idle" | "preparing" | "awaiting_signature" | "submitting";
+  isPending: boolean;
+  isConfirming: boolean;
+  isSuccess: boolean;
+  error: Error | null;
+  safeUrl: string | undefined;
+  reset: () => void;
+  pendingClaim: PendingClaimViaASafe | null;
+  activeCampaignId: string | null;
+}
+
+const truncateAddress = (address: string) => formatAddressForDisplay(address, 6, 4);
+
+interface PrepareClaimVariables {
+  campaignId: string;
+  eligibility: ClaimEligibility;
+  contractAddress: `0x${string}`;
+  claimerAddress: `0x${string}`;
+}
+
+export function useClaimViaASafe(
+  tenantId: string,
+  networkName: string = "optimism"
+): UseClaimViaASafeReturn {
+  const { address: userAddress } = useAccount();
+  const { data: walletClient } = useWalletClient();
+  const connectedChainId = useChainId();
+  const { switchChainAsync } = useSwitchChain();
+  const queryClient = useQueryClient();
+
+  const [pendingClaim, setPendingClaim] = useState<PendingClaimViaASafe | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [safeUrl, setSafeUrl] = useState<string | undefined>(undefined);
+
+  const chain = getChainByName(networkName);
+  const preparedChainId = chain.id as SupportedChainId;
+
+  const prepareMutation = useMutation({
+    mutationFn: async ({
+      campaignId,
+      eligibility,
+      contractAddress,
+      claimerAddress,
+    }: PrepareClaimVariables): Promise<PendingClaimViaASafe> => {
+      if (!userAddress) throw new Error("No user address");
+      if (!walletClient) throw new Error("Wallet not connected");
+
+      // Validate Safe is deployed
+      const isDeployed = await isSafeDeployed(claimerAddress, preparedChainId);
+      if (!isDeployed) {
+        throw new Error("Safe wallet is not deployed on this network");
+      }
+
+      // Verify user can propose to this Safe
+      const { canPropose } = await canProposeToSafe(claimerAddress, userAddress, preparedChainId);
+      if (!canPropose) {
+        throw new Error("You are not an owner or delegate of this Safe");
+      }
+
+      const claimAmount = BigInt(eligibility.amount);
+
+      toast.loading("Preparing Safe transaction...", { id: "safe-claim-prepare" });
+
+      return {
+        campaignId,
+        eligibility,
+        contractAddress,
+        claimerAddress,
+        claimAmount,
+      };
+    },
+    onSuccess: (data) => {
+      setPendingClaim(data);
+      toast.success("Safe transaction ready. Please sign to propose.", {
+        id: "safe-claim-prepare",
+      });
+    },
+    onError: (err) => {
+      const errorMsg = err instanceof Error ? err.message : "Failed to prepare claim";
+      toast.error(errorMsg, { id: "safe-claim-prepare" });
+    },
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: async (): Promise<{
+      safeUrl: string;
+      claimerAddress: `0x${string}`;
+    }> => {
+      if (!pendingClaim) throw new Error("No pending claim to submit");
+      if (!userAddress) throw new Error("No user address");
+      if (!walletClient) throw new Error("Wallet not connected");
+
+      setIsConfirming(true);
+      toast.loading("Proposing claim to Safe...", { id: "safe-claim-submit" });
+
+      try {
+        // Ensure the wallet is on the campaign's chain — wallets reject typed-data
+        // signatures whose domain chainId differs from the active chain.
+        if (connectedChainId !== preparedChainId) {
+          toast.loading(`Switching wallet to ${chain.name}...`, { id: "safe-claim-submit" });
+          await switchChainAsync({ chainId: preparedChainId });
+          toast.loading("Proposing claim to Safe...", { id: "safe-claim-submit" });
+        }
+
+        const campaignIdBytes = uuidToBytes16(pendingClaim.campaignId);
+
+        // The Safe will execute the claim itself (msg.sender = Safe). Since the Safe
+        // address is what's in the merkle tree as the eligible claimer, calling the
+        // standard `claim()` lets the contract verify the proof against msg.sender
+        // directly — no off-chain ECDSA signature needed (which a contract wallet
+        // can't produce anyway).
+        const claimData = encodeFunctionData({
+          abi: CLAIM_CAMPAIGNS_ABI,
+          functionName: "claim",
+          args: [campaignIdBytes, pendingClaim.eligibility.proof, pendingClaim.claimAmount],
+        });
+
+        const claimFee = BigInt(pendingClaim.eligibility.claimFee);
+
+        // Resolve Safe Transaction Service URL using the canonical Safe network ID
+        // (e.g. "optimism" for chain 10) — NOT NETWORKS.shortName which is EIP-3770 ("oeth").
+        const txServiceUrl = getSafeServiceUrl(preparedChainId);
+        const safeNetworkId = getSafeNetworkId(preparedChainId);
+        if (!txServiceUrl || !safeNetworkId) {
+          throw new Error(
+            `Safe Transaction Service is not available for ${chain.name}. ` +
+              `Please use a chain with Safe Transaction Service support.`
+          );
+        }
+
+        // Reuse the shared provider that handles eth_sign / personal_sign properly —
+        // safe.signHash() uses these under the hood.
+        const provider = createEthereumProvider(walletClient, preparedChainId);
+
+        const safe = await Safe.init({
+          provider,
+          signer: userAddress,
+          safeAddress: pendingClaim.claimerAddress,
+        });
+
+        // Create the Safe transaction for the claim. Safe Transaction Service rejects
+        // non-checksummed addresses with HTTP 422, so always pass them through getAddress.
+        const checksummedContractAddress = getAddress(pendingClaim.contractAddress);
+        const safeTx = await safe.createTransaction({
+          transactions: [
+            {
+              to: checksummedContractAddress,
+              value: claimFee.toString(),
+              data: claimData,
+            },
+          ],
+        });
+
+        // Get the transaction hash
+        const txHash = await safe.getTransactionHash(safeTx);
+
+        // Sign the transaction hash with the user's wallet
+        const signature = await safe.signHash(txHash);
+
+        // Propose the transaction via API
+        const proposalUrl = `${txServiceUrl}/api/v1/safes/${pendingClaim.claimerAddress}/multisig-transactions/`;
+
+        const proposalBody = {
+          to: getAddress(safeTx.data.to),
+          value: safeTx.data.value,
+          data: safeTx.data.data,
+          operation: safeTx.data.operation,
+          safeTxGas: String(safeTx.data.safeTxGas),
+          baseGas: String(safeTx.data.baseGas),
+          gasPrice: String(safeTx.data.gasPrice),
+          gasToken: getAddress(safeTx.data.gasToken),
+          refundReceiver: getAddress(safeTx.data.refundReceiver),
+          nonce: safeTx.data.nonce,
+          contractTransactionHash: txHash,
+          sender: getAddress(userAddress),
+          signature: signature.data,
+          origin: "GAP Claim Funds",
+        };
+
+        const response = await fetch(proposalUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(proposalBody),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Failed to propose transaction: ${response.status} ${errorText}`);
+        }
+
+        const networkShortName = NETWORKS[preparedChainId].shortName;
+        return {
+          safeUrl: `https://app.safe.global/transactions/queue?safe=${networkShortName}:${pendingClaim.claimerAddress}`,
+          claimerAddress: pendingClaim.claimerAddress,
+        };
+      } finally {
+        setIsConfirming(false);
+      }
+    },
+    onSuccess: ({ safeUrl, claimerAddress }) => {
+      setPendingClaim(null);
+      setSafeUrl(safeUrl);
+      toast.success(
+        `Claim proposed to Safe ${truncateAddress(claimerAddress)}. Awaiting execution.`,
+        { id: "safe-claim-submit" }
+      );
+      queryClient.invalidateQueries({
+        queryKey: ["claim-eligibility"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["claimed-statuses"],
+      });
+    },
+    onError: (err) => {
+      const { message } = sanitizeErrorMessage(err, "Claim Failed");
+      toast.error(message, { id: "safe-claim-submit" });
+    },
+  });
+
+  const step: UseClaimViaASafeReturn["step"] = prepareMutation.isPending
+    ? "preparing"
+    : submitMutation.isPending
+      ? "submitting"
+      : pendingClaim
+        ? "awaiting_signature"
+        : "idle";
+
+  const requestClaim = useCallback(
+    (
+      campaignId: string,
+      eligibility: ClaimEligibility,
+      contractAddress: `0x${string}`,
+      claimerAddress: `0x${string}`
+    ) => {
+      if (prepareMutation.isPending || submitMutation.isPending) return;
+      if (!isAddress(contractAddress)) return;
+      prepareMutation.mutate({ campaignId, eligibility, contractAddress, claimerAddress });
+    },
+    [prepareMutation, submitMutation]
+  );
+
+  const submitClaim = useCallback(() => {
+    if (!pendingClaim || submitMutation.isPending) return;
+    submitMutation.mutate();
+  }, [pendingClaim, submitMutation]);
+
+  const activeCampaignId = prepareMutation.isPending
+    ? (prepareMutation.variables?.campaignId ?? null)
+    : (pendingClaim?.campaignId ?? null);
+
+  const reset = useCallback(() => {
+    prepareMutation.reset();
+    submitMutation.reset();
+    setIsConfirming(false);
+    setSafeUrl(undefined);
+    setPendingClaim(null);
+  }, [prepareMutation, submitMutation]);
+
+  return {
+    requestClaim,
+    submitClaim,
+    step,
+    isPending: prepareMutation.isPending || (submitMutation.isPending && !isConfirming),
+    isConfirming,
+    isSuccess: submitMutation.isSuccess,
+    error: prepareMutation.error ?? submitMutation.error ?? null,
+    safeUrl,
+    reset,
+    pendingClaim,
+    activeCampaignId,
+  };
+}

--- a/utilities/safe.ts
+++ b/utilities/safe.ts
@@ -46,10 +46,19 @@ function getRpcUrl(chainId: SupportedChainId): string {
  * Gets the Safe Transaction Service URL for a chain
  * Uses the format: https://safe-transaction-{network}.safe.global
  */
-function getSafeServiceUrl(chainId: SupportedChainId): string | null {
+export function getSafeServiceUrl(chainId: SupportedChainId): string | null {
   const networkId = SAFE_NETWORK_IDS[chainId];
   if (!networkId) return null;
   return `https://safe-transaction-${networkId}.safe.global`;
+}
+
+/**
+ * Returns the Safe-compatible network identifier for a chain (e.g. "optimism" for chain 10).
+ * Used in app.safe.global URLs and Safe API endpoints — distinct from EIP-3770 short names
+ * like "oeth" that live in NETWORKS[chainId].shortName.
+ */
+export function getSafeNetworkId(chainId: SupportedChainId): string | null {
+  return SAFE_NETWORK_IDS[chainId] ?? null;
 }
 
 /**
@@ -393,7 +402,7 @@ export async function prepareDisbursementTransaction(
 /**
  * Creates an Ethereum provider compatible with Safe SDK from wagmi wallet client
  */
-function createEthereumProvider(walletClient: any, chainId: SupportedChainId) {
+export function createEthereumProvider(walletClient: any, chainId: SupportedChainId) {
   const rpcUrl = getRpcUrl(chainId);
 
   // Create a provider object that Safe SDK can understand

--- a/utilities/safe.ts
+++ b/utilities/safe.ts
@@ -1,6 +1,6 @@
 import SafeApiKit from "@safe-global/api-kit";
 import Safe from "@safe-global/protocol-kit";
-import { encodeFunctionData, erc20Abi, formatUnits, parseUnits } from "viem";
+import { encodeFunctionData, erc20Abi, formatUnits, parseUnits, type WalletClient } from "viem";
 import { NATIVE_TOKENS, NETWORKS, type SupportedChainId } from "../config/tokens";
 import type { DisbursementRecipient } from "../types/disbursement";
 import { getRPCClient, getRPCUrlByChainId } from "./rpcClient";
@@ -402,7 +402,7 @@ export async function prepareDisbursementTransaction(
 /**
  * Creates an Ethereum provider compatible with Safe SDK from wagmi wallet client
  */
-export function createEthereumProvider(walletClient: any, chainId: SupportedChainId) {
+export function createEthereumProvider(walletClient: WalletClient, chainId: SupportedChainId) {
   const rpcUrl = getRpcUrl(chainId);
 
   // Create a provider object that Safe SDK can understand
@@ -427,12 +427,13 @@ export function createEthereumProvider(walletClient: any, chainId: SupportedChai
           // Parse the typed data if it's a string
           const parsedTypedData = typeof typedData === "string" ? JSON.parse(typedData) : typedData;
 
-          // Verify the address matches the wallet client account
-          if (address?.toLowerCase() !== walletClient.account?.address?.toLowerCase()) {
-            throw new Error(`Address mismatch: ${address} vs ${walletClient.account?.address}`);
+          const account = walletClient.account;
+          if (!account || address?.toLowerCase() !== account.address.toLowerCase()) {
+            throw new Error(`Address mismatch: ${address} vs ${account?.address}`);
           }
 
           return await walletClient.signTypedData({
+            account,
             domain: parsedTypedData.domain,
             types: parsedTypedData.types,
             primaryType: parsedTypedData.primaryType,
@@ -444,12 +445,13 @@ export function createEthereumProvider(walletClient: any, chainId: SupportedChai
           // params[0] is the message, params[1] is the address
           const [message, address] = params;
 
-          // Verify the address matches the wallet client account
-          if (address?.toLowerCase() !== walletClient.account?.address?.toLowerCase()) {
-            throw new Error(`Address mismatch: ${address} vs ${walletClient.account?.address}`);
+          const account = walletClient.account;
+          if (!account || address?.toLowerCase() !== account.address.toLowerCase()) {
+            throw new Error(`Address mismatch: ${address} vs ${account?.address}`);
           }
 
           return await walletClient.signMessage({
+            account,
             message:
               typeof message === "string" && message.startsWith("0x") ? { raw: message } : message,
           });


### PR DESCRIPTION
## Summary

Adds a third path to the Claim Funds flow: when the alternate claimer is a **Safe wallet** that the connected user owns (or delegates for), they can propose the claim transaction to the Safe queue. Any other signer then confirms and executes from the Safe app — no need to coordinate a synchronous quorum to sign an off-chain authorization message.

## Why it's needed

The previous "delegated claim" flow asks the claimer to sign an EIP-712 message that the connected wallet then submits via `claimWithSig`. That works for EOAs but is impossible for Safes:

- `claimWithSig` verifies the signature with `ecrecover(...) == claimer`
- A Safe is a contract — it has no private key and produces no raw ECDSA signature
- The UI surfaced this as `Please select account 0x… in your wallet extension`, which a user can never satisfy for a contract address

## How it works

The Safe itself executes the standard `claim(campaignId, proof, amount)` so `msg.sender = Safe`, which matches the merkle tree entry. No off-chain signature needed; only one signature on the Safe transaction hash to propose.

**Flow**
1. User pastes a Safe address as the alternate claimer
2. `useCheckSafeOwnership` queries the campaign chain (Optimism for Hedgey) and detects ownership
3. Card renders **Propose Claim** (instead of "Authorize Claim")
4. Click → validates Safe is deployed and user is owner/delegate
5. Card flips to **Sign & Propose** → wallet auto-switches to the campaign chain → user signs the Safe tx hash → POST to Safe Transaction Service
6. Other signers confirm in the Safe app; once threshold is met, anyone executes
7. On execution, the Safe forwards `claim()` with `value: claimFee` — bytecode-equivalent to a direct EOA claim

## Changes

- **New** `src/features/claim-funds/hooks/use-claim-via-safe.ts` — prepare/submit mutations, chain switching, Safe SDK integration, proposal POST
- **New** `src/features/claim-funds/hooks/use-check-safe-ownership.ts` — scoped to the campaign's chain (not the wallet's connected chain) so ownership lookup hits the right RPC
- **Modified** `src/features/claim-funds/components/CampaignCard.tsx` — Safe-aware button states (Propose Claim → Sign & Propose → Submitting) and contextual alert text
- **Modified** `app/community/[communityId]/(whitelabel)/claim-funds/ClaimFundsClient.tsx` — wires the new hook and passes the campaign chainId
- **Modified** `utilities/safe.ts` — exports `getSafeServiceUrl`, `getSafeNetworkId`, and `createEthereumProvider` so the claim flow reuses the same Safe API plumbing the disbursement flow already uses

## Implementation notes (gotchas hit during dev)

- `useChainId()` returns the wallet's connected chain, not the Safe's chain — fixed by passing the campaign chainId explicitly
- `NETWORKS[chainId].shortName` is the EIP-3770 prefix (e.g. `oeth`) used in `app.safe.global` URLs, but the Safe Transaction Service API needs the canonical network id (e.g. `optimism`) — added `getSafeNetworkId` for clarity
- Safe Transaction Service rejects non-checksummed addresses with HTTP 422 — every address now goes through `viem.getAddress()` before the proposal POST
- `safe.signHash()` uses `personal_sign`/`eth_sign` under the hood, so the local custom provider was incomplete — now reuses the shared `createEthereumProvider` that handles all the signing methods

## Test plan

- [ ] Visit Claim Funds on a tenant with a Hedgey campaign (e.g. Optimism)
- [ ] Connect with a wallet that is **not** in the merkle tree
- [ ] Paste a Safe address that the wallet **owns** as alternate claimer
- [ ] Verify the card shows "Propose Claim" (and the Safe-specific blue alert)
- [ ] Click → wallet should switch to Optimism if needed → button flips to "Sign & Propose"
- [ ] Click "Sign & Propose" → wallet prompts for Safe tx hash signature → success toast
- [ ] Open the Safe queue at `app.safe.global` — pending tx visible, calling `claim()` with the right campaignId/proof/amount/value
- [ ] Other signer(s) confirm and execute → tokens transfer to the Safe
- [ ] Connect with a wallet that owns the Safe but **isn't** an owner — verify the Safe path is hidden and the regular delegated flow is offered
- [ ] Paste a non-Safe EOA address as alternate claimer — verify the existing delegated claim flow still works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safe wallet support for claiming funds. Users who own a Safe can now verify ownership and claim funds directly through their Safe account.
  * Integrated Safe claim workflow alongside existing delegation methods, allowing users to choose their preferred claiming path with appropriate status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->