### PR TITLE
fix(milestone-completion): cancel polling loops on component unmount

### DIFF
--- a/__tests__/unit/utilities/fetchData.test.tsx
+++ b/__tests__/unit/utilities/fetchData.test.tsx
@@ -160,4 +160,21 @@ describe("fetchData", () => {
     expect(pageInfo).toBeNull();
     expect(status).toBe(201);
   });
+
+  it("should_forward_AbortSignal_to_axios_request_config", async () => {
+    // Long-running polls need axios to abort an in-flight request the
+    // moment the caller's signal aborts — otherwise the request
+    // completes its current network round-trip before the loop's next
+    // abort check fires.
+    const mockResponse = { data: { ok: true }, status: 200 };
+    (axios.request as vi.Mock).mockResolvedValue(mockResponse);
+    (TokenManager.getToken as vi.Mock).mockResolvedValue(null);
+
+    const controller = new AbortController();
+    await fetchData("/test-endpoint", "GET", {}, {}, {}, true, false, undefined, controller.signal);
+
+    expect(axios.request).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
 });

--- a/__tests__/unit/utilities/retries.test.ts
+++ b/__tests__/unit/utilities/retries.test.ts
@@ -1,0 +1,76 @@
+import { RetryAbortedError, retryUntilConditionMet } from "@/utilities/retries";
+
+describe("retryUntilConditionMet — AbortSignal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should_reject_with_AbortError_when_signal_already_aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const condition = vi.fn().mockResolvedValue(false);
+
+    await expect(
+      retryUntilConditionMet(condition, undefined, 5, 100, controller.signal)
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(condition).not.toHaveBeenCalled();
+  });
+
+  it("should_stop_iterating_after_abort_fires_mid_loop", async () => {
+    const controller = new AbortController();
+    const condition = vi.fn().mockResolvedValue(false);
+
+    const promise = retryUntilConditionMet(condition, undefined, 10, 100, controller.signal);
+
+    // Allow the first condition check to run.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(condition).toHaveBeenCalledTimes(1);
+
+    // Trigger abort while the loop is sleeping between iterations.
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+
+    // No further condition checks fire after abort.
+    expect(condition).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_resolve_normally_when_condition_met_before_abort", async () => {
+    const controller = new AbortController();
+    const callback = vi.fn();
+    const condition = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const promise = retryUntilConditionMet(condition, callback, 10, 100, controller.signal);
+
+    await vi.advanceTimersByTimeAsync(150);
+    await promise;
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_resolve_normally_when_no_signal_provided_backward_compat", async () => {
+    const condition = vi.fn().mockResolvedValue(true);
+
+    await retryUntilConditionMet(condition, undefined, 5, 100);
+
+    expect(condition).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RetryAbortedError", () => {
+  it("should_carry_AbortError_name_so_callers_can_distinguish_cancellation", () => {
+    const err = new RetryAbortedError();
+    expect(err.name).toBe("AbortError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("should_accept_custom_message", () => {
+    const err = new RetryAbortedError("custom reason");
+    expect(err.message).toBe("custom reason");
+  });
+});

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -2,7 +2,7 @@ import type { GAP } from "@show-karma/karma-gap-sdk";
 import { GapContract } from "@show-karma/karma-gap-sdk/core/class/contract/GapContract";
 import { MilestoneCompleted } from "@show-karma/karma-gap-sdk/core/class/types/attestations";
 import type { Signer } from "ethers";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 import { useAccount } from "wagmi";
 import { errorManager } from "@/components/Utilities/errorManager";
@@ -49,6 +49,15 @@ interface MilestoneInstance {
 /**
  * Hook for handling milestone completion and verification workflow
  */
+function isAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
 export const useMilestoneCompletionVerification = ({
   projectId,
   programId,
@@ -60,6 +69,18 @@ export const useMilestoneCompletionVerification = ({
   const { startAttestation, showLoading, showSuccess, showError, changeStepperStep, dismiss } =
     useAttestationToast();
   const { setupChainAndWallet } = useSetupChainAndWallet();
+
+  // AbortController owns the in-flight verification's polling loop.
+  // React state updates and `onSuccess` callbacks that fire after the
+  // component unmounts trigger React's "state update on unmounted
+  // component" warning and waste network calls. The controller is
+  // refreshed at every `verifyMilestone` call and aborted on cleanup.
+  const controllerRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
 
   const setupChainAndWalletForMilestone = async (
     milestone: GrantMilestoneWithCompletion,
@@ -200,41 +221,48 @@ export const useMilestoneCompletionVerification = ({
     milestone: GrantMilestoneWithCompletion,
     checkCompletion: boolean,
     userAddress: string,
-    inputProgramId: string
+    inputProgramId: string,
+    signal?: AbortSignal
   ) => {
     // Normalize for comparison (supports both programId formats)
     const normalizedInputId = normalizeProgramId(inputProgramId);
 
-    await retryUntilConditionMet(async () => {
-      const updatedProject = await gapClient.fetch.projectById(data.project.uid);
+    await retryUntilConditionMet(
+      async () => {
+        const updatedProject = await gapClient.fetch.projectById(data.project.uid);
 
-      if (!updatedProject) return false;
+        if (!updatedProject) return false;
 
-      const updatedGrant = updatedProject.grants.find((g) => {
-        const storedId = g.details?.programId;
-        if (!storedId) return false;
-        return normalizeProgramId(storedId) === normalizedInputId;
-      });
+        const updatedGrant = updatedProject.grants.find((g) => {
+          const storedId = g.details?.programId;
+          if (!storedId) return false;
+          return normalizeProgramId(storedId) === normalizedInputId;
+        });
 
-      if (!updatedGrant) return false;
+        if (!updatedGrant) return false;
 
-      const updatedMilestone = updatedGrant.milestones?.find((m) => m.uid === milestone.uid);
+        const updatedMilestone = updatedGrant.milestones?.find((m) => m.uid === milestone.uid);
 
-      if (!updatedMilestone) return false;
+        if (!updatedMilestone) return false;
 
-      const isVerified = updatedMilestone.verified?.find(
-        (v) => v.attester?.toLowerCase() === userAddress.toLowerCase()
-      );
+        const isVerified = updatedMilestone.verified?.find(
+          (v) => v.attester?.toLowerCase() === userAddress.toLowerCase()
+        );
 
-      // If checking completion, ensure both are indexed
-      if (checkCompletion) {
-        const isCompleted = updatedMilestone.completed;
-        return !!(isCompleted && isVerified);
-      }
+        // If checking completion, ensure both are indexed
+        if (checkCompletion) {
+          const isCompleted = updatedMilestone.completed;
+          return !!(isCompleted && isVerified);
+        }
 
-      // Otherwise just check verification
-      return !!isVerified;
-    });
+        // Otherwise just check verification
+        return !!isVerified;
+      },
+      undefined,
+      undefined,
+      undefined,
+      signal
+    );
   };
 
   const completeViaBackend = async (
@@ -279,7 +307,8 @@ export const useMilestoneCompletionVerification = ({
       completionReason?: string;
       verificationComment: string;
     },
-    communityUID: string
+    communityUID: string,
+    signal?: AbortSignal
   ): Promise<boolean> => {
     const isVerificationOnly = !options.includeCompletion;
 
@@ -322,8 +351,15 @@ export const useMilestoneCompletionVerification = ({
         milestone,
         options.includeCompletion,
         address,
-        programId
+        programId,
+        signal
       );
+
+      if (signal?.aborted) {
+        // Component unmounted mid-poll. Skip the success toast and the
+        // "indexed" stepper update — neither is observable any more.
+        return false;
+      }
 
       changeStepperStep("indexed");
       showSuccess(
@@ -334,6 +370,10 @@ export const useMilestoneCompletionVerification = ({
 
       return true;
     } catch (error: any) {
+      if (isAbortError(error)) {
+        // Silent — caller's finally already dismisses the toast.
+        return false;
+      }
       dismiss();
       throw error;
     }
@@ -358,6 +398,12 @@ export const useMilestoneCompletionVerification = ({
 
     // Use chainId from milestone (where attestation will occur)
     const attestationChainId = milestone.chainId;
+
+    // Abort any prior in-flight verification and start a fresh controller.
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const { signal } = controller;
 
     setIsVerifying(true);
     startAttestation("Verifying milestone...");
@@ -417,8 +463,15 @@ export const useMilestoneCompletionVerification = ({
           completionReason,
           verificationComment,
         },
-        communityUID
+        communityUID,
+        signal
       );
+
+      // Component unmounted mid-flight. Skip onSuccess + further work;
+      // the consumer is gone and the success toast is meaningless.
+      if (signal.aborted) {
+        return;
+      }
 
       if (!onChainConfirmed) {
         throw new Error("On-chain attestation was not confirmed");
@@ -427,6 +480,10 @@ export const useMilestoneCompletionVerification = ({
       // Success callback - backend will sync to off-chain database automatically
       onSuccess?.();
     } catch (error: any) {
+      if (isAbortError(error)) {
+        // Silent — component unmounted during the flow.
+        return;
+      }
       console.error("Error verifying milestone:", error);
 
       // Check if user cancelled
@@ -440,7 +497,9 @@ export const useMilestoneCompletionVerification = ({
         });
       }
     } finally {
-      setIsVerifying(false);
+      if (!signal.aborted) {
+        setIsVerifying(false);
+      }
       dismiss();
     }
   };

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -18,7 +18,7 @@ import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
-import { retryUntilConditionMet } from "@/utilities/retries";
+import { isAbortError, retryUntilConditionMet } from "@/utilities/retries";
 import { sanitizeObject } from "@/utilities/sanitize";
 
 // Constants
@@ -49,15 +49,6 @@ interface MilestoneInstance {
 /**
  * Hook for handling milestone completion and verification workflow
  */
-function isAbortError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    (error as { name?: unknown }).name === "AbortError"
-  );
-}
-
 export const useMilestoneCompletionVerification = ({
   projectId,
   programId,

--- a/src/features/applications/hooks/use-submit-milestone-completion.ts
+++ b/src/features/applications/hooks/use-submit-milestone-completion.ts
@@ -15,18 +15,9 @@ import type { Application, MilestoneStatusEntry } from "@/types/whitelabel-entit
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
-import { retryUntilConditionMet } from "@/utilities/retries";
+import { isAbortError, retryUntilConditionMet } from "@/utilities/retries";
 import { sanitizeObject } from "@/utilities/sanitize";
 import { isUserCancellationError } from "@/utilities/wallet-errors";
-
-function isAbortError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    (error as { name?: unknown }).name === "AbortError"
-  );
-}
 
 export interface InvoiceFile {
   fileKey: string;
@@ -106,9 +97,20 @@ export function useSubmitMilestoneCompletion() {
       const grantUID = params.statusEntry.grantUID;
 
       // Abort any prior in-flight mutation and start a fresh controller
-      // for this submission. Concurrent mutations from the same hook
-      // instance would otherwise share state in confusing ways; the
-      // mutation queue already serializes them, but defensive reset.
+      // for this submission. Required because overwriting `controllerRef.current`
+      // below would orphan the previous controller — the unmount cleanup
+      // can only abort what the ref currently points to.
+      //
+      // Side effect: concurrent submissions on the same hook instance
+      // cancel each other's polls. React Query's `useMutation` does NOT
+      // serialize parallel `mutate()` calls; calling submit() twice fires
+      // both mutationFns in parallel. In practice wallet-driven attestations
+      // serialize at the wallet layer (one popup at a time), so the
+      // post-attestation poll for the cancelled mutation gets dropped —
+      // on-chain state is still correct, only the toast and `router.refresh()`
+      // for the earlier submission are suppressed. If per-milestone
+      // independent cancellation becomes a requirement, switch to a
+      // `Map<pendingKey, AbortController>` keyed by milestoneUID.
       controllerRef.current?.abort();
       const controller = new AbortController();
       controllerRef.current = controller;

--- a/src/features/applications/hooks/use-submit-milestone-completion.ts
+++ b/src/features/applications/hooks/use-submit-milestone-completion.ts
@@ -3,7 +3,7 @@
 import { MilestoneCompleted } from "@show-karma/karma-gap-sdk/core/class/types/attestations";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import type { Hex } from "viem";
 import { useAccount } from "wagmi";
@@ -18,6 +18,15 @@ import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { retryUntilConditionMet } from "@/utilities/retries";
 import { sanitizeObject } from "@/utilities/sanitize";
 import { isUserCancellationError } from "@/utilities/wallet-errors";
+
+function isAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
 
 export interface InvoiceFile {
   fileKey: string;
@@ -74,6 +83,19 @@ export function useSubmitMilestoneCompletion() {
   const pendingKeyFor = (milestoneUID: string, milestoneTitle: string) =>
     milestoneUID || milestoneTitle;
 
+  // Tracks the AbortController for any in-flight mutation. React Query
+  // v5 doesn't cancel `mutationFn` on unmount, so the polling loop
+  // would otherwise outlive the component, fire `router.refresh()` on a
+  // route the user already left, and burn ~30 unnecessary network
+  // requests. The controller is re-created at every mutation start and
+  // aborted on cleanup.
+  const controllerRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
+
   const mutation = useMutation({
     mutationFn: async (params: SubmitMilestoneCompletionParams) => {
       if (!address) {
@@ -82,6 +104,15 @@ export function useSubmitMilestoneCompletion() {
 
       const chainID = params.statusEntry.chainID;
       const grantUID = params.statusEntry.grantUID;
+
+      // Abort any prior in-flight mutation and start a fresh controller
+      // for this submission. Concurrent mutations from the same hook
+      // instance would otherwise share state in confusing ways; the
+      // mutation queue already serializes them, but defensive reset.
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      const { signal } = controller;
 
       const pendingKey = pendingKeyFor(params.milestoneUID, params.milestoneTitle);
       setPendingKeys((prev) => new Set(prev).add(pendingKey));
@@ -134,12 +165,24 @@ export function useSubmitMilestoneCompletion() {
         // failing the mutation. The indexer publishes BOTH application
         // and project-source milestones into milestoneStatuses[], so
         // this single poll covers every row in the Milestones tab.
+        //
+        // The signal cancels both the loop's sleep and the in-flight
+        // fetch when the consuming component unmounts mid-poll.
         let indexerCaughtUp = false;
+        let aborted = false;
         try {
           await retryUntilConditionMet(
             async () => {
               const [data] = await fetchData<Application>(
-                INDEXER.V2.FUNDING_APPLICATIONS.GET(params.referenceNumber)
+                INDEXER.V2.FUNDING_APPLICATIONS.GET(params.referenceNumber),
+                "GET",
+                {},
+                {},
+                {},
+                true,
+                false,
+                undefined,
+                signal
               );
               if (!data) return false;
               const entry = data.milestoneStatuses?.find(
@@ -154,13 +197,23 @@ export function useSubmitMilestoneCompletion() {
             },
             undefined,
             30,
-            2000
+            2000,
+            signal
           );
           indexerCaughtUp = true;
-        } catch {
+        } catch (error) {
+          if (isAbortError(error)) {
+            aborted = true;
+          }
           // Polling timed out — the on-chain attestation is still valid,
           // the indexer is just slow. Surface a softer message; the
           // badge will flip on the next page load.
+        }
+
+        // Component unmounted mid-poll. Skip every side-effect that would
+        // hit an unmounted route or surface a toast the user can't see.
+        if (aborted || signal.aborted) {
+          return;
         }
 
         toast.success(
@@ -183,11 +236,13 @@ export function useSubmitMilestoneCompletion() {
               invoiceFileKey: params.invoiceFile.fileKey,
               invoiceFileUrl: params.invoiceFile.fileUrl,
             });
+            if (signal.aborted) return;
             toast.success("Invoice submitted successfully");
             await queryClient.invalidateQueries({
               queryKey: QUERY_KEYS.APPLICATIONS.INVOICE_CONFIG(params.referenceNumber),
             });
           } catch {
+            if (signal.aborted) return;
             // Non-fatal — the on-chain completion already shipped.
             toast.error("Failed to submit invoice");
           }
@@ -201,6 +256,10 @@ export function useSubmitMilestoneCompletion() {
       }
     },
     onError: (error: Error) => {
+      if (isAbortError(error)) {
+        // Component unmounted mid-mutation — silent. No toast, no Sentry.
+        return;
+      }
       if (isUserCancellationError(error)) {
         toast.error("Completion cancelled");
         return;

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -15,6 +15,12 @@ import { sanitizeObject } from "./sanitize";
  * poll. Without it, an aborted poll iteration still completes its
  * current request before the next abort check fires.
  *
+ * **Caller contract** when passing `signal`: an aborted request lands in
+ * the catch path as an axios cancel error. The function returns the
+ * standard `[null, error, null, status]` tuple in that case; callers
+ * should use `isAbortError(err)` (from `utilities/retries`) when
+ * inspecting the error to distinguish cancellation from real failures.
+ *
  * @template T - Optional type parameter for response data (defaults to any for backward compatibility)
  * @returns Promise<[T, null, any, number] | [null, string, null, number]> - Tuple of [data, error, pageInfo, status]
  */

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -9,6 +9,12 @@ import { sanitizeObject } from "./sanitize";
  * This replaces the complex cookie-based token retrieval with
  * Privy's simplified token management.
  *
+ * The optional `signal` is forwarded to axios so a long-running request
+ * is cancelled when the caller aborts — used by the milestone-completion
+ * polling hook to halt in-flight fetches when a component unmounts mid-
+ * poll. Without it, an aborted poll iteration still completes its
+ * current request before the next abort check fires.
+ *
  * @template T - Optional type parameter for response data (defaults to any for backward compatibility)
  * @returns Promise<[T, null, any, number] | [null, string, null, number]> - Tuple of [data, error, pageInfo, status]
  */
@@ -20,7 +26,8 @@ export default async function fetchData<T = any>(
   headers = {},
   isAuthorized = true,
   cache: boolean | undefined = false,
-  baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL
+  baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
+  signal?: AbortSignal
 ): Promise<[T, null, any, number] | [null, string, null, number]> {
   try {
     const sanitizedData = sanitizeObject(axiosData);
@@ -38,6 +45,7 @@ export default async function fetchData<T = any>(
       headers: {
         ...headers,
       },
+      signal,
     };
 
     // Add authorization header if needed

--- a/utilities/retries.ts
+++ b/utilities/retries.ts
@@ -1,6 +1,18 @@
 import { errorManager } from "@/components/Utilities/errorManager";
 
 /**
+ * Error thrown when an abort signal cancels a retry loop. Carries
+ * `name: "AbortError"` so callers can distinguish abort from condition-
+ * never-met or operation-failed cases via a single check.
+ */
+export class RetryAbortedError extends Error {
+  readonly name = "AbortError" as const;
+  constructor(message = "Retry loop aborted") {
+    super(message);
+  }
+}
+
+/**
  * Retries a function with exponential backoff
  * @param operation The async function to retry
  * @param maxRetries The maximum number of retries
@@ -37,27 +49,78 @@ export async function retry<T>(
   throw new Error("Unexpected end of retry loop");
 }
 
+/**
+ * Polls an async condition function until it returns true or maxRetries
+ * is exhausted. The optional `signal` lets a React component cancel the
+ * loop on unmount — without it, the promise outlives the component and
+ * fires its callback / next-iteration network calls in a zombie state.
+ *
+ * Cancellation is checked at three points: before the condition fires,
+ * before the sleep, and after the sleep resolves. Sleeping is itself
+ * abortable via `signal.addEventListener("abort", ...)` so an in-flight
+ * sleep doesn't hold the loop open for the full delay after abort.
+ *
+ * On abort the function rejects with `RetryAbortedError` (`name:
+ * "AbortError"`) — callers should check `err.name === "AbortError"` and
+ * swallow it rather than reporting as a real failure.
+ */
 export const retryUntilConditionMet = async (
   conditionFn: () => Promise<boolean>,
   callbackFn?: () => void,
   maxRetries: number = 200,
-  delay: number = 1500
+  delay: number = 1500,
+  signal?: AbortSignal
 ) => {
+  if (signal?.aborted) {
+    throw new RetryAbortedError();
+  }
+
   let retries = maxRetries;
   while (retries > 0) {
+    if (signal?.aborted) {
+      throw new RetryAbortedError();
+    }
     try {
       const conditionMet = await conditionFn().catch(() => false);
+      if (signal?.aborted) {
+        throw new RetryAbortedError();
+      }
       if (conditionMet) {
         callbackFn?.();
         return;
       }
     } catch (error) {
+      if (error instanceof RetryAbortedError) throw error;
       console.error("Error checking condition:", error);
     }
     retries -= 1;
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    await abortableSleep(delay, signal);
   }
   throw new Error(
     "Condition was not met after maximum retries. The operation may not have completed successfully."
   );
 };
+
+/**
+ * `setTimeout` wrapped in a promise that resolves either when the delay
+ * elapses or when the signal aborts. The abort path rejects with
+ * `RetryAbortedError` so the caller's `while` loop exits on the next
+ * iteration's abort check.
+ */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new RetryAbortedError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new RetryAbortedError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/utilities/retries.ts
+++ b/utilities/retries.ts
@@ -4,12 +4,33 @@ import { errorManager } from "@/components/Utilities/errorManager";
  * Error thrown when an abort signal cancels a retry loop. Carries
  * `name: "AbortError"` so callers can distinguish abort from condition-
  * never-met or operation-failed cases via a single check.
+ *
+ * **Caller contract**: when the promise rejects, check
+ * `err.name === "AbortError"` (or use `isAbortError`) and treat it as
+ * cancellation, not as a failure. Don't surface toasts or capture to
+ * Sentry — the user navigated away.
  */
 export class RetryAbortedError extends Error {
-  readonly name = "AbortError" as const;
+  readonly name = "AbortError";
   constructor(message = "Retry loop aborted") {
     super(message);
   }
+}
+
+/**
+ * Type guard for AbortSignal-style cancellation errors. Matches both
+ * `RetryAbortedError` (this module) and axios's own AbortError shape,
+ * which both expose `name === "AbortError"`. Use this instead of
+ * `instanceof RetryAbortedError` so callers don't have to know which
+ * abort point fired.
+ */
+export function isAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
 }
 
 /**
@@ -56,13 +77,14 @@ export async function retry<T>(
  * fires its callback / next-iteration network calls in a zombie state.
  *
  * Cancellation is checked at three points: before the condition fires,
- * before the sleep, and after the sleep resolves. Sleeping is itself
- * abortable via `signal.addEventListener("abort", ...)` so an in-flight
+ * after it resolves, and during the sleep (via an abortable
+ * `setTimeout` wrapper). Sleeping is fully abortable so an in-flight
  * sleep doesn't hold the loop open for the full delay after abort.
  *
- * On abort the function rejects with `RetryAbortedError` (`name:
- * "AbortError"`) — callers should check `err.name === "AbortError"` and
- * swallow it rather than reporting as a real failure.
+ * **Caller contract**: on abort this rejects with `RetryAbortedError`
+ * (`name: "AbortError"`). Use the exported `isAbortError(err)` helper
+ * to distinguish cancellation from real failures. Cancellation should
+ * be swallowed silently (no toast, no Sentry) — the user navigated away.
  */
 export const retryUntilConditionMet = async (
   conditionFn: () => Promise<boolean>,


### PR DESCRIPTION
## Summary

`useSubmitMilestoneCompletion` and `useMilestoneCompletionVerification` both run a 60s `retryUntilConditionMet` poll inside their mutation function after an on-chain attestation submits. React Query v5 doesn't cancel `mutationFn` on unmount, so the poll outlives the component — burning ~30 unnecessary network requests, firing `router.refresh()` on a route the user already left, and surfacing success toasts on screens that no longer exist.

Pairs with [show-karma/gap-indexer#1720](https://github.com/show-karma/gap-indexer/pull/1720) (Bug L). Both surfaced during Phase 3 scoping ([DEV-274](https://linear.app/showkarma/issue/DEV-274/)); tracked under [DEV-276](https://linear.app/showkarma/issue/DEV-276/).

## Fix

Opt-in cancellation through the primitives both hooks use:

- **`retryUntilConditionMet`** accepts optional `signal?: AbortSignal`. Checked at the loop start, between iterations, and during the sleep itself (via an abortable `setTimeout` wrapper). On abort rejects with `RetryAbortedError` (`name: 'AbortError'`), exported so callers can distinguish cancellation from condition-never-met and silently swallow it.
- **`fetchData`** accepts optional `signal?: AbortSignal` and forwards it to axios's `requestConfig.signal` — interrupts an in-flight request immediately, not just at the next 2s loop tick.

Both signature changes are non-breaking optional trailing params. The 15+ other `retryUntilConditionMet` callers and 100+ `fetchData` callers continue working unchanged — only the two milestone-completion hooks opt in.

### Hook wiring

- `useSubmitMilestoneCompletion` owns an `AbortController` via `useRef`, refreshed at every mutation start. A `useEffect` cleanup aborts on unmount. Signal threaded into both the retry loop and the per-iteration `fetchData` call. `router.refresh()`, invoice submission, and `toast.success` are guarded with `if (signal.aborted) return`. `onError` swallows `AbortError` silently.
- `useMilestoneCompletionVerification` follows the same pattern — signal threaded through `attestMilestonesOnChain` → `pollForMilestoneStatus`, with `signal.aborted` guards on `onSuccess` and the success toast.

## Tests

- **New `__tests__/unit/utilities/retries.test.ts`** (6 cases): pre-aborted signal rejects immediately; abort mid-loop stops iteration on the next check; normal resolution unaffected by signal presence; backward compat without signal; `RetryAbortedError` carries the right name + message.
- **`__tests__/unit/utilities/fetchData.test.tsx`** extended with a signal pass-through assertion against axios's request config.
- **134 test files / 2,568 unit tests green**, up from 2,561 baseline (+7).
- `pnpm tsc --noEmit` — clean.
- `pnpm exec biome check --write` on touched files — clean.

### Hook integration tests deliberately omitted

The cancellation behavior is fully exercised at the primitive level (retries util + fetchData both prove abortability). The hook wiring is a straightforward `useEffect` cleanup + signal-threading pattern. Full hook tests would require 200+ LOC of wagmi / router / SDK / toast mocks for marginal additional coverage. If a regression slips, the primitive tests catch it. Flagging here so reviewers can push back if they want fuller coverage anyway.

## Risk

Low. Optional trailing params are non-breaking; other call sites unaffected. The change is observable only on unmount paths that were silently misbehaving before.

## Test plan

- [x] Unit tests green (134 files / 2,568 tests)
- [x] tsc + biome clean
- [ ] Manual: start a completion submission, navigate away before the 60s poll completes — verify no toast appears and no `router.refresh()` fires
- [ ] Manual: same flow with `useMilestoneCompletionVerification` in MilestonesReview admin page
- [ ] Manual: normal happy path (don't unmount) still works as before — toast appears, page refreshes, indexer poll completes

## Related

- Bug L (private-field leakage via `formData`): show-karma/gap-indexer#1720
- Surfaced during Phase 3 scoping: [DEV-274](https://linear.app/showkarma/issue/DEV-274/)
- Tracked under [DEV-276](https://linear.app/showkarma/issue/DEV-276/) (this fix + Bug L)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cancellation across milestone submission and verification flows: in-flight requests and polling are cancelled when leaving or restarting actions, preventing stale UI updates and avoiding spurious success/error notifications.

* **Tests**
  * Added unit tests covering cancellation behavior for requests and retry/poll loops, including abort handling and error naming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1401)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->