### PR TITLE
fix(gasless): use EOA's current on-chain nonce for EIP-7702 authorization

### DIFF
--- a/__tests__/unit/utilities/gasless/privy-signer.test.ts
+++ b/__tests__/unit/utilities/gasless/privy-signer.test.ts
@@ -273,7 +273,23 @@ describe("Privy Signer", () => {
       expect(result.chainId).toBe(42220);
     });
 
-    it("should use default nonce of 0", async () => {
+    it("should throw if nonce is not provided", async () => {
+      // A missing nonce used to silently default to 0, which is only
+      // valid on the EOA's very first EIP-7702 delegation and was
+      // rejected by the bundler on every subsequent call. The signer
+      // now requires the caller to supply the authority's current
+      // on-chain nonce explicitly.
+      const signer = await createPrivySignerForGasless(mockEmbeddedWallet, 10);
+
+      await expect(
+        signer.signAuthorization!({
+          contractAddress: "0xabcdef1234567890abcdef1234567890abcdef12" as `0x${string}`,
+          chainId: 10,
+        })
+      ).rejects.toThrow("EIP-7702 signAuthorization requires an explicit nonce");
+    });
+
+    it("should preserve a non-zero nonce", async () => {
       const mockSignature =
         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b";
       mockProvider.request.mockResolvedValue(mockSignature);
@@ -282,10 +298,10 @@ describe("Privy Signer", () => {
       const result = await signer.signAuthorization!({
         contractAddress: "0xabcdef1234567890abcdef1234567890abcdef12" as `0x${string}`,
         chainId: 10,
-        // nonce not specified, should default to 0
+        nonce: 7,
       });
 
-      expect(result.nonce).toBe(0);
+      expect(result.nonce).toBe(7);
     });
 
     it("should correctly parse signature components for v=27", async () => {

--- a/__tests__/unit/utilities/gasless/privy-signer.test.ts
+++ b/__tests__/unit/utilities/gasless/privy-signer.test.ts
@@ -337,5 +337,49 @@ describe("Privy Signer", () => {
       expect(result.yParity).toBe(1);
       expect(result.v).toBe(28n);
     });
+
+    it("should sign a different hash when the nonce changes", async () => {
+      // The whole bug was about the nonce not making it into the
+      // signed payload. Guard against a regression where the nonce is
+      // returned in metadata but not actually mixed into the hash.
+      const mockSignature =
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b";
+      mockProvider.request.mockResolvedValue(mockSignature);
+
+      const signer = await createPrivySignerForGasless(mockEmbeddedWallet, 10);
+      const params = {
+        contractAddress: "0xabcdef1234567890abcdef1234567890abcdef12" as `0x${string}`,
+        chainId: 10,
+      };
+      await signer.signAuthorization!({ ...params, nonce: 0 });
+      await signer.signAuthorization!({ ...params, nonce: 1 });
+      await signer.signAuthorization!({ ...params, nonce: 256 });
+
+      const hashes = mockProvider.request.mock.calls
+        .filter((call: unknown[]) => (call[0] as { method: string }).method === "secp256k1_sign")
+        .map((call: unknown[]) => (call[0] as { params: string[] }).params[0]);
+
+      expect(hashes).toHaveLength(3);
+      expect(new Set(hashes).size).toBe(3);
+    });
+
+    it("should accept nonces beyond a single byte (RLP encoding edge case)", async () => {
+      // numberToHex must produce a valid RLP-encodable hex regardless
+      // of magnitude. Wallets that have been around long enough to
+      // surface this bug are also long-lived enough to have multi-byte
+      // nonces.
+      const mockSignature =
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b";
+      mockProvider.request.mockResolvedValue(mockSignature);
+
+      const signer = await createPrivySignerForGasless(mockEmbeddedWallet, 10);
+      const result = await signer.signAuthorization!({
+        contractAddress: "0xabcdef1234567890abcdef1234567890abcdef12" as `0x${string}`,
+        chainId: 10,
+        nonce: 65537,
+      });
+
+      expect(result.nonce).toBe(65537);
+    });
   });
 });

--- a/__tests__/unit/utilities/gasless/providers.test.ts
+++ b/__tests__/unit/utilities/gasless/providers.test.ts
@@ -279,6 +279,7 @@ describe("ZeroDevProvider", () => {
 
       expect(mockGetTransactionCount).toHaveBeenCalledWith({
         address: mockSigner.address,
+        blockTag: "pending",
       });
       expect(mockSigner.signAuthorization).toHaveBeenCalledWith(
         expect.objectContaining({ nonce: 5 })

--- a/__tests__/unit/utilities/gasless/providers.test.ts
+++ b/__tests__/unit/utilities/gasless/providers.test.ts
@@ -78,11 +78,9 @@ vi.mock("@account-kit/smart-contracts", () => ({
   }),
 }));
 
-// Mock viem
-// createPublicClient must expose getTransactionCount: the ZeroDev EIP-7702
-// path fetches the EOA's current nonce from the public client and passes
-// it into the signed authorization tuple. vi.hoisted lets the factory
-// reference the spy without TDZ issues from vi.mock hoisting.
+// Mock viem. The ZeroDev EIP-7702 path reads `getTransactionCount` to
+// build the authorization, so the mock client exposes it via a hoisted
+// spy the tests can re-stub per case.
 const { mockGetTransactionCount } = vi.hoisted(() => ({
   mockGetTransactionCount: vi.fn().mockResolvedValue(0),
 }));
@@ -284,6 +282,90 @@ describe("ZeroDevProvider", () => {
       expect(mockSigner.signAuthorization).toHaveBeenCalledWith(
         expect.objectContaining({ nonce: 5 })
       );
+    });
+
+    it("should re-read the EOA nonce on every createClient call (no caching)", async () => {
+      // A future change that memoizes the nonce across calls would
+      // silently reintroduce the original bug for users who land more
+      // than one UserOp per session. Asserting freshness here is the
+      // cheapest guardrail.
+      mockGetTransactionCount.mockResolvedValueOnce(2).mockResolvedValueOnce(3);
+
+      const config = {
+        provider: "zerodev" as const,
+        chain: optimism,
+        rpcUrl: "https://rpc.optimism.test",
+        enabled: true,
+        zerodev: {
+          projectId: "test-project-id",
+          useEIP7702: true,
+        },
+      };
+
+      await provider.createClient({ chainId: optimism.id, signer: mockSigner, config });
+      await provider.createClient({ chainId: optimism.id, signer: mockSigner, config });
+
+      expect(mockGetTransactionCount).toHaveBeenCalledTimes(2);
+      const signAuthCalls = (mockSigner.signAuthorization as vi.Mock).mock.calls;
+      expect(signAuthCalls[0][0].nonce).toBe(2);
+      expect(signAuthCalls[1][0].nonce).toBe(3);
+    });
+
+    it("should fetch the nonce before signing the authorization", async () => {
+      // Ordering matters: signing must happen against a freshly-fetched
+      // nonce. If a refactor ever reversed these, the test would catch
+      // the regression even if both calls still appeared to "work."
+      const order: string[] = [];
+      mockGetTransactionCount.mockImplementationOnce(async () => {
+        order.push("fetch");
+        return 4;
+      });
+      (mockSigner.signAuthorization as vi.Mock).mockImplementationOnce(async () => {
+        order.push("sign");
+        return {
+          contractAddress: "0xKernelImplementation",
+          address: "0xKernelImplementation",
+          chainId: optimism.id,
+          nonce: 4,
+          r: "0x1234",
+          s: "0x5678",
+          v: 28n,
+          yParity: 1,
+        };
+      });
+
+      const config = {
+        provider: "zerodev" as const,
+        chain: optimism,
+        rpcUrl: "https://rpc.optimism.test",
+        enabled: true,
+        zerodev: { projectId: "test-project-id", useEIP7702: true },
+      };
+
+      await provider.createClient({ chainId: optimism.id, signer: mockSigner, config });
+
+      expect(order).toEqual(["fetch", "sign"]);
+    });
+
+    it("should fail closed (no fallback nonce) when getTransactionCount errors", async () => {
+      // Safety: if the public RPC errors, the provider must NOT
+      // silently fall back to a hardcoded nonce. The original bug
+      // would resurface under transient network failure if a future
+      // refactor added a try/catch around the fetch.
+      mockGetTransactionCount.mockRejectedValueOnce(new Error("RPC down"));
+
+      const config = {
+        provider: "zerodev" as const,
+        chain: optimism,
+        rpcUrl: "https://rpc.optimism.test",
+        enabled: true,
+        zerodev: { projectId: "test-project-id", useEIP7702: true },
+      };
+
+      await expect(
+        provider.createClient({ chainId: optimism.id, signer: mockSigner, config })
+      ).rejects.toThrow();
+      expect(mockSigner.signAuthorization).not.toHaveBeenCalled();
     });
 
     it("should create regular client when EIP-7702 is disabled", async () => {

--- a/__tests__/unit/utilities/gasless/providers.test.ts
+++ b/__tests__/unit/utilities/gasless/providers.test.ts
@@ -79,8 +79,17 @@ vi.mock("@account-kit/smart-contracts", () => ({
 }));
 
 // Mock viem
+// createPublicClient must expose getTransactionCount: the ZeroDev EIP-7702
+// path fetches the EOA's current nonce from the public client and passes
+// it into the signed authorization tuple. vi.hoisted lets the factory
+// reference the spy without TDZ issues from vi.mock hoisting.
+const { mockGetTransactionCount } = vi.hoisted(() => ({
+  mockGetTransactionCount: vi.fn().mockResolvedValue(0),
+}));
 vi.mock("viem", () => ({
-  createPublicClient: vi.fn().mockReturnValue({}),
+  createPublicClient: vi.fn().mockReturnValue({
+    getTransactionCount: mockGetTransactionCount,
+  }),
   http: vi.fn().mockReturnValue({}),
 }));
 
@@ -242,6 +251,38 @@ describe("ZeroDevProvider", () => {
 
       expect(result).not.toBeNull();
       expect(mockSigner.signAuthorization).toHaveBeenCalled();
+    });
+
+    it("should pass the EOA's current on-chain nonce into the EIP-7702 authorization", async () => {
+      // Regression: a hardcoded nonce: 0 silently broke every gasless
+      // attestation after the first per-chain because the bundler
+      // rejected the stale authorization. The provider must read the
+      // EOA's transaction count from the public client and forward it.
+      mockGetTransactionCount.mockResolvedValueOnce(5);
+
+      const config = {
+        provider: "zerodev" as const,
+        chain: optimism,
+        rpcUrl: "https://rpc.optimism.test",
+        enabled: true,
+        zerodev: {
+          projectId: "test-project-id",
+          useEIP7702: true,
+        },
+      };
+
+      await provider.createClient({
+        chainId: optimism.id,
+        signer: mockSigner,
+        config,
+      });
+
+      expect(mockGetTransactionCount).toHaveBeenCalledWith({
+        address: mockSigner.address,
+      });
+      expect(mockSigner.signAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({ nonce: 5 })
+      );
     });
 
     it("should create regular client when EIP-7702 is disabled", async () => {

--- a/utilities/gasless/providers/zerodev.provider.ts
+++ b/utilities/gasless/providers/zerodev.provider.ts
@@ -107,11 +107,9 @@ export class ZeroDevProvider implements IGaslessProvider {
 
     const implementationAddress = this.getKernelImplementationAddress();
 
-    // EIP-7702 binds the authorization to the authority EOA's current
-    // transaction count — the bundler rejects any tuple whose `nonce`
-    // doesn't match on-chain state, so it must be fetched, not hardcoded.
-    // `pending` matches viem's own `prepareAuthorization` and handles
-    // the edge case where the EOA already has a tx in the mempool.
+    // EIP-7702 binds the authorization to the EOA's current nonce; a
+    // hardcoded value gets rejected by the bundler. `pending` matches
+    // viem's `prepareAuthorization`.
     const eoaNonce = await publicClient.getTransactionCount({
       address: signer.address,
       blockTag: "pending",

--- a/utilities/gasless/providers/zerodev.provider.ts
+++ b/utilities/gasless/providers/zerodev.provider.ts
@@ -107,11 +107,19 @@ export class ZeroDevProvider implements IGaslessProvider {
 
     const implementationAddress = this.getKernelImplementationAddress();
 
-    // Sign the EIP-7702 authorization
+    // EIP-7702 binds the authorization to the authority EOA's current
+    // transaction count — the bundler rejects any tuple whose `nonce`
+    // doesn't match on-chain state, so it must be fetched, not hardcoded.
+    // (A hardcoded `0` happens to work for the very first delegation per
+    // chain and silently fails for every one after.)
+    const eoaNonce = await publicClient.getTransactionCount({
+      address: signer.address,
+    });
+
     const authorization = await signer.signAuthorization({
       contractAddress: implementationAddress,
       chainId,
-      nonce: 0,
+      nonce: eoaNonce,
     });
 
     // Create kernel account with EIP-7702

--- a/utilities/gasless/providers/zerodev.provider.ts
+++ b/utilities/gasless/providers/zerodev.provider.ts
@@ -110,10 +110,11 @@ export class ZeroDevProvider implements IGaslessProvider {
     // EIP-7702 binds the authorization to the authority EOA's current
     // transaction count — the bundler rejects any tuple whose `nonce`
     // doesn't match on-chain state, so it must be fetched, not hardcoded.
-    // (A hardcoded `0` happens to work for the very first delegation per
-    // chain and silently fails for every one after.)
+    // `pending` matches viem's own `prepareAuthorization` and handles
+    // the edge case where the EOA already has a tx in the mempool.
     const eoaNonce = await publicClient.getTransactionCount({
       address: signer.address,
+      blockTag: "pending",
     });
 
     const authorization = await signer.signAuthorization({

--- a/utilities/gasless/utils/privy-signer.ts
+++ b/utilities/gasless/utils/privy-signer.ts
@@ -161,7 +161,15 @@ export async function createPrivySignerForGasless(
       }
 
       const authChainId = authorization.chainId ?? chainId;
-      const authNonce = authorization.nonce ?? 0;
+      // Refuse a missing nonce instead of silently defaulting. Every
+      // EIP-7702 authorization must be bound to the authority EOA's
+      // current transaction count; a wrong nonce isn't caught at sign
+      // time — it's rejected at the bundler — so a default would just
+      // hide the mistake until then.
+      if (authorization.nonce === undefined) {
+        throw new Error("EIP-7702 signAuthorization requires an explicit nonce");
+      }
+      const authNonce = authorization.nonce;
 
       // Hash the authorization data according to EIP-7702 spec
       const hash = hashAuthorization({


### PR DESCRIPTION
Linear: [DEV-300](https://linear.app/showkarma/issue/DEV-300/fix-eip-7702-nonce-mismatch-breaking-gasless-attestations)

## Summary

Every gasless attestation after the first one per chain was failing for embedded-wallet (email/Google/Farcaster) users with:

> `Invalid EIP-7702 authorization: The nonce does not match the userOperation sender address`

`utilities/gasless/providers/zerodev.provider.ts` was hardcoding `nonce: 0` when signing the EIP-7702 authorization tuple. Bundlers validate that the tuple's `nonce` equals the authority EOA's current on-chain transaction count, so this only worked on the very first delegation per chain (when the count happens to be 0) and silently broke for every call after.

The bug landed in `eb9342202` (2025-12-22) and was preserved through the strategy-pattern refactor in `d974055ef` (2026-01-07). Every chain configured with `useEIP7702: true` is affected — Optimism, Arbitrum, Base, Mainnet, Polygon, Scroll, Sei, plus all testnets. The Alchemy/Celo path is unaffected because the Alchemy SDK fetches the nonce internally.

## Changes

- `zerodev.provider.ts`: read the EOA's current transaction count from the public client and pass it as the authorization `nonce`.
- `privy-signer.ts`: throw on a missing `nonce` instead of silently defaulting to 0, so the same class of bug can't surface through another caller (Alchemy SDK, future provider, etc).
- Tests updated: replaced the "should default to 0" assertion with a "should throw" assertion, added a non-zero passthrough test, and added a regression test on `ZeroDevProvider.createClient` that asserts the fetched nonce flows into `signAuthorization`.

## Test plan

- [x] `pnpm test __tests__/unit/utilities/gasless/` — 7 files, 148 tests pass
- [x] `pnpm test __tests__/unit/utilities/gasless/privy-signer.test.ts` — 21/21 pass
- [x] `pnpm test __tests__/unit/utilities/gasless/providers.test.ts` — 21/21 pass (including the new regression test)
- [ ] Manual: complete a milestone twice in a row on Optimism with an embedded wallet — first call should still succeed, second call should now succeed (previously failed with the bundler error)
- [ ] Manual: same flow on Base, to confirm the per-chain nonce is fetched per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EIP-7702 authorization nonce is now fetched from on-chain pending state and used for signing, preventing nonce mismatches and bundler rejections.
  * Signing requires an explicit nonce and will error if omitted.

* **Tests**
  * Expanded tests to assert explicit-nonce behavior, preserve provided nonces (including large/multibyte values), ensure payloads change when nonce changes, verify nonce is fetched before signing and re-fetched per call, and confirm failures propagate when nonce fetch fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
