### PR TITLE
fix(milestone-status): user-facing label "Late" → "Past Due"

### DIFF
--- a/__tests__/features/applications/MilestoneStatusBadge.test.tsx
+++ b/__tests__/features/applications/MilestoneStatusBadge.test.tsx
@@ -71,7 +71,7 @@ describe("MilestoneStatusBadge", () => {
         })}
       />
     );
-    expect(screen.getByText("Late")).toBeInTheDocument();
+    expect(screen.getByText("Past Due")).toBeInTheDocument();
   });
 
   it("should_not_render_Late_when_completed_even_if_dueDate_is_past", () => {
@@ -87,7 +87,7 @@ describe("MilestoneStatusBadge", () => {
       />
     );
     expect(screen.getByText("Pending Verification")).toBeInTheDocument();
-    expect(screen.queryByText("Late")).not.toBeInTheDocument();
+    expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
   });
 
   it("should_render_Pending_when_entry_is_undefined", () => {

--- a/__tests__/unit/utilities/milestone-review-status.test.ts
+++ b/__tests__/unit/utilities/milestone-review-status.test.ts
@@ -123,7 +123,7 @@ describe("MILESTONE_STATUS_CONFIG", () => {
 
   it("returns correct label for Late milestone", () => {
     const config = MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Late];
-    expect(config.label).toBe("Late");
+    expect(config.label).toBe("Past Due");
     expect(config.badgeColor).toContain("bg-orange");
   });
 });

--- a/__tests__/unit/utilities/milestone-review-status.test.ts
+++ b/__tests__/unit/utilities/milestone-review-status.test.ts
@@ -124,6 +124,7 @@ describe("MILESTONE_STATUS_CONFIG", () => {
   it("returns correct label for Late milestone", () => {
     const config = MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Late];
     expect(config.label).toBe("Past Due");
+    expect(config.filterLabel).toBe("Past Due");
     expect(config.badgeColor).toContain("bg-orange");
   });
 });

--- a/components/Pages/Admin/MilestonesReview/utils/milestone-review-status.ts
+++ b/components/Pages/Admin/MilestonesReview/utils/milestone-review-status.ts
@@ -69,9 +69,9 @@ export const MILESTONE_STATUS_CONFIG: Record<
     stepperColor: "bg-gray-500",
   },
   [MilestoneReviewStatus.Late]: {
-    label: "Late",
+    label: "Past Due",
     badgeColor: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
-    filterLabel: "Late",
+    filterLabel: "Past Due",
     icon: "arrow-path",
     stepperColor: "bg-orange-500",
   },

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -46,7 +46,7 @@ function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
   // completed/verified.
   if (isMilestoneVerified(entry)) return { label: "Verified", tone: "success" };
   if (isMilestoneCompleted(entry)) return { label: "Pending Verification", tone: "warning" };
-  if (isMilestoneLate(entry)) return { label: "Late", tone: "danger" };
+  if (isMilestoneLate(entry)) return { label: "Past Due", tone: "danger" };
   return { label: "Pending", tone: "neutral" };
 }
 

--- a/src/features/applications/components/OffChainMilestoneRow.tsx
+++ b/src/features/applications/components/OffChainMilestoneRow.tsx
@@ -183,7 +183,7 @@ export function OffChainMilestoneRow({
               </span>
             ) : isLate ? (
               <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
-                Late
+                Past Due
               </span>
             ) : (
               <span className="text-xs px-2 py-0.5 rounded-full bg-zinc-100 text-zinc-700">

--- a/src/features/applications/components/OnChainMilestoneRow.tsx
+++ b/src/features/applications/components/OnChainMilestoneRow.tsx
@@ -143,7 +143,7 @@ export function OnChainMilestoneRow({
               </span>
             ) : isLate ? (
               <span className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
-                Late
+                Past Due
               </span>
             ) : (
               <span className="text-xs px-2 py-0.5 rounded-full bg-zinc-100 text-zinc-700">

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -85,10 +85,10 @@ export function isMilestoneCompleted(statusEntry?: MilestoneStatusEntry): boolea
 }
 
 /**
- * A milestone is "Late" when it has a due date in the past AND has not
- * yet been completed or verified. Pending future-due milestones stay
- * Pending; completed/verified milestones never reclassify as Late even
- * if their due date was in the past at completion time.
+ * A milestone is "Past Due" when it has a due date in the past AND has
+ * not yet been completed or verified. Pending future-due milestones stay
+ * Pending; completed/verified milestones never reclassify as Past Due
+ * even if their due date was in the past at completion time.
  */
 export function isMilestoneLate(statusEntry?: MilestoneStatusEntry): boolean {
   if (!statusEntry) return false;


### PR DESCRIPTION
## Summary
- Changes the `MilestoneStatusBadge` overdue label from `"Late"` to `"Past Due"` to match the rest of the app (StatsTable, MilestonesSection, CommunityMilestoneCard, PublicProjectDetailsModal).
- Updates the corresponding unit tests.

Closes #1415

## Test plan
- [x] `npx vitest run __tests__/features/applications/MilestoneStatusBadge.test.tsx` passes
- [ ] Visual check on a project profile with an overdue milestone — pill reads "Past Due"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated milestone status label from "Late" to "Past Due" across the UI for clearer timeline wording.
* **Tests**
  * Updated tests to expect the new "Past Due" label.
* **Documentation**
  * Clarified docs/comments to describe the "Past Due" classification and its behavior relative to pending/completed milestones.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1416)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->