### PR TITLE
fix: ignore injected MetaMask connect failures

### DIFF
--- a/__tests__/unit/utilities/sentry/ignoreErrors.test.ts
+++ b/__tests__/unit/utilities/sentry/ignoreErrors.test.ts
@@ -1,0 +1,7 @@
+import { sentryIgnoreErrors } from "../../../../utilities/sentry/ignoreErrors";
+
+describe("sentryIgnoreErrors", () => {
+  it("suppresses MetaMask connection failures from the injected provider", () => {
+    expect(sentryIgnoreErrors).toContain("Failed to connect to MetaMask");
+  });
+});

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -14,6 +14,16 @@ const walletConnectErrors = [
   "WebSocket connection closed abnormally with code: 3000",
 ];
 
+const walletProviderErrors = [
+  // MetaMask's injected provider throws this when the extension aborts or
+  // rejects the connection handshake (popup dismissed, extension locked,
+  // another wallet extension competing for window.ethereum). Privy's login
+  // modal surfaces a user-facing error for this failure mode, so suppressing
+  // it in Sentry keeps the issue feed actionable.
+  // See https://karma-crypto-inc.sentry.io/issues/7453497949/
+  "Failed to connect to MetaMask",
+];
+
 const browserExtensionErrors = [
   // Browser extensions disconnecting ports (Chrome extensions, wallet extensions)
   // See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1BA
@@ -31,9 +41,6 @@ const notFoundErrors = ["Project not found", "Community not found"];
 export const sentryIgnoreErrors = [
   // user rejected a confirmation in the wallet
   "rejected the request",
-  // MetaMask can throw this from the injected provider when the extension aborts
-  // or rejects the connection handshake before our app receives a first-party frame.
-  "Failed to connect to MetaMask",
   // React internal error thrown when something outside react modifies the DOM
   // This is usually because of a browser extension or Chrome's built-in translate. There's no action to do.
   // See https://blog.sentry.io/making-your-javascript-projects-less-noisy/#ignore-un-actionable-errors
@@ -43,6 +50,7 @@ export const sentryIgnoreErrors = [
   `TypeError: can't access dead object`,
   ...unsupportedWalletErrors,
   ...walletConnectErrors,
+  ...walletProviderErrors,
   ...browserExtensionErrors,
   ...notFoundErrors,
 ];

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -31,6 +31,9 @@ const notFoundErrors = ["Project not found", "Community not found"];
 export const sentryIgnoreErrors = [
   // user rejected a confirmation in the wallet
   "rejected the request",
+  // MetaMask can throw this from the injected provider when the extension aborts
+  // or rejects the connection handshake before our app receives a first-party frame.
+  "Failed to connect to MetaMask",
   // React internal error thrown when something outside react modifies the DOM
   // This is usually because of a browser extension or Chrome's built-in translate. There's no action to do.
   // See https://blog.sentry.io/making-your-javascript-projects-less-noisy/#ignore-un-actionable-errors


### PR DESCRIPTION
## Summary

- suppress the injected MetaMask "Failed to connect to MetaMask" error in Sentry
- group the new entry alongside other wallet-extension noise rather than mixing it into the top-level array
- add the Sentry issue URL comment per the convention used by every other entry in `ignoreErrors.ts`
- document the Privy boundary so future triage doesn't suspect a UX regression

## Why this is noise-only, not a UX fix

The error originates from MetaMask's injected `inpage.js` (`Object.connect`) — no first-party stack frames. It fires when the user dismisses the popup, the extension is locked, or another wallet extension is competing for `window.ethereum`. **Privy's login modal already surfaces a user-facing error for this failure mode**, so the Sentry noise is not hiding a silent failure on the project page:

- `components/Utilities/PrivyWagmiProviders.tsx` registers `PrivyProvider` without an `onError` hook — Privy handles modal error display internally.
- The only first-party `connect()` call (the `wagmiCoreConnect` bridge at `PrivyWagmiProviders.tsx:90-99`) runs *after* Privy has already established a wallet, so it never originates this error.
- The injected-provider error reaches Sentry via the global `unhandledrejection` handler, not via a Karma-side throw site.

## Test Plan

- `pnpm exec vitest run --project unit __tests__/unit/utilities/sentry/ignoreErrors.test.ts` ✅
- `pnpm exec biome check utilities/sentry/ignoreErrors.ts __tests__/unit/utilities/sentry/ignoreErrors.test.ts` ✅
- `pnpm run test` *(fails on current `origin/main` baseline in unrelated localStorage/token-manager, donation-cart, and project-content tests; reproduced on refreshed `origin/main` before opening this PR)*

Refs: DEV-240