### PR TITLE
fix(markdown-editor): guard editor id against invalid CSS selector

### DIFF
--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -117,6 +117,11 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   // setValue→onChange→re-render cycle that trips React's max-update-depth.
   const safeValue = value ?? "";
 
+  // md-editor-rt builds `#${id} .cm-scroller` and runs querySelector on it.
+  // CSS identifiers can't start with a digit, so an id like "21_project_summary"
+  // (derived from a label like "21. Project Summary") throws SyntaxError.
+  const safeId = id && /^[0-9]/.test(id) ? `_${id}` : id;
+
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
@@ -200,7 +205,10 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
       {/* Header with label and preview toggle */}
       <div className="flex items-center justify-between mb-2">
         {label && (
-          <label htmlFor={id} className="block text-sm font-bold text-black dark:text-zinc-100">
+          <label
+            htmlFor={safeId}
+            className="block text-sm font-bold text-black dark:text-zinc-100"
+          >
             {label} {isRequired && <span className="text-red-500">*</span>}
           </label>
         )}
@@ -250,7 +258,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
           </div>
         ) : (
           <MdEditor
-            id={id}
+            id={safeId}
             className={cn(
               "flex-1",
               error && "border-red-500 dark:border-red-500",


### PR DESCRIPTION
## Summary

The Edit Application modal crashes with a `SyntaxError` when a form field's label starts with a digit (e.g. `"21. Project Summary"`):

```
SyntaxError: Failed to execute 'querySelector' on 'Element':
'#21_project_summary .cm-scroller' is not a valid selector.
```

## Root cause

`md-editor-rt` (used by `MarkdownEditor`) internally builds `` `#${id} .cm-scroller` `` and runs `querySelector` on it. `ApplicationSubmission.toFieldName("21. Project Summary")` produces `21_project_summary`, but CSS identifiers cannot start with a digit, so the selector throws.

## Fix

In `components/Utilities/MarkdownEditor.tsx`, derive a `safeId` that prepends `_` only when the incoming `id` starts with a digit, and use it for both the `<label htmlFor>` and the underlying `MdEditor`. Localised to the DOM id — form keys, validation schema, `findOriginalKey` matching, `data-field-id`, and previously-submitted application data are all untouched.

## Test plan

- [ ] Open an application whose form has a field label beginning with a digit (e.g. `21. Project Summary`)
- [ ] Click "Edit Application" (or navigate with `?edit=true`) — the modal opens without console errors
- [ ] The MarkdownEditor for that field renders, is editable, and `Edit/Preview` toggle works
- [ ] Clicking the field label focuses the editor (label `htmlFor` still binds)
- [ ] Submit the edit — payload keys remain human-readable labels (no `_`-prefixed keys leak into saved data)
- [ ] Regression check: applications whose labels do **not** start with a digit behave exactly as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown editor to correctly handle IDs that start with a numeric character.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->