### PR TITLE
fix: defer privy boot on public apply pages

### DIFF
--- a/__tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx
+++ b/__tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx
@@ -1,5 +1,10 @@
 import { act, render } from "@testing-library/react";
-import React from "react";
+
+const mockUsePathname = vi.fn(() => "/");
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
 
 // Mock heavy dependencies
 vi.mock("@tanstack/react-query", () => ({
@@ -93,5 +98,27 @@ describe("PrivyProviderWrapper", () => {
     expect(mockRIC).toHaveBeenCalledWith(expect.any(Function), {
       timeout: 5000,
     });
+  });
+
+  it("should skip anonymous idle Privy loading on public apply routes", async () => {
+    mockGetItem.mockReturnValue(null);
+    mockUsePathname.mockReturnValue("/programs/1045/apply");
+
+    const mockRIC = vi.fn();
+    window.requestIdleCallback = mockRIC;
+
+    const PrivyProviderWrapper = (await import("@/components/Utilities/PrivyProviderWrapper"))
+      .default;
+
+    await act(async () => {
+      render(
+        <PrivyProviderWrapper>
+          <div>child</div>
+        </PrivyProviderWrapper>
+      );
+    });
+
+    expect(mockRIC).not.toHaveBeenCalled();
+    expect(mockPrivyComponent).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/hooks/useAuth.privy-load.test.tsx
+++ b/__tests__/unit/hooks/useAuth.privy-load.test.tsx
@@ -1,0 +1,146 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
+
+vi.unmock("@/hooks/useAuth");
+
+const mockPush = vi.fn();
+const mockLogin = vi.fn();
+const mockLogout = vi.fn(async () => {});
+const mockGetAccessToken = vi.fn(async () => null);
+const mockLoadPrivy = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/programs/1045/apply",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: () => ({
+    isWhitelabel: false,
+    whitelabelConfig: null,
+  }),
+}));
+
+vi.mock("@/store/modals/projectCreate", () => ({
+  useProjectCreateModalStore: {
+    getState: () => ({ isProjectCreateModalOpen: false }),
+  },
+}));
+
+vi.mock("@/utilities/auth/compare-all-wallets", () => ({
+  compareAllWallets: vi.fn(() => true),
+}));
+
+vi.mock("@/utilities/pages", () => ({
+  PAGES: {
+    DASHBOARD: "/dashboard",
+  },
+}));
+
+const mockBridgeState = {
+  ready: false,
+  authenticated: false,
+  user: null as any,
+  login: mockLogin,
+  logout: mockLogout,
+  getAccessToken: mockGetAccessToken,
+  connectWallet: vi.fn(),
+  wallets: [] as any[],
+  isConnected: false,
+};
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => mockBridgeState,
+  useLoadPrivy: () => mockLoadPrivy,
+}));
+
+vi.mock("@wagmi/core", () => ({
+  watchAccount: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/utilities/wagmi/privy-config", () => ({
+  privyConfig: {},
+  getPrivyWagmiConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: {
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn(async () => null),
+    setPrivyInstance: vi.fn(),
+    clearCache: vi.fn(),
+  },
+}));
+
+function setBridgeState(overrides: Partial<typeof mockBridgeState>) {
+  Object.assign(mockBridgeState, overrides);
+}
+
+function resetBridgeState() {
+  Object.assign(mockBridgeState, {
+    ready: false,
+    authenticated: false,
+    user: null,
+    login: mockLogin,
+    logout: mockLogout,
+    getAccessToken: mockGetAccessToken,
+    connectWallet: vi.fn(),
+    wallets: [],
+    isConnected: false,
+  });
+}
+
+describe("useAuth deferred Privy loading", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    resetBridgeState();
+    window.history.replaceState({}, "", "/programs/1045/apply");
+  });
+
+  it("requests Privy load instead of calling login when SDK is not ready", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(mockLoadPrivy).toHaveBeenCalledTimes(1);
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("postLoginRedirect")).toBe("/programs/1045/apply");
+  });
+
+  it("retries login after Privy finishes loading", async () => {
+    const { result, rerender } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(mockLoadPrivy).toHaveBeenCalledTimes(1);
+    expect(mockLogin).not.toHaveBeenCalled();
+
+    setBridgeState({ ready: true });
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(mockLogin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -58,6 +58,7 @@ const mockLogin = vi.fn();
 const mockLogout = vi.fn();
 const mockGetAccessToken = vi.fn();
 const mockGetToken = vi.fn();
+const mockLoadPrivy = vi.fn();
 
 // Mock the bridge context that useAuth reads from
 const mockBridgeState = {
@@ -74,6 +75,7 @@ const mockBridgeState = {
 
 vi.mock("@/contexts/privy-bridge-context", () => ({
   usePrivyBridge: () => mockBridgeState,
+  useLoadPrivy: () => mockLoadPrivy,
   PrivyBridgeContext: {
     Provider: ({ children }: { children: any }) => children,
   },
@@ -143,6 +145,7 @@ function resetBridgeState() {
     wallets: [],
     isConnected: false,
   });
+  mockLoadPrivy.mockReset();
 }
 
 describe("useAuth - Query Key Consistency", () => {

--- a/components/Utilities/PrivyProviderWrapper.tsx
+++ b/components/Utilities/PrivyProviderWrapper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QueryClientProvider } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
 import { type ReactNode, useEffect, useState } from "react";
 import { WagmiProvider } from "wagmi";
 import {
@@ -23,6 +24,14 @@ type PrivyModule = {
   default: React.ComponentType<{ tenantConfig?: TenantConfig | null }>;
 };
 
+function isPublicApplyRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    /^\/community\/[^/]+\/programs\/[^/]+\/apply$/.test(pathname) ||
+    /^\/programs\/[^/]+\/apply$/.test(pathname)
+  );
+}
+
 interface PrivyProviderWrapperProps {
   children: ReactNode;
   tenantConfig?: TenantConfig | null;
@@ -43,6 +52,8 @@ function PrivyLoader({
   const [Privy, setPrivy] = useState<PrivyModule | null>(null);
   const setBridge = usePrivyBridgeSetter();
   const loadRequested = usePrivyLoadRequested();
+  const pathname = usePathname();
+  const skipAnonymousIdleLoad = isPublicApplyRoute(pathname);
 
   useEffect(() => {
     const doLoad = () => {
@@ -59,6 +70,13 @@ function PrivyLoader({
       return;
     }
 
+    // Public apply pages should not boot Privy for anonymous visitors until they
+    // explicitly ask to sign in. This avoids background auth.privy.io fetches on
+    // a route that users should be able to read and fill anonymously.
+    if (skipAnonymousIdleLoad) {
+      return;
+    }
+
     // Anonymous user — defer to idle callback with 5s timeout
     if (typeof window !== "undefined" && "requestIdleCallback" in window) {
       const id = requestIdleCallback(doLoad, { timeout: 5000 });
@@ -68,7 +86,7 @@ function PrivyLoader({
     // Fallback: setTimeout for browsers without requestIdleCallback
     const timer = setTimeout(doLoad, 5000);
     return () => clearTimeout(timer);
-  }, [setBridge, loadRequested]);
+  }, [setBridge, loadRequested, skipAnonymousIdleLoad]);
 
   return (
     <>

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -3,12 +3,11 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Hex } from "viem";
-import { usePrivyBridge } from "@/contexts/privy-bridge-context";
+import { useLoadPrivy, usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { useProjectCreateModalStore } from "@/store/modals/projectCreate";
 import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { getE2EMockAuthState } from "@/utilities/auth/e2e-auth";
 import { TokenManager } from "@/utilities/auth/token-manager";
-import { PAGES } from "@/utilities/pages";
 import { queryClient } from "@/utilities/query-client";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 
@@ -118,6 +117,7 @@ export const useAuth = () => {
     wallets,
     isConnected,
   } = usePrivyBridge();
+  const loadPrivy = useLoadPrivy();
 
   const router = useRouter();
   const pathname = usePathname();
@@ -135,6 +135,7 @@ export const useAuth = () => {
   const address = (primaryWallet?.address as Hex | undefined) || e2eMockAddress;
 
   const shouldLoginAfterLogout = useRef(false);
+  const shouldLoginAfterPrivyLoad = useRef(false);
   const prevAuthRef = useRef(authenticated);
   const prevUserIdRef = useRef<string | undefined>(user?.id);
   const authFailureCount = useRef(0);
@@ -233,6 +234,16 @@ export const useAuth = () => {
       login();
     }
   }, [authenticated, ready, login]);
+
+  // If login was requested before the Privy SDK finished loading, retry once the
+  // bridge reports ready. This lets public pages defer Privy boot until the user
+  // actually asks to sign in.
+  useEffect(() => {
+    if (shouldLoginAfterPrivyLoad.current && ready && !authenticated) {
+      shouldLoginAfterPrivyLoad.current = false;
+      login();
+    }
+  }, [ready, authenticated, login]);
 
   // Cross-tab logout synchronization
   // Compatible with both localStorage (default) and HttpOnly cookies
@@ -358,6 +369,12 @@ export const useAuth = () => {
       }
     }
 
+    if (!ready) {
+      shouldLoginAfterPrivyLoad.current = true;
+      loadPrivy();
+      return;
+    }
+
     // If authenticated but wallet not connected via wagmi, force re-login only when
     // the user has external wallets (not embedded). Embedded wallets (from Privy)
     // may not register with wagmi, so treat wallets.length > 0 as effectively connected.
@@ -377,7 +394,7 @@ export const useAuth = () => {
     if (!authenticated) {
       login();
     }
-  }, [isConnected, authenticated, wallets.length, logout, login]);
+  }, [ready, authenticated, isConnected, wallets, logout, login, loadPrivy]);
 
   const connectedAndAuth = useMemo(() => {
     if (isE2EMockAuthenticated) {


### PR DESCRIPTION
## Summary
- avoid idle-loading Privy for anonymous visitors on public apply routes
- request Privy only when the user explicitly triggers login, then retry login after the SDK finishes loading
- add focused tests for the public apply route guard and deferred login flow

## Testing
- `pnpm exec biome check components/Utilities/PrivyProviderWrapper.tsx hooks/useAuth.ts __tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx __tests__/unit/hooks/useAuth.privy-load.test.tsx`
- `pnpm exec vitest run --project unit __tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx`
- `pnpm exec vitest run --project unit __tests__/unit/hooks/useAuth.privy-load.test.tsx`
- `pnpm run test` *(fails in this worktree and on refreshed `origin/main` with the same existing baseline suites, including `components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx` and the known localStorage-based auth suites such as `__tests__/unit/hooks/useAuth.test.tsx`)*

Linear: DEV-264