### PR TITLE
fix: guard invalid project route params

### DIFF
--- a/utilities/__tests__/getProjectCachedData.test.ts
+++ b/utilities/__tests__/getProjectCachedData.test.ts
@@ -1,0 +1,63 @@
+import type { Project } from "@/types/v2/project";
+
+const mockGetProject = vi.fn();
+const mockNotFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+const mockRedirect = vi.fn();
+
+vi.mock("@/services/project.service", () => ({
+  getProject: (...args: unknown[]) => mockGetProject(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+}));
+
+function createMockProject(overrides: Partial<Project> = {}): Project {
+  return {
+    uid: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
+    chainID: 10,
+    owner: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as `0x${string}`,
+    details: {
+      title: "Test Project",
+      slug: "test-project",
+    },
+    members: [],
+    pointers: [],
+    createdAt: "2024-01-01",
+    ...overrides,
+  } as Project;
+}
+
+describe("getProjectCachedData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function loadModule() {
+    vi.resetModules();
+    return import("@/utilities/queries/getProjectCachedData");
+  }
+
+  it("returns project data for a valid slug", async () => {
+    mockGetProject.mockResolvedValue(createMockProject());
+
+    const { getProjectCachedData } = await loadModule();
+    const result = await getProjectCachedData("test-project");
+
+    expect(mockGetProject).toHaveBeenCalledWith("test-project");
+    expect(result.details.slug).toBe("test-project");
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits malformed placeholder slugs before fetching project data", async () => {
+    const { getProjectCachedData } = await loadModule();
+
+    await expect(getProjectCachedData("-nan-12")).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(mockGetProject).not.toHaveBeenCalled();
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/utilities/queries/getProjectCachedData.ts
+++ b/utilities/queries/getProjectCachedData.ts
@@ -5,7 +5,26 @@ import type { Project as ProjectResponse } from "@/types/v2/project";
 import { zeroUID } from "@/utilities/commons";
 import { PAGES } from "../pages";
 
+const PROJECT_UID_REGEX = /^0x[0-9a-fA-F]{64}$/;
+const PROJECT_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+
+const isValidProjectRouteParam = (projectId: string): boolean => {
+  const normalizedProjectId = projectId.trim();
+
+  if (!normalizedProjectId) {
+    return false;
+  }
+
+  return (
+    PROJECT_UID_REGEX.test(normalizedProjectId) || PROJECT_SLUG_REGEX.test(normalizedProjectId)
+  );
+};
+
 export const getProjectCachedData = cache(async (projectId: string): Promise<ProjectResponse> => {
+  if (!isValidProjectRouteParam(projectId)) {
+    notFound();
+  }
+
   const project = await getProject(projectId);
 
   if (!project || project.uid === zeroUID) {


### PR DESCRIPTION
## Summary
- reject malformed project route params like `/project/-nan-12` before the SSR path tries to fetch project data
- treat obviously invalid slugs as not-found so the project page fails closed instead of surfacing an SSR crash
- add focused coverage for the project route param guard

## Testing
- `pnpm exec vitest run --project unit utilities/__tests__/getProjectCachedData.test.ts`
- `pnpm exec biome check utilities/queries/getProjectCachedData.ts utilities/__tests__/getProjectCachedData.test.ts`
- `pnpm run test` *(fails on current `origin/main` baseline too in unrelated donation cart, auth/localStorage, and project content suites; also reproduces Vitest worker `EPIPE` instability in this Hermes environment)*

Linear: DEV-242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for project data caching functionality, covering valid project access and proper error handling for invalid or malformed project identifiers.

* **Bug Fixes**
  * Strengthened validation of project route parameters with explicit format verification to detect and reject invalid identifiers, ensuring users receive appropriate error pages when accessing projects with malformed parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1385)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->