### PR TITLE
fix(portfolio-reports): stop silent textarea wipe and guard regenerate

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PortfolioReportEditorPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage";
+import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import {
+  usePortfolioReport,
+  usePublishReport,
+  useRegenerateReport,
+  useUnpublishReport,
+  useUpdateReportContent,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => ({
+  HtmlReportFrame: ({ html }: { html?: string }) => <div data-testid="report-frame">{html}</div>,
+}));
+
+vi.mock("@/services/portfolio-reports.service", () => ({
+  downloadReportPdf: vi.fn(),
+}));
+
+vi.mock("@/hooks/communities/useCommunityAdminAccess");
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+
+const mockUseCommunityAdminAccess = vi.mocked(useCommunityAdminAccess);
+const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
+const mockUsePublishReport = vi.mocked(usePublishReport);
+const mockUseUnpublishReport = vi.mocked(useUnpublishReport);
+const mockUseRegenerateReport = vi.mocked(useRegenerateReport);
+const mockUseUpdateReportContent = vi.mocked(useUpdateReportContent);
+
+const community = {
+  uid: "community-1",
+  details: { slug: "filecoin", name: "Filecoin" },
+} as any;
+
+const baseReport = {
+  id: "report-1",
+  reportConfigId: "config-1",
+  communityId: "community-1",
+  runDate: "2026-03-15",
+  status: "draft",
+  content: "<p>Server content</p>",
+  dataSnapshot: {},
+  modelId: "gpt-4.1",
+  tokenUsage: null,
+  generatedAt: "2026-04-01T00:00:00.000Z",
+  generationError: null,
+  publishedAt: null,
+  publishedBy: null,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+};
+
+describe("PortfolioReportEditorPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCommunityAdminAccess.mockReturnValue({
+      hasAccess: true,
+      isLoading: false,
+    } as any);
+    mockUsePublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseUnpublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseRegenerateReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseUpdateReportContent.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+  });
+
+  describe("edit textarea seeding (Fix #1)", () => {
+    it("should_seed_textarea_with_report_content_when_dialog_opens", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+      expect(textarea.value).toBe("<p>Server content</p>");
+    });
+
+    it("should_not_reset_textarea_when_report_content_changes_while_dialog_is_open", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      const { rerender } = render(
+        <PortfolioReportEditorPage community={community} reportId="report-1" />
+      );
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+
+      await user.clear(textarea);
+      await user.type(textarea, "<p>My in-progress edits</p>");
+      expect(textarea.value).toBe("<p>My in-progress edits</p>");
+
+      // Simulate a background refetch / cache update returning different
+      // server content (e.g. another admin saved, or refetchOnWindowFocus).
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, content: "<p>Different server content</p>" },
+        isLoading: false,
+      } as any);
+      rerender(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      expect(textarea.value).toBe("<p>My in-progress edits</p>");
+    });
+
+    it("should_reseed_textarea_with_latest_content_when_dialog_reopens", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      const { rerender } = render(
+        <PortfolioReportEditorPage community={community} reportId="report-1" />
+      );
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, content: "<p>Updated server content</p>" },
+        isLoading: false,
+      } as any);
+      rerender(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+      expect(textarea.value).toBe("<p>Updated server content</p>");
+    });
+  });
+
+  describe("regenerate dialog (Fix #3)", () => {
+    it("should_show_standard_overwrite_warning_when_no_unsaved_edits_exist", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(screen.getByRole("heading", { name: /regenerate report/i })).toBeInTheDocument();
+      expect(screen.getByText(/spends llm tokens/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^continue$/i })).toBeInTheDocument();
+    });
+
+    it("should_show_unsaved_edits_warning_when_editDraft_differs_from_server_content", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+      await user.clear(textarea);
+      await user.type(textarea, "<p>Unsaved local edits</p>");
+      await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(screen.getByRole("heading", { name: /discard unsaved edits/i })).toBeInTheDocument();
+      expect(screen.getByText(/your unsaved edits will be lost/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /discard.*regenerate/i })).toBeInTheDocument();
+    });
+
+    it("should_call_regenerate_mutation_when_discard_and_regenerate_is_clicked", async () => {
+      const user = userEvent.setup();
+      const mutateAsync = vi.fn().mockResolvedValue(baseReport);
+      mockUseRegenerateReport.mockReturnValue({ isPending: false, mutateAsync } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+      await user.clear(textarea);
+      await user.type(textarea, "<p>Unsaved</p>");
+      await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+      await user.click(screen.getByRole("button", { name: /discard.*regenerate/i }));
+
+      expect(mutateAsync).toHaveBeenCalledWith("report-1");
+    });
+
+    it("should_not_treat_initial_empty_draft_as_unsaved_edits", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /discard unsaved edits/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -73,7 +73,7 @@ describe("PortfolioReportEditorPage", () => {
     mockUseUpdateReportContent.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
   });
 
-  describe("edit textarea seeding (Fix #1)", () => {
+  describe("edit textarea seeding", () => {
     it("should_seed_textarea_with_report_content_when_dialog_opens", async () => {
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
@@ -136,7 +136,7 @@ describe("PortfolioReportEditorPage", () => {
     });
   });
 
-  describe("regenerate dialog (Fix #3)", () => {
+  describe("regenerate dialog", () => {
     it("should_show_standard_overwrite_warning_when_no_unsaved_edits_exist", async () => {
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
@@ -200,6 +200,36 @@ describe("PortfolioReportEditorPage", () => {
       expect(
         screen.queryByRole("heading", { name: /discard unsaved edits/i })
       ).not.toBeInTheDocument();
+    });
+
+    it("should_not_show_unsaved_edits_warning_after_a_successful_save", async () => {
+      // Guards the brief window between save success and the React Query
+      // cache update propagating the saved content back into `report.content`.
+      // Without clearing editDraft on save, hasUnsavedEdits would be falsely
+      // true for that window and the dialog would warn about edits the user
+      // just saved.
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i) as HTMLTextAreaElement;
+      await user.clear(textarea);
+      await user.type(textarea, "<p>Edited and saved</p>");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /discard unsaved edits/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /^regenerate report/i })).toBeInTheDocument();
     });
   });
 });

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -63,12 +63,16 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   // Close the Edit dialog if a regenerate kicks off while it's open —
   // the draft is now stale (it was seeded from pre-regen content) and
-  // saving would clobber the freshly generated report. The user gets a
-  // toast so they know why their dialog disappeared.
+  // saving would clobber the freshly generated report. We also clear
+  // editDraft so a subsequent Regenerate click doesn't surface a
+  // misleading "unsaved edits" warning about content that no longer
+  // exists. The user gets a toast so they know why their dialog
+  // disappeared.
   const isReportRegenerating = report ? isReportGenerating(report) : false;
   useEffect(() => {
     if (showEditDialog && isReportRegenerating) {
       setShowEditDialog(false);
+      setEditDraft("");
       toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
         icon: "ℹ️",
       });
@@ -130,6 +134,9 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     try {
       await updateContentMutation.mutateAsync({ reportId, content: editDraft });
       setShowEditDialog(false);
+      // Clear so the brief window before React Query's cache update
+      // propagates doesn't make `hasUnsavedEdits` falsely true.
+      setEditDraft("");
       toast.success("Report content saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-reac
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
-import { DeleteDialog } from "@/components/DeleteDialog";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
@@ -61,12 +60,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const [editDraft, setEditDraft] = useState("");
   const [exportingPdf, setExportingPdf] = useState(false);
   const exportInFlight = useRef(false);
-
-  useEffect(() => {
-    if (showEditDialog && report?.content) {
-      setEditDraft(report.content);
-    }
-  }, [showEditDialog, report?.content]);
 
   // Close the Edit dialog if a regenerate kicks off while it's open —
   // the draft is now stale (it was seeded from pre-regen content) and
@@ -170,16 +163,47 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
+  // True when the user has typed in the Edit textarea and their local draft
+  // diverges from the server's saved content. We only warn about *user* edits,
+  // not the initial empty state before the dialog has ever been opened.
+  const hasUnsavedEdits = editDraft !== "" && editDraft !== (report.content ?? "");
+
   return (
     <div className="flex h-full flex-col">
-      <DeleteDialog
-        title="This re-runs the agentic generator with the current config and overwrites the existing content. Spends LLM tokens. Continue?"
-        deleteFunction={handleRegenerate}
-        isLoading={regenerateMutation.isPending}
-        externalIsOpen={showRegenerateDialog}
-        externalSetIsOpen={setShowRegenerateDialog}
-        buttonElement={null}
-      />
+      <Dialog open={showRegenerateDialog} onOpenChange={setShowRegenerateDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {hasUnsavedEdits ? "Discard unsaved edits and regenerate?" : "Regenerate report?"}
+            </DialogTitle>
+            <DialogDescription>
+              {hasUnsavedEdits
+                ? "You have unsaved changes in the editor. Regenerating will overwrite the report content and your unsaved edits will be lost. To keep a copy, cancel and export PDF first."
+                : "This re-runs the agentic generator with the current config and overwrites the existing content. Spends LLM tokens."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowRegenerateDialog(false)}
+              disabled={regenerateMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRegenerate}
+              disabled={regenerateMutation.isPending}
+            >
+              {regenerateMutation.isPending
+                ? "Starting…"
+                : hasUnsavedEdits
+                  ? "Discard & regenerate"
+                  : "Continue"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
         <DialogContent className="max-w-4xl">
@@ -243,7 +267,10 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setShowEditDialog(true)}
+            onClick={() => {
+              setEditDraft(report.content ?? "");
+              setShowEditDialog(true);
+            }}
             disabled={generating || !report.content}
           >
             <Pencil className="mr-1 h-3 w-3" />


### PR DESCRIPTION
## Summary

Two related fixes for the admin Portfolio Report editor flow, both reported by Erin during a live use-of-product session:

1. **Edit textarea silently wiped while typing.** The Edit dialog seeded `editDraft` via a `useEffect` whose dependency array included `report?.content`. Any refetch returning updated content (window focus, polling, save success) re-fired the effect and reset the textarea — losing the user's in-progress edits with no toast/feedback. Fix: seed `editDraft` in the Edit button's `onClick` so the value is captured at the moment of state transition, not synchronized via a reactive effect.

2. **Regenerate dialog didn't differentiate destructive-with-edits from destructive-no-edits.** A single generic warning ("overwrites the existing content. Spends LLM tokens.") on every Regenerate click. Now: if `editDraft` diverges from `report.content` (the user has unsaved local edits), the dialog title switches to "Discard unsaved edits and regenerate?", the body explains the loss explicitly, and the action button uses the destructive variant.

## Why

Erin (Filecoin admin) was editing a monthly report, switched windows briefly to read a Slack message, came back to a silently-reset textarea, then assumed Regenerate would somehow recover her edits — it wouldn't. The first fix prevents the silent reset entirely; the second telegraphs the irreversibility before the click.

## Files changed

- `components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx`: drop the seeding `useEffect`, seed in `onClick`, replace the DeleteDialog with a context-aware Dialog whose copy and action label adapt to whether unsaved edits exist
- `__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx`: 7 tests covering both fixes

## Test plan

- [x] `pnpm test -- PortfolioReportEditorPage` — 7/7 passing
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files (one pre-existing cognitive-complexity warning, not introduced by this PR)
- [x] `pnpm run build` exits 0
- [ ] Manual: open Edit, type, switch tabs, return — textarea should retain typing
- [ ] Manual: type in Edit then close (Cancel) → click Regenerate → dialog should switch to the "Discard unsaved edits" variant
- [ ] Manual: click Regenerate without ever having touched Edit → dialog shows the original "Regenerate report?" copy

## Out of scope

- localStorage draft persistence (would also have helped here, but not strictly required to stop the bug)
- Server-side content versioning / undo after a destructive regenerate