### PR TITLE
fix(communities): pass chainID to getCommunityResolver to avoid ethers NETWORK_ERROR

### DIFF
--- a/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
+++ b/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/components/Utilities/errorManager", () => ({
   errorManager: vi.fn(),
 }));
 
-const mockGetCommunityResolver = GAP.getCommunityResolver as unknown as vi.Mock;
+const mockGetCommunityResolver = vi.mocked(GAP.getCommunityResolver);
 
 const community = {
   uid: "0xcb67cd16cbdf4e9c3b6ed4c8f9424411a48be796d690750afc84f9288e7c7996",

--- a/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
+++ b/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
@@ -1,0 +1,69 @@
+import { GAP } from "@show-karma/karma-gap-sdk";
+import type { Community } from "@/types/v2/community";
+import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
+import { isCommunityAdminOf } from "@/utilities/sdk/communities/isCommunityAdmin";
+
+vi.mock("@show-karma/karma-gap-sdk", () => ({
+  GAP: {
+    getCommunityResolver: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/gapRpcConfig", () => ({
+  getGapRpcConfig: vi.fn(() => ({ 10: "https://rpc.optimism" })),
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+const mockGetCommunityResolver = GAP.getCommunityResolver as unknown as vi.Mock;
+
+const community = {
+  uid: "0xcb67cd16cbdf4e9c3b6ed4c8f9424411a48be796d690750afc84f9288e7c7996",
+  chainID: 10,
+} as unknown as Community;
+
+const address = "0x6166E1964447E0959bC7c8d543DB3ab82dB65044";
+
+describe("isCommunityAdminOf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes community.chainID to GAP.getCommunityResolver so the SDK uses a static RPC provider for the community's chain (prevents ethers v6 NETWORK_ERROR on wallet/community chain mismatch)", async () => {
+    mockGetCommunityResolver.mockResolvedValue({
+      isAdmin: vi.fn().mockResolvedValue(true),
+    });
+
+    const signer = { fake: "signer" } as any;
+
+    await isCommunityAdminOf(community, address, signer);
+
+    expect(mockGetCommunityResolver).toHaveBeenCalledWith(
+      signer,
+      getGapRpcConfig(),
+      community.chainID
+    );
+  });
+
+  it("returns the resolver.isAdmin result", async () => {
+    const isAdmin = vi.fn().mockResolvedValue(true);
+    mockGetCommunityResolver.mockResolvedValue({ isAdmin });
+
+    const result = await isCommunityAdminOf(community, address);
+
+    expect(result).toBe(true);
+    expect(isAdmin).toHaveBeenCalledWith(community.uid, address);
+  });
+
+  it("returns false when resolver throws (e.g. NETWORK_ERROR)", async () => {
+    mockGetCommunityResolver.mockRejectedValue(
+      new Error('network changed: 1 => 10  (event="changed", code=NETWORK_ERROR, version=6.11.0)')
+    );
+
+    const result = await isCommunityAdminOf(community, address);
+
+    expect(result).toBe(false);
+  });
+});

--- a/__tests__/utilities/sdk/projects/projectOwnershipTransfered.test.ts
+++ b/__tests__/utilities/sdk/projects/projectOwnershipTransfered.test.ts
@@ -1,0 +1,65 @@
+import type { Project } from "@show-karma/karma-gap-sdk";
+import { GAP } from "@show-karma/karma-gap-sdk";
+import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
+import { isOwnershipTransfered } from "@/utilities/sdk/projects/projectOwnershipTransfered";
+
+vi.mock("@show-karma/karma-gap-sdk", () => ({
+  GAP: {
+    getProjectResolver: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/gapRpcConfig", () => ({
+  getGapRpcConfig: vi.fn(() => ({ 10: "https://rpc.optimism" })),
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+const mockGetProjectResolver = vi.mocked(GAP.getProjectResolver);
+
+const project = {
+  uid: "0xproject",
+  chainID: 10,
+} as unknown as Project;
+
+const newOwner = "0x6166E1964447E0959bC7c8d543DB3ab82dB65044" as const;
+
+describe("isOwnershipTransfered", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes project.chainID to GAP.getProjectResolver so the SDK uses a static RPC provider for the project's chain (prevents ethers v6 NETWORK_ERROR on wallet/project chain mismatch)", async () => {
+    mockGetProjectResolver.mockResolvedValue({
+      isOwner: vi.fn().mockResolvedValue(true),
+    } as never);
+
+    const signer = { fake: "signer" } as never;
+
+    await isOwnershipTransfered(signer, project, newOwner);
+
+    expect(mockGetProjectResolver).toHaveBeenCalledWith(signer, getGapRpcConfig(), project.chainID);
+  });
+
+  it("returns the resolver.isOwner result", async () => {
+    const isOwner = vi.fn().mockResolvedValue(true);
+    mockGetProjectResolver.mockResolvedValue({ isOwner } as never);
+
+    const result = await isOwnershipTransfered({} as never, project, newOwner);
+
+    expect(result).toBe(true);
+    expect(isOwner).toHaveBeenCalledWith(project.uid, newOwner);
+  });
+
+  it("returns false when resolver throws (e.g. NETWORK_ERROR)", async () => {
+    mockGetProjectResolver.mockRejectedValue(
+      new Error('network changed: 1 => 10  (event="changed", code=NETWORK_ERROR, version=6.11.0)')
+    );
+
+    const result = await isOwnershipTransfered({} as never, project, newOwner);
+
+    expect(result).toBe(false);
+  });
+});

--- a/utilities/sdk/communities/isCommunityAdmin.ts
+++ b/utilities/sdk/communities/isCommunityAdmin.ts
@@ -19,7 +19,7 @@ export const isCommunityAdminOf = async (
 ): Promise<boolean> => {
   const { uid, chainID } = community;
   try {
-    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig());
+    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig(), chainID);
     if (!resolver) {
       errorManager(`Community resolver not available for chain ${chainID}`, null, {
         uid,

--- a/utilities/sdk/projects/projectOwnershipTransfered.ts
+++ b/utilities/sdk/projects/projectOwnershipTransfered.ts
@@ -10,7 +10,7 @@ export async function isOwnershipTransfered(
   try {
     const { uid, chainID } = project;
 
-    const resolver = await GAP.getProjectResolver(signer, getGapRpcConfig());
+    const resolver = await GAP.getProjectResolver(signer, getGapRpcConfig(), chainID);
 
     const response = await resolver.isOwner(uid, newOwner);
     const isowner = response;


### PR DESCRIPTION
## Summary

Fixes Sentry [GAP-FRONTEND-1ZY](https://karma-crypto-inc.sentry.io/issues/7470168634/) — `Error: network changed: 1 => 10 (code=NETWORK_ERROR, version=6.11.0)` thrown from `getNetwork` while checking community admin status.

### Root cause

`isCommunityAdminOf` called `GAP.getCommunityResolver(signer, getGapRpcConfig())` without an explicit `chainId`. The SDK then falls back to probing `signer.provider.getNetwork()` — but the user's wallet may be on a different chain than the community (e.g. wallet on Mainnet `1`, community on Optimism `10`). Ethers v6 detects the mismatch and throws `NETWORK_ERROR`.

### Fix

Pass `community.chainID` as the third argument. Per `karma-gap-sdk/core/class/GAP.ts:470`, an explicit `chainId` + `rpcConfig` makes the SDK build a static `JsonRpcProvider` for the target chain and skip the signer's network probe entirely — correct behavior for this read-only check.

Other `getCommunityResolver` callers (`AddAdminDialog`, `RemoveAdminDialog`) are write operations where the user is already on the correct chain; they are unaffected.

## Test plan

- [x] New unit tests in `__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts`:
  - asserts `getCommunityResolver` is called with `community.chainID`
  - happy path returns `resolver.isAdmin` result
  - returns `false` on NETWORK_ERROR (fallback path)
- [x] Verified red → green: test fails on previous code, passes with the fix
- [ ] Sentry issue stops occurring after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for community admin verification functionality to validate multiple scenarios and error handling
* **Bug Fixes**
  * Enhanced RPC configuration handling in community admin checks for improved reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1390)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->