### PR TITLE
feat(access-denied): improve permission denial language with RBAC-aware copy

### DIFF
--- a/__tests__/components/ui/AccessDenied.test.tsx
+++ b/__tests__/components/ui/AccessDenied.test.tsx
@@ -14,11 +14,13 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
+const mockUsePermissionContext = vi.fn(() => ({
+  roles: { primaryRole: "GUEST", roles: ["GUEST"], reviewerTypes: [] },
+  isLoading: false,
+}));
+
 vi.mock("@/src/core/rbac/context/permission-context", () => ({
-  usePermissionContext: vi.fn(() => ({
-    roles: { primaryRole: "GUEST", roles: ["GUEST"], reviewerTypes: [] },
-    isLoading: false,
-  })),
+  usePermissionContext: () => mockUsePermissionContext(),
 }));
 
 // lucide-react icons need to be mocked in jsdom

--- a/__tests__/components/ui/AccessDenied.test.tsx
+++ b/__tests__/components/ui/AccessDenied.test.tsx
@@ -14,6 +14,13 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: vi.fn(() => ({
+    roles: { primaryRole: "GUEST", roles: ["GUEST"], reviewerTypes: [] },
+    isLoading: false,
+  })),
+}));
+
 // lucide-react icons need to be mocked in jsdom
 vi.mock("lucide-react", () => ({
   AlertTriangle: (props: React.SVGProps<SVGSVGElement>) => (

--- a/app/admin/faucet/layout.tsx
+++ b/app/admin/faucet/layout.tsx
@@ -5,6 +5,8 @@ import { useEffect } from "react";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useAuth } from "@/hooks/useAuth";
 import { useFaucetAdmin } from "@/hooks/useFaucetAdmin";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 import { PAGES } from "@/utilities/pages";
 
 export default function FaucetAdminLayout({ children }: { children: React.ReactNode }) {
@@ -34,16 +36,11 @@ export default function FaucetAdminLayout({ children }: { children: React.ReactN
 
   if (!isAdmin) {
     return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-4">
-            Access Denied
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            You do not have permission to access the faucet admin panel.
-          </p>
-        </div>
-      </div>
+      <AccessDenied
+        title="Faucet admin access required"
+        requiredRoles={[Role.SUPER_ADMIN]}
+        contactLabel="the platform team"
+      />
     );
   }
 

--- a/app/admin/faucet/layout.tsx
+++ b/app/admin/faucet/layout.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useAuth } from "@/hooks/useAuth";
 import { useFaucetAdmin } from "@/hooks/useFaucetAdmin";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { faucetAdminDenial } from "@/src/components/ui/access-denied-presets";
 import { PAGES } from "@/utilities/pages";
 
 export default function FaucetAdminLayout({ children }: { children: React.ReactNode }) {
@@ -35,13 +35,7 @@ export default function FaucetAdminLayout({ children }: { children: React.ReactN
   }
 
   if (!isAdmin) {
-    return (
-      <AccessDenied
-        title="Faucet admin access required"
-        requiredRoles={[Role.SUPER_ADMIN]}
-        contactLabel="the platform team"
-      />
-    );
+    return <AccessDenied title="Faucet admin access required" {...faucetAdminDenial()} />;
   }
 
   return <>{children}</>;

--- a/app/community/[communityId]/manage/program-scores/page.tsx
+++ b/app/community/[communityId]/manage/program-scores/page.tsx
@@ -7,7 +7,7 @@ import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAc
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 
 export default function ProgramScoresPage() {
   const { communityId } = useParams() as { communityId: string };
@@ -25,12 +25,7 @@ export default function ProgramScoresPage() {
   }
 
   if (!hasAccess) {
-    return (
-      <AccessDenied
-        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
-        contactLabel={`a community administrator of ${community?.details?.name ?? "this community"}`}
-      />
-    );
+    return <AccessDenied {...communityAdminDenial(community?.details?.name)} />;
   }
 
   return (

--- a/app/community/[communityId]/manage/program-scores/page.tsx
+++ b/app/community/[communityId]/manage/program-scores/page.tsx
@@ -6,7 +6,8 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
-import { MESSAGES } from "@/utilities/messages";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 
 export default function ProgramScoresPage() {
   const { communityId } = useParams() as { communityId: string };
@@ -25,10 +26,10 @@ export default function ProgramScoresPage() {
 
   if (!hasAccess) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen text-center">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
-        <p className="text-gray-600">{MESSAGES.ADMIN.NOT_AUTHORIZED(communityId)}</p>
-      </div>
+      <AccessDenied
+        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
+        contactLabel={`a community administrator of ${community?.details?.name ?? "this community"}`}
+      />
     );
   }
 

--- a/app/community/[communityId]/manage/send-email/page.tsx
+++ b/app/community/[communityId]/manage/send-email/page.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 import { SendEmailComposer } from "./SendEmailComposer";
 
 function SendEmailContent({ communityId }: { communityId: string }) {
@@ -128,12 +128,7 @@ export default function SendEmailPage() {
   }
 
   if (!hasAccess) {
-    return (
-      <AccessDenied
-        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
-        contactLabel="a community administrator"
-      />
-    );
+    return <AccessDenied {...communityAdminDenial()} />;
   }
 
   return <SendEmailContent communityId={communityId} />;

--- a/app/community/[communityId]/manage/send-email/page.tsx
+++ b/app/community/[communityId]/manage/send-email/page.tsx
@@ -5,7 +5,8 @@ import { useParams } from "next/navigation";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
-import { MESSAGES } from "@/utilities/messages";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 import { SendEmailComposer } from "./SendEmailComposer";
 
 function SendEmailContent({ communityId }: { communityId: string }) {
@@ -128,12 +129,10 @@ export default function SendEmailPage() {
 
   if (!hasAccess) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] text-center">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">Access Denied</h1>
-        <p className="text-gray-600 dark:text-gray-400">
-          {MESSAGES.ADMIN.NOT_AUTHORIZED(communityId)}
-        </p>
-      </div>
+      <AccessDenied
+        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
+        contactLabel="a community administrator"
+      />
     );
   }
 

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -5,8 +5,8 @@ import { Skeleton } from "@/components/Utilities/Skeleton";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { manageLayoutDenial } from "@/src/components/ui/access-denied-presets";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
-import { Role } from "@/src/core/rbac/types";
 import { useOwnerStore } from "@/store/owner";
 import { PAGES } from "@/utilities/pages";
 import { ManageBreadcrumbs } from "./ManageBreadcrumbs";
@@ -82,14 +82,7 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
   if (!hasManageAccess) {
     return (
       <AccessDenied
-        requiredRoles={[
-          Role.COMMUNITY_ADMIN,
-          Role.PROGRAM_ADMIN,
-          Role.PROGRAM_REVIEWER,
-          Role.REGISTRY_ADMIN,
-          "Community Owner",
-        ]}
-        contactLabel={`a community administrator of ${community?.details?.name ?? "this community"}`}
+        {...manageLayoutDenial(community?.details?.name)}
         cta={{ label: "Go to Community", href: PAGES.COMMUNITY.ALL_GRANTS(communityId) }}
       />
     );

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -4,8 +4,9 @@ import { useParams } from "next/navigation";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
-import { Link } from "@/src/components/navigation/Link";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { Role } from "@/src/core/rbac/types";
 import { useOwnerStore } from "@/store/owner";
 import { PAGES } from "@/utilities/pages";
 import { ManageBreadcrumbs } from "./ManageBreadcrumbs";
@@ -80,20 +81,17 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
 
   if (!hasManageAccess) {
     return (
-      <div className="flex w-full min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">Access Denied</p>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-            You don&apos;t have permission to access this area.
-          </p>
-          <Link
-            href={PAGES.COMMUNITY.ALL_GRANTS(communityId)}
-            className="text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-          >
-            Go to Community
-          </Link>
-        </div>
-      </div>
+      <AccessDenied
+        requiredRoles={[
+          Role.COMMUNITY_ADMIN,
+          Role.PROGRAM_ADMIN,
+          Role.PROGRAM_REVIEWER,
+          Role.REGISTRY_ADMIN,
+          "Community Owner",
+        ]}
+        contactLabel={`a community administrator of ${community?.details?.name ?? "this community"}`}
+        cta={{ label: "Go to Community", href: PAGES.COMMUNITY.ALL_GRANTS(communityId) }}
+      />
     );
   }
 

--- a/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { AlertCircle, FileBadge, FileText, Globe, Plus, Search, Sparkles } from "lucide-react";
+import { AlertCircle, FileBadge, FileText, Globe, Plus, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { AddSourceDialog } from "@/components/Pages/Admin/KnowledgeBasePage/AddSourceDialog";
 import { SourceRow } from "@/components/Pages/Admin/KnowledgeBasePage/SourceRow";
 import { Button } from "@/components/Utilities/Button";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useKnowledgeSources } from "@/hooks/knowledge-base/useKnowledgeSources";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 import type { Community } from "@/types/v2/community";
 import type { KnowledgeSource, KnowledgeSourceKind } from "@/types/v2/knowledge-base";
 
@@ -84,7 +86,11 @@ export function KnowledgeBasePage({ community }: Props) {
   if (!hasAccess) {
     return (
       <PageFrame>
-        <AccessDeniedCard />
+        <AccessDenied
+          title="Knowledge base access required"
+          requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
+          contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
+        />
       </PageFrame>
     );
   }
@@ -488,22 +494,6 @@ function ErrorBlock({ message, onRetry }: { message: string; onRetry: () => void
       >
         Retry
       </button>
-    </div>
-  );
-}
-
-function AccessDeniedCard() {
-  return (
-    <div className="mx-auto mt-12 max-w-lg rounded-2xl border border-stone-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900/40">
-      <Sparkles
-        aria-hidden="true"
-        className="mx-auto mb-3 h-6 w-6 text-stone-400 dark:text-zinc-600"
-      />
-      <h2 className="text-lg font-semibold text-stone-900 dark:text-zinc-100">Admin only</h2>
-      <p className="mt-2 text-sm text-stone-600 dark:text-zinc-400">
-        Only community admins can manage knowledge sources. Ask a community admin if you need
-        access.
-      </p>
     </div>
   );
 }

--- a/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/Utilities/Button";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useKnowledgeSources } from "@/hooks/knowledge-base/useKnowledgeSources";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 import type { Community } from "@/types/v2/community";
 import type { KnowledgeSource, KnowledgeSourceKind } from "@/types/v2/knowledge-base";
 
@@ -88,8 +88,7 @@ export function KnowledgeBasePage({ community }: Props) {
       <PageFrame>
         <AccessDenied
           title="Knowledge base access required"
-          requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
-          contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
+          {...communityAdminDenial(community.details?.name)}
         />
       </PageFrame>
     );

--- a/components/Pages/Admin/KycSettingsPage.tsx
+++ b/components/Pages/Admin/KycSettingsPage.tsx
@@ -10,7 +10,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useKycConfig, useSaveKycConfig } from "@/hooks/useKycStatus";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 import { KycProviderType } from "@/types/kyc";
 import type { Community } from "@/types/v2/community";
 import { envVars } from "@/utilities/enviromentVars";
@@ -134,8 +134,7 @@ export function KycSettingsPage({ community }: KycSettingsPageProps) {
     return (
       <AccessDenied
         title="KYC settings access required"
-        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
-        contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
+        {...communityAdminDenial(community.details?.name)}
       />
     );
   }

--- a/components/Pages/Admin/KycSettingsPage.tsx
+++ b/components/Pages/Admin/KycSettingsPage.tsx
@@ -9,10 +9,11 @@ import { Button } from "@/components/Utilities/Button";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import { useKycConfig, useSaveKycConfig } from "@/hooks/useKycStatus";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 import { KycProviderType } from "@/types/kyc";
 import type { Community } from "@/types/v2/community";
 import { envVars } from "@/utilities/enviromentVars";
-import { MESSAGES } from "@/utilities/messages";
 
 // Use enum values for provider type validation
 const providerTypeValues = Object.values(KycProviderType) as [string, ...string[]];
@@ -129,12 +130,13 @@ export function KycSettingsPage({ community }: KycSettingsPageProps) {
     );
   }
 
-  // Show access denied if user is not an admin
   if (!hasAccess) {
     return (
-      <div className="flex w-full items-center justify-center h-96">
-        <p className="text-lg">{MESSAGES.ADMIN.NOT_AUTHORIZED(communityUID)}</p>
-      </div>
+      <AccessDenied
+        title="KYC settings access required"
+        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
+        contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
+      />
     );
   }
 

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -6,10 +6,8 @@ import {
   AtSymbolIcon,
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
-  ChevronLeftIcon,
   ClockIcon,
   DocumentTextIcon,
-  ExclamationTriangleIcon,
   SparklesIcon,
 } from "@heroicons/react/20/solid";
 import dynamic from "next/dynamic";
@@ -27,6 +25,7 @@ import { useMilestoneEvaluation } from "@/hooks/useMilestoneEvaluation";
 import { useProjectGrantMilestones } from "@/hooks/useProjectGrantMilestones";
 import type { GrantMilestoneWithCompletion, MilestoneEvaluationItem } from "@/services/milestones";
 import { Link } from "@/src/components/navigation/Link";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
 import {
   PermissionProvider,
   useIsReviewer,
@@ -34,7 +33,7 @@ import {
   usePermissionContext,
 } from "@/src/core/rbac/context/permission-context";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
-import { ReviewerType } from "@/src/core/rbac/types";
+import { ReviewerType, Role } from "@/src/core/rbac/types";
 import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
 import { PAGES } from "@/utilities/pages";
@@ -746,32 +745,19 @@ function MilestonesReviewPageContent({
 
   if (!isAuthorized) {
     return (
-      <div className="min-h-screen">
-        <div className="px-4 sm:px-6 lg:px-8 py-6">
-          <div className="bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800 rounded-lg p-6">
-            <div className="flex items-center gap-3 mb-3">
-              <ExclamationTriangleIcon className="h-6 w-6 text-red-600 dark:text-red-400" />
-              <h3 className="text-red-800 dark:text-red-200 font-semibold text-lg">
-                Unauthorized Access
-              </h3>
-            </div>
-            <p className="text-red-600 dark:text-red-400 mb-4">
-              {!address
-                ? "You must be logged in to access this page."
-                : "You do not have permission to access this page. Only community administrators, contract owners, staff, and program reviewers can review milestones."}
-            </p>
-            <Link href={PAGES.ADMIN.MILESTONES(communityId)}>
-              <Button className="flex flex-row items-center gap-2 px-4 py-2 bg-red-600 hover:bg-red-700 text-white">
-                <ChevronLeftIcon className="h-5 w-5" />
-                Back to Milestones Report
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </div>
+      <AccessDenied
+        title="Milestone review access required"
+        requiredRoles={[
+          Role.COMMUNITY_ADMIN,
+          Role.SUPER_ADMIN,
+          Role.PROGRAM_REVIEWER,
+          "Contract Owner",
+        ]}
+        contactLabel="a community administrator"
+        cta={{ label: "Back to Milestones Report", href: PAGES.ADMIN.MILESTONES(communityId) }}
+      />
     );
   }
-
   if (error || !data) {
     return (
       <div className="min-h-screen">

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -26,6 +26,7 @@ import { useProjectGrantMilestones } from "@/hooks/useProjectGrantMilestones";
 import type { GrantMilestoneWithCompletion, MilestoneEvaluationItem } from "@/services/milestones";
 import { Link } from "@/src/components/navigation/Link";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { milestoneReviewDenial } from "@/src/components/ui/access-denied-presets";
 import {
   PermissionProvider,
   useIsReviewer,
@@ -33,7 +34,7 @@ import {
   usePermissionContext,
 } from "@/src/core/rbac/context/permission-context";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
-import { ReviewerType, Role } from "@/src/core/rbac/types";
+import { ReviewerType } from "@/src/core/rbac/types";
 import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
 import { PAGES } from "@/utilities/pages";
@@ -747,13 +748,7 @@ function MilestonesReviewPageContent({
     return (
       <AccessDenied
         title="Milestone review access required"
-        requiredRoles={[
-          Role.COMMUNITY_ADMIN,
-          Role.SUPER_ADMIN,
-          Role.PROGRAM_REVIEWER,
-          "Contract Owner",
-        ]}
-        contactLabel="a community administrator"
+        {...milestoneReviewDenial()}
         cta={{ label: "Back to Milestones Report", href: PAGES.ADMIN.MILESTONES(communityId) }}
       />
     );

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -24,6 +24,8 @@ import {
   useUpdateReportContent,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
 import { downloadReportPdf } from "@/services/portfolio-reports.service";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { Role } from "@/src/core/rbac/types";
 import { isReportGenerating } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
@@ -87,11 +89,18 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     );
   }
 
-  if (!hasAccess || !report) {
+  if (!hasAccess) {
     return (
-      <div className="flex items-center justify-center p-12 text-zinc-500">
-        {!hasAccess ? "You don't have permission to view this page." : "Report not found."}
-      </div>
+      <AccessDenied
+        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
+        contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
+      />
+    );
+  }
+
+  if (!report) {
+    return (
+      <div className="flex items-center justify-center p-12 text-zinc-500">Report not found.</div>
     );
   }
 

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/hooks/portfolio-reports/usePortfolioReports";
 import { downloadReportPdf } from "@/services/portfolio-reports.service";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
-import { Role } from "@/src/core/rbac/types";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 import { isReportGenerating } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
@@ -90,12 +90,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   }
 
   if (!hasAccess) {
-    return (
-      <AccessDenied
-        requiredRoles={[Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN]}
-        contactLabel={`a community administrator of ${community.details?.name ?? "this community"}`}
-      />
-    );
+    return <AccessDenied {...communityAdminDenial(community.details?.name)} />;
   }
 
   if (!report) {

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -90,9 +90,8 @@ export function AccessDenied({
       );
     } else {
       const currentRoles =
-        currentRolesOverride && currentRolesOverride.length > 0
-          ? currentRolesOverride
-          : detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
+        currentRolesOverride ??
+        detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
       const currentList =
         currentRoles.length > 0
           ? formatList(currentRoles.map((r) => ROLE_LABELS[r]))

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -58,6 +58,58 @@ function DenialSkeleton() {
   );
 }
 
+interface DenialBodyProps {
+  authenticated: boolean;
+  requiredRoles?: ReadonlyArray<Role | string>;
+  requiredList: string | null;
+  currentRolesOverride?: ReadonlyArray<Role>;
+  detectedRoles: ReadonlyArray<Role>;
+  contactLabel?: string;
+  message?: string;
+}
+
+function DenialBody({
+  authenticated,
+  requiredRoles,
+  requiredList,
+  currentRolesOverride,
+  detectedRoles,
+  contactLabel,
+  message,
+}: DenialBodyProps) {
+  if (!requiredList) {
+    return (
+      <p className="text-muted-foreground mb-8">
+        {message ?? "You don't have permission to view this page."}
+      </p>
+    );
+  }
+
+  const roleWord = requiredRoles && requiredRoles.length === 1 ? "role" : "roles";
+
+  if (!authenticated) {
+    return (
+      <p className="text-muted-foreground mb-8">
+        You need to sign in to view this page. This page requires {requiredList} {roleWord}.
+      </p>
+    );
+  }
+
+  const currentRoles =
+    currentRolesOverride ?? detectedRoles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
+  const currentList =
+    currentRoles.length > 0
+      ? formatList(currentRoles.map((r) => ROLE_LABELS[r]))
+      : ROLE_LABELS[Role.NONE];
+
+  return (
+    <p className="text-muted-foreground mb-8">
+      You don&apos;t have access to this page. You need {requiredList} {roleWord}. Your account has:{" "}
+      {currentList}.{contactLabel ? ` Please contact ${contactLabel}.` : ""}
+    </p>
+  );
+}
+
 export function AccessDenied({
   title = "Access Denied",
   message,
@@ -78,39 +130,6 @@ export function AccessDenied({
 
   const requiredList =
     requiredRoles && requiredRoles.length > 0 ? formatList(requiredRoles.map(labelFor)) : null;
-
-  let body: React.ReactNode;
-  if (requiredList) {
-    if (!authenticated) {
-      body = (
-        <p className="text-muted-foreground mb-8">
-          You need to sign in to view this page. This page requires {requiredList}{" "}
-          {requiredRoles && requiredRoles.length === 1 ? "role" : "roles"}.
-        </p>
-      );
-    } else {
-      const currentRoles =
-        currentRolesOverride ??
-        detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
-      const currentList =
-        currentRoles.length > 0
-          ? formatList(currentRoles.map((r) => ROLE_LABELS[r]))
-          : ROLE_LABELS[Role.NONE];
-      body = (
-        <p className="text-muted-foreground mb-8">
-          You don&apos;t have access to this page. You need {requiredList}{" "}
-          {requiredRoles && requiredRoles.length === 1 ? "role" : "roles"}. Your account has:{" "}
-          {currentList}.{contactLabel ? ` Please contact ${contactLabel}.` : ""}
-        </p>
-      );
-    }
-  } else {
-    body = (
-      <p className="text-muted-foreground mb-8">
-        {message ?? "You don't have permission to view this page."}
-      </p>
-    );
-  }
 
   const handleClick = () => {
     if (cta) {
@@ -137,7 +156,15 @@ export function AccessDenied({
           </div>
 
           <h1 className="text-2xl font-bold mb-4">{title}</h1>
-          {body}
+          <DenialBody
+            authenticated={authenticated}
+            requiredRoles={requiredRoles}
+            requiredList={requiredList}
+            currentRolesOverride={currentRolesOverride}
+            detectedRoles={detectedRoles.roles}
+            contactLabel={contactLabel}
+            message={message}
+          />
 
           <Button type="button" onClick={handleClick}>
             <LogIn className="w-4 h-4 mr-2" />

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -5,20 +5,127 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuth } from "@/hooks/useAuth";
+import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+import { isValidRole, ROLE_LABELS, Role } from "@/src/core/rbac/types";
+
+interface AccessDeniedCta {
+  label: string;
+  href: string;
+}
 
 interface AccessDeniedProps {
   title?: string;
   message?: string;
   returnUrl?: string;
+  requiredRoles?: ReadonlyArray<Role | string>;
+  contactLabel?: string;
+  currentRolesOverride?: ReadonlyArray<Role>;
+  isLoading?: boolean;
+  cta?: AccessDeniedCta;
+}
+
+function formatList(items: ReadonlyArray<string>): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} or ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, or ${items[items.length - 1]}`;
+}
+
+function labelFor(role: Role | string): string {
+  if (typeof role === "string" && isValidRole(role)) {
+    return ROLE_LABELS[role];
+  }
+  if (typeof role === "string") {
+    return role;
+  }
+  return ROLE_LABELS[role];
+}
+
+function DenialSkeleton() {
+  return (
+    <div className="container py-16 flex items-center justify-center min-h-[60vh]">
+      <Card className="max-w-lg w-full">
+        <CardContent className="py-12 px-8">
+          <div className="animate-pulse space-y-4">
+            <div className="mx-auto h-20 w-20 rounded-full bg-gray-200 dark:bg-zinc-700" />
+            <div className="mx-auto h-6 w-1/2 rounded bg-gray-200 dark:bg-zinc-700" />
+            <div className="mx-auto h-4 w-3/4 rounded bg-gray-200 dark:bg-zinc-700" />
+            <div className="mx-auto h-10 w-32 rounded bg-gray-200 dark:bg-zinc-700" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
 }
 
 export function AccessDenied({
   title = "Access Denied",
-  message = "You don't have permission to view this page.",
+  message,
   returnUrl = "/",
+  requiredRoles,
+  contactLabel,
+  currentRolesOverride,
+  isLoading,
+  cta,
 }: AccessDeniedProps) {
   const { authenticated, login } = useAuth();
   const router = useRouter();
+  const { roles: detectedRoles, isLoading: isRbacLoading } = usePermissionContext();
+
+  if (isLoading || isRbacLoading) {
+    return <DenialSkeleton />;
+  }
+
+  const requiredList =
+    requiredRoles && requiredRoles.length > 0 ? formatList(requiredRoles.map(labelFor)) : null;
+
+  let body: React.ReactNode;
+  if (requiredList) {
+    if (!authenticated) {
+      body = (
+        <p className="text-muted-foreground mb-8">
+          You need to sign in to view this page. This page requires {requiredList}{" "}
+          {requiredRoles && requiredRoles.length === 1 ? "role" : "roles"}.
+        </p>
+      );
+    } else {
+      const currentRoles =
+        currentRolesOverride && currentRolesOverride.length > 0
+          ? currentRolesOverride
+          : detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
+      const currentList =
+        currentRoles.length > 0
+          ? formatList(currentRoles.map((r) => ROLE_LABELS[r]))
+          : ROLE_LABELS[Role.NONE];
+      body = (
+        <p className="text-muted-foreground mb-8">
+          You don&apos;t have access to this page. You need {requiredList}{" "}
+          {requiredRoles && requiredRoles.length === 1 ? "role" : "roles"}. Your account has:{" "}
+          {currentList}.{contactLabel ? ` Please contact ${contactLabel}.` : ""}
+        </p>
+      );
+    }
+  } else {
+    body = (
+      <p className="text-muted-foreground mb-8">
+        {message ?? "You don't have permission to view this page."}
+      </p>
+    );
+  }
+
+  const handleClick = () => {
+    if (cta) {
+      router.push(cta.href);
+      return;
+    }
+    if (!authenticated) {
+      login();
+      return;
+    }
+    router.push(returnUrl);
+  };
+
+  const buttonLabel = cta?.label ?? (authenticated ? "Go to Home" : "Sign In");
 
   return (
     <div className="container py-16 flex items-center justify-center min-h-[60vh]">
@@ -31,20 +138,11 @@ export function AccessDenied({
           </div>
 
           <h1 className="text-2xl font-bold mb-4">{title}</h1>
-          <p className="text-muted-foreground mb-8">{message}</p>
+          {body}
 
-          <Button
-            type="button"
-            onClick={() => {
-              if (!authenticated) {
-                login();
-              } else {
-                router.push(returnUrl);
-              }
-            }}
-          >
+          <Button type="button" onClick={handleClick}>
             <LogIn className="w-4 h-4 mr-2" />
-            {authenticated ? "Go to Home" : "Sign In"}
+            {buttonLabel}
           </Button>
         </CardContent>
       </Card>

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -43,7 +43,7 @@ function labelFor(role: Role | string): string {
 
 function DenialSkeleton() {
   return (
-    <div className="container py-16 flex items-center justify-center min-h-[60vh]">
+    <div className="container py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
       <Card className="max-w-lg w-full">
         <CardContent className="py-12 px-8">
           <div className="animate-pulse space-y-4">
@@ -127,7 +127,7 @@ export function AccessDenied({
   const buttonLabel = cta?.label ?? (authenticated ? "Go to Home" : "Sign In");
 
   return (
-    <div className="container py-16 flex items-center justify-center min-h-[60vh]">
+    <div className="container py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
       <Card className="max-w-lg">
         <CardContent className="text-center py-12 px-8">
           <div className="mb-6 flex justify-center">

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -43,7 +43,7 @@ function labelFor(role: Role | string): string {
 
 function DenialSkeleton() {
   return (
-    <div className="container py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
+    <div className="w-full mx-auto py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
       <Card className="max-w-lg w-full">
         <CardContent className="py-12 px-8">
           <div className="animate-pulse space-y-4">
@@ -127,7 +127,7 @@ export function AccessDenied({
   const buttonLabel = cta?.label ?? (authenticated ? "Go to Home" : "Sign In");
 
   return (
-    <div className="container py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
+    <div className="w-full mx-auto py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
       <Card className="max-w-lg">
         <CardContent className="text-center py-12 px-8">
           <div className="mb-6 flex justify-center">

--- a/src/components/ui/access-denied-presets.ts
+++ b/src/components/ui/access-denied-presets.ts
@@ -1,0 +1,49 @@
+import { Role } from "@/src/core/rbac/types";
+
+interface DenialPreset {
+  requiredRoles: ReadonlyArray<Role | string>;
+  contactLabel: string;
+}
+
+function communityContact(communityName?: string | null): string {
+  return `a community administrator of ${communityName ?? "this community"}`;
+}
+
+export function communityAdminDenial(communityName?: string | null): DenialPreset {
+  return {
+    requiredRoles: [Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN],
+    contactLabel: communityContact(communityName),
+  };
+}
+
+export function manageLayoutDenial(communityName?: string | null): DenialPreset {
+  return {
+    requiredRoles: [
+      Role.COMMUNITY_ADMIN,
+      Role.PROGRAM_ADMIN,
+      Role.PROGRAM_REVIEWER,
+      Role.REGISTRY_ADMIN,
+      "Community Owner",
+    ],
+    contactLabel: communityContact(communityName),
+  };
+}
+
+export function milestoneReviewDenial(communityName?: string | null): DenialPreset {
+  return {
+    requiredRoles: [
+      Role.COMMUNITY_ADMIN,
+      Role.SUPER_ADMIN,
+      Role.PROGRAM_REVIEWER,
+      "Contract Owner",
+    ],
+    contactLabel: communityContact(communityName),
+  };
+}
+
+export function faucetAdminDenial(): DenialPreset {
+  return {
+    requiredRoles: [Role.SUPER_ADMIN],
+    contactLabel: "the platform team",
+  };
+}

--- a/src/core/rbac/types/index.ts
+++ b/src/core/rbac/types/index.ts
@@ -14,5 +14,6 @@ export {
   isValidRole,
   ReviewerType,
   ROLE_HIERARCHY,
+  ROLE_LABELS,
   Role,
 } from "./role";

--- a/src/core/rbac/types/role.ts
+++ b/src/core/rbac/types/role.ts
@@ -17,6 +17,19 @@ export function isValidRole(role: string): role is Role {
   return ROLE_VALUES.has(role as Role);
 }
 
+export const ROLE_LABELS: Record<Role, string> = {
+  [Role.SUPER_ADMIN]: "Staff",
+  [Role.REGISTRY_ADMIN]: "Registry Admin",
+  [Role.COMMUNITY_ADMIN]: "Community Admin",
+  [Role.PROGRAM_ADMIN]: "Program Admin",
+  [Role.PROGRAM_CREATOR]: "Program Creator",
+  [Role.PROGRAM_REVIEWER]: "Program Reviewer",
+  [Role.MILESTONE_REVIEWER]: "Milestone Reviewer",
+  [Role.APPLICANT]: "Applicant",
+  [Role.GUEST]: "Guest",
+  [Role.NONE]: "No assigned role",
+};
+
 export const ROLE_HIERARCHY: Record<Role, number> = {
   [Role.NONE]: -1,
   [Role.GUEST]: 0,


### PR DESCRIPTION
## Summary

Replaces the generic *"Access Denied"* message with role-aware copy that tells the user **what they need**, **what they have**, and **who to contact**.

**Anonymous**
> You need to sign in to view this page. This page requires _Community Admin, Program Admin, Program Reviewer, Registry Admin, or Community Owner_ roles.

**Authenticated, insufficient role**
> You don't have access to this page. You need _Community Admin or Staff_. Your account has: _Applicant_. Please contact a community administrator of _Optimism_.

## What changed

- New `AccessDenied` props API: `requiredRoles`, `contactLabel`, optional `cta`, `currentRolesOverride`, `isLoading`.
- `AccessDenied` now reads `usePermissionContext()` to auto-detect current roles and shows a skeleton while RBAC is loading (prevents the auth-startup denial flash).
- New `ROLE_LABELS` map renders human-readable role names (`SUPER_ADMIN` → "Staff").
- Migrated 8 full-page denial screens: `ManageLayoutShell`, `KycSettingsPage`, `KnowledgeBasePage`, `MilestonesReview`, `PortfolioReportEditorPage`, `app/admin/faucet/layout.tsx`, send-email and program-scores manage pages.
- Split `PortfolioReportEditorPage`'s combined `!hasAccess || !report` branch — "Report not found." is now distinct from the denial card.

## Test plan

- [x] Unit tests: `__tests__/components/ui/AccessDenied.test.tsx` — 10/10 pass (loading skeleton, anonymous copy, plural/singular roles, current-role auto-detect, `cta` override, `Role | string` escape hatch).
- [x] RBAC regression: 268 existing tests still pass.
- [x] Live QA on logged-in Super Admin session: send-email / KYC settings / knowledge-base / portfolio-reports / `non-existent-report-id` all render the normal page — no false denial card (A3-A6 PASS).
- [x] Live QA on no-role wallet: manage-shell denial card renders the full new copy with "No assigned role" auto-detected (A2 PASS).
- [ ] Out of scope / follow-up: `/admin/faucet` has a pre-existing `useEffect` that redirects to `/` before AccessDenied can render — the migrated card on that route is unreachable until that redirect is removed in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-aware access denial UI with clearer, contextual messages and contact labels.
  * Optional CTA on access-denied screens to guide next steps.

* **Refactoring**
  * Replaced varied inline “Access Denied” states with a unified component across admin and community pages for consistent UX.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->