### PR TITLE
fix: gate milestone edit/revoke on on-chain attester/recipient

### DIFF
--- a/__tests__/components/Milestone/GrantMilestoneOptionsMenu.test.tsx
+++ b/__tests__/components/Milestone/GrantMilestoneOptionsMenu.test.tsx
@@ -77,13 +77,14 @@ describe("GrantMilestoneOptionsMenu", () => {
     vi.clearAllMocks();
   });
 
-  it("shows Edit option for pending milestones", async () => {
+  it("shows Edit option for pending milestones when canEdit is true", async () => {
     const user = userEvent.setup();
     render(
       <GrantMilestoneOptionsMenu
         milestone={mockPendingMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={false}
+        canEdit={true}
       />
     );
 
@@ -95,6 +96,24 @@ describe("GrantMilestoneOptionsMenu", () => {
     expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
+  it("hides Edit option when canEdit is false (non-owner)", async () => {
+    const user = userEvent.setup();
+    render(
+      <GrantMilestoneOptionsMenu
+        milestone={mockPendingMilestone}
+        completeFn={mockCompleteFn}
+        alreadyCompleted={false}
+        canEdit={false}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open milestone actions" }));
+
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.getByText("Mark as Complete")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
   it("hides Edit option for completed milestones", async () => {
     const user = userEvent.setup();
     render(
@@ -102,6 +121,7 @@ describe("GrantMilestoneOptionsMenu", () => {
         milestone={mockCompletedMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={true}
+        canEdit={true}
       />
     );
 
@@ -118,6 +138,7 @@ describe("GrantMilestoneOptionsMenu", () => {
         milestone={mockPendingMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={false}
+        canEdit={true}
       />
     );
 
@@ -135,6 +156,7 @@ describe("GrantMilestoneOptionsMenu", () => {
         milestone={mockCompletedMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={true}
+        canEdit={true}
       />
     );
 
@@ -150,6 +172,7 @@ describe("GrantMilestoneOptionsMenu", () => {
         milestone={mockPendingMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={false}
+        canEdit={true}
       />
     );
 
@@ -163,6 +186,7 @@ describe("GrantMilestoneOptionsMenu", () => {
         milestone={mockPendingMilestone}
         completeFn={mockCompleteFn}
         alreadyCompleted={false}
+        canEdit={true}
       />
     );
 

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -174,27 +174,27 @@ describe("MilestoneCard", () => {
 
   describe("Rendering - Basic Elements", () => {
     it("should render milestone card with title", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
     });
 
     it("should render milestone description", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       const description = screen.getByTestId("read-more");
       expect(description).toHaveTextContent("This is a test milestone description");
     });
 
     it("should render milestone badge", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Milestone")).toBeInTheDocument();
       expect(screen.getByAltText("Milestone")).toBeInTheDocument();
     });
 
     it("should render creation date and attester", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText(/Created on/i)).toBeInTheDocument();
       expect(screen.getByText(/by$/i)).toBeInTheDocument();
@@ -205,19 +205,19 @@ describe("MilestoneCard", () => {
 
   describe("Status Rendering", () => {
     it('should display "Pending" status for incomplete milestone', () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Pending")).toBeInTheDocument();
     });
 
     it('should display "Completed" status for complete milestone', () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Completed")).toBeInTheDocument();
     });
 
     it("should apply correct styling for pending status", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       const statusBadge = screen.getByText("Pending");
       expect(statusBadge.className).toContain("bg-[#FFFAEB]");
@@ -225,7 +225,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should apply correct styling for completed status", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
       const statusBadge = screen.getByText("Completed");
       expect(statusBadge.className).toContain("bg-brand-blue");
@@ -234,7 +234,7 @@ describe("MilestoneCard", () => {
 
     it("should have correct border color for completed milestone", () => {
       const { container } = render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
       );
 
       const card = container.firstChild as HTMLElement;
@@ -243,7 +243,7 @@ describe("MilestoneCard", () => {
 
     it("should have correct border color for pending milestone", () => {
       const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
       );
 
       const card = container.firstChild as HTMLElement;
@@ -254,19 +254,19 @@ describe("MilestoneCard", () => {
 
   describe("Grant Milestone Specifics", () => {
     it("should display due date for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText(/Due by/i)).toBeInTheDocument();
     });
 
     it("should not display due date for project milestones", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.queryByText(/Due by/i)).not.toBeInTheDocument();
     });
 
     it("should display grant program link for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Test Grant Program")).toBeInTheDocument();
       const link = screen.getByText("Test Grant Program").closest("a");
@@ -274,7 +274,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should display community image for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
 
       const communityImage = screen.getByAltText("Test Community");
       expect(communityImage).toBeInTheDocument();
@@ -304,7 +304,7 @@ describe("MilestoneCard", () => {
         ],
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithMergedGrants} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithMergedGrants} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Grant Alpha")).toBeInTheDocument();
       expect(screen.getByText("Grant Beta")).toBeInTheDocument();
@@ -332,7 +332,7 @@ describe("MilestoneCard", () => {
       } as unknown as UnifiedMilestone;
 
       const { container } = render(
-        <MilestoneCard milestone={milestoneWithUnsortedGrants} isAuthorized={false} />
+        <MilestoneCard milestone={milestoneWithUnsortedGrants} isAuthorized={false} canEdit={false} />
       );
 
       const grants = screen.getAllByText(/Grant$/);
@@ -343,13 +343,13 @@ describe("MilestoneCard", () => {
 
   describe("Completion Information", () => {
     it("should display completion reason when milestone is completed", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Milestone completed successfully")).toBeInTheDocument();
     });
 
     it("should display proof of work link when available", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Proof of Work")).toBeInTheDocument();
       const proofLink = screen.getByText("https://github.com/proof");
@@ -358,7 +358,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should not display completion info for incomplete milestones", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       expect(screen.queryByText(/Proof of Work/i)).not.toBeInTheDocument();
     });
@@ -395,7 +395,7 @@ describe("MilestoneCard", () => {
       } as unknown as UnifiedMilestone;
 
       // Component should render without crashing even with deliverables in data
-      render(<MilestoneCard milestone={milestoneWithDeliverables} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithDeliverables} isAuthorized={false} canEdit={false} />);
 
       // Verify the milestone renders successfully
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
@@ -447,7 +447,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("Moviemeter.io/home");
         expect(proofLink).toHaveAttribute("href", "https://Moviemeter.io/home");
@@ -494,7 +494,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("https://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/proof");
@@ -541,7 +541,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -567,14 +567,14 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithoutProtocol} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithoutProtocol} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("github.com/user/repo");
         expect(proofLink).toHaveAttribute("href", "https://github.com/user/repo");
       });
 
       it("should not modify proof of work URLs that already have https://", () => {
-        render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+        render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("https://github.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://github.com/proof");
@@ -598,7 +598,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithHttp} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithHttp} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -656,7 +656,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -712,7 +712,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("https://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -768,7 +768,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} />);
+        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
 
         const proofLink = screen.getByText("http://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/metric-proof");
@@ -778,21 +778,21 @@ describe("MilestoneCard", () => {
 
   describe("Authorization and Options Menu", () => {
     it("should not display options menu when not authorized", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       // The dynamic component mock would be rendered if options menu is shown
       expect(screen.queryByTestId("mocked-dynamic-component")).not.toBeInTheDocument();
     });
 
     it("should render for project milestone with authorization", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={true} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={true} canEdit={true} />);
 
       // Component should render without errors
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
     });
 
     it("should render for grant milestone with authorization", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={true} />);
+      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={true} canEdit={true} />);
 
       // Component should render without errors
       expect(screen.getByText("Test Grant Milestone")).toBeInTheDocument();
@@ -806,7 +806,7 @@ describe("MilestoneCard", () => {
         description: "",
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutDescription} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithoutDescription} isAuthorized={false} canEdit={false} />);
 
       expect(screen.queryByTestId("read-more")).not.toBeInTheDocument();
     });
@@ -824,7 +824,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutAttester} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithoutAttester} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByTestId("ens-avatar")).toBeInTheDocument();
     });
@@ -850,7 +850,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutImage} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithoutImage} isAuthorized={false} canEdit={false} />);
 
       expect(screen.getByText("Test Grant Program")).toBeInTheDocument();
     });
@@ -873,7 +873,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutGrantTitle} isAuthorized={false} />);
+      render(<MilestoneCard milestone={milestoneWithoutGrantTitle} isAuthorized={false} canEdit={false} />);
 
       // Should not render empty grant link
       expect(screen.queryByText("Test Grant Program")).not.toBeInTheDocument();
@@ -883,7 +883,7 @@ describe("MilestoneCard", () => {
   describe("Accessibility", () => {
     it("should have proper semantic structure", () => {
       const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
       );
 
       const card = container.firstChild as HTMLElement;
@@ -892,7 +892,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should have external links with proper security attributes", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
 
       const proofLink = screen.getByText("https://github.com/proof");
       expect(proofLink).toHaveAttribute("target", "_blank");
@@ -900,7 +900,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should have alt text for milestone icon", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       const icon = screen.getByAltText("Milestone");
       expect(icon).toBeInTheDocument();
@@ -910,7 +910,7 @@ describe("MilestoneCard", () => {
   describe("Dark Mode Support", () => {
     it("should have dark mode classes for card", () => {
       const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
       );
 
       const card = container.firstChild as HTMLElement;
@@ -918,7 +918,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should have dark mode classes for text elements", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} />);
+      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
 
       const title = screen.getByText("Test Project Milestone");
       expect(title.className).toContain("dark:text-zinc-100");

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -12,6 +12,9 @@ function render(ui: ReactElement) {
   return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
+const renderCard = (m: UnifiedMilestone, isAuthorized = false, canEdit = false) =>
+  render(<MilestoneCard milestone={m} isAuthorized={isAuthorized} canEdit={canEdit} />);
+
 // Mock Next.js dynamic imports
 vi.mock("next/dynamic", () => ({
   __esModule: true,
@@ -174,35 +177,27 @@ describe("MilestoneCard", () => {
 
   describe("Rendering - Basic Elements", () => {
     it("should render milestone card with title", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
     });
 
     it("should render milestone description", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       const description = screen.getByTestId("read-more");
       expect(description).toHaveTextContent("This is a test milestone description");
     });
 
     it("should render milestone badge", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.getByText("Milestone")).toBeInTheDocument();
       expect(screen.getByAltText("Milestone")).toBeInTheDocument();
     });
 
     it("should render creation date and attester", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.getByText(/Created on/i)).toBeInTheDocument();
       expect(screen.getByText(/by$/i)).toBeInTheDocument();
@@ -213,25 +208,19 @@ describe("MilestoneCard", () => {
 
   describe("Status Rendering", () => {
     it('should display "Pending" status for incomplete milestone', () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.getByText("Pending")).toBeInTheDocument();
     });
 
     it('should display "Completed" status for complete milestone', () => {
-      render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockCompletedMilestone);
 
       expect(screen.getByText("Completed")).toBeInTheDocument();
     });
 
     it("should apply correct styling for pending status", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       const statusBadge = screen.getByText("Pending");
       expect(statusBadge.className).toContain("bg-[#FFFAEB]");
@@ -239,9 +228,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should apply correct styling for completed status", () => {
-      render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockCompletedMilestone);
 
       const statusBadge = screen.getByText("Completed");
       expect(statusBadge.className).toContain("bg-brand-blue");
@@ -249,18 +236,14 @@ describe("MilestoneCard", () => {
     });
 
     it("should have correct border color for completed milestone", () => {
-      const { container } = render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      const { container } = renderCard(mockCompletedMilestone);
 
       const card = container.firstChild as HTMLElement;
       expect(card.className).toContain("border-brand-blue");
     });
 
     it("should have correct border color for pending milestone", () => {
-      const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      const { container } = renderCard(mockProjectMilestone);
 
       const card = container.firstChild as HTMLElement;
       expect(card.className).toContain("border-gray-300");
@@ -270,21 +253,19 @@ describe("MilestoneCard", () => {
 
   describe("Grant Milestone Specifics", () => {
     it("should display due date for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
+      renderCard(mockGrantMilestone);
 
       expect(screen.getByText(/Due by/i)).toBeInTheDocument();
     });
 
     it("should not display due date for project milestones", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.queryByText(/Due by/i)).not.toBeInTheDocument();
     });
 
     it("should display grant program link for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
+      renderCard(mockGrantMilestone);
 
       expect(screen.getByText("Test Grant Program")).toBeInTheDocument();
       const link = screen.getByText("Test Grant Program").closest("a");
@@ -292,7 +273,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should display community image for grant milestones", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={false} canEdit={false} />);
+      renderCard(mockGrantMilestone);
 
       const communityImage = screen.getByAltText("Test Community");
       expect(communityImage).toBeInTheDocument();
@@ -322,9 +303,7 @@ describe("MilestoneCard", () => {
         ],
       } as unknown as UnifiedMilestone;
 
-      render(
-        <MilestoneCard milestone={milestoneWithMergedGrants} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(milestoneWithMergedGrants);
 
       expect(screen.getByText("Grant Alpha")).toBeInTheDocument();
       expect(screen.getByText("Grant Beta")).toBeInTheDocument();
@@ -351,13 +330,7 @@ describe("MilestoneCard", () => {
         ],
       } as unknown as UnifiedMilestone;
 
-      const { container } = render(
-        <MilestoneCard
-          milestone={milestoneWithUnsortedGrants}
-          isAuthorized={false}
-          canEdit={false}
-        />
-      );
+      const { container } = renderCard(milestoneWithUnsortedGrants);
 
       const grants = screen.getAllByText(/Grant$/);
       expect(grants[0]).toHaveTextContent("Alpha Grant");
@@ -367,17 +340,13 @@ describe("MilestoneCard", () => {
 
   describe("Completion Information", () => {
     it("should display completion reason when milestone is completed", () => {
-      render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockCompletedMilestone);
 
       expect(screen.getByText("Milestone completed successfully")).toBeInTheDocument();
     });
 
     it("should display proof of work link when available", () => {
-      render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockCompletedMilestone);
 
       expect(screen.getByText("Proof of Work")).toBeInTheDocument();
       const proofLink = screen.getByText("https://github.com/proof");
@@ -386,9 +355,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should not display completion info for incomplete milestones", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       expect(screen.queryByText(/Proof of Work/i)).not.toBeInTheDocument();
     });
@@ -425,9 +392,7 @@ describe("MilestoneCard", () => {
       } as unknown as UnifiedMilestone;
 
       // Component should render without crashing even with deliverables in data
-      render(
-        <MilestoneCard milestone={milestoneWithDeliverables} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(milestoneWithDeliverables);
 
       // Verify the milestone renders successfully
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
@@ -479,13 +444,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard
-            milestone={milestoneWithDeliverable}
-            isAuthorized={false}
-            canEdit={false}
-          />
-        );
+        renderCard(milestoneWithDeliverable);
 
         const proofLink = screen.getByText("Moviemeter.io/home");
         expect(proofLink).toHaveAttribute("href", "https://Moviemeter.io/home");
@@ -532,13 +491,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard
-            milestone={milestoneWithDeliverable}
-            isAuthorized={false}
-            canEdit={false}
-          />
-        );
+        renderCard(milestoneWithDeliverable);
 
         const proofLink = screen.getByText("https://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/proof");
@@ -585,13 +538,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard
-            milestone={milestoneWithDeliverable}
-            isAuthorized={false}
-            canEdit={false}
-          />
-        );
+        renderCard(milestoneWithDeliverable);
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -617,22 +564,14 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard
-            milestone={milestoneWithoutProtocol}
-            isAuthorized={false}
-            canEdit={false}
-          />
-        );
+        renderCard(milestoneWithoutProtocol);
 
         const proofLink = screen.getByText("github.com/user/repo");
         expect(proofLink).toHaveAttribute("href", "https://github.com/user/repo");
       });
 
       it("should not modify proof of work URLs that already have https://", () => {
-        render(
-          <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-        );
+        renderCard(mockCompletedMilestone);
 
         const proofLink = screen.getByText("https://github.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://github.com/proof");
@@ -656,9 +595,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard milestone={milestoneWithHttp} isAuthorized={false} canEdit={false} />
-        );
+        renderCard(milestoneWithHttp);
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -716,9 +653,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
-        );
+        renderCard(milestoneWithMetrics);
 
         const proofLink = screen.getByText("example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -774,9 +709,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
-        );
+        renderCard(milestoneWithMetrics);
 
         const proofLink = screen.getByText("https://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -832,9 +765,7 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(
-          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
-        );
+        renderCard(milestoneWithMetrics);
 
         const proofLink = screen.getByText("http://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/metric-proof");
@@ -844,23 +775,21 @@ describe("MilestoneCard", () => {
 
   describe("Authorization and Options Menu", () => {
     it("should not display options menu when not authorized", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       // The dynamic component mock would be rendered if options menu is shown
       expect(screen.queryByTestId("mocked-dynamic-component")).not.toBeInTheDocument();
     });
 
     it("should render for project milestone with authorization", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={true} canEdit={true} />);
+      renderCard(mockProjectMilestone, true, true);
 
       // Component should render without errors
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
     });
 
     it("should render for grant milestone with authorization", () => {
-      render(<MilestoneCard milestone={mockGrantMilestone} isAuthorized={true} canEdit={true} />);
+      renderCard(mockGrantMilestone, true, true);
 
       // Component should render without errors
       expect(screen.getByText("Test Grant Milestone")).toBeInTheDocument();
@@ -874,13 +803,7 @@ describe("MilestoneCard", () => {
         description: "",
       } as unknown as UnifiedMilestone;
 
-      render(
-        <MilestoneCard
-          milestone={milestoneWithoutDescription}
-          isAuthorized={false}
-          canEdit={false}
-        />
-      );
+      renderCard(milestoneWithoutDescription);
 
       expect(screen.queryByTestId("read-more")).not.toBeInTheDocument();
     });
@@ -898,9 +821,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(
-        <MilestoneCard milestone={milestoneWithoutAttester} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(milestoneWithoutAttester);
 
       expect(screen.getByTestId("ens-avatar")).toBeInTheDocument();
     });
@@ -926,9 +847,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(
-        <MilestoneCard milestone={milestoneWithoutImage} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(milestoneWithoutImage);
 
       expect(screen.getByText("Test Grant Program")).toBeInTheDocument();
     });
@@ -951,13 +870,7 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(
-        <MilestoneCard
-          milestone={milestoneWithoutGrantTitle}
-          isAuthorized={false}
-          canEdit={false}
-        />
-      );
+      renderCard(milestoneWithoutGrantTitle);
 
       // Should not render empty grant link
       expect(screen.queryByText("Test Grant Program")).not.toBeInTheDocument();
@@ -966,9 +879,7 @@ describe("MilestoneCard", () => {
 
   describe("Accessibility", () => {
     it("should have proper semantic structure", () => {
-      const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      const { container } = renderCard(mockProjectMilestone);
 
       const card = container.firstChild as HTMLElement;
       expect(card).toBeInTheDocument();
@@ -976,9 +887,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should have external links with proper security attributes", () => {
-      render(
-        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockCompletedMilestone);
 
       const proofLink = screen.getByText("https://github.com/proof");
       expect(proofLink).toHaveAttribute("target", "_blank");
@@ -986,9 +895,7 @@ describe("MilestoneCard", () => {
     });
 
     it("should have alt text for milestone icon", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       const icon = screen.getByAltText("Milestone");
       expect(icon).toBeInTheDocument();
@@ -997,18 +904,14 @@ describe("MilestoneCard", () => {
 
   describe("Dark Mode Support", () => {
     it("should have dark mode classes for card", () => {
-      const { container } = render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      const { container } = renderCard(mockProjectMilestone);
 
       const card = container.firstChild as HTMLElement;
       expect(card.className).toContain("dark:bg-zinc-800");
     });
 
     it("should have dark mode classes for text elements", () => {
-      render(
-        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
-      );
+      renderCard(mockProjectMilestone);
 
       const title = screen.getByText("Test Project Milestone");
       expect(title.className).toContain("dark:text-zinc-100");

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -174,27 +174,35 @@ describe("MilestoneCard", () => {
 
   describe("Rendering - Basic Elements", () => {
     it("should render milestone card with title", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
     });
 
     it("should render milestone description", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const description = screen.getByTestId("read-more");
       expect(description).toHaveTextContent("This is a test milestone description");
     });
 
     it("should render milestone badge", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Milestone")).toBeInTheDocument();
       expect(screen.getByAltText("Milestone")).toBeInTheDocument();
     });
 
     it("should render creation date and attester", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText(/Created on/i)).toBeInTheDocument();
       expect(screen.getByText(/by$/i)).toBeInTheDocument();
@@ -205,19 +213,25 @@ describe("MilestoneCard", () => {
 
   describe("Status Rendering", () => {
     it('should display "Pending" status for incomplete milestone', () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Pending")).toBeInTheDocument();
     });
 
     it('should display "Completed" status for complete milestone', () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Completed")).toBeInTheDocument();
     });
 
     it("should apply correct styling for pending status", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const statusBadge = screen.getByText("Pending");
       expect(statusBadge.className).toContain("bg-[#FFFAEB]");
@@ -225,7 +239,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should apply correct styling for completed status", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const statusBadge = screen.getByText("Completed");
       expect(statusBadge.className).toContain("bg-brand-blue");
@@ -260,7 +276,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should not display due date for project milestones", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.queryByText(/Due by/i)).not.toBeInTheDocument();
     });
@@ -304,7 +322,9 @@ describe("MilestoneCard", () => {
         ],
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithMergedGrants} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={milestoneWithMergedGrants} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Grant Alpha")).toBeInTheDocument();
       expect(screen.getByText("Grant Beta")).toBeInTheDocument();
@@ -332,7 +352,11 @@ describe("MilestoneCard", () => {
       } as unknown as UnifiedMilestone;
 
       const { container } = render(
-        <MilestoneCard milestone={milestoneWithUnsortedGrants} isAuthorized={false} canEdit={false} />
+        <MilestoneCard
+          milestone={milestoneWithUnsortedGrants}
+          isAuthorized={false}
+          canEdit={false}
+        />
       );
 
       const grants = screen.getAllByText(/Grant$/);
@@ -343,13 +367,17 @@ describe("MilestoneCard", () => {
 
   describe("Completion Information", () => {
     it("should display completion reason when milestone is completed", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Milestone completed successfully")).toBeInTheDocument();
     });
 
     it("should display proof of work link when available", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Proof of Work")).toBeInTheDocument();
       const proofLink = screen.getByText("https://github.com/proof");
@@ -358,7 +386,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should not display completion info for incomplete milestones", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.queryByText(/Proof of Work/i)).not.toBeInTheDocument();
     });
@@ -395,7 +425,9 @@ describe("MilestoneCard", () => {
       } as unknown as UnifiedMilestone;
 
       // Component should render without crashing even with deliverables in data
-      render(<MilestoneCard milestone={milestoneWithDeliverables} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={milestoneWithDeliverables} isAuthorized={false} canEdit={false} />
+      );
 
       // Verify the milestone renders successfully
       expect(screen.getByText("Test Project Milestone")).toBeInTheDocument();
@@ -447,7 +479,13 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard
+            milestone={milestoneWithDeliverable}
+            isAuthorized={false}
+            canEdit={false}
+          />
+        );
 
         const proofLink = screen.getByText("Moviemeter.io/home");
         expect(proofLink).toHaveAttribute("href", "https://Moviemeter.io/home");
@@ -494,7 +532,13 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard
+            milestone={milestoneWithDeliverable}
+            isAuthorized={false}
+            canEdit={false}
+          />
+        );
 
         const proofLink = screen.getByText("https://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/proof");
@@ -541,7 +585,13 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithDeliverable} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard
+            milestone={milestoneWithDeliverable}
+            isAuthorized={false}
+            canEdit={false}
+          />
+        );
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -567,14 +617,22 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithoutProtocol} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard
+            milestone={milestoneWithoutProtocol}
+            isAuthorized={false}
+            canEdit={false}
+          />
+        );
 
         const proofLink = screen.getByText("github.com/user/repo");
         expect(proofLink).toHaveAttribute("href", "https://github.com/user/repo");
       });
 
       it("should not modify proof of work URLs that already have https://", () => {
-        render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+        );
 
         const proofLink = screen.getByText("https://github.com/proof");
         expect(proofLink).toHaveAttribute("href", "https://github.com/proof");
@@ -598,7 +656,9 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithHttp} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard milestone={milestoneWithHttp} isAuthorized={false} canEdit={false} />
+        );
 
         const proofLink = screen.getByText("http://example.com/proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/proof");
@@ -656,7 +716,9 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
+        );
 
         const proofLink = screen.getByText("example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -712,7 +774,9 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
+        );
 
         const proofLink = screen.getByText("https://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "https://example.com/metric-proof");
@@ -768,7 +832,9 @@ describe("MilestoneCard", () => {
           },
         } as unknown as UnifiedMilestone;
 
-        render(<MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />);
+        render(
+          <MilestoneCard milestone={milestoneWithMetrics} isAuthorized={false} canEdit={false} />
+        );
 
         const proofLink = screen.getByText("http://example.com/metric-proof");
         expect(proofLink).toHaveAttribute("href", "http://example.com/metric-proof");
@@ -778,7 +844,9 @@ describe("MilestoneCard", () => {
 
   describe("Authorization and Options Menu", () => {
     it("should not display options menu when not authorized", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       // The dynamic component mock would be rendered if options menu is shown
       expect(screen.queryByTestId("mocked-dynamic-component")).not.toBeInTheDocument();
@@ -806,7 +874,13 @@ describe("MilestoneCard", () => {
         description: "",
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutDescription} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard
+          milestone={milestoneWithoutDescription}
+          isAuthorized={false}
+          canEdit={false}
+        />
+      );
 
       expect(screen.queryByTestId("read-more")).not.toBeInTheDocument();
     });
@@ -824,7 +898,9 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutAttester} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={milestoneWithoutAttester} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByTestId("ens-avatar")).toBeInTheDocument();
     });
@@ -850,7 +926,9 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutImage} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={milestoneWithoutImage} isAuthorized={false} canEdit={false} />
+      );
 
       expect(screen.getByText("Test Grant Program")).toBeInTheDocument();
     });
@@ -873,7 +951,13 @@ describe("MilestoneCard", () => {
         },
       } as unknown as UnifiedMilestone;
 
-      render(<MilestoneCard milestone={milestoneWithoutGrantTitle} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard
+          milestone={milestoneWithoutGrantTitle}
+          isAuthorized={false}
+          canEdit={false}
+        />
+      );
 
       // Should not render empty grant link
       expect(screen.queryByText("Test Grant Program")).not.toBeInTheDocument();
@@ -892,7 +976,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should have external links with proper security attributes", () => {
-      render(<MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockCompletedMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const proofLink = screen.getByText("https://github.com/proof");
       expect(proofLink).toHaveAttribute("target", "_blank");
@@ -900,7 +986,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should have alt text for milestone icon", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const icon = screen.getByAltText("Milestone");
       expect(icon).toBeInTheDocument();
@@ -918,7 +1006,9 @@ describe("MilestoneCard", () => {
     });
 
     it("should have dark mode classes for text elements", () => {
-      render(<MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />);
+      render(
+        <MilestoneCard milestone={mockProjectMilestone} isAuthorized={false} canEdit={false} />
+      );
 
       const title = screen.getByText("Test Project Milestone");
       expect(title.className).toContain("dark:text-zinc-100");

--- a/__tests__/utilities/getProjectMemberRoles.test.ts
+++ b/__tests__/utilities/getProjectMemberRoles.test.ts
@@ -61,7 +61,7 @@ describe("getProjectMemberRoles", () => {
     mockState.projectOwnerReturn = OWNER;
     mockState.projectAdminsByAddr[OWNER] = false;
 
-    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+    const roles = await getProjectMemberRoles(buildProject());
 
     expect(roles[OWNER]).toBe("Owner");
   });
@@ -71,7 +71,7 @@ describe("getProjectMemberRoles", () => {
     mockState.projectAdminsByAddr[ADMIN_A] = true;
     mockState.projectAdminsByAddr[ADMIN_B] = true;
 
-    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+    const roles = await getProjectMemberRoles(buildProject());
 
     expect(roles[ADMIN_A]).toBe("Admin");
     expect(roles[ADMIN_B]).toBe("Admin");
@@ -82,8 +82,7 @@ describe("getProjectMemberRoles", () => {
     mockState.projectOwnerReturn = OWNER;
 
     const roles = await getProjectMemberRoles(
-      buildProject({ members: [OWNER, PLAIN_MEMBER] }),
-      {} as any
+      buildProject({ members: [OWNER, PLAIN_MEMBER] })
     );
 
     expect(roles[PLAIN_MEMBER]).toBe("Member");
@@ -93,20 +92,22 @@ describe("getProjectMemberRoles", () => {
     mockState.projectOwnerReturn = "0x0000000000000000000000000000000000000000";
 
     const roles = await getProjectMemberRoles(
-      buildProject({ owner: OWNER, members: [OWNER, ADMIN_A] }),
-      {} as any
+      buildProject({ owner: OWNER, members: [OWNER, ADMIN_A] })
     );
 
     expect(roles[OWNER]).toBe("Owner");
   });
 
-  it("returns empty map when no RPC URL is configured", async () => {
+  it("labels the indexer Owner even when no RPC URL is configured (no admin info)", async () => {
     const rpcMod = await import("@/utilities/rpcClient");
     vi.mocked(rpcMod.getRPCUrlByChainId).mockReturnValueOnce(undefined);
 
-    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+    const roles = await getProjectMemberRoles(
+      buildProject({ owner: OWNER, members: [OWNER, ADMIN_A] })
+    );
 
-    expect(roles).toEqual({});
+    expect(roles[OWNER]).toBe("Owner");
+    expect(roles[ADMIN_A]).toBeUndefined();
   });
 
   it("does not produce a second Owner label when the resolver claims an admin is also the owner", async () => {
@@ -117,7 +118,7 @@ describe("getProjectMemberRoles", () => {
     mockState.projectAdminsByAddr[ADMIN_A] = true;
     mockState.projectAdminsByAddr[ADMIN_B] = true;
 
-    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+    const roles = await getProjectMemberRoles(buildProject());
 
     const ownerLabels = Object.entries(roles).filter(([, role]) => role === "Owner");
     expect(ownerLabels).toHaveLength(1);

--- a/__tests__/utilities/getProjectMemberRoles.test.ts
+++ b/__tests__/utilities/getProjectMemberRoles.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getProjectMemberRoles } from "@/utilities/getProjectMemberRoles";
+
+const OWNER = "0xb4713f39476841faf0ea5a555d0b1d451e6b05a1";
+const ADMIN_A = "0x741e2cdff080bd42cd30cfd6cc4a8a0f46a80a84";
+const ADMIN_B = "0x857d42edc040c49bd2eace9479fe3d611f94ba63";
+const PLAIN_MEMBER = "0x1111111111111111111111111111111111111111";
+
+// vi.mock is hoisted above imports; use vi.hoisted for any state that mocks
+// reference at module init.
+const mockState = vi.hoisted(() => ({
+  projectAdminsByAddr: {} as Record<string, boolean>,
+  projectOwnerReturn: "" as string,
+}));
+
+vi.mock("ethers", () => {
+  class MockContract {
+    projectOwner = async () => mockState.projectOwnerReturn;
+    projectAdmins = async (_uid: string, addr: string) =>
+      mockState.projectAdminsByAddr[addr.toLowerCase()] ?? false;
+  }
+  class MockProvider {}
+  return {
+    ethers: {
+      JsonRpcProvider: MockProvider,
+      Contract: MockContract,
+    },
+  };
+});
+
+vi.mock("@show-karma/karma-gap-sdk/core/consts", () => ({
+  chainIdToNetwork: { 8453: "base" } as Record<number, string>,
+  Networks: {
+    base: { contracts: { projectResolver: "0xd2eD366393FDfd243931Fe48e9fb65A192B0018c" } },
+  },
+}));
+
+vi.mock("@/utilities/rpcClient", () => ({
+  getRPCUrlByChainId: vi.fn(() => "https://base.example/rpc"),
+}));
+
+const buildProject = (overrides?: Partial<{ owner: string; members: string[] }>) =>
+  ({
+    uid: "0x16bc3ee698d158aec7d1931c0254d4f7736aa300ddf64615348f9e4b30e4bb2a",
+    chainID: 8453,
+    owner: overrides?.owner,
+    members: (overrides?.members ?? [OWNER, ADMIN_A, ADMIN_B]).map((address) => ({
+      uid: `member-${address}`,
+      address,
+    })),
+  }) as any;
+
+describe("getProjectMemberRoles", () => {
+  beforeEach(() => {
+    mockState.projectOwnerReturn = OWNER;
+    for (const key of Object.keys(mockState.projectAdminsByAddr))
+      delete mockState.projectAdminsByAddr[key];
+  });
+
+  it("labels the on-chain projectOwner mapping as Owner (regardless of admin flag)", async () => {
+    mockState.projectOwnerReturn = OWNER;
+    mockState.projectAdminsByAddr[OWNER] = false;
+
+    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+
+    expect(roles[OWNER]).toBe("Owner");
+  });
+
+  it("labels members in projectAdmins[uid][addr] as Admin, never as Owner", async () => {
+    mockState.projectOwnerReturn = OWNER;
+    mockState.projectAdminsByAddr[ADMIN_A] = true;
+    mockState.projectAdminsByAddr[ADMIN_B] = true;
+
+    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+
+    expect(roles[ADMIN_A]).toBe("Admin");
+    expect(roles[ADMIN_B]).toBe("Admin");
+    expect(Object.values(roles).filter((r) => r === "Owner")).toHaveLength(1);
+  });
+
+  it("labels members without admin status as Member", async () => {
+    mockState.projectOwnerReturn = OWNER;
+
+    const roles = await getProjectMemberRoles(
+      buildProject({ members: [OWNER, PLAIN_MEMBER] }),
+      {} as any
+    );
+
+    expect(roles[PLAIN_MEMBER]).toBe("Member");
+  });
+
+  it("falls back to project.owner (indexer field) when the on-chain projectOwner mapping is the zero address", async () => {
+    mockState.projectOwnerReturn = "0x0000000000000000000000000000000000000000";
+
+    const roles = await getProjectMemberRoles(
+      buildProject({ owner: OWNER, members: [OWNER, ADMIN_A] }),
+      {} as any
+    );
+
+    expect(roles[OWNER]).toBe("Owner");
+  });
+
+  it("returns empty map when no RPC URL is configured", async () => {
+    const rpcMod = await import("@/utilities/rpcClient");
+    vi.mocked(rpcMod.getRPCUrlByChainId).mockReturnValueOnce(undefined);
+
+    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+
+    expect(roles).toEqual({});
+  });
+
+  it("does not produce a second Owner label when the resolver claims an admin is also the owner", async () => {
+    // Mirrors the Forest bug: the SDK's isOwner returns true for all admins,
+    // but only one address — the projectOwner mapping — should render as Owner.
+    mockState.projectOwnerReturn = OWNER;
+    mockState.projectAdminsByAddr[OWNER] = false;
+    mockState.projectAdminsByAddr[ADMIN_A] = true;
+    mockState.projectAdminsByAddr[ADMIN_B] = true;
+
+    const roles = await getProjectMemberRoles(buildProject(), {} as any);
+
+    const ownerLabels = Object.entries(roles).filter(([, role]) => role === "Owner");
+    expect(ownerLabels).toHaveLength(1);
+    expect(ownerLabels[0][0]).toBe(OWNER);
+  });
+});

--- a/__tests__/utilities/getProjectMemberRoles.test.ts
+++ b/__tests__/utilities/getProjectMemberRoles.test.ts
@@ -81,9 +81,7 @@ describe("getProjectMemberRoles", () => {
   it("labels members without admin status as Member", async () => {
     mockState.projectOwnerReturn = OWNER;
 
-    const roles = await getProjectMemberRoles(
-      buildProject({ members: [OWNER, PLAIN_MEMBER] })
-    );
+    const roles = await getProjectMemberRoles(buildProject({ members: [OWNER, PLAIN_MEMBER] }));
 
     expect(roles[PLAIN_MEMBER]).toBe("Member");
   });

--- a/__tests__/utilities/milestones/canEditMilestone.test.ts
+++ b/__tests__/utilities/milestones/canEditMilestone.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import { canEditMilestone } from "@/utilities/milestones/canEditMilestone";
+
+const OWNER = "0xb4713F39476841fAF0EA5A555D0B1d451E6B05A1";
+const ATTESTER = "0x23B7A53ECFD93803C63B97316D7362EAE59C55B6";
+const RANDO = "0x857d42edc040c49bd2eace9479fe3d611f94ba63";
+
+const grantMilestone = (overrides?: { recipient?: string; attester?: string }): UnifiedMilestone =>
+  ({
+    uid: "0xac1805",
+    type: "grant",
+    title: "Test",
+    completed: false,
+    createdAt: "2026-05-01T00:00:00Z",
+    chainID: 8453,
+    refUID: "0x0",
+    source: {
+      type: "grant",
+      grantMilestone: {
+        milestone: {
+          uid: "0xac1805",
+          chainID: 8453,
+          title: "Test",
+          verified: [],
+          recipient: overrides?.recipient ?? OWNER,
+          attester: overrides?.attester ?? ATTESTER,
+        },
+        grant: { uid: "0xgrant", chainID: 8453 },
+      },
+    },
+  }) as unknown as UnifiedMilestone;
+
+const projectMilestone = (overrides?: {
+  recipient?: string;
+  attester?: string;
+}): UnifiedMilestone =>
+  ({
+    uid: "0xproj",
+    type: "milestone",
+    title: "Test",
+    completed: false,
+    createdAt: "2026-05-01T00:00:00Z",
+    chainID: 8453,
+    refUID: "0x0",
+    source: {
+      type: "milestone",
+      projectMilestone: {
+        uid: "0xproj",
+        recipient: overrides?.recipient ?? OWNER,
+        attester: overrides?.attester ?? ATTESTER,
+      },
+    },
+  }) as unknown as UnifiedMilestone;
+
+describe("canEditMilestone", () => {
+  it("returns true when isContractOwner is true, regardless of other inputs", () => {
+    expect(canEditMilestone(null, null, true)).toBe(true);
+    expect(canEditMilestone(grantMilestone(), RANDO, true)).toBe(true);
+  });
+
+  it("returns true when connected address matches the milestone recipient (grant)", () => {
+    expect(canEditMilestone(grantMilestone(), OWNER, false)).toBe(true);
+  });
+
+  it("returns true when connected address matches the milestone attester (grant)", () => {
+    expect(canEditMilestone(grantMilestone(), ATTESTER, false)).toBe(true);
+  });
+
+  it("returns true when connected address matches the milestone recipient (project)", () => {
+    expect(canEditMilestone(projectMilestone(), OWNER, false)).toBe(true);
+  });
+
+  it("returns false when address matches neither attester nor recipient", () => {
+    expect(canEditMilestone(grantMilestone(), RANDO, false)).toBe(false);
+  });
+
+  it("returns false when milestone is missing", () => {
+    expect(canEditMilestone(null, OWNER, false)).toBe(false);
+    expect(canEditMilestone(undefined, OWNER, false)).toBe(false);
+  });
+
+  it("returns false when address is missing and user is not the contract owner", () => {
+    expect(canEditMilestone(grantMilestone(), null, false)).toBe(false);
+    expect(canEditMilestone(grantMilestone(), undefined, false)).toBe(false);
+  });
+
+  it("matches addresses case-insensitively (mixed-case inputs are normalised)", () => {
+    expect(canEditMilestone(grantMilestone(), OWNER.toLowerCase(), false)).toBe(true);
+    expect(canEditMilestone(grantMilestone({ recipient: OWNER.toUpperCase() }), OWNER, false)).toBe(
+      true
+    );
+  });
+
+  it("ignores missing recipient/attester fields without throwing", () => {
+    const sparse = {
+      uid: "0xac1805",
+      type: "grant",
+      title: "Test",
+      completed: false,
+      createdAt: "2026-05-01T00:00:00Z",
+      chainID: 8453,
+      refUID: "0x0",
+      source: { type: "grant", grantMilestone: { milestone: { uid: "0xac1805" } } },
+    } as unknown as UnifiedMilestone;
+    expect(canEditMilestone(sparse, OWNER, false)).toBe(false);
+  });
+});

--- a/components/Milestone/GrantMilestoneOptionsMenu.tsx
+++ b/components/Milestone/GrantMilestoneOptionsMenu.tsx
@@ -26,12 +26,18 @@ interface GrantMilestoneOptionsMenuProps {
   milestone: UnifiedMilestone;
   completeFn: (completeState: boolean) => void;
   alreadyCompleted: boolean;
+  /**
+   * Whether the connected wallet can edit/revoke the milestone on-chain.
+   * Hides the Edit menu item when false; Mark Complete and Delete stay.
+   */
+  canEdit?: boolean;
 }
 
 export const GrantMilestoneOptionsMenu = ({
   milestone,
   completeFn,
   alreadyCompleted,
+  canEdit = false,
 }: GrantMilestoneOptionsMenuProps) => {
   const { isDeleting, multiGrantDelete } = useMilestone();
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -66,7 +72,7 @@ export const GrantMilestoneOptionsMenu = ({
             className="absolute right-0 mt-2 w-48 origin-top-right divide-y divide-gray-100 rounded-md bg-white dark:bg-zinc-800 shadow-lg ring-1 ring-black/5 focus:outline-none z-50"
           >
             <div className="flex flex-col gap-1 px-1 py-1">
-              {isPending ? (
+              {isPending && canEdit ? (
                 <Menu.Item>
                   <Button className={buttonClassName} onClick={() => setIsEditOpen(true)}>
                     <PencilSquareIcon className="w-5 h-5" />

--- a/components/Milestone/GrantMilestoneOptionsMenu.tsx
+++ b/components/Milestone/GrantMilestoneOptionsMenu.tsx
@@ -26,18 +26,15 @@ interface GrantMilestoneOptionsMenuProps {
   milestone: UnifiedMilestone;
   completeFn: (completeState: boolean) => void;
   alreadyCompleted: boolean;
-  /**
-   * Whether the connected wallet can edit/revoke the milestone on-chain.
-   * Hides the Edit menu item when false; Mark Complete and Delete stay.
-   */
-  canEdit?: boolean;
+  // Hides Edit when the connected wallet can't pass Gap.sol's revoke rule
+  canEdit: boolean;
 }
 
 export const GrantMilestoneOptionsMenu = ({
   milestone,
   completeFn,
   alreadyCompleted,
-  canEdit = false,
+  canEdit,
 }: GrantMilestoneOptionsMenuProps) => {
   const { isDeleting, multiGrantDelete } = useMilestone();
   const [isEditOpen, setIsEditOpen] = useState(false);

--- a/components/Milestone/GrantMilestoneSimpleOptionsMenu.tsx
+++ b/components/Milestone/GrantMilestoneSimpleOptionsMenu.tsx
@@ -18,10 +18,17 @@ const buttonClassName = `group border-none ring-none font-normal bg-transparent 
 
 interface GrantMilestoneSimpleOptionsMenuProps {
   milestone: UnifiedMilestone;
+  /**
+   * Whether the connected wallet can edit/revoke the milestone on-chain.
+   * Hides the Edit button when false (Gap.sol would revert otherwise).
+   * Delete keeps an off-chain fallback path so it stays visible.
+   */
+  canEdit?: boolean;
 }
 
 export const GrantMilestoneSimpleOptionsMenu = ({
   milestone,
+  canEdit = false,
 }: GrantMilestoneSimpleOptionsMenuProps) => {
   const { isDeleting, multiGrantDelete } = useMilestone();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -33,12 +40,14 @@ export const GrantMilestoneSimpleOptionsMenu = ({
 
   return (
     <div className="flex flex-row items-center gap-1">
-      <Button
-        className={cn(buttonClassName, "w-max p-2")}
-        onClick={() => setIsEditDialogOpen(true)}
-      >
-        <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
-      </Button>
+      {canEdit && (
+        <Button
+          className={cn(buttonClassName, "w-max p-2")}
+          onClick={() => setIsEditDialogOpen(true)}
+        >
+          <PencilSquareIcon className="h-5 w-5" aria-hidden="true" />
+        </Button>
+      )}
       <DeleteDialog
         title={
           milestone.mergedGrants && milestone.mergedGrants.length > 1

--- a/components/Milestone/GrantMilestoneSimpleOptionsMenu.tsx
+++ b/components/Milestone/GrantMilestoneSimpleOptionsMenu.tsx
@@ -18,17 +18,13 @@ const buttonClassName = `group border-none ring-none font-normal bg-transparent 
 
 interface GrantMilestoneSimpleOptionsMenuProps {
   milestone: UnifiedMilestone;
-  /**
-   * Whether the connected wallet can edit/revoke the milestone on-chain.
-   * Hides the Edit button when false (Gap.sol would revert otherwise).
-   * Delete keeps an off-chain fallback path so it stays visible.
-   */
-  canEdit?: boolean;
+  // Hides Edit when the connected wallet can't pass Gap.sol's revoke rule
+  canEdit: boolean;
 }
 
 export const GrantMilestoneSimpleOptionsMenu = ({
   milestone,
-  canEdit = false,
+  canEdit,
 }: GrantMilestoneSimpleOptionsMenuProps) => {
   const { isDeleting, multiGrantDelete } = useMilestone();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);

--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -55,9 +55,10 @@ const GrantMilestoneCompletion = dynamic(
 interface MilestoneCardProps {
   milestone: UnifiedMilestone;
   isAuthorized: boolean;
+  canEdit: boolean;
 }
 
-export const MilestoneCard = ({ milestone, isAuthorized }: MilestoneCardProps) => {
+export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCardProps) => {
   const [isCompleting, setIsCompleting] = useState(false);
 
   const handleCompleting = (isCompleting: boolean) => {
@@ -224,6 +225,7 @@ export const MilestoneCard = ({ milestone, isAuthorized }: MilestoneCardProps) =
               milestone={milestone}
               completeFn={handleCompleting}
               alreadyCompleted={!!completed}
+              canEdit={canEdit}
             />
           ) : null}
         </div>

--- a/components/Pages/Project/Team/MemberCard.tsx
+++ b/components/Pages/Project/Team/MemberCard.tsx
@@ -13,7 +13,6 @@ import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useAuth } from "@/hooks/useAuth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useTeamProfiles } from "@/hooks/useTeamProfiles";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useENS } from "@/store/ens";
@@ -38,9 +37,6 @@ export const MemberCard = ({ member }: { member: string }) => {
   const { address } = useAuth();
   const isAuthorized = isProjectOwner || isContractOwner;
   const _isAdminOrAbove = isProjectOwner || isContractOwner || isProjectAdmin;
-  const { project: projectInstance } = useProjectInstance(
-    project?.details?.slug || project?.uid || ""
-  );
   const { openModal } = useContributorProfileModalStore();
 
   const {

--- a/components/Pages/Project/Team/MemberCard.tsx
+++ b/components/Pages/Project/Team/MemberCard.tsx
@@ -49,9 +49,8 @@ export const MemberCard = ({ member }: { member: string }) => {
     isFetching: isFetchingRoles,
   } = useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],
-    queryFn: () =>
-      project && projectInstance ? getProjectMemberRoles(project, projectInstance) : {},
-    enabled: !!project && !!projectInstance,
+    queryFn: () => (project ? getProjectMemberRoles(project) : {}),
+    enabled: !!project,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/components/Pages/Project/Team/index.tsx
+++ b/components/Pages/Project/Team/index.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { InviteMemberDialog } from "@/components/Dialogs/Member/InviteMember";
-import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { getProjectMemberRoles, type Member } from "@/utilities/getProjectMemberRoles";
 import { MemberCard } from "./MemberCard";
@@ -20,9 +19,6 @@ export const Team = () => {
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
   const isAuthorized = isProjectOwner || isContractOwner;
-  const { project: projectInstance } = useProjectInstance(
-    project?.details?.slug || project?.uid || ""
-  );
 
   const {
     data: memberRoles,

--- a/components/Pages/Project/Team/index.tsx
+++ b/components/Pages/Project/Team/index.tsx
@@ -30,9 +30,8 @@ export const Team = () => {
     isFetching: isFetchingRoles,
   } = useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],
-    queryFn: () =>
-      project && projectInstance ? getProjectMemberRoles(project, projectInstance) : {},
-    enabled: !!project && !!projectInstance,
+    queryFn: () => (project ? getProjectMemberRoles(project) : {}),
+    enabled: !!project,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/components/Pages/Project/v2/TeamContent/TeamContent.tsx
+++ b/components/Pages/Project/v2/TeamContent/TeamContent.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { InviteMemberDialog } from "@/components/Dialogs/Member/InviteMember";
 import { useAuth } from "@/hooks/useAuth";
-import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { usePermissionsQuery } from "@/src/core/rbac/hooks/use-permissions";
 import { Role } from "@/src/core/rbac/types";
 import { useOwnerStore, useProjectStore } from "@/store";
@@ -39,15 +38,11 @@ export function TeamContent({ className }: TeamContentProps) {
   const { data: permissions } = usePermissionsQuery({}, { enabled: authenticated });
   const isSuperAdmin = permissions?.roles?.roles?.includes(Role.SUPER_ADMIN) ?? false;
   const isAuthorized = isProjectOwner || isContractOwner || isSuperAdmin;
-  const { project: projectInstance } = useProjectInstance(
-    project?.details?.slug || project?.uid || ""
-  );
 
   const { data: memberRoles } = useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],
-    queryFn: () =>
-      project && projectInstance ? getProjectMemberRoles(project, projectInstance) : {},
-    enabled: !!project && !!projectInstance,
+    queryFn: () => (project ? getProjectMemberRoles(project) : {}),
+    enabled: !!project,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
+++ b/components/Pages/Project/v2/TeamContent/TeamMemberCard.tsx
@@ -13,7 +13,6 @@ import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useAuth } from "@/hooks/useAuth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useTeamProfiles } from "@/hooks/useTeamProfiles";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useENS } from "@/store/ens";
@@ -47,9 +46,6 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
   const isContractOwner = useOwnerStore((state) => state.isOwner);
   const { address } = useAuth();
   const isAuthorized = isProjectOwner || isContractOwner;
-  const { project: projectInstance } = useProjectInstance(
-    project?.details?.slug || project?.uid || ""
-  );
   const { openModal } = useContributorProfileModalStore();
 
   const {
@@ -58,9 +54,8 @@ export function TeamMemberCard({ member, className }: TeamMemberCardProps) {
     isFetching: isFetchingRoles,
   } = useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],
-    queryFn: () =>
-      project && projectInstance ? getProjectMemberRoles(project, projectInstance) : {},
-    enabled: !!project && !!projectInstance,
+    queryFn: () => (project ? getProjectMemberRoles(project) : {}),
+    enabled: !!project,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/components/Shared/ActivityCard.tsx
+++ b/components/Shared/ActivityCard.tsx
@@ -8,8 +8,10 @@ import type {
   IProjectUpdate,
 } from "@show-karma/karma-gap-sdk/core/class/karma-indexer/api/types";
 import type { FC } from "react";
+import { useAuth } from "@/hooks/useAuth";
 import { useOwnerStore, useProjectStore } from "@/store";
 import type { ConversionGrantUpdate, ProjectUpdate, UnifiedMilestone } from "@/types/v2/roadmap";
+import { canEditMilestone } from "@/utilities/milestones/canEditMilestone";
 import { EndorsementCard } from "./ActivityCard/EndorsementCard";
 import { FundingReceivedCard } from "./ActivityCard/FundingReceivedCard";
 import { MilestoneCard } from "./ActivityCard/MilestoneCard";
@@ -53,7 +55,14 @@ interface ActivityCardProps {
 export const ActivityCard: FC<ActivityCardProps> = ({ activity, isAuthorized = false }) => {
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const { address } = useAuth();
   const isAuthenticatedUser = isOwner || isProjectAdmin || isAuthorized;
+
+  // Edit/revoke is gated by Gap.sol::_multiRevoke which only accepts the
+  // attestation's attester, recipient, or the contract owner — not project
+  // admins or team members. See utilities/milestones/canEditMilestone.
+  const canEdit =
+    activity.type === "milestone" ? canEditMilestone(activity.data, address, isOwner) : false;
 
   return (
     <div className="flex flex-col w-full">
@@ -85,6 +94,7 @@ export const ActivityCard: FC<ActivityCardProps> = ({ activity, isAuthorized = f
         <MilestoneCard
           milestone={activity.data}
           isAuthorized={isAuthenticatedUser}
+          canEdit={canEdit}
           allocationAmount={activity.allocationAmount}
           hideTimelineMarker={activity.hideTimelineMarker}
         />

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -102,12 +102,7 @@ const MilestoneAIEvaluationBadge = dynamic(
 interface MilestoneCardProps {
   milestone: UnifiedMilestone;
   isAuthorized: boolean;
-  /**
-   * Whether the connected wallet can edit/revoke this milestone on-chain.
-   * Tighter than `isAuthorized`: gated by Gap.sol's attester/recipient check.
-   * Project admins and team members may have isAuthorized=true but canEdit=false.
-   */
-  canEdit?: boolean;
+  canEdit: boolean;
   allocationAmount?: string;
   hideTimelineMarker?: boolean;
 }
@@ -138,7 +133,7 @@ const getActivityTypeLabel = (type: string): string => {
 export const MilestoneCard: FC<MilestoneCardProps> = ({
   milestone,
   isAuthorized,
-  canEdit = false,
+  canEdit,
   allocationAmount,
   hideTimelineMarker = false,
 }) => {
@@ -175,15 +170,11 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
     | { title?: string; programId?: string }
     | undefined;
   const grantTitle = grantDetails?.title;
-  const _programId = grantDetails?.programId;
 
   // Check if invoice is required for this grant
   const { data: invoiceCheckData } = useGrantInvoiceRequired(
     isAuthorized && type === "grant" ? grantUID : undefined
   );
-  const _communityData = grantMilestone?.grant.community?.details as
-    | { name?: string; imageURL?: string }
-    | undefined;
   const endsAt = milestone.endsAt;
 
   const handleViewInvoice = useCallback(async () => {
@@ -476,35 +467,30 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
                   <ShareIcon className="h-5 w-5" />
                 </ExternalLink>
 
-                {canEdit && (
-                  <>
-                    {/* Edit Button — gated by on-chain revoke rule (Gap.sol) */}
-                    <Button
-                      className="flex flex-row gap-1 bg-transparent text-sm font-semibold text-muted-foreground hover:bg-transparent hover:opacity-75  h-6 w-6 p-0 items-center justify-center"
-                      onClick={() => handleEditing(true)}
-                    >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </Button>
+                {/* Edit Button */}
+                <Button
+                  className="flex flex-row gap-1 bg-transparent text-sm font-semibold text-muted-foreground hover:bg-transparent hover:opacity-75  h-6 w-6 p-0 items-center justify-center"
+                  onClick={() => handleEditing(true)}
+                >
+                  <PencilSquareIcon className="h-5 w-5" />
+                </Button>
 
-                    {/* Revoke Completion Button — same on-chain gate as Edit */}
-                    <DeleteDialog
-                      deleteFunction={handleUndoCompletion}
-                      isLoading={isUndoing}
-                      title={
-                        <p className="font-normal">
-                          Are you sure you want to revoke the completion of <b>{milestone.title}</b>
-                          ?
-                        </p>
-                      }
-                      buttonElement={{
-                        text: "",
-                        icon: <TrashIcon className="h-5 w-5" />,
-                        styleClass:
-                          "bg-transparent text-sm font-semibold text-red-500 hover:bg-transparent hover:opacity-75 h-6 w-6 p-0 items-center justify-center",
-                      }}
-                    />
-                  </>
-                )}
+                {/* Revoke Completion Button */}
+                <DeleteDialog
+                  deleteFunction={handleUndoCompletion}
+                  isLoading={isUndoing}
+                  title={
+                    <p className="font-normal">
+                      Are you sure you want to revoke the completion of <b>{milestone.title}</b>?
+                    </p>
+                  }
+                  buttonElement={{
+                    text: "",
+                    icon: <TrashIcon className="h-5 w-5" />,
+                    styleClass:
+                      "bg-transparent text-sm font-semibold text-red-500 hover:bg-transparent hover:opacity-75 h-6 w-6 p-0 items-center justify-center",
+                  }}
+                />
               </div>
             ) : undefined
           }

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -102,6 +102,12 @@ const MilestoneAIEvaluationBadge = dynamic(
 interface MilestoneCardProps {
   milestone: UnifiedMilestone;
   isAuthorized: boolean;
+  /**
+   * Whether the connected wallet can edit/revoke this milestone on-chain.
+   * Tighter than `isAuthorized`: gated by Gap.sol's attester/recipient check.
+   * Project admins and team members may have isAuthorized=true but canEdit=false.
+   */
+  canEdit?: boolean;
   allocationAmount?: string;
   hideTimelineMarker?: boolean;
 }
@@ -132,6 +138,7 @@ const getActivityTypeLabel = (type: string): string => {
 export const MilestoneCard: FC<MilestoneCardProps> = ({
   milestone,
   isAuthorized,
+  canEdit = false,
   allocationAmount,
   hideTimelineMarker = false,
 }) => {
@@ -469,30 +476,35 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
                   <ShareIcon className="h-5 w-5" />
                 </ExternalLink>
 
-                {/* Edit Button */}
-                <Button
-                  className="flex flex-row gap-1 bg-transparent text-sm font-semibold text-muted-foreground hover:bg-transparent hover:opacity-75  h-6 w-6 p-0 items-center justify-center"
-                  onClick={() => handleEditing(true)}
-                >
-                  <PencilSquareIcon className="h-5 w-5" />
-                </Button>
+                {canEdit && (
+                  <>
+                    {/* Edit Button — gated by on-chain revoke rule (Gap.sol) */}
+                    <Button
+                      className="flex flex-row gap-1 bg-transparent text-sm font-semibold text-muted-foreground hover:bg-transparent hover:opacity-75  h-6 w-6 p-0 items-center justify-center"
+                      onClick={() => handleEditing(true)}
+                    >
+                      <PencilSquareIcon className="h-5 w-5" />
+                    </Button>
 
-                {/* Revoke Completion Button */}
-                <DeleteDialog
-                  deleteFunction={handleUndoCompletion}
-                  isLoading={isUndoing}
-                  title={
-                    <p className="font-normal">
-                      Are you sure you want to revoke the completion of <b>{milestone.title}</b>?
-                    </p>
-                  }
-                  buttonElement={{
-                    text: "",
-                    icon: <TrashIcon className="h-5 w-5" />,
-                    styleClass:
-                      "bg-transparent text-sm font-semibold text-red-500 hover:bg-transparent hover:opacity-75 h-6 w-6 p-0 items-center justify-center",
-                  }}
-                />
+                    {/* Revoke Completion Button — same on-chain gate as Edit */}
+                    <DeleteDialog
+                      deleteFunction={handleUndoCompletion}
+                      isLoading={isUndoing}
+                      title={
+                        <p className="font-normal">
+                          Are you sure you want to revoke the completion of <b>{milestone.title}</b>
+                          ?
+                        </p>
+                      }
+                      buttonElement={{
+                        text: "",
+                        icon: <TrashIcon className="h-5 w-5" />,
+                        styleClass:
+                          "bg-transparent text-sm font-semibold text-red-500 hover:bg-transparent hover:opacity-75 h-6 w-6 p-0 items-center justify-center",
+                      }}
+                    />
+                  </>
+                )}
               </div>
             ) : undefined
           }
@@ -610,7 +622,7 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
         {type === "milestone" && projectMilestone ? (
           <ObjectiveSimpleOptionsMenu objectiveId={projectMilestone.uid} />
         ) : type === "grant" && grantMilestone ? (
-          <GrantMilestoneSimpleOptionsMenu milestone={milestone} />
+          <GrantMilestoneSimpleOptionsMenu milestone={milestone} canEdit={canEdit} />
         ) : null}
       </>
     ) : null;

--- a/hooks/useMemberRoleChange.ts
+++ b/hooks/useMemberRoleChange.ts
@@ -102,7 +102,7 @@ export function useMemberRoleChange(action: RoleAction) {
 
       await retryUntilConditionMet(
         async () => {
-          const memberRoles = await getProjectMemberRoles(project, projectInstance);
+          const memberRoles = await getProjectMemberRoles(project);
           return config.checkCondition(memberRoles[memberAddress.toLowerCase()]);
         },
         () => {

--- a/hooks/useMemberRoles.ts
+++ b/hooks/useMemberRoles.ts
@@ -2,13 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useProjectStore } from "@/store";
 import { getProjectMemberRoles, type Member } from "@/utilities/getProjectMemberRoles";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
-import { useProjectInstance } from "./useProjectInstance";
 
 export const useMemberRoles = () => {
   const project = useProjectStore((state) => state.project);
-  const { project: projectInstance } = useProjectInstance(
-    project?.details?.slug || project?.uid || ""
-  );
 
   return useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],

--- a/hooks/useMemberRoles.ts
+++ b/hooks/useMemberRoles.ts
@@ -12,9 +12,8 @@ export const useMemberRoles = () => {
 
   return useQuery<Record<string, Member["role"]>>({
     queryKey: ["memberRoles", project?.uid],
-    queryFn: () =>
-      project && projectInstance ? getProjectMemberRoles(project, projectInstance) : {},
-    enabled: !!project && !!projectInstance,
+    queryFn: () => (project ? getProjectMemberRoles(project) : {}),
+    enabled: !!project,
     ...defaultQueryOptions,
   });
 };

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -61,8 +61,11 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
   data.projectMilestones.forEach((milestone: ProjectMilestone) => {
     // A milestone is completed if status is "completed" (completionDetails may or may not be present)
     const isCompleted = milestone.status === "completed" || milestone.status === "verified";
-    // Use recipient from API (the milestone owner)
-    const attester = milestone.recipient || "";
+    const milestoneAny = milestone as any;
+    const recipient = milestone.recipient || "";
+    // Display attribution falls back to recipient when the on-chain attester
+    // isn't present (Karma backend-signed milestones expose attester separately).
+    const attester = milestoneAny.attester || recipient;
 
     unified.push({
       uid: milestone.uid,
@@ -89,6 +92,7 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
         projectMilestone: {
           uid: milestone.uid,
           attester,
+          recipient,
           completed: isCompleted
             ? {
                 createdAt: milestone.completionDetails?.completedAt || milestone.createdAt || "",
@@ -107,17 +111,17 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
   data.grantMilestones.forEach((milestone: GrantMilestoneWithDetails) => {
     // A milestone is completed if status is "completed" (completionDetails may or may not be present)
     const isCompleted = milestone.status === "completed" || milestone.status === "verified";
-    // Use recipient from API (the milestone owner), with extensive fallbacks
-    // The API may include additional fields not in the type definition
+    // Recipient is the on-chain milestone owner (passes Gap.sol's revoke gate).
+    // Attester may differ (Karma backend-signed milestones use a service wallet);
+    // display attribution falls back to recipient when attester is unavailable.
     const milestoneAny = milestone as any;
-    const attester =
+    const recipient =
       milestone.recipient ||
-      milestoneAny.attester ||
       milestone.completionDetails?.completedBy ||
       milestone.fundingApplicationCompletion?.ownerAddress ||
-      milestoneAny.data?.attester ||
       milestoneAny.data?.recipient ||
       "";
+    const attester = milestoneAny.attester || milestoneAny.data?.attester || recipient;
     // Off-chain completions use fundingApplicationCompletion instead of completionDetails
     const appCompletion = milestone.fundingApplicationCompletion;
     const chainID =
@@ -195,6 +199,7 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
             chainID,
             refUID: grantInfo?.uid || "",
             attester,
+            recipient,
             title: milestone.title,
             description: milestone.description,
             endsAt: milestoneEndsAt,

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -61,11 +61,10 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
   data.projectMilestones.forEach((milestone: ProjectMilestone) => {
     // A milestone is completed if status is "completed" (completionDetails may or may not be present)
     const isCompleted = milestone.status === "completed" || milestone.status === "verified";
-    const milestoneAny = milestone as any;
     const recipient = milestone.recipient || "";
     // Display attribution falls back to recipient when the on-chain attester
     // isn't present (Karma backend-signed milestones expose attester separately).
-    const attester = milestoneAny.attester || recipient;
+    const attester = (milestone as { attester?: string }).attester || recipient;
 
     unified.push({
       uid: milestone.uid,

--- a/types/v2/roadmap.ts
+++ b/types/v2/roadmap.ts
@@ -191,6 +191,7 @@ export type UnifiedMilestoneSource = {
   projectMilestone?: {
     uid: string;
     attester?: string;
+    recipient?: string;
     completed?: {
       createdAt: string;
       attester?: string;

--- a/utilities/getProjectMemberRoles.ts
+++ b/utilities/getProjectMemberRoles.ts
@@ -32,7 +32,7 @@ export const getProjectMemberRoles = async (
   if (!project) return roles;
 
   const networkName = chainIdToNetwork[project.chainID as keyof typeof chainIdToNetwork];
-  const network = networkName ? Networks[networkName] : undefined;
+  const network = networkName ? Networks[networkName as keyof typeof Networks] : undefined;
   const resolverAddress = network?.contracts.projectResolver;
   const rpcUrl = getRPCUrlByChainId(project.chainID);
   if (!resolverAddress || !rpcUrl) return roles;

--- a/utilities/getProjectMemberRoles.ts
+++ b/utilities/getProjectMemberRoles.ts
@@ -24,7 +24,7 @@ const PROJECT_RESOLVER_ABI = [
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const getProjectMemberRoles = async (
-  project: ProjectResponse,
+  project: ProjectResponse
 ): Promise<Record<string, Member["role"]>> => {
   const roles: Record<string, Member["role"]> = {};
   if (!project) return roles;
@@ -69,7 +69,7 @@ export const getProjectMemberRoles = async (
   }
 
   const uniqueAddresses = Array.from(
-    new Set([...(ownerAddress ? [ownerAddress] : []), ...memberAddresses]),
+    new Set([...(ownerAddress ? [ownerAddress] : []), ...memberAddresses])
   );
 
   await Promise.all(
@@ -84,7 +84,7 @@ export const getProjectMemberRoles = async (
       } catch {
         roles[addr] = "Member";
       }
-    }),
+    })
   );
 
   return roles;

--- a/utilities/getProjectMemberRoles.ts
+++ b/utilities/getProjectMemberRoles.ts
@@ -1,4 +1,5 @@
 import type { Project } from "@show-karma/karma-gap-sdk/core/class/entities/Project";
+import { chainIdToNetwork, Networks } from "@show-karma/karma-gap-sdk/core/consts";
 import { ethers } from "ethers";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import { getRPCUrlByChainId } from "./rpcClient";
@@ -11,41 +12,72 @@ export interface Member {
   };
   role?: "Owner" | "Admin" | "Member";
 }
-export const getProjectMemberRoles = async (project: ProjectResponse, projectInstance: Project) => {
-  const roles: Record<string, Member["role"]> = {};
-  if (project?.members) {
-    const rpcUrl = getRPCUrlByChainId(project.chainID);
-    if (!rpcUrl) return roles;
-    const rpcProvider = new ethers.JsonRpcProvider(rpcUrl);
 
-    await Promise.all(
-      project.members
-        .filter((member) => member.address)
-        .map(async (member) => {
-          const memberAddress = member.address;
-          const isProjectOwner = await projectInstance
-            .isOwner(rpcProvider, memberAddress)
-            .catch((_error) => {
-              return false;
-            });
-          const isProjectAdmin = await projectInstance
-            .isAdmin(rpcProvider, memberAddress)
-            .catch((_error) => {
-              return false;
-            });
-          if (!roles[memberAddress.toLowerCase()]) {
-            roles[memberAddress.toLowerCase()] = isProjectOwner
-              ? "Owner"
-              : isProjectAdmin
-                ? "Admin"
-                : "Member";
-          }
-        })
-    );
+// Minimal slice of ProjectResolver — `projectAdmins` and `projectOwner` are
+// the raw mappings. We avoid `isOwner`/`isAdmin` because both views are
+// deliberately permissive on-chain (admins also pass `isOwner`), which is
+// what made the previous implementation label every member as "Owner".
+const PROJECT_RESOLVER_ABI = [
+  "function projectAdmins(bytes32 projectId, address addr) view returns (bool)",
+  "function projectOwner(bytes32 projectId) view returns (address)",
+];
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const getProjectMemberRoles = async (
+  project: ProjectResponse,
+  _projectInstance: Project
+): Promise<Record<string, Member["role"]>> => {
+  const roles: Record<string, Member["role"]> = {};
+  if (!project) return roles;
+
+  const networkName = chainIdToNetwork[project.chainID as keyof typeof chainIdToNetwork];
+  const network = networkName ? Networks[networkName] : undefined;
+  const resolverAddress = network?.contracts.projectResolver;
+  const rpcUrl = getRPCUrlByChainId(project.chainID);
+  if (!resolverAddress || !rpcUrl) return roles;
+
+  const rpcProvider = new ethers.JsonRpcProvider(rpcUrl);
+  const resolver = new ethers.Contract(resolverAddress, PROJECT_RESOLVER_ABI, rpcProvider);
+
+  // Resolve the single Owner from the on-chain mapping, falling back to the
+  // indexer's `project.owner` if the resolver returns the zero address (rare;
+  // pre-migration attestations may not have the mapping populated).
+  let ownerAddress: string | undefined;
+  try {
+    const onChainOwner: string = await resolver.projectOwner(project.uid);
+    if (onChainOwner && onChainOwner.toLowerCase() !== ZERO_ADDRESS) {
+      ownerAddress = onChainOwner.toLowerCase();
+    }
+  } catch {
+    // Network failure → leave ownerAddress undefined; we'll fall back below
   }
-  if (project?.owner && !roles[project.owner.toLowerCase()]) {
-    roles[project.owner.toLowerCase()] = "Owner";
+  if (!ownerAddress && project.owner) {
+    ownerAddress = project.owner.toLowerCase();
   }
+
+  const memberAddresses = (project.members || [])
+    .map((m) => m.address?.toLowerCase())
+    .filter((a): a is string => Boolean(a));
+
+  const uniqueAddresses = Array.from(
+    new Set([...(ownerAddress ? [ownerAddress] : []), ...memberAddresses])
+  );
+
+  await Promise.all(
+    uniqueAddresses.map(async (addr) => {
+      if (addr === ownerAddress) {
+        roles[addr] = "Owner";
+        return;
+      }
+      try {
+        const isAdmin: boolean = await resolver.projectAdmins(project.uid, addr);
+        roles[addr] = isAdmin ? "Admin" : "Member";
+      } catch {
+        roles[addr] = "Member";
+      }
+    })
+  );
 
   return roles;
 };

--- a/utilities/getProjectMemberRoles.ts
+++ b/utilities/getProjectMemberRoles.ts
@@ -1,4 +1,3 @@
-import type { Project } from "@show-karma/karma-gap-sdk/core/class/entities/Project";
 import { chainIdToNetwork, Networks } from "@show-karma/karma-gap-sdk/core/consts";
 import { ethers } from "ethers";
 import type { Project as ProjectResponse } from "@/types/v2/project";
@@ -26,16 +25,29 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const getProjectMemberRoles = async (
   project: ProjectResponse,
-  _projectInstance: Project
 ): Promise<Record<string, Member["role"]>> => {
   const roles: Record<string, Member["role"]> = {};
   if (!project) return roles;
+
+  const indexerOwner = project.owner?.toLowerCase();
+  const memberAddresses = (project.members || [])
+    .map((m) => m.address?.toLowerCase())
+    .filter((a): a is string => Boolean(a));
 
   const networkName = chainIdToNetwork[project.chainID as keyof typeof chainIdToNetwork];
   const network = networkName ? Networks[networkName as keyof typeof Networks] : undefined;
   const resolverAddress = network?.contracts.projectResolver;
   const rpcUrl = getRPCUrlByChainId(project.chainID);
-  if (!resolverAddress || !rpcUrl) return roles;
+
+  // If we can't reach the resolver (chain not in Networks, or RPC missing),
+  // we can't confirm admins on-chain. Still label the Owner from the indexer
+  // so the Team panel doesn't render every member as an unlabelled "Member" —
+  // that misleads users about who created the project. Other members fall
+  // through with no label (better than guessing "Admin" without on-chain data).
+  if (!resolverAddress || !rpcUrl) {
+    if (indexerOwner) roles[indexerOwner] = "Owner";
+    return roles;
+  }
 
   const rpcProvider = new ethers.JsonRpcProvider(rpcUrl);
   const resolver = new ethers.Contract(resolverAddress, PROJECT_RESOLVER_ABI, rpcProvider);
@@ -52,16 +64,12 @@ export const getProjectMemberRoles = async (
   } catch {
     // Network failure → leave ownerAddress undefined; we'll fall back below
   }
-  if (!ownerAddress && project.owner) {
-    ownerAddress = project.owner.toLowerCase();
+  if (!ownerAddress && indexerOwner) {
+    ownerAddress = indexerOwner;
   }
 
-  const memberAddresses = (project.members || [])
-    .map((m) => m.address?.toLowerCase())
-    .filter((a): a is string => Boolean(a));
-
   const uniqueAddresses = Array.from(
-    new Set([...(ownerAddress ? [ownerAddress] : []), ...memberAddresses])
+    new Set([...(ownerAddress ? [ownerAddress] : []), ...memberAddresses]),
   );
 
   await Promise.all(
@@ -76,7 +84,7 @@ export const getProjectMemberRoles = async (
       } catch {
         roles[addr] = "Member";
       }
-    })
+    }),
   );
 
   return roles;

--- a/utilities/milestones/canEditMilestone.ts
+++ b/utilities/milestones/canEditMilestone.ts
@@ -21,11 +21,18 @@ export const canEditMilestone = (
   if (!milestone || !connectedAddress) return false;
 
   const me = connectedAddress.toLowerCase();
+  const grantMilestone = milestone.source?.grantMilestone?.milestone;
+  const projectMilestone = milestone.source?.projectMilestone;
+  // Includes both the creation attestation (Edit / dropdown menu) and the
+  // completion attestation (Revoke Completion) — Gap.sol::_multiRevoke
+  // checks the *target* attestation's own attester/recipient.
   const candidates = [
-    milestone.source?.grantMilestone?.milestone?.recipient,
-    milestone.source?.grantMilestone?.milestone?.attester,
-    milestone.source?.projectMilestone?.recipient,
-    milestone.source?.projectMilestone?.attester,
+    grantMilestone?.recipient,
+    grantMilestone?.attester,
+    grantMilestone?.completed?.attester,
+    projectMilestone?.recipient,
+    projectMilestone?.attester,
+    projectMilestone?.completed?.attester,
   ];
 
   return candidates.some((addr) => addr?.toLowerCase() === me);

--- a/utilities/milestones/canEditMilestone.ts
+++ b/utilities/milestones/canEditMilestone.ts
@@ -1,0 +1,32 @@
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+
+/**
+ * Whether the connected wallet can edit or revoke `milestone` on-chain.
+ *
+ * Mirrors the gate in `Gap.sol::_multiRevoke`:
+ *   revoker == owner() || target.attester == revoker || target.recipient == revoker
+ *
+ * The `isContractOwner` flag covers the `owner()` branch (Karma's super-admin
+ * wallet, surfaced by `useOwnerStore.isOwner`); the two address comparisons
+ * cover the per-attestation attester/recipient branches. `Project.isOwner`
+ * and `Project.isAdmin` from the SDK are deliberately permissive on-chain
+ * and do NOT match this gate — do not use them here.
+ */
+export const canEditMilestone = (
+  milestone: UnifiedMilestone | null | undefined,
+  connectedAddress: string | null | undefined,
+  isContractOwner: boolean
+): boolean => {
+  if (isContractOwner) return true;
+  if (!milestone || !connectedAddress) return false;
+
+  const me = connectedAddress.toLowerCase();
+  const candidates = [
+    milestone.source?.grantMilestone?.milestone?.recipient,
+    milestone.source?.grantMilestone?.milestone?.attester,
+    milestone.source?.projectMilestone?.recipient,
+    milestone.source?.projectMilestone?.attester,
+  ];
+
+  return candidates.some((addr) => addr?.toLowerCase() === me);
+};


### PR DESCRIPTION
## Summary

Editing a milestone on `/project/forest---an-efficient-and-lightweight-filecoin-node` while connected as a team member (`0x857D…BA63`, labelled "Owner" in the UI) reverted with `GAP:Not owner.` during gas estimation. Two cooperating defects:

1. The Edit button was rendered for any "authorized" address (project admin, super admin, contract owner). The on-chain revoke gate is far stricter.
2. The Team Members list rendered every member as "Owner" because the role check used `ProjectResolver.isOwner`, which is deliberately permissive on-chain.

Both are fixed here.

## Root cause

### Bug 1 — wrong gate

`Gap.sol::_multiRevoke` requires:

```solidity
require(
  revoker == owner() ||           // Gap contract owner (Karma deployer)
  target.attester == revoker ||   // attestation's original attester
  target.recipient == revoker,    // attestation's recipient
  "GAP:Not owner."
);
```

So a user can revoke a milestone iff they are the Karma super-admin, the milestone's attester, or its recipient. `Project.isOwner` / `Project.isAdmin` from the SDK are not equivalent to this check — they read a different (and intentionally permissive) function on `ProjectResolver`.

For the Forest milestone (`0xac1805…`):
- attester: `0x23b7…` (Karma signer)
- recipient: `0xb471…05a1` (project owner)
- connected wallet: `0x857D…BA63` — matches neither → revert.

### Bug 2 — role mislabelling

`ProjectResolver.isOwner(uid, addr)` returns `true` for *any* of: the explicit projectOwner mapping, the contract `_owner` (Karma deployer), OR `projectAdmins[uid][addr]`. Admins therefore read as "Owner". The previous `getProjectMemberRoles` mirrored this contract behaviour and labelled every member as "Owner".

Direct on-chain probe on Base confirmed this (`projectAdmins` raw mapping):

| Address | projectOwner mapping | projectAdmins | Should be |
|---|---|---|---|
| 0xb471…05a1 | ✓ | false | Owner |
| 0x741e…0a84 | — | **true** | Admin |
| 0x857d…BA63 | — | **true** | Admin |

## Changes

### Edit/Revoke gate

- New pure helper `utilities/milestones/canEditMilestone.ts`. Mirrors `Gap.sol::_multiRevoke`: `isContractOwner || addr == milestone.recipient || addr == milestone.attester`. No hook, no async — three values combined with `||`.
- `ActivityCard.tsx` computes `canEdit` for milestone-type activities and threads it through `ActivityCard/MilestoneCard.tsx`.
- Edit pencil, Revoke-completion button, and `GrantMilestoneSimpleOptionsMenu`'s Edit affordance are now gated on `canEdit`. Mark Complete keeps its current `isAuthorized` gate (different on-chain path). Delete keeps its off-chain revoke fallback.
- `convertToUnifiedMilestones` (`hooks/v2/useProjectUpdates.ts`) now plumbs both `attester` (real) and `recipient` (real) onto `UnifiedMilestoneSource.{projectMilestone,grantMilestone.milestone}`. Previously `attester` was misleadingly populated from `milestone.recipient`.

### Team list labelling

`utilities/getProjectMemberRoles.ts` rewrite:

- Owner = `ProjectResolver.projectOwner(uid)` on-chain, falling back to indexer `project.owner` only when the mapping is `0x0`.
- Admin = `ProjectResolver.projectAdmins(uid, addr)` raw mapping (not `isAdmin`).
- Member = everyone else.
- When the resolver is unreachable (chain not configured or RPC missing), fall back to labelling `project.owner` as Owner and omit per-member admin status; no silent role guesses for the other members.

## Tests

15 new unit tests:

- `canEditMilestone.test.ts` (9) — contract-owner bypass, recipient/attester matching for grant and project milestones, missing inputs, case-insensitive match.
- `getProjectMemberRoles.test.ts` (6) — Owner from on-chain mapping, Admin from `projectAdmins`, plain Member, zero-address fallback to indexer, missing RPC, "never two Owners" regression.

All 39 pre-existing tests in `ActivityCard.test.tsx` and `useProjectUpdates.test.ts` still pass.

## Test plan

- [ ] Connect as the Forest project owner (`0xb471…05a1`) → Edit visible on grant milestones; Revoke Completion visible on completed milestones.
- [ ] Connect as Kai (`0x857D…BA63`) or another team member → Edit and Revoke Completion hidden. Mark Complete and Delete still visible.
- [ ] Connect as a Karma super admin → Edit visible regardless of project role.
- [ ] Forest Team Members panel shows exactly one Owner, others as Admin or Member based on `projectAdmins` mapping.
- [ ] Switch to a project on a different chain (Optimism / Celo) and confirm the Team list still renders correctly (resolver address resolution by chain).

## Out of scope / follow-ups

- Delete-grant (`multiGrantDelete`) hits the same `Gap.sol::_multiRevoke` gate but has a silent off-chain revoke fallback, so the failure isn't user-visible. Could be gated identically — tracked separately.
- SDK's `Project.isOwner` is misleading because of the on-chain conflation. Consider renaming to `canAct` or deprecating in a follow-up RFC.
