### PR TITLE
fix(milestones-review): delete dialog never mounts + include staff in admin   gating

### DIFF
--- a/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
+++ b/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
@@ -1,0 +1,177 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render as rtlRender, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { MilestoneCard } from "@/components/Pages/Admin/MilestonesReview/MilestoneCard";
+import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source: string }) => <div>{source}</div>,
+}));
+
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  __esModule: true,
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock("@/hooks/useMilestoneImpactAnswers", () => ({
+  useMilestoneImpactAnswers: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: () => [null, vi.fn()],
+}));
+
+vi.mock("@/store/agentChat", () => ({
+  useAgentChatStore: (selector: (s: { setOpen: () => void; addMention: () => void }) => unknown) =>
+    selector({ setOpen: vi.fn(), addMention: vi.fn() }),
+}));
+
+vi.mock("@/utilities/milestoneTransforms", () => ({
+  toEditableUnifiedMilestone: vi.fn(),
+}));
+
+function createMilestone(
+  overrides?: Partial<GrantMilestoneWithCompletion>
+): GrantMilestoneWithCompletion {
+  return {
+    uid: "0xmilestone-uid",
+    chainId: 10,
+    programId: "program-001",
+    title: "Audit completion",
+    description: "Complete security audit",
+    dueDate: "2026-12-31T00:00:00Z",
+    status: "pending",
+    completionDetails: null,
+    verificationDetails: null,
+    fundingApplicationCompletion: null,
+    ...overrides,
+  };
+}
+
+const DEFAULT_PROPS = {
+  index: 0,
+  verifyingMilestoneId: null,
+  verificationComment: "",
+  isVerifying: false,
+  canVerifyMilestones: true,
+  canDeleteMilestones: true,
+  canEditMilestones: false,
+  onVerifyClick: vi.fn(),
+  onCancelVerification: vi.fn(),
+  onVerificationCommentChange: vi.fn(),
+  onSubmitVerification: vi.fn(),
+  onDeleteMilestone: vi.fn(() => Promise.resolve()),
+};
+
+describe("MilestoneCard (admin review) — overflow → delete dialog flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_open_delete_confirmation_dialog_when_user_clicks_delete_menu_item", () => {
+    const milestone = createMilestone();
+    render(<MilestoneCard {...DEFAULT_PROPS} milestone={milestone} />);
+
+    // Initially: menu closed, dialog closed
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Are you sure you want to delete/i)).not.toBeInTheDocument();
+
+    // Open the overflow menu
+    fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    // Click the Delete menu item
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+
+    // Regression: dialog must mount and become visible after the menu closes.
+    // Before the fix, DeleteDialog lived inside the menu's conditional, so
+    // setting isOverflowOpen=false unmounted it before Radix could open the
+    // modal portal — and the confirmation text never appeared.
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
+  });
+
+  it("should_call_onDeleteMilestone_when_user_confirms_in_dialog", async () => {
+    const onDeleteMilestone = vi.fn(() => Promise.resolve());
+    const milestone = createMilestone();
+
+    render(
+      <MilestoneCard
+        {...DEFAULT_PROPS}
+        milestone={milestone}
+        onDeleteMilestone={onDeleteMilestone}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    });
+
+    expect(onDeleteMilestone).toHaveBeenCalledTimes(1);
+    expect(onDeleteMilestone).toHaveBeenCalledWith(milestone);
+  });
+
+  it("should_allow_reopening_the_menu_after_canceling_the_dialog", () => {
+    render(<MilestoneCard {...DEFAULT_PROPS} milestone={createMilestone()} />);
+
+    // First trip: open menu → click delete → cancel dialog
+    fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+    expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByText(/Are you sure you want to delete/i)).not.toBeInTheDocument();
+
+    // Second trip: menu must open again. Before the fix, isDeleteDialogOpen
+    // stayed true after the failed first open, so re-clicking the overflow
+    // trigger flashed the modal instead of showing the dropdown.
+    fireEvent.click(screen.getByRole("button", { name: /more actions/i }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("should_not_render_overflow_trigger_when_canDeleteMilestones_is_false", () => {
+    render(
+      <MilestoneCard {...DEFAULT_PROPS} milestone={createMilestone()} canDeleteMilestones={false} />
+    );
+
+    expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+  });
+
+  it("should_not_render_overflow_trigger_when_milestone_has_a_completion", () => {
+    render(
+      <MilestoneCard
+        {...DEFAULT_PROPS}
+        milestone={createMilestone({
+          completionDetails: {
+            description: "submitted",
+            completedAt: "2026-01-01T00:00:00Z",
+            deliverables: [],
+          } as unknown as GrantMilestoneWithCompletion["completionDetails"],
+        })}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
+  });
+});

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -280,9 +280,9 @@ export function MilestoneCard({
     setIsCompletionExpanded((v) => !v);
   }, []);
 
-  const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
-    if (open) setIsOverflowOpen(false);
-    setIsDeleteDialogOpen(open);
+  const handleDeleteMenuClick = useCallback(() => {
+    setIsOverflowOpen(false);
+    setIsDeleteDialogOpen(true);
   }, []);
 
   const handleOverflowBlur = useCallback((e: React.FocusEvent) => {
@@ -404,45 +404,52 @@ export function MilestoneCard({
             </Button>
           )}
           {canDeleteMilestones && !hasCompletion && (
-            // biome-ignore lint/a11y/noStaticElementInteractions: wrapper needs onBlur to detect focus leaving the menu group; the interactive child is the trigger button below.
-            <div className="relative" ref={overflowRef} onBlur={handleOverflowBlur}>
-              <button
-                type="button"
-                onClick={handleToggleOverflow}
-                onKeyDown={handleOverflowKeyDown}
-                className="p-1 rounded hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors"
-                aria-label="More actions"
-                aria-haspopup="menu"
-                aria-expanded={isOverflowOpen}
-              >
-                <EllipsisVerticalIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
-              </button>
-              {isOverflowOpen && (
-                <div
-                  role="menu"
+            <>
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: wrapper needs onBlur to detect focus leaving the menu group; the interactive child is the trigger button below. */}
+              <div className="relative" ref={overflowRef} onBlur={handleOverflowBlur}>
+                <button
+                  type="button"
+                  onClick={handleToggleOverflow}
                   onKeyDown={handleOverflowKeyDown}
-                  className="absolute right-0 top-full mt-1 z-10 bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-md shadow-lg py-1 min-w-[140px]"
+                  className="p-1 rounded hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors"
+                  aria-label="More actions"
+                  aria-haspopup="menu"
+                  aria-expanded={isOverflowOpen}
                 >
-                  <DeleteDialog
-                    deleteFunction={() => onDeleteMilestone(milestone)}
-                    isLoading={isDeleting}
-                    title={
-                      <p className="font-normal">
-                        Are you sure you want to delete <b>{milestone.title}</b> milestone?
-                      </p>
-                    }
-                    buttonElement={{
-                      text: "Delete",
-                      icon: <TrashIcon className="w-4 h-4" />,
-                      styleClass:
-                        "flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 text-left",
-                    }}
-                    externalIsOpen={isDeleteDialogOpen}
-                    externalSetIsOpen={handleDeleteDialogOpenChange}
-                  />
-                </div>
-              )}
-            </div>
+                  <EllipsisVerticalIcon className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                </button>
+                {isOverflowOpen && (
+                  <div
+                    role="menu"
+                    onKeyDown={handleOverflowKeyDown}
+                    className="absolute right-0 top-full mt-1 z-10 bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-md shadow-lg py-1 min-w-[140px]"
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={handleDeleteMenuClick}
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 text-left"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+              {/* Rendered outside the overflow menu so closing the menu doesn't unmount the dialog mid-open. */}
+              <DeleteDialog
+                deleteFunction={() => onDeleteMilestone(milestone)}
+                isLoading={isDeleting}
+                title={
+                  <p className="font-normal">
+                    Are you sure you want to delete <b>{milestone.title}</b> milestone?
+                  </p>
+                }
+                buttonElement={null}
+                externalIsOpen={isDeleteDialogOpen}
+                externalSetIsOpen={setIsDeleteDialogOpen}
+              />
+            </>
           )}
         </div>
       </div>

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -33,6 +33,7 @@ import {
   useIsReviewerType,
   usePermissionContext,
 } from "@/src/core/rbac/context/permission-context";
+import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { ReviewerType } from "@/src/core/rbac/types";
 import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
@@ -482,6 +483,7 @@ function MilestonesReviewPageContent({
   const isReviewer = useIsReviewer();
   const isMilestoneReviewer = useIsReviewerType(ReviewerType.MILESTONE);
   const { isLoading: isLoadingReviewer } = usePermissionContext();
+  const { isStaff } = useStaff();
 
   // Determine if user can verify milestones (must be before early returns)
   // Only milestone reviewers, admins, contract owners, and staff can verify/complete/sync
@@ -490,9 +492,10 @@ function MilestonesReviewPageContent({
     [hasAdminAccess, isMilestoneReviewer]
   );
 
-  // Only community admins (and staff via admin access) can edit or delete milestones.
+  // Staff and community admins can edit or delete milestones — matches the
+  // backend service-level auth in milestone-on-chain-{edit,delete}.write.service.
   // Milestone reviewers verify completions but cannot mutate milestone definitions.
-  const canEditOrDeleteMilestones = hasAdminAccess;
+  const canEditOrDeleteMilestones = isStaff || hasAdminAccess;
 
   // Delete milestone hook with proper React Query mutation/query relationship
   const { deleteMilestoneAsync, isDeleting } = useDeleteMilestone({


### PR DESCRIPTION
## Summary

Two follow-ups to #1411 (merged):

1. **Delete confirmation dialog never appeared** when admins clicked overflow → Delete on the admin Milestones Review page. `DeleteDialog` was rendered inside the menu's conditional, so closing the menu unmounted the dialog mid-open. Reported on staging.
2. **Staff users were not seeing edit/delete controls** even though the backend authorizes them. The FE only checked `hasAdminAccess`; the backend allows staff OR community admin of the grant's community.

Related ticket: [DEV-286](https://linear.app/showkarma/issue/DEV-286/on-chain-milestone-delete-tighten-editdelete-auth).

## Root cause of (1) — unmount race

`DeleteDialog` was rendered inside the overflow menu's conditional:

```tsx
{isOverflowOpen && (
  <div role="menu" ...>
    <DeleteDialog ... />
  </div>
)}
```

Clicking the dialog's built-in trigger called `openModal()` → batched `setIsOverflowOpen(false)` + `setIsDeleteDialogOpen(true)` in the same render commit. React then unmounted the menu and `DeleteDialog` with it, **before** Radix's `<Dialog>` could mount its portal. No modal ever appeared.

`isDeleteDialogOpen` then stayed stuck `true`. The next 3-dot click re-mounted `DeleteDialog` with `externalIsOpen=true`, so the modal overlay immediately covered the menu — looked like the dropdown was broken.

## Fix in `ac2f996b`

- Hoist `DeleteDialog` **outside** the menu's conditional, mounted whenever delete is allowed
- Pass `buttonElement={null}` so `DeleteDialog` renders only the dialog itself, no built-in trigger
- Menu item is now a plain `<button role="menuitem">` calling a single `handleDeleteMenuClick` that closes the menu and opens the dialog in one step
- Dialog lifecycle is no longer tied to the menu's

## Fix in `35f9985c` — staff gating

`canEditOrDeleteMilestones = isStaff || hasAdminAccess`. Matches the backend's `MilestoneOnChainEditWriteService.verifyAuthorization` and `MilestoneOnChainDeleteWriteService.verifyAuthorization` which both allow staff OR community admin of the grant's community.

## Regression tests in `c1ef5244`

New file at `__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx`, 5 tests:

| Test | Coverage |
|---|---|
| `should_open_delete_confirmation_dialog_when_user_clicks_delete_menu_item` | The exact regression — locks in dialog visibility after the menu closes |
| `should_call_onDeleteMilestone_when_user_confirms_in_dialog` | End-to-end confirm path |
| `should_allow_reopening_the_menu_after_canceling_the_dialog` | Second-bug regression — menu reopens cleanly after the dialog closes |
| `should_not_render_overflow_trigger_when_canDeleteMilestones_is_false` | Visibility gate (reviewer) |
| `should_not_render_overflow_trigger_when_milestone_has_a_completion` | Visibility gate (post-completion) |

5/5 passing locally.

## Test plan

- [x] `pnpm test __tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx` → 5 passing
- [x] `pnpm test __tests__/integration/mutations/useDeleteMilestone.mutation.test.tsx` → 4 passing (no regression in the delete hook)
- [x] Biome clean on touched files
- [ ] Staging: as a community admin, click 3-dot on a Late milestone → Delete → confirm dialog appears → Continue → row removed
- [ ] Staging: as staff (no community-admin role), open Milestones Review → confirm edit/delete buttons render
- [ ] Staging: as a milestone reviewer (no admin/staff), confirm edit/delete buttons do NOT render
- [ ] Staging: Cancel → reopen 3-dot menu → menu opens cleanly (not the modal)

## Files

- `components/Pages/Admin/MilestonesReview/MilestoneCard.tsx` (+47 / -40)
- `components/Pages/Admin/MilestonesReview/index.tsx` (+5 / -2) — staff in gating
- `__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx` (new, 177 lines)