### PR TITLE
fix: fetch public program details without auth

### DIFF
--- a/__tests__/features/programs/hooks/use-program.test.tsx
+++ b/__tests__/features/programs/hooks/use-program.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+import { useProgram } from "@/src/features/programs/hooks/use-program";
+import fetchData from "@/utilities/fetchData";
+
+const buildClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+
+const wrapper =
+  (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+describe("useProgram", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = buildClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("fetches public program details without requiring auth", async () => {
+    const mockProgram = {
+      id: "program-12",
+      name: "Public Program",
+    };
+
+    (fetchData as vi.Mock).mockResolvedValueOnce([mockProgram, null, null, 200]);
+
+    const { result } = renderHook(() => useProgram("program-12"), {
+      wrapper: wrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.program).toEqual(mockProgram);
+    expect(fetchData).toHaveBeenCalledWith(
+      "/v2/funding-program-configs/program-12",
+      "GET",
+      {},
+      {},
+      {},
+      false
+    );
+  });
+});

--- a/src/features/programs/hooks/use-program.ts
+++ b/src/features/programs/hooks/use-program.ts
@@ -13,7 +13,7 @@ export function useProgram(programId: string): UseProgramReturn {
         {},
         {},
         {},
-        true
+        false
       );
       if (err) throw new Error(err);
       return res;


### PR DESCRIPTION
## Summary
- make the public program detail hook fetch funding program configs without auth bootstrap
- add a focused hook test covering the unauthenticated fetch path

## Testing
- `pnpm exec vitest run --project unit __tests__/features/programs/hooks/use-program.test.tsx`
- `pnpm run test` *(fails on this branch and on refreshed `origin/main` due to existing baseline issues in unrelated suites, including donation cart storage/localStorage failures and unrelated component expectation mismatches)*

## Risks
- public program detail fetches now skip auth headers, matching the existing public apply route for the same endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the program retrieval hook to verify proper data fetching and loading state management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1388)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->