### PR TITLE
fix: require signer before community admin check

### DIFF
--- a/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
+++ b/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
@@ -272,6 +272,17 @@ describe("useCheckCommunityAdmin", () => {
       expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
     });
 
+    it("should not fetch when signer is not ready", () => {
+      mockUseSigner.mockReturnValue(undefined as ReturnType<typeof useSigner>);
+
+      const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+    });
+
     it("should fetch when all conditions are met", async () => {
       mockIsCommunityAdminOf.mockResolvedValueOnce(true);
 

--- a/hooks/communities/useCheckCommunityAdmin.ts
+++ b/hooks/communities/useCheckCommunityAdmin.ts
@@ -44,13 +44,13 @@ export const useCheckCommunityAdmin = (
       signer
     ),
     queryFn: async () => {
-      if (!community || !checkAddress || !isAuth) {
+      if (!community || !checkAddress || !isAuth || !signer) {
         return false;
       }
 
       return await isCommunityAdminOf(community, checkAddress, signer);
     },
-    enabled: !!community && !!checkAddress && !!isAuth && options?.enabled !== false,
+    enabled: !!community && !!checkAddress && !!isAuth && !!signer && options?.enabled !== false,
     staleTime: ADMIN_CACHE_CONFIG.staleTime,
     gcTime: ADMIN_CACHE_CONFIG.gcTime,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary
- gate `useCheckCommunityAdmin` on an available signer before the admin query can run
- keep the hook returning `false` until signer initialization finishes instead of calling the SDK with `undefined`
- add a regression test for the no-signer startup race on the grant funding route

## Testing
- `pnpm exec vitest run --project unit __tests__/unit/hooks/useCheckCommunityAdmin.test.tsx`
- `pnpm run test` *(fails here and on refreshed `origin/main` because of existing unrelated baseline failures in donation cart/auth/RBAC/UI tests)*
