### PR TITLE
fix(funding): silence Connection closed on project profile prefetch (DEV-257)

### DIFF
--- a/__tests__/unit/services/project-grants.service.test.ts
+++ b/__tests__/unit/services/project-grants.service.test.ts
@@ -64,7 +64,7 @@ describe("project-grants.service", () => {
       const result = await getProjectGrants("test-project");
 
       expect(result).toEqual(mockGrants);
-      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("test-project"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(expect.stringContaining("test-project"));
     });
 
     it("should return array with single grant when API returns single object", async () => {
@@ -114,8 +114,8 @@ describe("project-grants.service", () => {
 
       await getProjectGrants("my-project-slug");
 
-      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("my-project-slug"));
-      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("/grants"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(expect.stringContaining("my-project-slug"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(expect.stringContaining("/grants"));
     });
 
     it("should call correct endpoint for project UID", async () => {
@@ -123,7 +123,7 @@ describe("project-grants.service", () => {
 
       await getProjectGrants("0x1234567890");
 
-      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("0x1234567890"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(expect.stringContaining("0x1234567890"));
     });
   });
 });

--- a/__tests__/unit/services/project-updates.service.test.ts
+++ b/__tests__/unit/services/project-updates.service.test.ts
@@ -51,7 +51,7 @@ describe("project-updates.service", () => {
       const result = await getProjectUpdates("project-slug");
 
       expect(result).toEqual(mockResponse);
-      expect(mockFetchData).toHaveBeenCalledWith(expect.stringContaining("project-slug"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(expect.stringContaining("project-slug"));
     });
 
     it("should append milestoneStatus query param when provided", async () => {
@@ -64,7 +64,7 @@ describe("project-updates.service", () => {
 
       await getProjectUpdates("project-slug", "completed");
 
-      expect(mockFetchData).toHaveBeenCalledWith(
+      expect(mockFetchData.mock.calls[0][0]).toEqual(
         expect.stringContaining("milestoneStatus=completed")
       );
     });
@@ -79,7 +79,9 @@ describe("project-updates.service", () => {
 
       await getProjectUpdates("project-slug");
 
-      expect(mockFetchData).toHaveBeenCalledWith(expect.not.stringContaining("milestoneStatus"));
+      expect(mockFetchData.mock.calls[0][0]).toEqual(
+        expect.not.stringContaining("milestoneStatus")
+      );
     });
 
     it("should return empty response without reporting on 404", async () => {

--- a/__tests__/unit/utilities/queries/prefetchProjectProfile.test.ts
+++ b/__tests__/unit/utilities/queries/prefetchProjectProfile.test.ts
@@ -66,6 +66,11 @@ describe("prefetchProjectProfile", () => {
         updates: true,
         impacts: true,
       });
+      expect(mockGetProjectGrants).toHaveBeenCalledWith(projectId, { isAuthorized: false });
+      expect(mockGetProjectUpdates).toHaveBeenCalledWith(projectId, undefined, {
+        isAuthorized: false,
+      });
+      expect(mockGetProjectImpacts).toHaveBeenCalledWith(projectId, { isAuthorized: false });
       expect(mockQueryClient.prefetchQuery).toHaveBeenCalledTimes(3);
     });
 

--- a/__tests__/unit/utilities/sentry/ignoreErrors.test.ts
+++ b/__tests__/unit/utilities/sentry/ignoreErrors.test.ts
@@ -1,7 +1,22 @@
 import { sentryIgnoreErrors } from "../../../../utilities/sentry/ignoreErrors";
 
+const matches = (value: string) =>
+  sentryIgnoreErrors.some((rule) =>
+    typeof rule === "string" ? value.includes(rule) : rule.test(value)
+  );
+
 describe("sentryIgnoreErrors", () => {
   it("suppresses MetaMask connection failures from the injected provider", () => {
     expect(sentryIgnoreErrors).toContain("Failed to connect to MetaMask");
+  });
+
+  it("suppresses Next.js streaming aborts surfaced as 'Connection closed.' (DEV-257)", () => {
+    expect(matches("Error: Connection closed.")).toBe(true);
+    expect(matches("Connection closed.")).toBe(true);
+  });
+
+  it("does not over-match unrelated 'connection' errors", () => {
+    expect(matches("WebSocket connection failed")).toBe(false);
+    expect(matches("Database connection refused")).toBe(false);
   });
 });

--- a/app/api/metadata/projects/[projectId]/route.tsx
+++ b/app/api/metadata/projects/[projectId]/route.tsx
@@ -15,7 +15,7 @@ export async function GET(
   const projectId = (await context.params).projectId;
   const [project, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
   if (!project) {
     return new ImageResponse(

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/complete-grant/page.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/complete-grant/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [projectInfo, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!projectInfo) {

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/edit/page.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/edit/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [projectInfo, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!projectInfo) {

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/impact-criteria/page.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/impact-criteria/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [project, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!project) {

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/layout.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/layout.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [projectInfo, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!projectInfo) {

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/milestones-and-updates/page.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/milestones-and-updates/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [project, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!project) {

--- a/app/project/[projectId]/(profile)/funding/[grantUid]/page.tsx
+++ b/app/project/[projectId]/(profile)/funding/[grantUid]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId, grantUid } = await params;
   const [project, grants] = await Promise.all([
     getProjectCachedData(projectId),
-    getProjectGrants(projectId),
+    getProjectGrants(projectId, { isAuthorized: false }),
   ]);
 
   if (!project) {

--- a/services/__tests__/project-profile-public-fetch-auth.test.ts
+++ b/services/__tests__/project-profile-public-fetch-auth.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression coverage for DEV-257.
+ *
+ * The public project-profile SSR/prefetch path must request grants, updates,
+ * and impacts WITHOUT an Authorization header so the server-rendered code
+ * never touches the browser-only `TokenManager`. Reaching for the token on
+ * the server was the original cause of `Error: Connection closed.` events
+ * on `/project/:projectId/funding`.
+ */
+
+import { getProjectGrants } from "../project-grants.service";
+import { getProjectImpacts } from "../project-impacts.service";
+import { getProjectUpdates } from "../project-updates.service";
+
+vi.mock("@/utilities/fetchData", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/utilities/indexer", () => ({
+  INDEXER: {
+    V2: {
+      PROJECTS: {
+        GRANTS: (slug: string) => `/v2/projects/${slug}/grants`,
+        IMPACTS: (slug: string) => `/v2/projects/${slug}/impacts`,
+        UPDATES: (slug: string) => `/v2/projects/${slug}/updates`,
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+import fetchData from "@/utilities/fetchData";
+
+const mockFetchData = fetchData as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchData.mockResolvedValue([[], null, null, 200]);
+});
+
+describe("public project profile fetch auth", () => {
+  it("passes isAuthorized=false for grants when requested", async () => {
+    await getProjectGrants("my-project", { isAuthorized: false });
+
+    const [url, method, , , , isAuthorized] = mockFetchData.mock.calls[0];
+    expect(url).toBe("/v2/projects/my-project/grants");
+    expect(method).toBe("GET");
+    expect(isAuthorized).toBe(false);
+  });
+
+  it("passes isAuthorized=false for impacts when requested", async () => {
+    await getProjectImpacts("my-project", { isAuthorized: false });
+
+    const [url, , , , , isAuthorized] = mockFetchData.mock.calls[0];
+    expect(url).toBe("/v2/projects/my-project/impacts");
+    expect(isAuthorized).toBe(false);
+  });
+
+  it("passes isAuthorized=false for updates when requested", async () => {
+    mockFetchData.mockResolvedValueOnce([
+      { projectUpdates: [], projectMilestones: [], grantMilestones: [], grantUpdates: [] },
+      null,
+      null,
+      200,
+    ]);
+    await getProjectUpdates("my-project", undefined, { isAuthorized: false });
+
+    const [url, , , , , isAuthorized] = mockFetchData.mock.calls[0];
+    expect(url).toBe("/v2/projects/my-project/updates");
+    expect(isAuthorized).toBe(false);
+  });
+
+  it("defaults to isAuthorized=true so authenticated callers keep working", async () => {
+    await getProjectGrants("my-project");
+    expect(mockFetchData.mock.calls[0][5]).toBe(true);
+  });
+
+  it("forwards AbortSignal to fetchData for grants when provided", async () => {
+    const controller = new AbortController();
+    await getProjectGrants("my-project", { isAuthorized: false, signal: controller.signal });
+    expect(mockFetchData.mock.calls[0][8]).toBe(controller.signal);
+  });
+
+  it("forwards AbortSignal to fetchData for impacts when provided", async () => {
+    const controller = new AbortController();
+    await getProjectImpacts("my-project", { isAuthorized: false, signal: controller.signal });
+    expect(mockFetchData.mock.calls[0][8]).toBe(controller.signal);
+  });
+
+  it("strips isAuthorized from the query string for updates", async () => {
+    mockFetchData.mockResolvedValueOnce([
+      { projectUpdates: [], projectMilestones: [], grantMilestones: [], grantUpdates: [] },
+      null,
+      null,
+      200,
+    ]);
+    await getProjectUpdates("my-project", undefined, { isAuthorized: false });
+
+    const url = mockFetchData.mock.calls[0][0] as string;
+    expect(url).not.toContain("isAuthorized");
+  });
+});

--- a/services/__tests__/project-updates.service.test.ts
+++ b/services/__tests__/project-updates.service.test.ts
@@ -44,14 +44,30 @@ beforeEach(() => {
 describe("getProjectUpdates — URL construction", () => {
   it("calls the base URL when no options are given", async () => {
     await getProjectUpdates("my-project");
-    expect(mockFetchData).toHaveBeenCalledWith("/v2/projects/my-project/updates");
+    expect(mockFetchData.mock.calls[0][0]).toBe("/v2/projects/my-project/updates");
   });
 
   it("appends milestoneStatus to the query string", async () => {
     await getProjectUpdates("my-project", "completed");
-    expect(mockFetchData).toHaveBeenCalledWith(
+    expect(mockFetchData.mock.calls[0][0]).toBe(
       "/v2/projects/my-project/updates?milestoneStatus=completed"
     );
+  });
+
+  it("defaults to isAuthorized=true on the fetchData call", async () => {
+    await getProjectUpdates("my-project");
+    expect(mockFetchData.mock.calls[0][5]).toBe(true);
+  });
+
+  it("forwards isAuthorized=false to fetchData when callers opt out", async () => {
+    await getProjectUpdates("my-project", undefined, { isAuthorized: false });
+    expect(mockFetchData.mock.calls[0][5]).toBe(false);
+  });
+
+  it("forwards an AbortSignal to fetchData when provided", async () => {
+    const controller = new AbortController();
+    await getProjectUpdates("my-project", undefined, { signal: controller.signal });
+    expect(mockFetchData.mock.calls[0][8]).toBe(controller.signal);
   });
 
   it("appends dateFrom and dateTo to the query string", async () => {

--- a/services/project-grants.service.ts
+++ b/services/project-grants.service.ts
@@ -3,6 +3,18 @@ import type { Grant } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
+export interface GetProjectGrantsOptions {
+  /**
+   * Whether the request should attach a Privy auth token. Defaults to `true`
+   * to preserve existing authenticated behaviour. The public project-profile
+   * SSR/prefetch path explicitly passes `false` to avoid touching the
+   * browser-only `TokenManager` on the server, which is the root cause of
+   * `Error: Connection closed.` events on `/project/:projectId/funding`.
+   */
+  isAuthorized?: boolean;
+  signal?: AbortSignal;
+}
+
 /**
  * Fetches grants for a project using V2 endpoint
  *
@@ -15,9 +27,21 @@ import { INDEXER } from "@/utilities/indexer";
  * - Dates are returned as ISO strings (not MongoDB objects)
  * - Supports both UID and slug identifiers
  */
-export const getProjectGrants = async (projectIdOrSlug: string): Promise<Grant[]> => {
+export const getProjectGrants = async (
+  projectIdOrSlug: string,
+  options: GetProjectGrantsOptions = {}
+): Promise<Grant[]> => {
+  const { isAuthorized = true, signal } = options;
   const [data, error, , status] = await fetchData<Grant | Grant[]>(
-    INDEXER.V2.PROJECTS.GRANTS(projectIdOrSlug)
+    INDEXER.V2.PROJECTS.GRANTS(projectIdOrSlug),
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized,
+    false,
+    undefined,
+    signal
   );
 
   if (error || !data) {

--- a/services/project-grants.service.ts
+++ b/services/project-grants.service.ts
@@ -3,7 +3,7 @@ import type { Grant } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
-export interface GetProjectGrantsOptions {
+interface GetProjectGrantsOptions {
   /**
    * Whether the request should attach a Privy auth token. Defaults to `true`
    * to preserve existing authenticated behaviour. The public project-profile

--- a/services/project-impacts.service.ts
+++ b/services/project-impacts.service.ts
@@ -24,15 +24,37 @@ export interface ProjectImpact {
   updatedAt?: string;
 }
 
+export interface GetProjectImpactsOptions {
+  /**
+   * Whether the request should attach a Privy auth token. Defaults to `true`.
+   * Public SSR/prefetch callers pass `false` so the server-rendered path does
+   * not touch the browser-only `TokenManager`.
+   */
+  isAuthorized?: boolean;
+  signal?: AbortSignal;
+}
+
 /**
  * Fetches project impacts using the dedicated API endpoint.
  *
  * @param projectIdOrSlug - The project UID or slug
  * @returns Promise<ProjectImpact[]> - Array of project impacts
  */
-export const getProjectImpacts = async (projectIdOrSlug: string): Promise<ProjectImpact[]> => {
+export const getProjectImpacts = async (
+  projectIdOrSlug: string,
+  options: GetProjectImpactsOptions = {}
+): Promise<ProjectImpact[]> => {
+  const { isAuthorized = true, signal } = options;
   const [data, error] = await fetchData<ProjectImpact[]>(
-    INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug)
+    INDEXER.V2.PROJECTS.IMPACTS(projectIdOrSlug),
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized,
+    false,
+    undefined,
+    signal
   );
 
   if (error || !data) {

--- a/services/project-impacts.service.ts
+++ b/services/project-impacts.service.ts
@@ -24,7 +24,7 @@ export interface ProjectImpact {
   updatedAt?: string;
 }
 
-export interface GetProjectImpactsOptions {
+interface GetProjectImpactsOptions {
   /**
    * Whether the request should attach a Privy auth token. Defaults to `true`.
    * Public SSR/prefetch callers pass `false` so the server-rendered path does

--- a/services/project-updates.service.ts
+++ b/services/project-updates.service.ts
@@ -9,6 +9,13 @@ import { INDEXER } from "@/utilities/indexer";
  */
 export interface GetProjectUpdatesOptions extends UpdatesFeedFilters {
   milestoneStatus?: "pending" | "completed" | "verified";
+  /**
+   * Whether the request should attach a Privy auth token. Defaults to `true`.
+   * Public SSR/prefetch callers pass `false` so the server-rendered path does
+   * not touch the browser-only `TokenManager`.
+   */
+  isAuthorized?: boolean;
+  signal?: AbortSignal;
 }
 
 /**
@@ -80,7 +87,7 @@ function buildUpdatesQueryString(opts: GetProjectUpdatesOptions): string {
 export const getProjectUpdates = async (
   projectIdOrSlug: string,
   milestoneStatus?: "pending" | "completed" | "verified",
-  filters?: UpdatesFeedFilters
+  filters?: GetProjectUpdatesOptions
 ): Promise<UpdatesApiResponse> => {
   const emptyResponse: UpdatesApiResponse = {
     projectUpdates: [],
@@ -89,11 +96,22 @@ export const getProjectUpdates = async (
     grantUpdates: [],
   };
 
+  const { isAuthorized = true, signal, ...queryFilters } = filters ?? {};
   const baseUrl = INDEXER.V2.PROJECTS.UPDATES(projectIdOrSlug);
-  const qs = buildUpdatesQueryString({ milestoneStatus, ...filters });
+  const qs = buildUpdatesQueryString({ milestoneStatus, ...queryFilters });
   const url = `${baseUrl}${qs}`;
 
-  const [data, error, , status] = await fetchData<UpdatesApiResponse>(url);
+  const [data, error, , status] = await fetchData<UpdatesApiResponse>(
+    url,
+    "GET",
+    {},
+    {},
+    {},
+    isAuthorized,
+    false,
+    undefined,
+    signal
+  );
 
   if (error || !data) {
     // Missing project routes are expected for unknown slugs and should not be sent to Sentry.

--- a/utilities/queries/prefetchProjectProfile.ts
+++ b/utilities/queries/prefetchProjectProfile.ts
@@ -31,20 +31,25 @@ export interface PrefetchResult {
  */
 export const prefetchProjectProfileData = cache(
   async (queryClient: QueryClient, projectId: string): Promise<PrefetchResult> => {
+    // The public project-profile path runs server-side during SSR/streaming.
+    // Touching `TokenManager` there (browser-only) caused the streamed response
+    // to abort and surfaced as `Error: Connection closed.` in Sentry on
+    // `/project/:projectId/funding`. Always request unauthenticated for the
+    // public prefetch — authenticated client hooks will hydrate after.
     const results = await Promise.allSettled([
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.GRANTS(projectId),
-        queryFn: () => getProjectGrants(projectId),
+        queryFn: () => getProjectGrants(projectId, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.UPDATES(projectId),
-        queryFn: () => getProjectUpdates(projectId),
+        queryFn: () => getProjectUpdates(projectId, undefined, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
       queryClient.prefetchQuery({
         queryKey: QUERY_KEYS.PROJECT.IMPACTS(projectId),
-        queryFn: () => getProjectImpacts(projectId),
+        queryFn: () => getProjectImpacts(projectId, { isAuthorized: false }),
         staleTime: 5 * 60 * 1000,
       }),
     ]);
@@ -75,7 +80,7 @@ export const prefetchProjectProfileData = cache(
  * Uses React.cache() for request deduplication.
  */
 export const getProjectGrantsCached = cache(async (projectId: string) => {
-  return getProjectGrants(projectId);
+  return getProjectGrants(projectId, { isAuthorized: false });
 });
 
 /**
@@ -83,7 +88,7 @@ export const getProjectGrantsCached = cache(async (projectId: string) => {
  * Uses React.cache() for request deduplication.
  */
 export const getProjectUpdatesCached = cache(async (projectId: string) => {
-  return getProjectUpdates(projectId);
+  return getProjectUpdates(projectId, undefined, { isAuthorized: false });
 });
 
 /**
@@ -91,5 +96,5 @@ export const getProjectUpdatesCached = cache(async (projectId: string) => {
  * Uses React.cache() for request deduplication.
  */
 export const getProjectImpactsCached = cache(async (projectId: string) => {
-  return getProjectImpacts(projectId);
+  return getProjectImpacts(projectId, { isAuthorized: false });
 });

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -33,6 +33,17 @@ const browserExtensionErrors = [
   "chrome.runtime.sendMessage() called from a webpage must specify an Extension ID",
 ];
 
+// Next.js throws `Error: Connection closed.` when a streaming SSR/RSC response
+// is aborted — most commonly because the user navigated away before the
+// stream finished, or a route prefetch was cancelled mid-flight. The error is
+// internal to Next's React server-renderer and there's no user-visible
+// failure (the client either renders the new route or retries the fetch).
+// Surfaced on `/project/:projectId/funding` because the profile page
+// prefetches grants/updates/impacts in parallel, multiplying the abort
+// surface area.
+// See https://karma-crypto-inc.sentry.io/issues/7104802234/ (DEV-257)
+const streamingAbortErrors = [/^Error: Connection closed\.?$/i, "Connection closed."];
+
 const sentryInstrumentationErrors = [
   // Sentry's own lazy-loaded Replay integration occasionally fails to fetch
   // (chunk eviction after a deploy, network blip, ad-blocker, CSP). Replay is
@@ -65,4 +76,5 @@ export const sentryIgnoreErrors = [
   ...browserExtensionErrors,
   ...sentryInstrumentationErrors,
   ...notFoundErrors,
+  ...streamingAbortErrors,
 ];


### PR DESCRIPTION
## Summary

Fixes [DEV-257](https://linear.app/showkarma/issue/DEV-257/sentry-gap-frontend-connection-closed-on-project-funding-page) — recurring `Error: Connection closed.` on `/project/:projectId/funding` (107 events / 55 users in Sentry issue [`7104802234`](https://karma-crypto-inc.sentry.io/issues/7104802234/)).

The error has two contributing root causes; this PR addresses both so the issue can be closed without depending on any other PR:

1. **Server-side auth touch on the public path.** `prefetchProjectProfileData` invokes the grants/updates/impacts services through `fetchData`, which unconditionally reaches for the Privy token via the browser-only `TokenManager`. On the SSR/streaming path that throws, the streamed response is aborted, and Next.js surfaces it as `Error: Connection closed.`
2. **Benign streaming aborts.** Even with auth fixed, Next.js still emits `Connection closed.` when a streaming RSC response is cancelled mid-flight (user navigates away). Those are not actionable and shouldn't reach Sentry.

## Changes

- Thread an `isAuthorized` option through `getProjectGrants`, `getProjectImpacts`, and `getProjectUpdates`. Default stays `true` so authenticated callers are unchanged.
- `prefetchProjectProfileData` and the three cached server helpers (`getProjectGrantsCached`, `getProjectUpdatesCached`, `getProjectImpactsCached`) now pass `isAuthorized: false`. The public SSR/prefetch path no longer touches `TokenManager`.
- Add an `AbortSignal` pass-through on each service for future abortable callers (clean resource handling).
- Add `Connection closed.` (string + regex) to `sentryIgnoreErrors` so residual streaming aborts stop polluting the issue feed. Filter is shared between client and server Sentry configs.

## Testing

- `pnpm exec vitest run --project unit services/__tests__/project-profile-public-fetch-auth.test.ts services/__tests__/project-updates.service.test.ts __tests__/unit/utilities/queries/prefetchProjectProfile.test.ts __tests__/unit/utilities/sentry/ignoreErrors.test.ts` — 38/38 passing.
- New coverage:
  - `services/__tests__/project-profile-public-fetch-auth.test.ts` — asserts `isAuthorized=false` reaches `fetchData` for all three services and that `AbortSignal` is forwarded.
  - `__tests__/unit/utilities/queries/prefetchProjectProfile.test.ts` — asserts the public prefetch wires `{ isAuthorized: false }` through.
  - `__tests__/unit/utilities/sentry/ignoreErrors.test.ts` — asserts the new regex/string match `Error: Connection closed.` without over-matching unrelated `connection` errors.
- Existing `project-updates.service.test.ts` updated for new arg shape; URL-construction expectations preserved.
- `pnpm exec biome check` — clean on all touched files.

## Risks

- Authenticated callers default to `isAuthorized: true`; this only changes the public project-profile SSR/prefetch path.
- The Sentry filter is narrow (`Connection closed.` literal + `^Error: Connection closed\.?$` regex). A test guards against over-matching unrelated `connection` errors.

## Test plan

- [ ] Open `/project/:projectId/funding` for a public project cold (no Privy session) and confirm grants/updates/impacts hydrate without console errors.
- [ ] Repeatedly navigate to and away from the funding tab to trigger stream aborts; confirm Sentry no longer ingests `Connection closed.` events.
- [ ] Authenticated user on the same page still sees their owner-only context (regression).
- [ ] Watch Sentry issue `7104802234` for 7 days post-deploy — expected to drop to ~0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for controlling authorization when fetching project profile data, enabling public profile access without authentication headers.

* **Bug Fixes**
  * Improved handling of Next.js streaming abort errors to prevent unnecessary error reporting.

* **Tests**
  * Expanded test coverage for authorization-controlled API requests and streaming error suppression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1427)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->