### PR TITLE
test(markdown-editor): regression coverage for digit-leading id fix

### DIFF
--- a/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.digit-leading-id.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.digit-leading-id.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @file Integration regression coverage for PR #1451.
+ *
+ * Opening the Edit Application modal threw `SyntaxError` whenever a textarea
+ * field's label started with a digit (e.g. `"21. Project Summary"`):
+ *   `toFieldName("21. Project Summary")` → `"21_project_summary"`, which
+ *   `MarkdownEditor` passed straight to `md-editor-rt`, whose internal
+ *   `document.querySelector('#${id} .cm-scroller')` rejected the digit-leading
+ *   selector and tore down the modal. The fix lives in `MarkdownEditor`
+ *   (covered by unit tests in `__tests__/components/Utilities/`); this file
+ *   pins the wiring at the `ApplicationSubmission` boundary so a future
+ *   refactor can't reintroduce the bug via a different path.
+ *
+ * These tests live in their own file (rather than appending to the very large
+ * `ApplicationSubmission.test.tsx`) to avoid tripping the oversized-file
+ * quality gate.
+ */
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import ApplicationSubmission from "@/components/FundingPlatform/ApplicationView/ApplicationSubmission";
+import type { IFormSchema } from "@/types/funding-platform";
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({
+    address: "0x1234567890123456789012345678901234567890",
+  }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/Utilities/Button", () => ({
+  Button: ({ children, onClick, disabled, type, isLoading, ...props }: any) => (
+    <button
+      onClick={onClick}
+      disabled={disabled || isLoading}
+      type={type}
+      data-testid={props["data-testid"] || "button"}
+      {...props}
+    >
+      {isLoading ? "Loading..." : children}
+    </button>
+  ),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: "light",
+    setTheme: vi.fn(),
+    resolvedTheme: "light",
+  }),
+}));
+
+// Mock MarkdownEditor — echo the `id` prop into a data-testid so we can
+// assert ApplicationSubmission is wiring it correctly. The fix itself is
+// covered by the real MarkdownEditor's unit tests.
+vi.mock("@/components/Utilities/MarkdownEditor", () => ({
+  MarkdownEditor: ({
+    label,
+    value,
+    onChange,
+    onBlur,
+    error,
+    description,
+    isRequired,
+    isDisabled,
+    placeholder,
+    id,
+  }: any) => (
+    <div>
+      {label && (
+        <label htmlFor={id}>
+          {label} {isRequired && <span className="text-red-500">*</span>}
+        </label>
+      )}
+      {description && <p>{description}</p>}
+      <textarea
+        id={id}
+        value={value || ""}
+        onChange={(e) => onChange?.(e.target.value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        disabled={isDisabled}
+        data-testid={`markdown-editor-${id}`}
+      />
+      {error && <p className="text-sm text-red-400 mt-1">{error}</p>}
+    </div>
+  ),
+}));
+
+describe("ApplicationSubmission — digit-leading textarea label (PR #1451 regression)", () => {
+  const digitLabelSchema: IFormSchema = {
+    title: "Test Form",
+    fields: [
+      {
+        id: "field-1",
+        type: "textarea",
+        label: "21. Project Summary",
+        required: false,
+        validation: {},
+      },
+    ],
+  };
+
+  const defaultProps = {
+    programId: "program-123",
+    chainId: 1,
+    formSchema: digitLabelSchema,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render edit modal without throwing for digit-leading textarea label", () => {
+    const initialData = { "21_project_summary": "Existing answer" };
+
+    expect(() =>
+      render(
+        <ApplicationSubmission {...defaultProps} initialData={initialData} isEditMode={true} />
+      )
+    ).not.toThrow();
+  });
+
+  it("should pre-fill the digit-leading textarea from transformed-key initialData", async () => {
+    const initialData = { "21_project_summary": "Existing answer" };
+
+    render(<ApplicationSubmission {...defaultProps} initialData={initialData} isEditMode={true} />);
+
+    await waitFor(() => {
+      const input = screen.getByLabelText(/21\. Project Summary/i) as HTMLTextAreaElement;
+      expect(input.value).toBe("Existing answer");
+    });
+  });
+
+  it("should pass the digit-leading id through to MarkdownEditor without mutating it", async () => {
+    // ApplicationSubmission must keep passing the raw transformed fieldName so
+    // MarkdownEditor receives it and can apply its safe-id guard. If
+    // ApplicationSubmission ever starts stripping the digit itself, the unit
+    // tests on MarkdownEditor would still pass but the wiring would be broken.
+    render(<ApplicationSubmission {...defaultProps} isEditMode={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-editor-21_project_summary")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/Utilities/MarkdownEditor.test.tsx
+++ b/__tests__/components/Utilities/MarkdownEditor.test.tsx
@@ -344,4 +344,84 @@ describe("MarkdownEditor", () => {
       expect(button).toHaveAttribute("aria-label", "Show preview");
     });
   });
+
+  // Regression tests for PR #1451 — md-editor-rt builds `#${id} .cm-scroller`
+  // and runs querySelector on it. CSS identifiers can't start with a digit,
+  // so an id like "21_project_summary" (derived from a form field labelled
+  // "21. Project Summary") would crash the Edit Application modal with a
+  // SyntaxError. The component prefixes a `_` only when the id starts with
+  // a digit, and uses the same safe id for both `label htmlFor` and the
+  // underlying MdEditor so the label/control binding stays intact.
+  describe("Safe ID Handling (digit-leading ids)", () => {
+    it("should prefix the underlying editor id with `_` when the id starts with a digit", () => {
+      render(<MarkdownEditor label="21. Project Summary" id="21_project_summary" />);
+
+      const textarea = screen.getByTestId("md-editor-textarea");
+      expect(textarea).toHaveAttribute("id", "_21_project_summary");
+    });
+
+    it("should prefix the label htmlFor with `_` when the id starts with a digit", () => {
+      render(<MarkdownEditor label="21. Project Summary" id="21_project_summary" />);
+
+      const label = screen.getByText(/21\. Project Summary/);
+      expect(label).toHaveAttribute("for", "_21_project_summary");
+    });
+
+    it("should keep label htmlFor and editor id in sync when prefixed", () => {
+      render(<MarkdownEditor label="9 Lives" id="9_lives" />);
+
+      const label = screen.getByText(/9 Lives/);
+      const textarea = screen.getByTestId("md-editor-textarea");
+
+      const labelFor = label.getAttribute("for");
+      const editorId = textarea.getAttribute("id");
+      expect(labelFor).toBe(editorId);
+      expect(labelFor).toBe("_9_lives");
+    });
+
+    it("should not prefix the id when it starts with a letter", () => {
+      render(<MarkdownEditor label="Project Summary" id="project_summary" />);
+
+      const textarea = screen.getByTestId("md-editor-textarea");
+      const label = screen.getByText("Project Summary");
+      expect(textarea).toHaveAttribute("id", "project_summary");
+      expect(label).toHaveAttribute("for", "project_summary");
+    });
+
+    it("should not prefix the id when it starts with an underscore", () => {
+      render(<MarkdownEditor label="Hidden" id="_already_safe" />);
+
+      const textarea = screen.getByTestId("md-editor-textarea");
+      expect(textarea).toHaveAttribute("id", "_already_safe");
+    });
+
+    it.each([
+      ["0_zero_indexed", "_0_zero_indexed"],
+      ["1question", "_1question"],
+      ["42-answer", "_42-answer"],
+      ["9", "_9"],
+    ])("should prefix `%s` to `%s`", (input, expected) => {
+      render(<MarkdownEditor label="Field" id={input} />);
+
+      const textarea = screen.getByTestId("md-editor-textarea");
+      expect(textarea).toHaveAttribute("id", expected);
+    });
+
+    it("should produce an id that is a valid CSS selector when prefixed", () => {
+      render(<MarkdownEditor label="21. Project Summary" id="21_project_summary" />);
+
+      const textarea = screen.getByTestId("md-editor-textarea");
+      const editorId = textarea.getAttribute("id");
+      expect(editorId).toBeTruthy();
+
+      // The whole point of the fix: `document.querySelector(`#${editorId} .cm-scroller`)`
+      // must NOT throw the SyntaxError that md-editor-rt's internal call raised
+      // when ids started with a digit.
+      expect(() => document.querySelector(`#${editorId} .cm-scroller`)).not.toThrow();
+    });
+
+    it("should not crash when no id is supplied", () => {
+      expect(() => render(<MarkdownEditor label="No id field" />)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds regression coverage for the fix landed in #1451. The Edit Application modal crashed with a `SyntaxError` whenever a form field's label started with a digit (e.g. `"21. Project Summary"`), because `md-editor-rt` internally runs `querySelector('#${id} .cm-scroller')` and CSS identifiers can't start with a digit. `MarkdownEditor` was updated to prefix a `_` only when the id begins with a digit and to use the same safe id for both `label htmlFor` and the underlying `MdEditor`. No tests were added at the time, so a future revert would land silently.

## What this adds

Two new `describe` blocks, no production-code changes:

**`MarkdownEditor.test.tsx` — Safe ID Handling (digit-leading ids)** (11 cases)
- digit-leading ids get a `_` prefix on both the label `htmlFor` and the editor id
- `htmlFor` and editor id stay in sync (label/control binding intact)
- non-digit and underscore-leading ids pass through unchanged
- parameterised cases (`0_zero_indexed`, `1question`, `42-answer`, `9`)
- `document.querySelector('#${safeId} .cm-scroller')` does **not** throw — the exact assertion the bug violated
- omitted id does not crash

**`ApplicationSubmission.test.tsx` — Textarea with digit-leading label (PR #1451 regression)** (3 cases)
- edit modal renders without throwing for a digit-leading textarea label
- pre-fills from transformed-key initialData (`21_project_summary`)
- raw digit-leading `fieldName` is passed through to `MarkdownEditor` — locks the wiring at the integration boundary so a future refactor of `ApplicationSubmission` can't reintroduce the bug via a different path

## Verification

- All 39 tests in `MarkdownEditor.test.tsx` pass with the fix in place
- All 99 tests in `ApplicationSubmission.test.tsx` pass
- Manually verified the new MarkdownEditor tests **fail** when the `safeId` line is reverted to the plain `id`, including the `querySelector` assertion that matches the original production failure
- Biome lint clean on both files

## Test plan

- [ ] CI green on `test/markdown-editor-safe-id-regression`
- [ ] (Optional) Locally revert `safeId` to `id` in `MarkdownEditor.tsx` and confirm at least 8 of the new tests fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests ensuring application submission fields with numeric-leading labels (e.g., "21. Project Summary") render and pre-fill correctly.
  * Added regression tests verifying markdown editor handles IDs starting with digits and maintains CSS selector compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->