### PR TITLE
fix(sitemap): bound counts fetch with timeout, extend maxDuration

### DIFF
--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -116,6 +116,19 @@ describe("app/sitemap.xml/route.ts — sitemap index GET handler", () => {
     expect(xml).toContain(`${SITE_URL}/sitemaps/communities/sitemap.xml`);
   }, 10000);
 
+  it("returns a valid sitemapindex when fetchSitemapCounts rejects (error fallback)", async () => {
+    mockFetchSitemapCounts.mockRejectedValue(new Error("upstream boom"));
+
+    const { GET } = await import("@/app/sitemap.xml/route");
+    const res = await GET();
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain("<sitemapindex");
+    expect(xml).toContain(`${SITE_URL}/sitemaps/static/sitemap.xml`);
+    expect(xml).toContain(`${SITE_URL}/sitemaps/communities/sitemap.xml`);
+  });
+
   it("emits <lastmod> values without fractional seconds (Google parser strictness)", async () => {
     mockFetchSitemapCounts.mockResolvedValue(null);
 

--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -97,6 +97,25 @@ describe("app/sitemap.xml/route.ts — sitemap index GET handler", () => {
     expect(xml).toContain(`${SITE_URL}/sitemaps/funding-programs/sitemap/1.xml`);
   });
 
+  it("returns a valid sitemapindex even if fetchSitemapCounts hangs (timeout fallback)", async () => {
+    // Never resolves — simulates a stalled indexer call.
+    mockFetchSitemapCounts.mockImplementation(() => new Promise(() => {}));
+
+    const { GET } = await import("@/app/sitemap.xml/route");
+    const start = Date.now();
+    const res = await GET();
+    const elapsed = Date.now() - start;
+    const xml = await res.text();
+
+    // Should resolve well under the function's maxDuration thanks to the
+    // 4s internal timeout in withTimeout.
+    expect(elapsed).toBeLessThan(8000);
+    expect(res.status).toBe(200);
+    expect(xml).toContain("<sitemapindex");
+    expect(xml).toContain(`${SITE_URL}/sitemaps/static/sitemap.xml`);
+    expect(xml).toContain(`${SITE_URL}/sitemaps/communities/sitemap.xml`);
+  }, 10000);
+
   it("emits <lastmod> values without fractional seconds (Google parser strictness)", async () => {
     mockFetchSitemapCounts.mockResolvedValue(null);
 

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -3,10 +3,28 @@ import type { SitemapKind } from "@/utilities/sitemap";
 import { computeChunkCount, fetchSitemapCounts, SITEMAP_PAGE_SIZE } from "@/utilities/sitemap";
 
 export const revalidate = 3600;
+// Cold starts can push the upstream counts fetch close to Vercel's default 10s
+// limit. Allow more headroom so a slow indexer round-trip never produces a
+// 504 — Googlebot interprets that as "Couldn't fetch".
+export const maxDuration = 30;
+
+const COUNTS_TIMEOUT_MS = 4000;
 
 interface SitemapEntry {
   loc: string;
   lastmod: string;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function formatLastmod(date: Date): string {
@@ -38,8 +56,11 @@ export async function GET(): Promise<Response> {
   // Communities sitemap (single file, not chunked)
   entries.push({ loc: `${SITE_URL}/sitemaps/communities/sitemap.xml`, lastmod: now });
 
-  // Chunked sitemaps — fetch counts to know how many chunks per kind
-  const counts = await fetchSitemapCounts();
+  // Chunked sitemaps — fetch counts to know how many chunks per kind. Bound
+  // the call so a slow indexer cannot stall the response past Googlebot's
+  // patience. On timeout, fall back to null and chunk counts default to 0
+  // (static + communities entries still render).
+  const counts = await withTimeout(fetchSitemapCounts(), COUNTS_TIMEOUT_MS, null);
 
   const kindConfig: Array<{
     kind: SitemapKind;

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -17,11 +17,12 @@ interface SitemapEntry {
 
 async function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const guardedPromise = promise.catch(() => fallback);
   const timeout = new Promise<T>((resolve) => {
     timer = setTimeout(() => resolve(fallback), ms);
   });
   try {
-    return await Promise.race([promise, timeout]);
+    return await Promise.race([guardedPromise, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary
Make `/sitemap.xml` resilient to cold starts and slow upstream so Googlebot never sees a 504.

## Problem
After #1446 shipped, the sitemap-index file is *correct* (200, right headers, milliseconds-free `<lastmod>`) but GSC still shows \"Couldn't fetch\". One smoking gun: the first prod request after deploy returned **`x-vercel-error: FUNCTION_INVOCATION_TIMEOUT`**. The route awaits `fetchSitemapCounts()` against the indexer on every ISR revalidation; a cold Vercel function plus a slow indexer round-trip can blow past Googlebot's fetch budget.

## Solution
1. Wrap `fetchSitemapCounts()` in a 4s timeout that falls back to `null`. Chunk counts then default to 0, while the always-required static + communities entries still render.
2. Bump `maxDuration` to 30s so the function has headroom on cold start.

Either alone reduces the timeout risk; together they make 504 essentially impossible.

## Testing
- New unit test simulates a hanging `fetchSitemapCounts()` and asserts the route still resolves in <8s with a valid `<sitemapindex>`.
- All 23 existing + new tests pass locally.
- `biome check` clean on touched files, `tsc --noEmit` clean.

## Risk
Low. Worst case after a timeout: the index serves only the static + communities child sitemaps for that revalidation (the next ISR cycle will pick up the chunks again). Far better than returning 504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout protection to sitemap generation to ensure requests complete within a bounded time window, even if background data fetches stall. If data retrieval exceeds the timeout, sitemaps gracefully fall back to default values.

* **Tests**
  * Added test coverage for sitemap timeout scenarios, verifying successful completion with valid response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->