### PR TITLE
fix(search): unwrap paginated envelope in searchProjects

### DIFF
--- a/__tests__/unit/services/project-search.service.test.ts
+++ b/__tests__/unit/services/project-search.service.test.ts
@@ -116,6 +116,27 @@ describe("project-search.service", () => {
         expect.stringContaining(encodeURIComponent("test & project"))
       );
     });
+
+    it("should unwrap paginated envelope { payload, pagination }", async () => {
+      mockFetchData.mockResolvedValueOnce([
+        { payload: mockProjects, pagination: { total: 2, page: 1, limit: 10 } },
+        null,
+        null,
+        200,
+      ]);
+
+      const result = await searchProjects("test");
+
+      expect(result).toEqual(mockProjects);
+    });
+
+    it("should return empty array when response has unexpected shape", async () => {
+      mockFetchData.mockResolvedValueOnce([{ unexpected: "shape" }, null, null, 200]);
+
+      const result = await searchProjects("test");
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe("searchProjectsV2 alias", () => {

--- a/services/project-search.service.ts
+++ b/services/project-search.service.ts
@@ -3,6 +3,10 @@ import type { Project as ProjectResponse } from "@/types/v2/project";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
+type SearchProjectsApiResponse =
+  | ProjectResponse[]
+  | { payload: ProjectResponse[]; pagination?: unknown };
+
 /**
  * Search projects using V2 API endpoint
  *
@@ -17,7 +21,7 @@ export const searchProjects = async (query: string, limit?: number): Promise<Pro
     return [];
   }
 
-  const [data, error] = await fetchData<ProjectResponse[]>(
+  const [data, error] = await fetchData<SearchProjectsApiResponse>(
     INDEXER.V2.PROJECTS.SEARCH(query, limit)
   );
 
@@ -28,7 +32,17 @@ export const searchProjects = async (query: string, limit?: number): Promise<Pro
     return [];
   }
 
-  return data;
+  // Backend switched from a flat array to a paginated envelope ({ payload, pagination }).
+  // Handle both shapes so older deployments and tests keep working.
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data.payload)) return data.payload;
+
+  errorManager(
+    "Project Search API returned unexpected shape",
+    new Error("Unexpected response shape"),
+    { context: "project-search.service", responseKeys: Object.keys(data) }
+  );
+  return [];
 };
 
 // Alias for backward compatibility during migration


### PR DESCRIPTION
## Summary

Fixes [GAP-FRONTEND-219](https://karma-crypto-inc.sentry.io/issues/7490693076/) — `TypeError: (intermediate value).filter is not a function` thrown in production when users typed into the Merge Project dialog's search input.

## Root cause

The `GET /v2/projects?q=<query>` backend endpoint changed its response shape from a flat `Project[]` array to a paginated envelope:

```json
{ "payload": [...], "pagination": {...} }
```

`searchProjects` in `services/project-search.service.ts` still typed the response as `ProjectResponse[]` and returned it raw, so call sites that did `projectsData.filter(...)` (e.g. `MergeProjectDialog.tsx:70`) crashed with `TypeError`. The failure happens inside a `debounce`d async function with no `.catch()`, so it surfaced as `onunhandledrejection` in Sentry.

The same mismatch also silently broke duplicate-title detection in `ProjectDialog/index.tsx:1006-1008` (its try/catch swallowed the error).

## Fix

`services/project-search.service.ts`: handle both the flat-array and the new paginated envelope, with a defensive empty-array fallback for any unexpected shape (logged via `errorManager`).

## Test plan

- [x] Unit tests pass (`vitest run __tests__/unit/services/project-search.service.test.ts`) — 10/10, including two new cases for the paginated envelope unwrap and the unexpected-shape fallback
- [ ] Manual: open Merge Project dialog, type a 3+ char query, confirm results render and no console error
- [ ] Manual: create a new project with a duplicate name, confirm the "similar name found" warning still triggers in ProjectDialog
- [ ] Verify Sentry GAP-FRONTEND-219 stops receiving new events after deploy