### PR TITLE
feat(whitelabel): add search and Skills link to navbar

### DIFF
--- a/src/components/navbar/whitelabel-navbar.tsx
+++ b/src/components/navbar/whitelabel-navbar.tsx
@@ -29,9 +29,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { Link } from "@/src/components/navigation/Link";
 import type { NavDropdown, NavItem } from "@/src/infrastructure/types/tenant";
 import { useTenantSafe } from "@/store/tenant";
+import { karmaLinks } from "@/utilities/karma/karma";
 import { cn } from "@/utilities/tailwind";
 import { NavbarAuthButtons } from "./navbar-auth-buttons";
 import { NavbarPermissionsProvider } from "./navbar-permissions-context";
+import { NavbarSearch } from "./navbar-search";
 import { NavbarUserMenu } from "./navbar-user-menu";
 import { ThemeToggleButton } from "./theme-toggle-button";
 
@@ -93,6 +95,11 @@ export function WhitelabelNavbar() {
           key: "docs",
           label: "Docs",
           href: tenantSocialLinks.docs,
+        },
+        {
+          key: "skills",
+          label: "Skills",
+          href: karmaLinks.skills,
         },
       ].filter((link): link is SocialLinkItem => Boolean(link)),
     [tenantSocialLinks]
@@ -198,6 +205,10 @@ export function WhitelabelNavbar() {
 
           {/* Desktop Nav */}
           <div className="hidden items-center gap-1 lg:flex">
+            {/* Search */}
+            <div className="mr-2">
+              <NavbarSearch />
+            </div>
             {/* My Applications - first when authenticated (matching reference) */}
             {authenticated && (
               <Link href={"/dashboard"} className={navStyles.desktopLink}>
@@ -352,6 +363,10 @@ export function WhitelabelNavbar() {
         {/* Mobile menu */}
         {isMenuOpen && (
           <div className="border-t border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900 lg:hidden">
+            {/* Mobile Search */}
+            <div className="mb-3">
+              <NavbarSearch onSelectItem={() => setIsMenuOpen(false)} />
+            </div>
             <div className="space-y-1">
               {authenticated && (
                 <Link


### PR DESCRIPTION
## Summary
- Add `NavbarSearch` (project/community search) to the whitelabel navbar — desktop and mobile — mirroring the main karmahq.xyz navbar.
- Append a "Skills" link to the Resources dropdown using `karmaLinks.skills`.

## Test plan
- [ ] Load a whitelabel (e.g. app.filpgf.io) and verify search input appears in the desktop navbar
- [ ] Type 3+ chars and confirm communities/projects results render
- [ ] Open Resources dropdown and confirm "Skills" appears (after any tenant socials) and opens the GitHub repo in a new tab
- [ ] Open mobile menu and confirm search input + Skills link appear and work