### PR TITLE
fix: avoid auth-required public project profile prefetches

### DIFF
--- a/__tests__/unit/utilities/queries/prefetchProjectProfile.test.ts
+++ b/__tests__/unit/utilities/queries/prefetchProjectProfile.test.ts
@@ -66,6 +66,11 @@ describe("prefetchProjectProfile", () => {
         updates: true,
         impacts: true,
       });
+      expect(mockGetProjectGrants).toHaveBeenCalledWith(projectId, { isAuthorized: false });
+      expect(mockGetProjectUpdates).toHaveBeenCalledWith(projectId, undefined, {
+        isAuthorized: false,
+      });
+      expect(mockGetProjectImpacts).toHaveBeenCalledWith(projectId, { isAuthorized: false });
       expect(mockQueryClient.prefetchQuery).toHaveBeenCalledTimes(3);
     });
 

--- a/services/__tests__/project-profile-public-fetch-auth.test.ts
+++ b/services/__tests__/project-profile-public-fetch-auth.test.ts
@@ -1,0 +1,73 @@
+import { getProjectGrants } from "../project-grants.service";
+import { getProjectImpacts } from "../project-impacts.service";
+import { getProjectUpdates } from "../project-updates.service";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      PROJECTS: {
+        GRANTS: (slug: string) => `/v2/projects/${slug}/grants`,
+        IMPACTS: (slug: string) => `/v2/projects/${slug}/impacts`,
+        UPDATES: (slug: string) => `/v2/projects/${slug}/updates`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = vi.mocked(fetchData);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchData.mockResolvedValue([[], null, null, 200] as never);
+});
+
+describe("public project profile fetch auth", () => {
+  it("passes isAuthorized=false for grants when requested", async () => {
+    await getProjectGrants("my-project", { isAuthorized: false });
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "/v2/projects/my-project/grants",
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+  });
+
+  it("passes isAuthorized=false for impacts when requested", async () => {
+    await getProjectImpacts("my-project", { isAuthorized: false });
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "/v2/projects/my-project/impacts",
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+  });
+
+  it("passes isAuthorized=false for updates when requested", async () => {
+    await getProjectUpdates("my-project", undefined, { isAuthorized: false });
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "/v2/projects/my-project/updates",
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+  });
+});

--- a/services/__tests__/project-updates.service.test.ts
+++ b/services/__tests__/project-updates.service.test.ts
@@ -41,16 +41,41 @@ beforeEach(() => {
   mockFetchData.mockResolvedValue([emptyResponse, null, null, 200]);
 });
 
+it("passes isAuthorized=false when public project profile fetches request it", async () => {
+  await getProjectUpdates("my-project", undefined, { isAuthorized: false });
+
+  expect(mockFetchData).toHaveBeenCalledWith(
+    "/v2/projects/my-project/updates",
+    "GET",
+    {},
+    {},
+    {},
+    false
+  );
+});
+
 describe("getProjectUpdates — URL construction", () => {
   it("calls the base URL when no options are given", async () => {
     await getProjectUpdates("my-project");
-    expect(mockFetchData).toHaveBeenCalledWith("/v2/projects/my-project/updates");
+    expect(mockFetchData).toHaveBeenCalledWith(
+      "/v2/projects/my-project/updates",
+      "GET",
+      {},
+      {},
+      {},
+      true
+    );
   });
 
   it("appends milestoneStatus to the query string", async () => {
     await getProjectUpdates("my-project", "completed");
     expect(mockFetchData).toHaveBeenCalledWith(
-      "/v2/projects/my-project/updates?milestoneStatus=completed"
+      "/v2/projects/my-project/updates?milestoneStatus=completed",
+      "GET",
+      {},
+      {},
+      {},
+      true
     );
   });
 

--- a/services/project-grants.service.ts
+++ b/services/project-grants.service.ts
@@ -3,6 +3,10 @@ import type { Grant } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
+export interface GetProjectGrantsOptions {
+  isAuthorized?: boolean;
+}
+
 /**
  * Fetches grants for a project using V2 endpoint
  *
@@ -15,9 +19,18 @@ import { INDEXER } from "@/utilities/indexer";
  * - Dates are returned as ISO strings (not MongoDB objects)
  * - Supports both UID and slug identifiers
  */
-export const getProjectGrants = async (projectIdOrSlug: string): Promise<Grant[]> => {
+export const getProjectGrants = async (
+  projectIdOrSlug: string,
+  options: GetProjectGrantsOptions = {}
+): Promise<Grant[]> => {
+  const { isAuthorized = true } = options;
   const [data, error, , status] = await fetchData<Grant | Grant[]>(
-    INDEXER.V2.PROJECTS.GRANTS(projectIdOrSlug)
+    INDEXER.V2.PROJECTS.GRANTS(projectIdOrSlug),
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized
   );
 
   if (error || !data) {

--- a/services/project-impacts.service.ts
+++ b/services/project-impacts.service.ts
@@ -24,15 +24,28 @@ export interface ProjectImpact {
   updatedAt?: string;
 }
 
+export interface GetProjectImpactsOptions {
+  isAuthorized?: boolean;
+}
+
 /**
  * Fetches project impacts using the dedicated API endpoint.
  *
  * @param projectIdOrSlug - The project UID or slug
  * @returns Promise<ProjectImpact[]> - Array of project impacts
  */
-export const getProjectImpacts = async (projectIdOrSlug: string): Promise<ProjectImpact[]> => {
+export const getProjectImpacts = async (
+  projectIdOrSlug: string,
+  options: GetProjectImpactsOptions = {}
+): Promise<ProjectImpact[]> => {
+  const { isAuthorized = true } = options;
   const [data, error] = await fetchData<ProjectImpact[]>(
-    INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug)
+    INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug),
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized
   );
 
   if (error || !data) {

--- a/services/project-updates.service.ts
+++ b/services/project-updates.service.ts
@@ -9,6 +9,7 @@ import { INDEXER } from "@/utilities/indexer";
  */
 export interface GetProjectUpdatesOptions extends UpdatesFeedFilters {
   milestoneStatus?: "pending" | "completed" | "verified";
+  isAuthorized?: boolean;
 }
 
 /**
@@ -80,7 +81,7 @@ function buildUpdatesQueryString(opts: GetProjectUpdatesOptions): string {
 export const getProjectUpdates = async (
   projectIdOrSlug: string,
   milestoneStatus?: "pending" | "completed" | "verified",
-  filters?: UpdatesFeedFilters
+  filters?: GetProjectUpdatesOptions
 ): Promise<UpdatesApiResponse> => {
   const emptyResponse: UpdatesApiResponse = {
     projectUpdates: [],
@@ -89,11 +90,19 @@ export const getProjectUpdates = async (
     grantUpdates: [],
   };
 
+  const { isAuthorized = true, ...queryFilters } = filters ?? {};
   const baseUrl = INDEXER.V2.PROJECTS.UPDATES(projectIdOrSlug);
-  const qs = buildUpdatesQueryString({ milestoneStatus, ...filters });
+  const qs = buildUpdatesQueryString({ milestoneStatus, ...queryFilters });
   const url = `${baseUrl}${qs}`;
 
-  const [data, error, , status] = await fetchData<UpdatesApiResponse>(url);
+  const [data, error, , status] = await fetchData<UpdatesApiResponse>(
+    url,
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized
+  );
 
   if (error || !data) {
     // Missing project routes are expected for unknown slugs and should not be sent to Sentry.

--- a/utilities/queries/prefetchProjectProfile.ts
+++ b/utilities/queries/prefetchProjectProfile.ts
@@ -34,17 +34,17 @@ export const prefetchProjectProfileData = cache(
     const results = await Promise.allSettled([
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.GRANTS(projectId),
-        queryFn: () => getProjectGrants(projectId),
+        queryFn: () => getProjectGrants(projectId, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.UPDATES(projectId),
-        queryFn: () => getProjectUpdates(projectId),
+        queryFn: () => getProjectUpdates(projectId, undefined, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.IMPACTS(projectId),
-        queryFn: () => getProjectImpacts(projectId),
+        queryFn: () => getProjectImpacts(projectId, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
     ]);
@@ -75,7 +75,7 @@ export const prefetchProjectProfileData = cache(
  * Uses React.cache() for request deduplication.
  */
 export const getProjectGrantsCached = cache(async (projectId: string) => {
-  return getProjectGrants(projectId);
+  return getProjectGrants(projectId, { isAuthorized: false });
 });
 
 /**
@@ -83,7 +83,7 @@ export const getProjectGrantsCached = cache(async (projectId: string) => {
  * Uses React.cache() for request deduplication.
  */
 export const getProjectUpdatesCached = cache(async (projectId: string) => {
-  return getProjectUpdates(projectId);
+  return getProjectUpdates(projectId, undefined, { isAuthorized: false });
 });
 
 /**
@@ -91,5 +91,5 @@ export const getProjectUpdatesCached = cache(async (projectId: string) => {
  * Uses React.cache() for request deduplication.
  */
 export const getProjectImpactsCached = cache(async (projectId: string) => {
-  return getProjectImpacts(projectId);
+  return getProjectImpacts(projectId, { isAuthorized: false });
 });


### PR DESCRIPTION
## Summary
- stop public project profile SSR/prefetch requests from going through auth-required indexer paths
- add explicit `isAuthorized` control to grants, updates, and impacts project-profile service fetches
- use unauthenticated fetches for the public project profile prefetch/cache path and cover the behavior with focused tests

## Testing
- `pnpm exec vitest run --project unit services/__tests__/project-profile-public-fetch-auth.test.ts services/__tests__/project-updates.service.test.ts __tests__/unit/utilities/queries/prefetchProjectProfile.test.ts`
- `pnpm run test` *(fails in this environment on baseline `origin/main` too; reproduced the same existing donation-cart/localStorage, permission-context, and unrelated UI expectation failures in a fresh `origin/main` worktree)*

## Risks
- authenticated callers still default to `isAuthorized: true`; this only changes the public project profile SSR/prefetch path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying authorization flags are correctly propagated when fetching public project profiles.
  * Updated authorization handling tests for project grants, impacts, and updates endpoints.

* **Refactor**
  * Modified project data services to accept optional authorization parameters and properly forward them in API requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1384)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->