### PR TITLE
fix: show project activities linked to grant on milestones-and-updates page

### DIFF
--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -4,7 +4,7 @@ import { type FC, useEffect, useMemo, useState } from "react";
 import { ActivityCard } from "@/components/Shared/ActivityCard";
 import { Button } from "@/components/Utilities/Button";
 import { getTokenByAddressAndChain } from "@/constants/supportedTokens";
-import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
+import { useGrantLinkedActivities } from "@/hooks/v2/useGrantLinkedActivities";
 import { usePayoutConfigByGrantPublic } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import type { Grant } from "@/types/v2/grant";
 import type { UnifiedMilestone, ProjectUpdate as V2ProjectUpdate } from "@/types/v2/roadmap";
@@ -58,19 +58,8 @@ const TabButton: FC<TabButtonProps> = ({ handleSelection, tab, tabName, selected
 export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
   const { milestones, updates } = grant;
   const params = useParams();
-  // Use the URL projectId segment so we share the React Query cache key with
-  // the project page's useProjectUpdates(projectId) call. Mutations on either
-  // page invalidate the same key.
-  const projectIdentifier = (params?.projectId as string) || "";
-  const { rawData: projectUpdatesData } = useProjectUpdates(projectIdentifier);
-
-  const linkedActivities: V2ProjectUpdate[] = useMemo(() => {
-    const all = projectUpdatesData?.projectUpdates || [];
-    const grantUidLower = grant.uid?.toLowerCase();
-    return all.filter((update) =>
-      update.associations?.funding?.some((f) => f.uid?.toLowerCase() === grantUidLower)
-    );
-  }, [projectUpdatesData, grant.uid]);
+  const projectIdentifier = typeof params?.projectId === "string" ? params.projectId : "";
+  const linkedActivities = useGrantLinkedActivities(projectIdentifier, grant.uid);
 
   const { data: payoutConfig } = usePayoutConfigByGrantPublic(grant.uid);
 

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -255,7 +255,7 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
     if (Array.isArray(completed)) return completed.length > 0;
     return !!completed;
   }).length;
-  const updatesLength = completedMilestonesCount + (updates?.length || 0);
+  const updatesLength = completedMilestonesCount + (updates?.length || 0) + linkedActivities.length;
   const milestonesCounter = milestones?.length || 0;
 
   return (
@@ -292,7 +292,7 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
             <div className="flex flex-row flex-wrap gap-5">
               <p className="text-base font-normal text-gray-500 max-sm:text-sm">
                 {milestonesCounter} {pluralize("Milestone", milestonesCounter)}, {updatesLength}{" "}
-                {pluralize("update", updatesLength)} in this grant
+                {pluralize("Update", updatesLength)} in this grant
               </p>
             </div>
           </div>

--- a/components/Pages/Grants/MilestonesAndUpdates/index.tsx
+++ b/components/Pages/Grants/MilestonesAndUpdates/index.tsx
@@ -2,8 +2,11 @@
 
 import dynamic from "next/dynamic";
 import Image from "next/image";
+import { useParams } from "next/navigation";
+import { useMemo } from "react";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { useTracksForProgram } from "@/hooks/useTracks";
+import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import type { Track } from "@/services/tracks";
 import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
 import { useOwnerStore, useProjectStore } from "@/store";
@@ -221,7 +224,19 @@ export default function MilestonesAndUpdates() {
   const { grant } = useGrantStore();
   const project = useProjectStore((state) => state.project);
   const { openProgressModalWithScreen } = useProgressModalStore();
-  const hasMilestonesOrUpdates = grant?.milestones?.length || grant?.updates?.length;
+  const params = useParams();
+  const projectIdentifier = (params?.projectId as string) || "";
+  const { rawData: projectUpdatesData } = useProjectUpdates(projectIdentifier);
+  const linkedActivitiesCount = useMemo(() => {
+    const all = projectUpdatesData?.projectUpdates || [];
+    const grantUidLower = grant?.uid?.toLowerCase();
+    if (!grantUidLower) return 0;
+    return all.filter((update) =>
+      update.associations?.funding?.some((f) => f.uid?.toLowerCase() === grantUidLower)
+    ).length;
+  }, [projectUpdatesData, grant?.uid]);
+  const hasMilestonesOrUpdates =
+    grant?.milestones?.length || grant?.updates?.length || linkedActivitiesCount;
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);

--- a/components/Pages/Grants/MilestonesAndUpdates/index.tsx
+++ b/components/Pages/Grants/MilestonesAndUpdates/index.tsx
@@ -3,10 +3,9 @@
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useParams } from "next/navigation";
-import { useMemo } from "react";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { useTracksForProgram } from "@/hooks/useTracks";
-import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
+import { useGrantLinkedActivities } from "@/hooks/v2/useGrantLinkedActivities";
 import type { Track } from "@/services/tracks";
 import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
 import { useOwnerStore, useProjectStore } from "@/store";
@@ -225,18 +224,10 @@ export default function MilestonesAndUpdates() {
   const project = useProjectStore((state) => state.project);
   const { openProgressModalWithScreen } = useProgressModalStore();
   const params = useParams();
-  const projectIdentifier = (params?.projectId as string) || "";
-  const { rawData: projectUpdatesData } = useProjectUpdates(projectIdentifier);
-  const linkedActivitiesCount = useMemo(() => {
-    const all = projectUpdatesData?.projectUpdates || [];
-    const grantUidLower = grant?.uid?.toLowerCase();
-    if (!grantUidLower) return 0;
-    return all.filter((update) =>
-      update.associations?.funding?.some((f) => f.uid?.toLowerCase() === grantUidLower)
-    ).length;
-  }, [projectUpdatesData, grant?.uid]);
+  const projectIdentifier = typeof params?.projectId === "string" ? params.projectId : "";
+  const linkedActivities = useGrantLinkedActivities(projectIdentifier, grant?.uid);
   const hasMilestonesOrUpdates =
-    grant?.milestones?.length || grant?.updates?.length || linkedActivitiesCount;
+    grant?.milestones?.length || grant?.updates?.length || linkedActivities.length;
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);

--- a/hooks/v2/__tests__/useGrantLinkedActivities.test.tsx
+++ b/hooks/v2/__tests__/useGrantLinkedActivities.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import { useGrantLinkedActivities } from "../useGrantLinkedActivities";
+
+vi.mock("@/services/project-updates.service", () => ({
+  getProjectUpdates: vi.fn(),
+}));
+
+import { getProjectUpdates } from "@/services/project-updates.service";
+import type { UpdatesApiResponse } from "@/types/v2/roadmap";
+
+const mockGetProjectUpdates = getProjectUpdates as vi.MockedFunction<typeof getProjectUpdates>;
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+
+const wrap = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+const GRANT_UID = "0xea21ef9e1c39915de09540a2be592076a4bca421f033cbb9a9f430084020d39c";
+const OTHER_GRANT_UID = "0xdeadbeef";
+
+const baseResponse: UpdatesApiResponse = {
+  projectUpdates: [
+    {
+      uid: "0xUpdateLinked",
+      recipient: "0x1",
+      title: "Linked",
+      description: "linked to grant",
+      verified: false,
+      startDate: null,
+      endDate: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      associations: {
+        funding: [{ uid: GRANT_UID, name: "Giv-Arb" }],
+        indicators: [],
+        deliverables: [],
+      },
+    },
+    {
+      uid: "0xUpdateUnlinked",
+      recipient: "0x1",
+      title: "Unlinked",
+      description: "no grant",
+      verified: false,
+      startDate: null,
+      endDate: null,
+      createdAt: "2025-01-02T00:00:00.000Z",
+      associations: { funding: [], indicators: [], deliverables: [] },
+    },
+    {
+      uid: "0xUpdateOtherGrant",
+      recipient: "0x1",
+      title: "Other",
+      description: "different grant",
+      verified: false,
+      startDate: null,
+      endDate: null,
+      createdAt: "2025-01-03T00:00:00.000Z",
+      associations: {
+        funding: [{ uid: OTHER_GRANT_UID, name: "Other" }],
+        indicators: [],
+        deliverables: [],
+      },
+    },
+  ],
+  projectMilestones: [],
+  grantMilestones: [],
+  grantUpdates: [],
+};
+
+describe("useGrantLinkedActivities", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("should_return_only_activities_linked_to_the_given_grant", async () => {
+    mockGetProjectUpdates.mockResolvedValueOnce(baseResponse);
+
+    const { result } = renderHook(() => useGrantLinkedActivities("project-slug", GRANT_UID), {
+      wrapper: wrap(queryClient),
+    });
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0].uid).toBe("0xUpdateLinked");
+  });
+
+  it("should_match_grant_uid_case_insensitively", async () => {
+    mockGetProjectUpdates.mockResolvedValueOnce(baseResponse);
+
+    const { result } = renderHook(
+      () => useGrantLinkedActivities("project-slug", GRANT_UID.toUpperCase()),
+      { wrapper: wrap(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+  });
+
+  it("should_return_empty_array_when_grant_uid_is_undefined", async () => {
+    mockGetProjectUpdates.mockResolvedValueOnce(baseResponse);
+
+    const { result } = renderHook(() => useGrantLinkedActivities("project-slug", undefined), {
+      wrapper: wrap(queryClient),
+    });
+
+    await waitFor(() => expect(mockGetProjectUpdates).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+
+  it("should_return_empty_array_when_no_updates_link_to_the_grant", async () => {
+    mockGetProjectUpdates.mockResolvedValueOnce(baseResponse);
+
+    const { result } = renderHook(() => useGrantLinkedActivities("project-slug", "0xunused"), {
+      wrapper: wrap(queryClient),
+    });
+
+    await waitFor(() => expect(mockGetProjectUpdates).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+});

--- a/hooks/v2/useGrantLinkedActivities.ts
+++ b/hooks/v2/useGrantLinkedActivities.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import type { ProjectUpdate as V2ProjectUpdate } from "@/types/v2/roadmap";
+import { useProjectUpdates } from "./useProjectUpdates";
+
+/**
+ * Returns the subset of a project's activity updates that are linked to a
+ * specific grant via `associations.funding[].uid`. Used by the grant
+ * milestones-and-updates page so activities created against the grant show
+ * up even when the grant has no milestones or grant-updates of its own.
+ *
+ * Shares the React Query cache key with `useProjectUpdates(projectId)` so
+ * mutations on either the project page or the grant page invalidate both.
+ */
+export function useGrantLinkedActivities(
+  projectIdOrSlug: string,
+  grantUid: string | undefined
+): V2ProjectUpdate[] {
+  const { rawData } = useProjectUpdates(projectIdOrSlug);
+
+  return useMemo(() => {
+    const all = rawData?.projectUpdates || [];
+    const grantUidLower = grantUid?.toLowerCase();
+    if (!grantUidLower) return [];
+    return all.filter((update) =>
+      update.associations?.funding?.some((f) => f.uid?.toLowerCase() === grantUidLower)
+    );
+  }, [rawData, grantUid]);
+}


### PR DESCRIPTION
## Summary

The grant milestones-and-updates page short-circuits to an empty state when the grant itself has no milestones and no grant-updates. Project activities (updates) linked to that grant via `associations.funding` were never shown — even though the project page (`?filter=updates`) correctly displayed them.

Example: https://www.karmahq.xyz/project/greenpill-dev-guild/funding/0xea21ef9e1c39915de09540a2be592076a4bca421f033cbb9a9f430084020d39c/milestones-and-updates rendered empty while the Greenpill Dev Guild project page showed the "Dev Guild Brand Kit Contest" activity linked to the Giv-Arb grant.

## Problem

`components/Pages/Grants/MilestonesAndUpdates/index.tsx` computed `hasMilestonesOrUpdates` from `grant.milestones` and `grant.updates` only. When both were empty, `MilestonesList` (which already filtered project activities by grant uid) never rendered.

## Solution

- Extract the funding-association filter into a shared `useGrantLinkedActivities(projectId, grantUid)` hook that reuses the same React Query cache key as `useProjectUpdates`, so a single network request feeds both the project page and the grant page.
- Include the linked-activity count in the empty-state guard and in the "N Milestones, M Updates in this grant" header.
- Capitalize "Update" to match the existing "Milestone" wording.

## Testing Steps

- [ ] Visit `/project/greenpill-dev-guild/funding/0xea21ef9e1c39915de09540a2be592076a4bca421f033cbb9a9f430084020d39c/milestones-and-updates` — the "Dev Guild Brand Kit Contest" activity should now appear.
- [ ] Visit a grant that genuinely has no milestones, no updates, and no linked activities — the empty state should still render with the existing CTA for project owners.
- [ ] Visit a grant that has milestones — counts and lists should be unchanged.
- [ ] `yarn test hooks/v2/__tests__/useGrantLinkedActivities.test.tsx` — 4 passing.

## Risk

Low. The change is additive: a new hook plus a count addition to an OR-chain. No behavioral change for grants that already had milestones or grant-updates.