### PR TITLE
fix(reviewer-picker): preselect roles, fix PATCH 404, polish Add button

### DIFF
--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
+import { Button as KarmaButton } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -204,21 +205,14 @@ const ReviewerPickerModal = ({
     mutationFn: async (toSave: SelectedRow[]) => {
       const settled = await Promise.allSettled(
         toSave.map(async (row) => {
+          // The POST `addReviewer` calls upsert user_profile with these fields,
+          // so dirty contact edits on pool rows propagate cross-program without a separate PATCH.
           const basePayload = {
             name: row.name,
             email: row.email,
             telegram: row.telegram || undefined,
             slack: row.slack || undefined,
           };
-
-          // PATCH dirty contact info once (pool rows only) — applies cross-program
-          if (row.kind === "pool" && isRowDirty(row)) {
-            await programReviewersService.updateReviewerContact(programId, {
-              email: row.original.email,
-              telegram: row.telegram || undefined,
-              slack: row.slack || undefined,
-            });
-          }
 
           const calls = row.roles.map((r) =>
             r === "program"
@@ -375,11 +369,17 @@ const ReviewerPickerModal = ({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All programs</SelectItem>
-                {reviewerPrograms.map((p) => (
-                  <SelectItem key={p.programId} value={p.programId}>
-                    {p.name} <span className="text-gray-400">({p.reviewerCount})</span>
-                  </SelectItem>
-                ))}
+                {reviewerPrograms.map((p) => {
+                  const availableCount =
+                    p.programId === programId
+                      ? Math.max(0, p.reviewerCount - assignedSet.size)
+                      : p.reviewerCount;
+                  return (
+                    <SelectItem key={p.programId} value={p.programId}>
+                      {p.name} <span className="text-gray-400">({availableCount})</span>
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
             <div className="inline-flex rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden h-8 text-xs">
@@ -520,21 +520,17 @@ const ReviewerPickerModal = ({
           >
             Cancel
           </Button>
-          <Button
-            type="button"
+          <KarmaButton
             onClick={handleSave}
             disabled={isSaving || rows.length === 0}
+            isLoading={isSaving}
             data-testid="save-btn"
+            className="flex items-center space-x-2"
           >
-            {isSaving ? (
-              <>
-                <Spinner className="h-4 w-4 mr-2 border-2" />
-                Saving…
-              </>
-            ) : (
-              `Save${rows.length > 0 ? ` (${rows.length} ${pluralize("reviewer", rows.length)})` : ""}`
-            )}
-          </Button>
+            {isSaving
+              ? "Adding…"
+              : `Add${rows.length > 0 ? ` (${rows.length} ${pluralize("reviewer", rows.length)})` : ""}`}
+          </KarmaButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
@@ -82,16 +82,11 @@ export function poolRowFromReviewer(
 ): PoolPickedRow {
   const telegram = reviewer.telegram ?? "";
   const slack = reviewer.slack ?? "";
-  const defaultAsCommunityRole: CommunityReviewerRole =
-    defaultRole === "milestone" ? "milestone-reviewer" : "program-reviewer";
-  // Prefer the launcher's role when the reviewer already has it; otherwise
-  // fall back to the reviewer's existing role so the chip doesn't pre-check
-  // a role the reviewer isn't associated with.
-  const initialRole: ReviewerRoleSelection = reviewer.roles.includes(defaultAsCommunityRole)
-    ? defaultRole
-    : reviewer.roles[0]
-      ? roleSelectionFromCommunityRole(reviewer.roles[0])
-      : defaultRole;
+  // Pre-check every role the reviewer already holds in the community pool
+  // so a multi-role pick (e.g. App + Milestone) is preserved on save.
+  const dedupedRoles = Array.from(new Set(reviewer.roles.map(roleSelectionFromCommunityRole)));
+  const initialRoles: ReviewerRoleSelection[] =
+    dedupedRoles.length > 0 ? dedupedRoles : [defaultRole];
   return {
     kind: "pool",
     id: reviewer.publicAddress,
@@ -100,7 +95,7 @@ export function poolRowFromReviewer(
     email: reviewer.email,
     telegram,
     slack,
-    roles: [initialRole],
+    roles: initialRoles,
     original: {
       name: reviewer.name,
       email: reviewer.email,

--- a/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.types.test.ts
+++ b/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.types.test.ts
@@ -27,7 +27,7 @@ function makePoolRow(overrides: Partial<PoolPickedRow> = {}): PoolPickedRow {
 }
 
 describe("poolRowFromReviewer", () => {
-  it("should_build_pool_row_with_default_role_from_launcher_when_reviewer_has_that_role", () => {
+  it("should_preselect_all_roles_the_reviewer_already_holds", () => {
     const row = poolRowFromReviewer(
       { ...baseReviewer, roles: ["program-reviewer", "milestone-reviewer"] },
       "milestone"
@@ -36,7 +36,8 @@ describe("poolRowFromReviewer", () => {
     expect(row.kind).toBe("pool");
     expect(row.id).toBe(baseReviewer.publicAddress);
     expect(row.publicAddress).toBe(baseReviewer.publicAddress);
-    expect(row.roles).toEqual(["milestone"]);
+    expect(row.roles).toEqual(expect.arrayContaining(["program", "milestone"]));
+    expect(row.roles).toHaveLength(2);
     expect(row.name).toBe("Alice");
     expect(row.email).toBe("alice@example.com");
     expect(row.telegram).toBe("alice_tg");


### PR DESCRIPTION
## Summary
Follow-up fixes for the community reviewer picker (#1402) found during staging QA.

## Changes
- **Preselect all roles a reviewer already holds.** When a community reviewer has both App + Milestone roles, adding them now pre-checks both roles on the right pane instead of collapsing to the launcher role.
- **Fix 404 on save with edited contact info.** Removed the pre-POST `PATCH /v2/funding-program-configs/:programId/reviewers/by-email` call — it 404'd because the reviewer doesn't yet exist on the destination program. The POST `addReviewer` already upserts `user_profile` (telegram/slack/name) via `resolveUserFromEmail`, so cross-program contact updates still propagate.
- **Reconcile program-filter dropdown count with visible list.** Subtract already-assigned reviewers from the count when the option refers to the current program, so `(4)` no longer disagrees with a 3-row list.
- **Polish save button.** Modal footer now uses `KarmaButton` (matches the launcher's style) and the label is `Add` instead of `Save`, with `Adding…` while pending.

## Test plan
- [ ] Open picker on a program where some community reviewers hold both App + Milestone roles → both roles checked by default on right pane.
- [ ] Pick a reviewer from another program, edit their telegram/slack, click Add → no 404, contact updates apply across programs.
- [ ] Program-filter dropdown count for "this program" matches the visible row count.
- [ ] Footer button matches the "+ Add reviewers" launcher visually; label reads `Add (N reviewers)`.