### PR TITLE
fix: harden sentry replay bootstrap

### DIFF
--- a/__tests__/infrastructure/instrumentation-client.test.ts
+++ b/__tests__/infrastructure/instrumentation-client.test.ts
@@ -10,6 +10,7 @@ const mockReplayConstructor = vi.fn(() => mockReplayInstance);
 const mockLazyLoadIntegration = vi.fn(() => Promise.resolve(mockReplayConstructor));
 const mockCaptureRequestError = vi.fn();
 const mockCaptureRouterTransitionStart = vi.fn();
+const mockCaptureMessage = vi.fn();
 
 vi.mock("@sentry/nextjs", () => ({
   init: mockInit,
@@ -17,6 +18,7 @@ vi.mock("@sentry/nextjs", () => ({
   lazyLoadIntegration: mockLazyLoadIntegration,
   captureRequestError: mockCaptureRequestError,
   captureRouterTransitionStart: mockCaptureRouterTransitionStart,
+  captureMessage: mockCaptureMessage,
 }));
 
 vi.mock("@/utilities/sentry/ignoreErrors", () => ({
@@ -63,16 +65,42 @@ describe("instrumentation-client", () => {
     expect(mockAddIntegration).toHaveBeenCalledWith(mockReplayInstance);
   });
 
-  it("swallows replay lazy-load failures", async () => {
-    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(new Error("load failed")));
+  it("logs and swallows replay lazy-load failures without calling addIntegration", async () => {
+    const loadError = new Error("load failed");
+    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(loadError));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
 
     await expect(import("@/instrumentation-client")).resolves.toBeDefined();
     await new Promise(process.nextTick);
 
     expect(mockAddIntegration).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("Sentry Replay lazy-load failed:", loadError);
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    randomSpy.mockRestore();
   });
 
-  it("does not add replay when Sentry returns a non-constructor", async () => {
+  it("samples replay lazy-load failures into Sentry at the configured rate", async () => {
+    const loadError = new Error("sampled failure");
+    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(loadError));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    await import("@/instrumentation-client");
+    await new Promise(process.nextTick);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith("Replay lazy-load failed", {
+      level: "warning",
+      extra: { error: "sampled failure" },
+    });
+
+    warnSpy.mockRestore();
+    randomSpy.mockRestore();
+  });
+
+  it("does not add replay when Sentry returns a non-callable", async () => {
     mockLazyLoadIntegration.mockImplementationOnce(() => Promise.resolve(null));
 
     await import("@/instrumentation-client");

--- a/__tests__/infrastructure/instrumentation-client.test.ts
+++ b/__tests__/infrastructure/instrumentation-client.test.ts
@@ -63,6 +63,24 @@ describe("instrumentation-client", () => {
     expect(mockAddIntegration).toHaveBeenCalledWith(mockReplayInstance);
   });
 
+  it("swallows replay lazy-load failures", async () => {
+    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(new Error("load failed")));
+
+    await expect(import("@/instrumentation-client")).resolves.toBeDefined();
+    await new Promise(process.nextTick);
+
+    expect(mockAddIntegration).not.toHaveBeenCalled();
+  });
+
+  it("does not add replay when Sentry returns a non-constructor", async () => {
+    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.resolve(null));
+
+    await import("@/instrumentation-client");
+    await new Promise(process.nextTick);
+
+    expect(mockAddIntegration).not.toHaveBeenCalled();
+  });
+
   it("exports onRequestError and onRouterTransitionStart", async () => {
     const exports = await import("@/instrumentation-client");
 

--- a/__tests__/infrastructure/instrumentation-client.test.ts
+++ b/__tests__/infrastructure/instrumentation-client.test.ts
@@ -10,7 +10,6 @@ const mockReplayConstructor = vi.fn(() => mockReplayInstance);
 const mockLazyLoadIntegration = vi.fn(() => Promise.resolve(mockReplayConstructor));
 const mockCaptureRequestError = vi.fn();
 const mockCaptureRouterTransitionStart = vi.fn();
-const mockCaptureMessage = vi.fn();
 
 vi.mock("@sentry/nextjs", () => ({
   init: mockInit,
@@ -18,7 +17,6 @@ vi.mock("@sentry/nextjs", () => ({
   lazyLoadIntegration: mockLazyLoadIntegration,
   captureRequestError: mockCaptureRequestError,
   captureRouterTransitionStart: mockCaptureRouterTransitionStart,
-  captureMessage: mockCaptureMessage,
 }));
 
 vi.mock("@/utilities/sentry/ignoreErrors", () => ({
@@ -69,35 +67,14 @@ describe("instrumentation-client", () => {
     const loadError = new Error("load failed");
     mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(loadError));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
 
     await expect(import("@/instrumentation-client")).resolves.toBeDefined();
     await new Promise(process.nextTick);
 
     expect(mockAddIntegration).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith("Sentry Replay lazy-load failed:", loadError);
-    expect(mockCaptureMessage).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
-    randomSpy.mockRestore();
-  });
-
-  it("samples replay lazy-load failures into Sentry at the configured rate", async () => {
-    const loadError = new Error("sampled failure");
-    mockLazyLoadIntegration.mockImplementationOnce(() => Promise.reject(loadError));
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-
-    await import("@/instrumentation-client");
-    await new Promise(process.nextTick);
-
-    expect(mockCaptureMessage).toHaveBeenCalledWith("Replay lazy-load failed", {
-      level: "warning",
-      extra: { error: "sampled failure" },
-    });
-
-    warnSpy.mockRestore();
-    randomSpy.mockRestore();
   });
 
   it("does not add replay when Sentry returns a non-callable", async () => {

--- a/__tests__/infrastructure/sentry-ignore-errors.test.ts
+++ b/__tests__/infrastructure/sentry-ignore-errors.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { sentryIgnoreErrors } from "@/utilities/sentry/ignoreErrors";
+
+describe("sentryIgnoreErrors", () => {
+  it("filters Sentry's lazy-loaded Replay integration load failures", () => {
+    expect(sentryIgnoreErrors).toContain("Error when loading integration: replayIntegration");
+  });
+});

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -32,10 +32,7 @@ Sentry.init({
 // (chunk eviction, network blip, ad-blocker, CSP), the factory call, or
 // `addIntegration` itself — so optional telemetry never crashes the page.
 // The error signature is also filtered via `sentryIgnoreErrors` (defense in
-// depth) and we sample a tiny fraction of failures to Sentry so a regression
-// in `lazyLoadIntegration` itself remains visible.
-const REPLAY_FAILURE_SAMPLE_RATE = 0.001;
-
+// depth) and we keep a console.warn locally for debugging.
 if (typeof window !== "undefined") {
   void Sentry.lazyLoadIntegration("replayIntegration")
     .then((replayIntegration) => {
@@ -47,13 +44,6 @@ if (typeof window !== "undefined") {
     })
     .catch((error) => {
       console.warn("Sentry Replay lazy-load failed:", error);
-
-      if (Math.random() < REPLAY_FAILURE_SAMPLE_RATE) {
-        Sentry.captureMessage("Replay lazy-load failed", {
-          level: "warning",
-          extra: { error: error instanceof Error ? error.message : String(error) },
-        });
-      }
     });
 }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -28,8 +28,14 @@ Sentry.init({
 
 // Lazy-load Replay after init — keeps ~400KB out of the shared bundle.
 // The Replay SDK is fetched on-demand and added to the existing Sentry client.
-// If the lazy load fails, keep the app running without Replay instead of
-// surfacing an uncaught client error from the instrumentation bootstrap path.
+// The `.catch` below covers any failure in this bootstrap chain — lazy fetch
+// (chunk eviction, network blip, ad-blocker, CSP), the factory call, or
+// `addIntegration` itself — so optional telemetry never crashes the page.
+// The error signature is also filtered via `sentryIgnoreErrors` (defense in
+// depth) and we sample a tiny fraction of failures to Sentry so a regression
+// in `lazyLoadIntegration` itself remains visible.
+const REPLAY_FAILURE_SAMPLE_RATE = 0.001;
+
 if (typeof window !== "undefined") {
   void Sentry.lazyLoadIntegration("replayIntegration")
     .then((replayIntegration) => {
@@ -39,9 +45,15 @@ if (typeof window !== "undefined") {
 
       Sentry.addIntegration(replayIntegration());
     })
-    .catch(() => {
-      // Ignore replay bootstrap failures. Replay is optional telemetry and
-      // should not create user-facing errors or noisy Sentry issues.
+    .catch((error) => {
+      console.warn("Sentry Replay lazy-load failed:", error);
+
+      if (Math.random() < REPLAY_FAILURE_SAMPLE_RATE) {
+        Sentry.captureMessage("Replay lazy-load failed", {
+          level: "warning",
+          extra: { error: error instanceof Error ? error.message : String(error) },
+        });
+      }
     });
 }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -28,10 +28,21 @@ Sentry.init({
 
 // Lazy-load Replay after init — keeps ~400KB out of the shared bundle.
 // The Replay SDK is fetched on-demand and added to the existing Sentry client.
+// If the lazy load fails, keep the app running without Replay instead of
+// surfacing an uncaught client error from the instrumentation bootstrap path.
 if (typeof window !== "undefined") {
-  Sentry.lazyLoadIntegration("replayIntegration").then((replayIntegration) => {
-    Sentry.addIntegration(replayIntegration());
-  });
+  void Sentry.lazyLoadIntegration("replayIntegration")
+    .then((replayIntegration) => {
+      if (typeof replayIntegration !== "function") {
+        return;
+      }
+
+      Sentry.addIntegration(replayIntegration());
+    })
+    .catch(() => {
+      // Ignore replay bootstrap failures. Replay is optional telemetry and
+      // should not create user-facing errors or noisy Sentry issues.
+    });
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -23,6 +23,17 @@ const browserExtensionErrors = [
   "chrome.runtime.sendMessage() called from a webpage must specify an Extension ID",
 ];
 
+const sentryInstrumentationErrors = [
+  // Sentry's own lazy-loaded Replay integration occasionally fails to fetch
+  // (chunk eviction after a deploy, network blip, ad-blocker, CSP). Replay is
+  // optional telemetry, so we filter the failure instead of surfacing it as a
+  // top-volume Sentry issue. The catch in `instrumentation-client.ts` handles
+  // the unhandled rejection; this entry is defense-in-depth in case the error
+  // reaches Sentry through a different code path.
+  // See https://karma-crypto-inc.sentry.io/issues/7403099774/
+  "Error when loading integration: replayIntegration",
+];
+
 // Expected "not found" errors when users access non-existent resources (e.g., deleted projects, old URLs)
 // These are normal 404-type scenarios, not bugs worth tracking
 // See https://karma-crypto-inc.sentry.io/issues/7205405990
@@ -41,5 +52,6 @@ export const sentryIgnoreErrors = [
   ...unsupportedWalletErrors,
   ...walletConnectErrors,
   ...browserExtensionErrors,
+  ...sentryInstrumentationErrors,
   ...notFoundErrors,
 ];


### PR DESCRIPTION
## Summary
- catch Sentry Replay lazy-load failures so optional telemetry bootstrap does not throw uncaught client errors
- skip `addIntegration` when the lazy-loaded value is missing or not callable
- add regression tests for the failure and malformed-integration paths

## Testing
- `pnpm exec vitest run --project unit __tests__/infrastructure/instrumentation-client.test.ts`
- `pnpm exec biome check instrumentation-client.ts __tests__/infrastructure/instrumentation-client.test.ts`
- `pnpm run test` *(fails on current `origin/main` baseline in unrelated donation-cart, localStorage, and UI expectation tests)*

Closes DEV-239
