### PR TITLE
feat(oauth-consent): role-grouped scopes and friendlier signer label

### DIFF
--- a/components/Pages/OAuthConsent/OAuthConsentClient.tsx
+++ b/components/Pages/OAuthConsent/OAuthConsentClient.tsx
@@ -240,11 +240,7 @@ export function OAuthConsentClient() {
   const interactionUid = searchParams.get("interaction");
   const { ready, authenticated, login, address, user, getAccessToken } = useAuth();
   const signedInLabel =
-    user?.email?.address ||
-    user?.google?.email ||
-    user?.farcaster?.displayName ||
-    user?.farcaster?.username ||
-    (address ? shortenAddress(address) : null);
+    user?.email?.address || user?.google?.email || (address ? shortenAddress(address) : null);
 
   const interactionQuery = useQuery({
     queryKey: ["oauth", "interaction", interactionUid],

--- a/components/Pages/OAuthConsent/OAuthConsentClient.tsx
+++ b/components/Pages/OAuthConsent/OAuthConsentClient.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { type ReactElement, useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
+import { useContributorProfile } from "@/hooks/useContributorProfile";
 import { envVars } from "@/utilities/enviromentVars";
 
 /**
@@ -239,8 +240,12 @@ export function OAuthConsentClient() {
   const searchParams = useSearchParams();
   const interactionUid = searchParams.get("interaction");
   const { ready, authenticated, login, address, user, getAccessToken } = useAuth();
+  const { profile } = useContributorProfile(address);
   const signedInLabel =
-    user?.email?.address || user?.google?.email || (address ? shortenAddress(address) : null);
+    profile?.data?.name ||
+    user?.email?.address ||
+    user?.google?.email ||
+    (address ? shortenAddress(address) : null);
 
   const interactionQuery = useQuery({
     queryKey: ["oauth", "interaction", interactionUid],

--- a/components/Pages/OAuthConsent/OAuthConsentClient.tsx
+++ b/components/Pages/OAuthConsent/OAuthConsentClient.tsx
@@ -238,7 +238,13 @@ function renderConsentGuard(args: ConsentGuardArgs): ReactElement | null {
 export function OAuthConsentClient() {
   const searchParams = useSearchParams();
   const interactionUid = searchParams.get("interaction");
-  const { ready, authenticated, login, address, getAccessToken } = useAuth();
+  const { ready, authenticated, login, address, user, getAccessToken } = useAuth();
+  const signedInLabel =
+    user?.email?.address ||
+    user?.google?.email ||
+    user?.farcaster?.displayName ||
+    user?.farcaster?.username ||
+    (address ? shortenAddress(address) : null);
 
   const interactionQuery = useQuery({
     queryKey: ["oauth", "interaction", interactionUid],
@@ -333,24 +339,50 @@ export function OAuthConsentClient() {
         </div>
       </div>
 
-      <ul className="mt-6 space-y-2 text-sm text-foreground">
-        <li className="flex items-start gap-2">
-          <Bullet />
-          Use the Karma MCP tools on your behalf — view your projects, grants, and impact data.
-        </li>
-        <li className="flex items-start gap-2">
-          <Bullet />
-          Take actions you can take yourself: create projects, post updates, and submit milestone
-          evidence.
-        </li>
-      </ul>
+      <p className="mt-6 text-sm text-foreground">This will allow {clientName} to:</p>
 
-      {address ? (
+      <div className="mt-4 space-y-5 text-sm text-foreground">
+        <div>
+          <p className="font-medium text-foreground">As a grant operator</p>
+          <ul className="mt-2 space-y-2">
+            <li className="flex items-start gap-2">
+              <Bullet />
+              Review programs, milestones, and reports
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <p className="font-medium text-foreground">As a project or non-profit</p>
+          <ul className="mt-2 space-y-2">
+            <li className="flex items-start gap-2">
+              <Bullet />
+              Search for funders that match your work
+            </li>
+            <li className="flex items-start gap-2">
+              <Bullet />
+              See your projects, grants, milestones, and impact data
+            </li>
+            <li className="flex items-start gap-2">
+              <Bullet />
+              Create and update projects on your behalf
+            </li>
+            <li className="flex items-start gap-2">
+              <Bullet />
+              Post updates and submit milestone evidence
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <p className="mt-6 text-xs text-muted-foreground">
+        {clientName} can only do what you can do. You can revoke access anytime.
+      </p>
+
+      {signedInLabel ? (
         <p className="mt-6 text-xs text-muted-foreground">
           Signed in as{" "}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
-            {shortenAddress(address)}
-          </code>
+          <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">{signedInLabel}</code>
         </p>
       ) : null}
 

--- a/components/Pages/OAuthConsent/OAuthConsentClient.tsx
+++ b/components/Pages/OAuthConsent/OAuthConsentClient.tsx
@@ -137,7 +137,7 @@ interface ConsentGuardArgs {
   redirectingTo: string | null;
 }
 
-function renderConsentGuard(args: ConsentGuardArgs): ReactElement | null {
+function renderConsentGuard(args: ConsentGuardArgs): ReactElement | undefined {
   const {
     interactionUid,
     ready,
@@ -233,7 +233,7 @@ function renderConsentGuard(args: ConsentGuardArgs): ReactElement | null {
       </Layout>
     );
   }
-  return null;
+  return undefined;
 }
 
 export function OAuthConsentClient() {
@@ -311,7 +311,15 @@ export function OAuthConsentClient() {
   });
   if (guard) return guard;
 
-  if (!interactionQuery.data) return null;
+  // Defensive: renderConsentGuard already handles every !interactionQuery.data
+  // branch, but TS narrowing doesn't carry across the function boundary.
+  if (!interactionQuery.data) {
+    return (
+      <Layout>
+        <Skeleton />
+      </Layout>
+    );
+  }
   const client = interactionQuery.data.client;
   const clientName = client?.clientName ?? client?.clientId ?? "Unknown app";
   const logoUri = client?.logoUri ?? null;


### PR DESCRIPTION
## Summary
- Restructure the OAuth consent body into role-based sections ("As a grant operator" / "As a project or non-profit") so users see exactly what scopes apply to them instead of a generic MCP-tooling blurb. Adds a reassurance line — "{clientName} can only do what you can do. You can revoke access anytime."
- Replace the wallet address in "Signed in as" with a friendlier identifier resolved from the Privy user: email → Google email → Farcaster display name/username → shortened wallet address as the fallback. Matches the priority used in `DashboardHeader.tsx`.

Both `clientName` references stay dynamic so the copy reads correctly for Claude, Cursor, or any future MCP client.

## Test plan
- [ ] Visit `/oauth/consent?interaction=<uid>` from a real MCP flow (or via a DCR helper) and verify the new sections render with the requesting client's name
- [ ] Email-login user: "Signed in as" shows the email address
- [ ] Google-login user: "Signed in as" shows the Google email
- [ ] Farcaster-login user: shows display name or username
- [ ] Wallet-only user: still falls back to the shortened `0x1234…abcd` form
- [ ] Confirm Allow/Cancel flows still redirect correctly (no behavioral changes intended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth consent screen to display user email address in place of wallet address when available.
  * Restructured permissions explanation to clarify allowed actions per grant operator and revocation options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1403)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->