### PR TITLE
fix(project-impacts): treat null API response as empty, not an error

### DIFF
--- a/services/project-impacts.service.ts
+++ b/services/project-impacts.service.ts
@@ -35,10 +35,14 @@ export const getProjectImpacts = async (projectIdOrSlug: string): Promise<Projec
     INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug)
   );
 
-  if (error || !data) {
+  if (error) {
     errorManager(`Project Impacts API Error: ${error}`, error, {
       context: "project-impacts.service",
     });
+    return [];
+  }
+
+  if (!Array.isArray(data)) {
     return [];
   }
 


### PR DESCRIPTION
## Summary

\`getProjectImpacts\` was treating \`data: null\` as a Sentry-worthy error. The indexer legitimately returns \`null\` for projects that have no impacts, and the combined guard \`if (error || !data)\` kept escalating those cases to Sentry as \`Project Impacts API Error: null\`. Split the guard so real errors still report, but null/non-array responses resolve to \`[]\` silently.

Closes GAP-FRONTEND-1YJ (DEV-242).

## Why this PR (and not #1385)

DEV-242's Linear title mentions \`/project/-nan-12\` which suggested a malformed-slug bug. The actual Sentry events tell a different story:

- Latest event today (2026-05-13 15:18) on \`/project/anu-in\`
- 554+ occurrences, all from **valid** project slugs (\`anu-in\`, \`zali\`, …)
- Error message: \`Project Impacts API Error: null\` — meaning \`error\` is null **and** \`data\` is null, both legitimate "no impacts" signals
- Stack trace points to \`project-impacts.service.ts:38\`, not the project route param parser

#1385 adds regex guards for malformed slugs in \`getProjectCachedData.ts\`. Useful defensively, but Next.js routing and the indexer already 404 on clearly malformed slugs, so that PR wouldn't have reduced the 554 events from valid slugs. Closing it in favor of this fix that targets the actual source.

## The change

\`\`\`diff
-  if (error || !data) {
+  if (error) {
     errorManager(\`Project Impacts API Error: \${error}\`, error, {
       context: \"project-impacts.service\",
     });
     return [];
   }
+
+  if (!Array.isArray(data)) {
+    return [];
+  }

   return data;
\`\`\`

A real error still goes to Sentry. A null / non-array response just becomes an empty array, same observable outcome to the page (renders the empty state) without flagging it as a backend failure.

## Verification

- \`pnpm exec biome check services/project-impacts.service.ts\` → clean
- Manual: hitting \`/project/anu-in\` (or any project with no impact records) currently fires the Sentry event. After this fix, the page renders the same empty state without firing.

## Follow up (separate work)

The indexer endpoint \`GET /projects/:idOrSlug/impacts\` could also be hardened to always return \`[]\` instead of \`null\` for the "no impacts" case. That's a backend cleanup; this PR is the FE-side stop-the-bleeding fix.

Refs DEV-242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and data validation for project impacts retrieval to ensure more reliable results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1406)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->