### PR TITLE
feat(applications): require funding requested & completion criteria on milestones

### DIFF
--- a/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
@@ -284,8 +284,8 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
             title: z.string().min(1, "Milestone title is required"),
             description: z.string().min(1, "Milestone description is required"),
             dueDate: z.string().min(1, "Due date is required"),
-            fundingRequested: z.string().optional(),
-            completionCriteria: z.string().optional(),
+            fundingRequested: z.string().min(1, "Funding requested is required"),
+            completionCriteria: z.string().min(1, "Completion criteria is required"),
           });
 
           // Build array schema with min/max validations

--- a/components/FundingPlatform/FormFields/MilestoneInput.tsx
+++ b/components/FundingPlatform/FormFields/MilestoneInput.tsx
@@ -183,14 +183,15 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
                 }}
               />
 
-              {/* Funding Requested - Optional */}
+              {/* Funding Requested */}
               <Controller
                 name={`${fieldKey}.${index}.fundingRequested`}
                 control={control}
+                rules={{ required: "Funding requested is required" }}
                 render={({ field: fundingField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-fundingRequested`} className={labelStyle}>
-                      Funding Requested (Optional)
+                      Funding Requested *
                     </label>
                     <input
                       {...fundingField}
@@ -210,19 +211,20 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
                 )}
               />
 
-              {/* Completion Criteria - Optional */}
+              {/* Completion Criteria */}
               <Controller
                 name={`${fieldKey}.${index}.completionCriteria`}
                 control={control}
+                rules={{ required: "Completion criteria is required" }}
                 render={({ field: criteriaField, fieldState }) => (
                   <MarkdownEditor
-                    label="Completion Criteria (Optional)"
+                    label="Completion Criteria"
                     placeholder="Define criteria for milestone completion"
                     value={criteriaField.value || ""}
                     onChange={criteriaField.onChange}
                     onBlur={criteriaField.onBlur}
                     error={fieldState.error?.message}
-                    isRequired={false}
+                    isRequired
                     isDisabled={isLoading}
                     id={`${fieldKey}-${index}-completionCriteria`}
                     height={150}

--- a/components/FundingPlatform/FormFields/__tests__/MilestoneInput.test.tsx
+++ b/components/FundingPlatform/FormFields/__tests__/MilestoneInput.test.tsx
@@ -120,9 +120,9 @@ describe("MilestoneInput Component", () => {
       const addButton = screen.getByRole("button", { name: /add milestone/i });
       fireEvent.click(addButton);
 
-      expect(screen.getByLabelText(/funding requested \(optional\)/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/funding requested \*/i)).toBeInTheDocument();
       // MarkdownEditor doesn't have proper label association, check for label text
-      expect(screen.getByText(/completion criteria \(optional\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/^completion criteria$/i)).toBeInTheDocument();
     });
 
     it("should accept text input for funding requested field", () => {
@@ -131,7 +131,7 @@ describe("MilestoneInput Component", () => {
       const addButton = screen.getByRole("button", { name: /add milestone/i });
       fireEvent.click(addButton);
 
-      const fundingInput = screen.getByLabelText(/funding requested \(optional\)/i);
+      const fundingInput = screen.getByLabelText(/funding requested \*/i);
       fireEvent.change(fundingInput, { target: { value: "$5,000 USD" } });
 
       expect(fundingInput).toHaveValue("$5,000 USD");
@@ -143,7 +143,7 @@ describe("MilestoneInput Component", () => {
       const addButton = screen.getByRole("button", { name: /add milestone/i });
       fireEvent.click(addButton);
 
-      const fundingInput = screen.getByLabelText(/funding requested \(optional\)/i);
+      const fundingInput = screen.getByLabelText(/funding requested \*/i);
 
       const formats = ["$5,000", "5000", "5000 USD", "€5,000"];
 
@@ -290,11 +290,11 @@ describe("MilestoneInput Component", () => {
       const addButton = screen.getByRole("button", { name: /add milestone/i });
       fireEvent.click(addButton);
 
-      const fundingInput = screen.getByLabelText(/funding requested \(optional\)/i);
+      const fundingInput = screen.getByLabelText(/funding requested \*/i);
       expect(fundingInput).toHaveValue("");
 
       // MarkdownEditor doesn't have proper label association, just verify label exists
-      expect(screen.getByText(/completion criteria \(optional\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/^completion criteria$/i)).toBeInTheDocument();
     });
   });
 

--- a/components/QuestionBuilder/FieldEditor.tsx
+++ b/components/QuestionBuilder/FieldEditor.tsx
@@ -222,10 +222,7 @@ export function FieldEditor({
                 htmlFor="milestone-funding-requested"
                 className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
               >
-                Funding Requested{" "}
-                <span className="text-green-600 dark:text-green-400 text-xs font-normal">
-                  (Optional)
-                </span>
+                Funding Requested <span className="text-red-500">*</span>
               </label>
               <input
                 id="milestone-funding-requested"
@@ -241,10 +238,7 @@ export function FieldEditor({
                 htmlFor="milestone-completion-criteria"
                 className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
               >
-                Completion Criteria{" "}
-                <span className="text-green-600 dark:text-green-400 text-xs font-normal">
-                  (Optional)
-                </span>
+                Completion Criteria <span className="text-red-500">*</span>
               </label>
               <textarea
                 id="milestone-completion-criteria"

--- a/components/QuestionBuilder/QuestionFormRenderer.tsx
+++ b/components/QuestionBuilder/QuestionFormRenderer.tsx
@@ -251,7 +251,7 @@ export function QuestionFormRenderer({
                   htmlFor={`milestone-funding-requested-${index}`}
                   className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
                 >
-                  Funding Requested (Optional)
+                  Funding Requested *
                 </label>
                 <input
                   id={`milestone-funding-requested-${index}`}
@@ -269,7 +269,7 @@ export function QuestionFormRenderer({
                   htmlFor={`milestone-completion-criteria-${index}`}
                   className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
                 >
-                  Completion Criteria (Optional)
+                  Completion Criteria *
                 </label>
                 <textarea
                   id={`milestone-completion-criteria-${index}`}

--- a/src/features/applications/components/MilestoneItem.tsx
+++ b/src/features/applications/components/MilestoneItem.tsx
@@ -128,7 +128,7 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`milestone-funding-${index}`}>Funding Requested (Optional)</Label>
+        <Label htmlFor={`milestone-funding-${index}`}>Funding Requested *</Label>
         <Input
           id={`milestone-funding-${index}`}
           placeholder="e.g., $5,000 USD or 5000"
@@ -143,12 +143,12 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
       </div>
 
       <MarkdownEditor
-        label="Completion Criteria (Optional)"
+        label="Completion Criteria"
         placeholder="Define criteria for milestone completion"
         value={milestone.completionCriteria || ""}
         onChange={(value) => handleFieldChange("completionCriteria", value)}
         isDisabled={disabled}
-        isRequired={false}
+        isRequired
         error={errors?.completionCriteria?.message}
       />
 

--- a/src/features/applications/hooks/__tests__/use-application-form.test.tsx
+++ b/src/features/applications/hooks/__tests__/use-application-form.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Regression test for the milestone "errors flash on Add" bug.
+ *
+ * Background: RHF v7.62's useFieldArray has an internal useEffect that
+ * fires the resolver on the array path after every append/remove,
+ * gated on:
+ *
+ *   _actioned.current
+ *   && (!mode.isOnSubmit || isSubmitted)
+ *   && !reValidateMode.isOnSubmit
+ *
+ * With `mode: "onBlur"` (the previous default in this hook) the second
+ * condition was always true regardless of submission state — so
+ * appending an empty milestone instantly re-ran zod, which returned
+ * nested errors for every required sub-field. The fix here is to keep
+ * `mode: "onSubmit"`. This file pins both the absence of eager errors
+ * AND the proxyFormState invariant: nothing in this hook may
+ * re-subscribe to `isValid` / `isDirty`, since that also triggers
+ * resolver passes on every state mutation.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { useFieldArray } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import type { ApplicationQuestion } from "@/types/whitelabel-entities";
+import { useApplicationForm } from "../use-application-form";
+
+const milestoneQuestion: ApplicationQuestion = {
+  id: "milestones",
+  type: "milestone",
+  label: "Project Milestones",
+  required: true,
+  validation: { minMilestones: 1, maxMilestones: 5 },
+};
+
+function useApplicationFormWithMilestones() {
+  const form = useApplicationForm([milestoneQuestion]);
+  const fa = useFieldArray({ control: form.control, name: "milestones" as never });
+  return { form, fa };
+}
+
+describe("useApplicationForm — useFieldArray eager-validation guard", () => {
+  it("does not populate per-field errors when a milestone is appended before any submit", () => {
+    const { result } = renderHook(() => useApplicationFormWithMilestones());
+
+    // Sanity: no errors initially.
+    expect(result.current.form.formState.errors).toEqual({});
+
+    act(() => {
+      result.current.fa.append({
+        title: "",
+        description: "",
+        dueDate: "",
+        fundingRequested: "",
+        completionCriteria: "",
+      } as never);
+    });
+
+    // The fix: no error tree was populated for `milestones` on append.
+    // If `mode` ever flips back to `'onBlur'` (or anything other than
+    // 'onSubmit'), or if a future edit re-subscribes to isValid /
+    // isDirty, RHF's internal useFieldArray effect will fire the
+    // resolver here and this assertion fails.
+    expect(result.current.form.formState.errors.milestones).toBeUndefined();
+  });
+
+  it("does not populate errors when a milestone is removed before any submit", () => {
+    const { result } = renderHook(() => useApplicationFormWithMilestones());
+
+    act(() => {
+      result.current.fa.append({
+        title: "T",
+        description: "D",
+        dueDate: `${new Date().getFullYear() + 1}-01-01`,
+        fundingRequested: "$1",
+        completionCriteria: "Done",
+      } as never);
+    });
+
+    act(() => {
+      result.current.fa.remove(0);
+    });
+
+    expect(result.current.form.formState.errors.milestones).toBeUndefined();
+  });
+
+  it("still rejects an empty milestone when validation is explicitly triggered", async () => {
+    // Counterpart guarantee: the resolver still works — required
+    // sub-fields DO fail when validation is actually run.
+    const { result } = renderHook(() => useApplicationFormWithMilestones());
+
+    act(() => {
+      result.current.fa.append({
+        title: "",
+        description: "",
+        dueDate: "",
+        fundingRequested: "",
+        completionCriteria: "",
+      } as never);
+    });
+
+    let isValid: boolean | undefined;
+    await act(async () => {
+      isValid = await result.current.form.validateForm();
+    });
+
+    expect(isValid).toBe(false);
+  });
+});

--- a/src/features/applications/hooks/use-application-form.ts
+++ b/src/features/applications/hooks/use-application-form.ts
@@ -100,11 +100,6 @@ export function useApplicationForm(
         },
         {} as Record<string, string>
       ),
-      // Derived from errors map instead of subscribing to formState.isValid
-      // — see destructure comment above. Nothing downstream actually reads
-      // these (verified via grep), so a derived approximation is enough.
-      isValid: Object.keys(errors).length === 0,
-      isDirty: false,
     },
 
     updateField,

--- a/src/features/applications/hooks/use-application-form.ts
+++ b/src/features/applications/hooks/use-application-form.ts
@@ -20,7 +20,12 @@ export function useApplicationForm(
   const {
     control,
     handleSubmit,
-    formState: { errors, isDirty, isValid },
+    // Subscribe ONLY to `errors`. Reading `isValid` (or `isDirty`) from
+    // formState makes RHF run the resolver on every state change to keep
+    // those proxy props fresh — including useFieldArray.append, which
+    // would flag every required sub-field on a fresh milestone the moment
+    // the user clicked "Add Milestone", before they had a chance to type.
+    formState: { errors },
     setValue,
     getValues,
     trigger,
@@ -29,7 +34,13 @@ export function useApplicationForm(
   } = useForm<ApplicationFormData>({
     resolver: zodResolver(schema),
     defaultValues: options?.initialData || {},
-    mode: "onBlur",
+    // mode: 'onSubmit' — RHF's useFieldArray has an internal effect that
+    // fires the resolver on every append/remove whenever mode != 'onSubmit',
+    // regardless of submission state. That made clicking "Add Milestone"
+    // immediately flag every required sub-field on the new (empty) row.
+    // The custom Inputs/MarkdownEditor in MilestoneItem don't propagate
+    // onBlur to RHF anyway, so onBlur mode was a no-op in practice.
+    mode: "onSubmit",
   });
 
   useEffect(() => {
@@ -89,8 +100,11 @@ export function useApplicationForm(
         },
         {} as Record<string, string>
       ),
-      isValid,
-      isDirty,
+      // Derived from errors map instead of subscribing to formState.isValid
+      // — see destructure comment above. Nothing downstream actually reads
+      // these (verified via grep), so a derived approximation is enough.
+      isValid: Object.keys(errors).length === 0,
+      isDirty: false,
     },
 
     updateField,

--- a/src/features/applications/lib/schema-builders/__tests__/milestone-schema.test.ts
+++ b/src/features/applications/lib/schema-builders/__tests__/milestone-schema.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { ApplicationQuestion } from "@/types/whitelabel-entities";
+import { buildMilestoneSchema } from "../milestone-schema";
+
+const FUTURE_DATE = `${new Date().getFullYear() + 1}-01-01`;
+
+const baseQuestion: ApplicationQuestion = {
+  id: "milestones",
+  type: "milestone",
+  label: "Project Milestones",
+  required: true,
+};
+
+const validMilestone = {
+  title: "Ship MVP",
+  description: "Build and release the initial product",
+  dueDate: FUTURE_DATE,
+  fundingRequested: "$10,000 USD",
+  completionCriteria: "Production deploy + monitoring live",
+};
+
+describe("buildMilestoneSchema — required sub-fields", () => {
+  it("accepts a milestone with all required fields populated", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+
+    const result = schema.safeParse([validMilestone]);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a milestone with empty fundingRequested", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+
+    const result = schema.safeParse([{ ...validMilestone, fundingRequested: "" }]);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain("Funding requested is required");
+    }
+  });
+
+  it("rejects a milestone with empty completionCriteria", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+
+    const result = schema.safeParse([{ ...validMilestone, completionCriteria: "" }]);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain("Completion criteria is required");
+    }
+  });
+
+  it("rejects a milestone missing fundingRequested entirely", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+    const { fundingRequested: _drop, ...withoutFunding } = validMilestone;
+
+    const result = schema.safeParse([withoutFunding]);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a milestone missing completionCriteria entirely", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+    const { completionCriteria: _drop, ...withoutCriteria } = validMilestone;
+
+    const result = schema.safeParse([withoutCriteria]);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("applies required sub-field validation even on optional milestone arrays", () => {
+    // When the milestone field is itself optional but a user adds a
+    // milestone, the new row's sub-fields must still meet the schema.
+    const schema = buildMilestoneSchema({ ...baseQuestion, required: false });
+
+    const result = schema.safeParse([{ ...validMilestone, fundingRequested: "" }]);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an empty array when the milestone field is optional", () => {
+    const schema = buildMilestoneSchema({ ...baseQuestion, required: false });
+
+    const result = schema.safeParse([]);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/features/applications/lib/schema-builders/milestone-schema.ts
+++ b/src/features/applications/lib/schema-builders/milestone-schema.ts
@@ -40,8 +40,8 @@ const milestoneSchema = z.object({
   title: z.string().min(1, "Title is required"),
   description: z.string().min(1, "Description is required"),
   dueDate: z.union([futureDateSchema, z.date()]),
-  fundingRequested: z.string().optional(),
-  completionCriteria: z.string().optional(),
+  fundingRequested: z.string().min(1, "Funding requested is required"),
+  completionCriteria: z.string().min(1, "Completion criteria is required"),
 });
 
 export function buildMilestoneSchema(q: ApplicationQuestion) {

--- a/src/features/applications/types.ts
+++ b/src/features/applications/types.ts
@@ -10,13 +10,6 @@ export interface ApplicationFormErrors {
   [questionId: string]: string;
 }
 
-export interface ApplicationFormState {
-  data: ApplicationFormData;
-  errors: ApplicationFormErrors;
-  isValid: boolean;
-  isDirty: boolean;
-}
-
 export interface UseApplicationSubmitReturn {
   submit: (
     programId: string,


### PR DESCRIPTION
## Summary

- Make **Funding Requested** and **Completion Criteria** required on every milestone, in both the application submission flow and the project-edit flow.
- Updates schemas, validation rules, UI labels, and QuestionBuilder previews to reflect the new requirement.
- Not retroactive: existing milestones in the database are untouched. Validation kicks in when a milestone is added or edited going forward.

## Changes

**Schemas — `.optional()` → `.min(1, "...required")`**
- `src/features/applications/lib/schema-builders/milestone-schema.ts`
- `components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx` (inline milestone schema)

**Form inputs — add `required` rules + relabel**
- `components/FundingPlatform/FormFields/MilestoneInput.tsx`: `rules={{ required }}` on both Controllers; label `(Optional)` → `*`
- `src/features/applications/components/MilestoneItem.tsx`: label `(Optional)` → `*`; `MarkdownEditor` `isRequired={false}` → `isRequired` for completion criteria

**QuestionBuilder previews (admin builder + live form renderer)**
- `components/QuestionBuilder/FieldEditor.tsx`: green "(Optional)" pill → red `*` for both fields
- `components/QuestionBuilder/QuestionFormRenderer.tsx`: label `(Optional)` → `*`

**Tests**
- `components/FundingPlatform/FormFields/__tests__/MilestoneInput.test.tsx`: assertions retargeted to the new copy; obsolete "optional fields can be empty" test renamed to reflect that the fields just start empty before submit. 26/26 tests pass.

## Notes on scope

- The backend partial-update DTO in `gap-indexer` (`milestone-edit.request.dto.ts`) is intentionally **not** changed — it's a PATCH-style endpoint where undefined-means-not-supplied is the correct contract for editing a single field at a time.
- Forward-only behavior change. No data migration is being performed for existing milestones without these values.

## Test plan

- [ ] In a program with milestone fields, try to submit an application with a milestone missing Funding Requested → expect inline error
- [ ] Same as above for Completion Criteria
- [ ] Filling both fields submits successfully
- [ ] In the QuestionBuilder admin view (and live form preview), the milestone preview shows red `*` next to Funding Requested and Completion Criteria
- [ ] In the project edit flow (MilestoneFieldArray / MilestoneItem), editing an existing milestone surfaces a validation error if either field is empty
- [ ] `pnpm test MilestoneInput MilestoneItem` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Milestone "Funding Requested" and "Completion Criteria" fields are now required instead of optional
  * Updated milestone form UI labels to indicate these fields are mandatory with required field indicators
  * Enhanced validation across all milestone input forms to enforce completion of these fields
  * Users must now provide funding amounts and completion criteria when creating or editing milestones

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->