### PR TITLE
feat(reviewer-picker): add-only mode with Select all + Post update button

### DIFF
--- a/components/FundingPlatform/ApplicationList/ApplicationList.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationList.tsx
@@ -13,6 +13,7 @@ import { ApplicationTable } from "./ApplicationTable";
 const EMPTY_KYC_MAP = new Map<string, KycStatusResponse | null>();
 
 interface IApplicationListComponentProps extends IApplicationListProps {
+  communityUID?: string;
   applications: IFundingApplication[];
   isLoading?: boolean;
   onStatusChange?: (
@@ -55,6 +56,7 @@ interface IApplicationListComponentProps extends IApplicationListProps {
 
 const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
   programId,
+  communityUID,
   applications,
   isLoading = false,
   onApplicationSelect,
@@ -167,6 +169,7 @@ const ApplicationListComponent: FC<IApplicationListComponentProps> = ({
         ) : (
           <ApplicationTable
             programId={programId}
+            communityUID={communityUID}
             applications={paginatedApplications}
             sortBy={sortBy}
             sortOrder={sortOrder}

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/Utilities/Button";
 import {
   useApplicationExport,
   useFundingApplications,
+  useFundingPrograms,
   useProgramConfig,
 } from "@/hooks/useFundingPlatform";
 import { useKycBatchStatusesByAppRef, useKycConfig } from "@/hooks/useKycStatus";
@@ -109,6 +110,13 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
   // Fetch program config and prompts to determine AI column visibility
   const { config } = useProgramConfig(programId);
   const { data: promptsData } = useProgramPrompts(programId);
+
+  // Fetch programs to derive communityUID (needed for the reviewer picker modal)
+  const { programs } = useFundingPrograms(communityId);
+  const communityUID = useMemo(
+    () => programs.find((p) => p.programId === programId)?.communityUID,
+    [programs, programId]
+  );
 
   // Fetch reviewers for the program
   const {
@@ -470,6 +478,7 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
       >
         <ApplicationList
           programId={programId}
+          communityUID={communityUID}
           applications={applications}
           isLoading={isLoading && applications.length === 0}
           onApplicationSelect={onApplicationSelect}

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { ArrowDownTrayIcon, FunnelIcon } from "@heroicons/react/24/outline";
+import { useMutation } from "@tanstack/react-query";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import debounce from "lodash.debounce";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import pluralize from "pluralize";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "react-hot-toast";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { Button } from "@/components/Utilities/Button";
 import {
@@ -210,6 +212,22 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
     router.replace(newUrl, { scroll: false });
   }, [filters, sortBy, sortOrder, pathname, router, searchParams]);
 
+  const statusChangeMutation = useMutation({
+    mutationFn: (vars: {
+      applicationId: string;
+      status: string;
+      note?: string;
+      approvedAmount?: string;
+      approvedCurrency?: string;
+    }) => updateApplicationStatus(vars),
+    onSuccess: () => {
+      refetch();
+    },
+    onError: () => {
+      toast.error("Failed to update application status. Please try again.");
+    },
+  });
+
   const handleStatusChange = useCallback(
     async (
       applicationId: string,
@@ -217,23 +235,16 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
       note?: string,
       approvedAmount?: string,
       approvedCurrency?: string
-    ) => {
-      try {
-        await updateApplicationStatus({
-          applicationId,
-          status,
-          note,
-          approvedAmount,
-          approvedCurrency,
-        });
-        // Refetch to get updated data
-        refetch();
-        // Call parent's onStatusChange if provided
-      } catch (error) {
-        console.error("Failed to update application status:", error);
-      }
+    ): Promise<void> => {
+      await statusChangeMutation.mutateAsync({
+        applicationId,
+        status,
+        note,
+        approvedAmount,
+        approvedCurrency,
+      });
     },
-    [updateApplicationStatus, refetch]
+    [statusChangeMutation]
   );
 
   const handleExport = useCallback(

--- a/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListWithAPI.tsx
@@ -113,11 +113,13 @@ const ApplicationListWithAPI: FC<IApplicationListWithAPIProps> = ({
   const { config } = useProgramConfig(programId);
   const { data: promptsData } = useProgramPrompts(programId);
 
-  // Fetch programs to derive communityUID (needed for the reviewer picker modal)
+  // Fetch programs to derive communityUID (needed for the reviewer picker modal).
+  // `programId` may arrive as `"programId_chainId"`, so normalize before matching.
+  const normalizedProgramId = useMemo(() => programId.split("_")[0], [programId]);
   const { programs } = useFundingPrograms(communityId);
   const communityUID = useMemo(
-    () => programs.find((p) => p.programId === programId)?.communityUID,
-    [programs, programId]
+    () => programs.find((p) => p.programId === normalizedProgramId)?.communityUID,
+    [programs, normalizedProgramId]
   );
 
   // Fetch reviewers for the program

--- a/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTable.tsx
@@ -14,6 +14,7 @@ const EMPTY_KYC_MAP = new Map<string, KycStatusResponse | null>();
 
 interface ApplicationTableProps {
   programId: string;
+  communityUID?: string;
   applications: IFundingApplication[];
   sortBy?: IApplicationFilters["sortBy"];
   sortOrder?: IApplicationFilters["sortOrder"];
@@ -53,6 +54,7 @@ interface ApplicationTableProps {
 
 const ApplicationTableComponent: FC<ApplicationTableProps> = ({
   programId,
+  communityUID,
   applications,
   sortBy,
   sortOrder,
@@ -211,6 +213,7 @@ const ApplicationTableComponent: FC<ApplicationTableProps> = ({
           <ApplicationTableRow
             key={application.referenceNumber}
             programId={programId}
+            communityUID={communityUID}
             application={application}
             showAIScoreColumn={showAIScoreColumn}
             showInternalAIScoreColumn={showInternalAIScoreColumn}

--- a/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx
@@ -35,6 +35,7 @@ const formatStatus = (status: string): string => {
 
 interface ApplicationTableRowProps {
   programId: string;
+  communityUID?: string;
   application: IFundingApplication;
   showAIScoreColumn: boolean;
   showInternalAIScoreColumn: boolean;
@@ -78,6 +79,7 @@ const getStatusBadge = (status: string) => (
 
 const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
   programId,
+  communityUID,
   application,
   showAIScoreColumn,
   showInternalAIScoreColumn,
@@ -209,6 +211,7 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
             <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
               <ReviewerAssignmentDropdown
                 programId={programId}
+                communityUID={communityUID}
                 applicationId={application.referenceNumber}
                 availableReviewers={programReviewers}
                 assignedReviewerAddresses={application.appReviewers || []}
@@ -226,6 +229,7 @@ const ApplicationTableRowComponent: FC<ApplicationTableRowProps> = ({
             <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
               <ReviewerAssignmentDropdown
                 programId={programId}
+                communityUID={communityUID}
                 applicationId={application.referenceNumber}
                 availableReviewers={milestoneReviewers}
                 assignedReviewerAddresses={application.milestoneReviewers || []}

--- a/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
+++ b/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { type FC, useCallback, useMemo, useState } from "react";
 import { toast } from "react-hot-toast";
 import InviteReviewerModal, {
@@ -9,6 +10,11 @@ import { type DropdownItem, MultiSelectDropdown } from "@/components/Utilities/M
 import { ReviewerType, useReviewerAssignment } from "@/hooks/useReviewerAssignment";
 import type { AddMilestoneReviewerRequest } from "@/services/milestone-reviewers.service";
 import type { AddReviewerRequest } from "@/services/program-reviewers.service";
+
+const ReviewerPickerModal = dynamic(
+  () => import("@/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal"),
+  { ssr: false }
+);
 
 /**
  * Shared base interface for reviewer types
@@ -26,6 +32,10 @@ export interface ReviewerBase {
 
 interface ReviewerAssignmentDropdownProps {
   programId: string;
+  /** When provided, the "Add reviewer" empty action opens the ReviewerPickerModal
+   *  (same component used by the question-builder), instead of the legacy
+   *  InviteReviewerModal. */
+  communityUID?: string;
   applicationId: string;
   availableReviewers: ReviewerBase[];
   assignedReviewerAddresses: string[];
@@ -39,6 +49,7 @@ interface ReviewerAssignmentDropdownProps {
 
 export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = ({
   programId,
+  communityUID,
   applicationId,
   availableReviewers,
   assignedReviewerAddresses,
@@ -48,6 +59,7 @@ export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = (
   isAddingReviewer = false,
 }) => {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   // Use custom hook for assignment logic
   const { assignReviewers, isLoading } = useReviewerAssignment({
@@ -79,8 +91,7 @@ export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = (
     [assignedReviewerAddresses]
   );
 
-  const reviewerActionLabel =
-    reviewerType === ReviewerType.APP ? "Add application reviewer" : "Add milestone reviewer";
+  const reviewerActionLabel = "Add reviewer";
 
   const handleInvited = useCallback(
     async (reviewer: InvitedReviewer) => {
@@ -101,6 +112,28 @@ export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = (
     [assignReviewers, normalizedAssignedAddresses]
   );
 
+  const pickerReviewerType = reviewerType === ReviewerType.APP ? "program" : "milestone";
+
+  // Disabled (grayed) pool rows in the picker: every reviewer already in the
+  // program pool (those are exactly `availableReviewers` for the current type).
+  // Application-assigned reviewers are a subset of these and inherit the disabled
+  // treatment automatically.
+  const disabledPoolAddresses = useMemo(
+    () =>
+      availableReviewers
+        .map((r) => r.publicAddress?.toLowerCase())
+        .filter((addr): addr is string => Boolean(addr)),
+    [availableReviewers]
+  );
+
+  const handleEmptyAction = () => {
+    if (communityUID) {
+      setIsPickerOpen(true);
+    } else {
+      setIsInviteModalOpen(true);
+    }
+  };
+
   return (
     <>
       <MultiSelectDropdown
@@ -113,17 +146,31 @@ export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = (
         disabled={isLoading}
         isLoading={isLoading}
         emptyActionLabel={reviewerActionLabel}
-        onEmptyAction={() => setIsInviteModalOpen(true)}
+        onEmptyAction={handleEmptyAction}
       />
-      <InviteReviewerModal
-        programId={programId}
-        isOpen={isInviteModalOpen}
-        onClose={() => setIsInviteModalOpen(false)}
-        reviewerType={reviewerType}
-        onInviteReviewer={onAddReviewer}
-        isInviting={isAddingReviewer}
-        onInvited={handleInvited}
-      />
+      {communityUID ? (
+        <ReviewerPickerModal
+          open={isPickerOpen}
+          onOpenChange={setIsPickerOpen}
+          communityUID={communityUID}
+          programId={programId}
+          reviewerType={pickerReviewerType}
+          assignedAddresses={[]}
+          disabledAddresses={disabledPoolAddresses}
+          initialMode="pool"
+          onCompleted={onAssignmentChange}
+        />
+      ) : (
+        <InviteReviewerModal
+          programId={programId}
+          isOpen={isInviteModalOpen}
+          onClose={() => setIsInviteModalOpen(false)}
+          reviewerType={reviewerType}
+          onInviteReviewer={onAddReviewer}
+          isInviting={isAddingReviewer}
+          onInvited={handleInvited}
+        />
+      )}
     </>
   );
 };

--- a/components/FundingPlatform/ApplicationList/__tests__/ReviewerAssignmentDropdown.test.tsx
+++ b/components/FundingPlatform/ApplicationList/__tests__/ReviewerAssignmentDropdown.test.tsx
@@ -553,7 +553,7 @@ describe("ReviewerAssignmentDropdown", () => {
 
       expect(screen.getByTestId("multi-select-dropdown")).toBeInTheDocument();
       expect(screen.queryByTestId(/option-/)).not.toBeInTheDocument();
-      expect(screen.getByTestId("empty-action")).toHaveTextContent("Add application reviewer");
+      expect(screen.getByTestId("empty-action")).toHaveTextContent("Add reviewer");
     });
 
     it("should handle empty assigned reviewers", () => {
@@ -608,7 +608,7 @@ describe("ReviewerAssignmentDropdown", () => {
         reviewerType: ReviewerType.APP,
       });
 
-      expect(screen.getByTestId("empty-action")).toHaveTextContent("Add application reviewer");
+      expect(screen.getByTestId("empty-action")).toHaveTextContent("Add reviewer");
     });
 
     it("should open the invite modal from the action when reviewers are available", () => {

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { MagnifyingGlassIcon, PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { MagnifyingGlassIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import pluralize from "pluralize";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 import { Button as KarmaButton } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
@@ -43,11 +43,12 @@ import type {
 } from "./ReviewerPickerModal.types";
 import {
   emptyNewRow,
-  isRowDirty,
   poolRowFromReviewer,
   roleSelectionFromCommunityRole,
 } from "./ReviewerPickerModal.types";
+import { RoleBadge } from "./RoleBadge";
 import { validateReviewerRow } from "./reviewer-validation";
+import { SelectedRowCard } from "./SelectedRowCard";
 
 const DEBOUNCE_DELAY_MS = 250;
 
@@ -57,26 +58,6 @@ function generateNewRowId(): string {
   }
   return `new-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
-
-// ─── Role badge ──────────────────────────────────────────────────────────────
-
-function RoleBadge({ role }: { role: CommunityReviewerRole }) {
-  const isApp = role === "program-reviewer";
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-        isApp
-          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-          : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
-      )}
-    >
-      {isApp ? "App" : "Milestone"}
-    </span>
-  );
-}
-
-// ─── Component ───────────────────────────────────────────────────────────────
 
 const ReviewerPickerModal = ({
   open,
@@ -468,7 +449,7 @@ const ReviewerPickerModal = ({
 
           {/* Pool */}
           <div className="flex items-center justify-between mb-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
               Community pool
             </p>
             <button
@@ -511,7 +492,7 @@ const ReviewerPickerModal = ({
                         isDisabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                         isSelected
                           ? "bg-blue-50 dark:bg-blue-900/20"
-                          : !isDisabled && "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                          : !isDisabled && "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
                       )}
                       data-testid={`pool-item-${r.publicAddress}`}
                     >
@@ -533,7 +514,7 @@ const ReviewerPickerModal = ({
                             ))}
                           </span>
                           {isDisabled && (
-                            <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                            <span className="inline-flex items-center rounded-full bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-zinc-600 dark:text-zinc-300">
                               Already in program
                             </span>
                           )}
@@ -587,139 +568,6 @@ const ReviewerPickerModal = ({
     </Dialog>
   );
 };
-
-// ─── Selected row card ───────────────────────────────────────────────────────
-
-interface SelectedRowCardProps {
-  row: SelectedRow;
-  onFieldChange: (
-    id: string,
-    field: "name" | "email" | "telegram" | "slack",
-    value: string
-  ) => void;
-  onToggleRole: (id: string, role: ReviewerRoleSelection) => void;
-  onRemove: (id: string) => void;
-}
-
-const SelectedRowCard = memo(function SelectedRowCard({
-  row,
-  onFieldChange,
-  onToggleRole,
-  onRemove,
-}: SelectedRowCardProps) {
-  const isPool = row.kind === "pool";
-  const hasError = !!row.error;
-  const dirty = isPool && isRowDirty(row);
-
-  return (
-    <div
-      className={cn(
-        "rounded-lg border bg-white dark:bg-gray-900/60 p-3",
-        hasError ? "border-red-300 dark:border-red-700" : "border-gray-200 dark:border-gray-700"
-      )}
-      data-testid={`selected-row-${row.id}`}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex-1 min-w-0">
-          {isPool ? (
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                {row.name || row.email}
-              </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{row.email}</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-2">
-              <Input
-                value={row.name}
-                onChange={(e) => onFieldChange(row.id, "name", e.target.value)}
-                placeholder="Name *"
-                className="h-9 text-sm"
-                aria-label="Reviewer name"
-              />
-              <Input
-                value={row.email}
-                onChange={(e) => onFieldChange(row.id, "email", e.target.value)}
-                placeholder="Email *"
-                className="h-9 text-sm"
-                aria-label="Reviewer email"
-              />
-            </div>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={() => onRemove(row.id)}
-          className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-          aria-label="Remove reviewer"
-          data-testid={`remove-row-${row.id}`}
-        >
-          <XMarkIcon className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="mt-2 grid grid-cols-2 gap-2">
-        <Input
-          value={row.telegram}
-          onChange={(e) => onFieldChange(row.id, "telegram", e.target.value)}
-          placeholder="Telegram (optional)"
-          className="h-8 text-xs"
-          aria-label="Telegram"
-        />
-        <Input
-          value={row.slack}
-          onChange={(e) => onFieldChange(row.id, "slack", e.target.value)}
-          placeholder="Slack (optional)"
-          className="h-8 text-xs"
-          aria-label="Slack"
-        />
-      </div>
-
-      <div className="mt-2 flex items-center justify-between gap-2 flex-wrap">
-        <div className="flex items-center gap-3">
-          <label
-            htmlFor={`role-program-${row.id}`}
-            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
-          >
-            <Checkbox
-              id={`role-program-${row.id}`}
-              checked={row.roles.includes("program")}
-              onCheckedChange={() => onToggleRole(row.id, "program")}
-              aria-label="App reviewer role"
-            />
-            App reviewer
-          </label>
-          <label
-            htmlFor={`role-milestone-${row.id}`}
-            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
-          >
-            <Checkbox
-              id={`role-milestone-${row.id}`}
-              checked={row.roles.includes("milestone")}
-              onCheckedChange={() => onToggleRole(row.id, "milestone")}
-              aria-label="Milestone reviewer role"
-            />
-            Milestone reviewer
-          </label>
-        </div>
-        {dirty && (
-          <span className="text-[10px] text-amber-700 dark:text-amber-400">
-            Contact edits apply across all programs.
-          </span>
-        )}
-      </div>
-
-      {hasError && (
-        <p
-          className="mt-2 text-xs text-red-600 dark:text-red-400"
-          data-testid={`row-error-${row.id}`}
-        >
-          {row.error}
-        </p>
-      )}
-    </div>
-  );
-});
 
 export default ReviewerPickerModal;
 

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.tsx
@@ -85,6 +85,7 @@ const ReviewerPickerModal = ({
   programId,
   reviewerType,
   assignedAddresses,
+  disabledAddresses,
   onCompleted,
   initialMode = "pool",
 }: ReviewerPickerModalProps) => {
@@ -133,6 +134,10 @@ const ReviewerPickerModal = ({
     () => new Set(assignedAddresses.map((a) => a.toLowerCase())),
     [assignedAddresses]
   );
+  const disabledSet = useMemo(
+    () => new Set((disabledAddresses ?? []).map((a) => a.toLowerCase())),
+    [disabledAddresses]
+  );
   const selectedAddressSet = useMemo(
     () => new Set(rows.flatMap((r) => (r.kind === "pool" ? [r.publicAddress.toLowerCase()] : []))),
     [rows]
@@ -160,6 +165,7 @@ const ReviewerPickerModal = ({
 
   const handleTogglePool = useCallback(
     (reviewer: CommunityReviewer) => {
+      if (disabledSet.has(reviewer.publicAddress.toLowerCase())) return;
       const existing = rows.find((r) => r.id === reviewer.publicAddress);
       if (existing) {
         handleRemoveRow(reviewer.publicAddress);
@@ -167,8 +173,32 @@ const ReviewerPickerModal = ({
         setRows((prev) => [...prev, poolRowFromReviewer(reviewer, defaultRole)]);
       }
     },
-    [rows, handleRemoveRow, defaultRole]
+    [rows, handleRemoveRow, defaultRole, disabledSet]
   );
+
+  // Bulk select/unselect every non-disabled, visible pool row.
+  const selectablePoolItems = useMemo(
+    () => visiblePoolItems.filter((r) => !disabledSet.has(r.publicAddress.toLowerCase())),
+    [visiblePoolItems, disabledSet]
+  );
+  const isAllSelected =
+    selectablePoolItems.length > 0 &&
+    selectablePoolItems.every((r) => selectedAddressSet.has(r.publicAddress.toLowerCase()));
+  const handleToggleAll = useCallback(() => {
+    if (selectablePoolItems.length === 0) return;
+    if (isAllSelected) {
+      const selectableIds = new Set(selectablePoolItems.map((r) => r.publicAddress));
+      setRows((prev) => prev.filter((r) => !(r.kind === "pool" && selectableIds.has(r.id))));
+      return;
+    }
+    setRows((prev) => {
+      const existingIds = new Set(prev.map((r) => r.id));
+      const toAdd = selectablePoolItems
+        .filter((r) => !existingIds.has(r.publicAddress))
+        .map((r) => poolRowFromReviewer(r, defaultRole));
+      return [...prev, ...toAdd];
+    });
+  }, [selectablePoolItems, isAllSelected, defaultRole]);
 
   const handleFieldChange = useCallback(
     (id: string, field: "name" | "email" | "telegram" | "slack", value: string) => {
@@ -437,9 +467,20 @@ const ReviewerPickerModal = ({
           </button>
 
           {/* Pool */}
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
-            Community pool
-          </p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Community pool
+            </p>
+            <button
+              type="button"
+              onClick={handleToggleAll}
+              disabled={selectablePoolItems.length === 0}
+              className="text-[11px] font-medium text-brand-blue hover:underline disabled:opacity-40 disabled:no-underline disabled:cursor-not-allowed"
+              data-testid="toggle-select-all-pool"
+            >
+              {isAllSelected ? "Unselect all" : "Select all"}
+            </button>
+          </div>
           {isPoolLoading ? (
             <div className="flex items-center justify-center py-10">
               <Spinner className="h-6 w-6" />
@@ -457,21 +498,26 @@ const ReviewerPickerModal = ({
             <ul className="space-y-1 pb-4">
               {visiblePoolItems.map((r) => {
                 const isSelected = selectedAddressSet.has(r.publicAddress.toLowerCase());
+                const isDisabled = disabledSet.has(r.publicAddress.toLowerCase());
                 return (
                   <li key={r.publicAddress}>
                     <button
                       type="button"
                       onClick={() => handleTogglePool(r)}
+                      disabled={isDisabled}
+                      aria-disabled={isDisabled}
                       className={cn(
-                        "w-full flex items-center gap-3 px-3 py-2 rounded-md text-left transition-colors cursor-pointer",
+                        "w-full flex items-center gap-3 px-3 py-2 rounded-md text-left transition-colors",
+                        isDisabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                         isSelected
                           ? "bg-blue-50 dark:bg-blue-900/20"
-                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                          : !isDisabled && "hover:bg-gray-50 dark:hover:bg-gray-800/50"
                       )}
                       data-testid={`pool-item-${r.publicAddress}`}
                     >
                       <Checkbox
-                        checked={isSelected}
+                        checked={isDisabled || isSelected}
+                        disabled={isDisabled}
                         tabIndex={-1}
                         aria-label={`Select ${r.name || r.email}`}
                         className="pointer-events-none"
@@ -486,6 +532,11 @@ const ReviewerPickerModal = ({
                               <RoleBadge key={role} role={role} />
                             ))}
                           </span>
+                          {isDisabled && (
+                            <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                              Already in program
+                            </span>
+                          )}
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
                           {r.email}

--- a/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
+++ b/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal.types.ts
@@ -130,6 +130,12 @@ export interface ReviewerPickerModalProps {
   reviewerType: "program" | "milestone";
   /** Wallet addresses already assigned to this program — hidden in left pane. */
   assignedAddresses: string[];
+  /**
+   * Wallet addresses that should be shown but visually disabled (grayed) in the pool.
+   * Used by the application page to indicate reviewers already in the program and/or
+   * already assigned to the current application.
+   */
+  disabledAddresses?: string[];
   /** Called after a fully-successful save so the parent can refetch/show a toast. */
   onCompleted?: () => void;
   /**

--- a/components/FundingPlatform/ReviewerPicker/RoleBadge.tsx
+++ b/components/FundingPlatform/ReviewerPicker/RoleBadge.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import type { CommunityReviewerRole } from "@/services/community-reviewers/community-reviewers.types";
+import { cn } from "@/utilities/tailwind";
+
+export function RoleBadge({ role }: { role: CommunityReviewerRole }) {
+  const isApp = role === "program-reviewer";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        isApp
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+          : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+      )}
+    >
+      {isApp ? "App" : "Milestone"}
+    </span>
+  );
+}

--- a/components/FundingPlatform/ReviewerPicker/SelectedRowCard.tsx
+++ b/components/FundingPlatform/ReviewerPicker/SelectedRowCard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { memo } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/utilities/tailwind";
+import {
+  isRowDirty,
+  type ReviewerRoleSelection,
+  type SelectedRow,
+} from "./ReviewerPickerModal.types";
+
+interface SelectedRowCardProps {
+  row: SelectedRow;
+  onFieldChange: (
+    id: string,
+    field: "name" | "email" | "telegram" | "slack",
+    value: string
+  ) => void;
+  onToggleRole: (id: string, role: ReviewerRoleSelection) => void;
+  onRemove: (id: string) => void;
+}
+
+export const SelectedRowCard = memo(function SelectedRowCard({
+  row,
+  onFieldChange,
+  onToggleRole,
+  onRemove,
+}: SelectedRowCardProps) {
+  const isPool = row.kind === "pool";
+  const hasError = !!row.error;
+  const dirty = isPool && isRowDirty(row);
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-white dark:bg-gray-900/60 p-3",
+        hasError ? "border-red-300 dark:border-red-700" : "border-gray-200 dark:border-gray-700"
+      )}
+      data-testid={`selected-row-${row.id}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          {isPool ? (
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                {row.name || row.email}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{row.email}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                value={row.name}
+                onChange={(e) => onFieldChange(row.id, "name", e.target.value)}
+                placeholder="Name *"
+                className="h-9 text-sm"
+                aria-label="Reviewer name"
+              />
+              <Input
+                value={row.email}
+                onChange={(e) => onFieldChange(row.id, "email", e.target.value)}
+                placeholder="Email *"
+                className="h-9 text-sm"
+                aria-label="Reviewer email"
+              />
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onRemove(row.id)}
+          className="p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          aria-label="Remove reviewer"
+          data-testid={`remove-row-${row.id}`}
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        <Input
+          value={row.telegram}
+          onChange={(e) => onFieldChange(row.id, "telegram", e.target.value)}
+          placeholder="Telegram (optional)"
+          className="h-8 text-xs"
+          aria-label="Telegram"
+        />
+        <Input
+          value={row.slack}
+          onChange={(e) => onFieldChange(row.id, "slack", e.target.value)}
+          placeholder="Slack (optional)"
+          className="h-8 text-xs"
+          aria-label="Slack"
+        />
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-3">
+          <label
+            htmlFor={`role-program-${row.id}`}
+            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
+          >
+            <Checkbox
+              id={`role-program-${row.id}`}
+              checked={row.roles.includes("program")}
+              onCheckedChange={() => onToggleRole(row.id, "program")}
+              aria-label="App reviewer role"
+            />
+            App reviewer
+          </label>
+          <label
+            htmlFor={`role-milestone-${row.id}`}
+            className="inline-flex items-center gap-1.5 text-xs text-gray-700 dark:text-gray-300 cursor-pointer"
+          >
+            <Checkbox
+              id={`role-milestone-${row.id}`}
+              checked={row.roles.includes("milestone")}
+              onCheckedChange={() => onToggleRole(row.id, "milestone")}
+              aria-label="Milestone reviewer role"
+            />
+            Milestone reviewer
+          </label>
+        </div>
+        {dirty && (
+          <span className="text-[10px] text-amber-700 dark:text-amber-400">
+            Contact edits apply across all programs.
+          </span>
+        )}
+      </div>
+
+      {hasError && (
+        <p
+          className="mt-2 text-xs text-red-600 dark:text-red-400"
+          data-testid={`row-error-${row.id}`}
+        >
+          {row.error}
+        </p>
+      )}
+    </div>
+  );
+});

--- a/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.test.tsx
+++ b/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.test.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 /**
- * ReviewerPickerModal — layout and save-payload tests
+ * ReviewerPickerModal — add-only flow tests
  *
  * Covers:
- * - Two-column layout renders when `applicationAssignment` is provided
- * - Single-column layout renders when `applicationAssignment` is absent
- * - Right-column × button removes address from staged save payload
- * - Save emits union of (kept-on-right) ∪ (selected-on-left)
+ * - Pool items render
+ * - `disabledAddresses` grays pool rows and blocks selection
+ * - Toggling a pool row adds/removes a staged row
+ * - "Select all" / "Unselect all" toggle
+ * - Save adds each new pool selection to the program reviewer service
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -28,9 +29,6 @@ vi.mock("react-hot-toast", () => ({
   toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn(), dismiss: vi.fn() },
 }));
 
-vi.mock("@/services/application-reviewers.service", () => ({
-  applicationReviewersService: { assignReviewers: vi.fn().mockResolvedValue(undefined) },
-}));
 vi.mock("@/services/program-reviewers.service", () => ({
   programReviewersService: { addReviewer: vi.fn().mockResolvedValue(undefined) },
 }));
@@ -140,12 +138,12 @@ vi.mock("@/utilities/queryKeys", () => ({
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
-import { applicationReviewersService } from "@/services/application-reviewers.service";
 import type { CommunityReviewer } from "@/services/community-reviewers/community-reviewers.types";
+import { programReviewersService } from "@/services/program-reviewers.service";
 import ReviewerPickerModal from "../ReviewerPickerModal";
 import type { ReviewerPickerModalProps } from "../ReviewerPickerModal.types";
 
-const mockAssignReviewers = vi.mocked(applicationReviewersService.assignReviewers);
+const mockAddProgramReviewer = vi.mocked(programReviewersService.addReviewer);
 
 const poolReviewers: CommunityReviewer[] = [
   {
@@ -217,101 +215,103 @@ function renderModal(props: Partial<ReviewerPickerModalProps> = {}) {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe("ReviewerPickerModal — layout", () => {
+describe("ReviewerPickerModal — pool rendering and disabled state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupHooks();
   });
 
-  it("renders single-column layout when applicationAssignment is not provided", () => {
+  it("renders all pool reviewers", () => {
     renderModal();
 
-    // In single-column mode there is no "This application" column header.
-    expect(screen.queryByText(/this application/i)).not.toBeInTheDocument();
-    // The pool section header is present.
-    expect(screen.getAllByText(/community pool/i).length).toBeGreaterThanOrEqual(1);
-    // The "Add new reviewer" button is visible in single-column mode.
-    expect(screen.getByTestId("add-new-reviewer-btn")).toBeInTheDocument();
-  });
-
-  it("renders two-column layout when applicationAssignment is provided", () => {
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-1",
-        currentlyAssigned: ["0xalice"],
-      },
-    });
-
-    // Both column headers must be present.
-    expect(screen.getAllByText(/community pool/i).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText(/this application/i).length).toBeGreaterThanOrEqual(1);
-
-    // Alice is currently assigned — should appear in the right column.
-    expect(screen.getByTestId("assigned-item-0xalice")).toBeInTheDocument();
-
-    // The "Add new reviewer" dashed-border button should NOT appear in app-assignment mode.
-    expect(screen.queryByTestId("add-new-reviewer-btn")).not.toBeInTheDocument();
-  });
-
-  it("shows pool items in left column in two-column mode", () => {
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-1",
-        currentlyAssigned: [],
-      },
-    });
-
-    // All three pool reviewers should be listed.
     expect(screen.getByTestId("pool-item-0xalice")).toBeInTheDocument();
     expect(screen.getByTestId("pool-item-0xbob")).toBeInTheDocument();
     expect(screen.getByTestId("pool-item-0xcarol")).toBeInTheDocument();
   });
+
+  it("disables pool rows whose addresses are in disabledAddresses", () => {
+    renderModal({ disabledAddresses: ["0xalice"] });
+
+    expect(screen.getByTestId("pool-item-0xalice")).toBeDisabled();
+    expect(screen.getByTestId("pool-item-0xbob")).not.toBeDisabled();
+  });
+
+  it("does not stage a disabled pool row when clicked", () => {
+    renderModal({ disabledAddresses: ["0xalice"] });
+
+    fireEvent.click(screen.getByTestId("pool-item-0xalice"));
+
+    expect(screen.queryByTestId("selected-row-0xalice")).not.toBeInTheDocument();
+  });
 });
 
-describe("ReviewerPickerModal — right-column × button", () => {
+describe("ReviewerPickerModal — pool toggling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupHooks();
   });
 
-  it("removes address from the right column when × is clicked", () => {
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-1",
-        currentlyAssigned: ["0xalice", "0xbob"],
-      },
-    });
+  it("adds a row to the selected list when a pool item is clicked", () => {
+    renderModal();
 
-    // Both should be visible initially.
-    expect(screen.getByTestId("assigned-item-0xalice")).toBeInTheDocument();
-    expect(screen.getByTestId("assigned-item-0xbob")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("pool-item-0xbob"));
 
-    // Click the × button for Alice.
-    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
-
-    // Alice is removed from the right column.
-    expect(screen.queryByTestId("assigned-item-0xalice")).not.toBeInTheDocument();
-    // Bob remains.
-    expect(screen.getByTestId("assigned-item-0xbob")).toBeInTheDocument();
+    expect(screen.getByTestId("selected-row-0xbob")).toBeInTheDocument();
   });
 
-  it("re-enables the removed address in the pool list so it can be re-selected", () => {
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-1",
-        currentlyAssigned: ["0xalice"],
-      },
-    });
+  it("removes the row when the same pool item is clicked again", () => {
+    renderModal();
 
-    // Alice starts as disabled (already assigned) in the pool.
-    const alicePoolBtn = screen.getByTestId("pool-item-0xalice");
-    expect(alicePoolBtn).toBeDisabled();
+    fireEvent.click(screen.getByTestId("pool-item-0xbob"));
+    expect(screen.getByTestId("selected-row-0xbob")).toBeInTheDocument();
 
-    // Remove Alice from the right column.
-    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
+    fireEvent.click(screen.getByTestId("pool-item-0xbob"));
+    expect(screen.queryByTestId("selected-row-0xbob")).not.toBeInTheDocument();
+  });
+});
 
-    // Now Alice should be enabled in the pool.
-    expect(alicePoolBtn).not.toBeDisabled();
+describe("ReviewerPickerModal — Select all / Unselect all", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHooks();
+  });
+
+  it("renders a 'Select all' button by default", () => {
+    renderModal();
+
+    expect(screen.getByTestId("toggle-select-all-pool")).toHaveTextContent(/select all/i);
+  });
+
+  it("stages every selectable pool row when 'Select all' is clicked", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId("toggle-select-all-pool"));
+
+    expect(screen.getByTestId("selected-row-0xalice")).toBeInTheDocument();
+    expect(screen.getByTestId("selected-row-0xbob")).toBeInTheDocument();
+    expect(screen.getByTestId("selected-row-0xcarol")).toBeInTheDocument();
+  });
+
+  it("excludes disabled rows from 'Select all'", () => {
+    renderModal({ disabledAddresses: ["0xalice"] });
+
+    fireEvent.click(screen.getByTestId("toggle-select-all-pool"));
+
+    expect(screen.queryByTestId("selected-row-0xalice")).not.toBeInTheDocument();
+    expect(screen.getByTestId("selected-row-0xbob")).toBeInTheDocument();
+    expect(screen.getByTestId("selected-row-0xcarol")).toBeInTheDocument();
+  });
+
+  it("flips to 'Unselect all' when every selectable row is staged, and unselects on click", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByTestId("toggle-select-all-pool"));
+    expect(screen.getByTestId("toggle-select-all-pool")).toHaveTextContent(/unselect all/i);
+
+    fireEvent.click(screen.getByTestId("toggle-select-all-pool"));
+    expect(screen.queryByTestId("selected-row-0xalice")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("selected-row-0xbob")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("selected-row-0xcarol")).not.toBeInTheDocument();
   });
 });
 
@@ -321,56 +321,26 @@ describe("ReviewerPickerModal — save payload", () => {
     setupHooks();
   });
 
-  it("save emits union of (kept-on-right) ∪ (selected-on-left) via assignReviewers", async () => {
-    // Alice and Bob are currently assigned; user removes Alice and selects Carol from the pool.
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-1",
-        currentlyAssigned: ["0xalice", "0xbob"],
-      },
-    });
+  it("calls programReviewersService.addReviewer once per staged pool row", async () => {
+    renderModal();
 
-    // Unassign Alice from the right column.
-    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
-
-    // Select Carol from the pool (left column).
+    fireEvent.click(screen.getByTestId("pool-item-0xalice"));
     fireEvent.click(screen.getByTestId("pool-item-0xcarol"));
 
-    // Click Save.
     fireEvent.click(screen.getByTestId("save-btn"));
 
     await waitFor(() => {
-      expect(mockAssignReviewers).toHaveBeenCalledTimes(1);
+      expect(mockAddProgramReviewer).toHaveBeenCalledTimes(2);
     });
 
-    const [applicationId, request] = mockAssignReviewers.mock.calls[0];
-    expect(applicationId).toBe("app-1");
-    // Final list should be Bob (kept) + Carol (newly added), Alice removed.
-    const addresses: string[] = request.appReviewerAddresses;
-    expect(addresses).toContain("0xbob");
-    expect(addresses).toContain("0xcarol");
-    expect(addresses).not.toContain("0xalice");
+    const emails = mockAddProgramReviewer.mock.calls.map((call) => call[1].email);
+    expect(emails).toContain("alice@example.com");
+    expect(emails).toContain("carol@example.com");
   });
 
-  it("save with only unassignments (no new selections) calls assignReviewers with reduced list", async () => {
-    renderModal({
-      applicationAssignment: {
-        applicationId: "app-2",
-        currentlyAssigned: ["0xalice", "0xbob"],
-      },
-    });
+  it("disables Save when nothing is staged", () => {
+    renderModal();
 
-    // Remove both.
-    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
-    fireEvent.click(screen.getByTestId("unassign-btn-0xbob"));
-
-    fireEvent.click(screen.getByTestId("save-btn"));
-
-    await waitFor(() => {
-      expect(mockAssignReviewers).toHaveBeenCalledTimes(1);
-    });
-
-    const [, request] = mockAssignReviewers.mock.calls[0];
-    expect(request.appReviewerAddresses).toHaveLength(0);
+    expect(screen.getByTestId("save-btn")).toBeDisabled();
   });
 });

--- a/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.test.tsx
+++ b/components/FundingPlatform/ReviewerPicker/__tests__/ReviewerPickerModal.test.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+/**
+ * ReviewerPickerModal — layout and save-payload tests
+ *
+ * Covers:
+ * - Two-column layout renders when `applicationAssignment` is provided
+ * - Single-column layout renders when `applicationAssignment` is absent
+ * - Right-column × button removes address from staged save payload
+ * - Save emits union of (kept-on-right) ∪ (selected-on-left)
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/utilities/tailwind", () => ({
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), error: vi.fn(), loading: vi.fn(), dismiss: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn(), dismiss: vi.fn() },
+}));
+
+vi.mock("@/services/application-reviewers.service", () => ({
+  applicationReviewersService: { assignReviewers: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("@/services/program-reviewers.service", () => ({
+  programReviewersService: { addReviewer: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("@/services/milestone-reviewers.service", () => ({
+  milestoneReviewersService: { addReviewer: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const mockUseCommunityReviewers = vi.fn();
+vi.mock("@/hooks/useCommunityReviewers", () => ({
+  useCommunityReviewers: (...args: unknown[]) => mockUseCommunityReviewers(...args),
+}));
+
+const mockUseCommunityReviewerPrograms = vi.fn();
+vi.mock("@/hooks/useCommunityReviewerPrograms", () => ({
+  useCommunityReviewerPrograms: (...args: unknown[]) => mockUseCommunityReviewerPrograms(...args),
+}));
+
+// Lightweight stubs for UI primitives
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input type="checkbox" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+vi.mock("@/components/Utilities/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    isLoading,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    isLoading?: boolean;
+    [key: string]: unknown;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} {...rest}>
+      {isLoading ? "Loading…" : children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/Utilities/Spinner", () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+vi.mock("./EmptyState", () => ({
+  default: ({ onAddNew }: { onAddNew: () => void }) => (
+    <button type="button" onClick={onAddNew} data-testid="empty-state">
+      Add reviewer
+    </button>
+  ),
+}));
+
+vi.mock("@/utilities/queryKeys", () => ({
+  QUERY_KEYS: {
+    REVIEWERS: {
+      PROGRAM: (id: string) => ["reviewers", "program", id],
+      MILESTONE: (id: string) => ["reviewers", "milestone", id],
+    },
+  },
+}));
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+import { applicationReviewersService } from "@/services/application-reviewers.service";
+import type { CommunityReviewer } from "@/services/community-reviewers/community-reviewers.types";
+import ReviewerPickerModal from "../ReviewerPickerModal";
+import type { ReviewerPickerModalProps } from "../ReviewerPickerModal.types";
+
+const mockAssignReviewers = vi.mocked(applicationReviewersService.assignReviewers);
+
+const poolReviewers: CommunityReviewer[] = [
+  {
+    publicAddress: "0xalice",
+    name: "Alice",
+    email: "alice@example.com",
+    telegram: "",
+    slack: "",
+    picture: undefined,
+    roles: ["program-reviewer"],
+    lastSeenAt: new Date().toISOString(),
+  },
+  {
+    publicAddress: "0xbob",
+    name: "Bob",
+    email: "bob@example.com",
+    telegram: "",
+    slack: "",
+    picture: undefined,
+    roles: ["program-reviewer"],
+    lastSeenAt: new Date().toISOString(),
+  },
+  {
+    publicAddress: "0xcarol",
+    name: "Carol",
+    email: "carol@example.com",
+    telegram: "",
+    slack: "",
+    picture: undefined,
+    roles: ["program-reviewer"],
+    lastSeenAt: new Date().toISOString(),
+  },
+];
+
+function setupHooks() {
+  mockUseCommunityReviewers.mockReturnValue({
+    items: poolReviewers,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  });
+  mockUseCommunityReviewerPrograms.mockReturnValue({ data: { items: [] } });
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderModal(props: Partial<ReviewerPickerModalProps> = {}) {
+  const qc = makeQueryClient();
+  const defaults: ReviewerPickerModalProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    communityUID: "community-1",
+    programId: "program-1",
+    reviewerType: "program",
+    assignedAddresses: [],
+    onCompleted: vi.fn(),
+  };
+  return render(
+    <QueryClientProvider client={qc}>
+      <ReviewerPickerModal {...defaults} {...props} />
+    </QueryClientProvider>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ReviewerPickerModal — layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHooks();
+  });
+
+  it("renders single-column layout when applicationAssignment is not provided", () => {
+    renderModal();
+
+    // In single-column mode there is no "This application" column header.
+    expect(screen.queryByText(/this application/i)).not.toBeInTheDocument();
+    // The pool section header is present.
+    expect(screen.getAllByText(/community pool/i).length).toBeGreaterThanOrEqual(1);
+    // The "Add new reviewer" button is visible in single-column mode.
+    expect(screen.getByTestId("add-new-reviewer-btn")).toBeInTheDocument();
+  });
+
+  it("renders two-column layout when applicationAssignment is provided", () => {
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-1",
+        currentlyAssigned: ["0xalice"],
+      },
+    });
+
+    // Both column headers must be present.
+    expect(screen.getAllByText(/community pool/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/this application/i).length).toBeGreaterThanOrEqual(1);
+
+    // Alice is currently assigned — should appear in the right column.
+    expect(screen.getByTestId("assigned-item-0xalice")).toBeInTheDocument();
+
+    // The "Add new reviewer" dashed-border button should NOT appear in app-assignment mode.
+    expect(screen.queryByTestId("add-new-reviewer-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows pool items in left column in two-column mode", () => {
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-1",
+        currentlyAssigned: [],
+      },
+    });
+
+    // All three pool reviewers should be listed.
+    expect(screen.getByTestId("pool-item-0xalice")).toBeInTheDocument();
+    expect(screen.getByTestId("pool-item-0xbob")).toBeInTheDocument();
+    expect(screen.getByTestId("pool-item-0xcarol")).toBeInTheDocument();
+  });
+});
+
+describe("ReviewerPickerModal — right-column × button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHooks();
+  });
+
+  it("removes address from the right column when × is clicked", () => {
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-1",
+        currentlyAssigned: ["0xalice", "0xbob"],
+      },
+    });
+
+    // Both should be visible initially.
+    expect(screen.getByTestId("assigned-item-0xalice")).toBeInTheDocument();
+    expect(screen.getByTestId("assigned-item-0xbob")).toBeInTheDocument();
+
+    // Click the × button for Alice.
+    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
+
+    // Alice is removed from the right column.
+    expect(screen.queryByTestId("assigned-item-0xalice")).not.toBeInTheDocument();
+    // Bob remains.
+    expect(screen.getByTestId("assigned-item-0xbob")).toBeInTheDocument();
+  });
+
+  it("re-enables the removed address in the pool list so it can be re-selected", () => {
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-1",
+        currentlyAssigned: ["0xalice"],
+      },
+    });
+
+    // Alice starts as disabled (already assigned) in the pool.
+    const alicePoolBtn = screen.getByTestId("pool-item-0xalice");
+    expect(alicePoolBtn).toBeDisabled();
+
+    // Remove Alice from the right column.
+    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
+
+    // Now Alice should be enabled in the pool.
+    expect(alicePoolBtn).not.toBeDisabled();
+  });
+});
+
+describe("ReviewerPickerModal — save payload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHooks();
+  });
+
+  it("save emits union of (kept-on-right) ∪ (selected-on-left) via assignReviewers", async () => {
+    // Alice and Bob are currently assigned; user removes Alice and selects Carol from the pool.
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-1",
+        currentlyAssigned: ["0xalice", "0xbob"],
+      },
+    });
+
+    // Unassign Alice from the right column.
+    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
+
+    // Select Carol from the pool (left column).
+    fireEvent.click(screen.getByTestId("pool-item-0xcarol"));
+
+    // Click Save.
+    fireEvent.click(screen.getByTestId("save-btn"));
+
+    await waitFor(() => {
+      expect(mockAssignReviewers).toHaveBeenCalledTimes(1);
+    });
+
+    const [applicationId, request] = mockAssignReviewers.mock.calls[0];
+    expect(applicationId).toBe("app-1");
+    // Final list should be Bob (kept) + Carol (newly added), Alice removed.
+    const addresses: string[] = request.appReviewerAddresses;
+    expect(addresses).toContain("0xbob");
+    expect(addresses).toContain("0xcarol");
+    expect(addresses).not.toContain("0xalice");
+  });
+
+  it("save with only unassignments (no new selections) calls assignReviewers with reduced list", async () => {
+    renderModal({
+      applicationAssignment: {
+        applicationId: "app-2",
+        currentlyAssigned: ["0xalice", "0xbob"],
+      },
+    });
+
+    // Remove both.
+    fireEvent.click(screen.getByTestId("unassign-btn-0xalice"));
+    fireEvent.click(screen.getByTestId("unassign-btn-0xbob"));
+
+    fireEvent.click(screen.getByTestId("save-btn"));
+
+    await waitFor(() => {
+      expect(mockAssignReviewers).toHaveBeenCalledTimes(1);
+    });
+
+    const [, request] = mockAssignReviewers.mock.calls[0];
+    expect(request.appReviewerAddresses).toHaveLength(0);
+  });
+});

--- a/components/Pages/Project/PostUpdateButton.tsx
+++ b/components/Pages/Project/PostUpdateButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { PenLine } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { usePermissionsQuery } from "@/src/core/rbac/hooks/use-permissions";
+import { Role } from "@/src/core/rbac/types";
+import { useOwnerStore, useProjectStore } from "@/store";
+import { useProgressModalStore } from "@/store/modals/progress";
+import { cn } from "@/utilities/tailwind";
+
+interface PostUpdateButtonProps {
+  className?: string;
+}
+
+export function PostUpdateButton({ className }: PostUpdateButtonProps) {
+  const { setIsProgressModalOpen } = useProgressModalStore();
+  const isOwner = useOwnerStore((state) => state.isOwner);
+  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const { authenticated } = useAuth();
+  const { data: permissions, isLoading: isPermissionsLoading } = usePermissionsQuery(
+    {},
+    { enabled: authenticated }
+  );
+  const isSuperAdmin = permissions?.roles?.roles?.includes(Role.SUPER_ADMIN) ?? false;
+
+  const isAuthorized =
+    isOwner || isProjectAdmin || isProjectOwner || (!isPermissionsLoading && isSuperAdmin);
+
+  if (!isAuthorized) return null;
+
+  return (
+    <Button
+      onClick={() => setIsProgressModalOpen(true)}
+      className={cn(
+        "h-10 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded-lg inline-flex items-center gap-2",
+        className
+      )}
+      data-testid="post-update-button"
+    >
+      <PenLine className="h-4 w-4" />
+      Post an update
+    </Button>
+  );
+}

--- a/components/Pages/Project/PostUpdateButton.tsx
+++ b/components/Pages/Project/PostUpdateButton.tsx
@@ -39,7 +39,7 @@ export function PostUpdateButton({ className }: PostUpdateButtonProps) {
       )}
       data-testid="post-update-button"
     >
-      <PenLine className="h-4 w-4" />
+      <PenLine className="size-4" />
       Post an update
     </Button>
   );

--- a/components/Pages/Project/ProjectOptionsMenu.tsx
+++ b/components/Pages/Project/ProjectOptionsMenu.tsx
@@ -3,7 +3,6 @@
 import {
   ArrowDownOnSquareIcon,
   ArrowsRightLeftIcon,
-  ChevronDownIcon,
   Cog6ToothIcon,
   CurrencyDollarIcon,
   FingerPrintIcon,
@@ -282,12 +281,11 @@ export const ProjectOptionsMenu = () => {
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white font-medium text-sm hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-zinc-900"
+              aria-label="Project settings"
+              className="inline-flex items-center justify-center h-10 w-10 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-zinc-900"
               data-testid="project-options-menu"
             >
               <Cog6ToothIcon className="h-5 w-5" aria-hidden="true" />
-              <span className="hidden sm:inline">Project Settings</span>
-              <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56 max-h-96 overflow-y-auto">

--- a/components/Pages/Project/ProjectOptionsMenu.tsx
+++ b/components/Pages/Project/ProjectOptionsMenu.tsx
@@ -282,7 +282,7 @@ export const ProjectOptionsMenu = () => {
             <button
               type="button"
               aria-label="Project settings"
-              className="inline-flex items-center justify-center h-10 w-10 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-zinc-900"
+              className="inline-flex items-center justify-center size-10 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 dark:focus:ring-offset-zinc-900"
               data-testid="project-options-menu"
             >
               <Cog6ToothIcon className="h-5 w-5" aria-hidden="true" />

--- a/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
+++ b/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
@@ -46,6 +46,11 @@ const ProjectOptionsMenu = dynamic(
   { ssr: false }
 );
 
+const PostUpdateButton = dynamic(
+  () => import("@/components/Pages/Project/PostUpdateButton").then((mod) => mod.PostUpdateButton),
+  { ssr: false }
+);
+
 const EndorsementsListDialog = dynamic(
   () => import("../EndorsementsListDialog").then((mod) => mod.EndorsementsListDialog),
   { ssr: false }
@@ -316,8 +321,9 @@ export function ProjectProfileLayout({
           <SidebarProfileCard project={project} isVerified={isVerified} />
         </div>
 
-        {/* Mobile: Project Settings - right aligned */}
-        <div className="lg:hidden flex justify-end">
+        {/* Mobile: Post an update + Project Settings - right aligned */}
+        <div className="lg:hidden flex justify-end items-center gap-2">
+          <PostUpdateButton />
           <ProjectOptionsMenu />
         </div>
 
@@ -352,8 +358,9 @@ export function ProjectProfileLayout({
             className="flex flex-col gap-6 flex-1 min-w-0"
             data-testid="project-main-content-area"
           >
-            {/* Desktop: Project Settings above tabs */}
-            <div className="hidden lg:flex lg:justify-end">
+            {/* Desktop: Post an update + Project Settings above tabs */}
+            <div className="hidden lg:flex lg:justify-end items-center gap-2">
+              <PostUpdateButton />
               <ProjectOptionsMenu />
             </div>
 

--- a/components/Pages/Project/v2/SidePanel/ProjectSidePanel.tsx
+++ b/components/Pages/Project/v2/SidePanel/ProjectSidePanel.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-import { PenLine } from "lucide-react";
 import dynamic from "next/dynamic";
 import type React from "react";
-import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/useAuth";
-import { usePermissionsQuery } from "@/src/core/rbac/hooks/use-permissions";
-import { Role } from "@/src/core/rbac/types";
-import { useOwnerStore, useProjectStore } from "@/store";
-import { useProgressModalStore } from "@/store/modals/progress";
 import type { Project } from "@/types/v2/project";
 import { cn } from "@/utilities/tailwind";
 import { useDonationVisibility } from "./DonateSection";
@@ -38,60 +31,14 @@ function Separator() {
   return <div className="h-px w-full bg-border" />;
 }
 
-/**
- * ProjectSidePanel is the desktop-only side panel containing:
- * - Post an update button (for authorized users)
- * - Main card with Donate, Endorse, Subscribe sections
- * - Separate Quick links card
- *
- * Width: 400px (fixed)
- * Visibility: Desktop only (lg: breakpoint)
- * Matches Figma design with neutral colors and 12px border radius
- */
-export function ProjectSidePanel({
-  project,
-  isVerified,
-  className,
-  serverSidePanel,
-}: ProjectSidePanelProps) {
-  const { setIsProgressModalOpen } = useProgressModalStore();
-
-  // Authorization checks for Post an update button
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const { authenticated } = useAuth();
-  const { data: permissions, isLoading: isPermissionsLoading } = usePermissionsQuery(
-    {},
-    { enabled: authenticated }
-  );
-  const isSuperAdmin = permissions?.roles?.roles?.includes(Role.SUPER_ADMIN) ?? false;
-
-  const isAuthorized =
-    isOwner || isProjectAdmin || isProjectOwner || (!isPermissionsLoading && isSuperAdmin);
+export function ProjectSidePanel({ project, isVerified, className }: ProjectSidePanelProps) {
   const showDonateSection = useDonationVisibility(project);
-
-  const handlePostUpdate = () => {
-    setIsProgressModalOpen(true);
-  };
 
   return (
     <aside
       className={cn("hidden lg:flex flex-col gap-4 w-[400px] shrink-0", className)}
       data-testid="project-side-panel"
     >
-      {/* Post an update button - only for authorized users */}
-      {isAuthorized && (
-        <Button
-          onClick={handlePostUpdate}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white rounded-lg flex items-center justify-center gap-2 py-5"
-          data-testid="post-update-button"
-        >
-          <PenLine className="h-4 w-4" />
-          Post an update
-        </Button>
-      )}
-
       {/* Outer card: profile + actions together */}
       <div className="flex flex-col rounded-xl border bg-secondary gap-2 p-2">
         {/* Inner white profile card — always render the full client version once

--- a/hooks/useFundingPlatform.ts
+++ b/hooks/useFundingPlatform.ts
@@ -370,7 +370,7 @@ export const useFundingApplications = (programId: string, filters: IApplicationF
     error: applicationsQuery.error, // Only show error if applications query fails, stats are optional
     statsError: statsQuery.error, // Separate error for stats (non-blocking)
     submitApplication: submitApplicationMutation.mutate,
-    updateApplicationStatus: updateStatusMutation.mutate,
+    updateApplicationStatus: updateStatusMutation.mutateAsync,
     isSubmitting: submitApplicationMutation.isPending,
     isUpdatingStatus: updateStatusMutation.isPending,
     refetch: () => {


### PR DESCRIPTION
## Summary

**Reviewer picker on the application page**
- Reverts the modal to add-only semantics (no more application-assignment branch).
- Reviewers already in the program pool — which includes those already assigned to the current application — are shown but disabled in the list.
- Adds a `Select all` / `Unselect all` toggle next to the Community pool header.
- Plumbs `communityUID` from `ApplicationListWithAPI` → `ApplicationList` → `ApplicationTable` → `ReviewerAssignmentDropdown` so the dropdown can launch the picker.
- New unit tests for `ReviewerPickerModal`.

**Project header**
- Extracts the "Post an update" button into a reusable `PostUpdateButton` component.
- Moves it from the desktop side panel into the header next to Project Settings on both desktop and mobile.
- Shrinks Project Settings to an icon-only button to balance the header row.

## Test plan

- [x] Typecheck passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (biome)
- [ ] Reviewer modal: opens in add-only mode, reviewers in program/application are grayed and unclickable
- [ ] `Select all` toggles to `Unselect all` once every selectable pool row is picked; click reverses
- [ ] Mobile + desktop: "Post an update" button renders next to Project Settings for authorized users only
- [ ] Project Settings dropdown still opens from the icon-only button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community-aware reviewer picker modal to avoid duplicate assignments
  * "Post an update" button for sharing project progress

* **Improvements**
  * Added Select all / Unselect all controls in reviewer pool
  * Empty-action label simplified to "Add reviewer"
  * Reviewer rows show "Already in program" badge when unavailable
  * Application status updates now refresh view and surface toast errors

* **Tests**
  * Expanded reviewer picker modal tests; updated dropdown tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1432)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->