### PR TITLE
feat: show grant chips on activities and on funding page

### DIFF
--- a/components/Forms/ProjectUpdate.tsx
+++ b/components/Forms/ProjectUpdate.tsx
@@ -670,7 +670,10 @@ export const ProjectUpdateForm: FC<ProjectUpdateFormProps> = ({
                 }
 
                 // Let the share dialog render before any route transition.
-                if (pathname !== updatesPath) {
+                // Only redirect for new activities. Edits should leave the user
+                // on whatever page they came from (e.g. the funding page) so
+                // they see the in-place refresh.
+                if (!isEditMode && pathname !== updatesPath) {
                   setTimeout(() => {
                     router.push(updatesPath);
                   }, 250);

--- a/components/Forms/ProjectUpdate.tsx
+++ b/components/Forms/ProjectUpdate.tsx
@@ -669,10 +669,7 @@ export const ProjectUpdateForm: FC<ProjectUpdateFormProps> = ({
                   });
                 }
 
-                // Let the share dialog render before any route transition.
-                // Only redirect for new activities. Edits should leave the user
-                // on whatever page they came from (e.g. the funding page) so
-                // they see the in-place refresh.
+                // Only redirect new activities. Edits stay on the current page (e.g. funding page) to show in-place refresh.
                 if (!isEditMode && pathname !== updatesPath) {
                   setTimeout(() => {
                     router.push(updatesPath);

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -298,7 +298,7 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
           </div>
 
           <div className="mt-3 flex w-full flex-col gap-6">
-            {selectedTabArray.map((item, idx) => {
+            {selectedTabArray.map((item) => {
               if (item.type === "update") {
                 const updatesArray = generalArray.filter((i) => i.type === "update");
                 const updatesIndex = updatesArray.findIndex(

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -1,9 +1,13 @@
+import { useParams } from "next/navigation";
 import pluralize from "pluralize";
 import { type FC, useEffect, useMemo, useState } from "react";
+import { ActivityCard } from "@/components/Shared/ActivityCard";
 import { Button } from "@/components/Utilities/Button";
 import { getTokenByAddressAndChain } from "@/constants/supportedTokens";
+import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { usePayoutConfigByGrantPublic } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import type { Grant } from "@/types/v2/grant";
+import type { UnifiedMilestone, ProjectUpdate as V2ProjectUpdate } from "@/types/v2/roadmap";
 import { normalizeTimestamp } from "@/utilities/formatDate";
 import { formatMilestoneAmount } from "@/utilities/formatMilestoneAmount";
 import { buildGrantMilestoneOrderMap } from "@/utilities/milestones/assignGrantMilestoneOrder";
@@ -53,6 +57,20 @@ const TabButton: FC<TabButtonProps> = ({ handleSelection, tab, tabName, selected
 
 export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
   const { milestones, updates } = grant;
+  const params = useParams();
+  // Use the URL projectId segment so we share the React Query cache key with
+  // the project page's useProjectUpdates(projectId) call. Mutations on either
+  // page invalidate the same key.
+  const projectIdentifier = (params?.projectId as string) || "";
+  const { rawData: projectUpdatesData } = useProjectUpdates(projectIdentifier);
+
+  const linkedActivities: V2ProjectUpdate[] = useMemo(() => {
+    const all = projectUpdatesData?.projectUpdates || [];
+    const grantUidLower = grant.uid?.toLowerCase();
+    return all.filter((update) =>
+      update.associations?.funding?.some((f) => f.uid?.toLowerCase() === grantUidLower)
+    );
+  }, [projectUpdatesData, grant.uid]);
 
   const { data: payoutConfig } = usePayoutConfigByGrantPublic(grant.uid);
 
@@ -126,14 +144,23 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
       });
     });
 
+    linkedActivities.forEach((activity) => {
+      merged.push({
+        object: activity,
+        date: getTimestampMs(activity.createdAt),
+        type: "activity",
+      });
+    });
+
     // Sort descending by date (newest first)
     return merged.sort((a, b) => b.date - a.date);
-  }, [updates, milestones]);
+  }, [updates, milestones, linkedActivities]);
 
   // Helper to properly check if a milestone is completed
   // API may return empty array [] which is truthy in JS but means not completed
   const isCompleted = (item: any): boolean => {
     if (item.type === "update") return true; // Updates are always "completed"
+    if (item.type === "activity") return true; // Activities are stateless; treat as completed
     const completed = item.object.completed;
     if (Array.isArray(completed)) return completed.length > 0;
     return !!completed;
@@ -182,6 +209,17 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
       return item.date; // fallback to pre-computed date (endsAt or createdAt)
     };
 
+    // Bucket 1: completed milestones, sorted by completion date desc.
+    // Bucket 2: everything else (pending milestones, grant updates, activities),
+    // sorted by createdAt desc. Activities use their own createdAt.
+    const completedMilestoneBucket = unsortedCompleted
+      .filter((item) => item.type === "milestone")
+      .sort((a, b) => getCompletedDate(b) - getCompletedDate(a));
+
+    const restBucket = generalArray
+      .filter((item) => !(item.type === "milestone" && isCompleted(item)))
+      .sort((a, b) => getAllDate(b) - getAllDate(a));
+
     return {
       // Completed: descending by completion/creation date (newest first)
       completedMilestones: [...unsortedCompleted].sort(
@@ -189,8 +227,8 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
       ),
       // Pending: ascending by due date (soonest first)
       pendingMilestones: [...unsortedPending].sort((a, b) => getPendingDate(a) - getPendingDate(b)),
-      // All: descending by date (newest first)
-      allMilestones: [...generalArray].sort((a, b) => getAllDate(b) - getAllDate(a)),
+      // All: completed milestones first, then everything else by createdAt desc
+      allMilestones: [...completedMilestoneBucket, ...restBucket],
     };
   }, [generalArray]);
 
@@ -260,7 +298,7 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
           </div>
 
           <div className="mt-3 flex w-full flex-col gap-6">
-            {selectedTabArray.map((item) => {
+            {selectedTabArray.map((item, idx) => {
               if (item.type === "update") {
                 const updatesArray = generalArray.filter((i) => i.type === "update");
                 const updatesIndex = updatesArray.findIndex(
@@ -278,6 +316,28 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
                     description={item.object?.text}
                     date={item.object.createdAt}
                     update={item.object}
+                  />
+                );
+              }
+
+              if (item.type === "activity") {
+                const activity = item.object as V2ProjectUpdate;
+                const unified: UnifiedMilestone = {
+                  uid: activity.uid,
+                  chainID: 0,
+                  refUID: "",
+                  type: "activity",
+                  title: activity.title,
+                  description: activity.description,
+                  completed: false,
+                  createdAt: activity.createdAt || new Date().toISOString(),
+                  projectUpdate: activity,
+                  source: { type: "update" },
+                };
+                return (
+                  <ActivityCard
+                    key={activity.uid}
+                    activity={{ type: "milestone", data: unified }}
                   />
                 );
               }

--- a/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
+++ b/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
@@ -41,8 +41,18 @@ export const ProjectUpdateFormBlock = ({ onClose, updateId }: ProjectUpdateFormB
     // invalidateQueries marks the cache stale AND triggers a background refetch.
     // Awaiting it ensures the refetch completes before we close the dialog,
     // so the updates list shows the new activity immediately.
+    // Invalidate every cached project-updates query for this project — the hook
+    // is keyed by whichever identifier the page used (uid on the project page,
+    // slug on the funding page), so a single-key invalidation can miss the
+    // surface the user is currently viewing.
+    const uid = project?.uid?.toLowerCase();
+    const slug = project?.details?.slug?.toLowerCase();
     await queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.PROJECT.UPDATES(project?.uid || ""),
+      predicate: (query) => {
+        if (query.queryKey[0] !== "project-updates") return false;
+        const id = (query.queryKey[1] as string | undefined)?.toLowerCase();
+        return id === uid || id === slug;
+      },
     });
     // No router.refresh() — the invalidation already refetched fresh data.
     // router.refresh() would re-render the server component and race with

--- a/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
+++ b/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
@@ -46,17 +46,18 @@ export const ProjectUpdateFormBlock = ({ onClose, updateId }: ProjectUpdateFormB
     // surface the user is currently viewing.
     const uid = project?.uid?.toLowerCase();
     const slug = project?.details?.slug?.toLowerCase();
-    await queryClient.invalidateQueries({
-      predicate: (query) => {
-        if (query.queryKey[0] !== "project-updates") return false;
-        const id = (query.queryKey[1] as string | undefined)?.toLowerCase();
-        return id === uid || id === slug;
-      },
-    });
-    // No router.refresh() — the invalidation already refetched fresh data.
-    // router.refresh() would re-render the server component and race with
-    // the client-side cache, potentially showing stale data.
-    onClose?.();
+    try {
+      await queryClient.invalidateQueries({
+        predicate: (query) => {
+          if (query.queryKey[0] !== "project-updates") return false;
+          const id = (query.queryKey[1] as string | undefined)?.toLowerCase();
+          return id === uid || id === slug;
+        },
+      });
+    } finally {
+      // Always close the dialog — the next mount will refetch if invalidation failed.
+      onClose?.();
+    }
   };
 
   // Show loading state while fetching data in edit mode

--- a/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
+++ b/components/Pages/Project/Updates/ProjectUpdateFormBlock.tsx
@@ -6,7 +6,6 @@ import { ProjectUpdateForm } from "@/components/Forms/ProjectUpdate";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { useProjectStore } from "@/store";
-import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 interface ProjectUpdateFormBlockProps {
   onClose?: () => void;

--- a/components/Shared/ActivityCard/GrantAssociation.tsx
+++ b/components/Shared/ActivityCard/GrantAssociation.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { ProfilePicture } from "@/components/Utilities/ProfilePicture";
 import { useProjectGrants } from "@/hooks/v2/useProjectGrants";
 import { useProjectStore } from "@/store";
-import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import type { UnifiedMilestone, ProjectUpdate as V2ProjectUpdate } from "@/types/v2/roadmap";
 import { PAGES } from "@/utilities/pages";
 
 // Shared UI component for rendering grant items
@@ -43,6 +43,9 @@ interface GrantAssociationProps {
   // For milestones (new functionality)
   milestone?: UnifiedMilestone;
 
+  // For V2 project updates (associations.funding[])
+  projectUpdate?: V2ProjectUpdate;
+
   // Styling options
   className?: string;
 }
@@ -51,6 +54,7 @@ export const GrantAssociation = ({
   update,
   index,
   milestone,
+  projectUpdate,
   className = "",
 }: GrantAssociationProps) => {
   const containerClass = `flex flex-row w-max flex-wrap gap-2 ${className}`;
@@ -58,6 +62,37 @@ export const GrantAssociation = ({
 
   // Fetch grants using dedicated hook
   const { grants } = useProjectGrants(project?.uid || "");
+
+  // Handle V2 project update — uses associations.funding[]
+  if (projectUpdate) {
+    const fundingLinks = projectUpdate.associations?.funding || [];
+    if (fundingLinks.length === 0) return null;
+
+    const projectSlug = project?.details?.slug || project?.uid || "";
+    const matched = fundingLinks
+      .map((funding) => {
+        const grant = grants.find((g) => g.uid?.toLowerCase() === funding.uid?.toLowerCase());
+        return { funding, grant };
+      })
+      .filter((entry) => entry.funding.uid);
+
+    if (matched.length === 0) return null;
+
+    return (
+      <div className={containerClass}>
+        {matched.map(({ funding, grant }) => (
+          <GrantItem
+            key={`activity-grant-${projectUpdate.uid}-${funding.uid}`}
+            href={PAGES.PROJECT.MILESTONES_AND_UPDATES(projectSlug, funding.uid || "")}
+            title={grant?.details?.title || funding.name || "Untitled Grant"}
+            communityImage={grant?.community?.details?.imageURL}
+            communityName={grant?.community?.details?.name}
+            keyPrefix={`activity-grant-${projectUpdate.uid}-${funding.uid}`}
+          />
+        ))}
+      </div>
+    );
+  }
 
   // Handle milestone data
   if (milestone) {

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -222,10 +222,6 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
     (projectMilestone?.completed?.data as any)?.deliverables ||
     (grantMilestone?.milestone.completed?.data as any)?.deliverables;
 
-  // See computeMilestoneCardCompletionGate for the full rule. Briefly: a
-  // completed milestone-shaped entry always renders the "Milestone Update"
-  // section, even with no narrative, so the timeline keeps surfacing the
-  // completion event and renderMilestoneCompletion can show "—".
   const { showSection: showCompletionSection, showTimelineHeader: showCompletionTimelineHeader } =
     computeMilestoneCardCompletionGate({
       type,

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -38,6 +38,7 @@ import { SHARE_TEXTS } from "@/utilities/share/text";
 import { cn } from "@/utilities/tailwind";
 import { ActivityActionsWrapper } from "./ActivityActionsWrapper";
 import { ActivityAttribution } from "./ActivityAttribution";
+import { GrantAssociation } from "./GrantAssociation";
 import { MilestoneCardLayout } from "./MilestoneCardLayout";
 import { computeMilestoneCardCompletionGate } from "./milestone-card-gating";
 import { PostedInfoTooltip } from "./PostedInfoTooltip";
@@ -529,6 +530,8 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
           {grantTitle}
         </Link>
       </div>
+    ) : type === "activity" && milestone.projectUpdate ? (
+      <GrantAssociation projectUpdate={milestone.projectUpdate} />
     ) : undefined;
 
   const showStatusBadge = type === "milestone" || type === "grant";

--- a/components/Shared/ActivityCard/ProjectUpdateCard.tsx
+++ b/components/Shared/ActivityCard/ProjectUpdateCard.tsx
@@ -8,6 +8,7 @@ import { EditUpdateDialog } from "../../Pages/Project/Updates/EditUpdateDialog";
 import { ActivityAttribution } from "./ActivityAttribution";
 import { ActivityMenu } from "./ActivityMenu";
 import { ActivityStatusHeader } from "./ActivityStatusHeader";
+import { GrantAssociation } from "./GrantAssociation";
 import { PostedInfoTooltip } from "./PostedInfoTooltip";
 
 interface ProjectUpdateCardProps {
@@ -69,6 +70,7 @@ export const ProjectUpdateCard: FC<ProjectUpdateCardProps> = ({ update, index, i
             <PostedInfoTooltip date={update.createdAt} attester={update.recipient} />
           </div>
           {title && <p className="text-xl font-semibold text-foreground">{title}</p>}
+          <GrantAssociation projectUpdate={update} />
         </div>
 
         {description && (


### PR DESCRIPTION
## Summary

Two display-only changes that surface the existing on-chain
`ProjectUpdate.grants[]` link in the UI:

1. **Project page** — activity cards now render grant chips for every
   grant the activity is tagged with, matching the milestone card
   pattern. Chips link to the grant's funding page.
2. **Funding page** (`/project/[slug]/funding/[grantUid]/milestones-and-updates`)
   — activities whose `associations.funding[]` references this grant
   are now shown alongside milestones, using the same `ActivityCard`
   component so the visual design stays consistent across surfaces.

Also fixes two latent edit-flow bugs surfaced while validating the
above:

- Cache invalidation is now predicate-based so it matches both the
  `uid` and `slug` cache keys (project page uses uid, funding page
  uses slug — single-key invalidation was missing one of them).
- Edits no longer redirect the user to the project updates page;
  they stay on whichever page they opened the dialog from and see
  the in-place refresh.

## Problem

`ProjectUpdate.grants[]` has been on-chain for a while but was not
visible anywhere in the UI. Users tagging an activity to a grant got
no feedback and the tagged activity never appeared next to the grant
on the funding page.

## Solution

- Added a V2 branch to `GrantAssociation` that handles
  `associations.funding[]` and renders one chip per linked grant.
- `MilestoneCard` (activity variant) and `ProjectUpdateCard` now
  render `GrantAssociation` in the header.
- `MilestonesList` (funding page) fetches project updates by the
  URL `projectId` segment (so it shares the project page's React
  Query cache), filters to activities linked to the current grant,
  and renders them via `ActivityCard` with a `UnifiedMilestone`
  wrapper so the design matches the project page exactly.
- `ProjectUpdateFormBlock` invalidates the project-updates cache
  for both `uid` and `slug` keys.
- `ProjectUpdateForm` skips the post-save redirect when editing.

## Testing

Verified manually via browser:

- [x] Project page: activity with 2 grants shows both chips
- [x] Project page: untagged activities show no chips
- [x] Funding page (grant A): tagged activity appears with chips
- [x] Funding page (grant B): same multi-grant activity also appears
- [x] Chip click navigates to the correct funding page
- [x] Edit flow from funding page refreshes in place, no redirect
- [x] No console errors across project page + both funding pages

All 8 scenarios in the QA plan pass.

## Risk

Low. All changes are additive/display-only. The cache invalidation
change is strictly more permissive (predicate matches what the
previous single-key call matched, plus the slug key). The redirect
change only affects edit mode; new-activity flow is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project updates linked to grants now appear in the milestones timeline.
  * Grant associations are displayed for activities and project updates.

* **Bug Fixes**
  * Fixed redirect behavior when editing activities to keep users on the current page.
  * Improved cache management to ensure project updates display correctly after editing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1435)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->