### PR TITLE
fix(milestones): show Past Due status when due date has passed

### DIFF
--- a/__tests__/utilities/milestones/getEffectiveMilestoneStatus.test.ts
+++ b/__tests__/utilities/milestones/getEffectiveMilestoneStatus.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
+
+const NOW = new Date("2026-06-01T00:00:00Z").getTime();
+const PAST_ISO = "2026-01-01T00:00:00Z";
+const FUTURE_ISO = "2027-01-01T00:00:00Z";
+
+describe("getEffectiveMilestoneStatus", () => {
+  it("returns PENDING when no status and no due date", () => {
+    expect(getEffectiveMilestoneStatus(null, null, NOW)).toBe(MilestoneLifecycleStatus.PENDING);
+  });
+
+  it("returns PAST_DUE when status is pending and due date is in the past", () => {
+    expect(getEffectiveMilestoneStatus("pending", PAST_ISO, NOW)).toBe(
+      MilestoneLifecycleStatus.PAST_DUE
+    );
+  });
+
+  it("stays PENDING when due date is in the future", () => {
+    expect(getEffectiveMilestoneStatus("pending", FUTURE_ISO, NOW)).toBe(
+      MilestoneLifecycleStatus.PENDING
+    );
+  });
+
+  it("preserves COMPLETED regardless of due date", () => {
+    expect(getEffectiveMilestoneStatus("completed", PAST_ISO, NOW)).toBe(
+      MilestoneLifecycleStatus.COMPLETED
+    );
+  });
+
+  it("preserves VERIFIED regardless of due date", () => {
+    expect(getEffectiveMilestoneStatus(MilestoneLifecycleStatus.VERIFIED, PAST_ISO, NOW)).toBe(
+      MilestoneLifecycleStatus.VERIFIED
+    );
+  });
+
+  it("accepts epoch milliseconds for due date", () => {
+    const pastMs = new Date(PAST_ISO).getTime();
+    expect(getEffectiveMilestoneStatus("pending", pastMs, NOW)).toBe(
+      MilestoneLifecycleStatus.PAST_DUE
+    );
+  });
+
+  it("accepts Date instance for due date", () => {
+    expect(getEffectiveMilestoneStatus("pending", new Date(PAST_ISO), NOW)).toBe(
+      MilestoneLifecycleStatus.PAST_DUE
+    );
+  });
+
+  it("falls back to PENDING on unparseable due date strings", () => {
+    expect(getEffectiveMilestoneStatus("pending", "not-a-date", NOW)).toBe(
+      MilestoneLifecycleStatus.PENDING
+    );
+  });
+
+  it("exposes user-facing labels for every status", () => {
+    expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING]).toBe("Pending");
+    expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.COMPLETED]).toBe("Completed");
+    expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED]).toBe("Verified");
+    expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE]).toBe("Past Due");
+  });
+});

--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -4,9 +4,14 @@ import Image from "next/image";
 import { useState } from "react";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { useMilestoneImpactAnswers } from "@/hooks/useMilestoneImpactAnswers";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
 import { useGrantInvoiceRequired } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { formatDate } from "@/utilities/formatDate";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { PAGES } from "@/utilities/pages";
 import { ReadMore } from "@/utilities/ReadMore";
 import { cn } from "@/utilities/tailwind";
@@ -105,6 +110,12 @@ export const MilestoneCard = ({ milestone, isAuthorized }: MilestoneCardProps) =
     grantMilestone?.completionDetails?.deliverables ||
     (grantMilestone?.milestone.completed?.data as any)?.deliverables;
 
+  const effectiveStatus = getEffectiveMilestoneStatus(
+    completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
+    endsAt && endsAt > 0 ? endsAt * 1000 : null
+  );
+  const isPastDue = effectiveStatus === MilestoneLifecycleStatus.PAST_DUE;
+
   // Determine border color and tag based on milestone type and status
   const getBorderColor = () => {
     if (completed) return "border-brand-blue";
@@ -118,17 +129,17 @@ export const MilestoneCard = ({ milestone, isAuthorized }: MilestoneCardProps) =
 
   const getStatusColor = () => {
     if (completed) return "bg-brand-blue text-white";
+    if (isPastDue) return "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300";
     return "bg-[#FFFAEB] text-[#B54708] dark:bg-[#FFFAEB]/10 dark:text-orange-100";
   };
 
   const getStatusBorder = () => {
     if (completed) return "";
+    if (isPastDue) return "border border-red-200 dark:border-red-900";
     return "border border-[#FEDF89]";
   };
 
-  const getStatusText = () => {
-    return completed ? "Completed" : "Pending";
-  };
+  const getStatusText = () => MILESTONE_STATUS_LABEL[effectiveStatus];
 
   // Function to handle completion for project milestones
   const handleProjectMilestoneCompletion = () => {

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -29,6 +29,10 @@ import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { INDEXER } from "@/utilities/indexer";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { PaymentStatusDropdown } from "./PaymentStatusDropdown";
@@ -47,40 +51,26 @@ const milestoneStatusConfig: Record<
   { label: string; dotColor: string; textColor: string }
 > = {
   [MilestoneLifecycleStatus.PENDING]: {
-    label: "Pending",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING],
     dotColor: "bg-gray-300 dark:bg-zinc-600",
     textColor: "text-gray-500 dark:text-zinc-500",
   },
   [MilestoneLifecycleStatus.COMPLETED]: {
-    label: "Completed",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.COMPLETED],
     dotColor: "bg-blue-400",
     textColor: "text-blue-600 dark:text-blue-400",
   },
   [MilestoneLifecycleStatus.VERIFIED]: {
-    label: "Verified",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED],
     dotColor: "bg-green-500",
     textColor: "text-green-600 dark:text-green-400",
   },
   [MilestoneLifecycleStatus.PAST_DUE]: {
-    label: "Past due",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE],
     dotColor: "bg-amber-500",
     textColor: "text-amber-600 dark:text-amber-400",
   },
 };
-
-function getEffectiveMilestoneStatus(
-  milestoneStatus: MilestoneLifecycleStatus | null,
-  milestoneDueDate: string | null
-): MilestoneLifecycleStatus {
-  const status = milestoneStatus || MilestoneLifecycleStatus.PENDING;
-  if (status === MilestoneLifecycleStatus.PENDING && milestoneDueDate) {
-    const due = new Date(milestoneDueDate);
-    if (due.getTime() < Date.now()) {
-      return MilestoneLifecycleStatus.PAST_DUE;
-    }
-  }
-  return status;
-}
 
 function getMilestoneStatusTooltip(
   effectiveStatus: MilestoneLifecycleStatus,

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -4,8 +4,13 @@ import { type FC, memo } from "react";
 import { MilestoneCardLayout } from "@/components/Shared/ActivityCard/MilestoneCardLayout";
 import { Badge } from "@/components/ui/badge";
 import { Link } from "@/src/components/navigation/Link";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 import { formatDate } from "@/utilities/formatDate";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { cn } from "@/utilities/tailwind";
 import { MilestoneCompletionInfo } from "./MilestoneCompletionInfo";
 
@@ -22,27 +27,14 @@ interface CommunityMilestoneCardProps {
   allocationAmount?: string;
 }
 
-type MilestoneStatusVariant = "completed" | "pastDue" | "pending";
-
-const STATUS_BADGE_CLASSES: Record<MilestoneStatusVariant, string> = {
-  completed: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-  pastDue: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
-  pending: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
-};
-
-const STATUS_BADGE_LABELS: Record<MilestoneStatusVariant, string> = {
-  completed: "Completed",
-  pastDue: "Past Due",
-  pending: "Pending",
-};
-
-const getStatusVariant = (
-  status: CommunityMilestoneUpdate["status"],
-  dueDate: string | null
-): MilestoneStatusVariant => {
-  if (status === "completed") return "completed";
-  if (dueDate && new Date(dueDate) < new Date()) return "pastDue";
-  return "pending";
+const STATUS_BADGE_CLASSES: Record<MilestoneLifecycleStatus, string> = {
+  [MilestoneLifecycleStatus.COMPLETED]:
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  [MilestoneLifecycleStatus.VERIFIED]:
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  [MilestoneLifecycleStatus.PAST_DUE]: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+  [MilestoneLifecycleStatus.PENDING]:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
 };
 
 const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
@@ -54,7 +46,7 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
   const projectTitle = milestone.project.details?.data?.title;
   const grantTitle = milestone.grant?.details?.data?.title || "Project Milestone";
 
-  const statusVariant = getStatusVariant(milestone.status, milestone.details.dueDate);
+  const effectiveStatus = getEffectiveMilestoneStatus(milestone.status, milestone.details.dueDate);
 
   const header = (
     <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
@@ -77,11 +69,11 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
       <div
         className={cn(
           "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium",
-          STATUS_BADGE_CLASSES[statusVariant]
+          STATUS_BADGE_CLASSES[effectiveStatus]
         )}
       >
         {isCompleted ? <CheckCircleIcon className="h-3 w-3" /> : <ClockIcon className="h-3 w-3" />}
-        {STATUS_BADGE_LABELS[statusVariant]}
+        {MILESTONE_STATUS_LABEL[effectiveStatus]}
       </div>
       {milestone.grantMilestoneIndex != null && milestone.grantMilestoneTotal != null ? (
         <Badge

--- a/components/Shared/ActivityCard/ActivityStatus.tsx
+++ b/components/Shared/ActivityCard/ActivityStatus.tsx
@@ -1,14 +1,16 @@
 import Image from "next/image";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import { MILESTONE_STATUS_LABEL } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { cn } from "@/utilities/tailwind";
 import type { ActivityType } from "./ActivityTypes";
 
 interface ActivityStatusProps {
   type: ActivityType;
-  completed?: boolean;
+  milestoneStatus?: MilestoneLifecycleStatus;
   className?: string;
 }
 
-export const ActivityStatus = ({ type, completed, className }: ActivityStatusProps) => {
+export const ActivityStatus = ({ type, milestoneStatus, className }: ActivityStatusProps) => {
   const getStatusColor = (label: string) => {
     switch (label) {
       case "ProjectUpdate":
@@ -57,26 +59,29 @@ export const ActivityStatus = ({ type, completed, className }: ActivityStatusPro
     return labelDictionary[type as keyof typeof labelDictionary] || "UPDATE";
   };
 
-  // For milestones, handle completion status differently
-  if (type === "Milestone" && completed !== undefined) {
-    const getCompletionStatusColor = () => {
-      if (completed) return "text-[#067647] bg-[#ECFDF3] dark:text-green-400 dark:bg-zinc-900";
-      return "bg-[#FFFAEB] text-[#B54708] dark:bg-zinc-900 dark:text-orange-300";
-    };
-
-    const getCompletionStatusText = () => {
-      return completed ? "Completed" : "Pending";
+  // For milestones, handle lifecycle status (pending / past_due / completed / verified)
+  if (type === "Milestone" && milestoneStatus !== undefined) {
+    const getMilestoneStatusColor = () => {
+      switch (milestoneStatus) {
+        case MilestoneLifecycleStatus.COMPLETED:
+        case MilestoneLifecycleStatus.VERIFIED:
+          return "text-[#067647] bg-[#ECFDF3] dark:text-green-400 dark:bg-zinc-900";
+        case MilestoneLifecycleStatus.PAST_DUE:
+          return "bg-red-50 text-red-700 dark:bg-zinc-900 dark:text-red-300";
+        default:
+          return "bg-[#FFFAEB] text-[#B54708] dark:bg-zinc-900 dark:text-orange-300";
+      }
     };
 
     return (
       <p
         className={cn(
           "px-3 py-1 rounded-[4px] text-xs font-semibold",
-          getCompletionStatusColor(),
+          getMilestoneStatusColor(),
           className
         )}
       >
-        {getCompletionStatusText()}
+        {MILESTONE_STATUS_LABEL[milestoneStatus]}
       </p>
     );
   }

--- a/components/Shared/ActivityCard/ActivityStatusHeader.tsx
+++ b/components/Shared/ActivityCard/ActivityStatusHeader.tsx
@@ -3,7 +3,9 @@ import type {
   IProjectUpdate,
 } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/api/types";
 import type { FC } from "react";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import { getEffectiveMilestoneStatus } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { ActivityStatus } from "./ActivityStatus";
 import type { ActivityType } from "./ActivityTypes";
 import { GrantAssociation } from "./GrantAssociation";
@@ -11,8 +13,10 @@ import { GrantAssociation } from "./GrantAssociation";
 interface ActivityStatusHeaderProps {
   /** The activity type to display in the left status pill */
   activityType: ActivityType;
-  /** Optional due date to display on the right */
+  /** Pre-formatted due date string for display (right side) */
   dueDate?: string | null;
+  /** Raw due date for computing past-due status. Accepts ISO string, epoch ms, or Date. */
+  rawDueDate?: string | number | Date | null;
   /** Whether to show completion status for milestones */
   showCompletionStatus?: boolean;
   /** Whether the milestone/activity is completed */
@@ -25,12 +29,12 @@ interface ActivityStatusHeaderProps {
   index?: number;
   /** Milestone data for grant association */
   milestone?: UnifiedMilestone;
-  /** Whether to show grant association */
 }
 
 export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
   activityType,
   dueDate,
+  rawDueDate,
   showCompletionStatus = false,
   completed = false,
   completionStatusClassName = "text-xs px-2 py-1",
@@ -38,6 +42,11 @@ export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
   index,
   milestone,
 }) => {
+  const effectiveStatus = getEffectiveMilestoneStatus(
+    completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
+    rawDueDate ?? null
+  );
+
   return (
     <div className="w-full flex flex-row gap-2">
       <div className="flex flex-row items-center justify-between w-full flex-wrap gap-2">
@@ -52,7 +61,7 @@ export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
         {showCompletionStatus && (
           <ActivityStatus
             type="Milestone"
-            completed={completed}
+            milestoneStatus={effectiveStatus}
             className={completionStatusClassName}
           />
         )}

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -20,11 +20,16 @@ import { useMilestoneActions } from "@/hooks/useMilestoneActions";
 import { useMilestoneImpactAnswers } from "@/hooks/useMilestoneImpactAnswers";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { Link } from "@/src/components/navigation/Link";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
 import { useGrantInvoiceRequired } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import { getGrantInvoiceDownloadUrl } from "@/src/features/payout-disbursement/services/payout-disbursement.service";
 import { useProjectStore } from "@/store";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { formatDate } from "@/utilities/formatDate";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { ReadMore } from "@/utilities/ReadMore";
@@ -527,6 +532,10 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
     ) : undefined;
 
   const showStatusBadge = type === "milestone" || type === "grant";
+  const effectiveStatus = getEffectiveMilestoneStatus(
+    completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
+    endsAt && endsAt > 0 ? endsAt * 1000 : null
+  );
   const showOrderBadge = type === "grant" && Boolean(milestone.grantMilestoneOrder);
   const showAllocationBadge = Boolean(allocationAmount);
   const showDueBadge = Boolean(endsAt && endsAt > 0);
@@ -544,12 +553,15 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
         <Badge
           variant="secondary"
           className={cn(
-            completed
+            effectiveStatus === MilestoneLifecycleStatus.COMPLETED ||
+              effectiveStatus === MilestoneLifecycleStatus.VERIFIED
               ? "text-emerald-700 bg-emerald-50 hover:bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950 dark:hover:bg-emerald-950"
-              : "bg-orange-50 hover:bg-orange-50 text-orange-700 dark:bg-orange-950 dark:hover:bg-orange-950 dark:text-orange-300"
+              : effectiveStatus === MilestoneLifecycleStatus.PAST_DUE
+                ? "text-red-700 bg-red-50 hover:bg-red-50 dark:text-red-300 dark:bg-red-950 dark:hover:bg-red-950"
+                : "bg-orange-50 hover:bg-orange-50 text-orange-700 dark:bg-orange-950 dark:hover:bg-orange-950 dark:text-orange-300"
           )}
         >
-          {completed ? "Completed" : "Pending"}
+          {MILESTONE_STATUS_LABEL[effectiveStatus]}
         </Badge>
       )}
       {showOrderBadge && milestone.grantMilestoneOrder && (

--- a/components/Shared/ActivityCard/UpdateCard.tsx
+++ b/components/Shared/ActivityCard/UpdateCard.tsx
@@ -123,18 +123,20 @@ export const UpdateCard: FC<UpdateCardProps> = ({ update, index, isAuthorized })
     update.type === "Milestone" ||
     update.type === "ProjectMilestone";
 
-  // Get due date for milestones
-  const getDueDate = () => {
+  // Get raw due date (epoch ms or ISO string) for milestones
+  const getRawDueDate = (): number | string | null => {
     if (update.type === "Milestone" || update.type === "ProjectMilestone") {
       const milestoneData = update.data as any;
-      if (milestoneData.endsAt) {
-        return formatDate(milestoneData.endsAt);
-      }
-      if (milestoneData.endDate) {
-        return formatDate(milestoneData.endDate);
-      }
+      if (milestoneData.endsAt) return milestoneData.endsAt;
+      if (milestoneData.endDate) return milestoneData.endDate;
     }
     return null;
+  };
+
+  // Get formatted due date for milestones
+  const getDueDate = () => {
+    const raw = getRawDueDate();
+    return raw == null ? null : formatDate(raw);
   };
 
   // Get completion status for milestones
@@ -165,6 +167,7 @@ export const UpdateCard: FC<UpdateCardProps> = ({ update, index, isAuthorized })
             <ActivityStatusHeader
               activityType={update.type as ActivityType}
               dueDate={getDueDate()}
+              rawDueDate={getRawDueDate()}
               showCompletionStatus={
                 update.type === "Milestone" || update.type === "ProjectMilestone"
               }

--- a/utilities/milestones/getEffectiveMilestoneStatus.ts
+++ b/utilities/milestones/getEffectiveMilestoneStatus.ts
@@ -1,0 +1,40 @@
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+
+type MilestoneStatusInput =
+  | MilestoneLifecycleStatus
+  | "pending"
+  | "completed"
+  | "verified"
+  | "past_due"
+  | null
+  | undefined;
+
+type MilestoneDueDateInput = Date | string | number | null | undefined;
+
+function toEpochMs(dueDate: MilestoneDueDateInput): number | null {
+  if (dueDate == null) return null;
+  if (dueDate instanceof Date) return dueDate.getTime();
+  if (typeof dueDate === "number") return dueDate;
+  const parsed = new Date(dueDate).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function getEffectiveMilestoneStatus(
+  status: MilestoneStatusInput,
+  dueDate: MilestoneDueDateInput,
+  now: number = Date.now()
+): MilestoneLifecycleStatus {
+  const normalized = (status as MilestoneLifecycleStatus) || MilestoneLifecycleStatus.PENDING;
+  if (normalized !== MilestoneLifecycleStatus.PENDING) return normalized;
+
+  const dueMs = toEpochMs(dueDate);
+  if (dueMs == null) return MilestoneLifecycleStatus.PENDING;
+  return dueMs < now ? MilestoneLifecycleStatus.PAST_DUE : MilestoneLifecycleStatus.PENDING;
+}
+
+export const MILESTONE_STATUS_LABEL: Record<MilestoneLifecycleStatus, string> = {
+  [MilestoneLifecycleStatus.PENDING]: "Pending",
+  [MilestoneLifecycleStatus.COMPLETED]: "Completed",
+  [MilestoneLifecycleStatus.VERIFIED]: "Verified",
+  [MilestoneLifecycleStatus.PAST_DUE]: "Past Due",
+};


### PR DESCRIPTION
## Summary

Funding milestone cards rendered a binary `Completed` / `Pending` badge and never surfaced `Past Due`, even though the community updates feed and admin control center already had that classification. The same milestone could appear as "Pending" on `/project/<slug>/funding/<uid>/milestones-and-updates` while a tenant's `/updates?filter=past_due` listed it correctly.

The bug was an oversight from prior unification work — PR #875 added the past-due check to `CommunityMilestoneCard`, but later "unify" PRs (#1257, #1360) copied the binary ternary from the legacy milestone card and never pulled the past-due logic in. Three components ended up with three near-identical status helpers, two of which weren't even reachable from the funding-tab card.

## Changes

- **New shared util** `utilities/milestones/getEffectiveMilestoneStatus.ts`
  - Accepts `status` (enum or string) + `dueDate` (`Date` / ISO string / epoch ms / `null`)
  - Returns canonical `MilestoneLifecycleStatus`
  - Exports `MILESTONE_STATUS_LABEL` (`Pending` / `Completed` / `Verified` / `Past Due`)
- **Removed duplicated logic** from `MilestonesSection.tsx` and `CommunityMilestoneCard.tsx`; both now consume the shared util.
- **Fixed the actual bug** in `components/Shared/ActivityCard/MilestoneCard.tsx` (funding-tab card) — now renders `Past Due` in red when an incomplete milestone's `endsAt` is in the past.
- **`ActivityStatus` / `ActivityStatusHeader`** — switched from `completed?: boolean` to `milestoneStatus?: MilestoneLifecycleStatus` and added a `rawDueDate` prop so callers can pass the underlying date (not just a formatted display string). `UpdateCard.tsx` updated accordingly.
- **Legacy `components/Milestone/MilestoneCard.tsx`** updated for consistency.

## Test plan

- [x] New unit tests for `getEffectiveMilestoneStatus` (9 cases — covers null, pending+past, pending+future, completed, verified, epoch ms, Date instance, unparseable string, labels)
- [x] All existing tests pass: `MilestoneCard.test.tsx` (41), `CommunityMilestoneCard.test.tsx` (41), `MilestonesSection.test.tsx` (9), `ActivityCard.test.tsx`, `milestone-card-gating.test.ts` — 98 total
- [x] Type check passes (`tsc --noEmit`)
- [ ] Manual: open the milestone in the reported URL on a preview build and confirm the badge reads `Past Due`