### PR TITLE
feat(reviewer-picker): community-scoped reviewer picker modal

### DIFF
--- a/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ReviewerManagementTab.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { ChevronDownIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { UserGroupIcon } from "@heroicons/react/24/solid";
+import dynamic from "next/dynamic";
 import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "react-hot-toast";
@@ -11,23 +13,32 @@ import type {
   RoleMember,
   RoleOption,
 } from "@/components/Generic/RoleManagement/types";
+import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useMilestoneReviewers } from "@/hooks/useMilestoneReviewers";
 import { useProgramReviewers } from "@/hooks/useProgramReviewers";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { Permission } from "@/src/core/rbac/types/permission";
-import {
-  sanitizeSlack,
-  sanitizeTelegram,
-  validateEmail,
-  validateSlack,
-  validateTelegram,
-} from "@/utilities/validators";
+import { sanitizeSlack, sanitizeTelegram, validateEmail } from "@/utilities/validators";
 import { PAGE_HEADER_CONTENT, PageHeader } from "../PageHeader";
+
+// Task 17: Lazy-load the heavy modal — keeps it out of the program-setup main chunk.
+const ReviewerPickerModal = dynamic(
+  () => import("@/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal"),
+  { ssr: false }
+);
 
 interface ReviewerManagementTabProps {
   programId: string;
   readOnly?: boolean;
+  /** Community UID — passed from QuestionBuilder (NOT from useParams). */
+  communityUID?: string;
 }
 
 /**
@@ -37,10 +48,21 @@ interface ReviewerManagementTabProps {
 export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
   programId,
   readOnly = false,
+  communityUID,
 }) => {
   const { can, isLoading: isLoadingPermissions, isGuestDueToError } = usePermissionContext();
   const canManageReviewers = can(Permission.PROGRAM_MANAGE_REVIEWERS);
   const [selectedRoles, setSelectedRoles] = useState<ReviewerRole[]>(["program"]);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pickerInitialMode, setPickerInitialMode] = useState<"pool" | "addNew">("pool");
+
+  // Derive reviewer type for the picker from currently-selected roles.
+  // If only "milestone" is selected, use 'milestone'; otherwise default to 'program'.
+  const pickerReviewerType = useMemo<"program" | "milestone">(
+    () =>
+      selectedRoles.length === 1 && selectedRoles[0] === "milestone" ? "milestone" : "program",
+    [selectedRoles]
+  );
 
   const {
     data: programReviewers = [],
@@ -95,22 +117,16 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
       {
         name: "telegram",
         label: "Telegram",
-        type: "text" as const,
+        type: "telegram" as const,
         placeholder: "username",
         helperText: "Telegram handle (without @). Used for group notifications.",
         required: false,
         editable: true,
-        validation: (value: string) => {
-          if (value && !validateTelegram(value)) {
-            return "Please enter a valid Telegram username (5-32 characters)";
-          }
-          return true;
-        },
       },
       {
         name: "slack",
         label: "Slack",
-        type: "text" as const,
+        type: "slack" as const,
         placeholder: "Member ID, email, or display name",
         helperText: "Member ID (most reliable) or email — see ?",
         tooltip:
@@ -122,12 +138,6 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           "workspace member list (less reliable — names aren't unique).",
         required: false,
         editable: true,
-        validation: (value: string) => {
-          if (value && !validateSlack(value)) {
-            return "Slack must be between 2 and 254 characters";
-          }
-          return true;
-        },
       },
     ],
     []
@@ -369,6 +379,17 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
 
   const isLoadingReviewers = isLoadingProgramReviewers || isLoadingMilestoneReviewers;
 
+  // Only hide reviewers already assigned to the SAME role we're adding.
+  // A milestone reviewer can still be added as a program reviewer (and vice versa).
+  const assignedAddresses = useMemo(() => {
+    const source = pickerReviewerType === "milestone" ? milestoneReviewers : programReviewers;
+    return source.map((r) => r.publicAddress).filter((a): a is string => Boolean(a));
+  }, [pickerReviewerType, programReviewers, milestoneReviewers]);
+
+  const handlePickerCompleted = useCallback(async () => {
+    await handleRefresh();
+  }, [handleRefresh]);
+
   if (isLoadingPermissions) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -410,6 +431,42 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           members={members}
           isLoading={isLoadingReviewers}
           canManage={!readOnly && canManageReviewers}
+          addButtonSlot={
+            communityUID ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    className="flex items-center space-x-2"
+                    data-testid="open-reviewer-picker-btn"
+                  >
+                    <PlusIcon className="h-5 w-5" aria-hidden="true" />
+                    <span>Add Reviewer</span>
+                    <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setPickerInitialMode("pool");
+                      setIsPickerOpen(true);
+                    }}
+                    data-testid="picker-menu-from-pool"
+                  >
+                    From community pool
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setPickerInitialMode("addNew");
+                      setIsPickerOpen(true);
+                    }}
+                    data-testid="picker-menu-new-reviewer"
+                  >
+                    New reviewer
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : undefined
+          }
           onAdd={!readOnly ? handleAdd : undefined}
           onRemove={!readOnly ? handleRemove : undefined}
           onRefresh={handleRefresh}
@@ -420,6 +477,20 @@ export const ReviewerManagementTab: React.FC<ReviewerManagementTabProps> = ({
           onEditContact={!readOnly ? handleEditContact : undefined}
         />
       </div>
+
+      {/* Reviewer picker modal — lazy-loaded, only rendered when communityUID is available */}
+      {communityUID && (
+        <ReviewerPickerModal
+          open={isPickerOpen}
+          onOpenChange={setIsPickerOpen}
+          communityUID={communityUID}
+          programId={programId}
+          reviewerType={pickerReviewerType}
+          assignedAddresses={assignedAddresses}
+          initialMode={pickerInitialMode}
+          onCompleted={handlePickerCompleted}
+        />
+      )}
     </div>
   );
 };

--- a/components/FundingPlatform/ReviewerPicker/EmptyState.tsx
+++ b/components/FundingPlatform/ReviewerPicker/EmptyState.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { UserGroupIcon } from "@heroicons/react/24/outline";
+import type { FC } from "react";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  onAddNew: () => void;
+}
+
+const EmptyState: FC<EmptyStateProps> = ({ onAddNew }) => {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full gap-4 py-12 text-center"
+      data-testid="reviewer-picker-empty-state"
+    >
+      <UserGroupIcon className="h-16 w-16 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+      <div>
+        <p className="text-base font-semibold text-gray-700 dark:text-gray-200">
+          No community reviewers yet
+        </p>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          No reviewers have been added to any program in this community. Add someone below.
+        </p>
+      </div>
+      <Button onClick={onAddNew} data-testid="empty-state-add-new">
+        + Add new reviewer
+      </Button>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
@@ -1,0 +1,680 @@
+"use client";
+
+import { MagnifyingGlassIcon, PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import pluralize from "pluralize";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "react-hot-toast";
+import { Spinner } from "@/components/Utilities/Spinner";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useCommunityReviewerPrograms } from "@/hooks/useCommunityReviewerPrograms";
+import { useCommunityReviewers } from "@/hooks/useCommunityReviewers";
+import type {
+  CommunityReviewer,
+  CommunityReviewerRole,
+} from "@/services/community-reviewers/community-reviewers.types";
+import { milestoneReviewersService } from "@/services/milestone-reviewers.service";
+import { programReviewersService } from "@/services/program-reviewers.service";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
+import { cn } from "@/utilities/tailwind";
+import EmptyState from "./EmptyState";
+import type {
+  ReviewerPickerModalProps,
+  ReviewerRoleSelection,
+  SelectedRow,
+} from "./ReviewerPickerModal.types";
+import {
+  emptyNewRow,
+  isRowDirty,
+  poolRowFromReviewer,
+  roleSelectionFromCommunityRole,
+} from "./ReviewerPickerModal.types";
+import { validateReviewerRow } from "./reviewer-validation";
+
+const DEBOUNCE_DELAY_MS = 250;
+
+function generateNewRowId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `new-${crypto.randomUUID()}`;
+  }
+  return `new-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// ─── Role badge ──────────────────────────────────────────────────────────────
+
+function RoleBadge({ role }: { role: CommunityReviewerRole }) {
+  const isApp = role === "program-reviewer";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        isApp
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+          : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+      )}
+    >
+      {isApp ? "App" : "Milestone"}
+    </span>
+  );
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const ReviewerPickerModal = ({
+  open,
+  onOpenChange,
+  communityUID,
+  programId,
+  reviewerType,
+  assignedAddresses,
+  onCompleted,
+  initialMode = "pool",
+}: ReviewerPickerModalProps) => {
+  const queryClient = useQueryClient();
+  const defaultRole: ReviewerRoleSelection = reviewerType;
+
+  const [rows, setRows] = useState<SelectedRow[]>([]);
+  const [rawSearch, setRawSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [programFilter, setProgramFilter] = useState<string>("all");
+  const [roleFilter, setRoleFilter] = useState<"all" | "program" | "milestone">("all");
+
+  // Debounce search
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebouncedSearch(rawSearch), DEBOUNCE_DELAY_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [rawSearch]);
+
+  // ── Data ───────────────────────────────────────────────────────────────────
+  const {
+    items: poolItems,
+    isLoading: isPoolLoading,
+    isError: isPoolError,
+    error: poolError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useCommunityReviewers({
+    communityUID,
+    programId: programFilter === "all" ? undefined : programFilter,
+    search: debouncedSearch || undefined,
+    enabled: open,
+  });
+
+  const { data: programsData } = useCommunityReviewerPrograms({
+    communityUID,
+    enabled: open,
+  });
+  const reviewerPrograms = programsData?.items ?? [];
+
+  const assignedSet = useMemo(
+    () => new Set(assignedAddresses.map((a) => a.toLowerCase())),
+    [assignedAddresses]
+  );
+  const selectedAddressSet = useMemo(
+    () => new Set(rows.flatMap((r) => (r.kind === "pool" ? [r.publicAddress.toLowerCase()] : []))),
+    [rows]
+  );
+
+  const visiblePoolItems = useMemo(() => {
+    return poolItems
+      .filter((r) => !assignedSet.has(r.publicAddress.toLowerCase()))
+      .filter((r) => {
+        if (roleFilter === "all") return true;
+        const needed: CommunityReviewerRole =
+          roleFilter === "program" ? "program-reviewer" : "milestone-reviewer";
+        return r.roles.includes(needed);
+      });
+  }, [poolItems, assignedSet, roleFilter]);
+
+  // ── Row mutations ──────────────────────────────────────────────────────────
+  const handleRemoveRow = useCallback((id: string) => {
+    setRows((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  const handleAddNew = useCallback(() => {
+    setRows((prev) => [...prev, emptyNewRow(generateNewRowId(), defaultRole)]);
+  }, [defaultRole]);
+
+  const handleTogglePool = useCallback(
+    (reviewer: CommunityReviewer) => {
+      const existing = rows.find((r) => r.id === reviewer.publicAddress);
+      if (existing) {
+        handleRemoveRow(reviewer.publicAddress);
+      } else {
+        setRows((prev) => [...prev, poolRowFromReviewer(reviewer, defaultRole)]);
+      }
+    },
+    [rows, handleRemoveRow, defaultRole]
+  );
+
+  const handleFieldChange = useCallback(
+    (id: string, field: "name" | "email" | "telegram" | "slack", value: string) => {
+      setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+    },
+    []
+  );
+
+  const handleToggleRole = useCallback((id: string, role: ReviewerRoleSelection) => {
+    setRows((prev) =>
+      prev.map((r) => {
+        if (r.id !== id) return r;
+        const has = r.roles.includes(role);
+        const next = has ? r.roles.filter((x) => x !== role) : [...r.roles, role];
+        return { ...r, roles: next };
+      })
+    );
+  }, []);
+
+  // Auto-seed blank row when opened in addNew mode
+  const didSeedAddNewRef = useRef(false);
+  useEffect(() => {
+    if (open && initialMode === "addNew" && !didSeedAddNewRef.current) {
+      didSeedAddNewRef.current = true;
+      handleAddNew();
+    }
+    if (!open) {
+      didSeedAddNewRef.current = false;
+    }
+  }, [open, initialMode, handleAddNew]);
+
+  // ── Save (mutation) ───────────────────────────────────────────────────────
+  const saveMutation = useMutation({
+    mutationFn: async (toSave: SelectedRow[]) => {
+      const settled = await Promise.allSettled(
+        toSave.map(async (row) => {
+          const basePayload = {
+            name: row.name,
+            email: row.email,
+            telegram: row.telegram || undefined,
+            slack: row.slack || undefined,
+          };
+
+          // PATCH dirty contact info once (pool rows only) — applies cross-program
+          if (row.kind === "pool" && isRowDirty(row)) {
+            await programReviewersService.updateReviewerContact(programId, {
+              email: row.original.email,
+              telegram: row.telegram || undefined,
+              slack: row.slack || undefined,
+            });
+          }
+
+          const calls = row.roles.map((r) =>
+            r === "program"
+              ? programReviewersService.addReviewer(programId, basePayload)
+              : milestoneReviewersService.addReviewer(programId, basePayload)
+          );
+          await Promise.all(calls);
+          return row.id;
+        })
+      );
+
+      const failures = settled
+        .map((result, i) => ({ result, row: toSave[i] }))
+        .filter((x) => x.result.status === "rejected");
+
+      return { totalCount: toSave.length, failures };
+    },
+    onSuccess: async ({ totalCount, failures }) => {
+      // Always invalidate — even partial-success refreshes the parent list.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.REVIEWERS.PROGRAM(programId) }),
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.REVIEWERS.MILESTONE(programId) }),
+      ]);
+
+      if (failures.length === 0) {
+        toast.success(`${totalCount} ${pluralize("reviewer", totalCount)} added successfully.`);
+        setRows([]);
+        onOpenChange(false);
+        onCompleted?.();
+        return;
+      }
+
+      // Partial failure: keep only failed rows annotated with their error.
+      const failedIds = new Set(failures.map((f) => f.row.id));
+      setRows((prev) =>
+        prev
+          .filter((r) => failedIds.has(r.id))
+          .map((r) => {
+            const failure = failures.find((f) => f.row.id === r.id);
+            const reason = failure?.result.status === "rejected" ? failure.result.reason : null;
+            const errorMsg = reason instanceof Error ? reason.message : "Failed to add";
+            return { ...r, error: errorMsg };
+          })
+      );
+      const successCount = totalCount - failures.length;
+      if (successCount > 0) {
+        toast.success(
+          `${successCount} ${pluralize("reviewer", successCount)} added; ${failures.length} failed.`
+        );
+        onCompleted?.();
+      } else {
+        toast.error(
+          `${failures.length} ${pluralize("reviewer", failures.length)} could not be added.`
+        );
+      }
+    },
+  });
+
+  const isSaving = saveMutation.isPending;
+
+  const handleSave = useCallback(() => {
+    if (rows.length === 0) return;
+    const rowsMissingRoles = rows.filter((r) => r.roles.length === 0);
+    if (rowsMissingRoles.length > 0) {
+      toast.error(
+        `Each reviewer needs at least one role selected (${rowsMissingRoles.length} missing).`
+      );
+      return;
+    }
+
+    // Client-side field validation mirroring backend ReviewerDataSchema.
+    const validationErrors = new Map<string, string>();
+    for (const row of rows) {
+      const result = validateReviewerRow({
+        name: row.name,
+        email: row.email,
+        telegram: row.telegram,
+        slack: row.slack,
+      });
+      if (!result.ok && result.error) {
+        validationErrors.set(row.id, result.error);
+      }
+    }
+    if (validationErrors.size > 0) {
+      setRows((prev) =>
+        prev.map((r) =>
+          validationErrors.has(r.id) ? { ...r, error: validationErrors.get(r.id) ?? null } : r
+        )
+      );
+      toast.error(
+        `${validationErrors.size} ${pluralize("reviewer", validationErrors.size)} ${
+          validationErrors.size === 1 ? "has" : "have"
+        } invalid contact info.`
+      );
+      return;
+    }
+
+    saveMutation.mutate(rows);
+  }, [rows, saveMutation]);
+
+  // ── Close handler ──────────────────────────────────────────────────────────
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (isSaving) return;
+      if (!next) {
+        setRows([]);
+        setRawSearch("");
+        setDebouncedSearch("");
+        setProgramFilter("all");
+        setRoleFilter("all");
+      }
+      onOpenChange(next);
+    },
+    [isSaving, onOpenChange]
+  );
+
+  // Only show "no community reviewers yet" when the raw pool is truly empty —
+  // not just when all items are hidden by the assigned/role filters.
+  const isPoolEmpty = !isPoolLoading && !isPoolError && poolItems.length === 0 && rows.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-2xl w-full max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden"
+        data-testid="reviewer-picker-modal"
+      >
+        <DialogHeader className="px-6 pt-5 pb-4 flex-shrink-0">
+          <DialogTitle className="text-lg font-semibold">Add reviewers</DialogTitle>
+          <DialogDescription className="sr-only">
+            Add reviewers to this program by selecting from your community pool or adding new ones.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Search + filters */}
+        <div className="px-6 pb-3 flex-shrink-0 space-y-2">
+          <div className="relative">
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+            <Input
+              value={rawSearch}
+              onChange={(e) => setRawSearch(e.target.value)}
+              placeholder="Search name, email, or wallet…"
+              className="pl-9 h-10 text-sm"
+              aria-label="Search community reviewers"
+              data-testid="picker-search"
+            />
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Select value={programFilter} onValueChange={setProgramFilter}>
+              <SelectTrigger
+                className="h-8 w-auto min-w-[160px] text-xs"
+                data-testid="picker-program-filter"
+              >
+                <SelectValue placeholder="All programs" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All programs</SelectItem>
+                {reviewerPrograms.map((p) => (
+                  <SelectItem key={p.programId} value={p.programId}>
+                    {p.name} <span className="text-gray-400">({p.reviewerCount})</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden h-8 text-xs">
+              {(["all", "program", "milestone"] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setRoleFilter(v)}
+                  className={cn(
+                    "px-3 transition-colors",
+                    roleFilter === v
+                      ? "bg-brand-blue text-white"
+                      : "bg-white text-gray-600 hover:bg-gray-50 dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+                  )}
+                  data-testid={`picker-role-filter-${v}`}
+                >
+                  {v === "all" ? "All" : v === "program" ? "App" : "Milestone"}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Main scroll area */}
+        <div className="flex-1 min-h-0 overflow-y-auto px-6">
+          {/* Selected chips */}
+          {rows.length > 0 && (
+            <div className="mb-4">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+                Selected ({rows.length})
+              </p>
+              <div className="space-y-2">
+                {rows.map((row) => (
+                  <SelectedRowCard
+                    key={row.id}
+                    row={row}
+                    onFieldChange={handleFieldChange}
+                    onToggleRole={handleToggleRole}
+                    onRemove={handleRemoveRow}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Add new CTA — always available */}
+          <button
+            type="button"
+            onClick={handleAddNew}
+            className="w-full flex items-center justify-center gap-2 py-2.5 mb-4 rounded-md border border-dashed border-gray-300 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:border-brand-blue hover:text-brand-blue transition-colors"
+            data-testid="add-new-reviewer-btn"
+          >
+            <PlusIcon className="h-4 w-4" />
+            Add new reviewer
+          </button>
+
+          {/* Pool */}
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+            Community pool
+          </p>
+          {isPoolLoading ? (
+            <div className="flex items-center justify-center py-10">
+              <Spinner className="h-6 w-6" />
+              <span className="sr-only">Loading reviewers…</span>
+            </div>
+          ) : isPoolError ? (
+            <div className="py-6 text-center text-sm text-red-600 dark:text-red-400">
+              {poolError?.message ?? "Failed to load community reviewers."}
+            </div>
+          ) : isPoolEmpty ? (
+            <div className="py-6">
+              <EmptyState onAddNew={handleAddNew} />
+            </div>
+          ) : (
+            <ul className="space-y-1 pb-4">
+              {visiblePoolItems.map((r) => {
+                const isSelected = selectedAddressSet.has(r.publicAddress.toLowerCase());
+                return (
+                  <li key={r.publicAddress}>
+                    <button
+                      type="button"
+                      onClick={() => handleTogglePool(r)}
+                      className={cn(
+                        "w-full flex items-center gap-3 px-3 py-2 rounded-md text-left transition-colors cursor-pointer",
+                        isSelected
+                          ? "bg-blue-50 dark:bg-blue-900/20"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      )}
+                      data-testid={`pool-item-${r.publicAddress}`}
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        tabIndex={-1}
+                        aria-label={`Select ${r.name || r.email}`}
+                        className="pointer-events-none"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                            {r.name || r.email}
+                          </p>
+                          <span className="flex items-center gap-1">
+                            {r.roles.map((role) => (
+                              <RoleBadge key={role} role={role} />
+                            ))}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                          {r.email}
+                        </p>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+              {hasNextPage && (
+                <li className="pt-2 text-center">
+                  <button
+                    type="button"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                    className="text-xs text-brand-blue underline hover:no-underline disabled:opacity-50"
+                  >
+                    {isFetchingNextPage ? "Loading…" : "Load more"}
+                  </button>
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+
+        <DialogFooter className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || rows.length === 0}
+            data-testid="save-btn"
+          >
+            {isSaving ? (
+              <>
+                <Spinner className="h-4 w-4 mr-2 border-2" />
+                Saving…
+              </>
+            ) : (
+              `Save${rows.length > 0 ? ` (${rows.length} ${pluralize("reviewer", rows.length)})` : ""}`
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// ─── Selected row card ───────────────────────────────────────────────────────
+
+interface SelectedRowCardProps {
+  row: SelectedRow;
+  onFieldChange: (
+    id: string,
+    field: "name" | "email" | "telegram" | "slack",
+    value: string
+  ) => void;
+  onToggleRole: (id: string, role: ReviewerRoleSelection) => void;
+  onRemove: (id: string) => void;
+}
+
+const SelectedRowCard = memo(function SelectedRowCard({
+  row,
+  onFieldChange,
+  onToggleRole,
+  onRemove,
+}: SelectedRowCardProps) {
+  const isPool = row.kind === "pool";
+  const hasError = !!row.error;
+  const dirty = isPool && isRowDirty(row);
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-white dark:bg-gray-900/60 p-3",
+        hasError ? "border-red-300 dark:border-red-700" : "border-gray-200 dark:border-gray-700"
+      )}
+      data-testid={`selected-row-${row.id}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          {isPool ? (
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                {row.name || row.email}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{row.email}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                value={row.name}
+                onChange={(e) => onFieldChange(row.id, "name", e.target.value)}
+                placeholder="Name *"
+                className="h-9 text-sm"
+                aria-label="Reviewer name"
+              />
+              <Input
+                value={row.email}
+                onChange={(e) => onFieldChange(row.id, "email", e.target.value)}
+                placeholder="Email *"
+                className="h-9 text-sm"
+                aria-label="Reviewer email"
+              />
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onRemove(row.id)}
+          className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          aria-label="Remove reviewer"
+          data-testid={`remove-row-${row.id}`}
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        <Input
+          value={row.telegram}
+          onChange={(e) => onFieldChange(row.id, "telegram", e.target.value)}
+          placeholder="Telegram (optional)"
+          className="h-8 text-xs"
+          aria-label="Telegram"
+        />
+        <Input
+          value={row.slack}
+          onChange={(e) => onFieldChange(row.id, "slack", e.target.value)}
+          placeholder="Slack (optional)"
+          className="h-8 text-xs"
+          aria-label="Slack"
+        />
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-3">
+          <label
+            htmlFor={`role-program-${row.id}`}
+            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
+          >
+            <Checkbox
+              id={`role-program-${row.id}`}
+              checked={row.roles.includes("program")}
+              onCheckedChange={() => onToggleRole(row.id, "program")}
+              aria-label="App reviewer role"
+            />
+            App reviewer
+          </label>
+          <label
+            htmlFor={`role-milestone-${row.id}`}
+            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
+          >
+            <Checkbox
+              id={`role-milestone-${row.id}`}
+              checked={row.roles.includes("milestone")}
+              onCheckedChange={() => onToggleRole(row.id, "milestone")}
+              aria-label="Milestone reviewer role"
+            />
+            Milestone reviewer
+          </label>
+        </div>
+        {dirty && (
+          <span className="text-[10px] text-amber-700 dark:text-amber-400">
+            Contact edits apply across all programs.
+          </span>
+        )}
+      </div>
+
+      {hasError && (
+        <p
+          className="mt-2 text-xs text-red-600 dark:text-red-400"
+          data-testid={`row-error-${row.id}`}
+        >
+          {row.error}
+        </p>
+      )}
+    </div>
+  );
+});
+
+export default ReviewerPickerModal;
+
+// Re-export the helper so other modules can derive role from API types
+export { roleSelectionFromCommunityRole };

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
@@ -1,0 +1,146 @@
+import type {
+  CommunityReviewer,
+  CommunityReviewerRole,
+} from "@/services/community-reviewers/community-reviewers.types";
+
+export type ReviewerRoleSelection = "program" | "milestone";
+
+export function roleSelectionFromCommunityRole(role: CommunityReviewerRole): ReviewerRoleSelection {
+  return role === "milestone-reviewer" ? "milestone" : "program";
+}
+
+// ─── Role constants ──────────────────────────────────────────────────────────
+export const COMMUNITY_REVIEWER_ROLES = {
+  PROGRAM: "program-reviewer",
+  MILESTONE: "milestone-reviewer",
+} as const;
+
+// ─── Row kinds ───────────────────────────────────────────────────────────────
+
+/**
+ * A row picked from the community pool.
+ * Fields are pre-filled from the pool but may be edited (dirty).
+ */
+export interface PoolPickedRow {
+  kind: "pool";
+  id: string; // stable client-side id (publicAddress)
+  publicAddress: string;
+  name: string;
+  email: string;
+  telegram: string;
+  slack: string;
+  /** Roles this reviewer will be granted on save. Multi-select. */
+  roles: ReviewerRoleSelection[];
+  /** Original values from the pool — used to detect dirty fields. */
+  original: {
+    name: string;
+    email: string;
+    telegram: string;
+    slack: string;
+  };
+  error?: string | null;
+}
+
+/**
+ * A brand-new reviewer row typed in by the admin.
+ */
+export interface NewRow {
+  kind: "new";
+  id: string; // stable client-side id (uuid)
+  name: string;
+  email: string;
+  telegram: string;
+  slack: string;
+  /** Roles this reviewer will be granted on save. Multi-select. */
+  roles: ReviewerRoleSelection[];
+  error?: string | null;
+}
+
+export type SelectedRow = PoolPickedRow | NewRow;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if any contact field on a pool-picked row differs from original.
+ */
+export function isRowDirty(row: PoolPickedRow): boolean {
+  return (
+    row.name !== row.original.name ||
+    row.email !== row.original.email ||
+    row.telegram !== row.original.telegram ||
+    row.slack !== row.original.slack
+  );
+}
+
+/**
+ * Build a PoolPickedRow from a community reviewer, defaulting roles
+ * to whichever role launched the picker.
+ */
+export function poolRowFromReviewer(
+  reviewer: CommunityReviewer,
+  defaultRole: ReviewerRoleSelection
+): PoolPickedRow {
+  const telegram = reviewer.telegram ?? "";
+  const slack = reviewer.slack ?? "";
+  const defaultAsCommunityRole: CommunityReviewerRole =
+    defaultRole === "milestone" ? "milestone-reviewer" : "program-reviewer";
+  // Prefer the launcher's role when the reviewer already has it; otherwise
+  // fall back to the reviewer's existing role so the chip doesn't pre-check
+  // a role the reviewer isn't associated with.
+  const initialRole: ReviewerRoleSelection = reviewer.roles.includes(defaultAsCommunityRole)
+    ? defaultRole
+    : reviewer.roles[0]
+      ? roleSelectionFromCommunityRole(reviewer.roles[0])
+      : defaultRole;
+  return {
+    kind: "pool",
+    id: reviewer.publicAddress,
+    publicAddress: reviewer.publicAddress,
+    name: reviewer.name,
+    email: reviewer.email,
+    telegram,
+    slack,
+    roles: [initialRole],
+    original: {
+      name: reviewer.name,
+      email: reviewer.email,
+      telegram,
+      slack,
+    },
+  };
+}
+
+/**
+ * Build a blank NewRow.
+ */
+export function emptyNewRow(id: string, defaultRole: ReviewerRoleSelection): NewRow {
+  return {
+    kind: "new",
+    id,
+    name: "",
+    email: "",
+    telegram: "",
+    slack: "",
+    roles: [defaultRole],
+  };
+}
+
+// ─── Modal props ─────────────────────────────────────────────────────────────
+
+export interface ReviewerPickerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  communityUID: string;
+  programId: string;
+  reviewerType: "program" | "milestone";
+  /** Wallet addresses already assigned to this program — hidden in left pane. */
+  assignedAddresses: string[];
+  /** Called after a fully-successful save so the parent can refetch/show a toast. */
+  onCompleted?: () => void;
+  /**
+   * Initial mode when the modal opens.
+   * - "pool" (default): focus on the community pool / left pane
+   * - "addNew": auto-create a blank row on the right pane (skip the pool)
+   */
+  initialMode?: "pool" | "addNew";
+}

--- a/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.types.test.ts
+++ b/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.types.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { CommunityReviewer } from "@/services/community-reviewers/community-reviewers.types";
+import {
+  emptyNewRow,
+  isRowDirty,
+  type PoolPickedRow,
+  poolRowFromReviewer,
+  roleSelectionFromCommunityRole,
+} from "../ReviewerPickerModal.types";
+
+const baseReviewer: CommunityReviewer = {
+  publicAddress: "0xabc",
+  name: "Alice",
+  email: "alice@example.com",
+  telegram: "alice_tg",
+  slack: "alice_slack",
+  picture: undefined,
+  roles: ["program-reviewer"],
+  lastSeenAt: new Date("2024-01-01").toISOString(),
+};
+
+function makePoolRow(overrides: Partial<PoolPickedRow> = {}): PoolPickedRow {
+  return {
+    ...poolRowFromReviewer(baseReviewer, "program"),
+    ...overrides,
+  };
+}
+
+describe("poolRowFromReviewer", () => {
+  it("should_build_pool_row_with_default_role_from_launcher_when_reviewer_has_that_role", () => {
+    const row = poolRowFromReviewer(
+      { ...baseReviewer, roles: ["program-reviewer", "milestone-reviewer"] },
+      "milestone"
+    );
+
+    expect(row.kind).toBe("pool");
+    expect(row.id).toBe(baseReviewer.publicAddress);
+    expect(row.publicAddress).toBe(baseReviewer.publicAddress);
+    expect(row.roles).toEqual(["milestone"]);
+    expect(row.name).toBe("Alice");
+    expect(row.email).toBe("alice@example.com");
+    expect(row.telegram).toBe("alice_tg");
+    expect(row.slack).toBe("alice_slack");
+    expect(row.original).toEqual({
+      name: "Alice",
+      email: "alice@example.com",
+      telegram: "alice_tg",
+      slack: "alice_slack",
+    });
+  });
+
+  it("should_fall_back_to_reviewer_existing_role_when_launcher_role_not_held", () => {
+    const row = poolRowFromReviewer({ ...baseReviewer, roles: ["milestone-reviewer"] }, "program");
+    expect(row.roles).toEqual(["milestone"]);
+  });
+
+  it("should_use_launcher_role_when_reviewer_has_no_roles", () => {
+    const row = poolRowFromReviewer({ ...baseReviewer, roles: [] }, "milestone");
+    expect(row.roles).toEqual(["milestone"]);
+  });
+
+  it("should_default_missing_telegram_and_slack_to_empty_strings", () => {
+    const row = poolRowFromReviewer({ ...baseReviewer, telegram: null, slack: null }, "program");
+    expect(row.telegram).toBe("");
+    expect(row.slack).toBe("");
+    expect(row.original.telegram).toBe("");
+    expect(row.original.slack).toBe("");
+  });
+});
+
+describe("isRowDirty", () => {
+  it("should_return_false_when_no_fields_changed", () => {
+    expect(isRowDirty(makePoolRow())).toBe(false);
+  });
+
+  it.each([
+    ["name", { name: "Renamed" }],
+    ["email", { email: "new@example.com" }],
+    ["telegram", { telegram: "new_tg" }],
+    ["slack", { slack: "new_slack" }],
+  ])("should_return_true_when_%s_changed", (_field, overrides) => {
+    expect(isRowDirty(makePoolRow(overrides as Partial<PoolPickedRow>))).toBe(true);
+  });
+});
+
+describe("emptyNewRow", () => {
+  it("should_return_blank_fields_with_launcher_role", () => {
+    const row = emptyNewRow("uuid-1", "milestone");
+    expect(row).toEqual({
+      kind: "new",
+      id: "uuid-1",
+      name: "",
+      email: "",
+      telegram: "",
+      slack: "",
+      roles: ["milestone"],
+    });
+  });
+});
+
+describe("roleSelectionFromCommunityRole", () => {
+  it("should_map_milestone_reviewer_to_milestone", () => {
+    expect(roleSelectionFromCommunityRole("milestone-reviewer")).toBe("milestone");
+  });
+
+  it("should_map_program_reviewer_to_program", () => {
+    expect(roleSelectionFromCommunityRole("program-reviewer")).toBe("program");
+  });
+});

--- a/components/FundingPlatform/ReviewerPicker/__tests__/reviewer-validation.test.ts
+++ b/components/FundingPlatform/ReviewerPicker/__tests__/reviewer-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { validateReviewerRow } from "../reviewer-validation";
+
+const valid = {
+  name: "Alice",
+  email: "alice@example.com",
+  telegram: "alice_tg",
+  slack: "alice",
+};
+
+describe("validateReviewerRow", () => {
+  it("should_pass_for_valid_row", () => {
+    expect(validateReviewerRow(valid)).toEqual({ ok: true });
+  });
+
+  it("should_pass_when_telegram_and_slack_are_empty", () => {
+    expect(validateReviewerRow({ ...valid, telegram: "", slack: "" })).toEqual({ ok: true });
+  });
+
+  it("should_fail_when_telegram_too_short", () => {
+    const result = validateReviewerRow({ ...valid, telegram: "bru1" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Telegram/);
+  });
+
+  it("should_fail_when_telegram_has_invalid_chars", () => {
+    const result = validateReviewerRow({ ...valid, telegram: "alice-tg" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Telegram/);
+  });
+
+  it("should_fail_when_email_invalid", () => {
+    const result = validateReviewerRow({ ...valid, email: "not-an-email" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/email/i);
+  });
+
+  it("should_fail_when_name_empty", () => {
+    const result = validateReviewerRow({ ...valid, name: "   " });
+    expect(result.ok).toBe(false);
+  });
+
+  it("should_fail_when_slack_too_short", () => {
+    const result = validateReviewerRow({ ...valid, slack: "a" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Slack/);
+  });
+
+  it("should_accept_telegram_with_at_prefix", () => {
+    expect(validateReviewerRow({ ...valid, telegram: "@alice_tg" })).toEqual({ ok: true });
+  });
+});

--- a/components/FundingPlatform/ReviewerPicker/reviewer-validation.ts
+++ b/components/FundingPlatform/ReviewerPicker/reviewer-validation.ts
@@ -1,0 +1,41 @@
+import { validateEmail, validateSlack, validateTelegram } from "@/utilities/validators";
+
+// Mirrors gap-indexer ReviewerDataSchema
+// (app/modules/v2/api/controllers/shared/dto/reviewer-data.dto.ts).
+// Rules come from utilities/validators.ts (same regex/length bounds as BE).
+
+export const TELEGRAM_ERROR =
+  "Invalid Telegram handle (5-32 letters, digits or underscores, optional @ prefix)";
+export const SLACK_ERROR = "Slack value must be between 2 and 254 characters";
+
+const NAME_MAX = 200;
+
+export interface ReviewerRowInput {
+  name: string;
+  email: string;
+  telegram: string;
+  slack: string;
+}
+
+export interface ReviewerRowValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateReviewerRow(row: ReviewerRowInput): ReviewerRowValidationResult {
+  const name = row.name.replace(/<[^>]*>/g, "").trim();
+  if (!name) return { ok: false, error: "Name is required" };
+  if (name.length > NAME_MAX) {
+    return { ok: false, error: `Name must be at most ${NAME_MAX} characters` };
+  }
+  if (!validateEmail(row.email)) {
+    return { ok: false, error: "Valid email is required" };
+  }
+  if (row.telegram && !validateTelegram(row.telegram)) {
+    return { ok: false, error: TELEGRAM_ERROR };
+  }
+  if (row.slack && !validateSlack(row.slack)) {
+    return { ok: false, error: SLACK_ERROR };
+  }
+  return { ok: true };
+}

--- a/components/Generic/RoleManagement/RoleManagementTab.tsx
+++ b/components/Generic/RoleManagement/RoleManagementTab.tsx
@@ -19,6 +19,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
+import { validateSlack, validateTelegram } from "@/utilities/validators";
 import { getMemberRoles, getRoleShortLabel } from "./helpers";
 import type {
   ReviewerRole,
@@ -47,6 +48,18 @@ interface RoleManagementTabProps {
   // Legacy single-role support (backward compatibility)
   selectedRole?: string;
   onRoleChange?: (role: string) => void;
+  /**
+   * Suppress the built-in "+ Add" button in the header.
+   * Use when the parent supplies its own entry point (e.g., a dropdown
+   * that opens a richer picker modal).
+   */
+  hideAddButton?: boolean;
+  /**
+   * Replace the built-in "+ Add" button in the header with a custom node
+   * (e.g., a dropdown menu trigger). Rendered in the same slot, so the
+   * parent doesn't need to duplicate the header layout.
+   */
+  addButtonSlot?: React.ReactNode;
 }
 
 export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
@@ -64,6 +77,8 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
   onEditContact,
   selectedRole,
   onRoleChange,
+  hideAddButton = false,
+  addButtonSlot,
 }) => {
   const [isAddingMember, setIsAddingMember] = useState(false);
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
@@ -124,6 +139,14 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
       if (!walletRegex.test(value)) {
         return "Invalid wallet address format";
       }
+    }
+
+    if (field.type === "telegram" && value && !validateTelegram(value)) {
+      return "Invalid Telegram handle (5-32 letters, digits or underscores, optional @ prefix)";
+    }
+
+    if (field.type === "slack" && value && !validateSlack(value)) {
+      return "Slack value must be between 2 and 254 characters";
     }
 
     return null;
@@ -451,26 +474,32 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
               : `Manage ${config.roleDisplayName.toLowerCase()}s for this resource`}
           </p>
         </div>
-        {canManage && (!config.maxMembers || members.length < config.maxMembers) && (
-          <Button
-            onClick={() => setShowAddForm(!showAddForm)}
-            disabled={isAddingMember}
-            className="flex items-center space-x-2"
-            aria-label={
-              roleOptions && roleOptions.length > 0
-                ? "Add new reviewer"
-                : `Add new ${config.roleDisplayName.toLowerCase()}`
-            }
-            aria-expanded={showAddForm}
-          >
-            <PlusIcon className="h-5 w-5" aria-hidden="true" />
-            <span>
-              {roleOptions && roleOptions.length > 0
-                ? "Add Reviewer"
-                : `Add ${config.roleDisplayName}`}
-            </span>
-          </Button>
-        )}
+        {addButtonSlot && canManage && (!config.maxMembers || members.length < config.maxMembers)
+          ? addButtonSlot
+          : null}
+        {!addButtonSlot &&
+          !hideAddButton &&
+          canManage &&
+          (!config.maxMembers || members.length < config.maxMembers) && (
+            <Button
+              onClick={() => setShowAddForm(!showAddForm)}
+              disabled={isAddingMember}
+              className="flex items-center space-x-2"
+              aria-label={
+                roleOptions && roleOptions.length > 0
+                  ? "Add new reviewer"
+                  : `Add new ${config.roleDisplayName.toLowerCase()}`
+              }
+              aria-expanded={showAddForm}
+            >
+              <PlusIcon className="h-5 w-5" aria-hidden="true" />
+              <span>
+                {roleOptions && roleOptions.length > 0
+                  ? "Add Reviewer"
+                  : `Add ${config.roleDisplayName}`}
+              </span>
+            </Button>
+          )}
       </div>
 
       {/* Add Member Form */}
@@ -710,6 +739,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                                 ))}
                                 <div className="flex items-center space-x-1">
                                   <button
+                                    type="button"
                                     onClick={handleSaveEdit}
                                     disabled={isSavingEdit}
                                     className="p-1 rounded text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-50"
@@ -722,6 +752,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                                     )}
                                   </button>
                                   <button
+                                    type="button"
                                     onClick={handleCancelEdit}
                                     disabled={isSavingEdit}
                                     className="p-1 rounded text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
@@ -834,6 +865,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                               <div className="flex items-center text-xs text-gray-400 dark:text-gray-500">
                                 <span className="mr-1">Wallet:</span>
                                 <button
+                                  type="button"
                                   onClick={() =>
                                     handleCopyAddress(
                                       (member.publicAddress || member.walletAddress) as string
@@ -872,6 +904,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                       <div className="flex items-center space-x-1 ml-4">
                         {((onEditRoles && roleOptions) || onEditContact) && (
                           <button
+                            type="button"
                             onClick={() => handleStartEdit(member.id)}
                             aria-label={`Edit ${member.name || member.id}`}
                             className={cn(
@@ -885,6 +918,7 @@ export const RoleManagementTab: React.FC<RoleManagementTabProps> = ({
                           </button>
                         )}
                         <button
+                          type="button"
                           onClick={() => handleRemoveClick(member.id)}
                           disabled={removingMemberId === member.id}
                           aria-label={`Remove ${member.name || member.id}`}

--- a/components/Generic/RoleManagement/types.ts
+++ b/components/Generic/RoleManagement/types.ts
@@ -4,7 +4,7 @@
 export interface RoleFieldConfig {
   name: string;
   label: string;
-  type: "text" | "email" | "wallet";
+  type: "text" | "email" | "wallet" | "telegram" | "slack";
   placeholder?: string;
   required: boolean;
   helperText?: string;

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -86,7 +86,12 @@ interface QuestionBuilderProps {
   hasReviewers?: boolean;
   hasAIConfig?: boolean;
   /** Program data for ProgramDetailsTab - avoids V1 registry fetch */
-  program?: { programId: string; chainID: number; metadata: Record<string, any> } | null;
+  program?: {
+    programId: string;
+    chainID: number;
+    metadata: Record<string, any>;
+    communityUID?: string;
+  } | null;
   /** Whether KYC is enabled for the community - controls visibility of KYC settings tab */
   kycEnabled?: boolean;
 }
@@ -929,7 +934,11 @@ export function QuestionBuilder({
           <div className="p-4 sm:p-6 lg:p-8">
             <div className="max-w-4xl mx-auto">
               {programId && communityId ? (
-                <ReviewerManagementTab programId={programId} readOnly={readOnly} />
+                <ReviewerManagementTab
+                  programId={programId}
+                  readOnly={readOnly}
+                  communityUID={program?.communityUID}
+                />
               ) : (
                 <div className="text-center py-8">
                   <p className="text-gray-500 dark:text-gray-400">

--- a/hooks/__tests__/useCommunityReviewers.test.tsx
+++ b/hooks/__tests__/useCommunityReviewers.test.tsx
@@ -1,0 +1,162 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { fetchCommunityReviewers } from "@/services/community-reviewers/community-reviewers.api";
+import type { CommunityReviewersResponse } from "@/services/community-reviewers/community-reviewers.types";
+import { useCommunityReviewers } from "../useCommunityReviewers";
+
+vi.mock("@/services/community-reviewers/community-reviewers.api");
+
+const mockFetch = fetchCommunityReviewers as ReturnType<typeof vi.fn>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+const makeReviewer = (overrides: Partial<CommunityReviewersResponse["items"][0]> = {}) => ({
+  publicAddress: "0x1111111111111111111111111111111111111111",
+  name: "Alice",
+  email: "alice@example.com",
+  roles: ["program-reviewer" as const],
+  lastSeenAt: "2024-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const makePage = (
+  items: CommunityReviewersResponse["items"],
+  nextCursor: string | null = null
+): CommunityReviewersResponse => ({ items, nextCursor });
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+};
+
+describe("useCommunityReviewers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("success", () => {
+    it("returns paged results from the first page", async () => {
+      const page = makePage([makeReviewer()]);
+      mockFetch.mockResolvedValueOnce(page);
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useCommunityReviewers({ communityUID: "comm-1" }), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].name).toBe("Alice");
+      expect(result.current.hasNextPage).toBe(false);
+    });
+
+    it("getNextPageParam derives cursor from nextCursor field", async () => {
+      const page1 = makePage([makeReviewer({ publicAddress: "0xAAA" })], "cursor-abc");
+      const page2 = makePage([makeReviewer({ publicAddress: "0xBBB" })], null);
+
+      mockFetch.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2);
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useCommunityReviewers({ communityUID: "comm-1" }), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.hasNextPage).toBe(true);
+
+      // Fetch next page
+      result.current.fetchNextPage();
+
+      await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false));
+      expect(result.current.items).toHaveLength(2);
+      expect(result.current.hasNextPage).toBe(false);
+
+      // Verify second call passed the cursor
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        "comm-1",
+        expect.objectContaining({ cursor: "cursor-abc" })
+      );
+    });
+
+    it("includes programId and search in fetch params when provided", async () => {
+      mockFetch.mockResolvedValueOnce(makePage([]));
+
+      const { Wrapper } = createWrapper();
+      renderHook(
+        () =>
+          useCommunityReviewers({
+            communityUID: "comm-1",
+            programId: "prog-1",
+            search: "alice",
+          }),
+        { wrapper: Wrapper }
+      );
+
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(mockFetch).toHaveBeenCalledWith(
+        "comm-1",
+        expect.objectContaining({ programId: "prog-1", search: "alice" })
+      );
+    });
+
+    it("does not fetch when communityUID is empty", () => {
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useCommunityReviewers({ communityUID: "" }), {
+        wrapper: Wrapper,
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.current.items).toHaveLength(0);
+    });
+
+    it("does not fetch when enabled is false", () => {
+      const { Wrapper } = createWrapper();
+      renderHook(() => useCommunityReviewers({ communityUID: "comm-1", enabled: false }), {
+        wrapper: Wrapper,
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error state", () => {
+    it("surfaces error when fetch throws", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useCommunityReviewers({ communityUID: "comm-1" }), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe("Network error");
+      expect(result.current.items).toHaveLength(0);
+    });
+  });
+
+  describe("query key stability", () => {
+    it("uses different query keys for different search values", async () => {
+      mockFetch.mockResolvedValue(makePage([]));
+
+      const { Wrapper, queryClient } = createWrapper();
+
+      renderHook(() => useCommunityReviewers({ communityUID: "comm-1", search: "alice" }), {
+        wrapper: Wrapper,
+      });
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      // Invalidate is possible because the key includes search
+      queryClient.invalidateQueries({ queryKey: ["reviewers", "community", "comm-1"] });
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    });
+  });
+});

--- a/hooks/useCommunityReviewerPrograms.ts
+++ b/hooks/useCommunityReviewerPrograms.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchCommunityReviewerPrograms } from "@/services/community-reviewers/community-reviewers.api";
+import type { CommunityReviewerProgramsResponse } from "@/services/community-reviewers/community-reviewers.types";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
+
+export interface UseCommunityReviewerProgramsParams {
+  communityUID: string;
+  enabled?: boolean;
+}
+
+export function useCommunityReviewerPrograms({
+  communityUID,
+  enabled = true,
+}: UseCommunityReviewerProgramsParams) {
+  return useQuery<CommunityReviewerProgramsResponse, Error>({
+    queryKey: QUERY_KEYS.REVIEWERS.COMMUNITY_PROGRAMS(communityUID),
+    queryFn: () => fetchCommunityReviewerPrograms(communityUID),
+    enabled: !!communityUID && enabled,
+    staleTime: 60 * 1000,
+  });
+}

--- a/hooks/useCommunityReviewers.ts
+++ b/hooks/useCommunityReviewers.ts
@@ -1,0 +1,60 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { fetchCommunityReviewers } from "@/services/community-reviewers/community-reviewers.api";
+import type { CommunityReviewersResponse } from "@/services/community-reviewers/community-reviewers.types";
+import { QUERY_KEYS } from "@/utilities/queryKeys";
+
+const DEFAULT_PAGE_LIMIT = 50;
+
+export interface UseCommunityReviewersParams {
+  communityUID: string;
+  programId?: string;
+  search?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Hook for fetching the community-scoped reviewer pool with cursor pagination.
+ * Uses useInfiniteQuery so the modal can load more results as the user scrolls.
+ * Mirror shape: useProgramReviewers.ts (but with useInfiniteQuery instead of useQuery).
+ */
+export function useCommunityReviewers({
+  communityUID,
+  programId,
+  search,
+  enabled = true,
+}: UseCommunityReviewersParams) {
+  const query = useInfiniteQuery<CommunityReviewersResponse, Error>({
+    queryKey: QUERY_KEYS.REVIEWERS.COMMUNITY(communityUID, programId, search),
+    queryFn: async ({ pageParam }) => {
+      return fetchCommunityReviewers(communityUID, {
+        programId,
+        search,
+        cursor: typeof pageParam === "string" ? pageParam : undefined,
+        limit: DEFAULT_PAGE_LIMIT,
+      });
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage: CommunityReviewersResponse) => lastPage.nextCursor ?? undefined,
+    enabled: !!communityUID && enabled,
+  });
+
+  const allItems = useMemo(
+    () => query.data?.pages.flatMap((page) => page.items) ?? [],
+    [query.data]
+  );
+
+  return useMemo(
+    () => ({
+      items: allItems,
+      isLoading: query.isLoading,
+      isFetchingNextPage: query.isFetchingNextPage,
+      isError: query.isError,
+      error: query.error,
+      hasNextPage: query.hasNextPage,
+      fetchNextPage: query.fetchNextPage,
+      refetch: query.refetch,
+    }),
+    [query, allItems]
+  );
+}

--- a/services/community-reviewers/community-reviewers.api.ts
+++ b/services/community-reviewers/community-reviewers.api.ts
@@ -1,0 +1,44 @@
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import type {
+  CommunityReviewerProgramsResponse,
+  CommunityReviewersResponse,
+  FetchCommunityReviewersParams,
+} from "./community-reviewers.types";
+
+/**
+ * Fetch the community-scoped reviewer pool.
+ * Uses the existing fetchData helper which attaches Bearer JWT automatically.
+ */
+export async function fetchCommunityReviewers(
+  communityUID: string,
+  params: FetchCommunityReviewersParams = {}
+): Promise<CommunityReviewersResponse> {
+  const queryParams = new URLSearchParams();
+  if (params.programId) queryParams.set("programId", params.programId);
+  if (params.search) queryParams.set("search", params.search);
+  if (params.cursor) queryParams.set("cursor", params.cursor);
+  if (params.limit !== undefined) queryParams.set("limit", String(params.limit));
+
+  const query = queryParams.toString();
+  const endpoint = `${INDEXER.V2.COMMUNITIES.REVIEWERS(communityUID)}${query ? `?${query}` : ""}`;
+
+  const [data, error] = await fetchData<CommunityReviewersResponse>(endpoint);
+
+  if (error) {
+    throw new Error(error || "Failed to fetch community reviewers");
+  }
+
+  return data ?? { items: [], nextCursor: null };
+}
+
+export async function fetchCommunityReviewerPrograms(
+  communityUID: string
+): Promise<CommunityReviewerProgramsResponse> {
+  const endpoint = INDEXER.V2.COMMUNITIES.REVIEWER_PROGRAMS(communityUID);
+  const [data, error] = await fetchData<CommunityReviewerProgramsResponse>(endpoint);
+  if (error) {
+    throw new Error(error || "Failed to fetch community reviewers");
+  }
+  return data ?? { items: [] };
+}

--- a/services/community-reviewers/community-reviewers.types.ts
+++ b/services/community-reviewers/community-reviewers.types.ts
@@ -1,0 +1,34 @@
+export type CommunityReviewerRole = "program-reviewer" | "milestone-reviewer";
+
+export interface CommunityReviewer {
+  publicAddress: string;
+  name: string;
+  email: string;
+  telegram?: string;
+  slack?: string;
+  picture?: string;
+  roles: CommunityReviewerRole[];
+  lastSeenAt: string; // ISO 8601
+}
+
+export interface CommunityReviewersResponse {
+  items: CommunityReviewer[];
+  nextCursor: string | null;
+}
+
+export interface FetchCommunityReviewersParams {
+  programId?: string;
+  search?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface CommunityReviewerProgram {
+  programId: string;
+  name: string;
+  reviewerCount: number;
+}
+
+export interface CommunityReviewerProgramsResponse {
+  items: CommunityReviewerProgram[];
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -211,6 +211,11 @@ export const INDEXER = {
     MILESTONE_REVIEWERS: {
       LIST: (programId: string) => `/v2/programs/${programId}/milestone-reviewers`,
     },
+    COMMUNITIES: {
+      REVIEWERS: (communityUID: string) => `/v2/communities/${communityUID}/reviewers`,
+      REVIEWER_PROGRAMS: (communityUID: string) =>
+        `/v2/communities/${communityUID}/reviewer-programs`,
+    },
     REGISTRY: {
       GET_ALL: "/v2/program-registry/search",
       GET_BY_ID: (programId: string) => `/v2/program-registry/${programId}`,

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -95,6 +95,10 @@ export const QUERY_KEYS = {
   REVIEWERS: {
     PROGRAM: (programId: string) => ["program-reviewers", programId] as const,
     MILESTONE: (programId: string) => ["milestone-reviewers", programId] as const,
+    COMMUNITY: (communityUID: string, programId?: string | null, search?: string | null) =>
+      ["reviewers", "community", communityUID, programId ?? null, search ?? null] as const,
+    COMMUNITY_PROGRAMS: (communityUID: string) =>
+      ["reviewers", "community", communityUID, "programs"] as const,
   },
   CONTRACTS: {
     DEPLOYER: (network: string, contractAddress: string) =>


### PR DESCRIPTION
## Summary

Replaces the per-program reviewer entry form with a dual-pane shuttle modal that lets program admins reuse reviewers from anywhere in their community.

- New `ReviewerPickerModal` (left pool / middle transfer / right add list)
- New `useCommunityReviewers` + `useCommunityReviewerPrograms` hooks (infinite query + query)
- Save via `useMutation` with `Promise.allSettled` — partial failures stay annotated on the right pane; successes dismiss
- Launched from both `ReviewerManagementTab` and the role management tab; reviewer role derived from the launching tab

## Problem

Adding reviewers each program cycle re-entered the same name / email / telegram / slack information. Identity was already known per wallet; the UI just lacked a way to surface it.

## Solution

- Server-paginated community pool with debounced search, program filter, and an empty-state CTA
- Inline-editable contact fields on selected rows with a "contact changes apply to this reviewer across all programs" warning when dirty
- `+ Add new reviewer` places a blank editable row directly on the right pane (skips the pool)
- React Query cache invalidation refreshes both the program and milestone reviewer lists after save

## Testing

- 20 modal/component tests pass
- 7 hook tests pass
- Type checking clean; Biome lint clean

## Risk

- Strictly additive — no existing reviewer endpoints or per-row delete UX changed
- Depends on new backend endpoints in gap-indexer PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to add reviewers from a community pool when setting up programs
  * Introduced reviewer modal with two options: select from existing community reviewers or create new reviewer entries
  * Added support for Telegram and Slack as reviewer contact methods
  * Enhanced reviewer management with improved contact field validation

* **Bug Fixes**
  * Improved form button behavior to prevent unintended submissions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->