### PR TITLE
feat(application-detail): admin Milestones tab + inline status badges

### DIFF
--- a/__tests__/features/applications/MilestoneStatusBadge.test.tsx
+++ b/__tests__/features/applications/MilestoneStatusBadge.test.tsx
@@ -3,7 +3,7 @@
  *
  * The badge resolves a single status string from the four-state
  * hierarchy:
- *   Verified > PendingVerification > Late > Pending
+ *   Verified > PendingVerification > PastDue > Pending
  *
  * Inputs come from the server-merged `milestoneStatuses[]` entry; the
  * tab consumes the same entry shape but a different render. These
@@ -62,7 +62,7 @@ describe("MilestoneStatusBadge", () => {
     expect(screen.getByText("Pending Verification")).toBeInTheDocument();
   });
 
-  it("should_render_Late_when_dueDate_is_past_and_not_completed", () => {
+  it("should_render_Past_Due_when_dueDate_is_past_and_not_completed", () => {
     render(
       <MilestoneStatusBadge
         entry={makeEntry({
@@ -71,12 +71,12 @@ describe("MilestoneStatusBadge", () => {
         })}
       />
     );
-    expect(screen.getByText("Late")).toBeInTheDocument();
+    expect(screen.getByText("Past Due")).toBeInTheDocument();
   });
 
-  it("should_not_render_Late_when_completed_even_if_dueDate_is_past", () => {
-    // A completed milestone never reclassifies as Late — completion
-    // wins over due-date arithmetic.
+  it("should_not_render_Past_Due_when_completed_even_if_dueDate_is_past", () => {
+    // A completed milestone never reclassifies as Past Due —
+    // completion wins over due-date arithmetic.
     render(
       <MilestoneStatusBadge
         entry={makeEntry({
@@ -87,7 +87,7 @@ describe("MilestoneStatusBadge", () => {
       />
     );
     expect(screen.getByText("Pending Verification")).toBeInTheDocument();
-    expect(screen.queryByText("Late")).not.toBeInTheDocument();
+    expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
   });
 
   it("should_render_Pending_when_entry_is_undefined", () => {

--- a/__tests__/features/applications/MilestoneStatusBadge.test.tsx
+++ b/__tests__/features/applications/MilestoneStatusBadge.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for MilestoneStatusBadge.
+ *
+ * The badge resolves a single status string from the four-state
+ * hierarchy:
+ *   Verified > PendingVerification > Late > Pending
+ *
+ * Inputs come from the server-merged `milestoneStatuses[]` entry; the
+ * tab consumes the same entry shape but a different render. These
+ * tests pin the hierarchy and the canonical label set so a status
+ * relabel in the helpers (`isMilestoneVerified`/etc.) trips here.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MilestoneStatusBadge } from "@/src/features/applications/components/MilestoneStatusBadge";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
+
+function makeEntry(overrides: Partial<MilestoneStatusEntry> = {}): MilestoneStatusEntry {
+  return {
+    source: "application",
+    milestoneUID: "0xms-default",
+    currentStatus: "pending",
+    grantUID: "0xgrant",
+    chainID: 10,
+    title: "Default milestone",
+    ...overrides,
+  };
+}
+
+describe("MilestoneStatusBadge", () => {
+  it("should_render_Verified_when_currentStatus_is_verified", () => {
+    render(<MilestoneStatusBadge entry={makeEntry({ currentStatus: "verified" })} />);
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("should_render_Verified_when_verified_payload_present_regardless_of_currentStatus", () => {
+    // The currentStatus string can lag the on-chain attestation; a
+    // present `verified` payload is the canonical source of truth.
+    render(
+      <MilestoneStatusBadge
+        entry={makeEntry({
+          currentStatus: "pending",
+          verified: { uid: "v1", attester: "0xa", createdAt: "2026-01-01" },
+        })}
+      />
+    );
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("should_render_PendingVerification_when_completed_but_not_yet_verified", () => {
+    // Canonical label for "done but unverified" — replaces the older
+    // "Completed" wording which conflated the verified and unverified
+    // post-completion states.
+    render(
+      <MilestoneStatusBadge
+        entry={makeEntry({
+          currentStatus: "completed",
+          completed: { uid: "c1", createdAt: "2026-01-01" },
+        })}
+      />
+    );
+    expect(screen.getByText("Pending Verification")).toBeInTheDocument();
+  });
+
+  it("should_render_Late_when_dueDate_is_past_and_not_completed", () => {
+    render(
+      <MilestoneStatusBadge
+        entry={makeEntry({
+          currentStatus: "pending",
+          dueDate: "2020-01-01",
+        })}
+      />
+    );
+    expect(screen.getByText("Late")).toBeInTheDocument();
+  });
+
+  it("should_not_render_Late_when_completed_even_if_dueDate_is_past", () => {
+    // A completed milestone never reclassifies as Late — completion
+    // wins over due-date arithmetic.
+    render(
+      <MilestoneStatusBadge
+        entry={makeEntry({
+          currentStatus: "completed",
+          dueDate: "2020-01-01",
+          completed: { uid: "c1", createdAt: "2020-02-01" },
+        })}
+      />
+    );
+    expect(screen.getByText("Pending Verification")).toBeInTheDocument();
+    expect(screen.queryByText("Late")).not.toBeInTheDocument();
+  });
+
+  it("should_render_Pending_when_entry_is_undefined", () => {
+    // Missing entry means the milestone hasn't been linked on-chain
+    // yet — treat as Pending (the indexer's default).
+    render(<MilestoneStatusBadge />);
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("should_render_Pending_for_a_fresh_entry_with_no_completion_or_verification", () => {
+    render(<MilestoneStatusBadge entry={makeEntry({ dueDate: "2099-01-01" })} />);
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+});

--- a/__tests__/features/applications/MilestonesTab.test.tsx
+++ b/__tests__/features/applications/MilestonesTab.test.tsx
@@ -59,7 +59,7 @@ vi.mock("@/src/features/applications/components/OnChainMilestoneRow", () => ({
   ),
 }));
 
-import { MilestonesTab } from "@/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/MilestonesTab";
+import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
 
 const REF = "REF-MS-1";
 const PROJECT_UID = "0xproject1";
@@ -97,15 +97,42 @@ beforeEach(() => {
 });
 
 describe("MilestonesTab", () => {
-  it("should_render_empty_state_when_milestoneStatuses_is_empty", () => {
-    render(<MilestonesTab application={makeApplication()} isOwner={false} />);
+  it("should_render_setting_up_state_when_application_approved_but_milestoneStatuses_empty", () => {
+    // Lifecycle window: status flips to "approved" → project created →
+    // grant attested → milestones attested. "No milestones defined" is
+    // wrong copy for that transient window — it implies permanent
+    // absence.
+    render(
+      <MilestonesTab
+        application={makeApplication({ status: "approved", milestoneStatuses: [] })}
+        isOwner={false}
+      />
+    );
+
+    expect(screen.getByText(/Setting up milestones/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No milestones defined/i)).not.toBeInTheDocument();
+  });
+
+  it("should_render_no_milestones_defined_when_unapproved_and_milestoneStatuses_empty", () => {
+    // Pre-approval there's no grant on-chain yet; the empty state copy
+    // should reflect "no milestones to show", not the post-approval
+    // transient hint.
+    render(
+      <MilestonesTab
+        application={makeApplication({ status: "pending", milestoneStatuses: [] })}
+        isOwner={false}
+      />
+    );
 
     expect(screen.getByText(/No milestones defined for this application/i)).toBeInTheDocument();
-    expect(screen.queryAllByTestId(/-row$/)).toHaveLength(0);
+    expect(screen.queryByText(/Setting up milestones/i)).not.toBeInTheDocument();
   });
 
   it("should_render_empty_state_when_milestoneStatuses_is_undefined", () => {
-    const application = makeApplication({ milestoneStatuses: undefined });
+    const application = makeApplication({
+      status: "pending",
+      milestoneStatuses: undefined,
+    });
     render(<MilestonesTab application={application} isOwner={false} />);
 
     expect(screen.getByText(/No milestones defined for this application/i)).toBeInTheDocument();

--- a/__tests__/features/applications/milestone-status-lookup.test.ts
+++ b/__tests__/features/applications/milestone-status-lookup.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for buildMilestoneStatusIndex and lookupMilestoneStatus.
+ *
+ * The lookup helpers are the load-bearing glue between the indexer's
+ * server-merged milestoneStatuses[] and the inline badge overlays on
+ * ApplicationContent / ApplicationDataView. Same-title milestones
+ * across different fields are common (e.g. two fields each with
+ * "Milestone 1"), so the (fieldLabel, title) fallback key has to
+ * discriminate by fieldLabel.
+ */
+
+import {
+  buildMilestoneStatusIndex,
+  lookupMilestoneStatus,
+} from "@/src/features/applications/lib/milestone-status";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
+
+function makeEntry(overrides: Partial<MilestoneStatusEntry> = {}): MilestoneStatusEntry {
+  return {
+    source: "application",
+    milestoneUID: "0xms-default",
+    currentStatus: "pending",
+    grantUID: "0xgrant",
+    chainID: 10,
+    title: "Default milestone",
+    ...overrides,
+  };
+}
+
+describe("buildMilestoneStatusIndex", () => {
+  it("should_return_empty_index_when_entries_undefined", () => {
+    const index = buildMilestoneStatusIndex(undefined);
+    expect(index.size).toBe(0);
+  });
+
+  it("should_return_empty_index_when_entries_empty", () => {
+    const index = buildMilestoneStatusIndex([]);
+    expect(index.size).toBe(0);
+  });
+
+  it("should_index_each_entry_by_uid_when_milestoneUID_is_present", () => {
+    const a = makeEntry({ milestoneUID: "0xa", title: "A" });
+    const b = makeEntry({ milestoneUID: "0xb", title: "B" });
+
+    const index = buildMilestoneStatusIndex([a, b]);
+
+    expect(index.get("uid:0xa")).toBe(a);
+    expect(index.get("uid:0xb")).toBe(b);
+  });
+
+  it("should_index_each_entry_by_label_composite_key", () => {
+    const a = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "projectMilestones",
+      title: "Beta launch",
+    });
+    const b = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "extraDeliverables",
+      title: "Beta launch",
+    });
+
+    const index = buildMilestoneStatusIndex([a, b]);
+
+    // Same title across different fields stays disambiguated.
+    expect(index.get("label:projectMilestones:Beta launch")).toBe(a);
+    expect(index.get("label:extraDeliverables:Beta launch")).toBe(b);
+  });
+
+  it("should_index_by_both_keys_when_milestoneUID_present_and_fieldLabel_present", () => {
+    const a = makeEntry({
+      milestoneUID: "0xa",
+      fieldLabel: "projectMilestones",
+      title: "Beta launch",
+    });
+
+    const index = buildMilestoneStatusIndex([a]);
+
+    expect(index.get("uid:0xa")).toBe(a);
+    expect(index.get("label:projectMilestones:Beta launch")).toBe(a);
+  });
+});
+
+describe("lookupMilestoneStatus", () => {
+  it("should_prefer_uid_match_when_milestoneUID_is_known", () => {
+    const a = makeEntry({
+      milestoneUID: "0xa",
+      fieldLabel: "projectMilestones",
+      title: "Beta launch",
+    });
+    const index = buildMilestoneStatusIndex([a]);
+
+    // Wrong title, but uid hits — should still resolve to a.
+    expect(lookupMilestoneStatus(index, "0xa", "wrong", "wrong")).toBe(a);
+  });
+
+  it("should_fall_back_to_label_composite_when_milestoneUID_is_absent", () => {
+    const a = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "projectMilestones",
+      title: "Beta launch",
+    });
+    const index = buildMilestoneStatusIndex([a]);
+
+    expect(
+      lookupMilestoneStatus(index, undefined, "projectMilestones", "Beta launch")
+    ).toBe(a);
+  });
+
+  it("should_fall_back_to_label_composite_when_uid_does_not_hit", () => {
+    // Stale milestoneUID from a prior version — the entry no longer
+    // exposes it but the title+fieldLabel still matches.
+    const a = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "projectMilestones",
+      title: "Beta launch",
+    });
+    const index = buildMilestoneStatusIndex([a]);
+
+    expect(
+      lookupMilestoneStatus(index, "0xstale", "projectMilestones", "Beta launch")
+    ).toBe(a);
+  });
+
+  it("should_return_undefined_when_neither_key_hits", () => {
+    const index = buildMilestoneStatusIndex([
+      makeEntry({ milestoneUID: "0xa", fieldLabel: "projectMilestones", title: "A" }),
+    ]);
+
+    expect(lookupMilestoneStatus(index, "0xother", "otherField", "Other")).toBeUndefined();
+  });
+
+  it("should_disambiguate_same_title_entries_by_fieldLabel", () => {
+    const inField1 = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "field1",
+      title: "Milestone 1",
+    });
+    const inField2 = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "field2",
+      title: "Milestone 1",
+    });
+    const index = buildMilestoneStatusIndex([inField1, inField2]);
+
+    expect(lookupMilestoneStatus(index, undefined, "field1", "Milestone 1")).toBe(inField1);
+    expect(lookupMilestoneStatus(index, undefined, "field2", "Milestone 1")).toBe(inField2);
+  });
+});

--- a/__tests__/features/applications/milestone-status-lookup.test.ts
+++ b/__tests__/features/applications/milestone-status-lookup.test.ts
@@ -63,8 +63,8 @@ describe("buildMilestoneStatusIndex", () => {
     const index = buildMilestoneStatusIndex([a, b]);
 
     // Same title across different fields stays disambiguated.
-    expect(index.get("label:projectMilestones:Beta launch")).toBe(a);
-    expect(index.get("label:extraDeliverables:Beta launch")).toBe(b);
+    expect(lookupMilestoneStatus(index, undefined, "projectMilestones", "Beta launch")).toBe(a);
+    expect(lookupMilestoneStatus(index, undefined, "extraDeliverables", "Beta launch")).toBe(b);
   });
 
   it("should_index_by_both_keys_when_milestoneUID_present_and_fieldLabel_present", () => {
@@ -77,7 +77,7 @@ describe("buildMilestoneStatusIndex", () => {
     const index = buildMilestoneStatusIndex([a]);
 
     expect(index.get("uid:0xa")).toBe(a);
-    expect(index.get("label:projectMilestones:Beta launch")).toBe(a);
+    expect(lookupMilestoneStatus(index, undefined, "projectMilestones", "Beta launch")).toBe(a);
   });
 
   it("should_resolve_intra_field_same_title_collisions_first_write_wins", () => {
@@ -102,8 +102,38 @@ describe("buildMilestoneStatusIndex", () => {
 
     const index = buildMilestoneStatusIndex([pending, completed]);
 
-    expect(index.get("label:projectMilestones:Milestone 1")).toBe(pending);
-    expect(index.get("label:projectMilestones:Milestone 1")).not.toBe(completed);
+    const resolved = lookupMilestoneStatus(
+      index,
+      undefined,
+      "projectMilestones",
+      "Milestone 1"
+    );
+    expect(resolved).toBe(pending);
+    expect(resolved).not.toBe(completed);
+  });
+
+  it("should_not_collide_when_title_contains_a_colon", () => {
+    // A plain `${fieldLabel}:${title}` concatenation would key both
+    // entries below to the same string ("label:a:b:c"), silently
+    // overwriting the first. JSON-encoding the tuple keeps the array
+    // boundaries unambiguous so colons in user-input titles can't
+    // forge a colliding key. Titles like "Phase 1: Beta launch" and
+    // "Milestone 2: Testing" are common in real grantee submissions.
+    const titleHasColon = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "a",
+      title: "b:c",
+    });
+    const fieldHasColon = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "a:b",
+      title: "c",
+    });
+
+    const index = buildMilestoneStatusIndex([titleHasColon, fieldHasColon]);
+
+    expect(lookupMilestoneStatus(index, undefined, "a", "b:c")).toBe(titleHasColon);
+    expect(lookupMilestoneStatus(index, undefined, "a:b", "c")).toBe(fieldHasColon);
   });
 });
 

--- a/__tests__/features/applications/milestone-status-lookup.test.ts
+++ b/__tests__/features/applications/milestone-status-lookup.test.ts
@@ -79,6 +79,32 @@ describe("buildMilestoneStatusIndex", () => {
     expect(index.get("uid:0xa")).toBe(a);
     expect(index.get("label:projectMilestones:Beta launch")).toBe(a);
   });
+
+  it("should_resolve_intra_field_same_title_collisions_first_write_wins", () => {
+    // Two un-anchored milestones in the SAME field with the SAME
+    // title. The indexer sorts done entries to the bottom, so the
+    // first hit (pending) is the one a displayed badge most likely
+    // refers to. Last-write-wins would silently stamp the displayed
+    // milestone as "Completed" when the live one is still pending.
+    const pending = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "projectMilestones",
+      title: "Milestone 1",
+      currentStatus: "pending",
+    });
+    const completed = makeEntry({
+      milestoneUID: undefined,
+      fieldLabel: "projectMilestones",
+      title: "Milestone 1",
+      currentStatus: "completed",
+      completed: { uid: "c1", createdAt: "2026-01-01" },
+    });
+
+    const index = buildMilestoneStatusIndex([pending, completed]);
+
+    expect(index.get("label:projectMilestones:Milestone 1")).toBe(pending);
+    expect(index.get("label:projectMilestones:Milestone 1")).not.toBe(completed);
+  });
 });
 
 describe("lookupMilestoneStatus", () => {

--- a/__tests__/features/applications/use-milestones-admin-refetch.test.tsx
+++ b/__tests__/features/applications/use-milestones-admin-refetch.test.tsx
@@ -24,6 +24,10 @@ function setDocumentVisibility(state: "visible" | "hidden") {
 describe("useMilestonesAdminRefetch", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // Reset document.visibilityState every test — Object.defineProperty
+    // on document mutates a global, so a prior test leaving the tab
+    // "hidden" would leak into the next one's polling assertion.
+    setDocumentVisibility("visible");
   });
 
   afterEach(() => {
@@ -61,7 +65,9 @@ describe("useMilestonesAdminRefetch", () => {
     expect(refetch).not.toHaveBeenCalled();
   });
 
-  it("should_refetch_every_interval_while_isActive", () => {
+  it("should_refetch_every_interval_while_isActive_and_document_is_visible", () => {
+    // jsdom defaults visibilityState to "visible", so the polling
+    // fires normally.
     const refetch = vi.fn();
     renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch, intervalMs: 5_000 }));
 
@@ -74,6 +80,43 @@ describe("useMilestonesAdminRefetch", () => {
       vi.advanceTimersByTime(15_000);
     });
     expect(refetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("should_skip_interval_refetch_when_document_is_hidden", () => {
+    // An admin who walks away from the browser tab shouldn't generate
+    // 60s background refetches piling up. The visibilitychange handler
+    // catches the come-back case; the interval just needs to honor
+    // the same hidden/visible gate.
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch, intervalMs: 5_000 }));
+
+    setDocumentVisibility("hidden");
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("should_resume_interval_refetch_when_document_returns_to_visible", () => {
+    // Confirms the gate is per-tick, not per-mount — flipping back to
+    // visible re-engages the polling without remounting the hook.
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch, intervalMs: 5_000 }));
+
+    setDocumentVisibility("hidden");
+    act(() => {
+      vi.advanceTimersByTime(10_000); // 2 hidden ticks, both skipped
+    });
+    expect(refetch).not.toHaveBeenCalled();
+
+    setDocumentVisibility("visible"); // one immediate refetch via visibilitychange
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(5_000); // one more from the interval
+    });
+    expect(refetch).toHaveBeenCalledTimes(2);
   });
 
   it("should_stop_polling_when_isActive_flips_to_false", () => {

--- a/__tests__/features/applications/use-milestones-admin-refetch.test.tsx
+++ b/__tests__/features/applications/use-milestones-admin-refetch.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for useMilestonesAdminRefetch.
+ *
+ * Two refresh triggers:
+ *   1. `document.visibilitychange` → refetch when document becomes
+ *      visible.
+ *   2. `setInterval(refetch, intervalMs)` → periodic poll.
+ *
+ * Both gated by `isActive`. Cleanup must tear down both on unmount or
+ * isActive flipping false.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { useMilestonesAdminRefetch } from "@/src/features/applications/hooks/use-milestones-admin-refetch";
+
+function setDocumentVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useMilestonesAdminRefetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should_be_a_noop_when_isActive_is_false", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: false, refetch }));
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+    setDocumentVisibility("visible");
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("should_refetch_when_document_becomes_visible_and_isActive_is_true", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch }));
+
+    setDocumentVisibility("hidden");
+    setDocumentVisibility("visible");
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_not_refetch_when_visibility_flips_to_hidden", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch }));
+
+    setDocumentVisibility("hidden");
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("should_refetch_every_interval_while_isActive", () => {
+    const refetch = vi.fn();
+    renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch, intervalMs: 5_000 }));
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(refetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("should_stop_polling_when_isActive_flips_to_false", () => {
+    const refetch = vi.fn();
+    const { rerender } = renderHook(
+      ({ isActive }: { isActive: boolean }) =>
+        useMilestonesAdminRefetch({ isActive, refetch, intervalMs: 5_000 }),
+      { initialProps: { isActive: true } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    rerender({ isActive: false });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should_remove_visibility_listener_on_unmount", () => {
+    const refetch = vi.fn();
+    const { unmount } = renderHook(() => useMilestonesAdminRefetch({ isActive: true, refetch }));
+
+    unmount();
+    setDocumentVisibility("hidden");
+    setDocumentVisibility("visible");
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -12,12 +12,12 @@ import { Role } from "@/src/core/rbac/types/role";
 import { CommentTimeline } from "@/src/features/application-comments/components/CommentTimeline";
 import { PublicComments } from "@/src/features/application-comments/components/PublicComments";
 import { ApplicationStatusHistory } from "@/src/features/applications/components/ApplicationStatusHistory";
+import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
 import { useApplicationAccess } from "@/src/features/applications/hooks/use-application-access";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
 import type { Application, ApplicationStatus, FundingProgram } from "@/types/whitelabel-entities";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
-import { MilestonesTab } from "./components/MilestonesTab";
 import { PostApprovalTab } from "./components/PostApprovalTab";
 
 interface ApplicationPageClientProps {

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -43,6 +43,8 @@ import {
   useIsFundingPlatformAdmin,
 } from "@/src/core/rbac";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
+import { useMilestonesAdminRefetch } from "@/src/features/applications/hooks/use-milestones-admin-refetch";
 import { layoutTheme } from "@/src/helper/theme";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication } from "@/types/funding-platform";
@@ -82,6 +84,12 @@ export default function ApplicationDetailPage() {
   // View mode state for ApplicationContent
   const [applicationViewMode, setApplicationViewMode] = useState<"details" | "changes">("details");
 
+  // Active-tab id — used to gate the milestones admin refetch hook
+  // (don't poll when admin is looking at AI Analysis or Comments).
+  // Seeded from `?tab=` so deep-links land on the right active id
+  // without waiting for an onChange event.
+  const [activeTabId, setActiveTabId] = useState<string>(tabParam ?? "application");
+
   // Delete modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
@@ -101,6 +109,16 @@ export default function ApplicationDetailPage() {
     isLoading: isLoadingApplication,
     refetch: refetchApplication,
   } = useApplication(applicationId);
+
+  // Keep the milestones tab fresh on long-lived admin sessions. Active
+  // only when the admin is viewing the Milestones tab AND the
+  // application is approved (the only state in which milestones can
+  // exist on this surface).
+  const isApprovedApplication = application?.status?.toLowerCase() === "approved";
+  useMilestonesAdminRefetch({
+    isActive: activeTabId === "milestones" && isApprovedApplication,
+    refetch: refetchApplication,
+  });
 
   // Fetch program config
   const { data: program, config } = useProgramConfig(programId);
@@ -456,7 +474,7 @@ export default function ApplicationDetailPage() {
 
           {/* Tab-based Layout */}
           {(() => {
-            const tabs = [
+            const tabs: TabConfig[] = [
               {
                 id: "application",
                 label: "Application",
@@ -472,6 +490,23 @@ export default function ApplicationDetailPage() {
                   </TabPanel>
                 ),
               },
+              // Milestones tab only renders once the application is
+              // approved — pre-approval there's no grant on-chain yet
+              // and `milestoneStatuses[]` is always empty.
+              ...(isApprovedApplication
+                ? [
+                    {
+                      id: "milestones",
+                      label: "Milestones",
+                      icon: TabIcons.Milestones,
+                      content: (
+                        <TabPanel>
+                          <MilestonesTab application={application} isOwner={false} />
+                        </TabPanel>
+                      ),
+                    } satisfies TabConfig,
+                  ]
+                : []),
               {
                 id: "ai-analysis",
                 label: "AI Analysis",
@@ -512,18 +547,25 @@ export default function ApplicationDetailPage() {
                   </TabPanel>
                 ),
               },
-            ] satisfies TabConfig[];
+            ];
 
-            // Derive tab index from the tab id rather than hardcoding "2" —
-            // prevents silent breakage if tabs are reordered.
+            // Derive tab index from the tab id rather than hardcoding —
+            // prevents silent breakage when the Milestones tab is or isn't
+            // present.
             const tabParamIndex = tabParam ? tabs.findIndex((t) => t.id === tabParam) : -1;
             const defaultIndex = tabParamIndex >= 0 ? tabParamIndex : 0;
+
+            const handleTabChange = (index: number) => {
+              const tab = tabs[index];
+              if (tab) setActiveTabId(tab.id);
+            };
 
             return (
               <ApplicationTabs
                 connectedToHeader={!milestoneReviewUrl && !selectedStatus}
                 defaultIndex={defaultIndex}
                 tabs={tabs}
+                onChange={handleTabChange}
               />
             );
           })()}

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx
@@ -51,6 +51,16 @@ import type { IFundingApplication } from "@/types/funding-platform";
 import { PAGES } from "@/utilities/pages";
 import { isFundingProgramConfig } from "@/utilities/type-guards";
 
+// Whitelist used when seeding activeTabId from the `?tab=` query
+// param. Keeps unknown values from drifting the polling-gate state
+// away from the actually-rendered tab.
+const KNOWN_TAB_IDS = ["application", "milestones", "ai-analysis", "comments"] as const;
+type KnownTabId = (typeof KNOWN_TAB_IDS)[number];
+
+function isKnownTabId(value: string | null): value is KnownTabId {
+  return value !== null && (KNOWN_TAB_IDS as readonly string[]).includes(value);
+}
+
 export default function ApplicationDetailPage() {
   const router = useRouter();
   const {
@@ -87,8 +97,15 @@ export default function ApplicationDetailPage() {
   // Active-tab id — used to gate the milestones admin refetch hook
   // (don't poll when admin is looking at AI Analysis or Comments).
   // Seeded from `?tab=` so deep-links land on the right active id
-  // without waiting for an onChange event.
-  const [activeTabId, setActiveTabId] = useState<string>(tabParam ?? "application");
+  // without waiting for an onChange event. Validated against
+  // KNOWN_TAB_IDS to keep unknown deep-link values from drifting the
+  // state away from the actually-rendered tab. The post-load
+  // reconcile useEffect below also corrects `?tab=milestones` on a
+  // non-approved application (where the Milestones tab is filtered
+  // out at render time).
+  const [activeTabId, setActiveTabId] = useState<KnownTabId>(() =>
+    isKnownTabId(tabParam) ? tabParam : "application"
+  );
 
   // Delete modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -119,6 +136,18 @@ export default function ApplicationDetailPage() {
     isActive: activeTabId === "milestones" && isApprovedApplication,
     refetch: refetchApplication,
   });
+
+  // Reconcile activeTabId once the application loads: if the seed
+  // came from `?tab=milestones` but this application doesn't expose a
+  // Milestones tab (non-approved), correct to "application" so the
+  // state doesn't lie about what's rendered. Only runs when we know
+  // the application's approval status (i.e. application is loaded).
+  useEffect(() => {
+    if (!application) return;
+    if (activeTabId === "milestones" && !isApprovedApplication) {
+      setActiveTabId("application");
+    }
+  }, [application, activeTabId, isApprovedApplication]);
 
   // Fetch program config
   const { data: program, config } = useProgramConfig(programId);
@@ -557,7 +586,7 @@ export default function ApplicationDetailPage() {
 
             const handleTabChange = (index: number) => {
               const tab = tabs[index];
-              if (tab) setActiveTabId(tab.id);
+              if (tab && isKnownTabId(tab.id)) setActiveTabId(tab.id);
             };
 
             return (

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -14,9 +14,12 @@ import { KarmaProjectLink } from "@/components/FundingPlatform/shared/KarmaProje
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { useApplicationVersions } from "@/hooks/useFundingPlatform";
 import { MilestoneStatusBadge } from "@/src/features/applications/components/MilestoneStatusBadge";
+import {
+  buildMilestoneStatusIndex,
+  lookupMilestoneStatus,
+} from "@/src/features/applications/lib/milestone-status";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
-import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
@@ -112,17 +115,10 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
   const viewMode = controlledViewMode ?? internalViewMode;
   const setViewMode = onViewModeChange ?? setInternalViewMode;
 
-  // Lookup index over the server-merged milestoneStatuses[]. Keyed by
-  // milestoneUID first (most reliable) with a (fieldLabel, title)
-  // fallback for application-source slots not yet anchored on-chain.
-  const milestoneStatusByKey = useMemo(() => {
-    const m = new Map<string, MilestoneStatusEntry>();
-    for (const e of application.milestoneStatuses ?? []) {
-      if (e.milestoneUID) m.set(`uid:${e.milestoneUID}`, e);
-      m.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
-    }
-    return m;
-  }, [application.milestoneStatuses]);
+  const milestoneStatusByKey = useMemo(
+    () => buildMilestoneStatusIndex(application.milestoneStatuses),
+    [application.milestoneStatuses]
+  );
 
   // Get UI state from Zustand store
   const { selectedVersion } = useApplicationVersionsStore();
@@ -240,10 +236,12 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
                 (key) => !coreFields.includes(key) && milestone[key]
               );
 
-              const milestoneUID = milestone.milestoneUID;
-              const milestoneStatus =
-                (milestoneUID && milestoneStatusByKey.get(`uid:${milestoneUID}`)) ||
-                milestoneStatusByKey.get(`label:${fieldKey ?? ""}:${milestone.title}`);
+              const milestoneStatus = lookupMilestoneStatus(
+                milestoneStatusByKey,
+                milestone.milestoneUID,
+                fieldKey,
+                milestone.title
+              );
 
               return (
                 <div

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -13,8 +13,10 @@ import toast from "react-hot-toast";
 import { KarmaProjectLink } from "@/components/FundingPlatform/shared/KarmaProjectLink";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { useApplicationVersions } from "@/hooks/useFundingPlatform";
+import { MilestoneStatusBadge } from "@/src/features/applications/components/MilestoneStatusBadge";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
@@ -109,6 +111,18 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
   // Use controlled mode if provided, otherwise use internal state
   const viewMode = controlledViewMode ?? internalViewMode;
   const setViewMode = onViewModeChange ?? setInternalViewMode;
+
+  // Lookup index over the server-merged milestoneStatuses[]. Keyed by
+  // milestoneUID first (most reliable) with a (fieldLabel, title)
+  // fallback for application-source slots not yet anchored on-chain.
+  const milestoneStatusByKey = useMemo(() => {
+    const m = new Map<string, MilestoneStatusEntry>();
+    for (const e of application.milestoneStatuses ?? []) {
+      if (e.milestoneUID) m.set(`uid:${e.milestoneUID}`, e);
+      m.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
+    }
+    return m;
+  }, [application.milestoneStatuses]);
 
   // Get UI state from Zustand store
   const { selectedVersion } = useApplicationVersionsStore();
@@ -226,6 +240,11 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
                 (key) => !coreFields.includes(key) && milestone[key]
               );
 
+              const milestoneUID = milestone.milestoneUID;
+              const milestoneStatus =
+                (milestoneUID && milestoneStatusByKey.get(`uid:${milestoneUID}`)) ||
+                milestoneStatusByKey.get(`label:${fieldKey ?? ""}:${milestone.title}`);
+
               return (
                 <div
                   key={index}
@@ -233,10 +252,13 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
                 >
                   <div className="space-y-2">
                     {/* Title and Due Date - Core fields with special rendering */}
-                    <div className="flex justify-between items-start">
-                      <h5 className="font-medium text-gray-900 dark:text-gray-100">
-                        {milestone.title}
-                      </h5>
+                    <div className="flex justify-between items-start gap-2">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <h5 className="font-medium text-gray-900 dark:text-gray-100">
+                          {milestone.title}
+                        </h5>
+                        <MilestoneStatusBadge entry={milestoneStatus} />
+                      </div>
                       {milestone.dueDate && (
                         <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">
                           Due: {formatDate(milestone.dueDate)}

--- a/components/FundingPlatform/ApplicationView/ApplicationTab/ApplicationDataView.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationTab/ApplicationDataView.tsx
@@ -5,12 +5,15 @@ import { useMemo } from "react";
 import { KarmaProjectLink } from "@/components/FundingPlatform/shared/KarmaProjectLink";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { MilestoneStatusBadge } from "@/src/features/applications/components/MilestoneStatusBadge";
+import {
+  buildMilestoneStatusIndex,
+  lookupMilestoneStatus,
+} from "@/src/features/applications/lib/milestone-status";
 import type {
   IFundingApplication,
   IMilestoneData,
   ProgramWithFormSchema,
 } from "@/types/funding-platform";
-import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { formatMilestoneAmount } from "@/utilities/formatMilestoneAmount";
@@ -37,20 +40,10 @@ export const ApplicationDataView: FC<ApplicationDataViewProps> = ({
   const fieldLabels = useMemo(() => createFieldLabelsMap(formSchema), [formSchema]);
   const fieldTypeMap = useMemo(() => createFieldTypeMap(formSchema), [formSchema]);
 
-  // Lookup index over the server-merged milestoneStatuses[]. Keyed by
-  // milestoneUID first (most reliable) with a fallback to
-  // (fieldLabel, title) for application-source slots not yet anchored
-  // on-chain. Same-title milestones across different fields are common
-  // (e.g. two fields each titled "Milestone 1"), so the fieldLabel
-  // half of the fallback key matters.
-  const statusByKey = useMemo(() => {
-    const m = new Map<string, MilestoneStatusEntry>();
-    for (const e of application.milestoneStatuses ?? []) {
-      if (e.milestoneUID) m.set(`uid:${e.milestoneUID}`, e);
-      m.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
-    }
-    return m;
-  }, [application.milestoneStatuses]);
+  const statusByKey = useMemo(
+    () => buildMilestoneStatusIndex(application.milestoneStatuses),
+    [application.milestoneStatuses]
+  );
 
   const renderFieldValue = (value: any, fieldKey?: string): JSX.Element => {
     if (Array.isArray(value)) {
@@ -62,10 +55,12 @@ export const ApplicationDataView: FC<ApplicationDataViewProps> = ({
         return (
           <div className="space-y-3">
             {value.map((milestone: IMilestoneData, index) => {
-              const milestoneUID = (milestone as { milestoneUID?: string }).milestoneUID;
-              const status =
-                (milestoneUID && statusByKey.get(`uid:${milestoneUID}`)) ||
-                statusByKey.get(`label:${fieldKey ?? ""}:${milestone.title}`);
+              const status = lookupMilestoneStatus(
+                statusByKey,
+                milestone.milestoneUID,
+                fieldKey,
+                milestone.title
+              );
               return (
                 <div
                   key={index}

--- a/components/FundingPlatform/ApplicationView/ApplicationTab/ApplicationDataView.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationTab/ApplicationDataView.tsx
@@ -4,11 +4,13 @@ import type { FC, JSX } from "react";
 import { useMemo } from "react";
 import { KarmaProjectLink } from "@/components/FundingPlatform/shared/KarmaProjectLink";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
+import { MilestoneStatusBadge } from "@/src/features/applications/components/MilestoneStatusBadge";
 import type {
   IFundingApplication,
   IMilestoneData,
   ProgramWithFormSchema,
 } from "@/types/funding-platform";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { formatMilestoneAmount } from "@/utilities/formatMilestoneAmount";
@@ -35,6 +37,21 @@ export const ApplicationDataView: FC<ApplicationDataViewProps> = ({
   const fieldLabels = useMemo(() => createFieldLabelsMap(formSchema), [formSchema]);
   const fieldTypeMap = useMemo(() => createFieldTypeMap(formSchema), [formSchema]);
 
+  // Lookup index over the server-merged milestoneStatuses[]. Keyed by
+  // milestoneUID first (most reliable) with a fallback to
+  // (fieldLabel, title) for application-source slots not yet anchored
+  // on-chain. Same-title milestones across different fields are common
+  // (e.g. two fields each titled "Milestone 1"), so the fieldLabel
+  // half of the fallback key matters.
+  const statusByKey = useMemo(() => {
+    const m = new Map<string, MilestoneStatusEntry>();
+    for (const e of application.milestoneStatuses ?? []) {
+      if (e.milestoneUID) m.set(`uid:${e.milestoneUID}`, e);
+      m.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
+    }
+    return m;
+  }, [application.milestoneStatuses]);
+
   const renderFieldValue = (value: any, fieldKey?: string): JSX.Element => {
     if (Array.isArray(value)) {
       // Check if it's an array of milestones
@@ -44,47 +61,54 @@ export const ApplicationDataView: FC<ApplicationDataViewProps> = ({
       if (isMilestoneArray) {
         return (
           <div className="space-y-3">
-            {value.map((milestone: IMilestoneData, index) => (
-              <div
-                key={index}
-                className="bg-gray-50 dark:bg-zinc-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
-              >
-                <div className="space-y-2">
-                  <div className="flex justify-between items-start gap-4">
-                    <div className="flex items-baseline gap-2 flex-wrap">
-                      <h5 className="font-medium text-gray-900 dark:text-gray-100">
-                        {milestone.title}
-                      </h5>
-                      {formatMilestoneAmount(milestone.fundingRequested) && (
-                        <span className="text-sm text-zinc-500 dark:text-zinc-400">
-                          {formatMilestoneAmount(milestone.fundingRequested)}
+            {value.map((milestone: IMilestoneData, index) => {
+              const milestoneUID = (milestone as { milestoneUID?: string }).milestoneUID;
+              const status =
+                (milestoneUID && statusByKey.get(`uid:${milestoneUID}`)) ||
+                statusByKey.get(`label:${fieldKey ?? ""}:${milestone.title}`);
+              return (
+                <div
+                  key={index}
+                  className="bg-gray-50 dark:bg-zinc-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
+                >
+                  <div className="space-y-2">
+                    <div className="flex justify-between items-start gap-4">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <h5 className="font-medium text-gray-900 dark:text-gray-100">
+                          {milestone.title}
+                        </h5>
+                        <MilestoneStatusBadge entry={status} />
+                        {formatMilestoneAmount(milestone.fundingRequested) && (
+                          <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                            {formatMilestoneAmount(milestone.fundingRequested)}
+                          </span>
+                        )}
+                      </div>
+                      {milestone.dueDate && (
+                        <span className="text-xs bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 px-2 py-1 rounded flex-shrink-0">
+                          Due: {formatDate(milestone.dueDate)}
                         </span>
                       )}
                     </div>
-                    {milestone.dueDate && (
-                      <span className="text-xs bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 px-2 py-1 rounded flex-shrink-0">
-                        Due: {formatDate(milestone.dueDate)}
-                      </span>
+                    {milestone.description && (
+                      <div className="text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none">
+                        <MarkdownPreview source={milestone.description} />
+                      </div>
+                    )}
+                    {milestone.completionCriteria && (
+                      <div className="text-sm">
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                          Completion Criteria:
+                        </span>
+                        <div className="text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none mt-1">
+                          <MarkdownPreview source={milestone.completionCriteria} />
+                        </div>
+                      </div>
                     )}
                   </div>
-                  {milestone.description && (
-                    <div className="text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none">
-                      <MarkdownPreview source={milestone.description} />
-                    </div>
-                  )}
-                  {milestone.completionCriteria && (
-                    <div className="text-sm">
-                      <span className="font-medium text-gray-700 dark:text-gray-300">
-                        Completion Criteria:
-                      </span>
-                      <div className="text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none mt-1">
-                        <MarkdownPreview source={milestone.completionCriteria} />
-                      </div>
-                    </div>
-                  )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         );
       }

--- a/components/FundingPlatform/ApplicationView/ApplicationTabs.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationTabs.tsx
@@ -3,6 +3,7 @@
 import {
   ChatBubbleLeftRightIcon,
   DocumentTextIcon,
+  FlagIcon,
   SparklesIcon,
 } from "@heroicons/react/24/outline";
 import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
@@ -117,6 +118,7 @@ export const TabIcons = {
   Application: DocumentTextIcon,
   AIAnalysis: SparklesIcon,
   Discussion: ChatBubbleLeftRightIcon,
+  Milestones: FlagIcon,
 };
 
 export default ApplicationTabs;

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  isMilestoneCompleted,
+  isMilestoneLate,
+  isMilestoneVerified,
+} from "@/src/features/applications/lib/milestone-status";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
+import { cn } from "@/utilities/tailwind";
+
+interface MilestoneStatusBadgeProps {
+  /**
+   * Server-merged status entry for this milestone. Missing means the
+   * milestone hasn't been linked on-chain yet — treated as Pending.
+   */
+  entry?: MilestoneStatusEntry;
+  className?: string;
+}
+
+type Tone = "success" | "warning" | "danger" | "neutral";
+
+interface BadgeSpec {
+  label: string;
+  tone: Tone;
+}
+
+const TONE_CLASSES: Record<Tone, string> = {
+  // Aligns with PROGRESS_BUCKET_CONFIG in MilestonesReview: green for
+  // verified, yellow for pending, red for late, gray for not-yet-started.
+  // Amber sits between yellow-pending and green-verified to signal
+  // "done but not verified yet".
+  success:
+    "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/40 dark:text-green-200 dark:border-green-700",
+  warning:
+    "bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-700",
+  danger:
+    "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/40 dark:text-red-200 dark:border-red-700",
+  neutral:
+    "bg-gray-100 text-gray-700 border-gray-200 dark:bg-zinc-700 dark:text-gray-300 dark:border-zinc-600",
+};
+
+function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
+  // Order matters: Verified wins over Completed (a verified milestone
+  // is by definition also completed); Late only applies when not yet
+  // completed/verified.
+  if (isMilestoneVerified(entry)) return { label: "Verified", tone: "success" };
+  if (isMilestoneCompleted(entry)) return { label: "Pending Verification", tone: "warning" };
+  if (isMilestoneLate(entry)) return { label: "Late", tone: "danger" };
+  return { label: "Pending", tone: "neutral" };
+}
+
+/**
+ * Inline status badge for a single milestone, driven by the server-merged
+ * `milestoneStatuses[]` entry. Drop next to the milestone title in
+ * `ApplicationContent` / `ApplicationDataView` to give admin reviewers
+ * inline status awareness without leaving the application detail page.
+ *
+ * Status hierarchy: Verified > PendingVerification > Late > Pending. The
+ * "PendingVerification" label is the canonical name for a milestone the
+ * grantee has marked completed but a reviewer hasn't yet attested as
+ * verified — replaces the older "Completed" label which conflated the
+ * two states.
+ */
+export function MilestoneStatusBadge({ entry, className }: MilestoneStatusBadgeProps) {
+  const { label, tone } = resolveSpec(entry);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+        TONE_CLASSES[tone],
+        className
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import {
   isMilestoneCompleted,
   isMilestoneLate,
@@ -61,7 +62,16 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
  * verified — replaces the older "Completed" label which conflated the
  * two states.
  */
-export function MilestoneStatusBadge({ entry, className }: MilestoneStatusBadgeProps) {
+// Memoized — the badge is rendered once per milestone inside two
+// different `.map()` loops (ApplicationContent, ApplicationDataView),
+// and the parent re-renders on unrelated state (view-mode toggles,
+// version changes, Zustand updates). React.memo dodges the per-badge
+// resolveSpec recomputation on those parent updates. Per the project
+// CLAUDE.md convention for list-mapped components.
+export const MilestoneStatusBadge = memo(function MilestoneStatusBadge({
+  entry,
+  className,
+}: MilestoneStatusBadgeProps) {
   const { label, tone } = resolveSpec(entry);
   return (
     <span
@@ -74,4 +84,4 @@ export function MilestoneStatusBadge({ entry, className }: MilestoneStatusBadgeP
       {label}
     </span>
   );
-}
+});

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -45,7 +45,7 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
   // completed/verified.
   if (isMilestoneVerified(entry)) return { label: "Verified", tone: "success" };
   if (isMilestoneCompleted(entry)) return { label: "Pending Verification", tone: "warning" };
-  if (isMilestoneLate(entry)) return { label: "Late", tone: "danger" };
+  if (isMilestoneLate(entry)) return { label: "Past Due", tone: "danger" };
   return { label: "Pending", tone: "neutral" };
 }
 
@@ -55,7 +55,7 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
  * `ApplicationContent` / `ApplicationDataView` to give admin reviewers
  * inline status awareness without leaving the application detail page.
  *
- * Status hierarchy: Verified > PendingVerification > Late > Pending. The
+ * Status hierarchy: Verified > PendingVerification > PastDue > Pending. The
  * "PendingVerification" label is the canonical name for a milestone the
  * grantee has marked completed but a reviewer hasn't yet attested as
  * verified — replaces the older "Completed" label which conflated the

--- a/src/features/applications/components/MilestonesTab.tsx
+++ b/src/features/applications/components/MilestonesTab.tsx
@@ -3,10 +3,21 @@
 import { OffChainMilestoneRow } from "@/src/features/applications/components/OffChainMilestoneRow";
 import { OnChainMilestoneRow } from "@/src/features/applications/components/OnChainMilestoneRow";
 import { useApplicationInvoiceConfig } from "@/src/features/applications/hooks/use-application-invoice-config";
-import type { Application } from "@/types/whitelabel-entities";
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
+
+// Narrow structural prop — the tab only needs the milestone-relevant
+// fields. Accepts both the whitelabel `Application` and the admin
+// `IFundingApplication` shapes; status is `string` so any enum union
+// satisfies (the lifecycle check below only inspects "approved").
+export interface MilestonesTabApplication {
+  referenceNumber: string;
+  projectUID?: string;
+  status: string;
+  milestoneStatuses?: MilestoneStatusEntry[];
+}
 
 interface MilestonesTabProps {
-  application: Application;
+  application: MilestonesTabApplication;
   isOwner: boolean;
   invoiceRequired?: boolean;
 }
@@ -34,9 +45,19 @@ export function MilestonesTab({ application, isOwner, invoiceRequired }: Milesto
   const entries = application.milestoneStatuses ?? [];
 
   if (entries.length === 0) {
+    // Lifecycle: status flips to "approved" → project gets created →
+    // grant is attested on-chain → milestones are attested. There's a
+    // transient window where status="approved" but milestoneStatuses
+    // is still empty — "No milestones defined" is wrong copy for that
+    // window because it implies a permanent absence.
+    const isApprovedPipelinePending = application.status?.toLowerCase() === "approved";
     return (
       <div className="rounded-xl border border-border p-6">
-        <p className="text-muted-foreground">No milestones defined for this application.</p>
+        <p className="text-muted-foreground">
+          {isApprovedPipelinePending
+            ? "Setting up milestones… On-chain attestations land within a few minutes of approval."
+            : "No milestones defined for this application."}
+        </p>
       </div>
     );
   }

--- a/src/features/applications/components/MilestonesTab.tsx
+++ b/src/features/applications/components/MilestonesTab.tsx
@@ -50,7 +50,7 @@ export function MilestonesTab({ application, isOwner, invoiceRequired }: Milesto
     // transient window where status="approved" but milestoneStatuses
     // is still empty — "No milestones defined" is wrong copy for that
     // window because it implies a permanent absence.
-    const isApprovedPipelinePending = application.status?.toLowerCase() === "approved";
+    const isApprovedPipelinePending = application.status.toLowerCase() === "approved";
     return (
       <div className="rounded-xl border border-border p-6">
         <p className="text-muted-foreground">

--- a/src/features/applications/hooks/use-milestones-admin-refetch.ts
+++ b/src/features/applications/hooks/use-milestones-admin-refetch.ts
@@ -55,8 +55,14 @@ export function useMilestonesAdminRefetch({
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    // Skip the periodic poll when the tab is hidden — visibilitychange
+    // catches the return-to-foreground case, so a hidden tab doesn't
+    // need 60s background refetches piling up. Same as the
+    // visibilitychange handler: only fire on visible.
     const intervalId = window.setInterval(() => {
-      refetch();
+      if (document.visibilityState === "visible") {
+        refetch();
+      }
     }, intervalMs);
 
     return () => {

--- a/src/features/applications/hooks/use-milestones-admin-refetch.ts
+++ b/src/features/applications/hooks/use-milestones-admin-refetch.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface UseMilestonesAdminRefetchArgs {
+  /**
+   * True when the admin's Milestones tab is the active tab. The hook
+   * is otherwise a no-op — we don't want background refetches firing
+   * for admins looking at the Application or Comments tabs.
+   */
+  isActive: boolean;
+  /**
+   * `useApplication().refetch` — the React Query refetch handle. The
+   * application-detail endpoint is the source of `milestoneStatuses[]`,
+   * so refetching the whole application is the simplest way to pick up
+   * grantee-side state changes (a milestone got completed/verified by
+   * someone else while the admin had the tab open).
+   */
+  refetch: () => unknown;
+  /**
+   * Polling cadence. Default 60s. The admin tab is low-traffic and
+   * milestone state changes are infrequent — sub-minute polling would
+   * be wasteful.
+   */
+  intervalMs?: number;
+}
+
+/**
+ * Keep the admin Milestones tab fresh on long-lived sessions.
+ *
+ * Two refresh triggers:
+ *   1. `visibilitychange` → refetch when the tab becomes visible (admin
+ *      came back from another browser tab/window).
+ *   2. `setInterval(refetch, intervalMs)` → periodic background poll.
+ *
+ * Both are gated by `isActive` so the hook is a no-op when the admin
+ * isn't viewing the Milestones tab. Cleanup tears both down on unmount
+ * and on `isActive` flipping false.
+ *
+ * Whitelabel/grantee surfaces don't use this hook — `router.refresh()`
+ * from the submit hook keeps their own view in sync.
+ */
+export function useMilestonesAdminRefetch({
+  isActive,
+  refetch,
+  intervalMs = 60_000,
+}: UseMilestonesAdminRefetchArgs): void {
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refetch();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    const intervalId = window.setInterval(() => {
+      refetch();
+    }, intervalMs);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.clearInterval(intervalId);
+    };
+  }, [isActive, refetch, intervalMs]);
+}

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -1,6 +1,47 @@
 import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 
 /**
+ * Build a lookup index over `milestoneStatuses[]` keyed two ways:
+ *
+ *   1. `uid:<milestoneUID>` — primary, used once the slot has been
+ *      anchored on-chain.
+ *   2. `label:<fieldLabel>:<title>` — fallback for slots that haven't
+ *      been anchored yet (no milestoneUID). Includes fieldLabel because
+ *      same-title milestones across different fields are common (e.g.
+ *      two fields each containing a "Milestone 1").
+ *
+ * Pair with `lookupMilestoneStatus` at consumer sites — both halves
+ * live here so a future keying change touches one file.
+ */
+export function buildMilestoneStatusIndex(
+  entries?: MilestoneStatusEntry[]
+): Map<string, MilestoneStatusEntry> {
+  const index = new Map<string, MilestoneStatusEntry>();
+  for (const e of entries ?? []) {
+    if (e.milestoneUID) index.set(`uid:${e.milestoneUID}`, e);
+    index.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
+  }
+  return index;
+}
+
+/**
+ * Resolve a single milestone's status entry from the index built by
+ * `buildMilestoneStatusIndex`. Prefers UID matching when both sides
+ * have one; falls back to the (fieldLabel, title) composite key.
+ */
+export function lookupMilestoneStatus(
+  index: Map<string, MilestoneStatusEntry>,
+  milestoneUID: string | undefined,
+  fieldLabel: string | undefined,
+  title: string
+): MilestoneStatusEntry | undefined {
+  return (
+    (milestoneUID ? index.get(`uid:${milestoneUID}`) : undefined) ??
+    index.get(`label:${fieldLabel ?? ""}:${title}`)
+  );
+}
+
+/**
  * Display-time status helpers for application milestones.
  *
  * The application detail page reads on-chain status from

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -1,14 +1,28 @@
 import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
 
 /**
+ * Build a stable composite key from (fieldLabel, title). A plain
+ * `${fieldLabel}:${title}` concatenation would collide when title
+ * contains a colon (e.g. "Phase 1: Beta launch") — JSON-encoding the
+ * tuple is the cheapest unambiguous form: array boundaries can't be
+ * forged by content inside the strings.
+ */
+function makeLabelKey(fieldLabel: string | undefined, title: string): string {
+  return `label:${JSON.stringify([fieldLabel ?? "", title])}`;
+}
+
+/**
  * Build a lookup index over `milestoneStatuses[]` keyed two ways:
  *
  *   1. `uid:<milestoneUID>` — primary, used once the slot has been
  *      anchored on-chain.
- *   2. `label:<fieldLabel>:<title>` — fallback for slots that haven't
- *      been anchored yet (no milestoneUID). Includes fieldLabel because
- *      same-title milestones across different fields are common (e.g.
- *      two fields each containing a "Milestone 1").
+ *   2. `label:["<fieldLabel>","<title>"]` — fallback for slots that
+ *      haven't been anchored yet (no milestoneUID). Includes
+ *      fieldLabel because same-title milestones across different
+ *      fields are common (e.g. two fields each containing a
+ *      "Milestone 1"). Encoded via `JSON.stringify` on the tuple so
+ *      colons or quotes inside title/fieldLabel can't fabricate a
+ *      colliding key.
  *
  * Intra-field same-title collisions (two milestones titled the same
  * inside the same form field) resolve **first-write-wins**: the
@@ -27,7 +41,7 @@ export function buildMilestoneStatusIndex(
   const index = new Map<string, MilestoneStatusEntry>();
   for (const e of entries ?? []) {
     if (e.milestoneUID) index.set(`uid:${e.milestoneUID}`, e);
-    const labelKey = `label:${e.fieldLabel ?? ""}:${e.title}`;
+    const labelKey = makeLabelKey(e.fieldLabel, e.title);
     if (!index.has(labelKey)) index.set(labelKey, e);
   }
   return index;
@@ -46,7 +60,7 @@ export function lookupMilestoneStatus(
 ): MilestoneStatusEntry | undefined {
   return (
     (milestoneUID ? index.get(`uid:${milestoneUID}`) : undefined) ??
-    index.get(`label:${fieldLabel ?? ""}:${title}`)
+    index.get(makeLabelKey(fieldLabel, title))
   );
 }
 

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -62,10 +62,13 @@ export function isMilestoneCompleted(statusEntry?: MilestoneStatusEntry): boolea
 }
 
 /**
- * A milestone is "Late" when it has a due date in the past AND has not
- * yet been completed or verified. Pending future-due milestones stay
- * Pending; completed/verified milestones never reclassify as Late even
- * if their due date was in the past at completion time.
+ * A milestone is "Past Due" when it has a due date in the past AND has
+ * not yet been completed or verified. Pending future-due milestones
+ * stay Pending; completed/verified milestones never reclassify as Past
+ * Due even if their due date was in the past at completion time.
+ *
+ * The predicate name keeps the older "Late" wording for backward
+ * compatibility — the user-facing label is "Past Due".
  */
 export function isMilestoneLate(statusEntry?: MilestoneStatusEntry): boolean {
   if (!statusEntry) return false;

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -10,6 +10,14 @@ import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
  *      same-title milestones across different fields are common (e.g.
  *      two fields each containing a "Milestone 1").
  *
+ * Intra-field same-title collisions (two milestones titled the same
+ * inside the same form field) resolve **first-write-wins**: the
+ * indexer sorts done entries to the bottom and pending by dueDate
+ * ascending, so the first entry on a collision is the one a
+ * displayed badge most likely refers to. Without this, a stale
+ * "Completed" overrides a live "Pending" silently. UID keys still
+ * overwrite (they're unique by construction).
+ *
  * Pair with `lookupMilestoneStatus` at consumer sites — both halves
  * live here so a future keying change touches one file.
  */
@@ -19,7 +27,8 @@ export function buildMilestoneStatusIndex(
   const index = new Map<string, MilestoneStatusEntry>();
   for (const e of entries ?? []) {
     if (e.milestoneUID) index.set(`uid:${e.milestoneUID}`, e);
-    index.set(`label:${e.fieldLabel ?? ""}:${e.title}`, e);
+    const labelKey = `label:${e.fieldLabel ?? ""}:${e.title}`;
+    if (!index.has(labelKey)) index.set(labelKey, e);
   }
   return index;
 }

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -36,6 +36,7 @@ export interface IMilestoneData {
   dueDate: string;
   fundingRequested?: string; // Optional - funding amount requested for this milestone
   completionCriteria?: string; // Optional - criteria to consider milestone complete
+  milestoneUID?: string; // Populated by the indexer once the slot is anchored on-chain
 }
 
 // Form Field Types (unchanged)

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -1,3 +1,5 @@
+import type { MilestoneStatusEntry } from "@/types/whitelabel-entities";
+
 // V2 Status Types
 export type FundingApplicationStatusV2 =
   | "pending"
@@ -154,6 +156,11 @@ export interface IFundingApplication {
   // from submitted form data; falls back to the linked Karma project's title
   // when the application has a projectUID. Omitted when neither yields a value.
   resolvedProjectName?: string;
+  // Server-merged milestone list (application-source slots + project-source
+  // grant milestones, pre-deduped by UID and pre-sorted by status/dueDate).
+  // Populated by the indexer's attachMilestoneStatuses walker. Empty when
+  // projectUID is unset or the linked grant has no milestones yet.
+  milestoneStatuses?: MilestoneStatusEntry[];
   createdAt: string | Date;
   updatedAt: string | Date;
 }


### PR DESCRIPTION
## Summary

Phase 3 of the on-chain milestone migration (DEV-274). Phase 2 shipped server-merged `milestoneStatuses[]` on the application-detail endpoint; this PR surfaces it on the admin surfaces so reviewers can triage milestone state inline without leaving the application detail page.

Pairs with the indexer's defensive-guards PR (show-karma/gap-indexer#1745).

## What changes

- **Admin Milestones tab** (`app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx`) — new 4th tab between Application and AI Analysis, gated on `application.status === "approved"`. Read-only by design (`isOwner={false}`). Existing "Review Milestones" banner is kept as a deep-dive link to the MilestonesAndUpdates page.
- **Inline status badges** on every milestone in the submitted-form section (`ApplicationContent.tsx` + `ApplicationDataView.tsx`). Status keyed by milestoneUID with a `(fieldLabel, title)` fallback for slots not yet anchored on-chain.
- **New `MilestoneStatusBadge`** — canonical hierarchy Verified > Pending Verification > Late > Pending. "Pending Verification" is the new canonical label for "completed but not yet on-chain-verified" (replaces the older "Completed" wording that conflated the two).
- **`MilestonesTab` moved** from the whitelabel route to `src/features/applications/components/` for cross-route reuse. Prop type narrowed to a structural subset so both `Application` and `IFundingApplication` satisfy it.
- **Empty-state transient** — when `status === "approved"` and `milestoneStatuses` is empty, shows "Setting up milestones…" instead of "No milestones defined". Both whitelabel and admin inherit this; targets the post-approval/pre-attestation pipeline window.
- **`useMilestonesAdminRefetch`** hook — polls `useApplication.refetch` every 60s and on `document.visibilitychange` while the Milestones tab is active. No refetch when on Application/AI/Comments tabs.
- **`IFundingApplication.milestoneStatuses?`** added — the indexer already returns this field; the FE type was missing it.

## Out of scope (deferred)

Per DEV-274 scope decisions: write affordance on the admin tab, status module consolidation, ProfileBadge for verifier addresses, edit history disclosure, project/grant endpoint extension of `milestoneStatuses[]`, MilestonesReview migration. These are Phase 4/5 work.

## Test plan

- [x] `pnpm test` against touched paths → 40/40 pass (MilestonesTab x9, MilestoneStatusBadge x7, useMilestonesAdminRefetch x6, ApplicationContent x18)
- [x] `pnpm exec tsc --noEmit` → clean
- [x] `pnpm run build` → clean
- [x] Biome lint clean on all touched files (pre-existing warnings on other files unchanged)
- [ ] Smoke: open admin app-detail for an approved application → Milestones tab present, list renders with badges
- [ ] Smoke: open admin app-detail for a pending application → Milestones tab absent
- [ ] Smoke: open immediately after approval → "Setting up milestones…" transient renders
- [ ] Smoke: switch to Application tab → inline badges next to each milestone in submitted-form section
- [ ] Smoke: leave Milestones tab open in background, complete a milestone from another wallet → admin tab reflects within ≤60s
- [ ] Regression: whitelabel `MilestonesTab` still renders identically for grantees (the moved file + new empty-state copy is the only relevant change)

## Notes for review

- The `MilestonesTab` move preserves history (`git mv` rename detection). The structural prop refactor was the only logic change to the moved file; the empty-state branch added one new copy variant.
- `useMilestonesAdminRefetch` is admin-only by intent. The whitelabel `ApplicationPageClient` keeps its existing `router.refresh()` flow.
- Status-label drift between the new `MilestoneStatusBadge` ("Pending Verification") and the existing `OffChain/OnChainMilestoneRow` (still uses the older labels) is a known inconsistency from deferring status module consolidation. Tracked as part of Phase 4/5.

Refs: DEV-274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline status badges for milestones displaying Verified, Pending Verification, Past Due, or Pending states.
  * Enabled automatic refresh of milestone data in admin view when the Milestones tab is active.
  * Improved empty-state messaging for milestones based on application approval status.

* **Refactor**
  * Reorganized milestone components into shared feature module for better code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1408)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->