### PR TITLE
feat(community): redesign community pages with editorial layout

### DIFF
--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -464,7 +464,8 @@ jobs:
   qa-execution:
     needs: [gate-check, qa-plan, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 2 claude attempts × 15 min hard timeout + setup overhead.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -565,9 +566,17 @@ jobs:
           QA_TEST_OTP: ${{ secrets.QA_TEST_OTP }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SHARD_ID: ${{ matrix.shard }}
+        # The claude CLI occasionally hangs in CI with no output (observed
+        # on PR #1373 public shard: 20 min timeout, zero log lines emitted).
+        # Wrap each attempt in a 15-minute hard timeout via coreutils
+        # `timeout` and retry once. A successful run produces
+        # qa-results-${SHARD_ID}.json — we treat that as the success signal
+        # so transient claude exit codes don't fail the shard when results
+        # were actually written. The outer step timeout (35 min) bounds the
+        # whole retry loop.
         run: |
-          claude --print --dangerously-skip-permissions \
-            "You are a strict senior QA executor. Read and follow the skill at .claude/skills/qa-executor/SKILL.md exactly.
+          set -uo pipefail
+          PROMPT="You are a strict senior QA executor. Read and follow the skill at .claude/skills/qa-executor/SKILL.md exactly.
             PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
             SHARD_ID=$SHARD_ID — execute ONLY scenarios in this shard per the skill's 'Sharded Execution' section.
               - SHARD_ID=public: run P-prefixed scenarios. Skip Privy login entirely.
@@ -577,7 +586,30 @@ jobs:
             Apply the skill's 'Speed Rules' strictly — targeted waits, no networkidle after in-page actions.
             After execution, rename qa-results.json to qa-results-\$SHARD_ID.json (the skill describes this).
             Do NOT post a separate PR comment — results will be aggregated in the pipeline verdict comment."
-        timeout-minutes: 20
+          MAX_ATTEMPTS=2
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "::group::claude attempt $attempt/$MAX_ATTEMPTS (shard=$SHARD_ID, hard timeout 15m)"
+            timeout --signal=KILL 15m claude --print --dangerously-skip-permissions "$PROMPT"
+            rc=$?
+            echo "::endgroup::"
+            echo "claude exit: $rc"
+            if [ -s "qa-results-${SHARD_ID}.json" ]; then
+              echo "qa-results-${SHARD_ID}.json present — treating shard as complete."
+              exit 0
+            fi
+            if [ "$rc" -eq 0 ]; then
+              echo "claude exited 0 but no qa-results-${SHARD_ID}.json was written."
+            elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+              echo "claude hung and was killed by the 15-minute hard timeout."
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Retrying after a 10s cooldown..."
+              sleep 10
+            fi
+          done
+          echo "::error::claude failed to produce qa-results-${SHARD_ID}.json after ${MAX_ATTEMPTS} attempts."
+          exit 1
+        timeout-minutes: 35
 
       - name: Upload QA execution artifacts (shard ${{ matrix.shard }})
         if: always()

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -590,10 +590,21 @@ jobs:
             After execution, rename qa-results.json to qa-results-\$SHARD_ID.json (the skill describes this).
             Do NOT post a separate PR comment — results will be aggregated in the pipeline verdict comment."
           MAX_ATTEMPTS=2
+          # Print version once for diagnostics — silent hangs in CI are
+          # otherwise impossible to attribute to a specific CLI build.
+          echo "claude version:"
+          claude --version || echo "(claude --version failed)"
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             echo "::group::claude attempt $attempt/$MAX_ATTEMPTS (shard=$SHARD_ID, hard timeout 15m)"
             rc=0
-            timeout --signal=KILL 15m claude --print --dangerously-skip-permissions "$PROMPT" || rc=$?
+            # `--debug` writes diagnostics to stderr so we can see WHERE the
+            # CLI hangs on silent failures (auth, MCP init, network, etc.).
+            # `stdbuf -oL -eL` line-buffers stdout/stderr so output streams
+            # in real time instead of being held in glibc's 4KB block buffer
+            # (which makes it look like the process is hung for minutes).
+            timeout --signal=KILL 15m \
+              stdbuf -oL -eL \
+              claude --print --debug --dangerously-skip-permissions "$PROMPT" || rc=$?
             echo "::endgroup::"
             echo "claude exit: $rc"
             if [ -s "qa-results-${SHARD_ID}.json" ]; then

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -575,7 +575,10 @@ jobs:
         # were actually written. The outer step timeout (35 min) bounds the
         # whole retry loop.
         run: |
-          set -uo pipefail
+          # GitHub Actions defaults to `bash -e`. Disable errexit explicitly
+          # so a non-zero claude exit (e.g. 137 from the timeout below) doesn't
+          # short-circuit the retry loop before `rc=$?` runs.
+          set +e -uo pipefail
           PROMPT="You are a strict senior QA executor. Read and follow the skill at .claude/skills/qa-executor/SKILL.md exactly.
             PR #$PR_NUMBER. Target: http://localhost:3000 (always — never a preview/vercel URL).
             SHARD_ID=$SHARD_ID — execute ONLY scenarios in this shard per the skill's 'Sharded Execution' section.
@@ -589,8 +592,8 @@ jobs:
           MAX_ATTEMPTS=2
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             echo "::group::claude attempt $attempt/$MAX_ATTEMPTS (shard=$SHARD_ID, hard timeout 15m)"
-            timeout --signal=KILL 15m claude --print --dangerously-skip-permissions "$PROMPT"
-            rc=$?
+            rc=0
+            timeout --signal=KILL 15m claude --print --dangerously-skip-permissions "$PROMPT" || rc=$?
             echo "::endgroup::"
             echo "claude exit: $rc"
             if [ -s "qa-results-${SHARD_ID}.json" ]; then

--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -314,12 +314,8 @@ describe("SourceRow", () => {
       // the content wrapper carries opacity-70. We collect classNames of
       // every dimmed element to assert the row visually communicates the
       // off state.
-      const dimmed = document.querySelectorAll(
-        `.${tileOpacityClass}, .${contentOpacityClass}`
-      );
-      return Array.from(dimmed).flatMap((el) =>
-        Array.from(el.classList)
-      );
+      const dimmed = document.querySelectorAll(`.${tileOpacityClass}, .${contentOpacityClass}`);
+      return Array.from(dimmed).flatMap((el) => Array.from(el.classList));
     }
 
     it("dims the row when source is paused", () => {
@@ -354,9 +350,7 @@ describe("SourceRow", () => {
   describe("edit action", () => {
     it("renders an Edit button between Pause and Delete", () => {
       renderRow(createSource());
-      expect(
-        screen.getByRole("button", { name: /edit source/i })
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /edit source/i })).toBeInTheDocument();
     });
 
     it("opens the Edit dialog populated with the current source values when clicked", async () => {
@@ -399,9 +393,7 @@ describe("SourceRow", () => {
       expect(screen.getByText(/read-only/i)).toBeInTheDocument();
       // The "Source type" radiogroup from AddSourceDialog must not appear
       // in the edit flow.
-      expect(
-        screen.queryByRole("radiogroup", { name: /source type/i })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("radiogroup", { name: /source type/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/Pages/Admin/ControlCenter/useControlCenterData.test.tsx
+++ b/__tests__/components/Pages/Admin/ControlCenter/useControlCenterData.test.tsx
@@ -20,9 +20,9 @@ vi.mock("@/hooks/useKycStatus", () => ({
 
 const mockUseCommunityPayouts = vi.fn();
 vi.mock("@/src/features/payout-disbursement", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/src/features/payout-disbursement")
-  >("@/src/features/payout-disbursement");
+  const actual = await vi.importActual<typeof import("@/src/features/payout-disbursement")>(
+    "@/src/features/payout-disbursement"
+  );
   return {
     ...actual,
     useCommunityPayouts: (...args: unknown[]) => mockUseCommunityPayouts(...args),
@@ -30,10 +30,7 @@ vi.mock("@/src/features/payout-disbursement", async () => {
   };
 });
 
-function makePayoutPayload(
-  resolvedProjectName: string | undefined,
-  title: string
-) {
+function makePayoutPayload(resolvedProjectName: string | undefined, title: string) {
   return {
     payload: [
       {
@@ -58,7 +55,12 @@ function makePayoutPayload(
           adminPayoutAmount: "1000",
           invoiceRequired: false,
         },
-        disbursements: { totalDisbursed: "0", totalsByToken: [], status: "NOT_STARTED", history: [] },
+        disbursements: {
+          totalDisbursed: "0",
+          totalsByToken: [],
+          status: "NOT_STARTED",
+          history: [],
+        },
         agreement: null,
         milestoneInvoices: [],
         paidMilestoneCount: 0,

--- a/__tests__/components/Pages/Communities/Funding/EditorialProgramCard.test.tsx
+++ b/__tests__/components/Pages/Communities/Funding/EditorialProgramCard.test.tsx
@@ -127,14 +127,10 @@ describe("computeProgramView", () => {
     });
   });
 
-  it("derives a deterministic accent class from programId", () => {
+  it("uses the platform brand accent for all programs", () => {
     const a = computeProgramView({ ...createProgram(), programId: "alpha" });
-    const b = computeProgramView({ ...createProgram(), programId: "alpha" });
-    const c = computeProgramView({ ...createProgram(), programId: "beta-different" });
-    expect(a.accentClass).toBe(b.accentClass);
-    expect(a.accentClass).toMatch(/^bg-/);
-    // Different ids should commonly differ; the accent palette has 7 entries so there's
-    // a collision chance, but "alpha" vs "beta-different" hash to distinct buckets.
-    expect(a.accentClass).not.toBe(c.accentClass);
+    const b = computeProgramView({ ...createProgram(), programId: "beta-different" });
+    expect(a.accentClass).toBe("bg-brand-500");
+    expect(b.accentClass).toBe("bg-brand-500");
   });
 });

--- a/__tests__/components/Pages/Communities/Funding/EditorialProgramCard.test.tsx
+++ b/__tests__/components/Pages/Communities/Funding/EditorialProgramCard.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @file Tests for computeProgramView pure function.
+ */
+
+import { computeProgramView } from "@/components/Pages/Communities/Funding/EditorialProgramCard";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+
+const FIXED_NOW = new Date("2026-05-07T12:00:00.000Z");
+
+const daysFromNow = (days: number): string =>
+  new Date(FIXED_NOW.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+
+const createProgram = (overrides: Partial<FundingProgram["metadata"]> = {}): FundingProgram => ({
+  programId: "program-1",
+  chainID: 1,
+  name: "Test Program",
+  applicationConfig: null,
+  metadata: {
+    title: "Test Program",
+    ...overrides,
+  },
+});
+
+describe("computeProgramView", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("status and urgency", () => {
+    it("returns deadline-passed/closed when endsAt is in the past", () => {
+      const view = computeProgramView(createProgram({ endsAt: daysFromNow(-1) }));
+      expect(view.status).toBe("deadline-passed");
+      expect(view.urgency).toBe("closed");
+      expect(view.daysLeft).toBe(0);
+    });
+
+    it("returns coming-soon/upcoming when startsAt is in the future", () => {
+      const view = computeProgramView(
+        createProgram({ startsAt: daysFromNow(5), endsAt: daysFromNow(30) })
+      );
+      expect(view.status).toBe("coming-soon");
+      expect(view.urgency).toBe("upcoming");
+    });
+
+    it("returns urgent when 3 or fewer days remain", () => {
+      const view = computeProgramView(createProgram({ endsAt: daysFromNow(2) }));
+      expect(view.urgency).toBe("urgent");
+      expect(view.daysLeft).toBe(2);
+    });
+
+    it("returns closing when 4-7 days remain", () => {
+      const view = computeProgramView(createProgram({ endsAt: daysFromNow(6) }));
+      expect(view.urgency).toBe("closing");
+      expect(view.daysLeft).toBe(6);
+    });
+
+    it("returns open when more than 7 days remain", () => {
+      const view = computeProgramView(createProgram({ endsAt: daysFromNow(20) }));
+      expect(view.urgency).toBe("open");
+      expect(view.status).toBe("open");
+    });
+
+    it("returns closed when metadata.status is inactive", () => {
+      const view = computeProgramView(
+        createProgram({ status: "inactive", endsAt: daysFromNow(10) })
+      );
+      expect(view.status).toBe("closed");
+      expect(view.urgency).toBe("closed");
+    });
+
+    it("returns null daysLeft when no endsAt is provided", () => {
+      const view = computeProgramView(createProgram({}));
+      expect(view.daysLeft).toBeNull();
+      expect(view.urgency).toBe("open");
+    });
+  });
+
+  describe("amount parsing", () => {
+    it("parses numeric strings with formatting characters", () => {
+      const view = computeProgramView(
+        createProgram({ programBudget: "$1,250,000", maxGrantSize: "50000 USD" })
+      );
+      expect(view.pool).toBe(1250000);
+      expect(view.maxGrant).toBe(50000);
+    });
+
+    it("returns 0 for missing or invalid amounts", () => {
+      const view = computeProgramView(createProgram({ programBudget: "abc" }));
+      expect(view.pool).toBe(0);
+      expect(view.maxGrant).toBe(0);
+    });
+  });
+
+  describe("applicants and category", () => {
+    it("prefers metrics.totalApplications over metadata.applicantsNumber", () => {
+      const view = computeProgramView({
+        ...createProgram({ applicantsNumber: 5 }),
+        metrics: {
+          totalApplications: 42,
+          approvedApplications: 10,
+        },
+      });
+      expect(view.applicants).toBe(42);
+    });
+
+    it("falls back to metadata.applicantsNumber when metrics is missing", () => {
+      const view = computeProgramView(createProgram({ applicantsNumber: 7 }));
+      expect(view.applicants).toBe(7);
+    });
+
+    it("uses first category, falling back to metadata.type", () => {
+      const withCategories = computeProgramView(
+        createProgram({ categories: ["Infra", "Tooling"] })
+      );
+      expect(withCategories.category).toBe("Infra");
+
+      const withType = computeProgramView(createProgram({ type: "RFP" }));
+      expect(withType.category).toBe("RFP");
+
+      const withNeither = computeProgramView(createProgram({}));
+      expect(withNeither.category).toBeNull();
+    });
+  });
+
+  it("derives a deterministic accent class from programId", () => {
+    const a = computeProgramView({ ...createProgram(), programId: "alpha" });
+    const b = computeProgramView({ ...createProgram(), programId: "alpha" });
+    const c = computeProgramView({ ...createProgram(), programId: "beta-different" });
+    expect(a.accentClass).toBe(b.accentClass);
+    expect(a.accentClass).toMatch(/^bg-/);
+    // Different ids should commonly differ; the accent palette has 7 entries so there's
+    // a collision chance, but "alpha" vs "beta-different" hash to distinct buckets.
+    expect(a.accentClass).not.toBe(c.accentClass);
+  });
+});

--- a/__tests__/components/Pages/Communities/Impact/ImpactOutcomes.test.tsx
+++ b/__tests__/components/Pages/Communities/Impact/ImpactOutcomes.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @file Tests for the ImpactOutcomes section: loading skeleton, empty state, populated rows.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ communityId: "filecoin" })),
+}));
+vi.mock("@/hooks/useCommunityAccent", () => ({
+  useCommunityAccent: vi.fn(() => "#0090FF"),
+}));
+vi.mock("@/hooks/v2/useCommunityDetails", () => ({
+  useCommunityDetails: vi.fn(() => ({
+    community: { details: { slug: "filecoin" } },
+  })),
+}));
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityStats: vi.fn(),
+}));
+
+import { ImpactOutcomes } from "@/components/Pages/Communities/Impact/ImpactOutcomes";
+import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
+
+const mockGetCommunityStats = getCommunityStats as vi.MockedFunction<typeof getCommunityStats>;
+
+const renderWith = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const utils = render(<ImpactOutcomes />, { wrapper });
+  return { queryClient, ...utils };
+};
+
+describe("ImpactOutcomes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a loading skeleton while stats are loading", () => {
+    mockGetCommunityStats.mockReturnValue(new Promise(() => {}));
+    const { container } = renderWith();
+    expect(container.querySelector("section")).toBeInTheDocument();
+    // Skeleton renders 4 placeholder rows
+    expect(container.querySelectorAll(".grid > div")).toHaveLength(4);
+  });
+
+  it("returns null when no items are derivable from stats", async () => {
+    mockGetCommunityStats.mockResolvedValue({
+      totalProjects: 0,
+      totalGrants: 0,
+      totalMilestones: 0,
+      projectUpdatesBreakdown: {
+        projectUpdates: 0,
+        grantUpdates: 0,
+        projectCompletedMilestones: 0,
+        grantCompletedMilestones: 0,
+      },
+    } as unknown as Awaited<ReturnType<typeof getCommunityStats>>);
+
+    const { container } = renderWith();
+    await waitFor(() => {
+      expect(container.querySelector("h3")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders populated outcome rows from stats", async () => {
+    mockGetCommunityStats.mockResolvedValue({
+      totalProjects: 12,
+      totalGrants: 4,
+      totalMilestones: 10,
+      projectUpdatesBreakdown: {
+        projectUpdates: 25,
+        grantUpdates: 8,
+        projectCompletedMilestones: 3,
+        grantCompletedMilestones: 2,
+      },
+    } as unknown as Awaited<ReturnType<typeof getCommunityStats>>);
+
+    renderWith();
+    await screen.findByText("Outcomes delivered");
+    expect(screen.getByText(/grants tracked across the community/)).toBeInTheDocument();
+    expect(screen.getByText(/funded teams shipping work/)).toBeInTheDocument();
+    expect(screen.getByText(/milestones shipped/)).toBeInTheDocument();
+    expect(screen.getByText(/milestone completion rate/)).toBeInTheDocument();
+    expect(screen.getByText(/project updates published by teams/)).toBeInTheDocument();
+    expect(screen.getByText(/grant updates from funded programs/)).toBeInTheDocument();
+    // 5/10 completed milestones = 50%
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useAgentStream.test.ts
+++ b/__tests__/hooks/useAgentStream.test.ts
@@ -676,7 +676,7 @@ describe("useAgentStream", () => {
         role: "assistant",
         content: "",
         timestamp: 1,
-        isStreaming: true
+        isStreaming: true,
       });
 
       const after = useAgentChatStore.getState();

--- a/__tests__/hooks/useChatRating.test.ts
+++ b/__tests__/hooks/useChatRating.test.ts
@@ -107,7 +107,6 @@ describe("useChatRating", () => {
     expect(stored?.rating).toBe(1);
   });
 
-
   it("should_forward_optional_comment_in_request_body", async () => {
     const { result } = renderHook(() => useChatRating("assistant-1", "trace-abc"));
 

--- a/__tests__/hooks/useCommunityAccent.test.tsx
+++ b/__tests__/hooks/useCommunityAccent.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @file Tests for useCommunityAccent override priority chain.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useCommunityAccent } from "@/hooks/useCommunityAccent";
+
+vi.mock("@/hooks/useDominantColor", () => ({
+  useDominantColor: vi.fn(() => null),
+}));
+vi.mock("@/hooks/v2/useCommunityDetails", () => ({
+  useCommunityDetails: vi.fn(),
+}));
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: vi.fn(),
+}));
+vi.mock("@/utilities/communityColors", () => ({
+  communityColors: {
+    "0xabc": "#ABCDEF",
+    filecoin: "#0090FF",
+  },
+}));
+
+import { useDominantColor } from "@/hooks/useDominantColor";
+import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
+import { useWhitelabel } from "@/utilities/whitelabel-context";
+
+const mockUseDominantColor = useDominantColor as vi.MockedFunction<typeof useDominantColor>;
+const mockUseCommunityDetails = useCommunityDetails as vi.MockedFunction<
+  typeof useCommunityDetails
+>;
+const mockUseWhitelabel = useWhitelabel as vi.MockedFunction<typeof useWhitelabel>;
+
+describe("useCommunityAccent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDominantColor.mockReturnValue(null);
+    mockUseWhitelabel.mockReturnValue({ config: null } as ReturnType<typeof useWhitelabel>);
+    mockUseCommunityDetails.mockReturnValue({
+      community: { uid: "0xabc", details: { slug: "filecoin" } },
+    } as ReturnType<typeof useCommunityDetails>);
+  });
+
+  it("prefers whitelabel config logoBackground over all other sources", () => {
+    mockUseWhitelabel.mockReturnValue({
+      config: { theme: { logoBackground: "#FF0000" } },
+    } as ReturnType<typeof useWhitelabel>);
+    mockUseDominantColor.mockReturnValue("#222222");
+    const { result } = renderHook(() => useCommunityAccent("filecoin"));
+    expect(result.current).toBe("#FF0000");
+  });
+
+  it("falls back to communityColors mapping by uid when no theme override", () => {
+    const { result } = renderHook(() => useCommunityAccent("filecoin"));
+    expect(result.current).toBe("#ABCDEF");
+  });
+
+  it("falls back to communityColors mapping by slug when uid not present", () => {
+    mockUseCommunityDetails.mockReturnValue({
+      community: { uid: "0xunknown", details: { slug: "filecoin" } },
+    } as ReturnType<typeof useCommunityDetails>);
+    const { result } = renderHook(() => useCommunityAccent("filecoin"));
+    expect(result.current).toBe("#0090FF");
+  });
+
+  it("falls back to dominant color extracted from logo", () => {
+    mockUseCommunityDetails.mockReturnValue({
+      community: { uid: "0xunknown", details: { slug: "unknown-slug", logoUrl: "x.png" } },
+    } as ReturnType<typeof useCommunityDetails>);
+    mockUseDominantColor.mockReturnValue("#123456");
+    const { result } = renderHook(() => useCommunityAccent("unknown-slug"));
+    expect(result.current).toBe("#123456");
+  });
+
+  it("falls back to a deterministic seeded palette color when nothing else matches", () => {
+    mockUseCommunityDetails.mockReturnValue({
+      community: { uid: "0xseed", details: { slug: "seeded" } },
+    } as ReturnType<typeof useCommunityDetails>);
+    const { result: a } = renderHook(() => useCommunityAccent("seeded"));
+    const { result: b } = renderHook(() => useCommunityAccent("seeded"));
+    expect(a.current).toBe(b.current);
+    expect(a.current).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+
+  it("returns a fallback color even when community details are missing", () => {
+    mockUseCommunityDetails.mockReturnValue({ community: null } as unknown as ReturnType<
+      typeof useCommunityDetails
+    >);
+    const { result } = renderHook(() => useCommunityAccent(undefined));
+    expect(result.current).toMatch(/^#[0-9A-Fa-f]{6}$/);
+  });
+});

--- a/__tests__/services/milestone-report.service.test.ts
+++ b/__tests__/services/milestone-report.service.test.ts
@@ -34,13 +34,7 @@ describe("milestoneReportService.getReport", () => {
   });
 
   it("should_call_v2_endpoint_with_pageLimit_and_sortField_query_params", async () => {
-    await milestoneReportService.getReport(
-      "filecoin",
-      2,
-      50,
-      "totalMilestones",
-      "desc"
-    );
+    await milestoneReportService.getReport("filecoin", 2, 50, "totalMilestones", "desc");
 
     const url = mockedFetch.mock.calls[0][0] as string;
 
@@ -54,14 +48,10 @@ describe("milestoneReportService.getReport", () => {
   });
 
   it("should_normalize_and_pass_program_ids_when_provided", async () => {
-    await milestoneReportService.getReport(
-      "filecoin",
-      1,
-      50,
-      "totalMilestones",
-      "desc",
-      ["100_42161", "200"]
-    );
+    await milestoneReportService.getReport("filecoin", 1, 50, "totalMilestones", "desc", [
+      "100_42161",
+      "200",
+    ]);
 
     const url = mockedFetch.mock.calls[0][0] as string;
 
@@ -81,17 +71,13 @@ describe("milestoneReportService.getReport", () => {
 
     const url = mockedFetch.mock.calls[0][0] as string;
 
-    expect(url).toContain(
-      "reviewerAddress=0x1234567890abcdef1234567890abcdef12345678"
-    );
+    expect(url).toContain("reviewerAddress=0x1234567890abcdef1234567890abcdef12345678");
   });
 
   it("should_throw_when_fetchData_returns_an_error", async () => {
     mockedFetch.mockResolvedValueOnce([null, new Error("network down")]);
 
-    await expect(
-      milestoneReportService.getReport("filecoin", 1, 50)
-    ).rejects.toThrow();
+    await expect(milestoneReportService.getReport("filecoin", 1, 50)).rejects.toThrow();
   });
 
   it("should_return_empty_response_when_fetchData_returns_null_data", async () => {

--- a/__tests__/utilities/portfolio-reports/period.test.ts
+++ b/__tests__/utilities/portfolio-reports/period.test.ts
@@ -20,12 +20,7 @@ const sched = (overrides: Partial<ReportSchedule> = {}): ReportSchedule => ({
 
 describe("portfolio-reports period utilities", () => {
   describe("RUN_DATE_REGEX / isRunDate", () => {
-    it.each([
-      "2026-04-01",
-      "2026-12-31",
-      "2024-02-29",
-      "1999-01-15",
-    ])("accepts %s", (value) => {
+    it.each(["2026-04-01", "2026-12-31", "2024-02-29", "1999-01-15"])("accepts %s", (value) => {
       expect(RUN_DATE_REGEX.test(value)).toBe(true);
       expect(isRunDate(value)).toBe(true);
     });
@@ -66,33 +61,33 @@ describe("portfolio-reports period utilities", () => {
     });
 
     it("renders weekly as 'Every week'", () => {
-      expect(
-        formatScheduleLabel(sched({ intervalUnit: "weeks", intervalCount: 1 }))
-      ).toMatch(/^Every week,/);
+      expect(formatScheduleLabel(sched({ intervalUnit: "weeks", intervalCount: 1 }))).toMatch(
+        /^Every week,/
+      );
     });
 
     it("calls out bi-weekly explicitly", () => {
-      expect(
-        formatScheduleLabel(sched({ intervalUnit: "weeks", intervalCount: 2 }))
-      ).toMatch(/^Every 2 weeks \(bi-weekly\),/);
+      expect(formatScheduleLabel(sched({ intervalUnit: "weeks", intervalCount: 2 }))).toMatch(
+        /^Every 2 weeks \(bi-weekly\),/
+      );
     });
 
     it("calls out quarterly explicitly", () => {
-      expect(
-        formatScheduleLabel(sched({ intervalUnit: "months", intervalCount: 3 }))
-      ).toMatch(/^Every 3 months \(quarterly\),/);
+      expect(formatScheduleLabel(sched({ intervalUnit: "months", intervalCount: 3 }))).toMatch(
+        /^Every 3 months \(quarterly\),/
+      );
     });
 
     it("renders monthly as 'Every month'", () => {
-      expect(
-        formatScheduleLabel(sched({ intervalUnit: "months", intervalCount: 1 }))
-      ).toMatch(/^Every month,/);
+      expect(formatScheduleLabel(sched({ intervalUnit: "months", intervalCount: 1 }))).toMatch(
+        /^Every month,/
+      );
     });
 
     it("renders custom 'every N units' for non-preset values", () => {
-      expect(
-        formatScheduleLabel(sched({ intervalUnit: "days", intervalCount: 10 }))
-      ).toMatch(/^Every 10 days,/);
+      expect(formatScheduleLabel(sched({ intervalUnit: "days", intervalCount: 10 }))).toMatch(
+        /^Every 10 days,/
+      );
     });
 
     it("appends 'runs forever' for ends.never", () => {
@@ -100,9 +95,7 @@ describe("portfolio-reports period utilities", () => {
     });
 
     it("appends 'until DATE' for ends.on_date", () => {
-      const out = formatScheduleLabel(
-        sched({ ends: { kind: "on_date", date: "2026-12-31" } })
-      );
+      const out = formatScheduleLabel(sched({ ends: { kind: "on_date", date: "2026-12-31" } }));
       expect(out).toContain("until");
       expect(out).toContain("Dec 31, 2026");
     });

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { Lock, RefreshCw, Search, X } from "lucide-react";
+import { ChevronDown, Lock, RefreshCw, Search, X } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getProjectTitle } from "@/components/FundingPlatform/helper/getProjectTitle";
 import { useProgramsWithConfig } from "@/features/programs/hooks/use-programs-with-config";
 import { Link } from "@/src/components/navigation/Link";
 import type { Application, ApplicationStatus } from "@/types/whitelabel-entities";
 import fetchData from "@/utilities/fetchData";
-import { formatDate } from "@/utilities/formatDate";
+import { renderRelativeTime } from "@/utilities/formatRelativeTime";
 import { cn } from "@/utilities/tailwind";
 
 interface BrowseApplicationsClientProps {
@@ -20,34 +20,71 @@ const statusOptions: Array<{
   value: ApplicationStatus | "all";
   label: string;
 }> = [
-  { value: "all", label: "All Statuses" },
+  { value: "all", label: "All" },
   { value: "pending", label: "Pending" },
-  { value: "under_review", label: "In Review" },
-  { value: "revision_requested", label: "Revision Requested" },
+  { value: "under_review", label: "Under review" },
+  { value: "revision_requested", label: "Needs info" },
   { value: "approved", label: "Approved" },
   { value: "rejected", label: "Rejected" },
 ];
 
-function getStatusColor(status: ApplicationStatus): string {
-  switch (status) {
-    case "approved":
-      return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400";
-    case "rejected":
-      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400";
-    case "pending":
-    case "resubmitted":
-      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400";
-    case "under_review":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400";
-    case "revision_requested":
-      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400";
-    default:
-      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
-  }
+interface StatusStyle {
+  pill: string;
+  dot: string;
+  label: string;
 }
 
-function formatStatusLabel(status: ApplicationStatus): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+const STATUS_STYLES: Record<ApplicationStatus, StatusStyle> = {
+  under_review: {
+    pill: "bg-blue-50 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300",
+    dot: "bg-blue-500",
+    label: "Under review",
+  },
+  pending: {
+    pill: "bg-blue-50 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300",
+    dot: "bg-blue-500",
+    label: "Pending",
+  },
+  resubmitted: {
+    pill: "bg-violet-50 text-violet-800 dark:bg-violet-950/40 dark:text-violet-300",
+    dot: "bg-violet-500",
+    label: "Resubmitted",
+  },
+  revision_requested: {
+    pill: "bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+    dot: "bg-amber-600",
+    label: "Needs info",
+  },
+  approved: {
+    pill: "bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+    dot: "bg-emerald-500",
+    label: "Approved",
+  },
+  rejected: {
+    pill: "bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300",
+    dot: "bg-red-600",
+    label: "Rejected",
+  },
+  draft: {
+    pill: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+    dot: "bg-zinc-500",
+    label: "Draft",
+  },
+};
+
+function StatusPill({ status }: { status: ApplicationStatus }) {
+  const style = STATUS_STYLES[status] ?? STATUS_STYLES.draft;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-semibold",
+        style.pill
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} aria-hidden />
+      {style.label}
+    </span>
+  );
 }
 
 interface ApplicationsPageData {
@@ -68,39 +105,39 @@ const ApplicationRowMemo = memo(function ApplicationRowInner({
   communityId: string;
 }) {
   const projectName = getProjectTitle(application);
-  const dateValue = formatDate(application.updatedAt || application.createdAt);
+  const submitted = application.createdAt;
   const href = `/community/${communityId}/browse-applications/${application.referenceNumber}`;
 
   return (
-    <tr className="border-b border-border transition-colors hover:bg-muted/50">
-      <td className="px-4 py-3 align-middle">
+    <tr className="border-b border-border transition-colors hover:bg-muted/40 last:border-b-0">
+      <td className="px-4 py-3.5 align-middle">
         <Link
           href={href}
-          className="font-medium text-foreground hover:text-primary hover:underline"
+          className="block font-semibold tracking-[-0.01em] text-foreground hover:underline"
         >
           {projectName}
         </Link>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="font-mono text-[11px]">{application.referenceNumber}</span>
+          {submitted ? (
+            <>
+              <span aria-hidden>·</span>
+              <span>submitted {renderRelativeTime(submitted, "")}</span>
+            </>
+          ) : null}
+        </div>
       </td>
-      <td className="px-4 py-3 align-middle">
+      <td className="px-4 py-3.5 align-middle">
+        <StatusPill status={application.status} />
+      </td>
+      <td className="px-4 py-3.5 align-middle text-right">
         <Link
           href={href}
-          className="font-mono text-sm text-muted-foreground hover:text-foreground hover:underline"
+          className="inline-flex items-center gap-1 text-sm font-medium text-foreground hover:underline"
         >
-          {application.referenceNumber}
+          View
+          <span aria-hidden>→</span>
         </Link>
-      </td>
-      <td className="px-4 py-3 align-middle">
-        <span
-          className={cn(
-            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
-            getStatusColor(application.status)
-          )}
-        >
-          {formatStatusLabel(application.status)}
-        </span>
-      </td>
-      <td className="px-4 py-3 align-middle text-sm text-muted-foreground">
-        <span className="font-medium text-foreground">{dateValue}</span>
       </td>
     </tr>
   );
@@ -113,37 +150,151 @@ function LoadingSkeleton() {
       <table className="w-full">
         <thead className="bg-muted/40">
           <tr className="border-b border-border">
-            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Project Name
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Project
             </th>
-            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Application Id
-            </th>
-            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
               Status
             </th>
-            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"></th>
+            <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground" />
           </tr>
         </thead>
         <tbody>
           {skeletonKeys.map((key) => (
-            <tr key={key} className="border-b border-border">
-              <td className="px-4 py-3">
-                <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
+            <tr key={key} className="border-b border-border last:border-b-0">
+              <td className="px-4 py-3.5">
+                <div className="h-4 w-3/5 animate-pulse rounded bg-muted" />
+                <div className="mt-2 h-3 w-2/5 animate-pulse rounded bg-muted/60" />
               </td>
-              <td className="px-4 py-3">
-                <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+              <td className="px-4 py-3.5">
+                <div className="h-5 w-24 animate-pulse rounded-full bg-muted" />
               </td>
-              <td className="px-4 py-3">
-                <div className="h-5 w-20 animate-pulse rounded-full bg-muted" />
-              </td>
-              <td className="px-4 py-3">
-                <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+              <td className="px-4 py-3.5 text-right">
+                <div className="ml-auto h-4 w-12 animate-pulse rounded bg-muted" />
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+interface StatCardItem {
+  label: string;
+  value: number;
+  accentClass: string;
+}
+
+function StatStrip({ items }: { items: StatCardItem[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+      {items.map((item) => (
+        <div key={item.label} className="rounded-xl border border-border bg-background px-4 py-3.5">
+          <div className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+            {item.label}
+          </div>
+          <div
+            className={cn(
+              "mt-0.5 text-2xl font-semibold tracking-[-0.02em] tabular-nums",
+              item.accentClass
+            )}
+          >
+            {item.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ProgramOption {
+  programId: string;
+  name: string;
+}
+
+function ProgramPillSelector({
+  programs,
+  selectedProgramId,
+  onSelect,
+}: {
+  programs: ProgramOption[];
+  selectedProgramId: string;
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const selected = programs.find((p) => p.programId === selectedProgramId);
+  const label = selected?.name ?? "Choose a program";
+
+  return (
+    <div ref={ref} className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="inline-flex items-center gap-2 rounded-full border border-brand-200/60 bg-brand-50 px-3 py-1.5 text-sm font-medium text-brand-800 transition hover:bg-brand-100 dark:border-brand-700/40 dark:bg-brand-900/30 dark:text-brand-200 dark:hover:bg-brand-900/50"
+      >
+        <span className="max-w-[260px] truncate">{label}</span>
+        <ChevronDown
+          className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")}
+          aria-hidden
+        />
+      </button>
+      {open ? (
+        <div
+          role="listbox"
+          className="absolute left-0 top-[calc(100%+6px)] z-30 max-h-[360px] w-[300px] overflow-y-auto rounded-xl border border-border bg-background p-1.5 shadow-[0_10px_40px_rgba(0,0,0,0.08)]"
+        >
+          <div className="px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+            Program
+          </div>
+          {programs.map((p) => {
+            const isActive = p.programId === selectedProgramId;
+            return (
+              <button
+                key={p.programId}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onClick={() => {
+                  onSelect(p.programId);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left text-sm",
+                  isActive
+                    ? "bg-brand-50 font-semibold text-foreground dark:bg-brand-900/30"
+                    : "text-foreground hover:bg-secondary"
+                )}
+              >
+                <span className="truncate">{p.name}</span>
+              </button>
+            );
+          })}
+          {programs.length === 0 ? (
+            <div className="px-2.5 py-3 text-sm text-muted-foreground">No programs available</div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -154,7 +305,7 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
   const pathname = usePathname();
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  const { programs, isLoading: isProgramsLoading } = useProgramsWithConfig(communityId);
+  const { programs } = useProgramsWithConfig(communityId);
 
   const [selectedProgramId, setSelectedProgramId] = useState<string>(
     () => searchParams.get("programId") || ""
@@ -172,24 +323,16 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
   const [searchInput, setSearchInput] = useState(() => searchParams.get("search") || "");
   const [debouncedSearch, setDebouncedSearch] = useState(searchInput);
 
-  // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchInput), 500);
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // Sync filter state to URL
   useEffect(() => {
     const params = new URLSearchParams();
-    if (selectedProgramId) {
-      params.set("programId", selectedProgramId);
-    }
-    if (statusFilter !== "all") {
-      params.set("status", statusFilter);
-    }
-    if (searchInput) {
-      params.set("search", searchInput);
-    }
+    if (selectedProgramId) params.set("programId", selectedProgramId);
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (searchInput) params.set("search", searchInput);
     const query = params.toString();
     router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
   }, [selectedProgramId, statusFilter, searchInput, pathname, router]);
@@ -197,6 +340,45 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
   const selectedProgram = programs.find((p) => p.programId === selectedProgramId);
   const hasPrivateApplicationsSetting =
     selectedProgram?.applicationConfig?.formSchema?.settings?.privateApplications;
+
+  const programMetrics = selectedProgram?.metrics;
+
+  const statItems: StatCardItem[] | null = useMemo(() => {
+    if (!programMetrics) return null;
+    const total = programMetrics.totalApplications ?? 0;
+    const pending = programMetrics.pendingApplications ?? 0;
+    const review = programMetrics.underReviewApplications ?? 0;
+    const revision = programMetrics.revisionRequestedApplications ?? 0;
+    const approved = programMetrics.approvedApplications ?? 0;
+    return [
+      { label: "Total", value: total, accentClass: "text-foreground" },
+      { label: "Awaiting review", value: pending, accentClass: "text-blue-600 dark:text-blue-400" },
+      { label: "In review", value: review, accentClass: "text-violet-600 dark:text-violet-400" },
+      {
+        label: "Needs info",
+        value: revision,
+        accentClass: "text-amber-600 dark:text-amber-400",
+      },
+      {
+        label: "Approved",
+        value: approved,
+        accentClass: "text-emerald-600 dark:text-emerald-400",
+      },
+    ];
+  }, [programMetrics]);
+
+  const chipCounts: Record<ApplicationStatus | "all", number> = useMemo(() => {
+    return {
+      all: programMetrics?.totalApplications ?? 0,
+      pending: programMetrics?.pendingApplications ?? 0,
+      under_review: programMetrics?.underReviewApplications ?? 0,
+      revision_requested: programMetrics?.revisionRequestedApplications ?? 0,
+      approved: programMetrics?.approvedApplications ?? 0,
+      rejected: programMetrics?.rejectedApplications ?? 0,
+      resubmitted: 0,
+      draft: 0,
+    };
+  }, [programMetrics]);
 
   const { data, isLoading, error, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<ApplicationsPageData>({
@@ -244,7 +426,6 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
 
   const hasActiveFilters = statusFilter !== "all" || searchInput.length > 0;
 
-  // Infinite scroll
   useEffect(() => {
     const currentRef = loadMoreRef.current;
     if (!currentRef || !hasNextPage || isFetchingNextPage) return;
@@ -264,107 +445,116 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
     };
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  const headerSubtitle = selectedProgram
+    ? `${programMetrics?.totalApplications ?? 0} application${
+        (programMetrics?.totalApplications ?? 0) === 1 ? "" : "s"
+      }${selectedProgram.name ? ` · ${selectedProgram.name}` : ""}`
+    : "Choose a program to browse public applications.";
+
   return (
-    <div className="space-y-6" data-testid="applications-list">
-      {/* Filter Bar */}
-      <div className="rounded-xl border border-border p-4 sm:p-5">
-        <div className="flex flex-col gap-4 lg:flex-row">
-          <div className="w-full lg:w-[320px]">
-            <label
-              htmlFor="program-select"
-              className="mb-1 block text-sm font-medium text-foreground"
-            >
-              Funding Program
-            </label>
-            <select
-              id="program-select"
-              value={selectedProgramId}
-              onChange={(e) => setSelectedProgramId(e.target.value)}
-              className="h-12 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-            >
-              <option value="">Choose a program...</option>
-              {programs.map((program) => (
-                <option key={program.programId} value={program.programId}>
-                  {program.name}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="flex-1">
-            <label
-              htmlFor="search-input"
-              className="mb-1 block text-sm font-medium text-foreground"
-            >
-              Search
-            </label>
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <input
-                id="search-input"
-                type="text"
-                placeholder="Search by project name or reference ID..."
-                value={searchInput}
-                disabled={!selectedProgramId}
-                onChange={(e) => setSearchInput(e.target.value)}
-                className="h-12 w-full rounded-lg border border-border bg-background pl-9 pr-8 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-              />
-              {searchInput && (
-                <button
-                  type="button"
-                  aria-label="Clear search"
-                  onClick={() => setSearchInput("")}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className="w-full sm:w-56 lg:w-52">
-            <label
-              htmlFor="status-select"
-              className="mb-1 block text-sm font-medium text-foreground"
-            >
-              Status
-            </label>
-            <select
-              id="status-select"
-              value={statusFilter}
-              disabled={!selectedProgramId}
-              onChange={(e) => setStatusFilter(e.target.value as ApplicationStatus | "all")}
-              className="h-12 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-            >
-              {statusOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
+    <div
+      className="space-y-6 [&>*]:animate-fade-in-up [&>*:nth-child(1)]:[animation-delay:0ms] [&>*:nth-child(2)]:[animation-delay:80ms] [&>*:nth-child(3)]:[animation-delay:160ms] [&>*:nth-child(4)]:[animation-delay:240ms]"
+      data-testid="applications-list"
+    >
+      {/* Header: title + program pill + subtitle */}
+      <header className="relative z-30 flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2.5">
+          <h1 className="text-[26px] md:text-[28px] font-semibold tracking-[-0.02em] text-foreground">
+            Browse applications
+          </h1>
+          {programs.length > 0 ? (
+            <ProgramPillSelector
+              programs={programs.map((p) => ({ programId: p.programId, name: p.name }))}
+              selectedProgramId={selectedProgramId}
+              onSelect={setSelectedProgramId}
+            />
+          ) : null}
         </div>
+        <p className="text-sm text-muted-foreground">{headerSubtitle}</p>
+      </header>
 
-        {selectedProgramId && hasActiveFilters && (
-          <div className="mt-3 flex justify-end">
+      {selectedProgramId && statItems ? <StatStrip items={statItems} /> : null}
+
+      {/* Filters: search + status chips inline */}
+      {selectedProgramId && !hasPrivateApplicationsSetting ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
+            <label htmlFor="application-search" className="sr-only">
+              Search applications
+            </label>
+            <input
+              id="application-search"
+              type="text"
+              placeholder="Search project or reference…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className="h-9 w-64 rounded-lg border border-border bg-background pl-8 pr-8 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+            />
+            {searchInput ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={() => setSearchInput("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+          <div role="tablist" aria-label="Filter by status" className="flex flex-wrap gap-1.5">
+            {statusOptions.map((option) => {
+              const isActive = statusFilter === option.value;
+              const count = chipCounts[option.value];
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setStatusFilter(option.value)}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-[13px] font-medium transition",
+                    isActive
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-border bg-background text-foreground hover:border-foreground/30"
+                  )}
+                >
+                  {option.label}
+                  <span
+                    className={cn(
+                      "text-[11px] tabular-nums",
+                      isActive ? "opacity-70" : "text-muted-foreground"
+                    )}
+                  >
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {hasActiveFilters ? (
             <button
               type="button"
               onClick={handleClearFilters}
-              className="flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="ml-auto inline-flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
             >
-              <X className="h-4 w-4" />
-              Clear Filters
+              <X className="h-3.5 w-3.5" />
+              Clear
             </button>
-          </div>
-        )}
-      </div>
+          ) : null}
+        </div>
+      ) : null}
 
-      {/* Applications Section */}
+      {/* Applications table / empty / error / private */}
       {selectedProgramId ? (
         hasPrivateApplicationsSetting ? (
           <div className="rounded-xl border-2 border-dashed border-border py-12 text-center">
             <Lock className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h3 className="mb-2 text-xl font-semibold text-foreground">Private Applications</h3>
+            <h3 className="mb-2 text-xl font-semibold text-foreground">Private applications</h3>
             <p className="mx-auto max-w-md text-muted-foreground">
               {selectedProgram?.name || "This program"} has configured their applications to be
               private. Application details are only visible to program administrators and
@@ -373,10 +563,15 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
           </div>
         ) : (
           <div>
-            <div className="mb-6">
-              <h2 className="text-2xl font-bold text-foreground">
-                Public Applications {!isLoading && `(${totalCount})`}
+            <div className="mb-4 flex items-baseline justify-between">
+              <h2 className="text-xl font-semibold tracking-[-0.015em] text-foreground">
+                Public applications
               </h2>
+              {!isLoading && totalCount > 0 ? (
+                <span className="text-sm tabular-nums text-muted-foreground">
+                  {totalCount} total
+                </span>
+              ) : null}
             </div>
 
             {isLoading ? (
@@ -389,56 +584,36 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
                 <button
                   type="button"
                   onClick={() => refetch()}
-                  className="flex items-center gap-2 mx-auto rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                  className="mx-auto flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
                 >
                   <RefreshCw className="h-4 w-4" />
                   Try Again
                 </button>
               </div>
-            ) : applications.length === 0 && statusFilter === "all" && !debouncedSearch ? (
+            ) : applications.length === 0 && !hasActiveFilters ? (
               <div className="rounded-xl border-2 border-dashed border-border py-12 text-center">
-                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-                  <span className="text-2xl text-muted-foreground">📄</span>
-                </div>
-                <h3 className="mb-2 text-xl font-semibold text-foreground">
-                  No Applications Found
-                </h3>
+                <h3 className="mb-2 text-xl font-semibold text-foreground">No applications yet</h3>
                 <p className="text-muted-foreground">
                   This program doesn't have any public applications yet.
                 </p>
               </div>
             ) : applications.length === 0 ? (
-              <div className="rounded-xl border-2 border-dashed border-border py-12 text-center">
-                <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-                  <span className="text-2xl text-muted-foreground">🔍</span>
-                </div>
-                <h3 className="mb-2 text-xl font-semibold text-foreground">
-                  No Matching Applications
-                </h3>
-                <p className="text-muted-foreground">
-                  {debouncedSearch && statusFilter !== "all"
-                    ? "No applications match your filters. Try adjusting your search or status."
-                    : debouncedSearch
-                      ? "No applications match your search. Try a different project name or reference ID."
-                      : "No applications match the selected status. Try a different status filter."}
-                </p>
+              <div className="rounded-xl border border-border py-12 text-center text-muted-foreground">
+                No applications match the current filters — try adjusting your search or status.
               </div>
             ) : (
               <div>
-                <div className="overflow-x-auto rounded-xl border border-border">
+                <div className="overflow-hidden rounded-xl border border-border bg-background">
                   <table className="w-full">
                     <thead className="bg-muted/40">
                       <tr className="border-b border-border">
-                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Project Name
+                        <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                          Project
                         </th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Application Id
-                        </th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
                           Status
                         </th>
-                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"></th>
+                        <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground" />
                       </tr>
                     </thead>
                     <tbody>
@@ -453,20 +628,20 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
                   </table>
                 </div>
 
-                {hasNextPage && (
+                {hasNextPage ? (
                   <div ref={loadMoreRef} className="flex justify-center py-8">
                     <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
                   </div>
-                )}
+                ) : null}
               </div>
             )}
           </div>
         )
       ) : (
         <div className="rounded-xl border-2 border-dashed border-border py-10 text-center">
-          <h3 className="mb-2 text-xl font-semibold text-foreground">Choose a Program</h3>
+          <h3 className="mb-2 text-xl font-semibold text-foreground">Choose a program</h3>
           <p className="text-muted-foreground">
-            Choose a funding program to browse public applications.
+            Pick a funding program from the selector above to browse its public applications.
           </p>
         </div>
       )}

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -332,10 +332,10 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
     const params = new URLSearchParams();
     if (selectedProgramId) params.set("programId", selectedProgramId);
     if (statusFilter !== "all") params.set("status", statusFilter);
-    if (searchInput) params.set("search", searchInput);
+    if (debouncedSearch) params.set("search", debouncedSearch);
     const query = params.toString();
     router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
-  }, [selectedProgramId, statusFilter, searchInput, pathname, router]);
+  }, [selectedProgramId, statusFilter, debouncedSearch, pathname, router]);
 
   const selectedProgram = programs.find((p) => p.programId === selectedProgramId);
   const hasPrivateApplicationsSetting =
@@ -505,7 +505,8 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
               </button>
             ) : null}
           </div>
-          <div role="tablist" aria-label="Filter by status" className="flex flex-wrap gap-1.5">
+          <fieldset className="flex flex-wrap gap-1.5 border-0 p-0 m-0">
+            <legend className="sr-only">Filter by status</legend>
             {statusOptions.map((option) => {
               const isActive = statusFilter === option.value;
               const count = chipCounts[option.value];
@@ -513,8 +514,7 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
                 <button
                   key={option.value}
                   type="button"
-                  role="tab"
-                  aria-selected={isActive}
+                  aria-pressed={isActive}
                   onClick={() => setStatusFilter(option.value)}
                   className={cn(
                     "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-[13px] font-medium transition",
@@ -535,7 +535,7 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
                 </button>
               );
             })}
-          </div>
+          </fieldset>
           {hasActiveFilters ? (
             <button
               type="button"

--- a/app/community/[communityId]/(with-header)/browse-applications/page.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/page.tsx
@@ -8,15 +8,7 @@ export default function BrowseApplicationsPage() {
   const communityId = params.communityId;
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="mb-8 text-center">
-        <h1 className="mb-4 text-4xl font-bold text-foreground">Browse Applications</h1>
-        <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
-          View all applications submitted to this community. Track funding requests and review
-          project proposals.
-        </p>
-      </div>
-
+    <div className="flex flex-col pb-20">
       <BrowseApplicationsClient communityId={communityId} />
     </div>
   );

--- a/app/community/[communityId]/(with-header)/financials/loading.tsx
+++ b/app/community/[communityId]/(with-header)/financials/loading.tsx
@@ -1,5 +1,57 @@
-import { LoadingSpinner } from "@/components/Utilities/LoadingSpinner";
+import { Skeleton } from "@/components/Utilities/Skeleton";
+
+const TABLE_COLS = Array.from({ length: 7 }, (_, i) => `c-${i}`);
+const TABLE_ROWS = Array.from({ length: 8 }, (_, i) => `r-${i}`);
+const KPI_KEYS = ["k0", "k1", "k2", "k3"];
 
 export default function Loading() {
-  return <LoadingSpinner />;
+  return (
+    <div className="flex flex-col gap-6 py-6 animate-fade-in-up">
+      {/* Page header skeleton */}
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-3 w-28" />
+        <Skeleton className="h-8 w-72" />
+        <Skeleton className="h-4 w-[420px] max-w-full" />
+      </div>
+
+      {/* KPI grid skeleton */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {KPI_KEYS.map((key) => (
+          <div key={key} className="rounded-2xl border border-border bg-background p-5 md:p-6">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="mt-3 h-8 w-28" />
+            <Skeleton className="mt-2 h-3 w-32" />
+          </div>
+        ))}
+      </div>
+
+      {/* Toolbar skeleton */}
+      <div className="flex flex-row flex-wrap items-center gap-3">
+        <Skeleton className="h-10 w-[260px] flex-1 max-w-[420px]" />
+        <Skeleton className="h-10 w-[140px]" />
+        <Skeleton className="h-10 w-[140px]" />
+        <Skeleton className="h-10 w-[140px]" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-2xl border border-border bg-background">
+        <div className="border-b border-border bg-secondary/40 px-5 py-3">
+          <div className="grid grid-cols-7 gap-4">
+            {TABLE_COLS.map((c) => (
+              <Skeleton key={c} className="h-3 w-16" />
+            ))}
+          </div>
+        </div>
+        <div className="divide-y divide-border">
+          {TABLE_ROWS.map((r) => (
+            <div key={r} className="grid grid-cols-7 gap-4 px-5 py-4">
+              {TABLE_COLS.map((c, i) => (
+                <Skeleton key={`${r}-${c}`} className={i === 0 ? "h-4 w-32" : "h-4 w-20"} />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/community/[communityId]/(with-header)/financials/page.tsx
+++ b/app/community/[communityId]/(with-header)/financials/page.tsx
@@ -89,7 +89,7 @@ export default async function FinancialsPage({ params }: { params: Params }) {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className="flex flex-col gap-5 py-6">
+      <div className="flex flex-col gap-5 py-6 animate-fade-in-up">
         <PublicControlCenter />
       </div>
     </HydrationBoundary>

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -86,7 +86,7 @@ export default function FundingOpportunitiesPage() {
   }, [programs]);
 
   const featured = programs[0];
-  const others = programs;
+  const others = programs.slice(1);
   const activeStatus: ProgramStatus | "all" = filters.status ?? "all";
 
   return (
@@ -211,9 +211,9 @@ function ProgramsContent({
         onSearchChange={onSearchChange}
         onStatusChange={onStatusChange}
       />
-      {programs.length === 0 || others.length === 0 ? (
+      {programs.length === 0 && hasActiveFilters ? (
         <ProgramsFilteredEmpty onClearFilters={onClearFilters} />
-      ) : (
+      ) : others.length > 0 ? (
         <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
           {others.map((program, idx) => (
             <div
@@ -225,7 +225,7 @@ function ProgramsContent({
             </div>
           ))}
         </div>
-      )}
+      ) : null}
     </>
   );
 }

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { AlertCircle, FileText, RefreshCw, Search } from "lucide-react";
-import { useParams } from "next/navigation";
-import { useMemo } from "react";
+import { AlertCircle, RefreshCw, Search } from "lucide-react";
+import Image from "next/image";
+import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo } from "react";
 import {
   computeProgramView,
   EditorialProgramCard,
@@ -23,12 +24,53 @@ const STATUS_TABS: Array<{ key: ProgramStatus | "all"; label: string }> = [
   { key: "ended", label: "Closed" },
 ];
 
+const VALID_STATUSES: ReadonlyArray<ProgramStatus | "all"> = ["all", "active", "upcoming", "ended"];
+
 const SKELETON_KEYS = ["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"];
 
 export default function FundingOpportunitiesPage() {
   const { communityId } = useParams<{ communityId: string }>();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { programs, loading, error, filters, setFilters, refetch } = usePrograms(communityId);
   const accentColor = useCommunityAccent(communityId);
+
+  const urlStatusRaw = searchParams.get("status");
+  const urlStatus: ProgramStatus | "all" | null =
+    urlStatusRaw && (VALID_STATUSES as readonly string[]).includes(urlStatusRaw)
+      ? (urlStatusRaw as ProgramStatus | "all")
+      : null;
+  const urlSearch = searchParams.get("q") ?? "";
+
+  // Seed filter store from URL on mount / when URL changes externally.
+  useEffect(() => {
+    const desiredStatus = urlStatus === "all" || urlStatus === null ? undefined : urlStatus;
+    const desiredSearch = urlSearch || undefined;
+    if (filters.status !== desiredStatus || filters.search !== desiredSearch) {
+      setFilters({ ...filters, status: desiredStatus, search: desiredSearch });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlStatus, urlSearch]);
+
+  const writeUrl = useCallback(
+    (next: { status?: ProgramStatus | "all"; search?: string }) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next.status && next.status !== "all") {
+        params.set("status", next.status);
+      } else {
+        params.delete("status");
+      }
+      if (next.search?.trim()) {
+        params.set("q", next.search.trim());
+      } else {
+        params.delete("q");
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
 
   const stats = useMemo(() => {
     let totalPool = 0;
@@ -109,10 +151,18 @@ export default function FundingOpportunitiesPage() {
         others={others}
         activeStatus={activeStatus}
         searchValue={filters.search ?? ""}
-        onSearchChange={(v) => setFilters({ ...filters, search: v || undefined })}
-        onStatusChange={(key) =>
-          setFilters({ ...filters, status: key === "all" ? undefined : key })
-        }
+        onSearchChange={(v) => {
+          setFilters({ ...filters, search: v || undefined });
+          writeUrl({ status: activeStatus, search: v });
+        }}
+        onStatusChange={(key) => {
+          setFilters({ ...filters, status: key === "all" ? undefined : key });
+          writeUrl({ status: key, search: filters.search });
+        }}
+        onClearFilters={() => {
+          setFilters({ ...filters, status: undefined, search: undefined });
+          writeUrl({ status: "all", search: "" });
+        }}
         onRetry={refetch}
       />
     </div>
@@ -130,6 +180,7 @@ interface ProgramsContentProps {
   searchValue: string;
   onSearchChange: (v: string) => void;
   onStatusChange: (key: ProgramStatus | "all") => void;
+  onClearFilters: () => void;
   onRetry: () => void;
 }
 
@@ -144,6 +195,7 @@ function ProgramsContent({
   searchValue,
   onSearchChange,
   onStatusChange,
+  onClearFilters,
   onRetry,
 }: ProgramsContentProps) {
   if (loading) return <ProgramsSkeleton />;
@@ -161,14 +213,8 @@ function ProgramsContent({
         onSearchChange={onSearchChange}
         onStatusChange={onStatusChange}
       />
-      {programs.length === 0 ? (
-        <div className="rounded-xl border border-border py-12 text-center text-muted-foreground">
-          No programs match the current filters — try adjusting your search or status.
-        </div>
-      ) : others.length === 0 ? (
-        <div className="rounded-xl border border-border py-12 text-center text-muted-foreground">
-          No additional programs match — try adjusting filters.
-        </div>
+      {programs.length === 0 || others.length === 0 ? (
+        <ProgramsFilteredEmpty onClearFilters={onClearFilters} />
       ) : (
         <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
           {others.map((program, idx) => (
@@ -379,13 +425,58 @@ function ProgramsError({ onRetry }: { onRetry: () => void }) {
 
 function ProgramsEmpty() {
   return (
-    <div className="rounded-xl border border-border py-16 text-center">
-      <FileText className="mx-auto mb-2 h-12 w-12 text-muted-foreground" />
-      <h3 className="mb-1 text-lg font-semibold">No programs available</h3>
-      <p className="text-muted-foreground">
-        There are currently no programs in this community. Check back later for new funding
-        opportunities.
-      </p>
+    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
+      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
+        <Image
+          src="/images/comments.png"
+          alt="No funding opportunities yet"
+          width={438}
+          height={185}
+          className="object-cover"
+          loading="lazy"
+        />
+        <div className="flex w-full flex-col items-center justify-center gap-3">
+          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
+            No programs available
+          </p>
+          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
+            There are currently no funding programs in this community. Check back later for new
+            opportunities.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgramsFilteredEmpty({ onClearFilters }: { onClearFilters: () => void }) {
+  return (
+    <div className="flex h-max flex-1 items-center justify-center rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 px-6 py-16">
+      <div className="flex max-w-[438px] flex-col items-center justify-center gap-6">
+        <Image
+          src="/images/comments.png"
+          alt="No matching programs"
+          width={438}
+          height={185}
+          className="object-cover"
+          loading="lazy"
+        />
+        <div className="flex w-full flex-col items-center justify-center gap-3">
+          <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
+            No programs match your filters
+          </p>
+          <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
+            Try a different status or search term to find more funding opportunities.
+          </p>
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="mt-2 inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-zinc-700 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-zinc-200 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/Pages/Communities/Funding/EditorialProgramCard";
 import { FeaturedProgram } from "@/components/Pages/Communities/Funding/FeaturedProgram";
 import { PageHero } from "@/components/Pages/Communities/PageHero";
-import { useCommunityAccent } from "@/hooks/useCommunityAccent";
 import { ProgramCardSkeleton } from "@/src/features/programs/components/ProgramCardSkeleton";
 import { usePrograms } from "@/src/features/programs/hooks/use-programs";
 import type { ProgramStatus } from "@/types/whitelabel-entities";
@@ -34,7 +33,6 @@ export default function FundingOpportunitiesPage() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { programs, loading, error, filters, setFilters, refetch } = usePrograms(communityId);
-  const accentColor = useCommunityAccent(communityId);
 
   const urlStatusRaw = searchParams.get("status");
   const urlStatus: ProgramStatus | "all" | null =
@@ -107,7 +105,7 @@ export default function FundingOpportunitiesPage() {
               <>
                 ${formatCurrency(stats.totalPool)} available
                 <br />
-                <span style={{ color: accentColor }}>
+                <span className="text-brand-500 dark:text-brand-400">
                   across {programs.length} program{programs.length === 1 ? "" : "s"}.
                 </span>
               </>

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -1,36 +1,391 @@
 "use client";
 
+import { AlertCircle, FileText, RefreshCw, Search } from "lucide-react";
 import { useParams } from "next/navigation";
-import { ProgramFilters } from "@/features/programs/components/program-filters";
-import { ProgramList } from "@/features/programs/components/program-list";
-import { usePrograms } from "@/features/programs/hooks/use-programs";
+import { useMemo } from "react";
+import {
+  computeProgramView,
+  EditorialProgramCard,
+} from "@/components/Pages/Communities/Funding/EditorialProgramCard";
+import { FeaturedProgram } from "@/components/Pages/Communities/Funding/FeaturedProgram";
+import { PageHero } from "@/components/Pages/Communities/PageHero";
+import { useCommunityAccent } from "@/hooks/useCommunityAccent";
+import { ProgramCardSkeleton } from "@/src/features/programs/components/ProgramCardSkeleton";
+import { usePrograms } from "@/src/features/programs/hooks/use-programs";
+import type { ProgramStatus } from "@/types/whitelabel-entities";
+import formatCurrency from "@/utilities/formatCurrency";
+import { cn } from "@/utilities/tailwind";
+
+const STATUS_TABS: Array<{ key: ProgramStatus | "all"; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "active", label: "Open" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "ended", label: "Closed" },
+];
+
+const SKELETON_KEYS = ["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"];
 
 export default function FundingOpportunitiesPage() {
   const { communityId } = useParams<{ communityId: string }>();
+  const { programs, loading, error, filters, setFilters, refetch } = usePrograms(communityId);
+  const accentColor = useCommunityAccent(communityId);
 
-  const { programs, loading, error, filters, setFilters, totalCount, refetch } =
-    usePrograms(communityId);
+  const stats = useMemo(() => {
+    let totalPool = 0;
+    let openCount = 0;
+    let closingNow = 0;
+    let applicants = 0;
+    for (const p of programs) {
+      const v = computeProgramView(p);
+      totalPool += v.pool;
+      applicants += v.applicants;
+      if (v.status === "open") openCount += 1;
+      if (v.urgency === "urgent" || v.urgency === "closing") closingNow += 1;
+    }
+    return { totalPool, openCount, closingNow, applicants };
+  }, [programs]);
+
+  const featured = programs[0];
+  const others = programs;
+  const activeStatus: ProgramStatus | "all" = filters.status ?? "all";
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-foreground">Funding Opportunities</h1>
-        <p className="mt-2 text-muted-foreground">
-          Browse available funding programs and apply for grants.
-        </p>
-      </div>
+    <div className="flex flex-col gap-10 pb-20 [&>*]:animate-fade-in-up [&>*:nth-child(1)]:[animation-delay:0ms] [&>*:nth-child(2)]:[animation-delay:80ms] [&>*:nth-child(3)]:[animation-delay:160ms]">
+      {loading ? (
+        <FundingHeroSkeleton />
+      ) : (
+        <PageHero
+          eyebrow={
+            stats.openCount > 0
+              ? `Open for funding · ${stats.openCount} live program${stats.openCount === 1 ? "" : "s"}`
+              : "Funding opportunities"
+          }
+          title={
+            stats.totalPool > 0 ? (
+              <>
+                ${formatCurrency(stats.totalPool)} available
+                <br />
+                <span style={{ color: accentColor }}>
+                  across {programs.length} program{programs.length === 1 ? "" : "s"}.
+                </span>
+              </>
+            ) : (
+              <>Funding opportunities</>
+            )
+          }
+          description="Browse open programs, review their criteria, and apply for grants supporting work in this community."
+          kpis={[
+            {
+              label: "Open programs",
+              value: stats.openCount,
+              sub: "accepting now",
+            },
+            {
+              label: "Closing this week",
+              value: stats.closingNow,
+              sub: "apply before deadline",
+              accent: stats.closingNow > 0 ? "danger" : "default",
+            },
+            {
+              label: "Total pool",
+              value: stats.totalPool > 0 ? `$${formatCurrency(stats.totalPool)}` : "—",
+              sub: "across all rounds",
+            },
+            {
+              label: "Applicants",
+              value: stats.applicants,
+              sub: "this round",
+            },
+          ]}
+        />
+      )}
 
-      <div className="mb-6">
-        <ProgramFilters filters={filters} onChange={setFilters} totalCount={totalCount} />
-      </div>
-
-      <ProgramList
-        programs={programs}
+      <ProgramsContent
         communityId={communityId}
         loading={loading}
         error={error}
+        programs={programs}
+        featured={featured}
+        others={others}
+        activeStatus={activeStatus}
+        searchValue={filters.search ?? ""}
+        onSearchChange={(v) => setFilters({ ...filters, search: v || undefined })}
+        onStatusChange={(key) =>
+          setFilters({ ...filters, status: key === "all" ? undefined : key })
+        }
         onRetry={refetch}
       />
+    </div>
+  );
+}
+
+interface ProgramsContentProps {
+  communityId: string;
+  loading: boolean;
+  error: Error | null;
+  programs: ReturnType<typeof usePrograms>["programs"];
+  featured: ReturnType<typeof usePrograms>["programs"][number] | undefined;
+  others: ReturnType<typeof usePrograms>["programs"];
+  activeStatus: ProgramStatus | "all";
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  onStatusChange: (key: ProgramStatus | "all") => void;
+  onRetry: () => void;
+}
+
+function ProgramsContent({
+  communityId,
+  loading,
+  error,
+  programs,
+  featured,
+  others,
+  activeStatus,
+  searchValue,
+  onSearchChange,
+  onStatusChange,
+  onRetry,
+}: ProgramsContentProps) {
+  if (loading) return <ProgramsSkeleton />;
+  if (error) return <ProgramsError onRetry={onRetry} />;
+
+  const hasActiveFilters = activeStatus !== "all" || searchValue.trim().length > 0;
+  if (programs.length === 0 && !hasActiveFilters) return <ProgramsEmpty />;
+
+  return (
+    <>
+      {featured ? <FeaturedProgram program={featured} communityId={communityId} /> : null}
+      <ProgramsToolbar
+        activeStatus={activeStatus}
+        searchValue={searchValue}
+        onSearchChange={onSearchChange}
+        onStatusChange={onStatusChange}
+      />
+      {programs.length === 0 ? (
+        <div className="rounded-xl border border-border py-12 text-center text-muted-foreground">
+          No programs match the current filters — try adjusting your search or status.
+        </div>
+      ) : others.length === 0 ? (
+        <div className="rounded-xl border border-border py-12 text-center text-muted-foreground">
+          No additional programs match — try adjusting filters.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {others.map((program, idx) => (
+            <div
+              key={program.programId}
+              className="animate-fade-in-up"
+              style={{ animationDelay: `${Math.min(idx, 8) * 60}ms` }}
+            >
+              <EditorialProgramCard program={program} communityId={communityId} />
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+interface ToolbarProps {
+  activeStatus: ProgramStatus | "all";
+  searchValue: string;
+  onSearchChange: (v: string) => void;
+  onStatusChange: (key: ProgramStatus | "all") => void;
+}
+
+function ProgramsToolbar({
+  activeStatus,
+  searchValue,
+  onSearchChange,
+  onStatusChange,
+}: ToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <h2 className="flex-1 text-xl md:text-2xl font-semibold tracking-[-0.02em] text-foreground">
+        All programs
+      </h2>
+
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <label htmlFor="program-search" className="sr-only">
+          Search programs
+        </label>
+        <input
+          id="program-search"
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search programs…"
+          className="h-9 w-56 rounded-lg border border-border bg-background pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500"
+        />
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Filter programs by status"
+        className="flex gap-0.5 rounded-lg bg-secondary p-[3px]"
+      >
+        {STATUS_TABS.map((tab) => {
+          const isActive = activeStatus === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onStatusChange(tab.key)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-[13px] font-medium transition",
+                isActive
+                  ? "bg-white dark:bg-zinc-900 text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.05)]"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FundingHeroSkeleton() {
+  return (
+    <section
+      aria-busy="true"
+      aria-label="Loading funding opportunities"
+      className="relative overflow-hidden mb-10 md:mb-12"
+    >
+      <div
+        aria-hidden
+        className="-z-10 pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-50/60 via-transparent to-transparent dark:from-brand-900/10"
+      />
+      <div className="grid gap-8 md:gap-12 md:grid-cols-[1.3fr_1fr]">
+        <div className="animate-pulse">
+          <div className="mb-3 inline-flex items-center gap-2">
+            <span className="h-1.5 w-1.5 rounded-full bg-brand-500/40" />
+            <div className="h-3 w-44 rounded-md bg-secondary" />
+          </div>
+          <div className="space-y-3">
+            <div className="h-10 md:h-12 lg:h-[52px] w-[80%] rounded-lg bg-secondary" />
+            <div className="h-10 md:h-12 lg:h-[52px] w-[55%] rounded-lg bg-secondary" />
+          </div>
+          <div className="mt-5 space-y-2">
+            <div className="h-4 w-[90%] max-w-prose rounded bg-secondary" />
+            <div className="h-4 w-[60%] max-w-prose rounded bg-secondary" />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border self-end animate-pulse">
+          {SKELETON_KEYS.slice(0, 4).map((key) => (
+            <div key={key} className="bg-background p-4 md:p-5">
+              <div className="h-3 w-20 rounded bg-secondary" />
+              <div className="mt-2 h-7 w-14 rounded bg-secondary" />
+              <div className="mt-1.5 h-3 w-24 rounded bg-secondary" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProgramsToolbarSkeleton() {
+  return (
+    <div className="flex flex-wrap items-center gap-3 animate-pulse" aria-hidden>
+      <div className="h-7 w-40 rounded bg-secondary flex-1" />
+      <div className="h-9 w-56 rounded-lg bg-secondary" />
+      <div className="h-9 w-64 rounded-lg bg-secondary" />
+    </div>
+  );
+}
+
+function FeaturedProgramSkeleton() {
+  return (
+    <div
+      className="relative overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-brand-50/40 via-background to-background p-8 md:p-10 animate-pulse"
+      aria-hidden
+    >
+      <div className="grid gap-8 md:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <div className="h-6 w-20 rounded-full bg-secondary" />
+            <div className="h-6 w-24 rounded-full bg-secondary" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-9 w-3/4 rounded-lg bg-secondary" />
+            <div className="h-9 w-1/2 rounded-lg bg-secondary" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 w-[90%] rounded bg-secondary" />
+            <div className="h-4 w-[70%] rounded bg-secondary" />
+          </div>
+          <div className="h-10 w-36 rounded-full bg-secondary" />
+        </div>
+        <div className="space-y-3 self-center">
+          <div className="flex justify-between border-b border-border pb-3">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+          <div className="flex justify-between border-b border-border pb-3">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+          <div className="flex justify-between">
+            <div className="h-4 w-20 rounded bg-secondary" />
+            <div className="h-5 w-16 rounded bg-secondary" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProgramsSkeleton() {
+  return (
+    <div data-testid="programs-loading" className="flex flex-col gap-6" aria-busy="true">
+      <FeaturedProgramSkeleton />
+      <ProgramsToolbarSkeleton />
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+        {SKELETON_KEYS.map((key) => (
+          <ProgramCardSkeleton key={key} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProgramsError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="rounded-xl border border-border py-12 text-center">
+      <AlertCircle className="mx-auto mb-2 h-12 w-12 text-destructive" />
+      <h3 className="mb-1 text-lg font-semibold">Failed to load programs</h3>
+      <p className="mb-4 text-muted-foreground">
+        Something went wrong while loading programs. Please try again.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mx-auto flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        <RefreshCw className="h-4 w-4" />
+        Try Again
+      </button>
+    </div>
+  );
+}
+
+function ProgramsEmpty() {
+  return (
+    <div className="rounded-xl border border-border py-16 text-center">
+      <FileText className="mx-auto mb-2 h-12 w-12 text-muted-foreground" />
+      <h3 className="mb-1 text-lg font-semibold">No programs available</h3>
+      <p className="text-muted-foreground">
+        There are currently no programs in this community. Check back later for new funding
+        opportunities.
+      </p>
     </div>
   );
 }

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -461,10 +461,10 @@ function ProgramsFilteredEmpty({ onClearFilters }: { onClearFilters: () => void 
         />
         <div className="flex w-full flex-col items-center justify-center gap-3">
           <p className="text-center text-lg font-semibold text-black dark:text-zinc-100">
-            No programs match your filters
+            More opportunities are on the way
           </p>
           <p className="text-center text-base font-normal text-gray-600 dark:text-zinc-400">
-            Try a different status or search term to find more funding opportunities.
+            Try other filters or check back later for new opportunities.
           </p>
           <button
             type="button"

--- a/app/community/[communityId]/(with-header)/impact/page.tsx
+++ b/app/community/[communityId]/(with-header)/impact/page.tsx
@@ -3,7 +3,7 @@ import { CommunityImpactCharts } from "@/components/Pages/Communities/Impact/Imp
 
 export default function ImpactPage() {
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-8 pb-20 animate-fade-in-up">
       <CommunityImpactCharts />
     </div>
   );

--- a/app/community/[communityId]/(with-header)/projects/page.tsx
+++ b/app/community/[communityId]/(with-header)/projects/page.tsx
@@ -35,7 +35,7 @@ export default async function CommunityProjectsPage(props: Props) {
   const defaultSelectedMaturityStage = "all" as MaturityStageOptions;
 
   return (
-    <div className="-my-4 flex flex-col w-full max-w-full py-2">
+    <div className="-my-4 flex flex-col w-full max-w-full py-2 animate-fade-in-up">
       <CommunityGrants
         categoriesOptions={categoriesOptions}
         defaultSelectedCategories={defaultSelectedCategories}

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -291,7 +291,7 @@ export default function CommunityUpdatesPage() {
           </div>
         ) : sortedRawData && sortedRawData.length > 0 ? (
           <>
-            <div className="flex flex-col gap-4 px-2">
+            <div className="flex flex-col gap-4">
               {sortedRawData.map((milestone) => (
                 <CommunityMilestoneCard
                   key={milestone.uid}

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -230,9 +230,12 @@ export default function CommunityUpdatesPage() {
 
           {/* Program filter */}
           <div className="flex flex-col gap-1.5 w-[260px] max-lg:w-full">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+            <label
+              htmlFor="filter-by-programs"
+              className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground"
+            >
               Program
-            </span>
+            </label>
             <SearchWithValueDropdown
               id="filter-by-programs"
               list={programs}
@@ -249,9 +252,12 @@ export default function CommunityUpdatesPage() {
 
           {/* Project filter */}
           <div className="flex flex-col gap-1.5 w-[260px] max-lg:w-full">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+            <label
+              htmlFor="filter-by-projects"
+              className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground"
+            >
               Project
-            </span>
+            </label>
             <SearchWithValueDropdown
               id="filter-by-projects"
               list={projectOptions}

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -200,18 +200,20 @@ export default function CommunityUpdatesPage() {
 
   return (
     <div className="flex flex-col items-center justify-start">
-      <div className="flex flex-col gap-6 max-w-full w-full">
+      <div className="flex flex-col gap-6 max-w-full w-full [&>*]:animate-fade-in-up [&>*:nth-child(1)]:[animation-delay:0ms] [&>*:nth-child(2)]:[animation-delay:80ms] [&>*:nth-child(3)]:[animation-delay:160ms]">
         {/* Filter row */}
-        <div className="px-3 py-4 bg-gray-100 dark:bg-zinc-900 rounded-lg flex flex-row  flex-wrap items-center w-full gap-4 max-lg:flex-col max-lg:gap-4 max-lg:justify-start max-lg:items-start">
-          {/* Left side - Filters */}
-          <div className="flex flex-row items-center gap-4 max-lg:w-full max-lg:flex-col max-lg:items-start">
-            {/* Status filter dropdown */}
+        <div className="flex flex-row flex-wrap items-end gap-5 w-full max-lg:flex-col max-lg:items-stretch">
+          {/* Status */}
+          <div className="flex flex-col gap-1.5 w-[180px] max-lg:w-full">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Status
+            </span>
             <Select
               value={selectedFilter}
               onValueChange={(value) => handleFilterChange(value as FilterOption)}
             >
               <SelectTrigger
-                className="flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue dark:bg-zinc-800 dark:text-zinc-200 dark:border-zinc-600 w-[130px]"
+                className="min-w-40 w-full justify-between flex flex-row cursor-default rounded-md border-0 bg-white dark:bg-zinc-800 dark:text-zinc-100 py-3 px-4 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6 h-auto"
                 aria-label="Filter by status"
               >
                 <SelectValue />
@@ -224,67 +226,61 @@ export default function CommunityUpdatesPage() {
                 ))}
               </SelectContent>
             </Select>
+          </div>
 
-            {/* Program filter */}
-            <div className="flex flex-row gap-2 items-center max-lg:w-full">
-              <Image
-                src="/icons/program.svg"
-                alt="program"
-                width={24}
-                height={24}
-                className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
-              />
-              <p className="text-gray-800 dark:text-zinc-100 text-sm font-semibold leading-normal whitespace-nowrap">
-                Program
-              </p>
-              <SearchWithValueDropdown
-                id="filter-by-programs"
-                list={programs}
-                onSelectFunction={(value: string) => changeSelectedProgramIdQuery(value)}
-                type="Programs"
-                selected={selectedProgram ? [selectedProgram.title] : []}
-                prefixUnselected="All"
-                buttonClassname="w-[200px] max-lg:w-full"
-                isMultiple={false}
-                cleanFunction={() => changeSelectedProgramIdQuery(null)}
-                isLoading={programsLoading}
-              />
-            </div>
+          {/* Program filter */}
+          <div className="flex flex-col gap-1.5 w-[260px] max-lg:w-full">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Program
+            </span>
+            <SearchWithValueDropdown
+              id="filter-by-programs"
+              list={programs}
+              onSelectFunction={(value: string) => changeSelectedProgramIdQuery(value)}
+              type="Programs"
+              selected={selectedProgram ? [selectedProgram.title] : []}
+              prefixUnselected="All"
+              buttonClassname="w-full"
+              isMultiple={false}
+              cleanFunction={() => changeSelectedProgramIdQuery(null)}
+              isLoading={programsLoading}
+            />
+          </div>
 
-            {/* Project filter */}
-            <div className="flex flex-row gap-2 items-center max-lg:w-full">
-              <Image
-                src="/icons/project.png"
-                alt="Project"
-                width={24}
-                height={24}
-                className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
-              />
-              <p className="text-gray-800 dark:text-zinc-100 text-sm font-semibold leading-normal whitespace-nowrap">
-                Project
-              </p>
-              <SearchWithValueDropdown
-                id="filter-by-projects"
-                list={projectOptions}
-                onSelectFunction={(value: string) => changeSelectedProjectIdQuery(value)}
-                type="Projects"
-                selected={selectedProject ? [selectedProject.title] : []}
-                prefixUnselected="All"
-                buttonClassname="w-[200px] max-lg:w-full"
-                isMultiple={false}
-                cleanFunction={() => changeSelectedProjectIdQuery(null)}
-                isLoading={projectsLoading}
-              />
-            </div>
+          {/* Project filter */}
+          <div className="flex flex-col gap-1.5 w-[260px] max-lg:w-full">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Project
+            </span>
+            <SearchWithValueDropdown
+              id="filter-by-projects"
+              list={projectOptions}
+              onSelectFunction={(value: string) => changeSelectedProjectIdQuery(value)}
+              type="Projects"
+              selected={selectedProject ? [selectedProject.title] : []}
+              prefixUnselected="All"
+              buttonClassname="w-full"
+              isMultiple={false}
+              cleanFunction={() => changeSelectedProjectIdQuery(null)}
+              isLoading={projectsLoading}
+            />
           </div>
 
           {/* Right side - Milestone count */}
-          <div className="flex items-center gap-2 ml-auto max-lg:ml-0">
-            <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
-              {isLoading
-                ? "Loading..."
-                : `${data?.pagination?.totalCount || 0} ${pluralize("milestone", data?.pagination?.totalCount || 0)} to update`}
-            </span>
+          <div className="ml-auto flex items-center gap-2 pb-1.5 max-lg:ml-0">
+            {isLoading ? (
+              <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-pulse" />
+                Loading…
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2 rounded-full border border-border bg-secondary/50 px-3 py-1 text-[12.5px] font-medium text-muted-foreground">
+                <span className="text-foreground tabular-nums font-semibold">
+                  {data?.pagination?.totalCount || 0}
+                </span>
+                {pluralize("milestone", data?.pagination?.totalCount || 0)} to update
+              </span>
+            )}
           </div>
         </div>
 

--- a/components/AgentChat/MessageRating.tsx
+++ b/components/AgentChat/MessageRating.tsx
@@ -28,9 +28,7 @@ const COMMENT_MAX_LENGTH = 1000;
  */
 export function MessageRatingButtons({ messageId, traceId }: MessageRatingProps) {
   const { rating, submit } = useChatRating(messageId, traceId);
-  const setCommentBoxOpen = useAgentChatStore(
-    (s) => s.setRatingCommentBoxOpenForMessageId
-  );
+  const setCommentBoxOpen = useAgentChatStore((s) => s.setRatingCommentBoxOpenForMessageId);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleThumbsUp = useCallback(async () => {
@@ -63,9 +61,7 @@ export function MessageRatingButtons({ messageId, traceId }: MessageRatingProps)
         disabled={isSubmitting}
         aria-label="Rate this response helpful"
         aria-pressed={rating === 1}
-        className={
-          rating === 1 ? "text-brand-blue" : "text-muted-foreground hover:text-foreground"
-        }
+        className={rating === 1 ? "text-brand-blue" : "text-muted-foreground hover:text-foreground"}
       >
         <ThumbsUpIcon className="size-3" />
       </Button>
@@ -97,9 +93,7 @@ export function MessageRatingCommentBox({ messageId, traceId }: MessageRatingPro
   const isOpenForThisMessage = useAgentChatStore(
     (s) => s.ratingCommentBoxOpenForMessageId === messageId
   );
-  const setCommentBoxOpen = useAgentChatStore(
-    (s) => s.setRatingCommentBoxOpenForMessageId
-  );
+  const setCommentBoxOpen = useAgentChatStore((s) => s.setRatingCommentBoxOpenForMessageId);
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -124,9 +118,7 @@ export function MessageRatingCommentBox({ messageId, traceId }: MessageRatingPro
         setCommentBoxOpen(null);
         setComment("");
       } else {
-        setSubmitError(
-          "Couldn't send your feedback. Check your connection and try again."
-        );
+        setSubmitError("Couldn't send your feedback. Check your connection and try again.");
       }
     } finally {
       setIsSubmitting(false);
@@ -158,12 +150,7 @@ export function MessageRatingCommentBox({ messageId, traceId }: MessageRatingPro
         </span>
       </div>
       <div className="flex items-center gap-2">
-        <Button
-          variant="default"
-          size="sm"
-          onClick={handleSubmitComment}
-          disabled={isSubmitting}
-        >
+        <Button variant="default" size="sm" onClick={handleSubmitComment} disabled={isSubmitting}>
           {isSubmitting ? "Sending…" : "Submit feedback"}
         </Button>
         <Button variant="ghost" size="sm" onClick={handleCancel} disabled={isSubmitting}>

--- a/components/AgentChat/MessageRating.tsx
+++ b/components/AgentChat/MessageRating.tsx
@@ -5,6 +5,7 @@ import { type ChangeEvent, useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useChatRating } from "@/hooks/useChatRating";
 import { useAgentChatStore } from "@/store/agentChat";
+import { cn } from "@/utilities/tailwind";
 
 interface MessageRatingProps {
   messageId: string;
@@ -61,7 +62,10 @@ export function MessageRatingButtons({ messageId, traceId }: MessageRatingProps)
         disabled={isSubmitting}
         aria-label="Rate this response helpful"
         aria-pressed={rating === 1}
-        className={rating === 1 ? "text-brand-blue" : "text-muted-foreground hover:text-foreground"}
+        className={cn(
+          "text-muted-foreground hover:text-foreground",
+          rating === 1 && "text-brand-blue"
+        )}
       >
         <ThumbsUpIcon className="size-3" />
       </Button>
@@ -72,9 +76,10 @@ export function MessageRatingButtons({ messageId, traceId }: MessageRatingProps)
         disabled={isSubmitting}
         aria-label="Rate this response unhelpful"
         aria-pressed={rating === -1}
-        className={
-          rating === -1 ? "text-destructive" : "text-muted-foreground hover:text-foreground"
-        }
+        className={cn(
+          "text-muted-foreground hover:text-foreground",
+          rating === -1 && "text-destructive"
+        )}
       >
         <ThumbsDownIcon className="size-3" />
       </Button>

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRightIcon } from "lucide-react";
+import { ChevronLeftIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
@@ -205,16 +205,15 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
       ) : null}
       <nav
         aria-label="Breadcrumb"
-        className="relative flex items-center gap-1.5 text-[13px] text-gray-500 dark:text-zinc-400 animate-fade-in-up"
+        className="relative flex items-center text-[13px] animate-fade-in-up"
       >
         <Link
           href={PAGES.COMMUNITIES}
-          className="hover:text-gray-900 dark:hover:text-white transition-colors"
+          className="inline-flex items-center gap-1 font-medium text-gray-500 hover:text-gray-900 dark:text-zinc-400 dark:hover:text-white transition-colors"
         >
-          Communities
+          <ChevronLeftIcon size={14} aria-hidden />
+          View all communities
         </Link>
-        <ChevronRightIcon size={12} className="text-gray-400 dark:text-zinc-600" />
-        <span className="font-medium text-gray-900 dark:text-white">{name}</span>
       </nav>
       <div className="relative flex flex-row gap-5 flex-wrap max-lg:flex-col items-center max-lg:items-stretch w-full">
         <div className="flex h-max shrink-0 flex-row items-center justify-start gap-[18px] min-w-0 max-lg:w-full">
@@ -263,7 +262,7 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
           />
         </div>
         <div
-          className="flex shrink-0 items-center gap-2 max-lg:w-full max-lg:justify-center animate-fade-in-up"
+          className="flex items-center gap-2 max-lg:w-full max-lg:justify-center lg:basis-full lg:justify-end xl:basis-auto xl:shrink-0 animate-fade-in-up"
           style={{ animationDelay: "240ms" }}
         >
           <button

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -116,15 +116,24 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
   }, []);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isEditable =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target?.isContentEditable === true ||
+        Boolean(target?.closest('[role="textbox"]'));
+      if (isEditable) return;
+
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (mod && (e.key === "k" || e.key === "K")) {
         e.preventDefault();
         openKarmaAssistant();
       }
     };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isMac, openKarmaAssistant]);
   const { isWhitelabel, config } = useWhitelabel();
   const uid = (community as Community)?.uid?.toLowerCase() || "";
@@ -141,7 +150,12 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
   const name = community?.details?.name ?? "";
   const description = community?.details?.description ?? "";
 
-  const { data: communityStats, isLoading: isStatsLoading } = useQuery({
+  const {
+    data: communityStats,
+    isLoading: isStatsLoading,
+    isError: isStatsError,
+    refetch: refetchStats,
+  } = useQuery({
     queryKey: ["community-stats", communityId],
     queryFn: () => getCommunityStats(communityId),
     enabled: !!communityId,
@@ -259,6 +273,10 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
             totalMilestones={communityStats?.totalMilestones}
             updatesBreakdown={updatesBreakdownNode}
             isLoading={isStatsLoading}
+            isError={isStatsError}
+            onRetry={() => {
+              void refetchStats();
+            }}
           />
         </div>
         <div

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -1,11 +1,29 @@
 "use client";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AwardIcon,
+  CalendarIcon,
+  CheckCircle2Icon,
+  ChevronRightIcon,
+  RadioIcon,
+  SparklesIcon,
+  UsersIcon,
+} from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { CommunityPageNavigator } from "@/components/Pages/Communities/CommunityPageNavigator";
-import { CommunityImpactStatCards } from "@/components/Pages/Communities/Impact/StatCards";
+import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
+import { BorderBeam } from "@/components/ui/border-beam";
+import { useDominantColor } from "@/hooks/useDominantColor";
 import { layoutTheme } from "@/src/helper/theme";
+import { useAgentChatStore } from "@/store/agentChat";
 import type { Community } from "@/types/v2/community";
 import { communityColors } from "@/utilities/communityColors";
+import formatCurrency from "@/utilities/formatCurrency";
+import { PAGES } from "@/utilities/pages";
+import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
 import { cn } from "@/utilities/tailwind";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 
@@ -40,48 +58,331 @@ const AdminCommunityHeader = ({ community }: { community: Community }) => {
   );
 };
 
+const ACCENT_PALETTE = [
+  "#0090FF",
+  "#2ED1A8",
+  "#7C3AED",
+  "#F59E0B",
+  "#EF4444",
+  "#06B6D4",
+  "#EC4899",
+  "#10B981",
+  "#6366F1",
+  "#F97316",
+];
+
+function pickAccent(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return ACCENT_PALETTE[hash % ACCENT_PALETTE.length];
+}
+
+function hexToRgba(hex: string, alpha: number): string | null {
+  const m = hex.trim().match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!m) return null;
+  let h = m[1];
+  if (h.length === 3)
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+type MetaRowStats = {
+  totalGrants?: number;
+  projectUpdates?: number;
+  completedMilestones?: number;
+  totalMilestones?: number;
+  updatesBreakdown?: React.ReactNode;
+};
+
+const MetaRow = ({
+  sinceYear,
+  projectsCount,
+  stats,
+}: {
+  sinceYear: number | null;
+  projectsCount: number | undefined;
+  stats?: MetaRowStats;
+}) => {
+  const hasStats = !!stats && (stats.totalGrants || stats.projectUpdates || stats.totalMilestones);
+  if (!sinceYear && !projectsCount && !hasStats) return null;
+  return (
+    <div className="flex gap-x-4 gap-y-1 mt-2.5 text-[12.5px] text-gray-500 dark:text-zinc-400 flex-wrap items-center">
+      {sinceYear ? (
+        <span className="inline-flex items-center gap-1.5">
+          <CalendarIcon size={13} /> Since {sinceYear}
+        </span>
+      ) : null}
+      {projectsCount ? (
+        <span className="inline-flex items-center gap-1.5">
+          <UsersIcon size={13} /> {formatCurrency(projectsCount)} projects
+        </span>
+      ) : null}
+      {stats?.totalGrants ? (
+        <span className="inline-flex items-center gap-1.5">
+          <AwardIcon size={13} /> {formatCurrency(stats.totalGrants)} grants
+        </span>
+      ) : null}
+      {stats?.projectUpdates ? (
+        stats.updatesBreakdown ? (
+          <InfoTooltip
+            content={stats.updatesBreakdown}
+            side="top"
+            align="start"
+            contentClassName="max-w-sm"
+            triggerAsChild
+          >
+            <span className="inline-flex items-center gap-1.5 cursor-help underline decoration-dotted decoration-gray-300 dark:decoration-zinc-600 underline-offset-2">
+              <RadioIcon size={13} /> {formatCurrency(stats.projectUpdates)} updates
+            </span>
+          </InfoTooltip>
+        ) : (
+          <span className="inline-flex items-center gap-1.5">
+            <RadioIcon size={13} /> {formatCurrency(stats.projectUpdates)} updates
+          </span>
+        )
+      ) : null}
+      {stats?.totalMilestones
+        ? (() => {
+            const completed = stats.completedMilestones ?? 0;
+            const pct = Math.min(100, (completed / stats.totalMilestones) * 100);
+            return (
+              <span className="inline-flex items-center gap-1.5 max-sm:flex max-sm:flex-col max-sm:items-start max-sm:gap-1 max-sm:w-full">
+                <span className="inline-flex items-center gap-1.5">
+                  <CheckCircle2Icon size={13} /> {completed}/{stats.totalMilestones} milestones
+                </span>
+                <span className="inline-flex items-center gap-1.5 max-sm:w-full">
+                  <span
+                    className="inline-block w-16 h-1 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-800 align-middle max-sm:flex-1"
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${pct.toFixed(0)}% of milestones completed`}
+                  >
+                    <span
+                      className="block h-full bg-emerald-500 dark:bg-emerald-400 transition-all"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </span>
+                  <span className="text-[11px] tabular-nums text-gray-400 dark:text-zinc-500">
+                    {pct.toFixed(0)}%
+                  </span>
+                </span>
+              </span>
+            );
+          })()
+        : null}
+    </div>
+  );
+};
+
 const NormalCommunityHeader = ({ community }: { community: Community }) => {
-  const _pathname = usePathname();
-  const _params = useParams();
+  const params = useParams();
+  const communityId = (params?.communityId as string) || community?.details?.slug || "";
+  const [isMac, setIsMac] = useState(false);
+  const setChatOpen = useAgentChatStore((s) => s.setOpen);
+  const setAgentContext = useAgentChatStore((s) => s.setAgentContext);
+  const communityName = community?.details?.name || "";
+
+  const openKarmaAssistant = useCallback(() => {
+    if (communityId) {
+      setAgentContext({ communityId });
+    }
+    setChatOpen(true);
+    // Wait for the chat shell + input to mount before focusing.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const editor = document.querySelector<HTMLElement>(
+          '[role="textbox"][aria-label="Chat message"]'
+        );
+        editor?.focus();
+      });
+    });
+  }, [communityId, setAgentContext, setChatOpen]);
+
+  useEffect(() => {
+    if (typeof navigator !== "undefined") {
+      setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent));
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = isMac ? e.metaKey : e.ctrlKey;
+      if (mod && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        openKarmaAssistant();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isMac, openKarmaAssistant]);
   const { isWhitelabel, config } = useWhitelabel();
+  const uid = (community as Community)?.uid?.toLowerCase() || "";
+  const slug = community?.details?.slug?.toLowerCase() || "";
+  const logoUrl = community?.details?.logoUrl;
+  const dominantColor = useDominantColor(logoUrl);
   const logoBg =
     config?.theme?.logoBackground ??
-    communityColors[(community as Community)?.uid?.toLowerCase() || "black"] ??
-    "#000000";
+    communityColors[uid] ??
+    communityColors[slug] ??
+    dominantColor ??
+    pickAccent(uid || slug || community?.details?.name || "community");
+
+  const name = community?.details?.name ?? "";
+  const description = community?.details?.description ?? "";
+
+  const { data: communityStats } = useQuery({
+    queryKey: ["community-stats", communityId],
+    queryFn: () => getCommunityStats(communityId),
+    enabled: !!communityId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const sinceYear = community?.createdAt ? new Date(community.createdAt).getFullYear() : null;
+  const projectsCount = communityStats?.totalProjects;
+  const breakdown = communityStats?.projectUpdatesBreakdown;
+  const completedMilestones = breakdown
+    ? breakdown.projectCompletedMilestones + breakdown.grantCompletedMilestones
+    : 0;
+  const updatesBreakdownNode = breakdown ? (
+    <div className="flex flex-col gap-1.5 p-1">
+      <div className="font-semibold text-xs mb-1 border-b border-gray-200 dark:border-zinc-700 pb-1">
+        Project Updates Breakdown
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Project Milestones</span>
+        <span className="font-medium">{breakdown.projectMilestones}</span>
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Project Milestone Completions</span>
+        <span className="font-medium">{breakdown.projectCompletedMilestones}</span>
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Project Updates</span>
+        <span className="font-medium">{breakdown.projectUpdates}</span>
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Grant Milestones</span>
+        <span className="font-medium">{breakdown.grantMilestones}</span>
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Grant Milestone Completions</span>
+        <span className="font-medium">{breakdown.grantCompletedMilestones}</span>
+      </div>
+      <div className="flex justify-between gap-3 text-xs">
+        <span className="text-gray-600 dark:text-gray-400">Grant Updates</span>
+        <span className="font-medium">{breakdown.grantUpdates}</span>
+      </div>
+    </div>
+  ) : null;
+
+  const accentPrimary = hexToRgba(logoBg, 0.1) ?? "rgba(0,144,255,0.07)";
+  const accentSecondary = hexToRgba(logoBg, 0.06) ?? "rgba(46,209,168,0.07)";
+  const ambientGradient = `radial-gradient(1200px 280px at 10% -20%, ${accentPrimary}, transparent 60%), radial-gradient(800px 220px at 95% 0%, ${accentSecondary}, transparent 60%)`;
 
   return (
     <div
       className={cn(
         layoutTheme.padding,
-        isWhitelabel
-          ? "py-0 flex flex-col gap-4 justify-between items-start pt-6 border-b border-gray-200 dark:border-gray-800"
-          : "py-0 flex flex-col gap-4 justify-between items-start mt-4 border-b border-gray-200 dark:border-gray-800"
+        "relative py-0 flex flex-col gap-7 justify-between items-start border-b border-gray-200 dark:border-zinc-800 bg-white dark:bg-black",
+        isWhitelabel ? "pt-7" : "pt-7"
       )}
     >
-      <div className="flex flex-row gap-4 flex-wrap max-lg:flex-col justify-between items-center w-full">
-        <div className="flex h-max flex-1 flex-row items-center justify-start gap-3 ">
-          <div className="p-3 rounded-xl" style={{ backgroundColor: logoBg }}>
-            <div className="flex justify-center border border-white rounded-full p-2">
+      {!isWhitelabel ? (
+        <div
+          className="pointer-events-none absolute inset-0 dark:opacity-40"
+          style={{ background: ambientGradient }}
+        />
+      ) : null}
+      <nav
+        aria-label="Breadcrumb"
+        className="relative flex items-center gap-1.5 text-[13px] text-gray-500 dark:text-zinc-400 animate-fade-in-up"
+      >
+        <Link
+          href={PAGES.COMMUNITIES}
+          className="hover:text-gray-900 dark:hover:text-white transition-colors"
+        >
+          Communities
+        </Link>
+        <ChevronRightIcon size={12} className="text-gray-400 dark:text-zinc-600" />
+        <span className="font-medium text-gray-900 dark:text-white">{name}</span>
+      </nav>
+      <div className="relative flex flex-row gap-6 flex-wrap max-lg:flex-col justify-between items-end w-full">
+        <div className="flex h-max flex-1 flex-row items-center justify-start gap-[18px] min-w-0">
+          <div
+            className="flex items-center justify-center rounded-[18px] shrink-0 shadow-[0_10px_30px_-10px_rgba(0,144,255,0.5),inset_0_1px_0_rgba(255,255,255,0.2)] max-lg:w-14 max-lg:h-14 animate-scale-in"
+            style={{ backgroundColor: logoBg, width: 72, height: 72, animationDelay: "60ms" }}
+          >
+            <div className="flex items-center justify-center rounded-full bg-white border-2 border-white/90 overflow-hidden w-[54px] h-[54px] max-lg:w-10 max-lg:h-10">
               <Image
-                alt={(community as Community)?.details?.name || "Community"}
-                src={(community as Community)?.details?.logoUrl || "/placeholder.png"}
-                width={56}
-                height={56}
-                className={
-                  "h-14 w-14 min-w-14 min-h-14 rounded-full max-lg:h-8 max-lg:w-8 max-lg:min-h-8 max-lg:min-w-8"
-                }
+                alt={name || "Community"}
+                src={community?.details?.logoUrl || "/placeholder.png"}
+                width={48}
+                height={48}
+                className="h-9 w-9 object-cover max-lg:h-7 max-lg:w-7"
               />
             </div>
           </div>
-          <div className="flex flex-col gap-0">
-            <p className="text-3xl font-body font-semibold text-black dark:text-white max-2xl:text-2xl max-lg:text-xl">
-              {community ? (community as Community)?.details?.name : ""}
-            </p>
+          <div
+            className="flex flex-col min-w-0 animate-fade-in-up"
+            style={{ animationDelay: "120ms" }}
+          >
+            <div className="flex items-center gap-2.5 flex-wrap mb-1">
+              <h1 className="text-[34px] max-2xl:text-3xl max-lg:text-2xl font-body font-semibold tracking-[-0.02em] leading-none text-black dark:text-white m-0">
+                {name}
+              </h1>
+            </div>
+            {description ? (
+              <p className="text-sm leading-[1.5] text-gray-600 dark:text-zinc-400 font-medium line-clamp-1 max-w-[620px] m-0">
+                {description}
+              </p>
+            ) : null}
+            <MetaRow
+              sinceYear={sinceYear}
+              projectsCount={projectsCount}
+              stats={{
+                totalGrants: communityStats?.totalGrants,
+                projectUpdates: communityStats?.projectUpdates,
+                completedMilestones,
+                totalMilestones: communityStats?.totalMilestones,
+                updatesBreakdown: updatesBreakdownNode,
+              }}
+            />
           </div>
         </div>
-        <CommunityImpactStatCards />
+        <div
+          className="flex items-center gap-2 max-lg:w-full max-lg:justify-center animate-fade-in-up"
+          style={{ animationDelay: "200ms" }}
+        >
+          <button
+            type="button"
+            onClick={openKarmaAssistant}
+            aria-label={`Ask Assistant about ${communityName || "this community"}`}
+            className="group relative overflow-hidden inline-flex items-center gap-2 pl-3 pr-3.5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-full text-[13px] font-medium text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)] transition-all"
+          >
+            <span className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-full bg-gradient-to-br from-brand-500 to-[#22c9a0] text-white">
+              <SparklesIcon size={12} />
+            </span>
+            Ask Assistant
+            <kbd className="ml-0.5 px-1.5 py-px font-mono text-[10.5px] bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded text-gray-500 dark:text-zinc-400">
+              {isMac ? "⌘" : "Ctrl"} K
+            </kbd>
+            <BorderBeam size={60} duration={5} colorFrom="#2ed1a8" colorTo="#0090FF" />
+          </button>
+        </div>
       </div>
-      <CommunityPageNavigator />
+      <div className="relative w-full animate-fade-in-up" style={{ animationDelay: "280ms" }}>
+        <CommunityPageNavigator />
+      </div>
     </div>
   );
 };

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -1,27 +1,18 @@
 "use client";
 import { useQuery } from "@tanstack/react-query";
-import {
-  AwardIcon,
-  CalendarIcon,
-  CheckCircle2Icon,
-  ChevronRightIcon,
-  RadioIcon,
-  SparklesIcon,
-  UsersIcon,
-} from "lucide-react";
+import { ChevronRightIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { HeaderStatsCards } from "@/components/Community/HeaderStatsCards";
 import { CommunityPageNavigator } from "@/components/Pages/Communities/CommunityPageNavigator";
-import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { BorderBeam } from "@/components/ui/border-beam";
 import { useDominantColor } from "@/hooks/useDominantColor";
 import { layoutTheme } from "@/src/helper/theme";
 import { useAgentChatStore } from "@/store/agentChat";
 import type { Community } from "@/types/v2/community";
 import { communityColors } from "@/utilities/communityColors";
-import formatCurrency from "@/utilities/formatCurrency";
 import { PAGES } from "@/utilities/pages";
 import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
 import { cn } from "@/utilities/tailwind";
@@ -94,96 +85,6 @@ function hexToRgba(hex: string, alpha: number): string | null {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-type MetaRowStats = {
-  totalGrants?: number;
-  projectUpdates?: number;
-  completedMilestones?: number;
-  totalMilestones?: number;
-  updatesBreakdown?: React.ReactNode;
-};
-
-const MetaRow = ({
-  sinceYear,
-  projectsCount,
-  stats,
-}: {
-  sinceYear: number | null;
-  projectsCount: number | undefined;
-  stats?: MetaRowStats;
-}) => {
-  const hasStats = !!stats && (stats.totalGrants || stats.projectUpdates || stats.totalMilestones);
-  if (!sinceYear && !projectsCount && !hasStats) return null;
-  return (
-    <div className="flex gap-x-4 gap-y-1 mt-2.5 text-[12.5px] text-gray-500 dark:text-zinc-400 flex-wrap items-center">
-      {sinceYear ? (
-        <span className="inline-flex items-center gap-1.5">
-          <CalendarIcon size={13} /> Since {sinceYear}
-        </span>
-      ) : null}
-      {projectsCount ? (
-        <span className="inline-flex items-center gap-1.5">
-          <UsersIcon size={13} /> {formatCurrency(projectsCount)} projects
-        </span>
-      ) : null}
-      {stats?.totalGrants ? (
-        <span className="inline-flex items-center gap-1.5">
-          <AwardIcon size={13} /> {formatCurrency(stats.totalGrants)} grants
-        </span>
-      ) : null}
-      {stats?.projectUpdates ? (
-        stats.updatesBreakdown ? (
-          <InfoTooltip
-            content={stats.updatesBreakdown}
-            side="top"
-            align="start"
-            contentClassName="max-w-sm"
-            triggerAsChild
-          >
-            <span className="inline-flex items-center gap-1.5 cursor-help underline decoration-dotted decoration-gray-300 dark:decoration-zinc-600 underline-offset-2">
-              <RadioIcon size={13} /> {formatCurrency(stats.projectUpdates)} updates
-            </span>
-          </InfoTooltip>
-        ) : (
-          <span className="inline-flex items-center gap-1.5">
-            <RadioIcon size={13} /> {formatCurrency(stats.projectUpdates)} updates
-          </span>
-        )
-      ) : null}
-      {stats?.totalMilestones
-        ? (() => {
-            const completed = stats.completedMilestones ?? 0;
-            const pct = Math.min(100, (completed / stats.totalMilestones) * 100);
-            return (
-              <span className="inline-flex items-center gap-1.5 max-sm:flex max-sm:flex-col max-sm:items-start max-sm:gap-1 max-sm:w-full">
-                <span className="inline-flex items-center gap-1.5">
-                  <CheckCircle2Icon size={13} /> {completed}/{stats.totalMilestones} milestones
-                </span>
-                <span className="inline-flex items-center gap-1.5 max-sm:w-full">
-                  <span
-                    className="inline-block w-16 h-1 rounded-full overflow-hidden bg-gray-200 dark:bg-zinc-800 align-middle max-sm:flex-1"
-                    role="progressbar"
-                    aria-valuenow={pct}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-label={`${pct.toFixed(0)}% of milestones completed`}
-                  >
-                    <span
-                      className="block h-full bg-emerald-500 dark:bg-emerald-400 transition-all"
-                      style={{ width: `${pct}%` }}
-                    />
-                  </span>
-                  <span className="text-[11px] tabular-nums text-gray-400 dark:text-zinc-500">
-                    {pct.toFixed(0)}%
-                  </span>
-                </span>
-              </span>
-            );
-          })()
-        : null}
-    </div>
-  );
-};
-
 const NormalCommunityHeader = ({ community }: { community: Community }) => {
   const params = useParams();
   const communityId = (params?.communityId as string) || community?.details?.slug || "";
@@ -240,14 +141,13 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
   const name = community?.details?.name ?? "";
   const description = community?.details?.description ?? "";
 
-  const { data: communityStats } = useQuery({
+  const { data: communityStats, isLoading: isStatsLoading } = useQuery({
     queryKey: ["community-stats", communityId],
     queryFn: () => getCommunityStats(communityId),
     enabled: !!communityId,
     staleTime: 5 * 60 * 1000,
   });
 
-  const sinceYear = community?.createdAt ? new Date(community.createdAt).getFullYear() : null;
   const projectsCount = communityStats?.totalProjects;
   const breakdown = communityStats?.projectUpdatesBreakdown;
   const completedMilestones = breakdown
@@ -346,17 +246,6 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
                 {description}
               </p>
             ) : null}
-            <MetaRow
-              sinceYear={sinceYear}
-              projectsCount={projectsCount}
-              stats={{
-                totalGrants: communityStats?.totalGrants,
-                projectUpdates: communityStats?.projectUpdates,
-                completedMilestones,
-                totalMilestones: communityStats?.totalMilestones,
-                updatesBreakdown: updatesBreakdownNode,
-              }}
-            />
           </div>
         </div>
         <div
@@ -366,13 +255,19 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
           <button
             type="button"
             onClick={openKarmaAssistant}
-            aria-label={`Ask Assistant about ${communityName || "this community"}`}
-            className="group relative overflow-hidden inline-flex items-center gap-2 pl-3 pr-3.5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-full text-[13px] font-medium text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)] transition-all"
+            aria-label={`Ask Karma about ${communityName || "this community"}`}
+            className="group relative overflow-hidden inline-flex items-center gap-2 pl-2.5 pr-3.5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-full text-[13px] font-medium text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)] transition-all"
           >
-            <span className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-full bg-gradient-to-br from-brand-500 to-[#22c9a0] text-white">
-              <SparklesIcon size={12} />
-            </span>
-            Ask Assistant
+            <Image
+              src="/logo/logo-dark.png"
+              width={20}
+              height={20}
+              alt=""
+              aria-hidden
+              quality={75}
+              className="rounded-full"
+            />
+            Ask Karma
             <kbd className="ml-0.5 px-1.5 py-px font-mono text-[10.5px] bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded text-gray-500 dark:text-zinc-400">
               {isMac ? "⌘" : "Ctrl"} K
             </kbd>
@@ -380,7 +275,18 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
           </button>
         </div>
       </div>
-      <div className="relative w-full animate-fade-in-up" style={{ animationDelay: "280ms" }}>
+      <div className="w-full animate-fade-in-up" style={{ animationDelay: "240ms" }}>
+        <HeaderStatsCards
+          projectsCount={projectsCount}
+          totalGrants={communityStats?.totalGrants}
+          projectUpdates={communityStats?.projectUpdates}
+          completedMilestones={completedMilestones}
+          totalMilestones={communityStats?.totalMilestones}
+          updatesBreakdown={updatesBreakdownNode}
+          isLoading={isStatsLoading}
+        />
+      </div>
+      <div className="relative w-full animate-fade-in-up" style={{ animationDelay: "320ms" }}>
         <CommunityPageNavigator />
       </div>
     </div>

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -216,8 +216,8 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
         <ChevronRightIcon size={12} className="text-gray-400 dark:text-zinc-600" />
         <span className="font-medium text-gray-900 dark:text-white">{name}</span>
       </nav>
-      <div className="relative flex flex-row gap-6 flex-wrap max-lg:flex-col justify-between items-end w-full">
-        <div className="flex h-max flex-1 flex-row items-center justify-start gap-[18px] min-w-0">
+      <div className="relative flex flex-row gap-5 flex-wrap max-lg:flex-col items-center max-lg:items-stretch w-full">
+        <div className="flex h-max shrink-0 flex-row items-center justify-start gap-[18px] min-w-0 max-lg:w-full">
           <div
             className="flex items-center justify-center rounded-[18px] shrink-0 shadow-[0_10px_30px_-10px_rgba(0,144,255,0.5),inset_0_1px_0_rgba(255,255,255,0.2)] max-lg:w-14 max-lg:h-14 animate-scale-in"
             style={{ backgroundColor: logoBg, width: 72, height: 72, animationDelay: "60ms" }}
@@ -249,8 +249,22 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
           </div>
         </div>
         <div
-          className="flex items-center gap-2 max-lg:w-full max-lg:justify-center animate-fade-in-up"
-          style={{ animationDelay: "200ms" }}
+          className="flex-1 min-w-0 animate-fade-in-up max-lg:w-full max-lg:flex-none"
+          style={{ animationDelay: "180ms" }}
+        >
+          <HeaderStatsCards
+            projectsCount={projectsCount}
+            totalGrants={communityStats?.totalGrants}
+            projectUpdates={communityStats?.projectUpdates}
+            completedMilestones={completedMilestones}
+            totalMilestones={communityStats?.totalMilestones}
+            updatesBreakdown={updatesBreakdownNode}
+            isLoading={isStatsLoading}
+          />
+        </div>
+        <div
+          className="flex shrink-0 items-center gap-2 max-lg:w-full max-lg:justify-center animate-fade-in-up"
+          style={{ animationDelay: "240ms" }}
         >
           <button
             type="button"
@@ -274,17 +288,6 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
             <BorderBeam size={60} duration={5} colorFrom="#2ed1a8" colorTo="#0090FF" />
           </button>
         </div>
-      </div>
-      <div className="w-full animate-fade-in-up" style={{ animationDelay: "240ms" }}>
-        <HeaderStatsCards
-          projectsCount={projectsCount}
-          totalGrants={communityStats?.totalGrants}
-          projectUpdates={communityStats?.projectUpdates}
-          completedMilestones={completedMilestones}
-          totalMilestones={communityStats?.totalMilestones}
-          updatesBreakdown={updatesBreakdownNode}
-          isLoading={isStatsLoading}
-        />
       </div>
       <div className="relative w-full animate-fade-in-up" style={{ animationDelay: "320ms" }}>
         <CommunityPageNavigator />

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { CheckIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
+import { Skeleton } from "@/components/Utilities/Skeleton";
+import formatCurrency from "@/utilities/formatCurrency";
+import { cn } from "@/utilities/tailwind";
+
+interface StatCardProps {
+  label: string;
+  value: ReactNode;
+  accentClass: string;
+  isLoading?: boolean;
+  tooltip?: ReactNode;
+  trailing?: ReactNode;
+  className?: string;
+}
+
+const StatCard = ({
+  label,
+  value,
+  accentClass,
+  isLoading,
+  tooltip,
+  trailing,
+  className,
+}: StatCardProps) => (
+  <div
+    className={cn(
+      "group relative flex flex-col gap-2 rounded-2xl border border-gray-200/80 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80",
+      className
+    )}
+  >
+    <span
+      aria-hidden
+      className={cn("absolute left-0 top-3 bottom-3 w-[3px] rounded-r-full", accentClass)}
+    />
+    <div className="flex items-baseline justify-between gap-2 pl-1.5">
+      {isLoading ? (
+        <Skeleton className="h-7 w-16" />
+      ) : (
+        <span className="text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white">
+          {value}
+        </span>
+      )}
+      {trailing}
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <span className="text-[12.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+        {label}
+      </span>
+      {tooltip ? (
+        <InfoTooltip content={tooltip} side="top" align="start" contentClassName="max-w-sm" />
+      ) : null}
+    </div>
+  </div>
+);
+
+interface MilestoneStatCardProps {
+  completed: number;
+  total: number;
+  isLoading?: boolean;
+}
+
+const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardProps) => {
+  const safeCompleted = Math.max(0, Math.min(completed, total));
+  const pct = total > 0 ? (safeCompleted / total) * 100 : 0;
+  const isComplete = total > 0 && safeCompleted === total;
+
+  return (
+    <div className="group relative flex flex-col gap-2 rounded-2xl border border-gray-200/80 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80 sm:col-span-2 lg:col-span-1">
+      <span
+        aria-hidden
+        className="absolute left-0 top-3 bottom-3 w-[3px] rounded-r-full bg-emerald-500"
+      />
+      <div className="flex items-baseline justify-between gap-2 pl-1.5">
+        {isLoading ? (
+          <Skeleton className="h-7 w-24" />
+        ) : (
+          <span className="text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+            {completed} <span className="text-gray-400 dark:text-zinc-500">/</span> {total}
+          </span>
+        )}
+        {isComplete && !isLoading ? (
+          <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+            <CheckIcon size={12} aria-hidden />
+          </span>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-1 pl-1.5">
+        <span className="text-[12.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+          Milestones completed
+        </span>
+      </div>
+      <div className="mt-0.5 flex items-center gap-2 pl-1.5">
+        <div
+          className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-800"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${pct.toFixed(0)}% of milestones completed`}
+        >
+          <span
+            className="block h-full bg-emerald-500 transition-all dark:bg-emerald-400"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="text-[11px] font-semibold tabular-nums text-gray-500 dark:text-zinc-400">
+          {pct.toFixed(0)}%
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export interface HeaderStatsCardsProps {
+  projectsCount?: number;
+  totalGrants?: number;
+  projectUpdates?: number;
+  completedMilestones: number;
+  totalMilestones?: number;
+  updatesBreakdown?: ReactNode;
+  isLoading?: boolean;
+}
+
+export const HeaderStatsCards = ({
+  projectsCount,
+  totalGrants,
+  projectUpdates,
+  completedMilestones,
+  totalMilestones,
+  updatesBreakdown,
+  isLoading,
+}: HeaderStatsCardsProps) => {
+  const hasData =
+    !!projectsCount || !!totalGrants || !!projectUpdates || !!totalMilestones || isLoading;
+  if (!hasData) return null;
+
+  return (
+    <div className="grid w-full grid-cols-2 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        label="Total projects"
+        value={projectsCount ? formatCurrency(projectsCount) : "—"}
+        accentClass="bg-sky-500"
+        isLoading={isLoading}
+      />
+      <StatCard
+        label="Total grants"
+        value={totalGrants ? formatCurrency(totalGrants) : "—"}
+        accentClass="bg-teal-500"
+        isLoading={isLoading}
+      />
+      <StatCard
+        label="Project updates"
+        value={projectUpdates ? formatCurrency(projectUpdates) : "—"}
+        accentClass="bg-amber-500"
+        isLoading={isLoading}
+        tooltip={updatesBreakdown}
+      />
+      <MilestoneStatCard
+        completed={completedMilestones}
+        total={totalMilestones ?? 0}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+};

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -119,7 +119,13 @@ export const HeaderStatsCards = ({
 }: HeaderStatsCardsProps) => {
   const hasData =
     !!projectsCount || !!totalGrants || !!projectUpdates || !!totalMilestones || isLoading;
-  if (!hasData) return null;
+  if (!hasData) {
+    return (
+      <output className="flex w-full items-center justify-end text-[12px] text-muted-foreground">
+        No stats yet — check back once projects start posting updates.
+      </output>
+    );
+  }
 
   return (
     <div className="flex w-full flex-wrap justify-end gap-2.5 lg:flex-nowrap [&>*]:flex-1 [&>*]:basis-[140px] lg:[&>*]:max-w-[180px]">

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -106,6 +106,8 @@ export interface HeaderStatsCardsProps {
   totalMilestones?: number;
   updatesBreakdown?: ReactNode;
   isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
 }
 
 export const HeaderStatsCards = ({
@@ -116,7 +118,26 @@ export const HeaderStatsCards = ({
   totalMilestones,
   updatesBreakdown,
   isLoading,
+  isError,
+  onRetry,
 }: HeaderStatsCardsProps) => {
+  if (isError) {
+    return (
+      <output className="flex w-full flex-wrap items-center justify-end gap-2 text-[12px] text-muted-foreground">
+        <span>Couldn&apos;t load community stats.</span>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-7 items-center rounded-md border border-border bg-background px-2.5 text-[12px] font-semibold text-foreground transition hover:bg-secondary"
+          >
+            Retry
+          </button>
+        ) : null}
+      </output>
+    );
+  }
+
   const hasData =
     !!projectsCount || !!totalGrants || !!projectUpdates || !!totalMilestones || isLoading;
   if (!hasData) {

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -1,61 +1,106 @@
 "use client";
 
-import { CheckIcon } from "lucide-react";
+import { AwardIcon, CheckIcon, FileTextIcon, FolderIcon, TargetIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import formatCurrency from "@/utilities/formatCurrency";
 import { cn } from "@/utilities/tailwind";
 
+type Tone = "sky" | "teal" | "amber" | "emerald";
+
+const TONE_STYLES: Record<
+  Tone,
+  { iconWrap: string; iconColor: string; ring: string; bg: string; bar: string; barTrack: string }
+> = {
+  sky: {
+    iconWrap: "bg-sky-50 dark:bg-sky-500/10",
+    iconColor: "text-sky-600 dark:text-sky-300",
+    ring: "ring-sky-100/80 dark:ring-sky-500/15",
+    bg: "from-sky-50/60 dark:from-sky-500/5",
+    bar: "bg-sky-500",
+    barTrack: "bg-sky-100 dark:bg-sky-500/15",
+  },
+  teal: {
+    iconWrap: "bg-teal-50 dark:bg-teal-500/10",
+    iconColor: "text-teal-600 dark:text-teal-300",
+    ring: "ring-teal-100/80 dark:ring-teal-500/15",
+    bg: "from-teal-50/60 dark:from-teal-500/5",
+    bar: "bg-teal-500",
+    barTrack: "bg-teal-100 dark:bg-teal-500/15",
+  },
+  amber: {
+    iconWrap: "bg-amber-50 dark:bg-amber-500/10",
+    iconColor: "text-amber-600 dark:text-amber-300",
+    ring: "ring-amber-100/80 dark:ring-amber-500/15",
+    bg: "from-amber-50/60 dark:from-amber-500/5",
+    bar: "bg-amber-500",
+    barTrack: "bg-amber-100 dark:bg-amber-500/15",
+  },
+  emerald: {
+    iconWrap: "bg-emerald-50 dark:bg-emerald-500/10",
+    iconColor: "text-emerald-600 dark:text-emerald-300",
+    ring: "ring-emerald-100/80 dark:ring-emerald-500/15",
+    bg: "from-emerald-50/60 dark:from-emerald-500/5",
+    bar: "bg-emerald-500",
+    barTrack: "bg-emerald-100 dark:bg-emerald-500/15",
+  },
+};
+
 interface StatCardProps {
   label: string;
   value: ReactNode;
-  accentClass: string;
+  tone: Tone;
+  icon: ReactNode;
   isLoading?: boolean;
   tooltip?: ReactNode;
-  trailing?: ReactNode;
-  className?: string;
 }
 
-const StatCard = ({
-  label,
-  value,
-  accentClass,
-  isLoading,
-  tooltip,
-  trailing,
-  className,
-}: StatCardProps) => (
-  <div
-    className={cn(
-      "group relative flex min-w-0 flex-col gap-1 rounded-xl border border-gray-200/80 bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80",
-      className
-    )}
-  >
-    <span
-      aria-hidden
-      className={cn("absolute left-0 top-2.5 bottom-2.5 w-[3px] rounded-r-full", accentClass)}
-    />
-    <div className="flex items-baseline justify-between gap-2 pl-1.5">
-      {isLoading ? (
-        <Skeleton className="h-6 w-12" />
-      ) : (
-        <span className="text-[20px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white truncate">
-          {value}
-        </span>
+const StatCard = ({ label, value, tone, icon, isLoading, tooltip }: StatCardProps) => {
+  const styles = TONE_STYLES[tone];
+  return (
+    <div
+      className={cn(
+        "group relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-2xl bg-white px-3.5 py-3 ring-1 transition-all hover:-translate-y-px hover:shadow-[0_10px_30px_-15px_rgba(15,23,42,0.18)] dark:bg-zinc-900/80",
+        styles.ring
       )}
-      {trailing}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-0 bg-gradient-to-br to-transparent opacity-70",
+          styles.bg
+        )}
+      />
+      <div className="relative flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
+            styles.iconWrap,
+            styles.iconColor
+          )}
+        >
+          {icon}
+        </span>
+        {tooltip ? (
+          <InfoTooltip content={tooltip} side="top" align="end" contentClassName="max-w-sm" />
+        ) : null}
+      </div>
+      <div className="relative flex flex-col gap-0.5">
+        {isLoading ? (
+          <Skeleton className="h-7 w-16" />
+        ) : (
+          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-gray-900 dark:text-white truncate">
+            {value}
+          </span>
+        )}
+        <span className="truncate text-[12px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+          {label}
+        </span>
+      </div>
     </div>
-    <div className="flex items-center gap-1 pl-1.5 min-w-0">
-      <span className="truncate text-[11.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
-        {label}
-      </span>
-      {tooltip ? (
-        <InfoTooltip content={tooltip} side="top" align="start" contentClassName="max-w-sm" />
-      ) : null}
-    </div>
-  </div>
-);
+  );
+};
 
 interface MilestoneStatCardProps {
   completed: number;
@@ -67,30 +112,52 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
   const safeCompleted = Math.max(0, Math.min(completed, total));
   const pct = total > 0 ? (safeCompleted / total) * 100 : 0;
   const isComplete = total > 0 && safeCompleted === total;
+  const styles = TONE_STYLES.emerald;
 
   return (
-    <div className="group relative flex min-w-0 flex-col gap-1 rounded-xl border border-gray-200/80 bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80 sm:col-span-2 lg:col-span-1">
+    <div
+      className={cn(
+        "group relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-2xl bg-white px-3.5 py-3 ring-1 transition-all hover:-translate-y-px hover:shadow-[0_10px_30px_-15px_rgba(15,23,42,0.18)] dark:bg-zinc-900/80",
+        styles.ring
+      )}
+    >
       <span
         aria-hidden
-        className="absolute left-0 top-2.5 bottom-2.5 w-[3px] rounded-r-full bg-emerald-500"
+        className={cn(
+          "pointer-events-none absolute inset-0 bg-gradient-to-br to-transparent opacity-70",
+          styles.bg
+        )}
       />
-      <div className="flex items-baseline justify-between gap-2 pl-1.5">
-        {isLoading ? (
-          <Skeleton className="h-6 w-20" />
+      <div className="relative flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
+            styles.iconWrap,
+            styles.iconColor
+          )}
+        >
+          <TargetIcon size={14} aria-hidden />
+        </span>
+        {isComplete && !isLoading ? (
+          <span className="inline-flex h-5 items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+            <CheckIcon size={10} aria-hidden /> Done
+          </span>
         ) : (
-          <span className="text-[20px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap truncate">
+          <span className="text-[11px] font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
+            {pct.toFixed(0)}%
+          </span>
+        )}
+      </div>
+      <div className="relative flex flex-col gap-1.5">
+        {isLoading ? (
+          <Skeleton className="h-7 w-24" />
+        ) : (
+          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap truncate">
             {completed} <span className="text-gray-400 dark:text-zinc-500">/</span> {total}
           </span>
         )}
-        {isComplete && !isLoading ? (
-          <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
-            <CheckIcon size={10} aria-hidden />
-          </span>
-        ) : null}
-      </div>
-      <div className="flex items-center gap-2 pl-1.5">
         <div
-          className="relative h-1 flex-1 min-w-0 overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-800"
+          className={cn("relative h-1 w-full overflow-hidden rounded-full", styles.barTrack)}
           role="progressbar"
           aria-valuenow={pct}
           aria-valuemin={0}
@@ -98,17 +165,14 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
           aria-label={`${pct.toFixed(0)}% of milestones completed`}
         >
           <span
-            className="block h-full bg-emerald-500 transition-all dark:bg-emerald-400"
+            className={cn("block h-full transition-all", styles.bar)}
             style={{ width: `${pct}%` }}
           />
         </div>
-        <span className="text-[11px] font-semibold tabular-nums text-gray-500 dark:text-zinc-400 shrink-0">
-          {pct.toFixed(0)}%
+        <span className="truncate text-[12px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+          Milestones
         </span>
       </div>
-      <span className="pl-1.5 text-[11.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400 truncate">
-        Milestones
-      </span>
     </div>
   );
 };
@@ -137,23 +201,26 @@ export const HeaderStatsCards = ({
   if (!hasData) return null;
 
   return (
-    <div className="grid w-full grid-cols-2 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="flex w-full flex-wrap justify-end gap-2.5 lg:flex-nowrap [&>*]:flex-1 [&>*]:basis-[140px] lg:[&>*]:max-w-[180px]">
       <StatCard
         label="Total projects"
         value={projectsCount ? formatCurrency(projectsCount) : "—"}
-        accentClass="bg-sky-500"
+        tone="sky"
+        icon={<FolderIcon size={14} aria-hidden />}
         isLoading={isLoading}
       />
       <StatCard
         label="Total grants"
         value={totalGrants ? formatCurrency(totalGrants) : "—"}
-        accentClass="bg-teal-500"
+        tone="teal"
+        icon={<AwardIcon size={14} aria-hidden />}
         isLoading={isLoading}
       />
       <StatCard
         label="Project updates"
         value={projectUpdates ? formatCurrency(projectUpdates) : "—"}
-        accentClass="bg-amber-500"
+        tone="amber"
+        icon={<FileTextIcon size={14} aria-hidden />}
         isLoading={isLoading}
         tooltip={updatesBreakdown}
       />

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -5,83 +5,26 @@ import type { ReactNode } from "react";
 import { InfoTooltip } from "@/components/Utilities/InfoTooltip";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import formatCurrency from "@/utilities/formatCurrency";
-import { cn } from "@/utilities/tailwind";
 
-type Tone = "sky" | "teal" | "amber" | "emerald";
+const CARD_BASE =
+  "group relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-2xl border border-border bg-background px-3.5 py-3 transition-all hover:-translate-y-px hover:border-foreground/15 hover:shadow-[0_10px_30px_-15px_rgba(15,23,42,0.18)]";
 
-const TONE_STYLES: Record<
-  Tone,
-  { iconWrap: string; iconColor: string; ring: string; bg: string; bar: string; barTrack: string }
-> = {
-  sky: {
-    iconWrap: "bg-sky-50 dark:bg-sky-500/10",
-    iconColor: "text-sky-600 dark:text-sky-300",
-    ring: "ring-sky-100/80 dark:ring-sky-500/15",
-    bg: "from-sky-50/60 dark:from-sky-500/5",
-    bar: "bg-sky-500",
-    barTrack: "bg-sky-100 dark:bg-sky-500/15",
-  },
-  teal: {
-    iconWrap: "bg-teal-50 dark:bg-teal-500/10",
-    iconColor: "text-teal-600 dark:text-teal-300",
-    ring: "ring-teal-100/80 dark:ring-teal-500/15",
-    bg: "from-teal-50/60 dark:from-teal-500/5",
-    bar: "bg-teal-500",
-    barTrack: "bg-teal-100 dark:bg-teal-500/15",
-  },
-  amber: {
-    iconWrap: "bg-amber-50 dark:bg-amber-500/10",
-    iconColor: "text-amber-600 dark:text-amber-300",
-    ring: "ring-amber-100/80 dark:ring-amber-500/15",
-    bg: "from-amber-50/60 dark:from-amber-500/5",
-    bar: "bg-amber-500",
-    barTrack: "bg-amber-100 dark:bg-amber-500/15",
-  },
-  emerald: {
-    iconWrap: "bg-emerald-50 dark:bg-emerald-500/10",
-    iconColor: "text-emerald-600 dark:text-emerald-300",
-    ring: "ring-emerald-100/80 dark:ring-emerald-500/15",
-    bg: "from-emerald-50/60 dark:from-emerald-500/5",
-    bar: "bg-emerald-500",
-    barTrack: "bg-emerald-100 dark:bg-emerald-500/15",
-  },
-};
+const ICON_WRAP =
+  "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-brand-50 text-brand-700 dark:bg-brand-500/10 dark:text-brand-400";
 
 interface StatCardProps {
   label: string;
   value: ReactNode;
-  tone: Tone;
   icon: ReactNode;
   isLoading?: boolean;
   tooltip?: ReactNode;
 }
 
-const StatCard = ({ label, value, tone, icon, isLoading, tooltip }: StatCardProps) => {
-  const styles = TONE_STYLES[tone];
+const StatCard = ({ label, value, icon, isLoading, tooltip }: StatCardProps) => {
   return (
-    <div
-      className={cn(
-        "group relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-2xl bg-white px-3.5 py-3 ring-1 transition-all hover:-translate-y-px hover:shadow-[0_10px_30px_-15px_rgba(15,23,42,0.18)] dark:bg-zinc-900/80",
-        styles.ring
-      )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "pointer-events-none absolute inset-0 bg-gradient-to-br to-transparent opacity-70",
-          styles.bg
-        )}
-      />
+    <div className={CARD_BASE}>
       <div className="relative flex items-start justify-between gap-2">
-        <span
-          className={cn(
-            "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
-            styles.iconWrap,
-            styles.iconColor
-          )}
-        >
-          {icon}
-        </span>
+        <span className={ICON_WRAP}>{icon}</span>
         {tooltip ? (
           <InfoTooltip content={tooltip} side="top" align="end" contentClassName="max-w-sm" />
         ) : null}
@@ -90,11 +33,11 @@ const StatCard = ({ label, value, tone, icon, isLoading, tooltip }: StatCardProp
         {isLoading ? (
           <Skeleton className="h-7 w-16" />
         ) : (
-          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-gray-900 dark:text-white truncate">
+          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-foreground truncate">
             {value}
           </span>
         )}
-        <span className="truncate text-[12px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+        <span className="truncate text-[12px] font-medium leading-tight text-muted-foreground">
           {label}
         </span>
       </div>
@@ -112,38 +55,19 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
   const safeCompleted = Math.max(0, Math.min(completed, total));
   const pct = total > 0 ? (safeCompleted / total) * 100 : 0;
   const isComplete = total > 0 && safeCompleted === total;
-  const styles = TONE_STYLES.emerald;
 
   return (
-    <div
-      className={cn(
-        "group relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-2xl bg-white px-3.5 py-3 ring-1 transition-all hover:-translate-y-px hover:shadow-[0_10px_30px_-15px_rgba(15,23,42,0.18)] dark:bg-zinc-900/80",
-        styles.ring
-      )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "pointer-events-none absolute inset-0 bg-gradient-to-br to-transparent opacity-70",
-          styles.bg
-        )}
-      />
+    <div className={CARD_BASE}>
       <div className="relative flex items-start justify-between gap-2">
-        <span
-          className={cn(
-            "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg",
-            styles.iconWrap,
-            styles.iconColor
-          )}
-        >
+        <span className={ICON_WRAP}>
           <TargetIcon size={14} aria-hidden />
         </span>
         {isComplete && !isLoading ? (
-          <span className="inline-flex h-5 items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+          <span className="inline-flex h-5 items-center gap-1 rounded-full bg-brand-50 px-1.5 text-[10px] font-semibold uppercase tracking-wide text-brand-700 dark:bg-brand-500/10 dark:text-brand-400">
             <CheckIcon size={10} aria-hidden /> Done
           </span>
         ) : (
-          <span className="text-[11px] font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
+          <span className="text-[11px] font-semibold tabular-nums text-brand-700 dark:text-brand-400">
             {pct.toFixed(0)}%
           </span>
         )}
@@ -152,24 +76,21 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
         {isLoading ? (
           <Skeleton className="h-7 w-24" />
         ) : (
-          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap truncate">
-            {completed} <span className="text-gray-400 dark:text-zinc-500">/</span> {total}
+          <span className="text-[22px] font-semibold leading-none tracking-[-0.025em] tabular-nums text-foreground whitespace-nowrap truncate">
+            {completed} <span className="text-muted-foreground/60">/</span> {total}
           </span>
         )}
         <div
-          className={cn("relative h-1 w-full overflow-hidden rounded-full", styles.barTrack)}
+          className="relative h-1 w-full overflow-hidden rounded-full bg-brand-50 dark:bg-brand-500/10"
           role="progressbar"
           aria-valuenow={pct}
           aria-valuemin={0}
           aria-valuemax={100}
           aria-label={`${pct.toFixed(0)}% of milestones completed`}
         >
-          <span
-            className={cn("block h-full transition-all", styles.bar)}
-            style={{ width: `${pct}%` }}
-          />
+          <span className="block h-full bg-brand-500 transition-all" style={{ width: `${pct}%` }} />
         </div>
-        <span className="truncate text-[12px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+        <span className="truncate text-[12px] font-medium leading-tight text-muted-foreground">
           Milestones
         </span>
       </div>
@@ -205,21 +126,18 @@ export const HeaderStatsCards = ({
       <StatCard
         label="Total projects"
         value={projectsCount ? formatCurrency(projectsCount) : "—"}
-        tone="sky"
         icon={<FolderIcon size={14} aria-hidden />}
         isLoading={isLoading}
       />
       <StatCard
         label="Total grants"
         value={totalGrants ? formatCurrency(totalGrants) : "—"}
-        tone="teal"
         icon={<AwardIcon size={14} aria-hidden />}
         isLoading={isLoading}
       />
       <StatCard
         label="Project updates"
         value={projectUpdates ? formatCurrency(projectUpdates) : "—"}
-        tone="amber"
         icon={<FileTextIcon size={14} aria-hidden />}
         isLoading={isLoading}
         tooltip={updatesBreakdown}

--- a/components/Community/HeaderStatsCards.tsx
+++ b/components/Community/HeaderStatsCards.tsx
@@ -28,26 +28,26 @@ const StatCard = ({
 }: StatCardProps) => (
   <div
     className={cn(
-      "group relative flex flex-col gap-2 rounded-2xl border border-gray-200/80 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80",
+      "group relative flex min-w-0 flex-col gap-1 rounded-xl border border-gray-200/80 bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80",
       className
     )}
   >
     <span
       aria-hidden
-      className={cn("absolute left-0 top-3 bottom-3 w-[3px] rounded-r-full", accentClass)}
+      className={cn("absolute left-0 top-2.5 bottom-2.5 w-[3px] rounded-r-full", accentClass)}
     />
     <div className="flex items-baseline justify-between gap-2 pl-1.5">
       {isLoading ? (
-        <Skeleton className="h-7 w-16" />
+        <Skeleton className="h-6 w-12" />
       ) : (
-        <span className="text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white">
+        <span className="text-[20px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white truncate">
           {value}
         </span>
       )}
       {trailing}
     </div>
-    <div className="flex items-center gap-1 pl-1.5">
-      <span className="text-[12.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
+    <div className="flex items-center gap-1 pl-1.5 min-w-0">
+      <span className="truncate text-[11.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
         {label}
       </span>
       {tooltip ? (
@@ -69,33 +69,28 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
   const isComplete = total > 0 && safeCompleted === total;
 
   return (
-    <div className="group relative flex flex-col gap-2 rounded-2xl border border-gray-200/80 bg-white px-4 py-3.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80 sm:col-span-2 lg:col-span-1">
+    <div className="group relative flex min-w-0 flex-col gap-1 rounded-xl border border-gray-200/80 bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)] dark:border-zinc-800 dark:bg-zinc-900/80 sm:col-span-2 lg:col-span-1">
       <span
         aria-hidden
-        className="absolute left-0 top-3 bottom-3 w-[3px] rounded-r-full bg-emerald-500"
+        className="absolute left-0 top-2.5 bottom-2.5 w-[3px] rounded-r-full bg-emerald-500"
       />
       <div className="flex items-baseline justify-between gap-2 pl-1.5">
         {isLoading ? (
-          <Skeleton className="h-7 w-24" />
+          <Skeleton className="h-6 w-20" />
         ) : (
-          <span className="text-[26px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap">
+          <span className="text-[20px] font-semibold leading-none tracking-[-0.02em] tabular-nums text-gray-900 dark:text-white whitespace-nowrap truncate">
             {completed} <span className="text-gray-400 dark:text-zinc-500">/</span> {total}
           </span>
         )}
         {isComplete && !isLoading ? (
-          <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
-            <CheckIcon size={12} aria-hidden />
+          <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-white">
+            <CheckIcon size={10} aria-hidden />
           </span>
         ) : null}
       </div>
-      <div className="flex items-center gap-1 pl-1.5">
-        <span className="text-[12.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400">
-          Milestones completed
-        </span>
-      </div>
-      <div className="mt-0.5 flex items-center gap-2 pl-1.5">
+      <div className="flex items-center gap-2 pl-1.5">
         <div
-          className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-800"
+          className="relative h-1 flex-1 min-w-0 overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-800"
           role="progressbar"
           aria-valuenow={pct}
           aria-valuemin={0}
@@ -107,10 +102,13 @@ const MilestoneStatCard = ({ completed, total, isLoading }: MilestoneStatCardPro
             style={{ width: `${pct}%` }}
           />
         </div>
-        <span className="text-[11px] font-semibold tabular-nums text-gray-500 dark:text-zinc-400">
+        <span className="text-[11px] font-semibold tabular-nums text-gray-500 dark:text-zinc-400 shrink-0">
           {pct.toFixed(0)}%
         </span>
       </div>
+      <span className="pl-1.5 text-[11.5px] font-medium leading-tight text-gray-500 dark:text-zinc-400 truncate">
+        Milestones
+      </span>
     </div>
   );
 };

--- a/components/CommunityGrants.tsx
+++ b/components/CommunityGrants.tsx
@@ -174,10 +174,10 @@ export const CommunityGrants = ({
   return (
     <div className="flex flex-col gap-4 w-full">
       <div className="flex items-center justify-between flex-row flex-wrap-reverse max-lg:flex-wrap max-lg:flex-col-reverse max-lg:justify-start max-lg:items-start gap-3 max-lg:gap-4">
-        <div className="flex items-center gap-x-3 flex-wrap gap-y-2 w-full">
+        <div className="flex items-stretch sm:items-end gap-x-3 flex-wrap gap-y-3 w-full">
           <ProgramFilter onChange={handleProgramChange} />
 
-          <div className="flex flex-1 flex-row gap-8 justify-end flex-wrap">
+          <div className="flex flex-1 flex-col sm:flex-row sm:items-center gap-y-3 gap-x-8 justify-start flex-wrap sm:pb-3">
             {selectedProgramId && (
               <TrackFilter
                 onChange={handleTrackChange}

--- a/components/Pages/Communities/CommunityPageNavigator.tsx
+++ b/components/Pages/Communities/CommunityPageNavigator.tsx
@@ -180,7 +180,7 @@ export const CommunityPageNavigator = () => {
   if (isAdminPage) return null;
 
   return (
-    <div className="flex flex-row max-md:overflow-x-auto max-md:scrollbar-none max-md:flex-nowrap flex-wrap pt-8 border-b border-gray-200 dark:border-zinc-700 justify-start items-center gap-6 h-max w-full">
+    <div className="flex flex-row flex-nowrap overflow-x-auto scrollbar-none pt-8 border-b border-gray-200 dark:border-zinc-700 justify-start items-center gap-6 h-max w-full">
       {visibleNavigationItems.map(({ id, path, title, Icon, isActive, showNewTag }) => {
         const href = path(communityId);
         const active = isActive(pathname);

--- a/components/Pages/Communities/CommunityPageNavigator.tsx
+++ b/components/Pages/Communities/CommunityPageNavigator.tsx
@@ -12,7 +12,6 @@ import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
-import { useFundingOpportunitiesCount } from "@/hooks/useFundingOpportunitiesCount";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { Link } from "@/src/components/navigation/Link";
 import { FINANCIALS_ENABLED_COMMUNITIES } from "@/utilities/community-flags";
@@ -125,11 +124,6 @@ export const CommunityPageNavigator = () => {
   const isAdminPage = pathname.includes("/manage");
 
   const { data: community } = useCommunityDetails(communityId);
-  // Skip fetching funding opportunities count on admin pages
-  const { data: fundingOpportunitiesCount } = useFundingOpportunitiesCount({
-    communityUid: community?.uid,
-    enabled: !isAdminPage,
-  });
   // Skip fetching programs on admin pages - the component returns null anyway
   const { data: programs } = useCommunityPrograms(communityId, {
     enabled: !isAdminPage,
@@ -144,9 +138,9 @@ export const CommunityPageNavigator = () => {
 
   const visibleNavigationItems = useMemo(() => {
     return NAVIGATION_ITEMS.filter((item) => {
-      // In whitelabel mode, always show funding opportunities (it's the landing page)
-      // In normal mode, hide it if there are no opportunities
-      if (item.id === "funding-opportunities" && fundingOpportunitiesCount === 0 && !isWhitelabel) {
+      // In whitelabel mode, always show funding opportunities (it's the landing page).
+      // In normal mode, hide it if the community has no programs at all (live or not).
+      if (item.id === "funding-opportunities" && programsCount === 0 && !isWhitelabel) {
         return false;
       }
       // Show browse applications if the community has at least one program (live or ended)
@@ -163,13 +157,7 @@ export const CommunityPageNavigator = () => {
       }
       return true;
     });
-  }, [
-    fundingOpportunitiesCount,
-    programsCount,
-    publishedReportsCount,
-    isWhitelabel,
-    isFinancialsEnabled,
-  ]);
+  }, [programsCount, publishedReportsCount, isWhitelabel, isFinancialsEnabled]);
 
   const activeLinkRef = useCallback((node: HTMLAnchorElement | null) => {
     if (node?.scrollIntoView) {

--- a/components/Pages/Communities/CommunityProjectEvaluatorPage.tsx
+++ b/components/Pages/Communities/CommunityProjectEvaluatorPage.tsx
@@ -842,7 +842,7 @@ function ChatScreen({
               />
               <div className="flex flex-col gap-0">
                 <p className="text-zinc-800 dark:text-zinc-200 text-lg font-semibold">
-                  Ask Karma AI
+                  Ask Karma Assistant
                 </p>
                 <p className="text-gray-600 dark:text-zinc-400 text-sm font-normal">
                   {messages.length > 0 && messages[0].timestamp

--- a/components/Pages/Communities/Financials/PublicControlCenter.tsx
+++ b/components/Pages/Communities/Financials/PublicControlCenter.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TableRow } from "@/components/Pages/Admin/ControlCenter/ControlCenterTable";
 import { ControlCenterTable } from "@/components/Pages/Admin/ControlCenter/ControlCenterTable";
 import { FilterToolbar } from "@/components/Pages/Admin/ControlCenter/FilterToolbar";
+import { PageHero } from "@/components/Pages/Communities/PageHero";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { Button } from "@/components/ui/button";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
@@ -335,13 +336,38 @@ export function PublicControlCenter() {
   return (
     <div className="my-4 flex flex-col gap-6 w-full">
       {/* Page Header — renders immediately */}
-      <div className="flex flex-col gap-1 px-4">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-zinc-100 tracking-tight">
-          Financials
-        </h1>
-        <p className="text-sm text-gray-500 dark:text-zinc-400 mt-0.5">
-          Overview of project agreements, milestones, and payments
-        </p>
+      <div className="px-4">
+        <PageHero
+          compact
+          eyebrow="Treasury"
+          title="Financials"
+          description="Overview of grants, agreements, milestones, and disbursements made through programs in this community."
+          kpis={[
+            {
+              label: "Tracked grants",
+              value: totalItems,
+              sub: totalItems === 1 ? "grant" : "grants",
+            },
+            {
+              label: "Signed agreements",
+              value: Object.values(agreementMap).filter((a) => a?.signed).length,
+              sub: "in good standing",
+              accent: "success",
+            },
+            {
+              label: "Disbursements",
+              value: Object.values(disbursementMap).filter((d) => d.history && d.history.length > 0)
+                .length,
+              sub: "with payouts on-chain",
+            },
+            {
+              label: "Awaiting action",
+              value: Object.values(disbursementMap).filter((d) => d.status === "pending").length,
+              sub: "pending review",
+              accent: "warning",
+            },
+          ]}
+        />
       </div>
 
       {/* Toolbar — renders immediately */}

--- a/components/Pages/Communities/Financials/PublicControlCenter.tsx
+++ b/components/Pages/Communities/Financials/PublicControlCenter.tsx
@@ -351,19 +351,19 @@ export function PublicControlCenter() {
             {
               label: "Signed agreements",
               value: Object.values(agreementMap).filter((a) => a?.signed).length,
-              sub: "in good standing",
+              sub: "in good standing (this page)",
               accent: "success",
             },
             {
               label: "Disbursements",
               value: Object.values(disbursementMap).filter((d) => d.history && d.history.length > 0)
                 .length,
-              sub: "with payouts on-chain",
+              sub: "with payouts on-chain (this page)",
             },
             {
               label: "Awaiting action",
               value: Object.values(disbursementMap).filter((d) => d.status === "pending").length,
-              sub: "pending review",
+              sub: "pending review (this page)",
               accent: "warning",
             },
           ]}

--- a/components/Pages/Communities/Funding/EditorialProgramCard.tsx
+++ b/components/Pages/Communities/Funding/EditorialProgramCard.tsx
@@ -20,23 +20,7 @@ interface ProgramComputed {
   accentClass: string;
 }
 
-const ACCENT_CYCLE = [
-  "bg-brand-500",
-  "bg-sky-500",
-  "bg-violet-500",
-  "bg-amber-500",
-  "bg-pink-500",
-  "bg-emerald-500",
-  "bg-orange-500",
-];
-
-function pickAccent(programId: string): string {
-  let hash = 0;
-  for (let i = 0; i < programId.length; i++) {
-    hash = (hash * 31 + programId.charCodeAt(i)) | 0;
-  }
-  return ACCENT_CYCLE[Math.abs(hash) % ACCENT_CYCLE.length];
-}
+const ACCENT_CLASS = "bg-brand-500";
 
 function parseAmount(raw?: string | number): number {
   if (raw == null) return 0;
@@ -79,7 +63,7 @@ export function computeProgramView(program: FundingProgram): ProgramComputed {
     maxGrant,
     applicants,
     category,
-    accentClass: pickAccent(program.programId),
+    accentClass: ACCENT_CLASS,
   };
 }
 

--- a/components/Pages/Communities/Funding/EditorialProgramCard.tsx
+++ b/components/Pages/Communities/Funding/EditorialProgramCard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { ArrowRight, CalendarClock, Users } from "lucide-react";
+import Link from "next/link";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import formatCurrency from "@/utilities/formatCurrency";
+import { PAGES } from "@/utilities/pages";
+import { cn } from "@/utilities/tailwind";
+
+type Urgency = "open" | "closing" | "urgent" | "closed" | "upcoming";
+
+interface ProgramComputed {
+  status: "open" | "closed" | "coming-soon" | "deadline-passed";
+  urgency: Urgency;
+  daysLeft: number | null;
+  pool: number;
+  maxGrant: number;
+  applicants: number;
+  category: string | null;
+  accentClass: string;
+}
+
+const ACCENT_CYCLE = [
+  "bg-brand-500",
+  "bg-sky-500",
+  "bg-violet-500",
+  "bg-amber-500",
+  "bg-pink-500",
+  "bg-emerald-500",
+  "bg-orange-500",
+];
+
+function pickAccent(programId: string): string {
+  let hash = 0;
+  for (let i = 0; i < programId.length; i++) {
+    hash = (hash * 31 + programId.charCodeAt(i)) | 0;
+  }
+  return ACCENT_CYCLE[Math.abs(hash) % ACCENT_CYCLE.length];
+}
+
+function parseAmount(raw?: string | number): number {
+  if (raw == null) return 0;
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : 0;
+  const cleaned = String(raw).replace(/[^0-9.]/g, "");
+  const n = Number.parseFloat(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function computeProgramView(program: FundingProgram): ProgramComputed {
+  const now = new Date();
+  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
+  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
+
+  let status: ProgramComputed["status"] = "open";
+  if (endsAt && now > endsAt) status = "deadline-passed";
+  else if (startsAt && now < startsAt) status = "coming-soon";
+  else if (program.metadata?.status === "inactive") status = "closed";
+
+  const daysLeft = endsAt
+    ? Math.max(0, Math.round((endsAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)))
+    : null;
+
+  let urgency: Urgency = "open";
+  if (status === "deadline-passed" || status === "closed") urgency = "closed";
+  else if (status === "coming-soon") urgency = "upcoming";
+  else if (daysLeft !== null && daysLeft <= 3) urgency = "urgent";
+  else if (daysLeft !== null && daysLeft <= 7) urgency = "closing";
+
+  const pool = parseAmount(program.metadata?.programBudget);
+  const maxGrant = parseAmount(program.metadata?.maxGrantSize);
+  const applicants = program.metrics?.totalApplications ?? program.metadata?.applicantsNumber ?? 0;
+  const category = program.metadata?.categories?.[0] ?? program.metadata?.type ?? null;
+
+  return {
+    status,
+    urgency,
+    daysLeft,
+    pool,
+    maxGrant,
+    applicants,
+    category,
+    accentClass: pickAccent(program.programId),
+  };
+}
+
+const URGENCY_BADGE: Record<Urgency, string> = {
+  urgent: "bg-red-600 text-white ring-1 ring-inset ring-red-700/40 dark:bg-red-500 dark:text-white",
+  closing:
+    "bg-amber-500 text-white ring-1 ring-inset ring-amber-600/40 dark:bg-amber-500 dark:text-white",
+  open: "bg-emerald-600 text-white ring-1 ring-inset ring-emerald-700/40 dark:bg-emerald-500 dark:text-white",
+  closed:
+    "bg-zinc-200 text-zinc-700 ring-1 ring-inset ring-zinc-300 dark:bg-zinc-800 dark:text-zinc-300 dark:ring-zinc-700",
+  upcoming:
+    "bg-sky-600 text-white ring-1 ring-inset ring-sky-700/40 dark:bg-sky-500 dark:text-white",
+};
+
+const DOT_COLOR: Record<Urgency, string> = {
+  urgent: "bg-white",
+  closing: "bg-white",
+  open: "bg-white",
+  closed: "bg-zinc-500 dark:bg-zinc-400",
+  upcoming: "bg-white",
+};
+
+function urgencyLabel(u: Urgency, daysLeft: number | null): string {
+  if (u === "closed") return "Closed";
+  if (u === "upcoming") return "Coming soon";
+  if (daysLeft === null) return "Open";
+  return `${daysLeft}d left`;
+}
+
+interface EditorialProgramCardProps {
+  program: FundingProgram;
+  communityId: string;
+}
+
+export function EditorialProgramCard({ program, communityId }: EditorialProgramCardProps) {
+  const view = computeProgramView(program);
+  const title = program.metadata?.title ?? program.name ?? "Untitled program";
+  const description = program.metadata?.shortDescription ?? program.metadata?.description ?? "";
+  const href = PAGES.COMMUNITY.PROGRAM_DETAIL(communityId, program.programId);
+  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
+  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
+  const dateLabel = (() => {
+    if (view.urgency === "upcoming" && startsAt) {
+      return `Opens ${startsAt.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+    }
+    if (endsAt) {
+      const formatted = endsAt.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+      return view.urgency === "closed" ? `Closed ${formatted}` : `Closes ${formatted}`;
+    }
+    return null;
+  })();
+
+  return (
+    <article className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-background transition duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_20px_40px_-24px_rgba(0,0,0,0.18)]">
+      {/* Top color stripe */}
+      <div className={cn("h-1.5 w-full", view.accentClass)} aria-hidden />
+
+      <div className="flex flex-1 flex-col gap-4 p-5 md:p-6">
+        <header className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+              URGENCY_BADGE[view.urgency]
+            )}
+          >
+            <span className={cn("h-1.5 w-1.5 rounded-full", DOT_COLOR[view.urgency])} aria-hidden />
+            {urgencyLabel(view.urgency, view.daysLeft)}
+          </span>
+        </header>
+
+        <div>
+          <h3 className="text-lg md:text-xl font-semibold tracking-[-0.015em] leading-snug text-foreground">
+            <Link
+              href={href}
+              className="outline-none after:absolute after:inset-0 after:content-[''] focus-visible:after:rounded-2xl focus-visible:after:ring-2 focus-visible:after:ring-brand-500"
+            >
+              {title}
+            </Link>
+          </h3>
+          {description ? (
+            <p className="mt-2 line-clamp-3 min-h-[3rem] text-[13.5px] leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+
+        {view.pool > 0 || view.maxGrant > 0 ? (
+          <dl className="grid grid-cols-2 gap-3 border-t border-border pt-4">
+            {view.pool > 0 ? (
+              <div>
+                <dt className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+                  Pool
+                </dt>
+                <dd className="mt-1 text-[18px] font-semibold tracking-[-0.015em] text-foreground">
+                  {`$${formatCurrency(view.pool)}`}
+                </dd>
+              </div>
+            ) : null}
+            {view.maxGrant > 0 ? (
+              <div>
+                <dt className="text-[10.5px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+                  Max grant
+                </dt>
+                <dd className="mt-1 text-[18px] font-semibold tracking-[-0.015em] text-foreground">
+                  {`$${formatCurrency(view.maxGrant)}`}
+                </dd>
+              </div>
+            ) : null}
+          </dl>
+        ) : null}
+
+        <footer className="mt-auto flex items-center justify-between text-xs text-muted-foreground">
+          {view.applicants > 0 ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" aria-hidden />
+              {view.applicants} {view.applicants === 1 ? "applicant" : "applicants"}
+            </span>
+          ) : (
+            <span />
+          )}
+          {dateLabel ? (
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarClock className="h-3.5 w-3.5" aria-hidden />
+              {dateLabel}
+            </span>
+          ) : null}
+          <span className="inline-flex items-center gap-1 font-medium text-foreground">
+            Details
+            <ArrowRight
+              className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </span>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/components/Pages/Communities/Funding/EditorialProgramCard.tsx
+++ b/components/Pages/Communities/Funding/EditorialProgramCard.tsx
@@ -84,22 +84,19 @@ export function computeProgramView(program: FundingProgram): ProgramComputed {
 }
 
 const URGENCY_BADGE: Record<Urgency, string> = {
-  urgent: "bg-red-600 text-white ring-1 ring-inset ring-red-700/40 dark:bg-red-500 dark:text-white",
-  closing:
-    "bg-amber-500 text-white ring-1 ring-inset ring-amber-600/40 dark:bg-amber-500 dark:text-white",
-  open: "bg-emerald-600 text-white ring-1 ring-inset ring-emerald-700/40 dark:bg-emerald-500 dark:text-white",
-  closed:
-    "bg-zinc-200 text-zinc-700 ring-1 ring-inset ring-zinc-300 dark:bg-zinc-800 dark:text-zinc-300 dark:ring-zinc-700",
-  upcoming:
-    "bg-sky-600 text-white ring-1 ring-inset ring-sky-700/40 dark:bg-sky-500 dark:text-white",
+  urgent: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  closing: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  open: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  closed: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  upcoming: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
 };
 
 const DOT_COLOR: Record<Urgency, string> = {
-  urgent: "bg-white",
-  closing: "bg-white",
-  open: "bg-white",
-  closed: "bg-zinc-500 dark:bg-zinc-400",
-  upcoming: "bg-white",
+  urgent: "bg-red-500",
+  closing: "bg-amber-500",
+  open: "bg-green-500",
+  closed: "bg-zinc-400 dark:bg-zinc-500",
+  upcoming: "bg-sky-500",
 };
 
 function urgencyLabel(u: Urgency, daysLeft: number | null): string {

--- a/components/Pages/Communities/Funding/EditorialProgramCard.tsx
+++ b/components/Pages/Communities/Funding/EditorialProgramCard.tsx
@@ -104,10 +104,10 @@ export function EditorialProgramCard({ program, communityId }: EditorialProgramC
   const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
   const dateLabel = (() => {
     if (view.urgency === "upcoming" && startsAt) {
-      return `Opens ${startsAt.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+      return `Opens ${startsAt.toLocaleDateString("en-US", { month: "short", day: "numeric" })}`;
     }
     if (endsAt) {
-      const formatted = endsAt.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+      const formatted = endsAt.toLocaleDateString("en-US", { month: "short", day: "numeric" });
       return view.urgency === "closed" ? `Closed ${formatted}` : `Closes ${formatted}`;
     }
     return null;

--- a/components/Pages/Communities/Funding/FeaturedProgram.tsx
+++ b/components/Pages/Communities/Funding/FeaturedProgram.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import formatCurrency from "@/utilities/formatCurrency";
+import { PAGES } from "@/utilities/pages";
+import { cn } from "@/utilities/tailwind";
+import { computeProgramView } from "./EditorialProgramCard";
+
+const URGENCY_BADGE: Record<string, string> = {
+  urgent: "bg-red-600 text-white ring-1 ring-inset ring-red-700/40",
+  closing: "bg-amber-500 text-white ring-1 ring-inset ring-amber-600/40",
+  open: "bg-emerald-600 text-white ring-1 ring-inset ring-emerald-700/40",
+  closed:
+    "bg-zinc-200 text-zinc-700 ring-1 ring-inset ring-zinc-300 dark:bg-zinc-800 dark:text-zinc-300 dark:ring-zinc-700",
+  upcoming: "bg-sky-600 text-white ring-1 ring-inset ring-sky-700/40",
+};
+
+const DOT_COLOR: Record<string, string> = {
+  urgent: "bg-white",
+  closing: "bg-white",
+  open: "bg-white",
+  closed: "bg-zinc-500 dark:bg-zinc-400",
+  upcoming: "bg-white",
+};
+
+export function FeaturedProgram({
+  program,
+  communityId,
+}: {
+  program: FundingProgram;
+  communityId: string;
+}) {
+  const view = computeProgramView(program);
+  const title = program.metadata?.title ?? program.name ?? "Featured program";
+  const summary = program.metadata?.shortDescription ?? program.metadata?.description ?? "";
+  const href = PAGES.COMMUNITY.PROGRAM_DETAIL(communityId, program.programId);
+  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
+  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
+  const deadlineLabel = endsAt
+    ? endsAt.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    : null;
+  const startLabel = startsAt
+    ? startsAt.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    : null;
+  const dateRowLabel =
+    view.urgency === "upcoming" ? "Opens" : view.urgency === "closed" ? "Closed" : "Deadline";
+  const dateRowValue = view.urgency === "upcoming" ? startLabel : deadlineLabel;
+
+  return (
+    <section
+      aria-label="Featured program"
+      className="relative overflow-hidden rounded-3xl border border-border bg-background"
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-50 via-background to-background dark:from-brand-900/20"
+        )}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-20 -top-20 h-[380px] w-[380px] rounded-full bg-brand-300/40 blur-3xl dark:bg-brand-500/10"
+      />
+
+      <div className="relative grid gap-8 p-8 md:grid-cols-[1.4fr_1fr] md:gap-12 md:p-11">
+        <div>
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold",
+                URGENCY_BADGE[view.urgency] ?? URGENCY_BADGE.open
+              )}
+            >
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full",
+                  DOT_COLOR[view.urgency] ?? DOT_COLOR.open
+                )}
+                aria-hidden
+              />
+              {view.daysLeft !== null && view.urgency !== "closed"
+                ? `${view.daysLeft} days left`
+                : view.urgency === "closed"
+                  ? "Closed"
+                  : "Open"}
+            </span>
+            <span className="rounded-full border border-border bg-background/70 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+              Featured
+            </span>
+          </div>
+
+          <h2 className="text-3xl md:text-4xl lg:text-[40px] font-semibold leading-[1.05] tracking-[-0.02em] text-foreground">
+            {title}
+          </h2>
+
+          {summary ? (
+            <p className="mt-4 max-w-prose text-[15px] md:text-[17px] leading-relaxed text-muted-foreground">
+              {summary}
+            </p>
+          ) : null}
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href={href}
+              className="inline-flex h-11 items-center gap-2 rounded-lg bg-foreground px-5 text-sm font-semibold text-background transition hover:bg-foreground/90"
+            >
+              {view.urgency === "closed" ? "View details" : "Apply before deadline"}
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+            <Link
+              href={href}
+              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-sm font-semibold text-foreground transition hover:bg-secondary"
+            >
+              View details
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-center gap-3.5">
+          {view.pool > 0 ? (
+            <KpiRow label="Total pool" value={`$${formatCurrency(view.pool)}`} big />
+          ) : null}
+          {view.maxGrant > 0 ? (
+            <KpiRow label="Max grant" value={`$${formatCurrency(view.maxGrant)}`} />
+          ) : null}
+          {dateRowValue ? <KpiRow label={dateRowLabel} value={dateRowValue} /> : null}
+          {view.applicants > 0 ? (
+            <KpiRow label="Applicants" value={`${view.applicants} teams`} />
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function KpiRow({ label, value, big = false }: { label: string; value: string; big?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 border-b border-border/70 pb-3 last:border-b-0">
+      <span className="text-[13px] font-medium text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "font-semibold tracking-[-0.015em] text-foreground",
+          big ? "text-[24px]" : "text-base"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/components/Pages/Communities/Funding/FeaturedProgram.tsx
+++ b/components/Pages/Communities/Funding/FeaturedProgram.tsx
@@ -9,20 +9,19 @@ import { cn } from "@/utilities/tailwind";
 import { computeProgramView } from "./EditorialProgramCard";
 
 const URGENCY_BADGE: Record<string, string> = {
-  urgent: "bg-red-600 text-white ring-1 ring-inset ring-red-700/40",
-  closing: "bg-amber-500 text-white ring-1 ring-inset ring-amber-600/40",
-  open: "bg-emerald-600 text-white ring-1 ring-inset ring-emerald-700/40",
-  closed:
-    "bg-zinc-200 text-zinc-700 ring-1 ring-inset ring-zinc-300 dark:bg-zinc-800 dark:text-zinc-300 dark:ring-zinc-700",
-  upcoming: "bg-sky-600 text-white ring-1 ring-inset ring-sky-700/40",
+  urgent: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  closing: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  open: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  closed: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  upcoming: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
 };
 
 const DOT_COLOR: Record<string, string> = {
-  urgent: "bg-white",
-  closing: "bg-white",
-  open: "bg-white",
-  closed: "bg-zinc-500 dark:bg-zinc-400",
-  upcoming: "bg-white",
+  urgent: "bg-red-500",
+  closing: "bg-amber-500",
+  open: "bg-green-500",
+  closed: "bg-zinc-400 dark:bg-zinc-500",
+  upcoming: "bg-sky-500",
 };
 
 export function FeaturedProgram({

--- a/components/Pages/Communities/Funding/FeaturedProgram.tsx
+++ b/components/Pages/Communities/Funding/FeaturedProgram.tsx
@@ -38,10 +38,10 @@ export function FeaturedProgram({
   const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
   const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
   const deadlineLabel = endsAt
-    ? endsAt.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    ? endsAt.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
     : null;
   const startLabel = startsAt
-    ? startsAt.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    ? startsAt.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
     : null;
   const dateRowLabel =
     view.urgency === "upcoming" ? "Opens" : view.urgency === "closed" ? "Closed" : "Deadline";
@@ -108,12 +108,14 @@ export function FeaturedProgram({
               {view.urgency === "closed" ? "View details" : "Apply before deadline"}
               <ArrowRight className="h-4 w-4" aria-hidden />
             </Link>
-            <Link
-              href={href}
-              className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-sm font-semibold text-foreground transition hover:bg-secondary"
-            >
-              View details
-            </Link>
+            {view.urgency !== "closed" ? (
+              <Link
+                href={href}
+                className="inline-flex h-11 items-center rounded-lg border border-border bg-background px-5 text-sm font-semibold text-foreground transition hover:bg-secondary"
+              >
+                View details
+              </Link>
+            ) : null}
           </div>
         </div>
 

--- a/components/Pages/Communities/Impact/CategoryRow.tsx
+++ b/components/Pages/Communities/Impact/CategoryRow.tsx
@@ -140,117 +140,138 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
     );
   }
 
+  const isOutcome = segment.impactSegmentType === "outcome";
+
   return (
-    <div ref={ref} className="flex flex-col w-full bg-[#F9FAFB] dark:bg-zinc-800 rounded mb-4">
-      <div className="px-6 pb-6 flex flex-col gap-y-4">
-        <div className="pt-3 flex flex-col gap-3">
-          <div
+    <div
+      ref={ref}
+      className="mb-4 flex w-full flex-col overflow-hidden rounded-2xl border border-border bg-background"
+    >
+      {/* Segment header — soft accent bar */}
+      <div
+        className={cn(
+          "flex flex-row items-center justify-between gap-3 border-b border-border px-5 py-4",
+          isOutcome
+            ? "bg-emerald-50/60 dark:bg-emerald-950/20"
+            : "bg-violet-50/60 dark:bg-violet-950/20"
+        )}
+      >
+        <div className="flex flex-row items-center gap-3">
+          <span
             className={cn(
-              "p-3 flex flex-row gap-3 justify-between items-start rounded",
-              segment.impactSegmentType === "outcome"
-                ? "bg-green-100 dark:bg-green-900"
-                : "bg-indigo-100 dark:bg-indigo-900"
+              "flex h-9 w-9 items-center justify-center rounded-lg",
+              isOutcome
+                ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                : "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300"
             )}
+            aria-hidden
           >
-            <div className="flex flex-row gap-3 items-center">
-              <Image
-                src={
-                  segment.impactSegmentType === "outcome"
-                    ? "/icons/outcome.svg"
-                    : "/icons/activity.svg"
-                }
-                alt={segment.impactSegmentType}
-                width={32}
-                height={32}
-              />
-              <div className="flex flex-col gap-0">
-                <p className="text-black dark:text-white text-lg font-semibold">
-                  {segment.impactSegmentName}
-                </p>
-                <p className="text-black dark:text-white text-base font-normal">
-                  {segment.impactSegmentDescription}
-                </p>
-              </div>
-            </div>
-            <p className="text-center text-slate-600 dark:text-gray-200 text-sm font-semibold px-3 py-1 bg-white dark:bg-zinc-700 rounded justify-start items-center">
-              {segment.impactIndicatorIds.length}{" "}
-              {pluralize("metric", segment.impactIndicatorIds.length)}
+            <Image
+              src={isOutcome ? "/icons/outcome.svg" : "/icons/activity.svg"}
+              alt=""
+              width={18}
+              height={18}
+            />
+          </span>
+          <div className="flex flex-col">
+            <p className="text-base font-semibold tracking-[-0.01em] text-foreground">
+              {segment.impactSegmentName}
+            </p>
+            {segment.impactSegmentDescription ? (
+              <p className="text-[13px] text-muted-foreground">
+                {segment.impactSegmentDescription}
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <span className="shrink-0 rounded-full border border-border bg-background px-2.5 py-1 text-[11px] font-semibold text-muted-foreground">
+          {segment.impactIndicatorIds.length}{" "}
+          {pluralize("metric", segment.impactIndicatorIds.length)}
+        </span>
+      </div>
+
+      {/* Chart body */}
+      <div className="px-5 py-5">
+        {isLoading ? (
+          <div className="flex h-40 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : error ? (
+          <div className="rounded-xl border border-dashed border-red-300 px-6 py-10 text-center dark:border-red-800/60">
+            <p className="text-base font-medium text-red-600 dark:text-red-400">
+              Error loading metrics
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">Unable to fetch indicator data</p>
+          </div>
+        ) : segment.impactIndicatorIds.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border px-6 py-10 text-center">
+            <p className="text-base font-medium text-foreground">No metrics available yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Impact indicators will appear here once projects start reporting data.
             </p>
           </div>
-
-          {/* Aggregated Chart Display */}
-          {isLoading ? (
-            <div className="flex justify-center items-center h-32 bg-white dark:bg-zinc-700 rounded-lg">
-              <Spinner />
-            </div>
-          ) : error ? (
-            <div className="p-8 text-center text-red-500 dark:text-red-400 bg-white dark:bg-zinc-700 rounded-lg border-2 border-dashed border-red-300 dark:border-red-600">
-              <p className="text-lg font-medium">Error loading metrics</p>
-              <p className="text-sm mt-1">Unable to fetch indicator data</p>
-            </div>
-          ) : segment.impactIndicatorIds.length === 0 ? (
-            <div className="p-8 text-center text-gray-500 dark:text-gray-400 bg-white dark:bg-zinc-700 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
-              <p className="text-lg font-medium">No metrics available yet</p>
-              <p className="text-sm mt-1">
-                Impact indicators will appear here once projects start reporting data
-              </p>
-            </div>
-          ) : aggregatedIndicators && aggregatedIndicators.length > 0 && chartData.length > 0 ? (
-            <Card className="bg-white dark:bg-zinc-700">
-              <div className="mb-4">
-                <div className="flex justify-between items-start mb-2">
-                  <h4 className="text-lg font-semibold text-black dark:text-white">
-                    Aggregated Impact Metrics
-                  </h4>
-                  <TimeframeSelector
-                    selectedTimeframe={selectedTimeframe}
-                    onTimeframeChange={setSelectedTimeframe}
-                  />
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {aggregatedIndicators.map((indicator, _index) => (
-                    <span
-                      key={indicator.id}
-                      className="px-2 py-1 text-xs rounded-full bg-gray-100 dark:bg-gray-600 text-gray-800 dark:text-gray-200"
-                    >
-                      {indicator.name} ({indicator.totalProjects}{" "}
-                      {pluralize("project", indicator.totalProjects)})
-                    </span>
-                  ))}
-                </div>
+        ) : aggregatedIndicators && aggregatedIndicators.length > 0 && chartData.length > 0 ? (
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-0.5">
+                <h4 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">
+                  Aggregated impact metrics
+                </h4>
+                <p className="text-xs text-muted-foreground">
+                  Combined indicator values across all participating projects.
+                </p>
               </div>
+              <TimeframeSelector
+                selectedTimeframe={selectedTimeframe}
+                onTimeframeChange={setSelectedTimeframe}
+              />
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {aggregatedIndicators.map((indicator) => (
+                <span
+                  key={indicator.id}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border bg-secondary/50 px-2.5 py-1 text-[12px] font-medium text-foreground"
+                >
+                  {indicator.name}
+                  <span className="text-[11px] tabular-nums text-muted-foreground">
+                    {indicator.totalProjects} {pluralize("project", indicator.totalProjects)}
+                  </span>
+                </span>
+              ))}
+            </div>
+            <div className="rounded-xl border border-border bg-background p-3">
               <AreaChart
                 data={chartData}
                 index="date"
                 categories={indicatorNames}
                 colors={colors.slice(0, indicatorNames.length)}
                 valueFormatter={valueFormatter}
-                yAxisWidth={80}
+                yAxisWidth={64}
                 enableLegendSlider
                 noDataText="No data available for the selected period"
                 className="h-72"
               />
-            </Card>
-          ) : (
-            <div className="bg-white dark:bg-zinc-700 rounded-lg border border-gray-200 dark:border-gray-600">
-              <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-gray-600">
-                <h4 className="text-lg font-semibold text-black dark:text-white">
-                  Aggregated Impact Metrics
-                </h4>
-                <TimeframeSelector
-                  selectedTimeframe={selectedTimeframe}
-                  onTimeframeChange={setSelectedTimeframe}
-                />
-              </div>
-              <div className="p-8 text-center text-gray-500 dark:text-gray-400">
-                <p className="text-lg font-medium">No data available</p>
-                <p className="text-sm mt-1">
-                  No data available for the selected period. Try selecting a different timeframe.
-                </p>
-              </div>
             </div>
-          )}
-        </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-3">
+              <h4 className="text-[15px] font-semibold tracking-[-0.01em] text-foreground">
+                Aggregated impact metrics
+              </h4>
+              <TimeframeSelector
+                selectedTimeframe={selectedTimeframe}
+                onTimeframeChange={setSelectedTimeframe}
+              />
+            </div>
+            <div className="rounded-xl border border-dashed border-border px-6 py-10 text-center">
+              <p className="text-base font-medium text-foreground">No data available</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                No data available for the selected period. Try a different timeframe.
+              </p>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -336,15 +357,16 @@ export const CategoryRow = ({ category }: { category: ProgramImpactDataResponse 
   const uniqueIndicatorCount = new Set(allIndicatorIds).size;
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-row gap-3 items-center">
-        <h2 className="text-2xl leading-6 font-bold text-black dark:text-white">
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-row items-center gap-3 border-b border-border pb-3">
+        <span aria-hidden className="inline-block h-5 w-1 rounded-full bg-foreground/80" />
+        <h3 className="text-lg md:text-xl font-semibold tracking-[-0.01em] text-foreground">
           {category.categoryName}
-        </h2>
-        {!projectSelected ? (
-          <p className="text-lg leading-6 text-gray-500 dark:text-zinc-200 font-medium">
+        </h3>
+        {!projectSelected && uniqueIndicatorCount > 0 ? (
+          <span className="ml-1 inline-flex items-center rounded-full border border-border bg-secondary/60 px-2.5 py-0.5 text-[11px] font-semibold tabular-nums text-muted-foreground">
             {uniqueIndicatorCount} {pluralize("indicator", uniqueIndicatorCount)}
-          </p>
+          </span>
         ) : null}
       </div>
       <CategoryBlocks category={category} />

--- a/components/Pages/Communities/Impact/CategoryRow.tsx
+++ b/components/Pages/Communities/Impact/CategoryRow.tsx
@@ -151,9 +151,7 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
       <div
         className={cn(
           "flex flex-row items-center justify-between gap-3 border-b border-border px-5 py-4",
-          isOutcome
-            ? "bg-emerald-50/60 dark:bg-emerald-950/20"
-            : "bg-violet-50/60 dark:bg-violet-950/20"
+          isOutcome ? "bg-brand-50/60 dark:bg-brand-500/10" : "bg-secondary/60 dark:bg-secondary/40"
         )}
       >
         <div className="flex flex-row items-center gap-3">
@@ -161,8 +159,8 @@ const AggregatedSegmentCard = ({ segment }: { segment: ProgramImpactSegment }) =
             className={cn(
               "flex h-9 w-9 items-center justify-center rounded-lg",
               isOutcome
-                ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
-                : "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300"
+                ? "bg-brand-100 text-brand-700 dark:bg-brand-500/20 dark:text-brand-400"
+                : "bg-muted text-muted-foreground"
             )}
             aria-hidden
           >

--- a/components/Pages/Communities/Impact/FilterRow.tsx
+++ b/components/Pages/Communities/Impact/FilterRow.tsx
@@ -10,16 +10,9 @@ export const CommunityImpactFilterRow = () => {
   if (isProjectDiscovery) return null;
 
   return (
-    <div className="px-3 py-4 bg-gray-100 dark:bg-zinc-900 rounded-lg flex flex-row items-center w-full gap-8 max-lg:flex-col max-lg:gap-4 max-lg:justify-start max-lg:items-start">
-      <h3 className="text-slate-800 dark:text-zinc-100 text-xl font-semibold font-['Inter'] leading-normal">
-        Filter by
-      </h3>
-      <div className="flex flex-row w-max max-w-full">
-        <ProgramFilter />
-      </div>
-      <div className="flex flex-row w-max max-w-full">
-        <ProjectFilter />
-      </div>
+    <div className="flex flex-row flex-wrap items-end gap-5 w-full max-lg:flex-col max-lg:items-stretch">
+      <ProgramFilter />
+      <ProjectFilter />
     </div>
   );
 };

--- a/components/Pages/Communities/Impact/ImpactCharts.tsx
+++ b/components/Pages/Communities/Impact/ImpactCharts.tsx
@@ -6,6 +6,7 @@ import type { ProgramImpactDataResponse } from "@/types/programs";
 import { formatDate } from "@/utilities/formatDate";
 import { CategoryRow } from "./CategoryRow";
 import { CommunityMetricsSection } from "./CommunityMetricsSection";
+import { ImpactOutcomes } from "./ImpactOutcomes";
 import { ProgramBanner } from "./ProgramBanner";
 
 export const prepareChartData = (
@@ -67,43 +68,50 @@ export const CommunityImpactCharts = () => {
   const showCommunityMetrics = !programSelected && !projectSelected;
 
   return (
-    <div className="flex flex-col gap-4 flex-1 mb-10">
+    <div className="flex flex-col gap-8 flex-1 mb-10">
       <ProgramBanner />
       {showCommunityMetrics && <CommunityMetricsSection />}
-      {isLoading ? (
-        <div className="flex justify-center items-center h-full">
-          <Spinner />
-        </div>
-      ) : orderedData?.length ? (
-        orderedData.map((category, index) => (
-          <div
-            key={`category-container-${category.categoryName}-${
-              projectSelected || "all"
-            }-${programSelected || "all"}-${index}`}
-          >
-            <CategoryRow
-              key={`category-row-${category.categoryName}-${
-                projectSelected || "all"
-              }-${programSelected || "all"}-${index}`}
-              category={category}
-            />
-            {index !== orderedData.length - 1 && (
+
+      <section className="flex flex-col gap-6">
+        {isLoading ? (
+          <div className="flex justify-center items-center py-10">
+            <Spinner />
+          </div>
+        ) : orderedData?.length ? (
+          <div className="flex flex-col">
+            {orderedData.map((category, index) => (
               <div
-                key={`category-divider-${category.categoryName}-${
+                key={`category-container-${category.categoryName}-${
                   projectSelected || "all"
                 }-${programSelected || "all"}-${index}`}
-                className="w-full my-8 h-px bg-gradient-to-r from-transparent via-gray-300 dark:via-gray-700 to-transparent"
-              />
-            )}
+              >
+                <CategoryRow
+                  key={`category-row-${category.categoryName}-${
+                    projectSelected || "all"
+                  }-${programSelected || "all"}-${index}`}
+                  category={category}
+                />
+                {index !== orderedData.length - 1 && (
+                  <div
+                    key={`category-divider-${category.categoryName}-${
+                      projectSelected || "all"
+                    }-${programSelected || "all"}-${index}`}
+                    className="w-full my-12 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+                  />
+                )}
+              </div>
+            ))}
           </div>
-        ))
-      ) : (
-        <div className="flex flex-col items-center justify-center py-10 text-center">
-          <p className="text-lg text-gray-600 dark:text-gray-400">
-            This community has not reported any impact segments yet.
-          </p>
-        </div>
-      )}
+        ) : (
+          <div className="rounded-2xl border border-dashed border-border py-10 text-center">
+            <p className="text-lg text-muted-foreground">
+              This community has not reported any impact segments yet.
+            </p>
+          </div>
+        )}
+      </section>
+
+      {showCommunityMetrics ? <ImpactOutcomes /> : null}
     </div>
   );
 };

--- a/components/Pages/Communities/Impact/ImpactOutcomes.tsx
+++ b/components/Pages/Communities/Impact/ImpactOutcomes.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "next/navigation";
+import { useCommunityAccent } from "@/hooks/useCommunityAccent";
+import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
+import formatCurrency from "@/utilities/formatCurrency";
+import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
+
+export function ImpactOutcomes() {
+  const params = useParams<{ communityId: string }>();
+  const communityId = params.communityId;
+  const accent = useCommunityAccent(communityId);
+  const { community } = useCommunityDetails(communityId);
+  const slug = community?.details?.slug ?? communityId;
+
+  const { data: stats } = useQuery({
+    queryKey: ["community-stats", communityId],
+    queryFn: () => getCommunityStats(slug || communityId),
+    enabled: !!communityId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!stats) return null;
+
+  const projects = stats.totalProjects ?? 0;
+  const grants = stats.totalGrants ?? 0;
+  const totalMilestones = stats.totalMilestones ?? 0;
+  const breakdown = stats.projectUpdatesBreakdown;
+  const completedMilestones = breakdown
+    ? breakdown.projectCompletedMilestones + breakdown.grantCompletedMilestones
+    : 0;
+  const projectUpdates = breakdown?.projectUpdates ?? 0;
+  const grantUpdates = breakdown?.grantUpdates ?? 0;
+  const completionPct =
+    totalMilestones > 0 ? Math.round((completedMilestones / totalMilestones) * 100) : 0;
+
+  const items: Array<[string, string]> = [];
+  if (grants > 0) items.push([formatCurrency(grants), "grants tracked across the community"]);
+  if (projects > 0) items.push([formatCurrency(projects), "funded teams shipping work"]);
+  if (totalMilestones > 0) {
+    items.push([
+      `${formatCurrency(completedMilestones)} of ${formatCurrency(totalMilestones)}`,
+      "milestones shipped",
+    ]);
+  }
+  if (completionPct > 0) items.push([`${completionPct}%`, "milestone completion rate"]);
+  if (projectUpdates > 0)
+    items.push([formatCurrency(projectUpdates), "project updates published by teams"]);
+  if (grantUpdates > 0)
+    items.push([formatCurrency(grantUpdates), "grant updates from funded programs"]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="impact-outcomes-title"
+      className="rounded-[20px] bg-secondary p-6 md:p-8"
+    >
+      <h3
+        id="impact-outcomes-title"
+        className="mb-5 text-xl md:text-[22px] font-semibold tracking-[-0.02em] text-foreground"
+      >
+        Outcomes delivered
+      </h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map(([value, label]) => (
+          <div
+            key={label}
+            className="flex items-baseline gap-3.5 rounded-xl border border-border bg-background p-4"
+          >
+            <span
+              className="text-xl md:text-[22px] font-semibold tracking-[-0.02em] tabular-nums whitespace-nowrap"
+              style={{ color: accent }}
+            >
+              {value}
+            </span>
+            <span className="text-sm text-muted-foreground">{label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/Pages/Communities/Impact/ImpactOutcomes.tsx
+++ b/components/Pages/Communities/Impact/ImpactOutcomes.tsx
@@ -2,10 +2,13 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
+import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useCommunityAccent } from "@/hooks/useCommunityAccent";
 import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
 import formatCurrency from "@/utilities/formatCurrency";
 import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
+
+const SKELETON_KEYS = ["a", "b", "c", "d"];
 
 export function ImpactOutcomes() {
   const params = useParams<{ communityId: string }>();
@@ -14,12 +17,34 @@ export function ImpactOutcomes() {
   const { community } = useCommunityDetails(communityId);
   const slug = community?.details?.slug ?? communityId;
 
-  const { data: stats } = useQuery({
+  const { data: stats, isLoading } = useQuery({
     queryKey: ["community-stats", communityId],
     queryFn: () => getCommunityStats(slug || communityId),
     enabled: !!communityId,
     staleTime: 5 * 60 * 1000,
   });
+
+  if (isLoading) {
+    return (
+      <section
+        aria-labelledby="impact-outcomes-title"
+        className="rounded-[20px] bg-secondary p-6 md:p-8"
+      >
+        <Skeleton className="mb-5 h-7 w-48" />
+        <div className="grid gap-3 sm:grid-cols-2">
+          {SKELETON_KEYS.map((key) => (
+            <div
+              key={key}
+              className="flex items-baseline gap-3.5 rounded-xl border border-border bg-background p-4"
+            >
+              <Skeleton className="h-7 w-16" />
+              <Skeleton className="h-4 w-40" />
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
 
   if (!stats) return null;
 

--- a/components/Pages/Communities/Impact/ImpactOutcomes.tsx
+++ b/components/Pages/Communities/Impact/ImpactOutcomes.tsx
@@ -46,7 +46,24 @@ export function ImpactOutcomes() {
     );
   }
 
-  if (!stats) return null;
+  if (!stats) {
+    return (
+      <section
+        aria-labelledby="impact-outcomes-title"
+        className="rounded-[20px] bg-secondary p-6 md:p-8"
+      >
+        <h3
+          id="impact-outcomes-title"
+          className="mb-2 text-xl md:text-[22px] font-semibold tracking-[-0.02em] text-foreground"
+        >
+          Outcomes delivered
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          We couldn&apos;t load community outcomes right now.
+        </p>
+      </section>
+    );
+  }
 
   const projects = stats.totalProjects ?? 0;
   const grants = stats.totalGrants ?? 0;
@@ -75,7 +92,24 @@ export function ImpactOutcomes() {
   if (grantUpdates > 0)
     items.push([formatCurrency(grantUpdates), "grant updates from funded programs"]);
 
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    return (
+      <section
+        aria-labelledby="impact-outcomes-title"
+        className="rounded-[20px] bg-secondary p-6 md:p-8"
+      >
+        <h3
+          id="impact-outcomes-title"
+          className="mb-2 text-xl md:text-[22px] font-semibold tracking-[-0.02em] text-foreground"
+        >
+          Outcomes delivered
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          No outcomes have been recorded for this community yet.
+        </p>
+      </section>
+    );
+  }
 
   return (
     <section

--- a/components/Pages/Communities/Impact/ImpactTabNavigator.tsx
+++ b/components/Pages/Communities/Impact/ImpactTabNavigator.tsx
@@ -4,10 +4,10 @@ import { Link } from "@/src/components/navigation/Link";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 
-const activeLinkStyle = "text-slate-700 dark:text-zinc-200 bg-white rounded-md dark:bg-zinc-600";
-const inactiveLinkStyle = "text-slate-500 dark:text-zinc-400 bg-transparent";
 const baseLinkStyle =
-  "px-3 py-2 max-lg:w-full rounded-md text-base font-semibold font-['Inter'] leading-normal w-max";
+  "relative px-1 pb-3 text-sm font-semibold tracking-[-0.005em] transition-colors max-lg:w-full max-lg:pb-2";
+const activeLinkStyle = "text-foreground";
+const inactiveLinkStyle = "text-muted-foreground hover:text-foreground";
 
 export const ImpactTabNavigator = () => {
   const params = useParams();
@@ -16,22 +16,39 @@ export const ImpactTabNavigator = () => {
   const isProjectDiscovery = pathname.includes("/project-discovery");
 
   return (
-    <div className="flex-row max-lg:flex-col px-1.5 py-2 rounded-lg bg-gray-100 dark:bg-zinc-900 justify-start items-center gap-4 flex h-max w-max max-w-full">
+    <div
+      role="tablist"
+      className="flex flex-row items-center gap-7 border-b border-border max-lg:flex-col max-lg:items-start max-lg:gap-3"
+    >
       <Link
         href={PAGES.COMMUNITY.IMPACT(communityId)}
         className={cn(baseLinkStyle, !isProjectDiscovery ? activeLinkStyle : inactiveLinkStyle)}
         aria-label="View impact"
+        aria-current={!isProjectDiscovery ? "page" : undefined}
         tabIndex={0}
       >
         Program Impact
+        {!isProjectDiscovery ? (
+          <span
+            aria-hidden
+            className="absolute -bottom-px left-0 right-0 h-0.5 rounded-full bg-foreground"
+          />
+        ) : null}
       </Link>
       <Link
         href={PAGES.COMMUNITY.PROJECT_DISCOVERY(communityId)}
         className={cn(baseLinkStyle, isProjectDiscovery ? activeLinkStyle : inactiveLinkStyle)}
         aria-label="Project Discovery"
+        aria-current={isProjectDiscovery ? "page" : undefined}
         tabIndex={0}
       >
         Project Discovery
+        {isProjectDiscovery ? (
+          <span
+            aria-hidden
+            className="absolute -bottom-px left-0 right-0 h-0.5 rounded-full bg-foreground"
+          />
+        ) : null}
       </Link>
     </div>
   );

--- a/components/Pages/Communities/Impact/ImpactTabNavigator.tsx
+++ b/components/Pages/Communities/Impact/ImpactTabNavigator.tsx
@@ -16,8 +16,8 @@ export const ImpactTabNavigator = () => {
   const isProjectDiscovery = pathname.includes("/project-discovery");
 
   return (
-    <div
-      role="tablist"
+    <nav
+      aria-label="Community impact sections"
       className="flex flex-row items-center gap-7 border-b border-border max-lg:flex-col max-lg:items-start max-lg:gap-3"
     >
       <Link
@@ -50,6 +50,6 @@ export const ImpactTabNavigator = () => {
           />
         ) : null}
       </Link>
-    </div>
+    </nav>
   );
 };

--- a/components/Pages/Communities/Impact/ProgramBanner.tsx
+++ b/components/Pages/Communities/Impact/ProgramBanner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 import { useParams, useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
@@ -9,17 +11,22 @@ import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
 import formatCurrency from "@/utilities/formatCurrency";
 import { getAllProgramsOfCommunity } from "@/utilities/registry/getAllProgramsOfCommunity";
 
+const normalizeProgramId = (raw: string | null): string | undefined => {
+  if (!raw) return undefined;
+  return raw.includes("_") ? raw.split("_")[0] : raw;
+};
+
 export const ProgramBanner = () => {
   const { communityId } = useParams<{ communityId: string }>();
   const searchParams = useSearchParams();
-  const programSelected = searchParams.get("programId");
+  const programSelected = normalizeProgramId(searchParams.get("programId"));
   const projectSelected = searchParams.get("projectId");
   const accent = useCommunityAccent(communityId);
   const { community } = useCommunityDetails(communityId);
   const communityName = community?.details?.name ?? "this community";
 
   const { data: impactData, isLoading: isImpactLoading } = useImpactMeasurement({
-    programId: programSelected ?? undefined,
+    programId: programSelected,
     projectId: projectSelected ?? undefined,
   });
 
@@ -34,16 +41,8 @@ export const ProgramBanner = () => {
 
   const [selectedProgramId] = useQueryState<string | null>("programId", {
     defaultValue: null,
-    serialize: (value) => {
-      if (!value) return "";
-      const normalized = value.includes("_") ? value.split("_")[0] : value;
-      return normalized;
-    },
-    parse: (value) => {
-      if (!value) return null;
-      const normalized = value.includes("_") ? value.split("_")[0] : value;
-      return normalized;
-    },
+    serialize: (value) => normalizeProgramId(value) ?? "",
+    parse: (value) => normalizeProgramId(value) ?? null,
   });
   const selectedProgram = programs?.find((program) => program.value === selectedProgramId);
 

--- a/components/Pages/Communities/Impact/ProgramBanner.tsx
+++ b/components/Pages/Communities/Impact/ProgramBanner.tsx
@@ -3,14 +3,21 @@ import { useParams, useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import pluralize from "pluralize";
 import { Skeleton } from "@/components/Utilities/Skeleton";
+import { useCommunityAccent } from "@/hooks/useCommunityAccent";
 import { useImpactMeasurement } from "@/hooks/useImpactMeasurement";
+import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
+import formatCurrency from "@/utilities/formatCurrency";
 import { getAllProgramsOfCommunity } from "@/utilities/registry/getAllProgramsOfCommunity";
 
 export const ProgramBanner = () => {
-  const { communityId } = useParams();
+  const { communityId } = useParams<{ communityId: string }>();
   const searchParams = useSearchParams();
   const programSelected = searchParams.get("programId");
   const projectSelected = searchParams.get("projectId");
+  const accent = useCommunityAccent(communityId);
+  const { community } = useCommunityDetails(communityId);
+  const communityName = community?.details?.name ?? "this community";
+
   const { data: impactData, isLoading: isImpactLoading } = useImpactMeasurement({
     programId: programSelected ?? undefined,
     projectId: projectSelected ?? undefined,
@@ -40,31 +47,59 @@ export const ProgramBanner = () => {
   });
   const selectedProgram = programs?.find((program) => program.value === selectedProgramId);
 
-  // Use stats from impact endpoint - consistent data source
   const totalProjects = impactData?.stats.totalProjects ?? 0;
   const totalCategories = impactData?.stats.totalCategories ?? 0;
 
+  const eyebrow = projectSelected
+    ? selectedProgram
+      ? `${selectedProgram.title} · Project filtered`
+      : "All programs · Project filtered"
+    : selectedProgram
+      ? selectedProgram.title
+      : "All programs";
+
   return (
-    <div className="px-4 py-3 border border-gray-300 rounded">
-      <div className="border-l-[#7839EE] border-l-2 pl-4">
-        <p className="text-black dark:text-zinc-300 text-2xl font-semibold">
-          {projectSelected
-            ? selectedProgram
-              ? `${selectedProgram?.title} (Project Filtered)`
-              : "All Programs (Project Filtered)"
-            : selectedProgram
-              ? `${selectedProgram?.title}`
-              : "All Programs"}
+    <section
+      aria-label="Program impact summary"
+      className="relative overflow-hidden rounded-[20px] border border-border bg-background px-7 py-3.5 md:px-9 md:py-4"
+      style={{
+        backgroundImage: `linear-gradient(135deg, ${accent}14, transparent 70%)`,
+      }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-20 -top-20 h-[380px] w-[380px] rounded-full blur-3xl"
+        style={{ background: `radial-gradient(circle, ${accent}33, transparent 70%)` }}
+      />
+
+      <div className="relative grid gap-6 md:grid-cols-[auto_1fr] md:items-center md:gap-12">
+        <div>
+          <div
+            className="mb-2.5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.08em]"
+            style={{ color: accent }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: accent }} aria-hidden />
+            {eyebrow}
+          </div>
+          {isImpactLoading ? (
+            <Skeleton className="h-10 w-72" />
+          ) : (
+            <h2 className="text-3xl md:text-4xl lg:text-[42px] font-semibold leading-[1.05] tracking-[-0.03em] text-foreground">
+              <span style={{ color: accent }}>
+                {formatCurrency(totalProjects)} {pluralize("project", totalProjects)}
+              </span>{" "}
+              <span className="text-muted-foreground">·</span>{" "}
+              <span className="text-muted-foreground">
+                {formatCurrency(totalCategories)} {pluralize("category", totalCategories)}
+              </span>
+            </h2>
+          )}
+        </div>
+        <p className="max-w-[520px] text-[15px] leading-relaxed text-muted-foreground md:justify-self-end">
+          Track the funded teams, milestones shipped, and the measurable outcomes attributed to
+          programs in {communityName}.
         </p>
-        {isImpactLoading ? (
-          <Skeleton className="w-40 h-8" />
-        ) : (
-          <span className="text-gray-500 dark:text-zinc-500 text-lg font-medium">
-            {totalProjects} {pluralize("Project", totalProjects)}, {totalCategories}{" "}
-            {pluralize("category", totalCategories)}
-          </span>
-        )}
       </div>
-    </div>
+    </section>
   );
 };

--- a/components/Pages/Communities/Impact/ProgramFilter.tsx
+++ b/components/Pages/Communities/Impact/ProgramFilter.tsx
@@ -45,7 +45,7 @@ export const ProgramFilter = ({ defaultProgramSelected, onChange }: ProgramFilte
         htmlFor="filter-by-programs"
         className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground"
       >
-        Program
+        Choose Program
       </label>
 
       <SearchWithValueDropdown

--- a/components/Pages/Communities/Impact/ProgramFilter.tsx
+++ b/components/Pages/Communities/Impact/ProgramFilter.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Image from "next/image";
 import { useParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
@@ -41,17 +40,13 @@ export const ProgramFilter = ({ defaultProgramSelected, onChange }: ProgramFilte
   const selectedProgram = programs?.find((program) => program.value === selectedProgramId);
 
   return (
-    <div className="flex flex-row gap-4 items-center flex-1 max-w-[400px]">
-      <Image
-        src={"/icons/program.svg"}
-        alt="program"
-        width={24}
-        height={24}
-        className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
-      />
-      <p className="text-gray-800 dark:text-zinc-100 text-base font-semibold leading-normal">
+    <div className="flex flex-col gap-1.5 flex-1 min-w-[220px] max-w-[400px]">
+      <label
+        htmlFor="filter-by-programs"
+        className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground"
+      >
         Program
-      </p>
+      </label>
 
       <SearchWithValueDropdown
         id="filter-by-programs"

--- a/components/Pages/Communities/Impact/ProjectFilter.tsx
+++ b/components/Pages/Communities/Impact/ProjectFilter.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Image from "next/image";
 import { useParams, useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -58,17 +57,10 @@ export const ProjectFilter = ({
   const selectedProject = projectOptions.find((project) => project.value === selectedProjectId);
 
   return (
-    <div className="flex flex-row gap-4 items-center flex-1 max-w-[450px]">
-      <Image
-        src={"/icons/project.png"}
-        alt="Project"
-        width={24}
-        height={24}
-        className="w-6 h-6 min-w-6 max-w-6 min-h-6 max-h-6"
-      />
-      <p className="text-gray-800 dark:text-zinc-100 text-base font-semibold leading-normal">
+    <div className="flex flex-col gap-1.5 flex-1 min-w-[220px] max-w-[450px]">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
         Project
-      </p>
+      </span>
 
       <SearchWithValueDropdown
         list={projectOptions}

--- a/components/Pages/Communities/PageHero.tsx
+++ b/components/Pages/Communities/PageHero.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/utilities/tailwind";
+
+export interface KpiItem {
+  label: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  accent?: "default" | "danger" | "success" | "warning" | "brand";
+}
+
+interface PageHeroProps {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  kpis?: KpiItem[];
+  rightSlot?: ReactNode;
+  className?: string;
+  compact?: boolean;
+}
+
+const ACCENT_CLASS: Record<NonNullable<KpiItem["accent"]>, string> = {
+  default: "text-foreground",
+  danger: "text-red-600 dark:text-red-400",
+  success: "text-emerald-600 dark:text-emerald-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  brand: "text-brand-700 dark:text-brand-400",
+};
+
+export function PageHero({
+  eyebrow,
+  title,
+  description,
+  kpis,
+  rightSlot,
+  className,
+  compact = false,
+}: PageHeroProps) {
+  const hasKpis = !!kpis && kpis.length > 0;
+  const hasRight = hasKpis || !!rightSlot;
+
+  return (
+    <section
+      className={cn("relative overflow-hidden", compact ? "mb-8" : "mb-10 md:mb-12", className)}
+      aria-labelledby="page-hero-title"
+    >
+      <div
+        className={cn(
+          "grid gap-8 md:gap-12",
+          hasRight ? "md:grid-cols-[1.3fr_1fr]" : "grid-cols-1"
+        )}
+      >
+        <div>
+          {eyebrow ? (
+            <div className="mb-3 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.08em] text-brand-700 dark:text-brand-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-brand-500" aria-hidden />
+              {eyebrow}
+            </div>
+          ) : null}
+
+          <h1
+            id="page-hero-title"
+            className={cn(
+              "font-semibold leading-[1.05] tracking-[-0.03em] text-foreground",
+              compact ? "text-3xl md:text-4xl" : "text-4xl md:text-5xl lg:text-[52px]"
+            )}
+          >
+            {title}
+          </h1>
+
+          {description ? (
+            <p className="mt-4 max-w-prose text-base md:text-[17px] leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+
+        {hasRight ? (
+          <div className="flex flex-col justify-end gap-5">
+            {rightSlot}
+            {hasKpis ? <KpiStrip items={kpis!} /> : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export function KpiStrip({ items }: { items: KpiItem[] }) {
+  const cols = items.length >= 4 ? "sm:grid-cols-2 lg:grid-cols-2" : "sm:grid-cols-2";
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-px overflow-hidden rounded-2xl border border-border bg-border",
+        cols
+      )}
+    >
+      {items.map((item, i) => (
+        <div key={`${item.label}-${i}`} className="bg-background p-4 md:p-5">
+          <div className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+            {item.label}
+          </div>
+          <div
+            className={cn(
+              "mt-1.5 text-2xl md:text-[26px] font-semibold tracking-[-0.02em]",
+              ACCENT_CLASS[item.accent ?? "default"]
+            )}
+          >
+            {item.value}
+          </div>
+          {item.sub ? <div className="mt-0.5 text-xs text-muted-foreground">{item.sub}</div> : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -23,6 +23,30 @@ function formatPublished(iso: string): string {
   });
 }
 
+function decodeBasicEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function extractTitle(content: string): string | null {
+  if (!content) return null;
+  const titleTag = content.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleTag?.[1]?.trim()) return decodeBasicEntities(titleTag[1]).trim();
+  const h1 = content.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (h1?.[1]) {
+    const stripped = h1[1].replace(/<[^>]+>/g, "").trim();
+    if (stripped) return decodeBasicEntities(stripped);
+  }
+  const mdHeading = content.match(/^#{1,2}\s+(.+)$/m);
+  if (mdHeading?.[1]) return mdHeading[1].trim();
+  return null;
+}
+
 const MONTH_ABBR = [
   "JAN",
   "FEB",
@@ -121,7 +145,7 @@ export function PublicReportListPage({ community }: Props) {
 
   if (isError) {
     return (
-      <div className="mx-auto max-w-4xl px-4 py-12">
+      <div className="w-full max-w-full py-2 animate-fade-in-up">
         <h1 className="mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
           Portfolio Reports
         </h1>
@@ -143,7 +167,7 @@ export function PublicReportListPage({ community }: Props) {
 
   if (sortedReports.length === 0) {
     return (
-      <div className="mx-auto max-w-4xl px-4 py-12">
+      <div className="w-full max-w-full py-2 animate-fade-in-up">
         <h1 className="mb-4 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
           Portfolio Reports
         </h1>
@@ -159,7 +183,7 @@ export function PublicReportListPage({ community }: Props) {
   const latest = sortedReports[0];
 
   return (
-    <div className="px-6 py-10 lg:px-10">
+    <div className="w-full max-w-full -my-4 py-2 animate-fade-in-up">
       <header className="mb-10">
         <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
           Portfolio Reports
@@ -187,16 +211,16 @@ export function PublicReportListPage({ community }: Props) {
               >
                 <Link
                   href={PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate)}
-                  className="group/link flex items-start justify-between gap-8"
+                  className="group/link flex items-start gap-8"
                 >
                   <div className="min-w-0 flex-1">
                     <p className="mb-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
                       {fmt.badge}
                     </p>
                     <h2 className="text-xl font-semibold tracking-tight text-zinc-900 transition-colors group-hover/link:text-blue-600 sm:text-2xl dark:text-zinc-100 dark:group-hover/link:text-blue-400">
-                      {fmt.label}
+                      {report.reportConfigName ?? extractTitle(report.content) ?? fmt.label}
                     </h2>
-                    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+                    <p className="mt-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
                       {excerpt}
                     </p>
                     <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">

--- a/components/ui/border-beam.tsx
+++ b/components/ui/border-beam.tsx
@@ -1,0 +1,60 @@
+"use client";
+import type * as React from "react";
+import { cn } from "@/utilities/tailwind";
+
+interface BorderBeamProps {
+  size?: number;
+  duration?: number;
+  delay?: number;
+  colorFrom?: string;
+  colorTo?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  reverse?: boolean;
+  initialOffset?: number;
+  borderWidth?: number;
+}
+
+export const BorderBeam = ({
+  className,
+  size = 50,
+  delay = 0,
+  duration = 6,
+  colorFrom = "#ffaa40",
+  colorTo = "#9c40ff",
+  style,
+  reverse = false,
+  initialOffset = 0,
+  borderWidth = 1,
+}: BorderBeamProps) => {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 rounded-[inherit] border border-transparent [mask-clip:padding-box,border-box] [mask-composite:intersect] [mask-image:linear-gradient(transparent,transparent),linear-gradient(#000,#000)]"
+      style={{ borderWidth: `${borderWidth}px` }}
+    >
+      <div
+        className={cn(
+          "absolute aspect-square bg-gradient-to-l from-[var(--color-from)] via-[var(--color-to)] to-transparent",
+          reverse ? "animate-border-beam-reverse" : "animate-border-beam",
+          className
+        )}
+        style={
+          {
+            width: size,
+            offsetPath: `rect(0 auto auto 0 round ${size}px)`,
+            offsetDistance: `${initialOffset}%`,
+            animationDuration: `${duration}s`,
+            animationDelay: `${-delay}s`,
+            "--color-from": colorFrom,
+            "--color-to": colorTo,
+            "--initial-offset": `${initialOffset}%`,
+            "--reverse-start": `${100 - initialOffset}%`,
+            "--reverse-end": `${-initialOffset}%`,
+            "--forward-end": `${100 + initialOffset}%`,
+            ...style,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+};

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -72,7 +72,13 @@ export default defineConfig({
     : {
         command: isCI ? "pnpm start" : "cross-env NEXT_PUBLIC_E2E_AUTH_BYPASS=true pnpm run dev",
         url: "http://localhost:3000",
-        reuseExistingServer: !isCI,
+        // Always reuse a server already listening on :3000. Some CI jobs
+        // (e.g. dogfood-auth-prep) start the standalone Next bundle out of
+        // band before invoking Playwright; without this, Playwright would
+        // try to spawn its own server and crash with "port already used".
+        // When no server is running, Playwright still falls back to running
+        // `command` above, so this is safe for jobs that don't pre-start.
+        reuseExistingServer: true,
         timeout: 120_000,
       },
 });

--- a/hooks/useChatRating.ts
+++ b/hooks/useChatRating.ts
@@ -2,9 +2,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { useCallback } from "react";
+import { useAgentChatStore } from "@/store/agentChat";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { envVars } from "@/utilities/enviromentVars";
-import { useAgentChatStore } from "@/store/agentChat";
 
 export type RatingValue = 1 | -1;
 
@@ -19,10 +19,7 @@ export interface UseChatRatingResult {
   submit: (value: RatingValue, comment?: string) => Promise<boolean>;
 }
 
-export function useChatRating(
-  messageId: string,
-  traceId: string | undefined
-): UseChatRatingResult {
+export function useChatRating(messageId: string, traceId: string | undefined): UseChatRatingResult {
   const rating = useAgentChatStore(
     (state) => state.messages.find((m) => m.id === messageId)?.rating ?? null
   );
@@ -33,21 +30,18 @@ export function useChatRating(
 
       try {
         const token = await TokenManager.getToken();
-        const response = await fetch(
-          `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/agent/rating`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
-            body: JSON.stringify({
-              traceId,
-              value,
-              ...(comment ? { comment } : {}),
-            }),
-          }
-        );
+        const response = await fetch(`${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/agent/rating`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            traceId,
+            value,
+            ...(comment ? { comment } : {}),
+          }),
+        });
 
         if (!response.ok) {
           // Capture the response body for triage — Langfuse 4xx errors

--- a/hooks/useCommunityAccent.ts
+++ b/hooks/useCommunityAccent.ts
@@ -1,0 +1,44 @@
+"use client";
+import { useDominantColor } from "@/hooks/useDominantColor";
+import { useCommunityDetails } from "@/hooks/v2/useCommunityDetails";
+import { communityColors } from "@/utilities/communityColors";
+import { useWhitelabel } from "@/utilities/whitelabel-context";
+
+const ACCENT_PALETTE = [
+  "#0090FF",
+  "#2ED1A8",
+  "#7C3AED",
+  "#F59E0B",
+  "#EF4444",
+  "#06B6D4",
+  "#EC4899",
+  "#10B981",
+  "#6366F1",
+  "#F97316",
+];
+
+function pickAccent(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return ACCENT_PALETTE[hash % ACCENT_PALETTE.length];
+}
+
+export function useCommunityAccent(communityIdOrSlug: string | undefined): string {
+  const { config } = useWhitelabel();
+  const { community } = useCommunityDetails(communityIdOrSlug);
+  const dominantColor = useDominantColor(community?.details?.logoUrl);
+
+  const uid = community?.uid?.toLowerCase() || "";
+  const slug = community?.details?.slug?.toLowerCase() || communityIdOrSlug?.toLowerCase() || "";
+  const seed = uid || slug || community?.details?.name || "community";
+
+  return (
+    config?.theme?.logoBackground ??
+    communityColors[uid] ??
+    communityColors[slug] ??
+    dominantColor ??
+    pickAccent(seed)
+  );
+}

--- a/hooks/useDominantColor.ts
+++ b/hooks/useDominantColor.ts
@@ -1,0 +1,120 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const cache = new Map<string, string>();
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0;
+  let s = 0;
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1));
+    if (max === rn) h = ((gn - bn) / d) % 6;
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return [h, s, l];
+}
+
+function extractDominant(img: HTMLImageElement): string | null {
+  try {
+    const size = 32;
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(img, 0, 0, size, size);
+    const { data } = ctx.getImageData(0, 0, size, size);
+
+    const buckets = new Map<
+      string,
+      { count: number; r: number; g: number; b: number; score: number }
+    >();
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const a = data[i + 3];
+      if (a < 200) continue;
+      const [, sat, light] = rgbToHsl(r, g, b);
+      // Skip near-white, near-black, and very desaturated pixels
+      if (light > 0.95 || light < 0.08) continue;
+      if (sat < 0.18) continue;
+      // Bucket by quantized RGB (24 levels per channel)
+      const key = `${r >> 5}-${g >> 5}-${b >> 5}`;
+      const score = sat * (1 - Math.abs(light - 0.5) * 0.6);
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.count += 1;
+        existing.r += r;
+        existing.g += g;
+        existing.b += b;
+        existing.score += score;
+      } else {
+        buckets.set(key, { count: 1, r, g, b, score });
+      }
+    }
+
+    if (buckets.size === 0) return null;
+    let best: { count: number; r: number; g: number; b: number; score: number } | null = null;
+    for (const bucket of buckets.values()) {
+      if (!best || bucket.score > best.score) best = bucket;
+    }
+    if (!best) return null;
+    return rgbToHex(
+      Math.round(best.r / best.count),
+      Math.round(best.g / best.count),
+      Math.round(best.b / best.count)
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function useDominantColor(imageUrl: string | undefined | null): string | null {
+  const [color, setColor] = useState<string | null>(() =>
+    imageUrl ? (cache.get(imageUrl) ?? null) : null
+  );
+
+  useEffect(() => {
+    if (!imageUrl) return;
+    const cached = cache.get(imageUrl);
+    if (cached) {
+      setColor(cached);
+      return;
+    }
+    let cancelled = false;
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => {
+      if (cancelled) return;
+      const dominant = extractDominant(img);
+      if (dominant) {
+        cache.set(imageUrl, dominant);
+        setColor(dominant);
+      }
+    };
+    img.onerror = () => {
+      // CORS or network error — silently fall back
+    };
+    img.src = imageUrl;
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrl]);
+
+  return color;
+}

--- a/src/features/programs/hooks/use-programs-with-config.ts
+++ b/src/features/programs/hooks/use-programs-with-config.ts
@@ -1,4 +1,4 @@
-import type { FundingProgramConfig } from "@/types/whitelabel-entities";
+import type { FundingProgram, FundingProgramConfig } from "@/types/whitelabel-entities";
 import { useProgramsList } from "./use-programs-list";
 
 export interface ProgramWithConfig {
@@ -7,6 +7,7 @@ export interface ProgramWithConfig {
   name: string;
   description?: string;
   applicationConfig?: FundingProgramConfig | null;
+  metrics?: FundingProgram["metrics"];
 }
 
 interface UseProgramsWithConfigReturn {
@@ -27,6 +28,7 @@ export function useProgramsWithConfig(communityId: string): UseProgramsWithConfi
       name: program.name || program.metadata?.title || `Program ${program.programId}`,
       description: program.metadata?.description,
       applicationConfig: program.applicationConfig,
+      metrics: program.metrics,
     }));
 
   return {

--- a/store/agentChat.ts
+++ b/store/agentChat.ts
@@ -121,17 +121,10 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       // If a trace_started SSE event arrived before this assistant message
       // existed, consume the buffered traceId and stamp it on the new
       // message — that's the path the rating UI gates on.
-      if (
-        message.role === "assistant" &&
-        !message.traceId &&
-        state.pendingTraceId
-      ) {
+      if (message.role === "assistant" && !message.traceId && state.pendingTraceId) {
         return {
-          messages: [
-            ...state.messages,
-            { ...message, traceId: state.pendingTraceId }
-          ],
-          pendingTraceId: null
+          messages: [...state.messages, { ...message, traceId: state.pendingTraceId }],
+          pendingTraceId: null,
         };
       }
       return { messages: [...state.messages, message] };
@@ -231,6 +224,6 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       error: null,
       isStreaming: false,
       pendingTraceId: null,
-      ratingCommentBoxOpenForMessageId: null
+      ratingCommentBoxOpenForMessageId: null,
     }),
 }));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,26 @@ module.exports = {
             height: "0",
           },
         },
+        "border-beam": {
+          "0%": { offsetDistance: "var(--initial-offset, 0%)" },
+          "100%": { offsetDistance: "var(--forward-end, 100%)" },
+        },
+        "border-beam-reverse": {
+          "0%": { offsetDistance: "var(--reverse-start, 100%)" },
+          "100%": { offsetDistance: "var(--reverse-end, 0%)" },
+        },
+        "fade-in-up": {
+          "0%": { opacity: "0", transform: "translateY(8px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+        "scale-in": {
+          "0%": { opacity: "0", transform: "scale(0.96)" },
+          "100%": { opacity: "1", transform: "scale(1)" },
+        },
       },
       animation: {
         marquee: "marquee 30s linear infinite",
@@ -109,6 +129,11 @@ module.exports = {
           "scroll var(--animation-duration, 40s) var(--animation-direction, forwards) linear infinite",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "border-beam": "border-beam var(--duration, 6s) linear infinite",
+        "border-beam-reverse": "border-beam-reverse var(--duration, 6s) linear infinite",
+        "fade-in-up": "fade-in-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) both",
+        "fade-in": "fade-in 0.4s ease-out both",
+        "scale-in": "scale-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both",
       },
       colors: {
         brand: {

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -35,6 +35,14 @@ export type PortfolioReportStatus = "generating" | "draft" | "failed" | "publish
 export interface PortfolioReport {
   id: string;
   reportConfigId: string;
+  /**
+   * Human-readable name from the originating ReportConfig (e.g.,
+   * "Weekly Operations Recap"). Only populated by the public list
+   * endpoint (`GET /communities/:slug/reports/published`); admin
+   * endpoints leave it `undefined`. `null` when the originating config
+   * has been deleted.
+   */
+  reportConfigName?: string | null;
   communityId: string;
   runDate: string;
   status: PortfolioReportStatus;

--- a/utilities/communityColors.ts
+++ b/utilities/communityColors.ts
@@ -1,5 +1,7 @@
 export const communityColors: Record<string, string> = {
   black: "#000000",
+  filecoin: "#0090FF",
+  celo: "#FCFF52",
   "0x8da4cb832907bf41a770cbadd460763ff1a55113c1c2ee99533ce8a80e138d87": "#000000",
   "0x6193e5151e8fde7f4ca2e16f31a42effe56cbafa126423941cbe7ff51a5143bd": "#448BF2",
   "0xa33a7c83cca23dca0537615282a89000e4d4c6d07b47d057c37d7b9f34b05d97": "#000000",

--- a/utilities/portfolio-reports/period.ts
+++ b/utilities/portfolio-reports/period.ts
@@ -24,11 +24,7 @@ export function formatRunDate(runDate: string): FormattedRunDate {
   const month = Number(monthStr);
   const day = Number(dayStr);
   const date = new Date(year, month - 1, day);
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day
-  ) {
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
     return { label: runDate, shortLabel: runDate, badge: runDate };
   }
   return {
@@ -64,8 +60,7 @@ function renderEveryClause(schedule: ReportSchedule): string {
     return "Every month";
   }
   if (intervalUnit === "weeks" && intervalCount === 2) return "Every 2 weeks (bi-weekly)";
-  if (intervalUnit === "months" && intervalCount === 3)
-    return "Every 3 months (quarterly)";
+  if (intervalUnit === "months" && intervalCount === 3) return "Every 3 months (quarterly)";
   return `Every ${intervalCount} ${intervalUnit}`;
 }
 
@@ -151,8 +146,7 @@ export function computeNextRuns(
   if (!startUtc) return [];
 
   const anchorUtc = toUtcDay(anchor);
-  const endUtc =
-    schedule.ends.kind === "on_date" ? parseIsoToUtc(schedule.ends.date) : null;
+  const endUtc = schedule.ends.kind === "on_date" ? parseIsoToUtc(schedule.ends.date) : null;
 
   const out: Date[] = [];
   let cursor = startUtc;
@@ -190,28 +184,20 @@ function addUtcMonths(d: Date, months: number): Date {
   const day = d.getUTCDate();
   const targetYear = year + Math.floor(month / 12);
   const targetMonth = ((month % 12) + 12) % 12;
-  const lastDay = new Date(
-    Date.UTC(targetYear, targetMonth + 1, 0)
-  ).getUTCDate();
+  const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
   const safeDay = Math.min(day, lastDay);
   return new Date(Date.UTC(targetYear, targetMonth, safeDay));
 }
 
 function toUtcDay(d: Date): Date {
-  return new Date(
-    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
-  );
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
 }
 
 function parseIsoToUtc(iso: string): Date | null {
   if (!RUN_DATE_REGEX.test(iso)) return null;
   const [y, m, d] = iso.split("-").map(Number);
   const date = new Date(Date.UTC(y, m - 1, d));
-  if (
-    date.getUTCFullYear() !== y ||
-    date.getUTCMonth() !== m - 1 ||
-    date.getUTCDate() !== d
-  ) {
+  if (date.getUTCFullYear() !== y || date.getUTCMonth() !== m - 1 || date.getUTCDate() !== d) {
     return null;
   }
   return date;
@@ -220,4 +206,3 @@ function parseIsoToUtc(iso: string): Date | null {
 function toIsoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
-


### PR DESCRIPTION
## Summary

Iterative redesign of community pages (Impact, Projects, Updates, Financials, Funding Opportunities, Browse Applications) with a more editorial, modern layout aligned with reference designs. Adds shared accent-color utilities, animation tokens, refined filters, improved skeletons, and tests.

## Changes

- **Header / shared PageHero**: redesigned community header, removed legacy "Verified ecosystem" pill.
- **Funding Opportunities**: new editorial Featured program and ProgramCard with status/urgency badges, pool/max-grant KPIs, deadline labels.
- **Browse Applications**: modernized layout and filters.
- **Impact**: editorial gradient program banner (project + category counts), redesigned tab navigator and filter row (clean labels, no icons, normalized widths), refined segment cards. ImpactOutcomes now renders a loading skeleton instead of returning null.
- **Updates**: modernized filter row matching Impact treatment, normalized dropdown widths, milestone count pill with tabular-nums.
- **Financials**: enhanced loading skeleton (header + KPI grid + toolbar + table) replacing bare spinner.
- **Cross-page**: staggered fade-in-up animations for projects/updates/financials.
- **Foundations**: accent color utilities (`useCommunityAccent`, `useDominantColor`) and animation tokens.

## Tests

- `computeProgramView` — status, urgency, amount parsing, applicants/category resolution, deterministic accent (13 cases)
- `useCommunityAccent` — override priority chain (6 cases)
- `ImpactOutcomes` — loading skeleton, empty state, populated rows (3 cases)

## Test plan

- [ ] Visit `/community/filecoin/impact`, `/projects`, `/updates`, `/financials`, `/funding-opportunities`, `/browse-applications` and verify layout
- [ ] Confirm filter widths align across Status / Program / Project dropdowns
- [ ] Verify ImpactOutcomes shows skeleton during initial load and populated rows after
- [ ] Check fade-in-up animations on page navigation
- [ ] Confirm dark mode rendering for all redesigned surfaces
- [ ] Run `pnpm test` and `pnpm lint:fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community Outcomes section, Featured Program card, and a reusable Page Hero with KPI strip
  * Status pills and inline debounced search for browsing applications
  * "Ask Karma Assistant" shortcut (Cmd/Ctrl+K) and community accent color extraction hook
  * Decorative BorderBeam component

* **Improvements**
  * Richer skeletons, expanded empty/error states, and fade-in-up animations
  * URL-synced filtering, refined program selector, and updated table/row layouts
  * Header stats: retry and clearer no-data messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->