### PR TITLE
feat(sitemap): add /projects tab to communities sitemap

### DIFF
--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,7 +1,15 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
 
-const communitySubPages = ["funding-opportunities", "impact", "projects", "updates"] as const;
+const communitySubPages = [
+  "funding-opportunities",
+  "browse-applications",
+  "projects",
+  "updates",
+  "impact",
+  "financials",
+  "reports",
+] as const;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
 
-const communitySubPages = ["funding-opportunities", "impact", "updates"] as const;
+const communitySubPages = ["funding-opportunities", "impact", "projects", "updates"] as const;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();


### PR DESCRIPTION
## Summary

Communities expose four primary tabs on the public site (`funding-opportunities`, `impact`, `projects`, `updates`). The sitemap was emitting only three of them — `/projects`, a high-value index page that lists every project enrolled in a community, was hidden from search crawlers.

## Testing

- `npx biome check app/sitemaps/communities/sitemap.ts` clean.
- Manual: visit `https://www.karmahq.xyz/community/filecoin/projects` — page returns 200 and lists projects.

## Risk

- Trivial. One-line addition to the `communitySubPages` tuple.
- After deploy, the chunked sitemap will include `~N more URLs` where N = `chosenCommunities().length`.