### PR TITLE
chore: bump minimum package release age to 60 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-minimum-release-age=10080
+minimum-release-age=86400
 save-exact=true


### PR DESCRIPTION
## Overview

Raises the minimum package release age gate from 7 days to 60 days.

## Change

`.npmrc`: `minimum-release-age` 10080 -> 86400 (minutes, 60 days).

pnpm refuses to install any dependency version published less than this window ago, reducing exposure to freshly-published malicious or compromised package releases (supply-chain protection).

## Testing

- `pnpm install` resolves against versions older than 60 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package management configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1437)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->