### PR TITLE
fix: suppress project impact 404 noise

### DIFF
--- a/__tests__/unit/services/project-impacts.service.test.ts
+++ b/__tests__/unit/services/project-impacts.service.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @file Tests for project-impacts.service
+ * @description Tests project impacts fetch behavior and error reporting
+ */
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "http://localhost:4000",
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/fetchData");
+
+import { errorManager } from "@/components/Utilities/errorManager";
+import { getProjectImpacts } from "@/services/project-impacts.service";
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as vi.MockedFunction<typeof fetchData>;
+const mockErrorManager = errorManager as vi.MockedFunction<typeof errorManager>;
+
+describe("project-impacts.service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getProjectImpacts", () => {
+    const mockImpacts = [
+      {
+        uid: "impact-1",
+        refUID: "ref-1",
+        chainID: 10,
+        data: {
+          work: "Ship feature",
+          impact: "Helped users",
+        },
+      },
+    ];
+
+    it("should return impacts data on success", async () => {
+      mockFetchData.mockResolvedValueOnce([mockImpacts, null, null, 200]);
+
+      const result = await getProjectImpacts("project-slug");
+
+      expect(result).toEqual(mockImpacts);
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("project-slug"));
+      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("/impacts"));
+    });
+
+    it("should return empty array without reporting on 404", async () => {
+      mockFetchData.mockResolvedValueOnce([
+        null,
+        "Project with identifier unknown not found",
+        null,
+        404,
+      ]);
+
+      const result = await getProjectImpacts("unknown");
+
+      expect(result).toEqual([]);
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    });
+
+    it("should report non-404 errors", async () => {
+      mockFetchData.mockResolvedValueOnce([null, "Server error", null, 500]);
+
+      const result = await getProjectImpacts("project-slug");
+
+      expect(result).toEqual([]);
+      expect(mockErrorManager).toHaveBeenCalledWith(
+        "Project Impacts API Error: Server error",
+        "Server error",
+        {
+          context: "project-impacts.service",
+        }
+      );
+    });
+  });
+});

--- a/services/project-impacts.service.ts
+++ b/services/project-impacts.service.ts
@@ -31,11 +31,15 @@ export interface ProjectImpact {
  * @returns Promise<ProjectImpact[]> - Array of project impacts
  */
 export const getProjectImpacts = async (projectIdOrSlug: string): Promise<ProjectImpact[]> => {
-  const [data, error] = await fetchData<ProjectImpact[]>(
+  const [data, error, , status] = await fetchData<ProjectImpact[]>(
     INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug)
   );
 
   if (error || !data) {
+    if (status === 404) {
+      return [];
+    }
+
     errorManager(`Project Impacts API Error: ${error}`, error, {
       context: "project-impacts.service",
     });


### PR DESCRIPTION
## Summary
- treat 404 responses from the project impacts endpoint as an expected empty state instead of reporting them as frontend API errors
- add focused unit coverage for success, 404, and non-404 impact fetch behavior

## Testing
- pnpm exec vitest run --project unit __tests__/unit/services/project-impacts.service.test.ts
- pnpm exec biome check services/project-impacts.service.ts __tests__/unit/services/project-impacts.service.test.ts
- pnpm run test *(baseline failure reproduced on refreshed `origin/main`: unrelated auth/cart/project-content suites already fail in this environment, including `components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx` and auth/e2e-localstorage tests)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for project impact queries to appropriately distinguish between missing projects and other system errors, improving reliability and enabling more accurate error reporting.

* **Tests**
  * Added unit test coverage for project impact retrieval to validate proper handling of successful queries, missing projects, and various error conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1381)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->