### PR TITLE
fix(funding): silence transient Network Error noise and add retry UI

### DIFF
--- a/__tests__/unit/utilities/errorManager.test.tsx
+++ b/__tests__/unit/utilities/errorManager.test.tsx
@@ -63,4 +63,25 @@ describe("errorManager", () => {
       },
     });
   });
+
+  it("should NOT capture transient axios Network Error (DEV-236)", () => {
+    const networkErr = Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" });
+
+    errorManager("Project Grants API Error: Network Error", networkErr, {
+      context: "project-grants.service",
+    });
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("should still capture HTTP errors (e.g. 500) that carry a response", () => {
+    const httpErr = {
+      message: "Request failed with status code 500",
+      response: { status: 500 },
+    };
+
+    errorManager("Project Grants API Error", httpErr);
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
 });

--- a/components/Pages/Project/v2/Content/FundingContentWrapper.tsx
+++ b/components/Pages/Project/v2/Content/FundingContentWrapper.tsx
@@ -1,18 +1,45 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { FundingContentSkeleton } from "@/components/Pages/Project/v2/Skeletons/FundingContentSkeleton";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import { FundingContent } from "../FundingPage/FundingContent";
 
 /**
  * Wrapper component for FundingContent that fetches project data.
+ *
+ * Renders three explicit states (loading / error / success). The error
+ * state surfaces a retry CTA for transient network failures instead of
+ * leaving the page in an indefinite loading spinner — see DEV-236.
  */
 export function FundingContentWrapper() {
   const { projectId } = useParams();
-  const { project, isLoading } = useProjectProfile(projectId as string);
+  const { project, isProjectLoading, isError, refetch } = useProjectProfile(projectId as string);
 
-  if (isLoading || !project) {
-    return <div className="animate-pulse text-gray-500">Loading funding...</div>;
+  if (isProjectLoading) {
+    return <FundingContentSkeleton />;
+  }
+
+  if (isError || !project) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-zinc-100">
+          Couldn&apos;t load funding details
+        </h2>
+        <p className="max-w-md text-sm text-gray-600 dark:text-zinc-400">
+          We hit a network issue while loading this project. Check your connection and try again.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            void refetch();
+          }}
+          className="mt-2 rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+        >
+          Try again
+        </button>
+      </div>
+    );
   }
 
   return <FundingContent project={project} />;

--- a/components/Pages/Project/v2/Content/FundingContentWrapper.tsx
+++ b/components/Pages/Project/v2/Content/FundingContentWrapper.tsx
@@ -23,10 +23,10 @@ export function FundingContentWrapper() {
   if (isError || !project) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-zinc-100">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
           Couldn&apos;t load funding details
         </h2>
-        <p className="max-w-md text-sm text-gray-600 dark:text-zinc-400">
+        <p className="max-w-md text-sm text-zinc-600 dark:text-zinc-400">
           We hit a network issue while loading this project. Check your connection and try again.
         </p>
         <button

--- a/components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx
+++ b/components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
+import type { Project } from "@/types/v2/project";
 import { FundingContentWrapper } from "../FundingContentWrapper";
+
+type ProjectProfileResult = ReturnType<typeof useProjectProfile>;
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "test-project" }),
@@ -23,20 +26,20 @@ vi.mock("../../FundingPage/FundingContent", () => ({
 
 const useProjectProfileMock = vi.mocked(useProjectProfile);
 
-function setup(overrides: Partial<ReturnType<typeof useProjectProfile>>) {
+function setup(overrides: Partial<ProjectProfileResult>) {
   useProjectProfileMock.mockReturnValue({
     project: null,
     isProjectLoading: false,
     isError: false,
     refetch: vi.fn(),
-  } as unknown as ReturnType<typeof useProjectProfile>);
+  } as unknown as ProjectProfileResult);
   useProjectProfileMock.mockReturnValueOnce({
     project: null,
     isProjectLoading: false,
     isError: false,
     refetch: vi.fn(),
     ...overrides,
-  } as unknown as ReturnType<typeof useProjectProfile>);
+  } as unknown as ProjectProfileResult);
 }
 
 describe("FundingContentWrapper", () => {
@@ -66,7 +69,7 @@ describe("FundingContentWrapper", () => {
 
   it("renders the funding content when the project is loaded", () => {
     setup({
-      project: { uid: "0x123", details: { title: "P" } } as any,
+      project: { uid: "0x123", details: { title: "P" } } as unknown as Project,
       isProjectLoading: false,
       isError: false,
     });

--- a/components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx
+++ b/components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
+import { FundingContentWrapper } from "../FundingContentWrapper";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "test-project" }),
+}));
+
+vi.mock("@/hooks/v2/useProjectProfile", () => ({
+  useProjectProfile: vi.fn(),
+}));
+
+vi.mock("@/components/Pages/Project/v2/Skeletons/FundingContentSkeleton", () => ({
+  FundingContentSkeleton: () => <div data-testid="funding-skeleton" />,
+}));
+
+vi.mock("../../FundingPage/FundingContent", () => ({
+  FundingContent: ({ project }: { project: { uid: string } }) => (
+    <div data-testid="funding-content">{project.uid}</div>
+  ),
+}));
+
+const useProjectProfileMock = vi.mocked(useProjectProfile);
+
+function setup(overrides: Partial<ReturnType<typeof useProjectProfile>>) {
+  useProjectProfileMock.mockReturnValue({
+    project: null,
+    isProjectLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useProjectProfile>);
+  useProjectProfileMock.mockReturnValueOnce({
+    project: null,
+    isProjectLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useProjectProfile>);
+}
+
+describe("FundingContentWrapper", () => {
+  it("renders the loading skeleton while the project is loading", () => {
+    setup({ isProjectLoading: true });
+    render(<FundingContentWrapper />);
+    expect(screen.getByTestId("funding-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders an error state with a retry CTA when the project fetch fails (DEV-236)", () => {
+    const refetch = vi.fn();
+    setup({ isError: true, refetch });
+
+    render(<FundingContentWrapper />);
+
+    expect(screen.getByText(/couldn't load funding details/i)).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryButton);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an error state when the project is missing (404 after load)", () => {
+    setup({ project: null, isProjectLoading: false, isError: false });
+    render(<FundingContentWrapper />);
+    expect(screen.getByText(/couldn't load funding details/i)).toBeInTheDocument();
+  });
+
+  it("renders the funding content when the project is loaded", () => {
+    setup({
+      project: { uid: "0x123", details: { title: "P" } } as any,
+      isProjectLoading: false,
+      isError: false,
+    });
+
+    render(<FundingContentWrapper />);
+    expect(screen.getByTestId("funding-content")).toHaveTextContent("0x123");
+  });
+});

--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { isTransientNetworkError } from "@/utilities/sentry/transientErrors";
 
 // Lazy import toast to avoid issues in server components
 let toast: typeof import("react-hot-toast").default | null = null;
@@ -68,6 +69,15 @@ export const errorManager = (
       }
     }
   }
+  // Transient browser-side network errors (offline, CORS preflight, ad-
+  // blocker, navigation abort) produce stacks that are pure minified Axios
+  // bundle frames with no actionable signal. They get retried by React
+  // Query and surface to the user as an error UI, so drop them on the
+  // floor for Sentry. See DEV-236 / GAP-FRONTEND-13P.
+  if (isTransientNetworkError(error)) {
+    return;
+  }
+
   const errorToCapture = error?.originalError || error?.message;
   Sentry.captureException(error, {
     extra: {

--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -20,6 +20,24 @@ const getToast = () => {
   return toast;
 };
 
+// Checks whether the error's code/message (or its originalError's code/message)
+// contains a given substring, case-insensitive. Centralizes the triple-
+// optional-chain pattern used throughout this module so the main function
+// stays under biome's cognitive-complexity ceiling.
+type ErrorLike = {
+  code?: string;
+  message?: string;
+  originalError?: { code?: string; message?: string };
+};
+const errorContains = (error: ErrorLike | null | undefined, needle: string): boolean => {
+  const n = needle.toLowerCase();
+  return (
+    !!error?.originalError?.code?.toLowerCase()?.includes(n) ||
+    !!error?.originalError?.message?.toLowerCase()?.includes(n) ||
+    !!error?.message?.toLowerCase()?.includes(n)
+  );
+};
+
 export const errorManager = (
   errorMessage: string,
   error: any,
@@ -29,19 +47,11 @@ export const errorManager = (
   }
 ) => {
   if (error?.originalError || error?.message) {
-    const wasRejected =
-      error?.originalError?.code?.toLowerCase()?.includes("reject") ||
-      error?.originalError?.message?.toLowerCase()?.includes("reject") ||
-      error?.message?.toLowerCase()?.includes("reject");
-    const couldNotSwitchChain =
-      error?.originalError?.code?.toLowerCase()?.includes("switch chain") ||
-      error?.originalError?.message?.toLowerCase()?.includes("switch chain") ||
-      error?.message?.toLowerCase()?.includes("switch chain");
-    if (wasRejected) {
+    if (errorContains(error, "reject")) {
       return;
     }
     const targetNetwork = extra?.targetNetwork;
-    if (couldNotSwitchChain) {
+    if (errorContains(error, "switch chain")) {
       const toastInstance = getToast();
       if (toastInstance) {
         toastInstance.error(
@@ -52,10 +62,7 @@ export const errorManager = (
     }
   }
   if (toastError?.error) {
-    const wasRPCIssue =
-      error?.originalError?.code?.toLowerCase()?.includes("rpc error") ||
-      error?.originalError?.message?.toLowerCase()?.includes("rpc error") ||
-      error?.message?.toLowerCase()?.includes("rpc error");
+    const wasRPCIssue = errorContains(error, "rpc error");
     const toastInstance = getToast();
     if (toastInstance) {
       if (wasRPCIssue) {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,12 +4,22 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
+import { isTransientNetworkError } from "./utilities/sentry/transientErrors";
 
 Sentry.init({
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   ignoreErrors: sentryIgnoreErrors,
   integrations: [],
+  // Defence in depth for transient Axios "Network Error" events that
+  // bubble through code paths bypassing `errorManager` (raw React errors,
+  // third-party SDK fetches). See DEV-236 / GAP-FRONTEND-13P.
+  beforeSend(event, hint) {
+    if (isTransientNetworkError(hint?.originalException)) {
+      return null;
+    }
+    return event;
+  },
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.01,

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -52,6 +52,11 @@ export default async function fetchData<T = any>(
         ...headers,
       },
       signal,
+      // Default timeout for all requests so a hung connection surfaces as
+      // an axios error the data layer can retry instead of leaving the UI
+      // in an indefinite loading state. Authorized indexer requests below
+      // keep their longer ceiling for legacy long-poll endpoints.
+      timeout: 30000,
     };
 
     // Add authorization header if needed

--- a/utilities/queries/__tests__/defaultOptions.test.ts
+++ b/utilities/queries/__tests__/defaultOptions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { defaultQueryOptions } from "../defaultOptions";
+
+const retry = defaultQueryOptions.retry as (failureCount: number, error: unknown) => boolean;
+
+describe("defaultQueryOptions.retry", () => {
+  it("never retries 401 unauthorized", () => {
+    const err = { response: { status: 401 } };
+    expect(retry(0, err)).toBe(false);
+  });
+
+  it("never retries 429 rate-limit", () => {
+    const err = { response: { status: 429 } };
+    expect(retry(0, err)).toBe(false);
+  });
+
+  it("never retries aborted requests", () => {
+    const err = { code: "ERR_CANCELED", message: "canceled" };
+    expect(retry(0, err)).toBe(false);
+  });
+
+  it("retries transient network errors up to 2 times", () => {
+    const err = Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" });
+    expect(retry(0, err)).toBe(true);
+    expect(retry(1, err)).toBe(true);
+    expect(retry(2, err)).toBe(false);
+  });
+
+  it("retries generic errors once", () => {
+    const err = { response: { status: 500 } };
+    expect(retry(0, err)).toBe(true);
+    expect(retry(1, err)).toBe(false);
+  });
+});

--- a/utilities/queries/defaultOptions.ts
+++ b/utilities/queries/defaultOptions.ts
@@ -1,17 +1,29 @@
+import { isAxiosAbortError, isTransientNetworkError } from "@/utilities/sentry/transientErrors";
+
 /**
- * Smart retry function that skips retries for rate-limited (429) and
- * unauthorized (401) responses, while allowing one retry for other failures.
+ * Smart retry function:
+ * - Never retry rate limits (429) or auth failures (401)
+ * - Never retry user-cancelled requests (route change / abort)
+ * - Allow up to 2 retries for transient network errors (no HTTP response —
+ *   offline blip, CORS preflight, blocker, etc.). These are the dominant
+ *   cause of the funding-page Sentry noise (DEV-236) and usually succeed
+ *   on retry.
+ * - Allow one retry for everything else
  */
 function shouldRetry(failureCount: number, error: unknown): boolean {
-  // Extract HTTP status from various error shapes
-  const status = (error as any)?.response?.status ?? (error as any)?.status ?? undefined;
+  if (isAxiosAbortError(error)) {
+    return false;
+  }
 
-  // Never retry rate limits or auth failures
+  const status = (error as any)?.response?.status ?? (error as any)?.status ?? undefined;
   if (status === 429 || status === 401) {
     return false;
   }
 
-  // Allow one retry for all other errors
+  if (isTransientNetworkError(error)) {
+    return failureCount < 2;
+  }
+
   return failureCount < 1;
 }
 
@@ -22,4 +34,8 @@ export const defaultQueryOptions = {
   refetchOnMount: true,
   refetchOnReconnect: false,
   retry: shouldRetry,
+  // Exponential backoff capped at 5s. Default is a constant 1s which
+  // hammers the indexer during a transient outage and fails fast enough
+  // that the user sees the error UI before the network recovers.
+  retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 5000),
 };

--- a/utilities/sentry/__tests__/transientErrors.test.ts
+++ b/utilities/sentry/__tests__/transientErrors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isAxiosAbortError, isTransientNetworkError } from "../transientErrors";
+
+describe("isTransientNetworkError", () => {
+  it("detects axios Network Error with no response", () => {
+    const err = Object.assign(new Error("Network Error"), { code: "ERR_NETWORK" });
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("detects axios timeout (ECONNABORTED)", () => {
+    const err = Object.assign(new Error("timeout of 30000ms exceeded"), { code: "ECONNABORTED" });
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("detects 'Failed to fetch' from native fetch / Safari 'Load failed'", () => {
+    expect(isTransientNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isTransientNetworkError(new TypeError("Load failed"))).toBe(true);
+  });
+
+  it("treats user-cancelled requests as transient (skip Sentry, but caller decides on retry)", () => {
+    const err = Object.assign(new Error("canceled"), { code: "ERR_CANCELED" });
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("does NOT match errors that carry an HTTP response", () => {
+    const err = {
+      message: "Request failed with status code 500",
+      response: { status: 500, data: { message: "boom" } },
+    };
+    expect(isTransientNetworkError(err)).toBe(false);
+  });
+
+  it("does NOT match unrelated runtime errors", () => {
+    expect(isTransientNetworkError(new TypeError("Cannot read property 'x' of undefined"))).toBe(
+      false
+    );
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("isAxiosAbortError", () => {
+  it("detects ERR_CANCELED", () => {
+    expect(isAxiosAbortError({ code: "ERR_CANCELED", message: "canceled" })).toBe(true);
+  });
+
+  it("detects native AbortError by name", () => {
+    const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(isAxiosAbortError(err)).toBe(true);
+  });
+
+  it("does not flag generic network errors", () => {
+    expect(isAxiosAbortError({ code: "ERR_NETWORK", message: "Network Error" })).toBe(false);
+  });
+});

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -1,0 +1,86 @@
+/**
+ * Helpers for detecting transient/unactionable network errors that should
+ * not be sent to Sentry and SHOULD be retried by the data layer.
+ *
+ * Context: Sentry issue GAP-FRONTEND-13P ("AxiosError: Network Error" on the
+ * project funding page) ran at 923 events / 49 users. The signature comes
+ * from `XMLHttpRequest.onerror` — i.e. the browser never received a usable
+ * HTTP response. This is produced by:
+ *   - request aborted by browser (route change, BFCache, unload)
+ *   - user offline / DNS failure / TLS reset
+ *   - ad-blocker or privacy extension blocking the host
+ *   - CORS preflight failure
+ *   - mixed content (HTTPS page → HTTP endpoint)
+ *
+ * None of these are actionable from a Sentry event — the stack only
+ * contains the minified Axios bundle. The right behavior is: retry on the
+ * client, surface an error UI to the user, and keep Sentry signal clean.
+ */
+
+const TRANSIENT_MESSAGE_FRAGMENTS = ["network error", "failed to fetch", "load failed"];
+
+const TRANSIENT_AXIOS_CODES = new Set([
+  "ERR_NETWORK",
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_CONNECTION_RESET",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+]);
+
+const ABORT_CODES = new Set(["ERR_CANCELED", "ABORT_ERR"]);
+
+function getErrorMessage(error: unknown): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === "string") return msg;
+  }
+  return "";
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  return undefined;
+}
+
+function hasHttpResponse(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "response" in error &&
+    !!(error as { response?: unknown }).response
+  );
+}
+
+/**
+ * True when the error represents a cancellation (route change, unmount,
+ * AbortController). These should never reach Sentry and should never be
+ * retried.
+ */
+export function isAxiosAbortError(error: unknown): boolean {
+  const code = getErrorCode(error);
+  if (code && ABORT_CODES.has(code)) return true;
+  const name = (error as { name?: unknown } | null)?.name;
+  return name === "CanceledError" || name === "AbortError";
+}
+
+/**
+ * True when the error is a transient network failure that has no HTTP
+ * response attached. Used to (a) suppress Sentry noise and (b) opt in to
+ * additional React Query retries.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+  if (!error) return false;
+  if (isAxiosAbortError(error)) return true;
+  if (hasHttpResponse(error)) return false;
+
+  const code = getErrorCode(error);
+  if (code && TRANSIENT_AXIOS_CODES.has(code)) return true;
+
+  const message = getErrorMessage(error).toLowerCase();
+  return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}


### PR DESCRIPTION
## Overview

Fixes [DEV-236](https://linear.app/showkarma/issue/DEV-236) / Sentry `GAP-FRONTEND-13P` — recurring `AxiosError: Network Error` on the project funding page (923 events, 49 users).

## Problem

The Sentry signature `AxiosError: Network Error` originates from `XMLHttpRequest.onerror` — the request never received an HTTP response. Causes are unactionable from a Sentry event (offline blip, CORS preflight, ad-blocker, route abort) and the captured stack contains only minified Axios bundle frames.

Compounding the noise:

- Project services (`getProjectGrants/Updates/Impacts`) explicitly call `errorManager()` on every fetch failure, which calls `Sentry.captureException` — so every transient hiccup logs an event even though React Query retries.
- React Query retried network errors **only once**, then gave up.
- `fetchData` had no timeout for unauthenticated requests — hung connections never failed.
- `FundingContentWrapper` rendered an indefinite loading spinner on error: no error state, no retry CTA. Violates the repo Pre-PR checklist rule "every data-fetching component handles loading, empty, AND error states — never return null".

## Solution

1. **`utilities/sentry/transientErrors.ts`** *(new)* — `isTransientNetworkError()` / `isAxiosAbortError()` helpers detecting axios errors with no HTTP response (`ERR_NETWORK`, timeouts, `"Failed to fetch"`, `"Load failed"`, aborts).
2. **`components/Utilities/errorManager.tsx`** — early-return for transient errors so Sentry stops getting spammed. This is the root cause of the noise.
3. **`instrumentation-client.ts`** — `beforeSend` filter as defense in depth for paths that bypass `errorManager` (raw React errors, third-party SDK fetches).
4. **`utilities/queries/defaultOptions.ts`** — retry transient errors up to **2×** with exponential backoff capped at 5 s; never retry abort/401/429.
5. **`utilities/fetchData.ts`** — 30 s default timeout for unauthenticated requests so hung connections fail fast and the retry policy can kick in. Authenticated requests keep their longer ceiling for legacy long-poll endpoints.
6. **`components/Pages/Project/v2/Content/FundingContentWrapper.tsx`** — three explicit states (loading skeleton / error with Try again CTA / success).

## Why This Approach

A previously linked PR (#1384) removes auth headers from public SSR prefetch. That fix is correct for DEV-256 but cannot produce browser `AxiosError: Network Error` events — SSR runs in Node and missing auth would surface as a 401 with a response body, not a network-layer error.

This PR attacks the actual mechanism that produces the Sentry signal (explicit `captureException` from services on transient browser failures) and pairs it with UX improvements (more retries, real error UI, request timeout) so the underlying flakes self-heal instead of being papered over.

Defense in depth: `errorManager` filter + Sentry `beforeSend` filter both call the same `isTransientNetworkError` helper, so any code path that surfaces a transient error gets filtered consistently.

## Testing Steps

1. `pnpm exec vitest run --project unit utilities/sentry utilities/queries __tests__/unit/utilities/errorManager.test.tsx components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx` — 23 tests pass (18 new + 5 existing).
2. In dev, throttle the network to "Offline" in DevTools and load `/project/<slug>/funding`. Expect:
   - "Couldn't load funding details" with a **Try again** button (no infinite spinner).
   - Clicking Try again refetches the project data.
3. Restore network → success state renders.
4. With `NEXT_PUBLIC_VERCEL_ENV=production` and an empty Sentry DSN sink, verify the `beforeSend` hook drops events whose `originalException` is an axios `Network Error`.

## Technical Details

| File | Change |
|------|--------|
| `utilities/sentry/transientErrors.ts` | **NEW** — `isTransientNetworkError()` / `isAxiosAbortError()` |
| `components/Utilities/errorManager.tsx` | Skip `Sentry.captureException` for transient errors |
| `instrumentation-client.ts` | `Sentry.init.beforeSend` filter |
| `utilities/queries/defaultOptions.ts` | New retry policy with exponential backoff |
| `utilities/fetchData.ts` | 30 s default timeout |
| `components/Pages/Project/v2/Content/FundingContentWrapper.tsx` | Explicit loading/error/success states + retry CTA |
| `__tests__/unit/utilities/errorManager.test.tsx` | +2 tests |
| `utilities/sentry/__tests__/transientErrors.test.ts` | **NEW** — 9 tests |
| `utilities/queries/__tests__/defaultOptions.test.ts` | **NEW** — 5 tests |
| `components/Pages/Project/v2/Content/__tests__/FundingContentWrapper.test.tsx` | **NEW** — 4 tests |

## Verification Plan (post-merge)

Watch Sentry issue `GAP-FRONTEND-13P` event rate for 7 days. Target: ≥ 70 % reduction. If not achieved, real (non-transient) errors are hiding under the noise and need separate triage.

## Related Issues

Fixes DEV-236 (Linear). Does **not** supersede or replace PR #1384 — that PR is the correct fix for DEV-256 and should still merge.

## Checklist

- [x] Tests added (18 new)
- [x] No `return null` in data-fetching component (loading/error/success all rendered)
- [x] No hardcoded colors (uses Tailwind theme classes / existing `primary-*` tokens)
- [x] No `console.log` / `console.debug` / `console.warn`
- [x] No `any` casts added (existing service-layer `any` preserved)
- [x] Lint passes (`pnpm biome check`)
- [x] Backwards compatible — only adds opt-in helper plus stricter Sentry/retry policy