### PR TITLE
fix: funding-opportunities pluralization + restore Resources dropdown when logged in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ pnpm lint:fix           # Biome lint + format
 - **No barrel exports**: Import directly from source files, not `index.ts` re-exports. Existing barrel exports in `types/`, `store/`, `utilities/sdk/` are legacy — don't add new ones.
 - **Heavy libs**: Must use `dynamic()` or lazy `import()` — never top-level import of chart/editor/markdown libs.
 - **Zustand resets**: When adding state properties, update `initialState` too — `reset()` spreads it and will miss new fields.
+- **Pluralization**: Any dynamic count rendered next to a noun MUST use the `pluralize` library (`pluralize("team", count)`). No manual ternaries, no hardcoded plural-only nouns. Strings like `"1 teams"`, `"0 apply"`, `"1 days left"` are bugs.
+- **Empty-state conditional rendering**: UI blocks tied to a count or array (e.g. "Closing this week — N apply before deadline") must be hidden entirely when the count is 0. Don't render "0 …" copy.
 
 ## Auth Gotchas
 

--- a/__tests__/navbar/integration/navigation-flow.test.tsx
+++ b/__tests__/navbar/integration/navigation-flow.test.tsx
@@ -148,7 +148,7 @@ describe("Navigation Flow Integration Tests", () => {
     // doesn't propagate `isLoggedIn=true` from the test's `authFixture.authState`
     // through to <NavbarDesktopNavigation /> when rendered directly. Needs the
     // file-level _refs hoisted-mock pattern used by auth-flow.test.tsx.
-    it("should hide Resources dropdown when logged in", () => {
+    it("should show Resources dropdown when logged in", () => {
       const authFixture = getAuthFixture("authenticated-basic");
 
       renderWithProviders(<NavbarDesktopNavigation />, {
@@ -160,7 +160,7 @@ describe("Navigation Flow Integration Tests", () => {
         name: /resources/i,
       });
 
-      expect(resourcesTrigger).not.toBeInTheDocument();
+      expect(resourcesTrigger).toBeInTheDocument();
     });
   });
 
@@ -233,7 +233,7 @@ describe("Navigation Flow Integration Tests", () => {
 
       const drawer = screen.getByRole("dialog");
 
-      // Verify all sections including Resources (only visible when logged out)
+      // Verify all sections including Resources
       expect(within(drawer).getByText("For Projects")).toBeInTheDocument();
       expect(within(drawer).getByText("For Funders")).toBeInTheDocument();
       // Explore renders as subsections
@@ -241,7 +241,7 @@ describe("Navigation Flow Integration Tests", () => {
       expect(within(drawer).getByText("Resources")).toBeInTheDocument();
     });
 
-    it("should hide Resources in mobile drawer when logged in", async () => {
+    it("should show Resources in mobile drawer when logged in", async () => {
       const user = userEvent.setup();
       const authFixture = getAuthFixture("authenticated-basic");
 
@@ -259,10 +259,8 @@ describe("Navigation Flow Integration Tests", () => {
 
       const drawer = screen.getByRole("dialog");
 
-      // Resources section should not be in mobile drawer
-      const resourcesSections = within(drawer).queryAllByText("Resources");
-      // Should be 0 or if present, not in a section header context
-      expect(resourcesSections.length).toBeLessThan(2);
+      // Resources section is now shown in both auth states
+      expect(within(drawer).getByText("Resources")).toBeInTheDocument();
     });
   });
 

--- a/__tests__/navbar/unit/navbar-desktop-navigation.test.tsx
+++ b/__tests__/navbar/unit/navbar-desktop-navigation.test.tsx
@@ -271,7 +271,7 @@ describe("NavbarDesktopNavigation", () => {
       expect(resourcesButton).toBeInTheDocument();
     });
 
-    it('should NOT render "Resources" dropdown when logged in', () => {
+    it('should render "Resources" dropdown when logged in', () => {
       const authFixture = getAuthFixture("authenticated-basic");
       setLocalRefsLoggedIn(authFixture.authState.address);
 
@@ -283,7 +283,7 @@ describe("NavbarDesktopNavigation", () => {
       const resourcesButton = screen.queryByRole("button", {
         name: /resources/i,
       });
-      expect(resourcesButton).not.toBeInTheDocument();
+      expect(resourcesButton).toBeInTheDocument();
     });
 
     it("should have chevron icons on all dropdown triggers", () => {
@@ -475,7 +475,7 @@ describe("NavbarDesktopNavigation", () => {
       // which means the authenticated path is rendering
     });
 
-    it("should NOT show Resources dropdown when logged in", () => {
+    it("should show Resources dropdown when logged in", () => {
       const authFixture = getAuthFixture("authenticated-basic");
 
       renderWithProviders(<NavbarDesktopNavigation />, {
@@ -486,7 +486,7 @@ describe("NavbarDesktopNavigation", () => {
       const resourcesButton = screen.queryByRole("button", {
         name: /resources/i,
       });
-      expect(resourcesButton).not.toBeInTheDocument();
+      expect(resourcesButton).toBeInTheDocument();
     });
 
     it("should render quick action buttons and Explore dropdown when logged in", () => {

--- a/app/community/[communityId]/(with-header)/funding-opportunities/error.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Link } from "@/src/components/navigation/Link";
+
+export default function FundingOpportunitiesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-xl">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading funding opportunities. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -126,7 +126,7 @@ export default function FundingOpportunitiesPage() {
                   {
                     label: "Closing this week",
                     value: stats.closingNow,
-                    sub: `${pluralize("application", stats.closingNow, false)} before deadline`,
+                    sub: "apply before deadline",
                     accent: "danger" as const,
                   },
                 ]

--- a/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
+++ b/app/community/[communityId]/(with-header)/funding-opportunities/page.tsx
@@ -3,6 +3,7 @@
 import { AlertCircle, RefreshCw, Search } from "lucide-react";
 import Image from "next/image";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
 import { useCallback, useEffect, useMemo } from "react";
 import {
   computeProgramView,
@@ -97,7 +98,7 @@ export default function FundingOpportunitiesPage() {
         <PageHero
           eyebrow={
             stats.openCount > 0
-              ? `Open for funding · ${stats.openCount} live program${stats.openCount === 1 ? "" : "s"}`
+              ? `Open for funding · ${stats.openCount} live ${pluralize("program", stats.openCount)}`
               : "Funding opportunities"
           }
           title={
@@ -106,7 +107,7 @@ export default function FundingOpportunitiesPage() {
                 ${formatCurrency(stats.totalPool)} available
                 <br />
                 <span className="text-brand-500 dark:text-brand-400">
-                  across {programs.length} program{programs.length === 1 ? "" : "s"}.
+                  across {programs.length} {pluralize("program", programs.length)}.
                 </span>
               </>
             ) : (
@@ -120,12 +121,16 @@ export default function FundingOpportunitiesPage() {
               value: stats.openCount,
               sub: "accepting now",
             },
-            {
-              label: "Closing this week",
-              value: stats.closingNow,
-              sub: "apply before deadline",
-              accent: stats.closingNow > 0 ? "danger" : "default",
-            },
+            ...(stats.closingNow > 0
+              ? [
+                  {
+                    label: "Closing this week",
+                    value: stats.closingNow,
+                    sub: `${pluralize("application", stats.closingNow, false)} before deadline`,
+                    accent: "danger" as const,
+                  },
+                ]
+              : []),
             {
               label: "Total pool",
               value: stats.totalPool > 0 ? `$${formatCurrency(stats.totalPool)}` : "—",

--- a/components/Pages/Communities/Funding/FeaturedProgram.tsx
+++ b/components/Pages/Communities/Funding/FeaturedProgram.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
+import pluralize from "pluralize";
 import type { FundingProgram } from "@/types/whitelabel-entities";
 import formatCurrency from "@/utilities/formatCurrency";
 import { PAGES } from "@/utilities/pages";
@@ -80,7 +81,7 @@ export function FeaturedProgram({
                 aria-hidden
               />
               {view.daysLeft !== null && view.urgency !== "closed"
-                ? `${view.daysLeft} days left`
+                ? `${view.daysLeft} ${pluralize("day", view.daysLeft)} left`
                 : view.urgency === "closed"
                   ? "Closed"
                   : "Open"}
@@ -128,7 +129,10 @@ export function FeaturedProgram({
           ) : null}
           {dateRowValue ? <KpiRow label={dateRowLabel} value={dateRowValue} /> : null}
           {view.applicants > 0 ? (
-            <KpiRow label="Applicants" value={`${view.applicants} teams`} />
+            <KpiRow
+              label="Applicants"
+              value={`${view.applicants} ${pluralize("team", view.applicants)}`}
+            />
           ) : null}
         </div>
       </div>

--- a/src/components/navbar/navbar-desktop-navigation.tsx
+++ b/src/components/navbar/navbar-desktop-navigation.tsx
@@ -55,6 +55,41 @@ function NavDropdownTrigger({ children }: { children: React.ReactNode }) {
   );
 }
 
+function ResourcesDropdown() {
+  return (
+    <DropdownMenu>
+      <NavDropdownTrigger>Resources</NavDropdownTrigger>
+      <DropdownMenuContent align="end" className="p-0">
+        <div className="flex flex-col gap-4 px-4 py-4 w-max">
+          <ResourcesContent variant="desktop" />
+          <hr className="h-[1px] w-full border-border" />
+          <div className="flex flex-col items-start justify-start w-full">
+            <MenuSection title="Follow" variant="desktop" />
+            <div className="flex flex-row items-center w-full justify-between gap-4 py-2">
+              {socialMediaLinks.map((social) => {
+                const IconComponent = social.icon;
+                return (
+                  <ExternalLink
+                    key={social.name}
+                    href={social.href}
+                    className={cn(
+                      menuStyles.itemText,
+                      "flex items-center justify-center rounded-full transition-colors"
+                    )}
+                    aria-label={social.name}
+                  >
+                    <IconComponent className="w-5 h-5" />
+                  </ExternalLink>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 const socialMediaLinks = [
   {
     name: "Twitter",
@@ -135,37 +170,7 @@ export function NavbarDesktopNavigation() {
 
       {!isLoggedIn ? (
         <div className="flex flex-row items-center gap-4">
-          {/* Resources Dropdown */}
-          <DropdownMenu>
-            <NavDropdownTrigger>Resources</NavDropdownTrigger>
-            <DropdownMenuContent align="end" className="p-0">
-              <div className="flex flex-col gap-4 px-4 py-4 w-max">
-                <ResourcesContent variant="desktop" />
-                <hr className="h-[1px] w-full border-border" />
-                <div className="flex flex-col items-start justify-start w-full">
-                  <MenuSection title="Follow" variant="desktop" />
-                  <div className="flex flex-row items-center w-full justify-between gap-4 py-2">
-                    {socialMediaLinks.map((social) => {
-                      const IconComponent = social.icon;
-                      return (
-                        <ExternalLink
-                          key={social.name}
-                          href={social.href}
-                          className={cn(
-                            menuStyles.itemText,
-                            "flex items-center justify-center rounded-full transition-colors"
-                          )}
-                          aria-label={social.name}
-                        >
-                          <IconComponent className="w-5 h-5" />
-                        </ExternalLink>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <ResourcesDropdown />
 
           {/* Auth Buttons */}
           <NavbarAuthButtons />
@@ -184,6 +189,7 @@ export function NavbarDesktopNavigation() {
       {isLoggedIn && (
         <div className="hidden lg:flex items-center gap-3">
           <div className="flex flex-row items-center gap-2">
+            <ResourcesDropdown />
             <ExternalLink
               href={SOCIALS.DOCS}
               className="p-2 text-muted-foreground hover:text-foreground transition-colors rounded-full"

--- a/src/components/navbar/navbar-mobile-menu.tsx
+++ b/src/components/navbar/navbar-mobile-menu.tsx
@@ -235,31 +235,29 @@ export function NavbarMobileMenu() {
                 <ExploreContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
               </div>
 
-              {/* Resources Section - Only when NOT logged in */}
-              {!isLoggedIn && (
-                <div className="border-b border-border py-3">
-                  <MenuSection title="Resources" variant="mobile" />
-                  <ResourcesContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
-                  <div className="mt-4 pt-4 border-t border-border">
-                    <MenuSection title="Follow" variant="mobile" className="mb-4" />
-                    <div className="flex items-center gap-2">
-                      {socialMediaLinks.map((social) => {
-                        const IconComponent = social.icon;
-                        return (
-                          <ExternalLink
-                            key={social.name}
-                            href={social.href}
-                            className="w-10 h-10 flex items-center justify-center rounded-full transition-colors"
-                            aria-label={social.name}
-                          >
-                            <IconComponent className="w-8 h-8 text-muted-foreground" />
-                          </ExternalLink>
-                        );
-                      })}
-                    </div>
+              {/* Resources Section */}
+              <div className="border-b border-border py-3">
+                <MenuSection title="Resources" variant="mobile" />
+                <ResourcesContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
+                <div className="mt-4 pt-4 border-t border-border">
+                  <MenuSection title="Follow" variant="mobile" className="mb-4" />
+                  <div className="flex items-center gap-2">
+                    {socialMediaLinks.map((social) => {
+                      const IconComponent = social.icon;
+                      return (
+                        <ExternalLink
+                          key={social.name}
+                          href={social.href}
+                          className="w-10 h-10 flex items-center justify-center rounded-full transition-colors"
+                          aria-label={social.name}
+                        >
+                          <IconComponent className="w-8 h-8 text-muted-foreground" />
+                        </ExternalLink>
+                      );
+                    })}
                   </div>
                 </div>
-              )}
+              </div>
 
               {/* Mobile Auth */}
               {isLoggedIn ? (
@@ -295,24 +293,6 @@ export function NavbarMobileMenu() {
                     <LogOutIcon className={menuStyles.itemIcon} />
                     <span className={menuStyles.itemText}>Log out</span>
                   </button>
-                  <div className="mt-4 pt-4 border-t border-border flex flex-col items-center">
-                    <MenuSection title="Follow" variant="mobile" className="mb-4" />
-                    <div className="flex items-center gap-2">
-                      {socialMediaLinks.map((social) => {
-                        const IconComponent = social.icon;
-                        return (
-                          <ExternalLink
-                            key={social.name}
-                            href={social.href}
-                            className="w-10 h-10 flex items-center justify-center rounded-full transition-colors"
-                            aria-label={social.name}
-                          >
-                            <IconComponent className="w-8 h-8 text-muted-foreground" />
-                          </ExternalLink>
-                        );
-                      })}
-                    </div>
-                  </div>
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## Summary
- **Funding opportunities page** — replace manual singular/plural ternaries with the `pluralize` library so we stop shipping copy like `1 teams` and `1 days left`. Hide the "Closing this week" KPI entirely when the count is 0 (previously rendered "0 apply before deadline" on app.filpgf.io).
- **Navbar** — restore the **Resources** dropdown (Docs, Blog, Skills, Follow socials) in the logged-in state. Was previously only visible to logged-out users on both desktop and mobile.
- **Conventions** — add a CLAUDE.md rule requiring `pluralize` for any dynamic count and hiding count-driven blocks when empty.
- **Plumbing** — add the missing `error.tsx` for the funding-opportunities route per the gap-app-v2 app-router convention.

## Files
- `app/community/[communityId]/(with-header)/funding-opportunities/page.tsx` — `pluralize` in hero copy, conditional KPI render
- `app/community/[communityId]/(with-header)/funding-opportunities/error.tsx` — new error boundary
- `components/Pages/Communities/Funding/FeaturedProgram.tsx` — `pluralize` for `teams` / `days left`
- `src/components/navbar/navbar-desktop-navigation.tsx` — extract `ResourcesDropdown` and render in logged-in branch
- `src/components/navbar/navbar-mobile-menu.tsx` — Resources section now always renders; remove duplicate Follow block from the auth section
- `__tests__/navbar/**` — update assertions to reflect Resources visibility in both auth states
- `CLAUDE.md` — pluralize + empty-state-conditional rules

## Test plan
- [ ] Funding-opportunities page with 1 open program → hero reads "1 live program" (not "1 programs")
- [ ] Same page with 0 programs closing this week → "Closing this week" KPI is not rendered
- [ ] FeaturedProgram card with `applicants=1` → "1 team" (not "1 teams")
- [ ] FeaturedProgram card with `daysLeft=1` → "1 day left" (not "1 days left")
- [ ] Logged in, desktop nav → "Resources" dropdown trigger appears next to Docs/theme/profile and reveals Docs/Blog/Skills + social icons
- [ ] Logged in, mobile drawer → Resources section appears with Follow socials; the logout button is followed only by drawer close (no duplicate Follow block)
- [ ] Logged out, desktop and mobile → behavior unchanged