### PR TITLE
fix(sitemap): align /sitemap.xml response with Google's sitemap-index parser

### DIFF
--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -97,6 +97,32 @@ describe("app/sitemap.xml/route.ts — sitemap index GET handler", () => {
     expect(xml).toContain(`${SITE_URL}/sitemaps/funding-programs/sitemap/1.xml`);
   });
 
+  it("emits <lastmod> values without fractional seconds (Google parser strictness)", async () => {
+    mockFetchSitemapCounts.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/sitemap.xml/route");
+    const res = await GET();
+    const xml = await res.text();
+
+    const lastmodMatches = xml.match(/<lastmod>([^<]+)<\/lastmod>/g) ?? [];
+    expect(lastmodMatches.length).toBeGreaterThan(0);
+    for (const tag of lastmodMatches) {
+      expect(tag).not.toMatch(/\.\d{3}Z/);
+      expect(tag).toMatch(/<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z<\/lastmod>/);
+    }
+  });
+
+  it("sets Content-Type, Content-Disposition, and Cache-Control matching child sitemaps", async () => {
+    mockFetchSitemapCounts.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/sitemap.xml/route");
+    const res = await GET();
+
+    expect(res.headers.get("Content-Type")).toBe("application/xml");
+    expect(res.headers.get("Content-Disposition")).toBe("inline");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+  });
+
   it("falls back to 1 chunk per kind when fetchSitemapCounts returns null", async () => {
     mockFetchSitemapCounts.mockResolvedValue(null);
 

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -9,8 +9,15 @@ interface SitemapEntry {
   lastmod: string;
 }
 
+function formatLastmod(date: Date): string {
+  // W3C Datetime without fractional seconds — Google's sitemap parser is
+  // strict here and has been observed to reject the default ISO 8601 form
+  // with milliseconds (e.g. "2026-05-18T16:08:48.340Z").
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
 function buildSitemapIndex(entries: SitemapEntry[]): string {
-  const now = new Date().toISOString();
+  const now = formatLastmod(new Date());
   const items = entries
     .map(
       (e) =>
@@ -22,7 +29,7 @@ function buildSitemapIndex(entries: SitemapEntry[]): string {
 }
 
 export async function GET(): Promise<Response> {
-  const now = new Date().toISOString();
+  const now = formatLastmod(new Date());
   const entries: SitemapEntry[] = [];
 
   // Static pages sitemap
@@ -80,8 +87,13 @@ export async function GET(): Promise<Response> {
 
   return new Response(xml, {
     headers: {
-      "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      // Match the headers Next.js emits for the child sitemaps under
+      // app/sitemaps/*/sitemap.ts. The previous "application/xml; charset=utf-8"
+      // caused GSC to classify this file as Type=Unknown and report
+      // "Couldn't fetch" even though the XML validated against siteindex.xsd.
+      "Content-Type": "application/xml",
+      "Content-Disposition": "inline",
+      "Cache-Control": "public, max-age=0, must-revalidate",
     },
   });
 }


### PR DESCRIPTION
## Summary

Google Search Console has been reporting **"Couldn't fetch"** / **Type=Unknown** for `https://www.karmahq.xyz/sitemap.xml` for over a week, even though:

- The XML validates against the official `siteindex.xsd`
- `curl` as Googlebot returns 200 OK with valid content
- URL Inspection on the same URL reports `Page fetch: Successful`
- Every **child** sitemap under `/sitemaps/*/sitemap.xml` is read successfully by GSC (just submitted `/sitemaps/static/sitemap.xml` → "Success, 36 pages")

The two observable differences between the working children (generated by Next.js's native `MetadataRoute.Sitemap` pipeline) and the hand-rolled index handler are HTTP response headers and the `<lastmod>` format.

## Changes

`app/sitemap.xml/route.ts`:

- `Content-Type`: drop `; charset=utf-8` → bare `application/xml` (matches children)
- Add `Content-Disposition: inline` (children send it)
- `Cache-Control`: switch to `public, max-age=0, must-revalidate` (children's value)
- `<lastmod>`: drop milliseconds — strip `.NNN` from the ISO 8601 string. Google's sitemap parser has been observed to reject the default `2026-05-18T16:08:48.340Z` form.

ISR is still active via `export const revalidate = 3600`, so origin load is unchanged.

## Honest confidence

**~60-70%.** This is the best-supported hypothesis from the data we have, but it's not proven — GSC doesn't expose its parser's error reason and Vercel edge cache means we couldn't reproduce a divergent server response. If GSC still fails 24h after deploy, the next step is adding instrumentation (or moving to Next.js's native sitemap-index generation) to capture the actual response Google receives.

## Test plan

- [x] `pnpm exec vitest run __tests__/app/sitemap.test.ts` — 20/20 pass
- [x] `pnpm exec biome check app/sitemap.xml/route.ts` — clean
- [ ] After deploy: curl `https://www.karmahq.xyz/sitemap.xml` and confirm new headers (`application/xml`, `content-disposition: inline`, `max-age=0`)
- [ ] In GSC: remove the failing `/sitemap.xml` row, resubmit, wait 24h, verify Status flips to **Success** and Type to **Sitemap index**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap timestamp formatting for consistency and better compatibility with web standards.

* **Chores**
  * Updated sitemap HTTP headers and caching directives for optimal browser and search engine behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->