### PR TITLE
 fix(milestones): match grant by normalized programId so edit button can render

### DIFF
--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -126,6 +126,11 @@ export async function fetchApplicationMilestoneEvaluation(
   return data ?? { evaluations: [] };
 }
 
+function stripChainSuffix(programId: string | undefined): string | undefined {
+  if (!programId) return programId;
+  return programId.includes("_") ? programId.split("_")[0] : programId;
+}
+
 async function fetchGrantByProgramId(
   projectUid: string,
   programId: string
@@ -138,7 +143,11 @@ async function fetchGrantByProgramId(
     return undefined;
   }
 
-  return grants.find((g) => g.details?.programId === programId);
+  // Compare in normalized form: grant.details.programId may be stored as
+  // either "1013" or "1013_42161" depending on when the grant was created,
+  // while the caller always passes the chain-stripped form.
+  const normalizedTarget = stripChainSuffix(programId);
+  return grants.find((g) => stripChainSuffix(g.details?.programId) === normalizedTarget);
 }
 
 export async function fetchProjectGrantMilestones(


### PR DESCRIPTION
## Summary

Follow-up to #1411 + #1412. On staging, the edit button still didn't render for staff/admins on the admin Milestones Review page, even though delete did. The asymmetry traced to a comparison bug in the grant lookup, not the gating logic shipped in #1412.

Related: [DEV-286](https://linear.app/showkarma/issue/DEV-286/on-chain-milestone-delete-tighten-editdelete-auth).

## Root cause

`fetchGrantByProgramId` normalized its **input** (stripped the chainId suffix) but compared against the **un-normalized** value stored on the grant:

```ts
// before
async function fetchGrantByProgramId(projectUid, programId) {
  ...
  return grants.find((g) => g.details?.programId === programId);
  //                        "1013_42161"            === "1013"  → false
}
```

Caller (`fetchProjectGrantMilestones`) strips the suffix before calling, so `programId` arrives as `"1013"`. Grants stored as `"1013_42161"` never match → `grant` returned `undefined` → `data.grant` undefined → `grantUID` / `grantChainID` undefined → `unifiedMilestone` null → **edit hidden**.

Delete still rendered because its gate doesn't depend on grant context.

## Fix

Normalize **both sides** of the comparison via a `stripChainSuffix` helper, so the lookup works regardless of whether `details.programId` was stored as `"1013"` or `"1013_42161"`.

## Verification trace

Filecoin Batch 1 grant on staging:

- Stored `details.programId`: `"1013_42161"`
- Caller's `programId` after normalization: `"1013"`
- After fix: `stripChainSuffix("1013_42161") === "1013"` → matches
- Resolved: `grant.uid = "0x014aa9..."`, `grant.chainID = 8453`
- `unifiedMilestone` now built → edit gate passes for non-completed, non-verified milestones

## Backward compatibility

Legacy grants stored as bare `"1013"`: `stripChainSuffix("1013")` is `"1013"` (no underscore). Still matches.

## Files

- `services/milestones.ts` (+10 / -1)
