### PR TITLE
feat(milestones-review): wire on-chain delete + restrict edit/delete to admins

### DIFF
--- a/__tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx
+++ b/__tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from "@tanstack/react-query";
 import { act, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import toast from "react-hot-toast";
@@ -6,10 +7,29 @@ import type { GrantMilestoneWithCompletion } from "@/services/milestones";
 import { envVars } from "@/utilities/enviromentVars";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { installMswLifecycle, server } from "../../msw/server";
-import { createTestQueryClient, renderHookWithProviders } from "../../utils/render";
+import { renderHookWithProviders } from "../../utils/render";
+
+// Local QueryClient with persistent cache so rollback assertions can read the
+// restored data without racing React Query's garbage collector.
+function createPersistentQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
 
 vi.mock("@/utilities/auth/token-manager", () => ({
   TokenManager: { getToken: vi.fn().mockResolvedValue("test-token") },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ address: "0xrequester", ready: true }),
+}));
+
+vi.mock("@/hooks/useMixpanel", () => ({
+  useMixpanel: () => ({ mixpanel: { reportEvent: vi.fn() } }),
 }));
 
 vi.mock("react-hot-toast", async () => {
@@ -63,14 +83,20 @@ describe("useDeleteMilestone (mutation integration)", () => {
   it("should_resolve_and_invoke_onSuccess_when_backend_revokes_milestone", async () => {
     const onSuccess = vi.fn();
     const milestone = createMilestone();
+    const observedBody = vi.fn();
 
     server.use(
-      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, ({ params }) =>
-        HttpResponse.json({
-          milestoneUID: params.milestoneUID as string,
-          revocationSuccess: true,
-          revocationTxHash: "0xtx",
-        })
+      http.delete(
+        `${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`,
+        async ({ params, request }) => {
+          const body = await request.json();
+          observedBody(body);
+          return HttpResponse.json({
+            milestoneUID: params.milestoneUID as string,
+            revocationSuccess: true,
+            revocationTxHash: "0xtx",
+          });
+        }
       )
     );
 
@@ -86,12 +112,13 @@ describe("useDeleteMilestone (mutation integration)", () => {
       expect(result.current.isDeleting).toBe(false);
     });
 
+    expect(observedBody).toHaveBeenCalledWith({ chainID: milestone.chainId });
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("should_roll_back_optimistic_removal_when_backend_rejects", async () => {
-    const queryClient = createTestQueryClient();
+    const queryClient = createPersistentQueryClient();
     const queryKey = QUERY_KEYS.MILESTONES.PROJECT_GRANT_MILESTONES(PROJECT_ID, PROGRAM_ID);
     const milestone = createMilestone();
     const originalData = { grantMilestones: [milestone] };
@@ -139,5 +166,34 @@ describe("useDeleteMilestone (mutation integration)", () => {
     });
 
     expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("should_treat_revocationSuccess_false_as_failure_and_rollback", async () => {
+    const queryClient = createPersistentQueryClient();
+    const queryKey = QUERY_KEYS.MILESTONES.PROJECT_GRANT_MILESTONES(PROJECT_ID, PROGRAM_ID);
+    const milestone = createMilestone();
+    const originalData = { grantMilestones: [milestone] };
+    queryClient.setQueryData(queryKey, originalData);
+
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, ({ params }) =>
+        HttpResponse.json({
+          milestoneUID: params.milestoneUID as string,
+          revocationSuccess: false,
+        })
+      )
+    );
+
+    const { result } = renderHookWithProviders(
+      () => useDeleteMilestone({ projectId: PROJECT_ID, programId: PROGRAM_ID }),
+      { queryClient }
+    );
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(milestone)).rejects.toThrow();
+    });
+
+    expect(queryClient.getQueryData(queryKey)).toEqual(originalData);
+    expect(toast.error).toHaveBeenCalled();
   });
 });

--- a/__tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx
+++ b/__tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx
@@ -1,29 +1,11 @@
-/**
- * Mutation integration tests for useDeleteMilestone hook.
- *
- * Milestone deletion is being migrated to on-chain attestations
- * (revocation via `MilestoneCanceled`) and is not available yet.
- * Until the attestation flow ships, the hook surfaces a clear
- * "not available" error rather than pretending to succeed.
- *
- * These tests lock in that honest-failure contract:
- *   - mutation rejects with the documented message
- *   - cache is rolled back so the row reappears (no false optimism)
- *   - onSuccess callback never fires
- *
- * When the on-chain delete attestation lands, replace this suite with
- * tests that exercise the real submission flow.
- */
-
 import { act, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import toast from "react-hot-toast";
-import {
-  DELETE_MILESTONE_NOT_AVAILABLE_MESSAGE,
-  useDeleteMilestone,
-} from "@/hooks/useDeleteMilestone";
+import { useDeleteMilestone } from "@/hooks/useDeleteMilestone";
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+import { envVars } from "@/utilities/enviromentVars";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
-import { installMswLifecycle } from "../../msw/server";
+import { installMswLifecycle, server } from "../../msw/server";
 import { createTestQueryClient, renderHookWithProviders } from "../../utils/render";
 
 vi.mock("@/utilities/auth/token-manager", () => ({
@@ -52,19 +34,23 @@ installMswLifecycle();
 
 const PROJECT_ID = "project-001";
 const PROGRAM_ID = "program-001";
+const MILESTONE_UID = "milestone-uid-001";
+const INDEXER_BASE = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
 
-function createMilestoneWithCompletion(
+function createMilestone(
   overrides?: Partial<GrantMilestoneWithCompletion>
 ): GrantMilestoneWithCompletion {
   return {
-    uid: "milestone-uid-001",
+    uid: MILESTONE_UID,
     chainId: 10,
+    programId: PROGRAM_ID,
     title: "Audit Completion",
     description: "Complete security audit",
     dueDate: "2024-12-31T00:00:00Z",
     status: "pending",
     completionDetails: null,
     verificationDetails: null,
+    fundingApplicationCompletion: null,
     ...overrides,
   };
 }
@@ -74,38 +60,49 @@ describe("useDeleteMilestone (mutation integration)", () => {
     vi.clearAllMocks();
   });
 
-  it("should_reject_with_not_available_error_until_on_chain_delete_lands", async () => {
+  it("should_resolve_and_invoke_onSuccess_when_backend_revokes_milestone", async () => {
     const onSuccess = vi.fn();
-    const milestone = createMilestoneWithCompletion();
+    const milestone = createMilestone();
+
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, ({ params }) =>
+        HttpResponse.json({
+          milestoneUID: params.milestoneUID as string,
+          revocationSuccess: true,
+          revocationTxHash: "0xtx",
+        })
+      )
+    );
 
     const { result } = renderHookWithProviders(() =>
       useDeleteMilestone({ projectId: PROJECT_ID, programId: PROGRAM_ID, onSuccess })
     );
 
     await act(async () => {
-      await expect(result.current.deleteMilestoneAsync(milestone)).rejects.toThrow(
-        DELETE_MILESTONE_NOT_AVAILABLE_MESSAGE
-      );
+      await result.current.deleteMilestoneAsync(milestone);
     });
 
     await waitFor(() => {
       expect(result.current.isDeleting).toBe(false);
     });
 
-    // No success path fired.
-    expect(onSuccess).not.toHaveBeenCalled();
-    expect(toast.success).not.toHaveBeenCalled();
-    // User-facing error surfaced via toast.
-    expect(toast.error).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("should_roll_back_optimistic_removal_so_the_row_reappears_on_failure", async () => {
+  it("should_roll_back_optimistic_removal_when_backend_rejects", async () => {
     const queryClient = createTestQueryClient();
     const queryKey = QUERY_KEYS.MILESTONES.PROJECT_GRANT_MILESTONES(PROJECT_ID, PROGRAM_ID);
-    const milestone = createMilestoneWithCompletion();
+    const milestone = createMilestone();
     const originalData = { grantMilestones: [milestone] };
 
     queryClient.setQueryData(queryKey, originalData);
+
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, () =>
+        HttpResponse.json({ message: "Access denied" }, { status: 403 })
+      )
+    );
 
     const { result } = renderHookWithProviders(
       () => useDeleteMilestone({ projectId: PROJECT_ID, programId: PROGRAM_ID }),
@@ -116,7 +113,31 @@ describe("useDeleteMilestone (mutation integration)", () => {
       await expect(result.current.deleteMilestoneAsync(milestone)).rejects.toThrow();
     });
 
-    // Cache restored — the user must not see the row vanish on a failure.
     expect(queryClient.getQueryData(queryKey)).toEqual(originalData);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("should_reject_without_calling_backend_when_chainId_is_missing", async () => {
+    const requestSpy = vi.fn();
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, () => {
+        requestSpy();
+        return HttpResponse.json({}, { status: 200 });
+      })
+    );
+
+    const milestone = createMilestone({ chainId: 0 as unknown as number });
+
+    const { result } = renderHookWithProviders(() =>
+      useDeleteMilestone({ projectId: PROJECT_ID, programId: PROGRAM_ID })
+    );
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(milestone)).rejects.toThrow(
+        /missing chainId/
+      );
+    });
+
+    expect(requestSpy).not.toHaveBeenCalled();
   });
 });

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -403,7 +403,7 @@ export function MilestoneCard({
               <PencilSquareIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
             </Button>
           )}
-          {canDeleteMilestones && milestone.fundingApplicationCompletion && (
+          {canDeleteMilestones && !hasCompletion && (
             // biome-ignore lint/a11y/noStaticElementInteractions: wrapper needs onBlur to detect focus leaving the menu group; the interactive child is the trigger button below.
             <div className="relative" ref={overflowRef} onBlur={handleOverflowBlur}>
               <button

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -492,7 +492,7 @@ function MilestonesReviewPageContent({
 
   // Only community admins (and staff via admin access) can edit or delete milestones.
   // Milestone reviewers verify completions but cannot mutate milestone definitions.
-  const canEditOrDeleteMilestones = useMemo(() => hasAdminAccess || false, [hasAdminAccess]);
+  const canEditOrDeleteMilestones = hasAdminAccess;
 
   // Delete milestone hook with proper React Query mutation/query relationship
   const { deleteMilestoneAsync, isDeleting } = useDeleteMilestone({

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -490,12 +490,9 @@ function MilestonesReviewPageContent({
     [hasAdminAccess, isMilestoneReviewer]
   );
 
-  // Determine if user can delete milestones
-  // Contract owners, community admins, staff, and milestone reviewers can delete milestones
-  const canDeleteMilestones = useMemo(
-    () => hasAdminAccess || isMilestoneReviewer || false,
-    [hasAdminAccess, isMilestoneReviewer]
-  );
+  // Only community admins (and staff via admin access) can edit or delete milestones.
+  // Milestone reviewers verify completions but cannot mutate milestone definitions.
+  const canEditOrDeleteMilestones = useMemo(() => hasAdminAccess || false, [hasAdminAccess]);
 
   // Delete milestone hook with proper React Query mutation/query relationship
   const { deleteMilestoneAsync, isDeleting } = useDeleteMilestone({
@@ -973,8 +970,8 @@ function MilestonesReviewPageContent({
                       verificationComment={verificationComment}
                       isVerifying={isVerifying}
                       canVerifyMilestones={canVerifyMilestones}
-                      canDeleteMilestones={canDeleteMilestones}
-                      canEditMilestones={canVerifyMilestones}
+                      canDeleteMilestones={canEditOrDeleteMilestones}
+                      canEditMilestones={canEditOrDeleteMilestones}
                       grantUID={grant?.uid}
                       grantChainID={grant?.chainID}
                       projectUid={project.uid}

--- a/hooks/useDeleteMilestone.ts
+++ b/hooks/useDeleteMilestone.ts
@@ -5,6 +5,9 @@ import type {
   GrantMilestoneWithCompletion,
   ProjectGrantMilestonesResponse,
 } from "@/services/milestones";
+import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
+import { envVars } from "@/utilities/enviromentVars";
+import { INDEXER } from "@/utilities/indexer";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 interface UseDeleteMilestoneParams {
@@ -13,23 +16,11 @@ interface UseDeleteMilestoneParams {
   onSuccess?: () => void;
 }
 
-/**
- * On-chain milestone deletion (revocation of the `Milestone` attestation
- * via `MilestoneCanceled`) is not yet wired into the SDK + indexer
- * pipeline — that work is tracked under the Phase 3 follow-up (DEV-234).
- *
- * Until the attestation flow ships, this hook fails fast with a clear
- * "not available yet" error rather than silently pretending success.
- * The earlier behaviour (return success without doing anything) showed
- * the milestone disappear from the UI optimistically and then reappear
- * on the next refetch, which was indistinguishable from a backend bug.
- *
- * Callers should keep the integration in place — once the on-chain
- * delete attestation lands, the mutationFn body is the only thing that
- * needs to change.
- */
-export const DELETE_MILESTONE_NOT_AVAILABLE_MESSAGE =
-  "Milestone deletion is being migrated to on-chain attestations and isn't available yet. Reach out to the team if you need a milestone removed.";
+interface DeleteMilestoneResponse {
+  milestoneUID: string;
+  revocationSuccess: boolean;
+  revocationTxHash?: string;
+}
 
 export const useDeleteMilestone = ({
   projectId,
@@ -40,20 +31,31 @@ export const useDeleteMilestone = ({
   const { showError } = useAttestationToast();
 
   const deleteMilestoneMutation = useMutation({
-    mutationFn: async (_milestone: GrantMilestoneWithCompletion) => {
-      throw new Error(DELETE_MILESTONE_NOT_AVAILABLE_MESSAGE);
+    mutationFn: async (milestone: GrantMilestoneWithCompletion) => {
+      if (!milestone.chainId) {
+        throw new Error("Cannot delete milestone: missing chainId");
+      }
+      if (!programId) {
+        throw new Error("Cannot delete milestone: missing programId");
+      }
+
+      const apiClient = createAuthenticatedApiClient(envVars.NEXT_PUBLIC_GAP_INDEXER_URL, 60000);
+
+      const response = await apiClient.delete<DeleteMilestoneResponse>(
+        INDEXER.MILESTONE.ON_CHAIN_DELETE(milestone.uid),
+        { data: { chainID: milestone.chainId, programId } }
+      );
+
+      return response.data;
     },
     onMutate: async (milestone) => {
-      // Snapshot the previous value so the (now always-firing) onError
-      // restores the cache cleanly — without this the consumer would
-      // see the row vanish before the toast appears.
       const queryKey = QUERY_KEYS.MILESTONES.PROJECT_GRANT_MILESTONES(projectId, programId);
       await queryClient.cancelQueries({ queryKey });
       const previousData = queryClient.getQueryData<ProjectGrantMilestonesResponse | null>(
         queryKey
       );
       queryClient.setQueryData<ProjectGrantMilestonesResponse | null>(queryKey, (oldData) => {
-        if (!oldData || !oldData.grantMilestones || !Array.isArray(oldData.grantMilestones)) {
+        if (!oldData?.grantMilestones || !Array.isArray(oldData.grantMilestones)) {
           return oldData;
         }
         return {
@@ -64,8 +66,6 @@ export const useDeleteMilestone = ({
       return { previousData };
     },
     onSuccess: () => {
-      // Unreachable while mutationFn always throws — kept so the wiring
-      // is correct the moment the on-chain delete attestation lands.
       onSuccess?.();
     },
     onError: (error: Error, milestone, context) => {

--- a/hooks/useDeleteMilestone.ts
+++ b/hooks/useDeleteMilestone.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
+import { useAuth } from "@/hooks/useAuth";
+import { useMixpanel } from "@/hooks/useMixpanel";
 import type {
   GrantMilestoneWithCompletion,
   ProjectGrantMilestonesResponse,
@@ -28,7 +30,9 @@ export const useDeleteMilestone = ({
   onSuccess,
 }: UseDeleteMilestoneParams) => {
   const queryClient = useQueryClient();
-  const { showError } = useAttestationToast();
+  const { showError, showSuccess } = useAttestationToast();
+  const { address } = useAuth();
+  const { mixpanel } = useMixpanel();
 
   const deleteMilestoneMutation = useMutation({
     mutationFn: async (milestone: GrantMilestoneWithCompletion) => {
@@ -39,12 +43,33 @@ export const useDeleteMilestone = ({
         throw new Error("Cannot delete milestone: missing programId");
       }
 
+      // The on-chain attester for the revocation is always the Karma admin
+      // wallet, so the only audit trail of who *requested* the delete lives
+      // in product analytics. Tracking before the network call captures
+      // intent even if the request fails downstream.
+      mixpanel.reportEvent({
+        event: "milestone:delete:requested",
+        properties: {
+          requestedBy: address,
+          milestoneUID: milestone.uid,
+          milestoneTitle: milestone.title,
+          programId,
+          chainID: milestone.chainId,
+        },
+      });
+
       const apiClient = createAuthenticatedApiClient(envVars.NEXT_PUBLIC_GAP_INDEXER_URL, 60000);
 
       const response = await apiClient.delete<DeleteMilestoneResponse>(
         INDEXER.MILESTONE.ON_CHAIN_DELETE(milestone.uid),
-        { data: { chainID: milestone.chainId, programId } }
+        { data: { chainID: milestone.chainId } }
       );
+
+      if (!response.data.revocationSuccess) {
+        throw new Error(
+          "On-chain milestone revocation failed. Please retry; if it persists, contact support."
+        );
+      }
 
       return response.data;
     },
@@ -65,7 +90,18 @@ export const useDeleteMilestone = ({
       });
       return { previousData };
     },
-    onSuccess: () => {
+    onSuccess: (data, milestone) => {
+      mixpanel.reportEvent({
+        event: "milestone:delete:success",
+        properties: {
+          requestedBy: address,
+          milestoneUID: milestone.uid,
+          programId,
+          chainID: milestone.chainId,
+          revocationTxHash: data.revocationTxHash,
+        },
+      });
+      showSuccess("Milestone deleted");
       onSuccess?.();
     },
     onError: (error: Error, milestone, context) => {
@@ -73,6 +109,16 @@ export const useDeleteMilestone = ({
       if (context?.previousData) {
         queryClient.setQueryData(queryKey, context.previousData);
       }
+      mixpanel.reportEvent({
+        event: "milestone:delete:failed",
+        properties: {
+          requestedBy: address,
+          milestoneUID: milestone.uid,
+          programId,
+          chainID: milestone.chainId,
+          error: error?.message,
+        },
+      });
       showError(error?.message || "Failed to delete milestone");
       errorManager(`Failed to delete milestone "${milestone.title}"`, error, {
         milestoneUID: milestone.uid,

--- a/hooks/useMilestoneEdit.ts
+++ b/hooks/useMilestoneEdit.ts
@@ -4,6 +4,8 @@ import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
+import { useAuth } from "@/hooks/useAuth";
+import { useMixpanel } from "@/hooks/useMixpanel";
 import { useProjectStore } from "@/store";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
@@ -50,6 +52,8 @@ export const useMilestoneEdit = (options?: UseMilestoneEditOptions) => {
   const projectUid = options?.projectUid || storeProject?.uid || "";
   const projectSlug = options?.projectSlug || storeProject?.details?.slug || "";
   const { refetch: refetchGrants } = useProjectGrants(projectUid);
+  const { address: authAddress } = useAuth();
+  const { mixpanel } = useMixpanel();
 
   const invalidateAllProjectQueries = async () => {
     const invalidations: Promise<void>[] = [];
@@ -117,6 +121,19 @@ export const useMilestoneEdit = (options?: UseMilestoneEditOptions) => {
     setIsEditing(true);
     showLoading("Editing milestone...");
 
+    // The on-chain attester for the new+revoke attestations is the Karma
+    // admin wallet, so audit of who *requested* the edit lives in analytics.
+    mixpanel.reportEvent({
+      event: "milestone:edit:requested",
+      properties: {
+        requestedBy: authAddress,
+        milestoneUID: milestone.uid,
+        milestoneTitle: milestone.title,
+        programId,
+        chainID: milestone.chainID,
+      },
+    });
+
     try {
       const apiClient = createAuthenticatedApiClient(envVars.NEXT_PUBLIC_GAP_INDEXER_URL, 60000);
 
@@ -162,8 +179,30 @@ export const useMilestoneEdit = (options?: UseMilestoneEditOptions) => {
       );
 
       await invalidateAllProjectQueries();
+      mixpanel.reportEvent({
+        event: "milestone:edit:success",
+        properties: {
+          requestedBy: authAddress,
+          milestoneUID: milestone.uid,
+          newMilestoneUID: response.data.newMilestoneUID,
+          programId,
+          chainID: milestone.chainID,
+          txHash: response.data.txHash,
+          revocationSuccess: response.data.revocationSuccess,
+        },
+      });
       showSuccess("Milestone edited successfully!");
     } catch (error) {
+      mixpanel.reportEvent({
+        event: "milestone:edit:failed",
+        properties: {
+          requestedBy: authAddress,
+          milestoneUID: milestone.uid,
+          programId,
+          chainID: milestone.chainID,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       showError("There was an error editing the milestone");
       errorManager("Error editing milestone", error, {
         milestoneData: milestone,

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -443,6 +443,7 @@ export const INDEXER = {
     },
     EVALUATION: (milestoneUID: string) => `/v2/milestones/${milestoneUID}/evaluation`,
     ON_CHAIN_EDIT: (milestoneUID: string) => `/v2/milestones/${milestoneUID}/on-chain-edit`,
+    ON_CHAIN_DELETE: (milestoneUID: string) => `/v2/milestones/${milestoneUID}/on-chain-delete`,
   },
   CATEGORIES: {
     CREATE: (idOrSlug: string) => `/categories/create/${idOrSlug}`,


### PR DESCRIPTION
## Summary

- Wires the admin Milestones Review UI to the new on-chain delete endpoint shipping in [show-karma/gap-indexer#1753](https://github.com/show-karma/gap-indexer/pull/1753). Replaces the stubbed `useDeleteMilestone` hook (which always threw "not available yet") with a real React Query mutation that revokes the milestone's on-chain attestation server-side.
- Restricts the edit and delete buttons in `MilestonesReview` to **community admins only**. Milestone reviewers can still verify completions but no longer see milestone-mutation controls. Matches the backend auth model in the indexer PR.
- Adds Mixpanel tracking for both delete and edit so we have an audit trail of who initiated each operation — the on-chain attester is always the Karma admin wallet, so without this we cannot answer "who deleted milestone X" from chain data alone.

Related ticket: [DEV-286](https://linear.app/showkarma/issue/DEV-286/on-chain-milestone-delete-tighten-editdelete-auth).
Backend PR (lockstep): show-karma/gap-indexer#1753.

## Why

Milestones now live on-chain end-to-end. The previous delete flow was a frontend stub that threw a "being migrated" error on every click — there was no working delete capability for admins. The new indexer endpoint resolves auth from the milestone attestation's grant `refUID` server-side, so the FE just needs to send `chainID` and let the backend authorize.

Reviewers retain their verify/complete/sync powers; only edit and delete are restricted to admins.

## Capability matrix

| Action | Community admin | Milestone reviewer |
|---|---|---|
| Verify milestone completion | yes | yes |
| Edit milestone definition | yes | no |
| Delete milestone | yes | no |

## Mixpanel events (new)

The on-chain attester for both edit (revoke-old + create-new) and delete (revoke) is always the Karma admin wallet (`GAP_ADMIN_PRIVATE_KEY`). The original requester's identity is never written on-chain, so the only audit trail of who-requested-what lives in product analytics.

Events fire from `useDeleteMilestone` and `useMilestoneEdit` (API path only — the SDK-direct path used by grantees is unchanged since the grantee signs themselves):

| Event | When |
|---|---|
| `gap:milestone:delete:requested` | User confirmed delete; before the network call |
| `gap:milestone:delete:success` | Backend returned `revocationSuccess: true` |
| `gap:milestone:delete:failed` | Network error, 4xx, 5xx, or `revocationSuccess: false` |
| `gap:milestone:edit:requested` | User submitted the edit form; before the PUT |
| `gap:milestone:edit:success` | Backend returned and the new milestone UID was indexed |
| `gap:milestone:edit:failed` | Any error path in the edit flow |

Each event carries: `requestedBy` (wallet address from `useAuth`), `milestoneUID`, `milestoneTitle`, `programId`, `chainID`. Success events additionally carry `txHash` / `revocationTxHash` / `newMilestoneUID` where applicable.

## Changes by file

- `hooks/useDeleteMilestone.ts` — replaced the stub. Calls `DELETE /v2/milestones/:milestoneUID/on-chain-delete` with body `{ chainID }`. Keeps the optimistic-removal + cache rollback structure. Throws early when `chainId` or `programId` are missing. **Throws when `revocationSuccess: false`** so the optimistic UI removal is rolled back and the user sees an error toast rather than the row silently disappearing. Fires success toast on completion. Tracks all three events.
- `hooks/useMilestoneEdit.ts` — adds Mixpanel tracking around the existing on-chain edit API path (`editMilestoneViaApi`). No behavior change beyond observability.
- `components/Pages/Admin/MilestonesReview/index.tsx` — splits `canVerifyMilestones` (admin or reviewer) from `canEditOrDeleteMilestones` (admin only). Both `canDeleteMilestones` and `canEditMilestones` props now use the admin-only flag. Drops the redundant `|| false`.
- `components/Pages/Admin/MilestonesReview/MilestoneCard.tsx` — delete visibility changed from `canDeleteMilestones && milestone.fundingApplicationCompletion` to `canDeleteMilestones && !hasCompletion`, so admins can remove on-chain milestones that don't yet have a completion attestation (which was the entire point — the old gate was a legacy off-chain check).
- `utilities/indexer.ts` — adds `MILESTONE.ON_CHAIN_DELETE(uid)` constant.
- `__tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx` — rewritten suite. Covers: success invokes `onSuccess` and asserts the request body shape; 403 rolls back the cache; missing `chainId` short-circuits before any network call; `revocationSuccess: false` is treated as failure and triggers rollback. Test fixture uses a persistent `QueryClient` (gcTime: Infinity) so React Query's GC doesn't race rollback assertions.

## Review fixes applied in commit `dd76456`

- **`revocationSuccess: false` is now a failure path** — was previously silently treated as success, leaving the optimistic cache update in place and the row visually deleted while the on-chain revocation hadn't actually completed
- **Tests assert the request body shape** in the success path — a regression that renames `chainID` → `chainId` or drops the field would have surfaced only in manual QA before
- **Dropped `|| false`** from `canEditOrDeleteMilestones` since `hasAdminAccess` is already boolean
- **Success toast** on delete completion — row vanishing alone isn't enough feedback
- **Persistent `QueryClient`** in the rollback tests to stop React Query's garbage collector from clearing the cache before the assertion can read it (was racing with `gcTime: 0` in the default test fixture)

## Test plan

- [x] `pnpm test __tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx` — 4/4 passing
- [x] biome check clean (one pre-existing complexity warning on `MilestoneCard` unrelated to this change)
- [ ] Manual: as a community admin, open Milestones Review → click delete on a Late/Not-Started milestone → confirm the on-chain revocation completes, the row is removed, success toast fires, and `gap:milestone:delete:success` appears in Mixpanel for the connected wallet
- [ ] Manual: as a milestone reviewer (not admin), open Milestones Review → confirm no edit or delete controls render on any milestone card
- [ ] Manual: as a community admin, open a milestone that already has a completion submitted → confirm delete is hidden
- [ ] Manual: as a community admin, edit a milestone title → confirm `gap:milestone:edit:success` fires with the requester address and new UID
- [ ] Manual: trigger a server error (e.g. submit while disconnected) → confirm the row reappears (optimistic rollback), error toast fires, and `*:failed` event includes the error message

## Dependency

Requires the new indexer endpoint to be deployed in lockstep. The hook will return a server error until show-karma/gap-indexer#1753 is merged and deployed.