### PR TITLE
feat(milestones): show deliverables and metrics in review workspace

### DIFF
--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -344,7 +344,7 @@ export function MilestoneCard({
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     return () => observer.disconnect();
-  }, [completionText]);
+  }, [completionText, completionDeliverables, milestoneMetrics]);
 
   return (
     <div
@@ -534,94 +534,96 @@ export function MilestoneCard({
                 )}
               >
                 <MarkdownPreview source={completionText} />
+                {completionDeliverables.length > 0 && (
+                  <div className="mt-3 flex flex-col gap-2">
+                    <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                      Deliverables
+                    </p>
+                    {completionDeliverables.map((deliverable, idx) => (
+                      <div
+                        key={`${deliverable.name ?? "deliverable"}-${idx}`}
+                        className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                      >
+                        <div className="flex flex-col gap-1">
+                          {deliverable.name && (
+                            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                              {deliverable.name}
+                            </p>
+                          )}
+                          {deliverable.description && (
+                            <p className="text-sm text-gray-600 dark:text-gray-400">
+                              {deliverable.description}
+                            </p>
+                          )}
+                          {deliverable.proof && (
+                            <a
+                              href={
+                                deliverable.proof.startsWith("http")
+                                  ? deliverable.proof
+                                  : `https://${deliverable.proof}`
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-brand-blue hover:underline text-sm break-all"
+                            >
+                              {deliverable.proof}
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {milestoneMetrics && milestoneMetrics.length > 0 && (
+                  <div className="mt-3 flex flex-col gap-2">
+                    <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                      Metrics
+                    </p>
+                    {milestoneMetrics.map((metric, idx) => {
+                      const datapoint = metric.datapoints?.[0];
+                      return (
+                        <div
+                          key={metric.id || `${metric.name}-${idx}`}
+                          className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                        >
+                          <div className="flex flex-col gap-1">
+                            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                              {metric.name || "Untitled Indicator"}
+                            </p>
+                            {datapoint && (
+                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                                Value:{" "}
+                                <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                                  {datapoint.value}
+                                </span>
+                                {metric.unitOfMeasure ? ` ${metric.unitOfMeasure}` : ""}
+                              </p>
+                            )}
+                            {datapoint?.proof && (
+                              <a
+                                href={
+                                  datapoint.proof.startsWith("http")
+                                    ? datapoint.proof
+                                    : `https://${datapoint.proof}`
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-brand-blue hover:underline text-sm break-all"
+                              >
+                                {datapoint.proof}
+                              </a>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
               {hasLongCompletion && !isCompletionExpanded && (
                 <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-blue-50 dark:from-blue-900/10 to-transparent pointer-events-none" />
               )}
             </div>
-            {completionDeliverables.length > 0 && (
-              <div className="mt-3 flex flex-col gap-2">
-                <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
-                  Deliverables
-                </p>
-                {completionDeliverables.map((deliverable, idx) => (
-                  <div
-                    key={`${deliverable.name ?? "deliverable"}-${idx}`}
-                    className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
-                  >
-                    <div className="flex flex-col gap-1">
-                      {deliverable.name && (
-                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                          {deliverable.name}
-                        </p>
-                      )}
-                      {deliverable.description && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400">
-                          {deliverable.description}
-                        </p>
-                      )}
-                      {deliverable.proof && (
-                        <a
-                          href={
-                            deliverable.proof.startsWith("http")
-                              ? deliverable.proof
-                              : `https://${deliverable.proof}`
-                          }
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-brand-blue hover:underline text-sm break-all"
-                        >
-                          {deliverable.proof}
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-            {milestoneMetrics && milestoneMetrics.length > 0 && (
-              <div className="mt-3 flex flex-col gap-2">
-                <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">Metrics</p>
-                {milestoneMetrics.map((metric, idx) => {
-                  const datapoint = metric.datapoints?.[0];
-                  return (
-                    <div
-                      key={metric.id || `${metric.name}-${idx}`}
-                      className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
-                    >
-                      <div className="flex flex-col gap-1">
-                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                          {metric.name || "Untitled Indicator"}
-                        </p>
-                        {datapoint && (
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
-                            Value:{" "}
-                            <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                              {datapoint.value}
-                            </span>
-                            {metric.unitOfMeasure ? ` ${metric.unitOfMeasure}` : ""}
-                          </p>
-                        )}
-                        {datapoint?.proof && (
-                          <a
-                            href={
-                              datapoint.proof.startsWith("http")
-                                ? datapoint.proof
-                                : `https://${datapoint.proof}`
-                            }
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-brand-blue hover:underline text-sm break-all"
-                          >
-                            {datapoint.proof}
-                          </a>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
               Submitted:{" "}
               {formatDate(

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -31,6 +31,12 @@ import { getMilestoneStatus, MILESTONE_STATUS_CONFIG } from "./utils/milestone-r
 // before paint (no flash of unclamped content).
 const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
+const PROOF_URL_PROTOCOL_RE = /^https?:\/\//i;
+
+function ensureProofUrl(proof: string): string {
+  return PROOF_URL_PROTOCOL_RE.test(proof) ? proof : `https://${proof}`;
+}
+
 const AIEvaluationModal = dynamic(
   () => import("./AIEvaluationModal").then((m) => ({ default: m.AIEvaluationModal })),
   { ssr: false }
@@ -229,9 +235,11 @@ export function MilestoneCard({
   // Metrics (impact indicators) attached to this on-chain completion. The hook
   // skips the fetch when no UID is passed, so funding-application-only
   // completions don't trigger a request.
-  const { data: milestoneMetrics } = useMilestoneImpactAnswers({
-    milestoneUID: useOnChainData && hasCompletion ? milestone.uid : undefined,
+  const shouldShowMetricsSection = useOnChainData && hasCompletion;
+  const milestoneMetricsQuery = useMilestoneImpactAnswers({
+    milestoneUID: shouldShowMetricsSection ? milestone.uid : undefined,
   });
+  const milestoneMetrics = milestoneMetricsQuery.data;
 
   const statusInfo = useMemo(() => {
     const status = getMilestoneStatus(milestone);
@@ -557,11 +565,7 @@ export function MilestoneCard({
                           )}
                           {deliverable.proof && (
                             <a
-                              href={
-                                deliverable.proof.startsWith("http")
-                                  ? deliverable.proof
-                                  : `https://${deliverable.proof}`
-                              }
+                              href={ensureProofUrl(deliverable.proof)}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-brand-blue hover:underline text-sm break-all"
@@ -574,49 +578,72 @@ export function MilestoneCard({
                     ))}
                   </div>
                 )}
-                {milestoneMetrics && milestoneMetrics.length > 0 && (
+                {shouldShowMetricsSection && (
                   <div className="mt-3 flex flex-col gap-2">
                     <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
                       Metrics
                     </p>
-                    {milestoneMetrics.map((metric, idx) => {
-                      const datapoint = metric.datapoints?.[0];
-                      return (
-                        <div
-                          key={metric.id || `${metric.name}-${idx}`}
-                          className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                    {milestoneMetricsQuery.isLoading ? (
+                      <output
+                        aria-label="Loading metrics"
+                        className="block border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800 animate-pulse"
+                      >
+                        <span className="block h-4 w-1/3 bg-gray-200 dark:bg-zinc-700 rounded" />
+                        <span className="mt-2 block h-3 w-1/4 bg-gray-100 dark:bg-zinc-700/70 rounded" />
+                      </output>
+                    ) : milestoneMetricsQuery.isError ? (
+                      <div className="border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/10 rounded-lg p-3 flex flex-col gap-2">
+                        <p className="text-sm text-red-700 dark:text-red-300">
+                          Failed to load metrics.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => milestoneMetricsQuery.refetch()}
+                          className="self-start text-xs font-medium text-red-700 dark:text-red-300 hover:underline"
                         >
-                          <div className="flex flex-col gap-1">
-                            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                              {metric.name || "Untitled Indicator"}
-                            </p>
-                            {datapoint && (
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                Value:{" "}
-                                <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                                  {datapoint.value}
-                                </span>
-                                {metric.unitOfMeasure ? ` ${metric.unitOfMeasure}` : ""}
+                          Retry
+                        </button>
+                      </div>
+                    ) : milestoneMetrics && milestoneMetrics.length > 0 ? (
+                      milestoneMetrics.map((metric, idx) => {
+                        const datapoint = metric.datapoints?.[0];
+                        return (
+                          <div
+                            key={metric.id || `${metric.name}-${idx}`}
+                            className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                          >
+                            <div className="flex flex-col gap-1">
+                              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                {metric.name || "Untitled Indicator"}
                               </p>
-                            )}
-                            {datapoint?.proof && (
-                              <a
-                                href={
-                                  datapoint.proof.startsWith("http")
-                                    ? datapoint.proof
-                                    : `https://${datapoint.proof}`
-                                }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-brand-blue hover:underline text-sm break-all"
-                              >
-                                {datapoint.proof}
-                              </a>
-                            )}
+                              {datapoint && (
+                                <p className="text-sm text-gray-600 dark:text-gray-400">
+                                  Value:{" "}
+                                  <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                                    {datapoint.value}
+                                  </span>
+                                  {metric.unitOfMeasure ? ` ${metric.unitOfMeasure}` : ""}
+                                </p>
+                              )}
+                              {datapoint?.proof && (
+                                <a
+                                  href={ensureProofUrl(datapoint.proof)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-brand-blue hover:underline text-sm break-all"
+                                >
+                                  {datapoint.proof}
+                                </a>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      );
-                    })}
+                        );
+                      })
+                    ) : (
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        No metrics submitted.
+                      </p>
+                    )}
                   </div>
                 )}
               </div>

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -18,6 +18,7 @@ import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileN
 import { Button } from "@/components/Utilities/Button";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useMilestoneImpactAnswers } from "@/hooks/useMilestoneImpactAnswers";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
@@ -219,6 +220,18 @@ export function MilestoneCard({
     () => milestone.verificationDetails !== null,
     [milestone.verificationDetails]
   );
+
+  const completionDeliverables = useMemo(
+    () => (useOnChainData ? (milestone.completionDetails?.deliverables ?? []) : []),
+    [useOnChainData, milestone.completionDetails?.deliverables]
+  );
+
+  // Metrics (impact indicators) attached to this on-chain completion. The hook
+  // skips the fetch when no UID is passed, so funding-application-only
+  // completions don't trigger a request.
+  const { data: milestoneMetrics } = useMilestoneImpactAnswers({
+    milestoneUID: useOnChainData && hasCompletion ? milestone.uid : undefined,
+  });
 
   const statusInfo = useMemo(() => {
     const status = getMilestoneStatus(milestone);
@@ -526,6 +539,89 @@ export function MilestoneCard({
                 <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-blue-50 dark:from-blue-900/10 to-transparent pointer-events-none" />
               )}
             </div>
+            {completionDeliverables.length > 0 && (
+              <div className="mt-3 flex flex-col gap-2">
+                <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                  Deliverables
+                </p>
+                {completionDeliverables.map((deliverable, idx) => (
+                  <div
+                    key={`${deliverable.name ?? "deliverable"}-${idx}`}
+                    className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                  >
+                    <div className="flex flex-col gap-1">
+                      {deliverable.name && (
+                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          {deliverable.name}
+                        </p>
+                      )}
+                      {deliverable.description && (
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {deliverable.description}
+                        </p>
+                      )}
+                      {deliverable.proof && (
+                        <a
+                          href={
+                            deliverable.proof.startsWith("http")
+                              ? deliverable.proof
+                              : `https://${deliverable.proof}`
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-brand-blue hover:underline text-sm break-all"
+                        >
+                          {deliverable.proof}
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {milestoneMetrics && milestoneMetrics.length > 0 && (
+              <div className="mt-3 flex flex-col gap-2">
+                <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">Metrics</p>
+                {milestoneMetrics.map((metric, idx) => {
+                  const datapoint = metric.datapoints?.[0];
+                  return (
+                    <div
+                      key={metric.id || `${metric.name}-${idx}`}
+                      className="border border-gray-200 dark:border-zinc-600 rounded-lg p-3 bg-white dark:bg-zinc-800"
+                    >
+                      <div className="flex flex-col gap-1">
+                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          {metric.name || "Untitled Indicator"}
+                        </p>
+                        {datapoint && (
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            Value:{" "}
+                            <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                              {datapoint.value}
+                            </span>
+                            {metric.unitOfMeasure ? ` ${metric.unitOfMeasure}` : ""}
+                          </p>
+                        )}
+                        {datapoint?.proof && (
+                          <a
+                            href={
+                              datapoint.proof.startsWith("http")
+                                ? datapoint.proof
+                                : `https://${datapoint.proof}`
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-brand-blue hover:underline text-sm break-all"
+                          >
+                            {datapoint.proof}
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
               Submitted:{" "}
               {formatDate(

--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -1,6 +1,7 @@
 import type { IProjectDetails } from "@show-karma/karma-gap-sdk";
 import { errorManager } from "@/components/Utilities/errorManager";
 import type { Grant } from "@/types/v2/grant";
+import type { ProjectUpdateDeliverable } from "@/types/v2/roadmap";
 import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
 import { envVars } from "@/utilities/enviromentVars";
 import fetchData from "@/utilities/fetchData";
@@ -33,6 +34,8 @@ export interface GrantMilestoneCompletionDetails {
   completedBy: string;
   attestationUID?: string;
   proofOfWork?: string;
+  completionPercentage?: number;
+  deliverables?: ProjectUpdateDeliverable[];
 }
 
 // Grant milestone verification details (on-chain data)


### PR DESCRIPTION
## Summary
- Reviewers using the milestone review workspace (`…/funding-platform/<programId>/milestones/<grant>?from=application#milestone-<uid>`) only saw the completion description — Deliverables and Metrics shown on the public project page were missing.
- Pull `deliverables` from the on-chain `completionDetails` and fetch impact indicators via `useMilestoneImpactAnswers`, then render both inside the existing Completion Details card (mirroring the project page card layout).
- Extended `GrantMilestoneCompletionDetails` to expose `deliverables` and `completionPercentage` (already returned by the indexer, just not in the FE type).

## Test plan
- [ ] Open a milestone with completion data on the review workspace, e.g. `community/filecoin/manage/funding-platform/992/milestones/<grant>#milestone-<uid>`.
- [ ] Verify Deliverables list renders under the Completion Details text (name, description, proof link).
- [ ] Verify Metrics list renders for milestones with impact indicator data (name, datapoint value + unit, proof link).
- [ ] Confirm milestones with no deliverables / no metrics don't render an empty section.
- [ ] Confirm milestones whose only completion is a funding-application completion (no on-chain attestation) don't trigger the metrics fetch and render unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Deliverables section to milestone completion details, displaying deliverable names, descriptions, and clickable proof links for verification.
  * Added Metrics section showing metric names, values, and corresponding proof links.
  * Enhanced presentation and support for on-chain milestone completion data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->