### PR TITLE
fix: use Privy identity address instead of wagmi-connected wallet

### DIFF
--- a/__tests__/components/Cards/GrantCard.test.tsx
+++ b/__tests__/components/Cards/GrantCard.test.tsx
@@ -273,7 +273,7 @@ describe("GrantCard", () => {
       expect(screen.getByText(/0\/0.*Milestones/i)).toBeInTheDocument();
     });
 
-    it("should show activity badge even when 0 updates", () => {
+    it("should hide updates badge when there are 0 updates", () => {
       const grantWithoutUpdates = {
         ...mockGrant,
         updates: [],
@@ -282,8 +282,7 @@ describe("GrantCard", () => {
 
       render(<GrantCard grant={grantWithoutUpdates} index={0} />);
 
-      // Updates badge should still be visible when 0
-      expect(screen.getByText(/0.*Update/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Update/i)).not.toBeInTheDocument();
     });
 
     it("should handle grant without categories", () => {

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -4,9 +4,9 @@ import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioRe
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
-vi.mock("@/components/Utilities/MarkdownPreview", () => ({
-  MarkdownPreview: ({ source }: { source?: string }) => (
-    <div data-testid="markdown-preview">{source}</div>
+vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => ({
+  HtmlReportFrame: ({ html }: { html?: string }) => (
+    <div data-testid="markdown-preview">{html}</div>
   ),
 }));
 
@@ -23,7 +23,7 @@ const draftReport = {
   communityId: "community-1",
   runDate: "2026-03-15",
   status: "draft",
-  markdown: "# Draft report body",
+  content: "# Draft report body",
   dataSnapshot: {},
   modelId: "gpt-4.1",
   tokenUsage: null,
@@ -122,7 +122,6 @@ describe("PortfolioReportPreviewPage", () => {
         "href",
         "/community/filecoin/manage/portfolio-reports"
       );
-      expect(screen.getByText("Draft")).toBeInTheDocument();
       expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
     });
 

--- a/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
+++ b/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
@@ -94,8 +94,7 @@ describe("CommunityStatCards", () => {
       // Milestones card: completed = 30 + 25 = 55, total = 137
       expect(screen.getByText("55 / 137")).toBeInTheDocument();
       expect(screen.getByText("Completed / Total Milestones")).toBeInTheDocument();
-      expect(screen.getByText("40.1%")).toBeInTheDocument();
-      expect(screen.getByText("59.9%")).toBeInTheDocument();
+      expect(screen.getByText("40%")).toBeInTheDocument();
 
       const bar = screen.getByRole("progressbar");
       expect(bar).toHaveAttribute("aria-valuenow", String((55 / 137) * 100));
@@ -124,8 +123,7 @@ describe("CommunityStatCards", () => {
       renderWithProviders(<CommunityStatCards />);
 
       expect(await screen.findByText("0 / 0")).toBeInTheDocument();
-      const percents = screen.getAllByText("0.0%");
-      expect(percents.length).toBe(2);
+      expect(screen.getByText("0%")).toBeInTheDocument();
     });
 
     it("renders dash when values are zero or falsy", async () => {

--- a/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
+++ b/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
@@ -4,37 +4,52 @@
  * The hook uses address-based filtering where:
  *   - undefined = "All Reviewers"
  *   - string = specific reviewer's address
+ *
+ * Default selection: the current user's address is preselected iff it appears
+ * in the community reviewer list, regardless of admin/role state.
  */
 
+import type { CommunityReviewer } from "@/hooks/useCommunityMilestoneReviewers";
 import { computeDefaultReviewerAddress } from "@/hooks/useReportPageData";
 
 describe("useReportPageData reviewer filter logic (address-based)", () => {
-  const testAddress = "0x1234567890abcdef1234567890abcdef12345678";
+  const userAddress = "0x1234567890abcdef1234567890abcdef12345678";
+  const otherAddress = "0xabcdef1234567890abcdef1234567890abcdef12";
+
+  const makeReviewer = (publicAddress: string, name?: string): CommunityReviewer => ({
+    publicAddress,
+    name,
+  });
 
   describe("computeDefaultReviewerAddress", () => {
-    it("defaults to user address when isMilestoneReviewer is true and hasAccess is false", () => {
-      const result = computeDefaultReviewerAddress(true, false, testAddress);
-      expect(result).toBe(testAddress);
+    it("returns the matching reviewer's address when the user is in the reviewer list", () => {
+      const reviewers = [makeReviewer(otherAddress, "Alice"), makeReviewer(userAddress, "Bob")];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBe(userAddress);
     });
 
-    it("defaults to undefined when hasAccess is true (admin), even if isMilestoneReviewer", () => {
-      const result = computeDefaultReviewerAddress(true, true, testAddress);
-      expect(result).toBeUndefined();
+    it("matches case-insensitively (checksummed vs lowercase address)", () => {
+      const reviewers = [makeReviewer(userAddress.toLowerCase())];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress.toUpperCase())).toBe(
+        userAddress.toLowerCase()
+      );
     });
 
-    it("defaults to undefined when isMilestoneReviewer is false", () => {
-      const result = computeDefaultReviewerAddress(false, false, testAddress);
-      expect(result).toBeUndefined();
+    it("returns undefined when the user is not in the reviewer list", () => {
+      const reviewers = [makeReviewer(otherAddress, "Alice")];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBeUndefined();
     });
 
-    it("defaults to undefined when hasAccess is true and isMilestoneReviewer is false", () => {
-      const result = computeDefaultReviewerAddress(false, true, testAddress);
-      expect(result).toBeUndefined();
+    it("returns undefined when currentUserAddress is undefined", () => {
+      const reviewers = [makeReviewer(userAddress)];
+      expect(computeDefaultReviewerAddress(reviewers, undefined)).toBeUndefined();
     });
 
-    it("returns undefined when reviewer has no address", () => {
-      const result = computeDefaultReviewerAddress(true, false, undefined);
-      expect(result).toBeUndefined();
+    it("returns undefined when reviewers list is empty", () => {
+      expect(computeDefaultReviewerAddress([], userAddress)).toBeUndefined();
+    });
+
+    it("returns undefined when reviewers list is undefined (not loaded yet)", () => {
+      expect(computeDefaultReviewerAddress(undefined, userAddress)).toBeUndefined();
     });
   });
 
@@ -48,13 +63,13 @@ describe("useReportPageData reviewer filter logic (address-based)", () => {
         pendingPage = 1;
       };
 
-      handleReviewerAddressChange(testAddress);
-      expect(selectedReviewerAddress).toBe(testAddress);
+      handleReviewerAddressChange(userAddress);
+      expect(selectedReviewerAddress).toBe(userAddress);
       expect(pendingPage).toBe(1);
     });
 
     it("can switch to undefined (all reviewers)", () => {
-      let selectedReviewerAddress: string | undefined = testAddress;
+      let selectedReviewerAddress: string | undefined = userAddress;
       let pendingPage = 5;
 
       const handleReviewerAddressChange = (address: string | undefined) => {
@@ -68,8 +83,7 @@ describe("useReportPageData reviewer filter logic (address-based)", () => {
     });
 
     it("can switch between different reviewer addresses", () => {
-      let selectedReviewerAddress: string | undefined = testAddress;
-      const otherAddress = "0xabcdef1234567890abcdef1234567890abcdef12";
+      let selectedReviewerAddress: string | undefined = userAddress;
 
       const handleReviewerAddressChange = (address: string | undefined) => {
         selectedReviewerAddress = address;
@@ -81,19 +95,19 @@ describe("useReportPageData reviewer filter logic (address-based)", () => {
   });
 
   describe("integration: default address drives effective address", () => {
-    it("reviewer-only user defaults to seeing their own milestones", () => {
-      const defaultAddress = computeDefaultReviewerAddress(true, false, testAddress);
-      expect(defaultAddress).toBe(testAddress);
+    it("user who is a registered reviewer defaults to seeing their own milestones", () => {
+      const reviewers = [makeReviewer(userAddress)];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBe(userAddress);
     });
 
-    it("admin user defaults to seeing all milestones", () => {
-      const defaultAddress = computeDefaultReviewerAddress(true, true, testAddress);
-      expect(defaultAddress).toBeUndefined();
+    it("admin who is also a reviewer defaults to themselves (not 'All Reviewers')", () => {
+      const reviewers = [makeReviewer(otherAddress), makeReviewer(userAddress)];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBe(userAddress);
     });
 
-    it("non-reviewer, non-admin user defaults to seeing all milestones", () => {
-      const defaultAddress = computeDefaultReviewerAddress(false, false, testAddress);
-      expect(defaultAddress).toBeUndefined();
+    it("user not in reviewer list defaults to seeing all milestones", () => {
+      const reviewers = [makeReviewer(otherAddress)];
+      expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBeUndefined();
     });
   });
 });

--- a/__tests__/navbar/unit/menu-items.test.tsx
+++ b/__tests__/navbar/unit/menu-items.test.tsx
@@ -182,7 +182,7 @@ describe("Menu Items Configuration", () => {
     it("should have valid configuration", () => {
       expect(resourcesItems).toBeDefined();
       expect(Array.isArray(resourcesItems)).toBe(true);
-      expect(resourcesItems.length).toBe(2);
+      expect(resourcesItems.length).toBe(3);
     });
 
     it("should have all required properties for each item", () => {

--- a/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
+++ b/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
@@ -20,6 +20,7 @@ vi.mock("wagmi", () => ({
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(() => ({
     authenticated: true,
+    address: "0xMockWalletAddress",
   })),
 }));
 
@@ -91,6 +92,7 @@ describe("useCheckCommunityAdmin", () => {
     } as ReturnType<typeof useAccount>);
     mockUseAuth.mockReturnValue({
       authenticated: true,
+      address: mockAddress,
     } as ReturnType<typeof useAuth>);
     mockUseSigner.mockReturnValue("mockSigner" as ReturnType<typeof useSigner>);
   });
@@ -248,9 +250,10 @@ describe("useCheckCommunityAdmin", () => {
     });
 
     it("should not fetch when no address is available", () => {
-      mockUseAccount.mockReturnValue({
+      mockUseAuth.mockReturnValue({
+        authenticated: true,
         address: undefined,
-      } as ReturnType<typeof useAccount>);
+      } as ReturnType<typeof useAuth>);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),

--- a/__tests__/unit/hooks/useIsCommunityAdmin.test.tsx
+++ b/__tests__/unit/hooks/useIsCommunityAdmin.test.tsx
@@ -16,6 +16,14 @@ vi.mock("wagmi", () => ({
   })),
 }));
 
+// Mock useAuth hook
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(() => ({
+    authenticated: true,
+    address: "0xMockWalletAddress",
+  })),
+}));
+
 // Mock useCommunityDetails
 vi.mock("@/hooks/communities/useCommunityDetails", () => ({
   useCommunityDetails: vi.fn(),
@@ -29,8 +37,10 @@ vi.mock("@/hooks/communities/useCheckCommunityAdmin", () => ({
 import { useAccount } from "wagmi";
 import { useCheckCommunityAdmin } from "@/hooks/communities/useCheckCommunityAdmin";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
+import { useAuth } from "@/hooks/useAuth";
 
 const mockUseAccount = useAccount as vi.MockedFunction<typeof useAccount>;
+const mockUseAuth = useAuth as vi.MockedFunction<typeof useAuth>;
 const mockUseCommunityDetails = useCommunityDetails as vi.MockedFunction<
   typeof useCommunityDetails
 >;
@@ -100,6 +110,10 @@ describe("useIsCommunityAdmin", () => {
     mockUseAccount.mockReturnValue({
       address: mockAddress,
     } as ReturnType<typeof useAccount>);
+    mockUseAuth.mockReturnValue({
+      authenticated: true,
+      address: mockAddress,
+    } as ReturnType<typeof useAuth>);
     mockUseCommunityDetails.mockReturnValue(
       defaultCommunityQueryResult as ReturnType<typeof useCommunityDetails>
     );
@@ -487,9 +501,10 @@ describe("useIsCommunityAdmin", () => {
     });
 
     it("should handle no connected wallet", () => {
-      mockUseAccount.mockReturnValue({
+      mockUseAuth.mockReturnValue({
+        authenticated: true,
         address: undefined,
-      } as ReturnType<typeof useAccount>);
+      } as ReturnType<typeof useAuth>);
       // When no wallet is connected, admin check should return false
       mockUseCheckCommunityAdmin.mockReturnValue({
         ...defaultAdminQueryResult,

--- a/app/admin/faucet/layout.tsx
+++ b/app/admin/faucet/layout.tsx
@@ -2,14 +2,14 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { useAccount } from "wagmi";
 import { Spinner } from "@/components/Utilities/Spinner";
+import { useAuth } from "@/hooks/useAuth";
 import { useFaucetAdmin } from "@/hooks/useFaucetAdmin";
 import { PAGES } from "@/utilities/pages";
 
 export default function FaucetAdminLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const { isConnected } = useAccount();
+  const { isConnected } = useAuth();
   const { isAdmin, isLoading } = useFaucetAdmin();
   useEffect(() => {
     // Redirect if not connected or not admin

--- a/app/admin/faucet/layout.tsx
+++ b/app/admin/faucet/layout.tsx
@@ -9,10 +9,11 @@ import { PAGES } from "@/utilities/pages";
 
 export default function FaucetAdminLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const { isConnected } = useAuth();
+  const { isConnected, ready } = useAuth();
   const { isAdmin, isLoading } = useFaucetAdmin();
   useEffect(() => {
-    // Redirect if not connected or not admin
+    if (!ready) return;
+
     if (!isConnected) {
       router.push(PAGES.HOME);
       return;
@@ -21,9 +22,9 @@ export default function FaucetAdminLayout({ children }: { children: React.ReactN
     if (!isLoading && !isAdmin) {
       router.push(PAGES.HOME);
     }
-  }, [isConnected, isAdmin, isLoading, router]);
+  }, [ready, isConnected, isAdmin, isLoading, router]);
 
-  if (isLoading) {
+  if (!ready || isLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
         <Spinner />

--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -68,7 +68,8 @@ type SchemaType = z.infer<typeof profileSchema>;
 
 export const ContributorProfileDialog: FC = () => {
   const project = useProjectStore((state) => state.project);
-  const { address, chain, isConnected } = useAccount();
+  const { chain } = useAccount();
+  const { address, isConnected, authenticated: isAuth, login } = useAuth();
   const { closeModal, isModalOpen: isOpen, isGlobal } = useContributorProfileModalStore();
 
   // Fetch contributor profile using React Query
@@ -99,11 +100,9 @@ export const ContributorProfileDialog: FC = () => {
     reValidateMode: "onChange",
     mode: "onChange",
   });
-  const { login } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const { startAttestation, showLoading, showSuccess, showError, dismiss, changeStepperStep } =
     useAttestationToast();
-  const { authenticated: isAuth } = useAuth();
   const refreshProject = useProjectStore((state) => state.refreshProject);
 
   const isAllowed = isConnected && isAuth;

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -474,7 +474,7 @@ function MilestonesReviewPageContent({
   const searchParams = useSearchParams();
   const searchParamsString = searchParams.toString();
 
-  const { address } = useAuth();
+  const { address, ready } = useAuth();
   const { hasAccess: hasAdminAccess, isLoading: isLoadingAdminAccess } =
     useCommunityAdminAccess(communityId);
 
@@ -729,7 +729,7 @@ function MilestonesReviewPageContent({
   }, [milestones, activeFilter]);
 
   // Show loading while checking authorization
-  if (isLoading || isLoadingReviewer || isLoadingAdminAccess) {
+  if (!ready || isLoading || isLoadingReviewer || isLoadingAdminAccess) {
     return (
       <div className="min-h-screen">
         <div className="px-4 sm:px-6 lg:px-8 py-6">

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -15,10 +15,10 @@ import {
 import dynamic from "next/dynamic";
 import { usePathname, useSearchParams } from "next/navigation";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { useAccount } from "wagmi";
 import { Button } from "@/components/Utilities/Button";
 import { Badge } from "@/components/ui/badge";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import { useAuth } from "@/hooks/useAuth";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
 import { useDeleteMilestone } from "@/hooks/useDeleteMilestone";
 import { useFundingApplicationByProjectUID } from "@/hooks/useFundingApplicationByProjectUID";
@@ -474,7 +474,7 @@ function MilestonesReviewPageContent({
   const searchParams = useSearchParams();
   const searchParamsString = searchParams.toString();
 
-  const { address } = useAccount();
+  const { address } = useAuth();
   const { hasAccess: hasAdminAccess, isLoading: isLoadingAdminAccess } =
     useCommunityAdminAccess(communityId);
 

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -110,16 +110,6 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
   const isCheckingPermissions =
     !ready || isLoadingRbac || isLoadingAdminAccess || isLoadingReviewerPrograms;
 
-  const reportData = useReportPageData({
-    communityId,
-    grantPrograms,
-    hasAccess,
-    isAuthorized,
-    reviewerPrograms: reviewerPrograms ?? [],
-    currentUserAddress: address,
-    isMilestoneReviewer,
-  });
-
   const allProgramIds = useMemo(
     () =>
       grantPrograms
@@ -131,11 +121,29 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
     [grantPrograms]
   );
 
-  const reviewerProgramIds = useMemo(() => {
-    if (!isAuthorized) return [];
-    const ids = reportData.effectiveProgramIds;
-    return ids.length > 0 ? ids : allProgramIds;
-  }, [isAuthorized, reportData.effectiveProgramIds, allProgramIds]);
+  // Fetch reviewers across all programs in the community so the dropdown's
+  // default selection (and "(You)" label) can resolve even before the user
+  // applies a program filter.
+  const reviewerProgramIds = useMemo(
+    () => (isAuthorized ? allProgramIds : []),
+    [isAuthorized, allProgramIds]
+  );
+
+  const {
+    reviewers,
+    isLoading: isLoadingReviewers,
+    isError: isReviewersError,
+  } = useCommunityMilestoneReviewers(reviewerProgramIds);
+
+  const reportData = useReportPageData({
+    communityId,
+    grantPrograms,
+    hasAccess,
+    isAuthorized,
+    reviewerPrograms: reviewerPrograms ?? [],
+    currentUserAddress: address,
+    reviewers,
+  });
 
   // Extract unique grant UIDs from both pending milestones and stats reports
   const allGrantUIDs = useMemo(() => {
@@ -150,12 +158,6 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
   }, [reportData.pendingMilestones, reportData.reports]);
 
   const { allocationMap, grantTotalMap } = useMilestoneAllocationsByGrants(allGrantUIDs);
-
-  const {
-    reviewers,
-    isLoading: isLoadingReviewers,
-    isError: isReviewersError,
-  } = useCommunityMilestoneReviewers(reviewerProgramIds);
 
   useEffect(() => {
     if (isReviewersError) {

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -94,7 +94,7 @@ interface ReportMilestonePageProps {
 export const ReportMilestonePage = ({ community, grantPrograms }: ReportMilestonePageProps) => {
   const params = useParams();
   const communityId = params.communityId as string;
-  const { authenticated: isAuth, isConnected, address } = useAuth();
+  const { authenticated: isAuth, isConnected, address, ready } = useAuth();
   const { hasAccess, isLoading: isLoadingAdminAccess } = useCommunityAdminAccess(community?.uid);
   const isMilestoneReviewer = useIsReviewerType(ReviewerType.MILESTONE);
   const { isLoading: isLoadingRbac, isReviewer } = usePermissionContext();
@@ -107,7 +107,8 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
     return isMilestoneReviewer || isReviewer;
   }, [isConnected, isAuth, hasAccess, isMilestoneReviewer, isReviewer]);
 
-  const isCheckingPermissions = isLoadingRbac || isLoadingAdminAccess || isLoadingReviewerPrograms;
+  const isCheckingPermissions =
+    !ready || isLoadingRbac || isLoadingAdminAccess || isLoadingReviewerPrograms;
 
   const reportData = useReportPageData({
     communityId,

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -3,7 +3,6 @@ import { ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo } from "react";
 import { toast } from "react-hot-toast";
-import { useAccount } from "wagmi";
 import { PendingVerificationTable } from "@/components/Pages/Admin/PendingVerificationTable";
 import { ReviewerFilterDropdown } from "@/components/Pages/Admin/ReviewerFilterDropdown";
 import { StatsGrid } from "@/components/Pages/Admin/StatsGrid";
@@ -95,8 +94,7 @@ interface ReportMilestonePageProps {
 export const ReportMilestonePage = ({ community, grantPrograms }: ReportMilestonePageProps) => {
   const params = useParams();
   const communityId = params.communityId as string;
-  const { isConnected, address } = useAccount();
-  const { authenticated: isAuth } = useAuth();
+  const { authenticated: isAuth, isConnected, address } = useAuth();
   const { hasAccess, isLoading: isLoadingAdminAccess } = useCommunityAdminAccess(community?.uid);
   const isMilestoneReviewer = useIsReviewerType(ReviewerType.MILESTONE);
   const { isLoading: isLoadingRbac, isReviewer } = usePermissionContext();

--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/DetailsScreen.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/DetailsScreen.tsx
@@ -4,7 +4,6 @@ import type React from "react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { isAddress } from "viem";
-import { useAccount } from "wagmi";
 import { z } from "zod";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
@@ -82,7 +81,6 @@ export const DetailsScreen: React.FC = () => {
   const selectedProject = useProjectStore((state) => state.project);
   const _refreshProject = useProjectStore((state) => state.refreshProject);
   const router = useRouter();
-  const { address, isConnected, connector, chain } = useAccount();
 
   // Fetch grants using dedicated hook
   const { grants } = useProjectGrants(selectedProject?.uid || "");

--- a/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/NewGrant/screens/MilestonesScreen.tsx
@@ -47,8 +47,8 @@ export const MilestonesScreen: React.FC = () => {
   const selectedProject = useProjectStore((state) => state.project);
   const { refetch: refetchGrants } = useProjectGrants(selectedProject?.uid || "");
   const router = useRouter();
-  const { address, isConnected, connector, chain } = useAccount();
-  const { authenticated: isAuth } = useAuth();
+  const { connector, chain } = useAccount();
+  const { authenticated: isAuth, address, isConnected } = useAuth();
   const { gap } = useGap();
   const { smartWalletAddress, setupChainAndWallet } = useSetupChainAndWallet();
   const {

--- a/components/Pages/MyProjects/index.tsx
+++ b/components/Pages/MyProjects/index.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { useTheme } from "next-themes";
 import pluralize from "pluralize";
 import { useState } from "react";
-import { useAccount } from "wagmi";
 /* eslint-disable @next/next/no-img-element */
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import Pagination from "@/components/Utilities/Pagination";
@@ -45,8 +44,7 @@ const pickColor = (index: number) => {
 };
 
 export default function MyProjects() {
-  const { isConnected, address } = useAccount();
-  const { authenticated: isAuth } = useAuth();
+  const { authenticated: isAuth, isConnected, address } = useAuth();
   const { theme: currentTheme } = useTheme();
   const { setIsOnboarding } = useOnboarding();
   const { mixpanel } = useMixpanel();

--- a/components/Pages/ProgramRegistry/ManageProgramList.tsx
+++ b/components/Pages/ProgramRegistry/ManageProgramList.tsx
@@ -50,6 +50,7 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
   isAllowed,
 }) => {
   const { address } = useAuth();
+  const normalizedAddress = address?.toLowerCase();
   const searchParams = useSearchParams();
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -489,7 +490,7 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
                 <span
                   key={index}
                   className={`mr-1 inline-flex items-center rounded-md  px-2 py-1 text-xs font-medium text-black ring-1 ring-inset ring-zinc-600/20 ${
-                    admin.toLowerCase() === address?.toLowerCase() ? "bg-blue-100" : "bg-zinc-50"
+                    admin.toLowerCase() === normalizedAddress ? "bg-blue-100" : "bg-zinc-50"
                   }`}
                 >
                   <EthereumAddressToProfileName address={admin.toLowerCase()} />
@@ -598,7 +599,7 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
     ],
     [
       isAllowed,
-      address?.toLowerCase,
+      normalizedAddress,
       approveOrReject,
       editFn,
       selectProgram,

--- a/components/Pages/ProgramRegistry/ManageProgramList.tsx
+++ b/components/Pages/ProgramRegistry/ManageProgramList.tsx
@@ -15,7 +15,6 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { type FC, useMemo, useRef, useState } from "react";
-import { useAccount } from "wagmi";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Discord2Icon, Telegram2Icon, Twitter2Icon } from "@/components/Icons";
 import { BlogIcon } from "@/components/Icons/Blog";
@@ -23,6 +22,7 @@ import { DiscussionIcon } from "@/components/Icons/Discussion";
 import { OrganizationIcon } from "@/components/Icons/Organization";
 import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
+import { useAuth } from "@/hooks/useAuth";
 import { formatDate } from "@/utilities/formatDate";
 import { ReadMore } from "@/utilities/ReadMore";
 import { registryHelper } from "./helper";
@@ -49,7 +49,7 @@ export const ManageProgramList: FC<ManageProgramListProps> = ({
   selectProgram,
   isAllowed,
 }) => {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const searchParams = useSearchParams();
   const [sorting, setSorting] = useState<SortingState>([]);
 

--- a/components/Pages/ProgramRegistry/MyProgramList.tsx
+++ b/components/Pages/ProgramRegistry/MyProgramList.tsx
@@ -15,7 +15,6 @@ import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { type FC, useMemo, useRef, useState } from "react";
-import { useAccount } from "wagmi";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Discord2Icon, Telegram2Icon, Twitter2Icon } from "@/components/Icons";
 import { BlogIcon } from "@/components/Icons/Blog";
@@ -23,6 +22,7 @@ import { DiscussionIcon } from "@/components/Icons/Discussion";
 import { OrganizationIcon } from "@/components/Icons/Organization";
 import { Button } from "@/components/Utilities/Button";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
+import { useAuth } from "@/hooks/useAuth";
 import { formatDate } from "@/utilities/formatDate";
 import { ReadMore } from "@/utilities/ReadMore";
 import { registryHelper } from "./helper";
@@ -47,7 +47,7 @@ export const MyProgramList: FC<MyProgramListProps> = ({
   isAllowed,
 }) => {
   const searchParams = useSearchParams();
-  const { address } = useAccount();
+  const { address } = useAuth();
 
   const [sorting, setSorting] = useState<SortingState>([]);
 

--- a/components/Pages/ProgramRegistry/MyProgramList.tsx
+++ b/components/Pages/ProgramRegistry/MyProgramList.tsx
@@ -48,6 +48,7 @@ export const MyProgramList: FC<MyProgramListProps> = ({
 }) => {
   const searchParams = useSearchParams();
   const { address } = useAuth();
+  const normalizedAddress = address?.toLowerCase();
 
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -433,7 +434,7 @@ export const MyProgramList: FC<MyProgramListProps> = ({
                 <span
                   key={index}
                   className={`mr-1 inline-flex items-center rounded-md  px-2 py-1 text-xs font-medium text-black ring-1 ring-inset ring-zinc-600/20 ${
-                    admin.toLowerCase() === address?.toLowerCase() ? "bg-blue-100" : "bg-zinc-50"
+                    admin.toLowerCase() === normalizedAddress ? "bg-blue-100" : "bg-zinc-50"
                   }`}
                 >
                   <EthereumAddressToProfileName address={admin.toLowerCase()} />
@@ -481,7 +482,7 @@ export const MyProgramList: FC<MyProgramListProps> = ({
     ],
     [
       isAllowed,
-      address?.toLowerCase,
+      normalizedAddress,
       editFn,
       searchParams.get,
       selectProgram,

--- a/components/Pages/Project/Impact/VerifyImpactDialog.tsx
+++ b/components/Pages/Project/Impact/VerifyImpactDialog.tsx
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
+import { useAuth } from "@/hooks/useAuth";
 import { useCanVerifyMilestone } from "@/hooks/useCanVerifyMilestone";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
@@ -64,7 +65,7 @@ export const VerifyImpactDialog: FC<VerifyImpactDialogProps> = ({
   function openModal() {
     setIsOpen(true);
   }
-  const { address, isConnected } = useAccount();
+  const { address } = useAuth();
 
   const hasVerifiedThis = address
     ? impact?.verified?.find((v) => v.attester?.toLowerCase() === address?.toLowerCase())

--- a/components/Pages/Project/ProjectSubTabs.tsx
+++ b/components/Pages/Project/ProjectSubTabs.tsx
@@ -1,7 +1,6 @@
 "use client";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useMemo } from "react";
-import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
 import { useProjectStore } from "@/store";
 import { useEndorsementStore } from "@/store/modals/endorsement";
@@ -10,8 +9,7 @@ import { EndorsementList } from "../ProgramRegistry/EndorsementList";
 export const ProjectSubTabs = () => {
   const project = useProjectStore((state) => state.project);
   const { setIsEndorsementOpen: setIsOpen } = useEndorsementStore();
-  const { address, isConnected } = useAccount();
-  const { authenticated: isAuth, login } = useAuth();
+  const { address, isConnected, authenticated: isAuth, login } = useAuth();
 
   const userHasEndorsed = useMemo(() => {
     if (!address || !isConnected || !isAuth || !project?.endorsements?.length) return false;

--- a/components/Pages/Project/Team/MemberCard.tsx
+++ b/components/Pages/Project/Team/MemberCard.tsx
@@ -4,7 +4,6 @@ import { PencilIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import type { Hex } from "viem";
-import { useAccount } from "wagmi";
 import { DeleteMemberDialog } from "@/components/Dialogs/Member/DeleteMember";
 import { DemoteMemberDialog } from "@/components/Dialogs/Member/DemoteMember";
 import { PromoteMemberDialog } from "@/components/Dialogs/Member/PromoteMember";
@@ -12,6 +11,7 @@ import { GithubIcon, LinkedInIcon, Twitter2Icon } from "@/components/Icons";
 import { FarcasterIcon } from "@/components/Icons/Farcaster";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Skeleton } from "@/components/Utilities/Skeleton";
+import { useAuth } from "@/hooks/useAuth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useTeamProfiles } from "@/hooks/useTeamProfiles";
@@ -35,7 +35,7 @@ export const MemberCard = ({ member }: { member: string }) => {
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const { address } = useAccount();
+  const { address } = useAuth();
   const isAuthorized = isProjectOwner || isContractOwner;
   const _isAdminOrAbove = isProjectOwner || isContractOwner || isProjectAdmin;
   const { project: projectInstance } = useProjectInstance(

--- a/components/Pages/Project/v2/GrantDetail/GrantDetailLayout.tsx
+++ b/components/Pages/Project/v2/GrantDetail/GrantDetailLayout.tsx
@@ -4,7 +4,6 @@ import { ArrowLeftIcon, PencilSquareIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { useAccount } from "wagmi";
 import { GrantCompleteButton } from "@/components/Pages/GrantMilestonesAndUpdates/GrantCompleteButton";
 import { GrantContext } from "@/components/Pages/GrantMilestonesAndUpdates/GrantContext";
 import { GrantDelete } from "@/components/Pages/GrantMilestonesAndUpdates/GrantDelete";
@@ -39,7 +38,6 @@ export function GrantDetailLayout({ children }: GrantDetailLayoutProps) {
   const params = useParams();
   const pathname = usePathname();
   const router = useRouter();
-  const { address } = useAccount();
 
   const projectIdFromUrl = params.projectId as string;
   const grantUid = params.grantUid as string;
@@ -53,7 +51,7 @@ export function GrantDetailLayout({ children }: GrantDetailLayoutProps) {
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
 
   // Check admin status
-  useIsCommunityAdmin(grant?.data?.communityUID, address, {
+  useIsCommunityAdmin(grant?.data?.communityUID, undefined, {
     zustandSync: { setIsCommunityAdmin },
   });
 

--- a/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
+++ b/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
@@ -4,7 +4,6 @@ import { PencilIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import type { Hex } from "viem";
-import { useAccount } from "wagmi";
 import { DeleteMemberDialog } from "@/components/Dialogs/Member/DeleteMember";
 import { DemoteMemberDialog } from "@/components/Dialogs/Member/DemoteMember";
 import { PromoteMemberDialog } from "@/components/Dialogs/Member/PromoteMember";
@@ -12,6 +11,7 @@ import { GithubIcon, LinkedInIcon, Twitter2Icon } from "@/components/Icons";
 import { FarcasterIcon } from "@/components/Icons/Farcaster";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Skeleton } from "@/components/Utilities/Skeleton";
+import { useAuth } from "@/hooks/useAuth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useTeamProfiles } from "@/hooks/useTeamProfiles";
@@ -45,7 +45,7 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
   const [, copy] = useCopyToClipboard();
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const { address } = useAccount();
+  const { address } = useAuth();
   const isAuthorized = isProjectOwner || isContractOwner;
   const { project: projectInstance } = useProjectInstance(
     project?.details?.slug || project?.uid || ""

--- a/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
+++ b/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
@@ -378,19 +378,20 @@ describe("ActivityFeed", () => {
       render(<ActivityFeed milestones={mockMilestones} />);
 
       const icons = screen.getAllByTestId("timeline-icon");
-      // First milestone is type "milestone" - should have indigo background
-      expect(icons[0]).toHaveClass("bg-indigo-50");
+      // Sort order: completed items first. Of the mock data, only milestone-2 (grant)
+      // is completed; milestone-1 (milestone) is the first uncompleted item → icons[1].
+      expect(icons[1]).toHaveClass("bg-indigo-50");
     });
 
     it("should show blue icon for grant type", () => {
       render(<ActivityFeed milestones={mockMilestones} activeFilters={["milestones"]} />);
 
       const icons = screen.getAllByTestId("timeline-icon");
-      // "milestone" type has indigo, "grant" type has blue
-      // With milestones filter, both milestone and grant types are shown
+      // With milestones filter, both milestone and grant types are shown.
+      // Completed items sort first, so grant (completed) → icons[0], milestone → icons[1].
       expect(icons).toHaveLength(2);
-      expect(icons[0]).toHaveClass("bg-indigo-50");
-      expect(icons[1]).toHaveClass("bg-blue-50");
+      expect(icons[0]).toHaveClass("bg-blue-50");
+      expect(icons[1]).toHaveClass("bg-indigo-50");
     });
   });
 

--- a/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
+++ b/components/Pages/Project/v2/__tests__/TeamMemberCard.test.tsx
@@ -15,6 +15,14 @@ vi.mock("wagmi", () => ({
   useAccount: () => ({ address: "0x1234567890123456789012345678901234567890" }),
 }));
 
+// Mock useAuth
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    authenticated: true,
+    address: "0x1234567890123456789012345678901234567890",
+  }),
+}));
+
 // Mock project store
 const mockProject = {
   uid: "0x1234567890123456789012345678901234567890" as `0x${string}`,

--- a/components/Searchbar/SearchList.tsx
+++ b/components/Searchbar/SearchList.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
 import type {
   SearchCommunityResult,
@@ -33,8 +32,7 @@ export const SearchList: React.FC<Props> = ({
   onInteractionStart,
   onInteractionEnd,
 }) => {
-  const { isConnected } = useAccount();
-  const { authenticated: isAuth, login } = useAuth();
+  const { authenticated: isAuth, login, isConnected } = useAuth();
   const [shouldOpen, setShouldOpen] = useState(false);
   const router = useRouter();
 

--- a/hooks/communities/useCheckCommunityAdmin.ts
+++ b/hooks/communities/useCheckCommunityAdmin.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Hex } from "viem";
-import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
 import type { Community } from "@/types/v2/community";
 import { ADMIN_CACHE_CONFIG } from "@/utilities/cache-config";
@@ -30,9 +29,8 @@ export const useCheckCommunityAdmin = (
   address?: string | Hex,
   options?: UseCheckCommunityAdminOptions
 ) => {
-  const { address: accountAddress } = useAccount();
   const signer = useSigner();
-  const { authenticated: isAuth } = useAuth();
+  const { authenticated: isAuth, address: accountAddress } = useAuth();
 
   const checkAddress = address || accountAddress;
 

--- a/hooks/communities/useIsCommunityAdmin.ts
+++ b/hooks/communities/useIsCommunityAdmin.ts
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import type { Hex } from "viem";
-import { useAccount } from "wagmi";
 import { useCheckCommunityAdmin } from "@/hooks/communities/useCheckCommunityAdmin";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
+import { useAuth } from "@/hooks/useAuth";
 
 interface UseIsCommunityAdminOptions {
   enabled?: boolean;
@@ -30,7 +30,7 @@ export const useIsCommunityAdmin = (
   userAddress?: string | Hex,
   options?: UseIsCommunityAdminOptions
 ) => {
-  const { address: accountAddress } = useAccount();
+  const { address: accountAddress } = useAuth();
   const address = userAddress || accountAddress;
   const communityQuery = useCommunityDetails(communityUIDorSlug);
 

--- a/hooks/useFaucetAdmin.ts
+++ b/hooks/useFaucetAdmin.ts
@@ -2,19 +2,19 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/useAuth";
 import { faucetService } from "@/utilities/faucet/faucetService";
 
 /**
  * Check if current wallet is the faucet owner
  */
 export const useFaucetAdmin = () => {
-  const { address, isConnecting } = useAccount();
+  const { address, ready } = useAuth();
   const { config, isLoading } = useFaucetConfig();
 
   return {
     isAdmin: address?.toLowerCase() === config?.faucetAddress.toLowerCase(),
-    isLoading: isConnecting || isLoading,
+    isLoading: !ready || isLoading,
   };
 };
 

--- a/hooks/usePermissions.ts
+++ b/hooks/usePermissions.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
 import type { FundingProgram } from "@/services/fundingPlatformService";
 import { PermissionsService } from "@/services/permissions.service";
@@ -71,15 +70,14 @@ type ReviewerProgramsResponse = FundingProgram[];
  * ```
  */
 export const usePermissions = (options: PermissionOptions = {}) => {
-  const { address: wagmiAddress } = useAccount();
-  const { authenticated: isAuth, getAccessToken: getToken, ready } = useAuth();
+  const { authenticated: isAuth, getAccessToken: getToken, ready, address } = useAuth();
   const { programId, action, role, enabled = true } = options;
 
   const query = useQuery({
-    queryKey: ["permissions", programId, action, role, wagmiAddress?.toLowerCase() ?? null, isAuth],
+    queryKey: ["permissions", programId, action, role, address?.toLowerCase() ?? null, isAuth],
     queryFn: async () => {
       // These checks are defense-in-depth; the query shouldn't run if !enabled
-      if (!isAuth || !wagmiAddress || !ready) {
+      if (!isAuth || !address || !ready) {
         return {
           hasPermission: false,
           permissions: [],
@@ -185,7 +183,7 @@ export const usePermissions = (options: PermissionOptions = {}) => {
       };
     },
     ...defaultQueryOptions,
-    enabled: enabled && !!isAuth && !!wagmiAddress,
+    enabled: enabled && !!isAuth && !!address,
     staleTime: 1 * 60 * 1000, // Cache for 1 minute
     retry: (failureCount, error) => {
       // Retry only network errors, not auth issues

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -3,6 +3,7 @@ import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
+import type { CommunityReviewer } from "@/hooks/useCommunityMilestoneReviewers";
 import { usePendingVerificationMilestones } from "@/hooks/usePendingVerificationMilestones";
 import { milestoneReportService } from "@/services/milestone-report.service";
 import { downloadCommunityReport } from "@/utilities/downloadReports";
@@ -90,15 +91,22 @@ interface UseReportPageDataOptions {
   isAuthorized: boolean;
   reviewerPrograms: Array<{ programId: string }>;
   currentUserAddress?: string;
-  isMilestoneReviewer?: boolean;
+  reviewers?: CommunityReviewer[];
 }
 
+/**
+ * Default the reviewer filter to the current user iff their address matches
+ * one of the community's known reviewers. Independent of admin/role state —
+ * if you appear in the reviewer list, the page should open scoped to you.
+ */
 export function computeDefaultReviewerAddress(
-  isMilestoneReviewer: boolean,
-  hasAccess: boolean,
+  reviewers: CommunityReviewer[] | undefined,
   currentUserAddress?: string
 ): string | undefined {
-  return isMilestoneReviewer && !hasAccess ? currentUserAddress : undefined;
+  if (!currentUserAddress || !reviewers?.length) return undefined;
+  const lower = currentUserAddress.toLowerCase();
+  const match = reviewers.find((r) => r.publicAddress.toLowerCase() === lower);
+  return match?.publicAddress;
 }
 
 export function useReportPageData({
@@ -108,7 +116,7 @@ export function useReportPageData({
   isAuthorized,
   reviewerPrograms,
   currentUserAddress,
-  isMilestoneReviewer = false,
+  reviewers,
 }: UseReportPageDataOptions) {
   const [activeTab, setActiveTab] = useQueryState<TabId>("tab", {
     defaultValue: "pending-verification",
@@ -124,22 +132,19 @@ export function useReportPageData({
     programIdsQueryOptions
   );
 
-  // Reviewer filter: address-based. Reviewers default to own address, admins to "all" (undefined).
+  // Reviewer filter: defaults to the current user when they appear in the
+  // community reviewer list, regardless of admin role. Otherwise "All Reviewers".
   const [selectedReviewerAddress, setSelectedReviewerAddress] = useState<string | undefined>(() =>
-    computeDefaultReviewerAddress(isMilestoneReviewer, hasAccess, currentUserAddress)
+    computeDefaultReviewerAddress(reviewers, currentUserAddress)
   );
   const hasUserSelectedFilter = useRef(false);
 
-  // Sync selectedReviewerAddress when isMilestoneReviewer/hasAccess resolve after mount
+  // Sync selectedReviewerAddress when reviewers / currentUserAddress resolve after mount
   useEffect(() => {
     if (hasUserSelectedFilter.current) return;
-    const computed = computeDefaultReviewerAddress(
-      isMilestoneReviewer,
-      hasAccess,
-      currentUserAddress
-    );
+    const computed = computeDefaultReviewerAddress(reviewers, currentUserAddress);
     setSelectedReviewerAddress(computed);
-  }, [isMilestoneReviewer, hasAccess, currentUserAddress]);
+  }, [reviewers, currentUserAddress]);
 
   // Reset user's manual filter selection when context changes
   useEffect(() => {

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -120,17 +120,17 @@ export function NavbarUserMenu() {
             ) : (
               <CircleUser className="h-8 w-8 min-h-8 min-w-8 max-h-8 max-w-8 text-muted-foreground" />
             )}
-            {profile?.data?.name ? (
-              <span className="text-sm text-muted-foreground hidden xl:inline px-2">
-                {profile?.data?.name}
-              </span>
-            ) : user?.farcaster ? (
+            {user?.farcaster ? (
               <span className="text-sm text-muted-foreground hidden xl:inline px-2">
                 {user.farcaster.displayName || user.farcaster.username}
               </span>
             ) : getUserEmail(user) ? (
               <span className="text-sm text-muted-foreground hidden xl:inline px-2">
                 {getUserEmail(user)}
+              </span>
+            ) : profile?.data?.name ? (
+              <span className="text-sm text-muted-foreground hidden xl:inline px-2">
+                {profile?.data?.name}
               </span>
             ) : address ? (
               <EthereumAddressToProfileName


### PR DESCRIPTION
## Summary

- When a user is authenticated via Privy (email/social) but has MetaMask connected to a different wallet, `useAccount()` from wagmi returns the MetaMask address rather than the Privy primary wallet. This caused identity-based features (Reviewer dropdown on `community/filecoin/manage/milestones-report`, admin checks, "is current user" comparisons, permission queries) to use the wrong address.
- Replace `useAccount()` with `useAuth()` for identity reads across 19 source files (hooks, admin pages, project pages, program registry, dialogs, search, forms). Wagmi is still used for transaction signing (`signer`, `connector`, `chain`).
- Update tests accordingly + fix 7 pre-existing stale test failures (resources menu count, grant card updates badge, activity feed sort order, portfolio report `HtmlReportFrame`, community stat card percent format).

## Reproduction (original bug)

1. Log in via Privy with email
2. Connect MetaMask to a different address
3. Visit `staging.karmahq.xyz/community/filecoin/manage/milestones-report`
4. The Reviewer dropdown showed the MetaMask address instead of the Privy-authenticated user

## Test plan

- [x] Full unit test suite passes (653 files, 11469 tests)
- [ ] Manually verify Reviewer dropdown shows Privy-authenticated user when MetaMask is connected to a different wallet
- [ ] Verify community admin / reviewer / faucet admin checks resolve against the Privy identity
- [ ] Verify "edit profile" / "is current user" badges on team member cards work for email-only Privy users
- [ ] Verify transaction signing (grant creation, milestone updates, impact verification) still uses the active wagmi signer/chain