### PR TITLE
revert(milestone-status): user-facing label "Past Due" → "Late"

### DIFF
--- a/__tests__/features/applications/MilestoneStatusBadge.test.tsx
+++ b/__tests__/features/applications/MilestoneStatusBadge.test.tsx
@@ -3,7 +3,7 @@
  *
  * The badge resolves a single status string from the four-state
  * hierarchy:
- *   Verified > PendingVerification > PastDue > Pending
+ *   Verified > PendingVerification > Late > Pending
  *
  * Inputs come from the server-merged `milestoneStatuses[]` entry; the
  * tab consumes the same entry shape but a different render. These
@@ -62,7 +62,7 @@ describe("MilestoneStatusBadge", () => {
     expect(screen.getByText("Pending Verification")).toBeInTheDocument();
   });
 
-  it("should_render_Past_Due_when_dueDate_is_past_and_not_completed", () => {
+  it("should_render_Late_when_dueDate_is_past_and_not_completed", () => {
     render(
       <MilestoneStatusBadge
         entry={makeEntry({
@@ -71,12 +71,12 @@ describe("MilestoneStatusBadge", () => {
         })}
       />
     );
-    expect(screen.getByText("Past Due")).toBeInTheDocument();
+    expect(screen.getByText("Late")).toBeInTheDocument();
   });
 
-  it("should_not_render_Past_Due_when_completed_even_if_dueDate_is_past", () => {
-    // A completed milestone never reclassifies as Past Due —
-    // completion wins over due-date arithmetic.
+  it("should_not_render_Late_when_completed_even_if_dueDate_is_past", () => {
+    // A completed milestone never reclassifies as Late — completion
+    // wins over due-date arithmetic.
     render(
       <MilestoneStatusBadge
         entry={makeEntry({
@@ -87,7 +87,7 @@ describe("MilestoneStatusBadge", () => {
       />
     );
     expect(screen.getByText("Pending Verification")).toBeInTheDocument();
-    expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
+    expect(screen.queryByText("Late")).not.toBeInTheDocument();
   });
 
   it("should_render_Pending_when_entry_is_undefined", () => {

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -46,7 +46,7 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
   // completed/verified.
   if (isMilestoneVerified(entry)) return { label: "Verified", tone: "success" };
   if (isMilestoneCompleted(entry)) return { label: "Pending Verification", tone: "warning" };
-  if (isMilestoneLate(entry)) return { label: "Past Due", tone: "danger" };
+  if (isMilestoneLate(entry)) return { label: "Late", tone: "danger" };
   return { label: "Pending", tone: "neutral" };
 }
 
@@ -56,7 +56,7 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
  * `ApplicationContent` / `ApplicationDataView` to give admin reviewers
  * inline status awareness without leaving the application detail page.
  *
- * Status hierarchy: Verified > PendingVerification > PastDue > Pending. The
+ * Status hierarchy: Verified > PendingVerification > Late > Pending. The
  * "PendingVerification" label is the canonical name for a milestone the
  * grantee has marked completed but a reviewer hasn't yet attested as
  * verified — replaces the older "Completed" label which conflated the

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -85,13 +85,10 @@ export function isMilestoneCompleted(statusEntry?: MilestoneStatusEntry): boolea
 }
 
 /**
- * A milestone is "Past Due" when it has a due date in the past AND has
- * not yet been completed or verified. Pending future-due milestones
- * stay Pending; completed/verified milestones never reclassify as Past
- * Due even if their due date was in the past at completion time.
- *
- * The predicate name keeps the older "Late" wording for backward
- * compatibility — the user-facing label is "Past Due".
+ * A milestone is "Late" when it has a due date in the past AND has not
+ * yet been completed or verified. Pending future-due milestones stay
+ * Pending; completed/verified milestones never reclassify as Late even
+ * if their due date was in the past at completion time.
  */
 export function isMilestoneLate(statusEntry?: MilestoneStatusEntry): boolean {
   if (!statusEntry) return false;


### PR DESCRIPTION
## Summary

Revert of commit `a4b5ff79` (merged in #1408). The earlier "Late → Past Due" rename re-introduced terminology the team had previously decided against — the rest of the milestone surface uses "Late":

- `components/Pages/Admin/MilestonesReview/utils/milestone-review-status.ts` → `label: "Late"`, `filterLabel: "Late"`
- General codebase prose and existing display strings

Restoring consistency so the new `MilestoneStatusBadge` matches the established vocabulary.

## Changes

Touches the same three files the original rename did:

- `src/features/applications/components/MilestoneStatusBadge.tsx` — badge label + hierarchy comment (`PastDue` → `Late`)
- `src/features/applications/lib/milestone-status.ts` — `isMilestoneLate` docstring restored
- `__tests__/features/applications/MilestoneStatusBadge.test.tsx` — 2 test names + 3 assertions

The predicate function name (`isMilestoneLate`) was already "Late" in both versions — internal identifier, untouched here.

## Test plan

- [x] `pnpm test __tests__/features/applications/MilestoneStatusBadge.test.tsx` → 7/7 pass
- [x] `pnpm exec tsc --noEmit` → clean
- [ ] Smoke: open an approved application detail page with a past-due milestone → badge reads "Late" (not "Past Due")