### PR TITLE
feat(hermes): Phase 2 — Org Brain editor + Work board

### DIFF
--- a/app/org/error.tsx
+++ b/app/org/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <h1 className="text-2xl font-semibold">Couldn&apos;t load Org Brain</h1>
+      <p className="mt-3 text-sm text-red-600">{error.message}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded border px-4 py-2"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/app/org/loading.tsx
+++ b/app/org/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="h-8 w-48 animate-pulse rounded bg-gray-200" />
+      <div className="mt-8 space-y-3">
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+      </div>
+    </main>
+  );
+}

--- a/app/org/page.tsx
+++ b/app/org/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { BrandForm } from "@/src/features/org-brain/BrandForm";
+import { MissionForm } from "@/src/features/org-brain/MissionForm";
+import { PAGES } from "@/utilities/pages";
+
+type Tab = "mission" | "brand";
+
+export default function OrgBrainPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const [slug, setSlug] = useState<string | undefined>(undefined);
+  const [tab, setTab] = useState<Tab>("mission");
+
+  useEffect(() => {
+    setSlug(params.get("slug") ?? undefined);
+    const initial = params.get("tab");
+    if (initial === "brand" || initial === "mission") setTab(initial);
+  }, [params]);
+
+  if (!slug) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-2xl font-semibold">Org Brain</h1>
+        <p className="mt-4 text-gray-700">
+          Set up your team first to start filling in your org context.
+        </p>
+        <button
+          type="button"
+          onClick={() => router.push(PAGES.TEAM.ONBOARDING)}
+          className="mt-6 rounded bg-black px-4 py-2 text-white"
+        >
+          Set up my team
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <header>
+        <h1 className="text-2xl font-semibold">Org Brain</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          The shared context your team uses in every conversation. Saved here,
+          referenced everywhere.
+        </p>
+      </header>
+
+      <nav className="mt-8 flex gap-1 border-b" role="tablist">
+        <TabButton active={tab === "mission"} onClick={() => setTab("mission")}>
+          Mission
+        </TabButton>
+        <TabButton active={tab === "brand"} onClick={() => setTab("brand")}>
+          Brand
+        </TabButton>
+      </nav>
+
+      <section className="mt-8">
+        {tab === "mission" ? <MissionForm slug={slug} /> : <BrandForm slug={slug} />}
+      </section>
+    </main>
+  );
+}
+
+function TabButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`px-4 py-2 text-sm font-medium ${
+        active
+          ? "border-b-2 border-black text-black"
+          : "text-gray-500 hover:text-gray-700"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/app/work/error.tsx
+++ b/app/work/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <h1 className="text-2xl font-semibold">Couldn&apos;t load the work board</h1>
+      <p className="mt-3 text-sm text-red-600">{error.message}</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded border px-4 py-2"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/app/work/loading.tsx
+++ b/app/work/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-7xl px-6 py-12">
+      <div className="h-8 w-48 animate-pulse rounded bg-gray-200" />
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-5">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-64 animate-pulse rounded bg-gray-100" />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/work/loading.tsx
+++ b/app/work/loading.tsx
@@ -2,8 +2,8 @@ export default function Loading() {
   return (
     <main className="mx-auto max-w-7xl px-6 py-12">
       <div className="h-8 w-48 animate-pulse rounded bg-gray-200" />
-      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-5">
-        {[0, 1, 2, 3, 4].map((i) => (
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
           <div key={i} className="h-64 animate-pulse rounded bg-gray-100" />
         ))}
       </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { WorkBoard } from "@/src/features/work-board/WorkBoard";
+import { PAGES } from "@/utilities/pages";
+
+export default function WorkPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const [slug, setSlug] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setSlug(params.get("slug") ?? undefined);
+  }, [params]);
+
+  if (!slug) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-2xl font-semibold">Work</h1>
+        <p className="mt-4 text-gray-700">
+          Set up your team first to see what they&apos;re working on.
+        </p>
+        <button
+          type="button"
+          onClick={() => router.push(PAGES.TEAM.ONBOARDING)}
+          className="mt-6 rounded bg-black px-4 py-2 text-white"
+        >
+          Set up my team
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-7xl px-6 py-12">
+      <header>
+        <h1 className="text-2xl font-semibold">Work</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Everything your team is doing — drop new tasks here, watch them move,
+          comment to nudge.
+        </p>
+      </header>
+
+      <WorkBoard slug={slug} />
+    </main>
+  );
+}

--- a/hooks/useOrgBrain.ts
+++ b/hooks/useOrgBrain.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-hot-toast";
+import {
+  type BrandData,
+  hermesClient,
+  type MissionData,
+  type OrgBrainResponse,
+  type OrgBrainTopic,
+} from "@/lib/hermes-client";
+
+const brainKeys = {
+  all: ["org-brain"] as const,
+  topic: (slug: string, topic: OrgBrainTopic) =>
+    [...brainKeys.all, slug, topic] as const,
+};
+
+export function useOrgBrain<TData = Record<string, unknown>>(
+  slug: string | undefined,
+  topic: OrgBrainTopic
+) {
+  return useQuery<OrgBrainResponse<TData>>({
+    queryKey: brainKeys.topic(slug ?? "anon", topic),
+    enabled: Boolean(slug),
+    queryFn: () => hermesClient.getOrgBrain<TData>(slug as string, topic),
+  });
+}
+
+export function useUpdateMission(slug: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: MissionData) =>
+      hermesClient.putOrgBrain(slug, "mission", payload),
+    onMutate: async (payload) => {
+      await qc.cancelQueries({ queryKey: brainKeys.topic(slug, "mission") });
+      const previous = qc.getQueryData<OrgBrainResponse<MissionData>>(
+        brainKeys.topic(slug, "mission")
+      );
+      qc.setQueryData<OrgBrainResponse<MissionData>>(
+        brainKeys.topic(slug, "mission"),
+        { topic: "mission", exists: true, data: payload }
+      );
+      return { previous };
+    },
+    onError: (err, _payload, ctx) => {
+      if (ctx?.previous !== undefined) {
+        qc.setQueryData(brainKeys.topic(slug, "mission"), ctx.previous);
+      }
+      toast.error(err instanceof Error ? err.message : "Could not save");
+    },
+    onSuccess: () => toast.success("Mission saved"),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: brainKeys.topic(slug, "mission") }),
+  });
+}
+
+export function useUpdateBrand(slug: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: BrandData) =>
+      hermesClient.putOrgBrain(slug, "brand", payload),
+    onMutate: async (payload) => {
+      await qc.cancelQueries({ queryKey: brainKeys.topic(slug, "brand") });
+      const previous = qc.getQueryData<OrgBrainResponse<BrandData>>(
+        brainKeys.topic(slug, "brand")
+      );
+      qc.setQueryData<OrgBrainResponse<BrandData>>(
+        brainKeys.topic(slug, "brand"),
+        { topic: "brand", exists: true, data: payload }
+      );
+      return { previous };
+    },
+    onError: (err, _payload, ctx) => {
+      if (ctx?.previous !== undefined) {
+        qc.setQueryData(brainKeys.topic(slug, "brand"), ctx.previous);
+      }
+      toast.error(err instanceof Error ? err.message : "Could not save");
+    },
+    onSuccess: () => toast.success("Brand saved"),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: brainKeys.topic(slug, "brand") }),
+  });
+}

--- a/hooks/useWorkBoard.ts
+++ b/hooks/useWorkBoard.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-hot-toast";
+import {
+  hermesClient,
+  type WorkTask,
+  type WorkTaskComment,
+  type WorkTaskStatus,
+} from "@/lib/hermes-client";
+
+const workKeys = {
+  all: ["work"] as const,
+  list: (slug: string) => [...workKeys.all, "list", slug] as const,
+  task: (slug: string, id: string) => [...workKeys.all, "task", slug, id] as const,
+};
+
+export function useWorkTasks(slug: string | undefined) {
+  return useQuery<WorkTask[]>({
+    queryKey: workKeys.list(slug ?? "anon"),
+    enabled: Boolean(slug),
+    queryFn: () => hermesClient.listWorkTasks(slug as string),
+    refetchInterval: 15_000,
+  });
+}
+
+export function useWorkTask(slug: string | undefined, taskId: string | undefined) {
+  return useQuery<WorkTask & { comments: WorkTaskComment[] }>({
+    queryKey: workKeys.task(slug ?? "anon", taskId ?? "anon"),
+    enabled: Boolean(slug && taskId),
+    queryFn: async () => {
+      const task = (await hermesClient.getWorkTask(
+        slug as string,
+        taskId as string
+      )) as WorkTask & { comments: WorkTaskComment[] };
+      return task;
+    },
+  });
+}
+
+export function useCreateWorkTask(slug: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { title: string; description?: string; assignee?: string }) =>
+      hermesClient.createWorkTask(slug, input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: workKeys.list(slug) });
+      toast.success("Task added");
+    },
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : "Could not add task"),
+  });
+}
+
+export function useUpdateWorkTaskStatus(slug: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { taskId: string; status: WorkTaskStatus }) =>
+      hermesClient.updateWorkTaskStatus(slug, input.taskId, input.status),
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: workKeys.list(slug) });
+      const previous = qc.getQueryData<WorkTask[]>(workKeys.list(slug));
+      if (previous) {
+        qc.setQueryData<WorkTask[]>(
+          workKeys.list(slug),
+          previous.map((t) =>
+            t.id === input.taskId ? { ...t, status: input.status } : t
+          )
+        );
+      }
+      return { previous };
+    },
+    onError: (err, _input, ctx) => {
+      if (ctx?.previous) {
+        qc.setQueryData(workKeys.list(slug), ctx.previous);
+      }
+      toast.error(err instanceof Error ? err.message : "Could not move task");
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: workKeys.list(slug) }),
+  });
+}
+
+export function useAddWorkComment(slug: string, taskId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: string) =>
+      hermesClient.addWorkTaskComment(slug, taskId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: workKeys.task(slug, taskId) });
+      toast.success("Comment added");
+    },
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : "Could not comment"),
+  });
+}

--- a/lib/hermes-client.ts
+++ b/lib/hermes-client.ts
@@ -113,12 +113,7 @@ export interface BrandData {
   sensitiveTopics?: string;
 }
 
-export type WorkTaskStatus =
-  | "queued"
-  | "working"
-  | "blocked"
-  | "ready-for-review"
-  | "done";
+export type WorkTaskStatus = "queued" | "working" | "blocked" | "done";
 
 export interface WorkTask {
   id: string;

--- a/lib/hermes-client.ts
+++ b/lib/hermes-client.ts
@@ -78,6 +78,67 @@ export interface UpdateAboutInput {
   content: string;
 }
 
+export type OrgBrainTopic = "mission" | "brand";
+
+export interface OrgBrainResponse<TData = Record<string, unknown>> {
+  topic: OrgBrainTopic;
+  exists: boolean;
+  data: TData;
+}
+
+export interface MissionData {
+  legalName?: string;
+  ein?: string;
+  missionStatement?: string;
+  website?: string;
+  theoryOfChange?: string;
+  targetPopulation?: string;
+  geographicScope?: string;
+  yearFounded?: string;
+  fiscalSponsor?: string;
+  leadership?: Array<{ name: string; role: string }>;
+}
+
+export interface BrandData {
+  voice?: string;
+  tones?: {
+    donor_email?: string;
+    proposal?: string;
+    social?: string;
+  };
+  boilerplates?: Array<{ name: string; body: string }>;
+  wordDos?: string[];
+  wordDonts?: string[];
+  taglines?: string[];
+  sensitiveTopics?: string;
+}
+
+export type WorkTaskStatus =
+  | "queued"
+  | "working"
+  | "blocked"
+  | "ready-for-review"
+  | "done";
+
+export interface WorkTask {
+  id: string;
+  title: string;
+  description?: string;
+  status: WorkTaskStatus;
+  assignee?: string;
+  parentId?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkTaskComment {
+  id: string;
+  taskId: string;
+  author?: string;
+  body: string;
+  createdAt: string;
+}
+
 // Single instance reused across hooks. The shared API client handles auth
 // (Bearer token) and 401 refresh — see utilities/auth/api-client.ts.
 const api = createAuthenticatedApiClient();
@@ -104,6 +165,79 @@ export const hermesClient = {
     await api.put(INDEXER.HERMES.SOUL(input.slug, input.role), {
       content: input.content,
     });
+  },
+
+  async getOrgBrain<TData = Record<string, unknown>>(
+    slug: string,
+    topic: OrgBrainTopic
+  ): Promise<OrgBrainResponse<TData>> {
+    const { data } = await api.get<OrgBrainResponse<TData>>(
+      INDEXER.HERMES.BRAIN(slug, topic)
+    );
+    return data;
+  },
+
+  async putOrgBrain(
+    slug: string,
+    topic: OrgBrainTopic,
+    payload: MissionData | BrandData
+  ): Promise<void> {
+    await api.put(INDEXER.HERMES.BRAIN(slug, topic), payload);
+  },
+
+  async listWorkTasks(slug: string): Promise<WorkTask[]> {
+    const { data } = await api.get<{ tasks: WorkTask[] }>(
+      INDEXER.HERMES.WORK_TASKS(slug)
+    );
+    return data.tasks;
+  },
+
+  async getWorkTask(slug: string, taskId: string): Promise<WorkTask> {
+    const { data } = await api.get<WorkTask>(
+      INDEXER.HERMES.WORK_TASK(slug, taskId)
+    );
+    return data;
+  },
+
+  async createWorkTask(
+    slug: string,
+    input: { title: string; description?: string; assignee?: string }
+  ): Promise<WorkTask> {
+    const { data } = await api.post<WorkTask>(
+      INDEXER.HERMES.WORK_TASKS(slug),
+      input
+    );
+    return data;
+  },
+
+  async updateWorkTaskStatus(
+    slug: string,
+    taskId: string,
+    status: WorkTaskStatus
+  ): Promise<void> {
+    await api.put(INDEXER.HERMES.WORK_TASK_STATUS(slug, taskId), { status });
+  },
+
+  async listWorkTaskComments(
+    slug: string,
+    taskId: string
+  ): Promise<WorkTaskComment[]> {
+    const { data } = await api.get<{ comments: WorkTaskComment[] }>(
+      INDEXER.HERMES.WORK_TASK_COMMENTS(slug, taskId)
+    );
+    return data.comments;
+  },
+
+  async addWorkTaskComment(
+    slug: string,
+    taskId: string,
+    body: string
+  ): Promise<WorkTaskComment> {
+    const { data } = await api.post<WorkTaskComment>(
+      INDEXER.HERMES.WORK_TASK_COMMENTS(slug, taskId),
+      { body }
+    );
+    return data;
   },
 
   async provision(input: ProvisionOrgInput): Promise<HermesOrgResponse> {

--- a/src/features/org-brain/BrandForm.tsx
+++ b/src/features/org-brain/BrandForm.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useOrgBrain, useUpdateBrand } from "@/hooks/useOrgBrain";
+import type { BrandData } from "@/lib/hermes-client";
+
+interface Props {
+  slug: string;
+}
+
+interface BrandFormShape {
+  voice: string;
+  tones: { donor_email: string; proposal: string; social: string };
+  boilerplates: string;
+  wordDos: string;
+  wordDonts: string;
+  taglines: string;
+  sensitiveTopics: string;
+}
+
+const EMPTY: BrandFormShape = {
+  voice: "",
+  tones: { donor_email: "", proposal: "", social: "" },
+  boilerplates: "",
+  wordDos: "",
+  wordDonts: "",
+  taglines: "",
+  sensitiveTopics: "",
+};
+
+function toForm(data: BrandData | undefined): BrandFormShape {
+  if (!data) return EMPTY;
+  return {
+    voice: data.voice ?? "",
+    tones: {
+      donor_email: data.tones?.donor_email ?? "",
+      proposal: data.tones?.proposal ?? "",
+      social: data.tones?.social ?? "",
+    },
+    boilerplates: (data.boilerplates ?? [])
+      .map((b) => b.body)
+      .join("\n\n"),
+    wordDos: (data.wordDos ?? []).join(", "),
+    wordDonts: (data.wordDonts ?? []).join(", "),
+    taglines: (data.taglines ?? []).join("\n"),
+    sensitiveTopics: data.sensitiveTopics ?? "",
+  };
+}
+
+function fromForm(values: BrandFormShape): BrandData {
+  const splitLines = (s: string) =>
+    s
+      .split(/\n\s*\n/)
+      .map((x) => x.trim())
+      .filter(Boolean);
+  const splitCsv = (s: string) =>
+    s
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+  const splitNl = (s: string) =>
+    s
+      .split("\n")
+      .map((x) => x.trim())
+      .filter(Boolean);
+  return {
+    voice: values.voice.trim() || undefined,
+    tones: {
+      donor_email: values.tones.donor_email.trim() || undefined,
+      proposal: values.tones.proposal.trim() || undefined,
+      social: values.tones.social.trim() || undefined,
+    },
+    boilerplates: splitLines(values.boilerplates).map((body, i) => ({
+      name: `Boilerplate ${i + 1}`,
+      body,
+    })),
+    wordDos: splitCsv(values.wordDos),
+    wordDonts: splitCsv(values.wordDonts),
+    taglines: splitNl(values.taglines),
+    sensitiveTopics: values.sensitiveTopics.trim() || undefined,
+  };
+}
+
+export function BrandForm({ slug }: Props) {
+  const { data, isLoading, isError, error, refetch } = useOrgBrain<BrandData>(
+    slug,
+    "brand"
+  );
+  const update = useUpdateBrand(slug);
+
+  const { register, handleSubmit, reset, formState } = useForm<BrandFormShape>({
+    defaultValues: EMPTY,
+  });
+
+  useEffect(() => {
+    if (data) reset(toForm(data.data));
+  }, [data, reset]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="h-24 animate-pulse rounded bg-gray-100" />
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 p-4">
+        <p className="text-sm text-red-700">
+          {error instanceof Error ? error.message : "Failed to load brand"}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 rounded border px-3 py-1 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit((values) => update.mutate(fromForm(values)))}
+      className="space-y-6"
+    >
+      <Field
+        label="Brand voice"
+        hint="A short description of how the org sounds (e.g. warm, plainspoken, urgent)."
+      >
+        <textarea
+          {...register("voice")}
+          rows={2}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <fieldset className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <legend className="col-span-full text-sm font-medium">Tone by channel</legend>
+        <Field label="Donor email">
+          <input
+            {...register("tones.donor_email")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+        <Field label="Proposal">
+          <input
+            {...register("tones.proposal")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+        <Field label="Social">
+          <input
+            {...register("tones.social")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+      </fieldset>
+
+      <Field
+        label="Boilerplate paragraphs"
+        hint="One paragraph per block, separated by a blank line."
+      >
+        <textarea
+          {...register("boilerplates")}
+          rows={6}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm font-mono"
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Words / phrases to use" hint="Comma-separated.">
+          <input
+            {...register("wordDos")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+        <Field label="Words / phrases to avoid" hint="Comma-separated.">
+          <input
+            {...register("wordDonts")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+      </div>
+
+      <Field label="Taglines" hint="One per line.">
+        <textarea
+          {...register("taglines")}
+          rows={3}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <Field
+        label="Sensitive topics or framing notes"
+        hint="What employees should escalate to humans before writing about."
+      >
+        <textarea
+          {...register("sensitiveTopics")}
+          rows={3}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <div className="flex items-center gap-3 border-t pt-4">
+        <button
+          type="submit"
+          disabled={update.isPending || !formState.isDirty}
+          className="rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          {update.isPending ? "Saving…" : "Save brand"}
+        </button>
+        {update.isError ? (
+          <span className="text-sm text-red-600">
+            {update.error instanceof Error ? update.error.message : "Save failed"}
+          </span>
+        ) : null}
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint ? <span className="mt-1 block text-xs text-gray-500">{hint}</span> : null}
+    </label>
+  );
+}

--- a/src/features/org-brain/MissionForm.tsx
+++ b/src/features/org-brain/MissionForm.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { useOrgBrain, useUpdateMission } from "@/hooks/useOrgBrain";
+import type { MissionData } from "@/lib/hermes-client";
+
+interface Props {
+  slug: string;
+}
+
+const EMPTY: MissionData = {
+  legalName: "",
+  ein: "",
+  missionStatement: "",
+  website: "",
+  theoryOfChange: "",
+  targetPopulation: "",
+  geographicScope: "",
+  yearFounded: "",
+  fiscalSponsor: "",
+  leadership: [],
+};
+
+export function MissionForm({ slug }: Props) {
+  const { data, isLoading, isError, error, refetch } = useOrgBrain<MissionData>(
+    slug,
+    "mission"
+  );
+  const update = useUpdateMission(slug);
+
+  const form = useForm<MissionData>({ defaultValues: EMPTY });
+  const { register, handleSubmit, control, reset, formState } = form;
+  const leadership = useFieldArray({ control, name: "leadership" });
+
+  useEffect(() => {
+    if (data) reset({ ...EMPTY, ...data.data });
+  }, [data, reset]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+        <div className="h-10 animate-pulse rounded bg-gray-100" />
+        <div className="h-24 animate-pulse rounded bg-gray-100" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 p-4">
+        <p className="text-sm text-red-700">
+          {error instanceof Error ? error.message : "Failed to load mission"}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 rounded border px-3 py-1 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit((values) => {
+        const trimmed: MissionData = {
+          ...values,
+          leadership: (values.leadership ?? []).filter((l) => l.name?.trim()),
+        };
+        update.mutate(trimmed);
+      })}
+      className="space-y-6"
+    >
+      <Field label="Legal name">
+        <input
+          {...register("legalName")}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          placeholder="Acme Foundation, Inc."
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="EIN">
+          <input
+            {...register("ein")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+            placeholder="12-3456789"
+          />
+        </Field>
+        <Field label="Year founded">
+          <input
+            {...register("yearFounded")}
+            inputMode="numeric"
+            maxLength={4}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+            placeholder="2014"
+          />
+        </Field>
+      </div>
+
+      <Field label="Website">
+        <input
+          {...register("website")}
+          type="url"
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          placeholder="https://acme.org"
+        />
+      </Field>
+
+      <Field label="Mission statement">
+        <textarea
+          {...register("missionStatement")}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          rows={3}
+        />
+      </Field>
+
+      <Field label="Theory of change">
+        <textarea
+          {...register("theoryOfChange")}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          rows={3}
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Target population">
+          <input
+            {...register("targetPopulation")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+        <Field label="Geographic scope">
+          <input
+            {...register("geographicScope")}
+            className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          />
+        </Field>
+      </div>
+
+      <Field label="Fiscal sponsor (if any)">
+        <input
+          {...register("fiscalSponsor")}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">Leadership</legend>
+        {leadership.fields.map((field, i) => (
+          <div key={field.id} className="grid grid-cols-12 gap-2">
+            <input
+              {...register(`leadership.${i}.name` as const)}
+              placeholder="Name"
+              className="col-span-4 rounded border px-3 py-2 text-sm"
+            />
+            <input
+              {...register(`leadership.${i}.role` as const)}
+              placeholder="Role"
+              className="col-span-7 rounded border px-3 py-2 text-sm"
+            />
+            <button
+              type="button"
+              onClick={() => leadership.remove(i)}
+              className="col-span-1 rounded border text-sm text-gray-600 hover:bg-gray-50"
+              aria-label="Remove leadership row"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() => leadership.append({ name: "", role: "" })}
+          className="rounded border px-3 py-1.5 text-sm"
+        >
+          + Add leader
+        </button>
+      </fieldset>
+
+      <div className="flex items-center gap-3 border-t pt-4">
+        <button
+          type="submit"
+          disabled={update.isPending || !formState.isDirty}
+          className="rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          {update.isPending ? "Saving…" : "Save mission"}
+        </button>
+        {update.isError ? (
+          <span className="text-sm text-red-600">
+            {update.error instanceof Error ? update.error.message : "Save failed"}
+          </span>
+        ) : null}
+      </div>
+    </form>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/features/work-board/WorkBoard.tsx
+++ b/src/features/work-board/WorkBoard.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import { useMemo, useState } from "react";
 import {
   useCreateWorkTask,
@@ -19,8 +28,14 @@ const COLUMNS: Array<{ status: WorkTaskStatus; label: string }> = [
   { status: "queued", label: "Queued" },
   { status: "working", label: "Working" },
   { status: "blocked", label: "Blocked" },
-  { status: "ready-for-review", label: "Ready for review" },
   { status: "done", label: "Done" },
+];
+
+const USER_DROPPABLE_STATUSES: WorkTaskStatus[] = [
+  "queued",
+  "working",
+  "blocked",
+  "done",
 ];
 
 interface Props {
@@ -34,12 +49,27 @@ export function WorkBoard({ slug }: Props) {
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   const [showNew, setShowNew] = useState(false);
 
+  // Require a small drag distance before drag starts so card clicks
+  // (which open the drawer) still work normally.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const targetStatus = event.over?.id as WorkTaskStatus | undefined;
+    const taskId = event.active.id as string;
+    if (!targetStatus) return;
+    if (!USER_DROPPABLE_STATUSES.includes(targetStatus)) return;
+    const current = (tasks ?? []).find((t) => t.id === taskId);
+    if (!current || current.status === targetStatus) return;
+    update.mutate({ taskId, status: targetStatus });
+  };
+
   const byStatus = useMemo(() => {
     const groups: Record<WorkTaskStatus, WorkTask[]> = {
       queued: [],
       working: [],
       blocked: [],
-      "ready-for-review": [],
       done: [],
     };
     for (const t of tasks ?? []) {
@@ -51,7 +81,7 @@ export function WorkBoard({ slug }: Props) {
 
   if (isLoading) {
     return (
-      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-5">
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-4">
         {COLUMNS.map((c) => (
           <div key={c.status} className="h-64 animate-pulse rounded bg-gray-100" />
         ))}
@@ -105,20 +135,22 @@ export function WorkBoard({ slug }: Props) {
         />
       ) : null}
 
-      <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-5">
-        {COLUMNS.map((col) => (
-          <Column
-            key={col.status}
-            label={col.label}
-            status={col.status}
-            tasks={byStatus[col.status]}
-            onOpen={(id) => setOpenTaskId(id)}
-            onMove={(taskId, status) =>
-              update.mutate({ taskId, status })
-            }
-          />
-        ))}
-      </div>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+          {COLUMNS.map((col) => (
+            <Column
+              key={col.status}
+              label={col.label}
+              status={col.status}
+              tasks={byStatus[col.status]}
+              onOpen={(id) => setOpenTaskId(id)}
+              onMove={(taskId, status) =>
+                update.mutate({ taskId, status })
+              }
+            />
+          ))}
+        </div>
+      </DndContext>
 
       {openTaskId ? (
         <WorkTaskDrawer
@@ -144,8 +176,23 @@ function Column({
   onOpen: (id: string) => void;
   onMove: (taskId: string, status: WorkTaskStatus) => void;
 }) {
+  const droppable = USER_DROPPABLE_STATUSES.includes(status);
+  const { setNodeRef, isOver } = useDroppable({
+    id: status,
+    disabled: !droppable,
+  });
+
   return (
-    <div className="rounded-lg border bg-gray-50 p-3">
+    <div
+      ref={setNodeRef}
+      className={`rounded-lg border p-3 transition-colors ${
+        isOver && droppable
+          ? "border-black bg-gray-100"
+          : droppable
+            ? "border-gray-200 bg-gray-50"
+            : "border-dashed border-gray-200 bg-gray-50/60"
+      }`}
+    >
       <div className="flex items-baseline justify-between">
         <h3 className="text-sm font-semibold">{label}</h3>
         <span className="text-xs text-gray-500">{tasks.length}</span>
@@ -153,31 +200,75 @@ function Column({
       <ul className="mt-3 space-y-2">
         {tasks.length === 0 ? (
           <li className="rounded border border-dashed border-gray-200 px-3 py-6 text-center text-xs text-gray-400">
-            Nothing here
+            {droppable ? "Drop here" : "Nothing here"}
           </li>
         ) : null}
         {tasks.map((t) => (
-          <li key={t.id}>
-            <button
-              type="button"
-              onClick={() => onOpen(t.id)}
-              className="block w-full rounded border bg-white p-3 text-left shadow-sm transition hover:shadow"
-            >
-              <div className="text-sm font-medium">{t.title}</div>
-              {t.assignee ? (
-                <div className="mt-1 text-xs text-gray-500">
-                  {TEAM_ROLE_LABELS[t.assignee as TeamRole] ?? t.assignee}
-                </div>
-              ) : null}
-              <StatusMover
-                current={status}
-                onMove={(next) => onMove(t.id, next)}
-              />
-            </button>
-          </li>
+          <TaskCard
+            key={t.id}
+            task={t}
+            currentStatus={status}
+            onOpen={onOpen}
+            onMove={onMove}
+          />
         ))}
       </ul>
     </div>
+  );
+}
+
+function TaskCard({
+  task,
+  currentStatus,
+  onOpen,
+  onMove,
+}: {
+  task: WorkTask;
+  currentStatus: WorkTaskStatus;
+  onOpen: (id: string) => void;
+  onMove: (taskId: string, status: WorkTaskStatus) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: task.id });
+
+  const style = transform
+    ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      }
+    : undefined;
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={isDragging ? "opacity-50" : ""}
+    >
+      <div
+        {...listeners}
+        {...attributes}
+        role="button"
+        tabIndex={0}
+        onClick={() => onOpen(task.id)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen(task.id);
+          }
+        }}
+        className="block w-full cursor-grab rounded border bg-white p-3 text-left shadow-sm transition hover:shadow active:cursor-grabbing"
+      >
+        <div className="text-sm font-medium">{task.title}</div>
+        {task.assignee ? (
+          <div className="mt-1 text-xs text-gray-500">
+            {TEAM_ROLE_LABELS[task.assignee as TeamRole] ?? task.assignee}
+          </div>
+        ) : null}
+        <StatusMover
+          current={currentStatus}
+          onMove={(next) => onMove(task.id, next)}
+        />
+      </div>
+    </li>
   );
 }
 
@@ -188,11 +279,7 @@ function StatusMover({
   current: WorkTaskStatus;
   onMove: (next: WorkTaskStatus) => void;
 }) {
-  // Users can set: queued, blocked, ready-for-review, done. "working" is
-  // dispatcher-only.
-  const targets = (
-    ["queued", "blocked", "ready-for-review", "done"] as WorkTaskStatus[]
-  ).filter((s) => s !== current);
+  const targets = USER_DROPPABLE_STATUSES.filter((s) => s !== current);
 
   return (
     <div className="mt-2 flex flex-wrap gap-1">

--- a/src/features/work-board/WorkBoard.tsx
+++ b/src/features/work-board/WorkBoard.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  useCreateWorkTask,
+  useUpdateWorkTaskStatus,
+  useWorkTasks,
+} from "@/hooks/useWorkBoard";
+import {
+  TEAM_ROLE_LABELS,
+  type TeamRole,
+  VISIBLE_TEAM_ROLES,
+  type WorkTask,
+  type WorkTaskStatus,
+} from "@/lib/hermes-client";
+import { WorkTaskDrawer } from "./WorkTaskDrawer";
+
+const COLUMNS: Array<{ status: WorkTaskStatus; label: string }> = [
+  { status: "queued", label: "Queued" },
+  { status: "working", label: "Working" },
+  { status: "blocked", label: "Blocked" },
+  { status: "ready-for-review", label: "Ready for review" },
+  { status: "done", label: "Done" },
+];
+
+interface Props {
+  slug: string;
+}
+
+export function WorkBoard({ slug }: Props) {
+  const { data: tasks, isLoading, isError, error, refetch } = useWorkTasks(slug);
+  const create = useCreateWorkTask(slug);
+  const update = useUpdateWorkTaskStatus(slug);
+  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+  const [showNew, setShowNew] = useState(false);
+
+  const byStatus = useMemo(() => {
+    const groups: Record<WorkTaskStatus, WorkTask[]> = {
+      queued: [],
+      working: [],
+      blocked: [],
+      "ready-for-review": [],
+      done: [],
+    };
+    for (const t of tasks ?? []) {
+      const bucket = groups[t.status as WorkTaskStatus] ?? groups.queued;
+      bucket.push(t);
+    }
+    return groups;
+  }, [tasks]);
+
+  if (isLoading) {
+    return (
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-5">
+        {COLUMNS.map((c) => (
+          <div key={c.status} className="h-64 animate-pulse rounded bg-gray-100" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="mt-8 rounded border border-red-200 bg-red-50 p-6">
+        <p className="text-sm text-red-700">
+          {error instanceof Error ? error.message : "Failed to load tasks"}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 rounded border px-3 py-1 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const empty = (tasks ?? []).length === 0;
+
+  return (
+    <>
+      <div className="mt-6 flex items-center justify-between">
+        <p className="text-sm text-gray-600">
+          {empty ? "No tasks yet — add the first one to kick off your team." : null}
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowNew(true)}
+          className="rounded bg-black px-4 py-2 text-sm font-medium text-white"
+        >
+          + New task
+        </button>
+      </div>
+
+      {showNew ? (
+        <NewTaskForm
+          onSubmit={(input) =>
+            create.mutate(input, {
+              onSuccess: () => setShowNew(false),
+            })
+          }
+          onCancel={() => setShowNew(false)}
+          pending={create.isPending}
+        />
+      ) : null}
+
+      <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-5">
+        {COLUMNS.map((col) => (
+          <Column
+            key={col.status}
+            label={col.label}
+            status={col.status}
+            tasks={byStatus[col.status]}
+            onOpen={(id) => setOpenTaskId(id)}
+            onMove={(taskId, status) =>
+              update.mutate({ taskId, status })
+            }
+          />
+        ))}
+      </div>
+
+      {openTaskId ? (
+        <WorkTaskDrawer
+          slug={slug}
+          taskId={openTaskId}
+          onClose={() => setOpenTaskId(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function Column({
+  label,
+  status,
+  tasks,
+  onOpen,
+  onMove,
+}: {
+  label: string;
+  status: WorkTaskStatus;
+  tasks: WorkTask[];
+  onOpen: (id: string) => void;
+  onMove: (taskId: string, status: WorkTaskStatus) => void;
+}) {
+  return (
+    <div className="rounded-lg border bg-gray-50 p-3">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold">{label}</h3>
+        <span className="text-xs text-gray-500">{tasks.length}</span>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {tasks.length === 0 ? (
+          <li className="rounded border border-dashed border-gray-200 px-3 py-6 text-center text-xs text-gray-400">
+            Nothing here
+          </li>
+        ) : null}
+        {tasks.map((t) => (
+          <li key={t.id}>
+            <button
+              type="button"
+              onClick={() => onOpen(t.id)}
+              className="block w-full rounded border bg-white p-3 text-left shadow-sm transition hover:shadow"
+            >
+              <div className="text-sm font-medium">{t.title}</div>
+              {t.assignee ? (
+                <div className="mt-1 text-xs text-gray-500">
+                  {TEAM_ROLE_LABELS[t.assignee as TeamRole] ?? t.assignee}
+                </div>
+              ) : null}
+              <StatusMover
+                current={status}
+                onMove={(next) => onMove(t.id, next)}
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function StatusMover({
+  current,
+  onMove,
+}: {
+  current: WorkTaskStatus;
+  onMove: (next: WorkTaskStatus) => void;
+}) {
+  // Users can set: queued, blocked, ready-for-review, done. "working" is
+  // dispatcher-only.
+  const targets = (
+    ["queued", "blocked", "ready-for-review", "done"] as WorkTaskStatus[]
+  ).filter((s) => s !== current);
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      {targets.map((t) => (
+        <span
+          key={t}
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            e.stopPropagation();
+            onMove(t);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+              onMove(t);
+            }
+          }}
+          className="cursor-pointer rounded border bg-gray-50 px-2 py-0.5 text-[10px] text-gray-600 hover:bg-gray-100"
+        >
+          → {t}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function NewTaskForm({
+  onSubmit,
+  onCancel,
+  pending,
+}: {
+  onSubmit: (input: {
+    title: string;
+    description?: string;
+    assignee?: string;
+  }) => void;
+  onCancel: () => void;
+  pending: boolean;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [assignee, setAssignee] = useState<string>("");
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!title.trim()) return;
+        onSubmit({
+          title: title.trim(),
+          description: description.trim() || undefined,
+          assignee: assignee || undefined,
+        });
+      }}
+      className="mt-4 rounded border bg-white p-4"
+    >
+      <input
+        autoFocus
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Task title"
+        className="w-full rounded border px-3 py-2 text-sm"
+        required
+        maxLength={500}
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Optional description"
+        rows={3}
+        className="mt-3 w-full rounded border px-3 py-2 text-sm"
+        maxLength={8000}
+      />
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        <label className="text-xs text-gray-600">
+          Assign to{" "}
+          <select
+            value={assignee}
+            onChange={(e) => setAssignee(e.target.value)}
+            className="ml-2 rounded border px-2 py-1 text-sm"
+          >
+            <option value="">Unassigned</option>
+            {VISIBLE_TEAM_ROLES.map((role) => (
+              <option key={role} value={role}>
+                {TEAM_ROLE_LABELS[role]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border px-3 py-1.5 text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={pending || !title.trim()}
+            className="rounded bg-black px-3 py-1.5 text-sm text-white disabled:bg-gray-300"
+          >
+            {pending ? "Adding…" : "Add task"}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/features/work-board/WorkTaskDrawer.tsx
+++ b/src/features/work-board/WorkTaskDrawer.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useAddWorkComment, useWorkTask } from "@/hooks/useWorkBoard";
+
+interface Props {
+  slug: string;
+  taskId: string;
+  onClose: () => void;
+}
+
+export function WorkTaskDrawer({ slug, taskId, onClose }: Props) {
+  const { data, isLoading, isError, error } = useWorkTask(slug, taskId);
+  const addComment = useAddWorkComment(slug, taskId);
+  const [body, setBody] = useState("");
+
+  return (
+    <aside
+      className="fixed inset-y-0 right-0 z-50 w-full max-w-lg overflow-y-auto border-l bg-white p-6 shadow-2xl"
+      role="dialog"
+      aria-label="Task details"
+    >
+      <header className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">
+            {isLoading ? "Loading…" : data?.title ?? "Task"}
+          </h2>
+          {data ? (
+            <div className="mt-1 text-xs text-gray-500">
+              {data.status} · {data.assignee ?? "Unassigned"}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-1 text-gray-500 hover:bg-gray-100"
+        >
+          ×
+        </button>
+      </header>
+
+      {isError ? (
+        <p className="mt-6 text-sm text-red-600">
+          {error instanceof Error ? error.message : "Failed to load"}
+        </p>
+      ) : null}
+
+      {data?.description ? (
+        <p className="mt-4 whitespace-pre-wrap text-sm text-gray-700">
+          {data.description}
+        </p>
+      ) : null}
+
+      <section className="mt-8">
+        <h3 className="text-sm font-semibold">Comments</h3>
+        {data && (data.comments ?? []).length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">
+            No comments yet. Add the first one below.
+          </p>
+        ) : null}
+        <ul className="mt-3 space-y-3">
+          {(data?.comments ?? []).map((c) => (
+            <li key={c.id} className="rounded border bg-gray-50 p-3 text-sm">
+              <div className="text-xs text-gray-500">{c.author ?? "anonymous"}</div>
+              <p className="mt-1 whitespace-pre-wrap">{c.body}</p>
+            </li>
+          ))}
+        </ul>
+
+        <form
+          className="mt-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!body.trim()) return;
+            addComment.mutate(body.trim(), {
+              onSuccess: () => setBody(""),
+            });
+          }}
+        >
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Add a comment"
+            rows={3}
+            maxLength={8000}
+            className="w-full rounded border px-3 py-2 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={!body.trim() || addComment.isPending}
+            className="mt-2 rounded bg-black px-3 py-1.5 text-sm text-white disabled:bg-gray-300"
+          >
+            {addComment.isPending ? "Posting…" : "Post comment"}
+          </button>
+        </form>
+      </section>
+    </aside>
+  );
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -795,5 +795,14 @@ export const INDEXER = {
     ORG: (slug: string) => `/v2/hermes/orgs/${slug}`,
     PROFILES: (slug: string) => `/v2/hermes/orgs/${slug}/profiles`,
     SOUL: (slug: string, profile: string) => `/v2/hermes/orgs/${slug}/profiles/${profile}/soul`,
+    BRAIN: (slug: string, topic: "mission" | "brand") =>
+      `/v2/hermes/orgs/${slug}/brain/${topic}`,
+    WORK_TASKS: (slug: string) => `/v2/hermes/orgs/${slug}/work/tasks`,
+    WORK_TASK: (slug: string, taskId: string) =>
+      `/v2/hermes/orgs/${slug}/work/tasks/${taskId}`,
+    WORK_TASK_STATUS: (slug: string, taskId: string) =>
+      `/v2/hermes/orgs/${slug}/work/tasks/${taskId}/status`,
+    WORK_TASK_COMMENTS: (slug: string, taskId: string) =>
+      `/v2/hermes/orgs/${slug}/work/tasks/${taskId}/comments`,
   },
 };

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -160,6 +160,8 @@ export const PAGES = {
     DIRECTORY: `/team`,
     MEMBER: (role: string) => `/team/${role}`,
   },
+  ORG: `/org`,
+  WORK: `/work`,
 };
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 frontend for the nonprofit AI employees product. Stacks on top of #1424 (Phase 1).

- `/org` — structured Mission and Brand forms, backed by the new `/v2/hermes/orgs/:slug/brain/:topic` indexer endpoint.
- `/work` — kanban board with five product-language columns (Queued / Working / Blocked / Ready for review / Done). Cards mover-chips PUT the new product status; the indexer translates to the right Hermes verb. WorkTaskDrawer shows full task + threaded comments.
- All mutations use React Query `useMutation` with optimistic updates. Loading/error states for both routes. Three-state rule honored throughout.

## Pairs with

- show-karma/gap-indexer#1775

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Browser e2e against running Hermes + indexer:
  - `/org?slug=acme` renders Mission tab; Brand tab switches in
  - Mission API round-trip persisted to container's `mission.yaml` + rendered `mission.md`
  - `/work?slug=acme` renders 5 columns with seeded tasks in the right columns
  - Clicking `→ queued` on a Blocked card moves it to Queued (verified via indexer GET)