### PR TITLE
fix: add American spelling "user canceled" to isUserCancellationError

### DIFF
--- a/utilities/wallet-errors.ts
+++ b/utilities/wallet-errors.ts
@@ -4,7 +4,8 @@
  *
  * Covers MetaMask (code 4001, "User rejected"), Privy embedded wallet
  * ("Signature rejected"), and other common wallet providers ("user denied",
- * "user cancelled"). Also unwraps errors nested under `originalError`.
+ * "user cancelled", "user canceled"). Also unwraps errors nested under
+ * `originalError`.
  */
 export function isUserCancellationError(error: unknown): boolean {
   const err = error as Record<string, any> | null | undefined;
@@ -17,6 +18,7 @@ export function isUserCancellationError(error: unknown): boolean {
       msg.includes("user rejected") ||
       msg.includes("user denied") ||
       msg.includes("user cancelled") ||
+      msg.includes("user canceled") ||
       msg.includes("signature rejected") ||
       layer?.name === "UserRejectedRequestError"
     );


### PR DESCRIPTION
## Summary

Fixes #1194

`isUserCancellationError` in `utilities/wallet-errors.ts` only checked for the British spelling `"user cancelled"` but not the American spelling `"user canceled"`. Some wallets (notably WalletConnect) emit `"user canceled transaction"` which would not be detected as a user cancellation.

## Changes

- Added `msg.includes("user canceled")` alongside the existing `msg.includes("user cancelled")` check
- Updated JSDoc to reflect the new coverage

## Impact

Without this fix, WalletConnect errors with American spelling fall through to the generic error path, showing a misleading error message instead of "Grant completion cancelled".

---
*Generated with Auto Bounty Hunter.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of user-initiated cancellation and rejection errors to recognize additional message variations across different providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1405)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->