### PR TITLE
fix: handle wallet network changes during signer setup

### DIFF
--- a/hooks/__tests__/useSetupChainAndWallet.test.ts
+++ b/hooks/__tests__/useSetupChainAndWallet.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react";
+import toast from "react-hot-toast";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSetupChainAndWallet } from "../useSetupChainAndWallet";
+
+const mockEnsureCorrectChain = vi.fn();
+vi.mock("@/utilities/ensureCorrectChain", () => ({
+  ensureCorrectChain: (...args: unknown[]) => mockEnsureCorrectChain(...args),
+}));
+
+const mockGetAttestationSigner = vi.fn();
+vi.mock("../useZeroDevSigner", () => ({
+  useZeroDevSigner: () => ({
+    getAttestationSigner: mockGetAttestationSigner,
+    isGaslessAvailable: false,
+    attestationAddress: "0xabc",
+    hasEmbeddedWallet: false,
+    hasExternalWallet: true,
+  }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+describe("useSetupChainAndWallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    mockEnsureCorrectChain.mockResolvedValue({
+      success: true,
+      chainId: 11155420,
+      gapClient: { id: "gap-client" },
+    });
+  });
+
+  it("returns signer setup details when chain and signer setup succeed", async () => {
+    const walletSigner = { signMessage: vi.fn() };
+    mockGetAttestationSigner.mockResolvedValue(walletSigner);
+
+    const { result } = renderHook(() => useSetupChainAndWallet());
+
+    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    await act(async () => {
+      setupResult = await result.current.setupChainAndWallet({
+        targetChainId: 11155420,
+        currentChainId: 1,
+        switchChainAsync: vi.fn(),
+      });
+    });
+
+    expect(setupResult).toEqual({
+      gapClient: { id: "gap-client" },
+      walletSigner,
+      chainId: 11155420,
+      isGasless: false,
+    });
+  });
+
+  it("returns null and shows a toast when signer setup hits a network-changed wallet error", async () => {
+    mockGetAttestationSigner.mockRejectedValue(
+      Object.assign(new Error('network changed: 1 => 11155420 (event="changed", code=NETWORK_ERROR)'), {
+        code: "NETWORK_ERROR",
+      })
+    );
+
+    const { result } = renderHook(() => useSetupChainAndWallet());
+
+    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    await act(async () => {
+      setupResult = await result.current.setupChainAndWallet({
+        targetChainId: 11155420,
+        currentChainId: 1,
+        switchChainAsync: vi.fn(),
+      });
+    });
+
+    expect(setupResult).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Wallet network changed while preparing the transaction. Please try again."
+    );
+  });
+});

--- a/hooks/__tests__/useSetupChainAndWallet.test.ts
+++ b/hooks/__tests__/useSetupChainAndWallet.test.ts
@@ -61,11 +61,44 @@ describe("useSetupChainAndWallet", () => {
     });
   });
 
-  it("returns null and shows a toast when signer setup hits a network-changed wallet error", async () => {
+  it("retries once and succeeds when only the first signer attempt hits a network-changed error", async () => {
+    const walletSigner = { signMessage: vi.fn() };
+    mockGetAttestationSigner
+      .mockRejectedValueOnce(
+        Object.assign(
+          new Error('network changed: 1 => 11155420 (event="changed", code=NETWORK_ERROR)'),
+          { code: "NETWORK_ERROR" }
+        )
+      )
+      .mockResolvedValueOnce(walletSigner);
+
+    const { result } = renderHook(() => useSetupChainAndWallet());
+
+    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    await act(async () => {
+      setupResult = await result.current.setupChainAndWallet({
+        targetChainId: 11155420,
+        currentChainId: 1,
+        switchChainAsync: vi.fn(),
+      });
+    });
+
+    expect(mockGetAttestationSigner).toHaveBeenCalledTimes(2);
+    expect(setupResult).toEqual({
+      gapClient: { id: "gap-client" },
+      walletSigner,
+      chainId: 11155420,
+      isGasless: false,
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("returns null and shows a toast when both signer attempts hit a network-changed error", async () => {
     mockGetAttestationSigner.mockRejectedValue(
-      Object.assign(new Error('network changed: 1 => 11155420 (event="changed", code=NETWORK_ERROR)'), {
-        code: "NETWORK_ERROR",
-      })
+      Object.assign(
+        new Error('network changed: 1 => 11155420 (event="changed", code=NETWORK_ERROR)'),
+        { code: "NETWORK_ERROR" }
+      )
     );
 
     const { result } = renderHook(() => useSetupChainAndWallet());
@@ -79,9 +112,28 @@ describe("useSetupChainAndWallet", () => {
       });
     });
 
+    expect(mockGetAttestationSigner).toHaveBeenCalledTimes(2);
     expect(setupResult).toBeNull();
     expect(toast.error).toHaveBeenCalledWith(
       "Wallet network changed while preparing the transaction. Please try again."
     );
+  });
+
+  it("re-throws non-network signer errors so they surface to Sentry instead of being swallowed", async () => {
+    const fatalError = new Error("Unsupported chain: 9999");
+    mockGetAttestationSigner.mockRejectedValue(fatalError);
+
+    const { result } = renderHook(() => useSetupChainAndWallet());
+
+    await expect(
+      result.current.setupChainAndWallet({
+        targetChainId: 9999,
+        currentChainId: 1,
+        switchChainAsync: vi.fn(),
+      })
+    ).rejects.toThrow("Unsupported chain: 9999");
+
+    expect(mockGetAttestationSigner).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/hooks/__tests__/useSetupChainAndWallet.test.ts
+++ b/hooks/__tests__/useSetupChainAndWallet.test.ts
@@ -28,8 +28,7 @@ vi.mock("react-hot-toast", () => ({
 
 describe("useSetupChainAndWallet", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.resetAllMocks();
 
     mockEnsureCorrectChain.mockResolvedValue({
       success: true,
@@ -44,7 +43,7 @@ describe("useSetupChainAndWallet", () => {
 
     const { result } = renderHook(() => useSetupChainAndWallet());
 
-    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    let setupResult!: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
     await act(async () => {
       setupResult = await result.current.setupChainAndWallet({
         targetChainId: 11155420,
@@ -59,6 +58,7 @@ describe("useSetupChainAndWallet", () => {
       chainId: 11155420,
       isGasless: false,
     });
+    expect(mockGetAttestationSigner).toHaveBeenCalledTimes(1);
   });
 
   it("retries once and succeeds when only the first signer attempt hits a network-changed error", async () => {
@@ -74,7 +74,7 @@ describe("useSetupChainAndWallet", () => {
 
     const { result } = renderHook(() => useSetupChainAndWallet());
 
-    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    let setupResult!: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
     await act(async () => {
       setupResult = await result.current.setupChainAndWallet({
         targetChainId: 11155420,
@@ -103,7 +103,7 @@ describe("useSetupChainAndWallet", () => {
 
     const { result } = renderHook(() => useSetupChainAndWallet());
 
-    let setupResult: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
+    let setupResult!: Awaited<ReturnType<typeof result.current.setupChainAndWallet>>;
     await act(async () => {
       setupResult = await result.current.setupChainAndWallet({
         targetChainId: 11155420,

--- a/hooks/useSetupChainAndWallet.ts
+++ b/hooks/useSetupChainAndWallet.ts
@@ -44,10 +44,10 @@ function isNetworkChangedError(error: unknown): boolean {
     return false;
   }
 
-  const errorWithCode = error as Error & { code?: string };
-
+  // ethers v6 emits `code: "NETWORK_ERROR"` for this case. The message check
+  // is defense in depth for wrappers that strip the code but preserve the text.
   return (
-    errorWithCode.code === "NETWORK_ERROR" ||
+    ("code" in error && (error as { code: unknown }).code === "NETWORK_ERROR") ||
     error.message.toLowerCase().includes("network changed")
   );
 }
@@ -133,7 +133,6 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
           throw error;
         }
 
-        console.warn("Wallet network changed during signer setup:", error);
         toast.error("Wallet network changed while preparing the transaction. Please try again.");
 
         return null;

--- a/hooks/useSetupChainAndWallet.ts
+++ b/hooks/useSetupChainAndWallet.ts
@@ -47,8 +47,30 @@ function isNetworkChangedError(error: unknown): boolean {
   const errorWithCode = error as Error & { code?: string };
 
   return (
-    errorWithCode.code === "NETWORK_ERROR" || error.message.toLowerCase().includes("network changed")
+    errorWithCode.code === "NETWORK_ERROR" ||
+    error.message.toLowerCase().includes("network changed")
   );
+}
+
+// Wallet providers can briefly report the old chain right after a switch,
+// which trips ethers' NETWORK_ERROR guard. A short pause + single retry
+// handles the transient race without bothering the user.
+const NETWORK_CHANGED_RETRY_DELAY_MS = 250;
+
+async function getSignerWithNetworkChangeRetry(
+  getSigner: (chainId: number) => Promise<Signer>,
+  chainId: number
+): Promise<Signer> {
+  try {
+    return await getSigner(chainId);
+  } catch (error) {
+    if (!isNetworkChangedError(error)) {
+      throw error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, NETWORK_CHANGED_RETRY_DELAY_MS));
+    return await getSigner(chainId);
+  }
 }
 
 /**
@@ -95,7 +117,7 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
       }
 
       try {
-        const walletSigner = await getAttestationSigner(chainId);
+        const walletSigner = await getSignerWithNetworkChangeRetry(getAttestationSigner, chainId);
 
         return {
           gapClient,
@@ -104,13 +126,15 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
           isGasless: isGaslessAvailable,
         };
       } catch (error) {
-        console.warn("Failed to prepare wallet signer:", error);
+        // Only swallow NETWORK_ERROR — other failures (unsupported chain, no
+        // wallet, signer construction) are real bugs and must surface to
+        // Sentry instead of being hidden behind a generic toast.
+        if (!isNetworkChangedError(error)) {
+          throw error;
+        }
 
-        toast.error(
-          isNetworkChangedError(error)
-            ? "Wallet network changed while preparing the transaction. Please try again."
-            : "Failed to prepare wallet for this transaction. Please try again."
-        );
+        console.warn("Wallet network changed during signer setup:", error);
+        toast.error("Wallet network changed while preparing the transaction. Please try again.");
 
         return null;
       }

--- a/hooks/useSetupChainAndWallet.ts
+++ b/hooks/useSetupChainAndWallet.ts
@@ -3,6 +3,7 @@
 import type { GAP } from "@show-karma/karma-gap-sdk";
 import type { Signer } from "ethers";
 import { useCallback, useMemo } from "react";
+import toast from "react-hot-toast";
 import { ensureCorrectChain } from "@/utilities/ensureCorrectChain";
 import { useZeroDevSigner } from "./useZeroDevSigner";
 
@@ -36,6 +37,18 @@ interface UseSetupChainAndWalletResult {
 
   /** Whether user has an external wallet (MetaMask, etc.) */
   hasExternalWallet: boolean;
+}
+
+function isNetworkChangedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errorWithCode = error as Error & { code?: string };
+
+  return (
+    errorWithCode.code === "NETWORK_ERROR" || error.message.toLowerCase().includes("network changed")
+  );
 }
 
 /**
@@ -81,14 +94,26 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
         return null;
       }
 
-      const walletSigner = await getAttestationSigner(chainId);
+      try {
+        const walletSigner = await getAttestationSigner(chainId);
 
-      return {
-        gapClient,
-        walletSigner,
-        chainId,
-        isGasless: isGaslessAvailable,
-      };
+        return {
+          gapClient,
+          walletSigner,
+          chainId,
+          isGasless: isGaslessAvailable,
+        };
+      } catch (error) {
+        console.warn("Failed to prepare wallet signer:", error);
+
+        toast.error(
+          isNetworkChangedError(error)
+            ? "Wallet network changed while preparing the transaction. Please try again."
+            : "Failed to prepare wallet for this transaction. Please try again."
+        );
+
+        return null;
+      }
     },
     [getAttestationSigner, isGaslessAvailable]
   );


### PR DESCRIPTION
## Summary
- catch wallet signer preparation failures in `useSetupChainAndWallet`
- show a user-facing toast when the wallet network changes mid-setup instead of surfacing an uncaught error
- add a regression test covering the `NETWORK_ERROR` path

## Testing
- `pnpm exec vitest run --project unit hooks/__tests__/useSetupChainAndWallet.test.ts`
- `pnpm run test` *(fails on this branch and on refreshed `origin/main` because of existing unrelated baseline failures in donation cart/auth/RBAC/UI tests)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved wallet and chain setup resilience by introducing an automatic retry mechanism for transient network errors encountered during initialization.
  * Added user-friendly error notifications when network connectivity issues persist after automatic retry, prompting users to attempt the operation again.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1386)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->