### PR TITLE
fix: use community chain for admin resolver

### DIFF
--- a/utilities/sdk/communities/__tests__/isCommunityAdmin.test.ts
+++ b/utilities/sdk/communities/__tests__/isCommunityAdmin.test.ts
@@ -1,0 +1,81 @@
+import { GAP } from "@show-karma/karma-gap-sdk";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
+import { isCommunityAdminOf } from "../isCommunityAdmin";
+
+vi.mock("@show-karma/karma-gap-sdk", () => ({
+  GAP: {
+    getCommunityResolver: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/gapRpcConfig", () => ({
+  getGapRpcConfig: vi.fn(() => ({ 10: "https://optimism-rpc.example" })),
+}));
+
+const mockGetCommunityResolver = vi.mocked(GAP.getCommunityResolver);
+const mockErrorManager = vi.mocked(errorManager);
+const mockGetGapRpcConfig = vi.mocked(getGapRpcConfig);
+
+const mockCommunity = {
+  uid: "0x1234567890123456789012345678901234567890",
+  chainID: 10,
+} as const;
+
+const mockAddress = "0xabc123";
+const mockSigner = { provider: { getNetwork: vi.fn() } };
+
+describe("isCommunityAdminOf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the community chain ID when creating the resolver", async () => {
+    const mockResolver = {
+      isAdmin: vi.fn().mockResolvedValue(true),
+    };
+
+    mockGetCommunityResolver.mockResolvedValue(mockResolver as never);
+
+    const result = await isCommunityAdminOf(
+      mockCommunity as never,
+      mockAddress,
+      mockSigner as never
+    );
+
+    expect(result).toBe(true);
+    expect(mockGetGapRpcConfig).toHaveBeenCalledTimes(1);
+    expect(mockGetCommunityResolver).toHaveBeenCalledWith(
+      mockSigner,
+      mockGetGapRpcConfig.mock.results[0]?.value,
+      mockCommunity.chainID
+    );
+    expect(mockResolver.isAdmin).toHaveBeenCalledWith(mockCommunity.uid, mockAddress);
+  });
+
+  it("returns false and reports the error when resolver lookup fails", async () => {
+    const resolverError = new Error("unsupported network");
+    mockGetCommunityResolver.mockRejectedValue(resolverError);
+
+    const result = await isCommunityAdminOf(
+      mockCommunity as never,
+      mockAddress,
+      mockSigner as never
+    );
+
+    expect(result).toBe(false);
+    expect(mockErrorManager).toHaveBeenCalledWith(
+      `Error checking if user ${mockAddress} is community(${mockCommunity.uid}) admin`,
+      resolverError,
+      {
+        uid: mockCommunity.uid,
+        chainID: mockCommunity.chainID,
+        address: mockAddress,
+      }
+    );
+  });
+});

--- a/utilities/sdk/communities/isCommunityAdmin.ts
+++ b/utilities/sdk/communities/isCommunityAdmin.ts
@@ -19,7 +19,7 @@ export const isCommunityAdminOf = async (
 ): Promise<boolean> => {
   const { uid, chainID } = community;
   try {
-    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig());
+    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig(), chainID);
     if (!resolver) {
       errorManager(`Community resolver not available for chain ${chainID}`, null, {
         uid,


### PR DESCRIPTION
## Summary
- use the community's configured chain when creating the GAP community resolver during admin checks
- avoid deriving the resolver network from the connected wallet chain on the milestones admin flow
- add a unit test covering resolver chain selection and error handling

## Testing
- pnpm exec biome check utilities/sdk/communities/isCommunityAdmin.ts utilities/sdk/communities/__tests__/isCommunityAdmin.test.ts
- pnpm exec vitest run --project unit utilities/sdk/communities/__tests__/isCommunityAdmin.test.ts
- pnpm run test *(currently fails on a clean origin/main checkout as well; existing unrelated failures include donation cart, auth/e2e localStorage, portfolio report preview, financials copy, and project main content tests)*

Closes DEV-245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for community admin verification function, including scenarios for successful admin checks and error handling.

* **Bug Fixes**
  * Updated community admin verification logic to correctly pass chain information when resolving community details, improving support for multi-chain environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->