### PR TITLE
fix: render checkbox field options instead of single boolean

### DIFF
--- a/src/features/applications/components/ApplicationFormField.tsx
+++ b/src/features/applications/components/ApplicationFormField.tsx
@@ -268,17 +268,43 @@ export function ApplicationFormField({
 
           case "checkbox":
             return (
-              <div className="flex items-center gap-2" data-field-id={question.id}>
-                <Checkbox
-                  checked={!!field.value}
-                  onCheckedChange={(checked) => field.onChange(checked)}
-                  disabled={disabled}
-                  id={question.id}
-                />
-                <Label htmlFor={question.id} className="cursor-pointer">
+              <div className="w-full flex flex-col gap-2" data-field-id={question.id}>
+                <Label>
                   {question.label}
                   {question.required && <span className="text-destructive ml-0.5">*</span>}
                 </Label>
+                {question.description && (
+                  <FieldDescription source={question.description as string} />
+                )}
+                <div className="space-y-2 rounded-md border border-input p-3">
+                  {question.options?.map((option) => {
+                    const values = (field.value as string[]) || [];
+                    const isChecked = values.includes(option.value);
+                    return (
+                      <div key={option.value} className="flex items-center gap-2 cursor-pointer">
+                        <Checkbox
+                          id={`${question.id}-${option.value}`}
+                          checked={isChecked}
+                          onCheckedChange={(checked) => {
+                            const current = (field.value as string[]) || [];
+                            if (checked) {
+                              field.onChange([...current, option.value]);
+                            } else {
+                              field.onChange(current.filter((v) => v !== option.value));
+                            }
+                          }}
+                          disabled={disabled}
+                        />
+                        <label
+                          htmlFor={`${question.id}-${option.value}`}
+                          className="text-sm cursor-pointer"
+                        >
+                          {option.label}
+                        </label>
+                      </div>
+                    );
+                  })}
+                </div>
                 {error && <p className="text-sm text-destructive">{error}</p>}
               </div>
             );

--- a/src/features/applications/components/ApplicationFormField.tsx
+++ b/src/features/applications/components/ApplicationFormField.tsx
@@ -61,7 +61,7 @@ function MultiOptionCheckboxGroup({
         {question.required && <span className="text-destructive ml-0.5">*</span>}
       </Label>
       {question.description && <FieldDescription source={question.description as string} />}
-      <div className="space-y-2 rounded-md border border-input p-3">
+      <div className="space-y-2">
         {question.options?.map((option) => (
           <div key={option.value} className="flex items-center gap-2">
             <Checkbox

--- a/src/features/applications/components/ApplicationFormField.tsx
+++ b/src/features/applications/components/ApplicationFormField.tsx
@@ -29,6 +29,58 @@ function FieldDescription({ source }: { source: string }) {
   );
 }
 
+interface MultiOptionCheckboxGroupProps {
+  question: ApplicationQuestion;
+  value: unknown;
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  error?: string;
+}
+
+function MultiOptionCheckboxGroup({
+  question,
+  value,
+  onChange,
+  disabled,
+  error,
+}: MultiOptionCheckboxGroupProps) {
+  const selected: string[] = Array.isArray(value) ? value : [];
+
+  const toggleOption = (optionValue: string, checked: boolean) => {
+    if (checked) {
+      onChange([...selected, optionValue]);
+    } else {
+      onChange(selected.filter((v) => v !== optionValue));
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col gap-2" data-field-id={question.id}>
+      <Label>
+        {question.label}
+        {question.required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      {question.description && <FieldDescription source={question.description as string} />}
+      <div className="space-y-2 rounded-md border border-input p-3">
+        {question.options?.map((option) => (
+          <div key={option.value} className="flex items-center gap-2">
+            <Checkbox
+              id={`${question.id}-${option.value}`}
+              checked={selected.includes(option.value)}
+              onCheckedChange={(checked) => toggleOption(option.value, checked === true)}
+              disabled={disabled}
+            />
+            <label htmlFor={`${question.id}-${option.value}`} className="text-sm cursor-pointer">
+              {option.label}
+            </label>
+          </div>
+        ))}
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}
+
 export function ApplicationFormField({
   question,
   control,
@@ -179,46 +231,15 @@ export function ApplicationFormField({
             );
 
           case "multiselect":
+          case "checkbox":
             return (
-              <div className="w-full flex flex-col gap-2" data-field-id={question.id}>
-                <Label>
-                  {question.label}
-                  {question.required && <span className="text-destructive ml-0.5">*</span>}
-                </Label>
-                {question.description && (
-                  <FieldDescription source={question.description as string} />
-                )}
-                <div className="space-y-2 rounded-md border border-input p-3">
-                  {question.options?.map((option) => {
-                    const values = (field.value as string[]) || [];
-                    const isChecked = values.includes(option.value);
-                    return (
-                      <div key={option.value} className="flex items-center gap-2 cursor-pointer">
-                        <Checkbox
-                          id={`${question.id}-${option.value}`}
-                          checked={isChecked}
-                          onCheckedChange={(checked) => {
-                            const current = (field.value as string[]) || [];
-                            if (checked) {
-                              field.onChange([...current, option.value]);
-                            } else {
-                              field.onChange(current.filter((v) => v !== option.value));
-                            }
-                          }}
-                          disabled={disabled}
-                        />
-                        <label
-                          htmlFor={`${question.id}-${option.value}`}
-                          className="text-sm cursor-pointer"
-                        >
-                          {option.label}
-                        </label>
-                      </div>
-                    );
-                  })}
-                </div>
-                {error && <p className="text-sm text-destructive">{error}</p>}
-              </div>
+              <MultiOptionCheckboxGroup
+                question={question}
+                value={field.value}
+                onChange={field.onChange}
+                disabled={disabled}
+                error={error}
+              />
             );
 
           case "date":
@@ -264,49 +285,6 @@ export function ApplicationFormField({
                 question={question}
                 disabled={disabled}
               />
-            );
-
-          case "checkbox":
-            return (
-              <div className="w-full flex flex-col gap-2" data-field-id={question.id}>
-                <Label>
-                  {question.label}
-                  {question.required && <span className="text-destructive ml-0.5">*</span>}
-                </Label>
-                {question.description && (
-                  <FieldDescription source={question.description as string} />
-                )}
-                <div className="space-y-2 rounded-md border border-input p-3">
-                  {question.options?.map((option) => {
-                    const values = (field.value as string[]) || [];
-                    const isChecked = values.includes(option.value);
-                    return (
-                      <div key={option.value} className="flex items-center gap-2 cursor-pointer">
-                        <Checkbox
-                          id={`${question.id}-${option.value}`}
-                          checked={isChecked}
-                          onCheckedChange={(checked) => {
-                            const current = (field.value as string[]) || [];
-                            if (checked) {
-                              field.onChange([...current, option.value]);
-                            } else {
-                              field.onChange(current.filter((v) => v !== option.value));
-                            }
-                          }}
-                          disabled={disabled}
-                        />
-                        <label
-                          htmlFor={`${question.id}-${option.value}`}
-                          className="text-sm cursor-pointer"
-                        >
-                          {option.label}
-                        </label>
-                      </div>
-                    );
-                  })}
-                </div>
-                {error && <p className="text-sm text-destructive">{error}</p>}
-              </div>
             );
 
           case "radio": {

--- a/src/features/applications/lib/form-utils.ts
+++ b/src/features/applications/lib/form-utils.ts
@@ -132,7 +132,7 @@ export function transformDataForDisplay(
           mappedData[q.id] = "";
           break;
         case "checkbox":
-          mappedData[q.id] = false;
+          mappedData[q.id] = [];
           break;
         default:
           break;

--- a/src/features/applications/lib/form-utils.ts
+++ b/src/features/applications/lib/form-utils.ts
@@ -120,6 +120,12 @@ export function transformDataForDisplay(
   const mappedData = mapLabelsToFields(apiData, questions);
 
   for (const q of questions) {
+    if (q.type === "checkbox" && !Array.isArray(mappedData[q.id])) {
+      // Pre-fix data stored checkbox as a boolean; reset to empty selection
+      // since there are no options to map the old boolean onto.
+      mappedData[q.id] = [];
+      continue;
+    }
     if (!(q.id in mappedData)) {
       switch (q.type) {
         case "text":
@@ -130,9 +136,6 @@ export function transformDataForDisplay(
         case "select":
         case "radio":
           mappedData[q.id] = "";
-          break;
-        case "checkbox":
-          mappedData[q.id] = [];
           break;
         default:
           break;


### PR DESCRIPTION
## Summary

- The `checkbox` case in `ApplicationFormField` rendered a single boolean checkbox using the question label, ignoring `question.options` — so a multi-option checkbox configured in QuestionBuilder appeared on the application form as just one checkbox with the question title next to it.
- Aligned the renderer with the rest of the stack (`buildMultiselectSchema`, `ApplicationSubmission`, `QuestionFormRenderer`): one `<Checkbox>` per option, value is `string[]`.
- Default missing checkbox data to `[]` (not `false`) in `form-utils.ts` to match the schema shape.

## Changes

- `src/features/applications/components/ApplicationFormField.tsx` — checkbox case mirrors the `multiselect` case.
- `src/features/applications/lib/form-utils.ts` — checkbox default is `[]`.

## Test plan

- [ ] Build a form in QuestionBuilder with a `checkbox` field containing multiple options.
- [ ] Open the application form as an applicant; verify each option renders as its own checkbox under the question label.
- [ ] Select one or more options and submit; verify the submitted value is an array of the selected option values.
- [ ] Reopen a draft / resubmission where checkbox values were previously stored as an array; verify checked state restores correctly.
- [ ] Reopen a draft where the checkbox field was missing; verify it defaults to no selections (no validation error for non-required fields).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application form checkboxes now support selecting multiple options simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->