### PR TITLE
feat(ask-karma): tenant-aware AI assistant page

### DIFF
--- a/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
@@ -1,0 +1,162 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Smoke tests for the ask-karma routes (root and community). The inner
+ * `AskKarmaPage` is mocked to a sentinel so we test only that the server
+ * components correctly resolve their tenant/community context and pass
+ * the right config down.
+ */
+
+const askKarmaPageSpy = vi.fn();
+
+vi.mock("@/src/features/ask-karma/components/ask-karma-page", () => ({
+  AskKarmaPage: (props: { config: { heading: string }; communityId?: string }) => {
+    askKarmaPageSpy(props);
+    return (
+      <div
+        data-testid="ask-karma-page"
+        data-community-id={props.communityId ?? ""}
+        data-heading={props.config.heading}
+      >
+        AskKarmaPage
+      </div>
+    );
+  },
+}));
+
+const mockCommunity = {
+  uid: "0x123",
+  details: { name: "Filecoin", slug: "filecoin" },
+};
+
+vi.mock("@/utilities/queries/v2/getCommunityData", () => ({
+  getCommunityDetails: vi.fn().mockResolvedValue(mockCommunity),
+}));
+
+const mockGetWhitelabelContext = vi.fn().mockResolvedValue({
+  isWhitelabel: false,
+  communitySlug: null,
+  config: null,
+  tenantConfig: { id: "karma", name: "Karma" },
+});
+
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: () => mockGetWhitelabelContext(),
+}));
+
+const renderAsyncPage = async (
+  importer: () => Promise<{ default: (props: unknown) => Promise<React.ReactElement> }>,
+  props: unknown
+) => {
+  const { default: Page } = await importer();
+  const result = await Page(props);
+  return render(result);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetWhitelabelContext.mockResolvedValue({
+    isWhitelabel: false,
+    communitySlug: null,
+    config: null,
+    tenantConfig: { id: "karma", name: "Karma" },
+  });
+});
+
+describe("/ask-karma (root) page", () => {
+  it("renders AskKarmaPage with the default config when not on a whitelabel", async () => {
+    await renderAsyncPage(() => import("@/app/ask-karma/page"), {});
+    expect(screen.getByTestId("ask-karma-page")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-page")).toHaveAttribute("data-heading", "Ask us anything");
+    expect(askKarmaPageSpy).toHaveBeenCalled();
+    const props = askKarmaPageSpy.mock.calls[0][0];
+    expect(props.communityId).toBeUndefined();
+  });
+
+  it("passes the whitelabel community id and tenant-specific config when on a whitelabel domain", async () => {
+    mockGetWhitelabelContext.mockResolvedValueOnce({
+      isWhitelabel: true,
+      communitySlug: "filecoin",
+      config: { domain: "app.filpgf.io", communitySlug: "filecoin", tenantId: "filecoin" },
+      tenantConfig: { id: "filecoin", name: "Filecoin" },
+    });
+    await renderAsyncPage(() => import("@/app/ask-karma/page"), {});
+    const props = askKarmaPageSpy.mock.calls[0][0];
+    expect(props.communityId).toBe("filecoin");
+    // Filecoin gets the bespoke config — the heading still says "Ask us
+    // anything" but the example questions array differs from the default.
+    expect(props.config.exampleQuestions.some((q: string) => q.includes("fil.one"))).toBe(true);
+  });
+
+  it("generateMetadata produces a tenant-aware title", async () => {
+    mockGetWhitelabelContext.mockResolvedValueOnce({
+      isWhitelabel: true,
+      communitySlug: "filecoin",
+      config: { domain: "app.filpgf.io", communitySlug: "filecoin", tenantId: "filecoin" },
+      tenantConfig: { id: "filecoin", name: "Filecoin" },
+    });
+    const { generateMetadata } = await import("@/app/ask-karma/page");
+    const meta = await generateMetadata();
+    expect(meta.title).toContain("Filecoin");
+    expect(meta.alternates?.canonical).toBe("/ask-karma");
+  });
+});
+
+describe("/community/[communityId]/ask-karma (community) page", () => {
+  it("renders AskKarmaPage with the community id from params", async () => {
+    await renderAsyncPage(
+      () => import("@/app/community/[communityId]/(with-header)/ask-karma/page"),
+      { params: Promise.resolve({ communityId: "filecoin" }) }
+    );
+    expect(screen.getByTestId("ask-karma-page")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-page")).toHaveAttribute("data-community-id", "filecoin");
+    const props = askKarmaPageSpy.mock.calls[0][0];
+    expect(props.config.exampleQuestions.some((q: string) => q.includes("fil.one"))).toBe(true);
+  });
+
+  it("calls notFound when the community cannot be resolved", async () => {
+    // Re-mock to return a missing community.
+    vi.doMock("@/utilities/queries/v2/getCommunityData", () => ({
+      getCommunityDetails: vi.fn().mockResolvedValue(null),
+    }));
+    vi.resetModules();
+
+    const notFound = vi.fn(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
+    vi.doMock("next/navigation", () => ({
+      notFound,
+    }));
+
+    await expect(
+      renderAsyncPage(() => import("@/app/community/[communityId]/(with-header)/ask-karma/page"), {
+        params: Promise.resolve({ communityId: "unknown" }),
+      })
+    ).rejects.toThrow();
+
+    expect(notFound).toHaveBeenCalled();
+
+    vi.doUnmock("@/utilities/queries/v2/getCommunityData");
+    vi.doUnmock("next/navigation");
+  });
+
+  it("generateMetadata produces a community-aware title", async () => {
+    vi.resetModules();
+    vi.doMock("@/utilities/queries/v2/getCommunityData", () => ({
+      getCommunityDetails: vi
+        .fn()
+        .mockResolvedValue({ uid: "0x123", details: { name: "Filecoin", slug: "filecoin" } }),
+    }));
+    const { generateMetadata } = await import(
+      "@/app/community/[communityId]/(with-header)/ask-karma/page"
+    );
+    const meta = await generateMetadata({
+      params: Promise.resolve({ communityId: "filecoin" }),
+    });
+    expect(meta.title).toContain("Filecoin");
+    expect(meta.alternates?.canonical).toBe("/community/filecoin/ask-karma");
+    vi.doUnmock("@/utilities/queries/v2/getCommunityData");
+  });
+});

--- a/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
@@ -163,6 +163,50 @@ describe("AskKarmaChat", () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
+  it("uses instant scroll (behavior: auto) while streaming to avoid jank", () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "a1", role: "assistant", content: "Streaming...", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={true}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(scrollSpy).toHaveBeenCalled();
+    const lastCallArg = scrollSpy.mock.calls.at(-1)?.[0];
+    expect(lastCallArg).toMatchObject({ behavior: "auto" });
+  });
+
+  it("uses smooth scroll when not streaming", () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "a1", role: "assistant", content: "Done.", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={false}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(scrollSpy).toHaveBeenCalled();
+    const lastCallArg = scrollSpy.mock.calls.at(-1)?.[0];
+    expect(lastCallArg).toMatchObject({ behavior: "smooth" });
+  });
+
   it("forwards textarea submissions to onSend", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
@@ -19,7 +19,7 @@ const config: AskKarmaConfig = {
   exampleQuestions: [],
   featuredTopicsHeading: "Topics",
   featuredTopics: [],
-  assistantTitle: "AI Assistant",
+  assistantTitle: "Karma Assistant",
   assistantSubtitle: "Here to help 24/7",
 };
 
@@ -50,7 +50,7 @@ describe("AskKarmaChat", () => {
         onBack={vi.fn()}
       />
     );
-    expect(screen.getByRole("heading", { name: "AI Assistant" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Karma Assistant" })).toBeInTheDocument();
     expect(screen.getByText("Here to help 24/7")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /back to topics/i })).toBeInTheDocument();
   });

--- a/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AskKarmaChat } from "@/src/features/ask-karma/components/ask-karma-chat";
+import type { AskKarmaConfig } from "@/src/features/ask-karma/types";
+import type { ChatMessage } from "@/store/agentChat";
+
+vi.mock("@/src/components/ai-elements/message-response", () => ({
+  MessageResponse: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+const config: AskKarmaConfig = {
+  heading: "Ask us anything",
+  subheading: "Sub",
+  inputPlaceholder: "Ask…",
+  examplesIntro: "Examples:",
+  exampleQuestions: [],
+  featuredTopicsHeading: "Topics",
+  featuredTopics: [],
+  assistantTitle: "AI Assistant",
+  assistantSubtitle: "Here to help 24/7",
+};
+
+function buildMsg(overrides: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">): ChatMessage {
+  return {
+    content: "",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement scrollIntoView; stub it so the smooth-scroll
+  // effect in AskKarmaChat doesn't throw and pollute test output.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("AskKarmaChat", () => {
+  it("renders the assistant header with title, subtitle, and back button", () => {
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("heading", { name: "AI Assistant" })).toBeInTheDocument();
+    expect(screen.getByText("Here to help 24/7")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /back to topics/i })).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no messages and not streaming", () => {
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/ask a question to get started/i)).toBeInTheDocument();
+  });
+
+  it("renders user and assistant messages with their respective testids", () => {
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "u1", role: "user", content: "Hi", timestamp: Date.now() }),
+      buildMsg({ id: "a1", role: "assistant", content: "Hello!", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={false}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("ask-karma-message-user")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-message-assistant")).toBeInTheDocument();
+    expect(screen.getByText("Hi")).toBeInTheDocument();
+    // Assistant content is rendered inside the markdown component
+    expect(screen.getByTestId("markdown")).toHaveTextContent("Hello!");
+  });
+
+  it("shows thinking dots when streaming with empty last assistant message", () => {
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "a1", role: "assistant", content: "", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={true}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("thinking-dots")).toBeInTheDocument();
+  });
+
+  it("does not show thinking dots once the assistant has streamed content", () => {
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "a1", role: "assistant", content: "Partial answer", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={true}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("thinking-dots")).not.toBeInTheDocument();
+  });
+
+  it("renders error alert when error is present", () => {
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error="Connection failed"
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Connection failed");
+  });
+
+  it("invokes onBack when the back button is clicked", async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={onBack}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /back to topics/i }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards textarea submissions to onSend", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error={null}
+        onSend={onSend}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await user.type(textarea, "Follow-up");
+    await user.keyboard("{Enter}");
+    expect(onSend).toHaveBeenCalledWith("Follow-up");
+  });
+});

--- a/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
@@ -89,4 +89,29 @@ describe("AskKarmaInput", () => {
     // Value is intentional and asserted so it can't be lowered silently.
     expect(textarea).toHaveAttribute("maxLength", "4000");
   });
+
+  it("ignores Enter while IME composition is active", async () => {
+    const { fireEvent } = await import("@testing-library/react");
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText("Type your message...") as HTMLTextAreaElement;
+    // Manually set value (fireEvent.change to avoid userEvent typing one
+    // char at a time — we only care about the Enter behaviour).
+    fireEvent.change(textarea, { target: { value: "konnichiwa" } });
+    // CJK users press Enter to confirm a composition candidate. The
+    // KeyboardEvent's `isComposing` flag propagates to event.nativeEvent
+    // in React's synthetic event.
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter when IME composition is not active", async () => {
+    const { fireEvent } = await import("@testing-library/react");
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText("Type your message...") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("hello");
+  });
 });

--- a/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
@@ -82,4 +82,11 @@ describe("AskKarmaInput", () => {
     render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} placeholder="Ask anything…" />);
     expect(screen.getByPlaceholderText("Ask anything…")).toBeInTheDocument();
   });
+
+  it("caps chat message length to prevent oversized prompts", () => {
+    render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    // Value is intentional and asserted so it can't be lowered silently.
+    expect(textarea).toHaveAttribute("maxLength", "4000");
+  });
 });

--- a/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AskKarmaInput } from "@/src/features/ask-karma/components/ask-karma-input";
+
+describe("AskKarmaInput", () => {
+  it("disables the send button while empty", () => {
+    render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} />);
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
+  });
+
+  it("enables the send button once the textarea has content", async () => {
+    const user = userEvent.setup();
+    render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} />);
+    await user.type(screen.getByPlaceholderText("Type your message..."), "hello");
+    expect(screen.getByLabelText("Send message")).not.toBeDisabled();
+  });
+
+  it("submits on Enter and clears the textarea", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await user.type(textarea, "Hello world");
+    await user.keyboard("{Enter}");
+    expect(onSubmit).toHaveBeenCalledWith("Hello world");
+    expect(textarea).toHaveValue("");
+  });
+
+  it("does not submit on shift+Enter (newline)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await user.type(textarea, "Hello{Shift>}{Enter}{/Shift}world");
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("Hello\nworld");
+  });
+
+  it("submits when the send button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    await user.type(screen.getByPlaceholderText("Type your message..."), "Click me");
+    await user.click(screen.getByLabelText("Send message"));
+    expect(onSubmit).toHaveBeenCalledWith("Click me");
+  });
+
+  it("ignores submits with only whitespace", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={false} />);
+    await user.type(screen.getByPlaceholderText("Type your message..."), "   ");
+    await user.keyboard("{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit while streaming", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaInput onSubmit={onSubmit} isStreaming={true} onStop={vi.fn()} />);
+    // While streaming, the send button is replaced by a stop button — there
+    // is no "Send message" affordance to interact with.
+    expect(screen.queryByLabelText("Send message")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Stop response")).toBeInTheDocument();
+    // Pressing Enter in the textarea should also be a no-op while streaming.
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await user.type(textarea, "hi");
+    await user.keyboard("{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("renders the stop button while streaming and invokes onStop when clicked", async () => {
+    const user = userEvent.setup();
+    const onStop = vi.fn();
+    render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={true} onStop={onStop} />);
+    await user.click(screen.getByLabelText("Stop response"));
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports a custom placeholder", () => {
+    render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} placeholder="Ask anything…" />);
+    expect(screen.getByPlaceholderText("Ask anything…")).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
@@ -1,0 +1,210 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AskKarmaPage } from "@/src/features/ask-karma/components/ask-karma-page";
+import { ASK_KARMA_ANIMATION } from "@/src/features/ask-karma/components/ask-karma-start";
+import type { AskKarmaConfig } from "@/src/features/ask-karma/types";
+import { useAgentChatStore } from "@/store/agentChat";
+
+const mockSendMessage = vi.fn();
+const mockAbort = vi.fn();
+
+vi.mock("@/hooks/useAgentStream", () => ({
+  useAgentStream: () => ({
+    sendMessage: mockSendMessage,
+    abort: mockAbort,
+    sendConfirmation: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/components/ai-elements/message-response", () => ({
+  MessageResponse: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+const config: AskKarmaConfig = {
+  heading: "Ask us anything",
+  subheading: "Sub",
+  inputPlaceholder: "Ask…",
+  examplesIntro: "Examples:",
+  // Keep this short so the chip → fly → type sequence completes in tests
+  // without burning seconds of timer advancement per assertion.
+  exampleQuestions: ["Hi?"],
+  featuredTopicsHeading: "Topics",
+  featuredTopics: [],
+  assistantTitle: "AI Assistant",
+  assistantSubtitle: "Here to help 24/7",
+};
+
+const VIEW_LEAVE_MS = 220; // matches FADE_OUT_MS in ask-karma-page.tsx
+
+// Walk the chip → fly → type → submit sequence in phases. React state
+// updates fire useEffects that schedule the next timer, so we have to flush
+// between phases — see comment in ask-karma-start.test.tsx for full details.
+async function advanceChipFlow(text: string): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50);
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.FLY_DURATION_MS + 20);
+  });
+  for (let i = 0; i < text.length; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.TYPE_SPEED_MS);
+    });
+  }
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.POST_TYPE_PAUSE_MS + 30);
+  });
+}
+
+function resetStore() {
+  useAgentChatStore.setState({
+    messages: [],
+    isOpen: false,
+    isStreaming: false,
+    error: null,
+    agentContext: null,
+    pendingMentions: [],
+    pendingTraceId: null,
+    ratingCommentBoxOpenForMessageId: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("AskKarmaPage", () => {
+  it("renders the start view by default", () => {
+    render(<AskKarmaPage config={config} />);
+    expect(screen.getByTestId("ask-karma-start-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("ask-karma-chat-view")).not.toBeInTheDocument();
+  });
+
+  it("clears messages and sets the agent context to the community on mount", () => {
+    useAgentChatStore.setState({
+      messages: [{ id: "x", role: "user", content: "stale", timestamp: 0 }],
+      agentContext: { projectId: "other" },
+    });
+    render(<AskKarmaPage config={config} communityId="filecoin" />);
+    expect(useAgentChatStore.getState().messages).toHaveLength(0);
+    expect(useAgentChatStore.getState().agentContext).toEqual({ communityId: "filecoin" });
+  });
+
+  it("sets the agent context to null when rendered without a communityId", () => {
+    render(<AskKarmaPage config={config} />);
+    expect(useAgentChatStore.getState().agentContext).toBeNull();
+  });
+
+  it("transitions to the chat view after a chip is clicked", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaPage config={config} />);
+
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+
+    // Walk the chip animation so the start view actually calls onSubmit.
+    await advanceChipFlow(config.exampleQuestions[0]);
+
+    expect(mockSendMessage).toHaveBeenCalledWith(config.exampleQuestions[0]);
+    expect(screen.getByTestId("ask-karma-start-view")).toHaveAttribute(
+      "data-view-state",
+      "leaving-start"
+    );
+
+    // After the parent's fade-out (220ms), the chat view replaces the start view.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(VIEW_LEAVE_MS + 30);
+    });
+    expect(screen.queryByTestId("ask-karma-start-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-chat-view")).toBeInTheDocument();
+  });
+
+  it("aborts and returns to the start view when the back button is clicked", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaPage config={config} />);
+
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    await advanceChipFlow(config.exampleQuestions[0]);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(VIEW_LEAVE_MS + 30);
+    });
+    expect(screen.getByTestId("ask-karma-chat-view")).toBeInTheDocument();
+
+    act(() => {
+      useAgentChatStore.setState({
+        messages: [{ id: "u1", role: "user", content: "Hi", timestamp: Date.now() }],
+      });
+    });
+
+    await user.click(screen.getByRole("button", { name: /back to topics/i }));
+    expect(mockAbort).toHaveBeenCalled();
+    expect(screen.getByTestId("ask-karma-chat-view")).toHaveAttribute(
+      "data-view-state",
+      "leaving-chat"
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(VIEW_LEAVE_MS + 30);
+    });
+    expect(screen.queryByTestId("ask-karma-chat-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-start-view")).toBeInTheDocument();
+    expect(useAgentChatStore.getState().messages).toHaveLength(0);
+  });
+
+  it("does not send empty submissions", async () => {
+    const user = userEvent.setup();
+    render(<AskKarmaPage config={config} />);
+    const input = screen.getByPlaceholderText(config.inputPlaceholder);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(screen.getByTestId("ask-karma-start-view")).toBeInTheDocument();
+  });
+
+  it("aborts and clears state on unmount", () => {
+    const { unmount } = render(<AskKarmaPage config={config} communityId="filecoin" />);
+    act(() => {
+      useAgentChatStore.setState({
+        messages: [{ id: "x", role: "user", content: "leftover", timestamp: 0 }],
+        agentContext: { communityId: "filecoin" },
+      });
+    });
+    unmount();
+    expect(mockAbort).toHaveBeenCalled();
+    expect(useAgentChatStore.getState().messages).toHaveLength(0);
+    expect(useAgentChatStore.getState().agentContext).toBeNull();
+  });
+
+  it("does not trigger another view transition when already in chat", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaPage config={config} />);
+
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    await advanceChipFlow(config.exampleQuestions[0]);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(VIEW_LEAVE_MS + 30);
+    });
+    expect(screen.getByTestId("ask-karma-chat-view")).toHaveAttribute("data-view-state", "chat");
+
+    // Send a follow-up while already in chat — state should remain "chat",
+    // sendMessage should still be invoked. Follow-ups skip the chip
+    // animation; they hit sendMessage immediately.
+    mockSendMessage.mockClear();
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    await user.type(textarea, "Follow-up");
+    await user.keyboard("{Enter}");
+    expect(mockSendMessage).toHaveBeenCalledWith("Follow-up");
+    expect(screen.getByTestId("ask-karma-chat-view")).toHaveAttribute("data-view-state", "chat");
+  });
+});

--- a/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
@@ -33,7 +33,7 @@ const config: AskKarmaConfig = {
   exampleQuestions: ["Hi?"],
   featuredTopicsHeading: "Topics",
   featuredTopics: [],
-  assistantTitle: "AI Assistant",
+  assistantTitle: "Karma Assistant",
   assistantSubtitle: "Here to help 24/7",
 };
 

--- a/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
@@ -185,6 +185,22 @@ describe("AskKarmaPage", () => {
     expect(useAgentChatStore.getState().agentContext).toBeNull();
   });
 
+  it("locks pointer events and marks aria-hidden on the start view during fade-out", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaPage config={config} />);
+
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    await advanceChipFlow(config.exampleQuestions[0]);
+
+    const startView = screen.getByTestId("ask-karma-start-view");
+    expect(startView).toHaveAttribute("data-view-state", "leaving-start");
+    expect(startView).toHaveAttribute("aria-hidden", "true");
+    // pointer-events-none class is what blocks click forwarding in the
+    // browser; assert it so a refactor that drops it gets caught.
+    expect(startView.className).toContain("pointer-events-none");
+  });
+
   it("does not trigger another view transition when already in chat", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
@@ -1,0 +1,272 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ASK_KARMA_ANIMATION,
+  AskKarmaStart,
+} from "@/src/features/ask-karma/components/ask-karma-start";
+import type { AskKarmaConfig } from "@/src/features/ask-karma/types";
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    asChild: _asChild,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    variant?: string;
+    size?: string;
+  }) => <span {...props}>{children}</span>,
+}));
+
+const config: AskKarmaConfig = {
+  heading: "Ask us anything",
+  subheading: "Learn how funding works.",
+  inputPlaceholder: "Questions? Ask the AI Assistant",
+  examplesIntro: "Some examples to get the juices flowing:",
+  exampleQuestions: ["How do I submit a milestone?", "Why can't I access a project?"],
+  featuredTopicsHeading: "Check out these featured topics",
+  featuredTopics: [
+    {
+      icon: "dollar",
+      title: "Open Funding Rounds",
+      description: "Browse programs",
+      links: [{ label: "View open rounds", href: "/funding-opportunities" }],
+    },
+    {
+      icon: "trending-up",
+      title: "Track Active Projects",
+      cta: { label: "View Funded Projects", href: "/projects" },
+    },
+  ],
+  assistantTitle: "AI Assistant",
+  assistantSubtitle: "Here to help 24/7",
+};
+
+// React's setState → useEffect chain doesn't run between timer fires when
+// you advance time in one giant chunk; we have to flush the timer queue at
+// each phase boundary so the next phase's effect gets a chance to schedule
+// its own timers. This helper walks the chip → fly → type → submit chain
+// in the same order the component does.
+async function advanceChipAnimation(text: string): Promise<void> {
+  // 1) Flush the double-RAF that commits the start position then flips
+  //    the chip clone to its end position.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50);
+  });
+  // 2) Fire the FlyingChip onArrive timeout (FLY_DURATION_MS) — moves the
+  //    parent into the "typing" phase.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.FLY_DURATION_MS + 20);
+  });
+  // 3) Drive the typing interval one character at a time. We can't bulk-
+  //    advance because every tick mutates state and the post-type timeout
+  //    is only scheduled when the final character ticks through.
+  for (let i = 0; i < text.length; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.TYPE_SPEED_MS);
+    });
+  }
+  // 4) Fire the post-type pause and the final onSubmit call.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.POST_TYPE_PAUSE_MS + 30);
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("AskKarmaStart — static rendering", () => {
+  it("renders the heading, subheading, and section headings from config", () => {
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: config.heading, level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(config.subheading)).toBeInTheDocument();
+    expect(screen.getByText(config.examplesIntro)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: config.featuredTopicsHeading, level: 2 })
+    ).toBeInTheDocument();
+  });
+
+  it("renders all example question chips", () => {
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    for (const q of config.exampleQuestions) {
+      expect(screen.getByRole("button", { name: q })).toBeInTheDocument();
+    }
+  });
+
+  it("renders all featured topic cards", () => {
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    for (const topic of config.featuredTopics) {
+      expect(screen.getByRole("heading", { name: topic.title })).toBeInTheDocument();
+    }
+  });
+
+  it("renders chips inside a <ul> with one <li> each", () => {
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    const intro = screen.getByText(config.examplesIntro);
+    const list = intro.parentElement?.querySelector("ul");
+    expect(list).not.toBeNull();
+    const items = within(list as HTMLElement).getAllByRole("listitem");
+    expect(items).toHaveLength(config.exampleQuestions.length);
+  });
+});
+
+describe("AskKarmaStart — direct input submissions", () => {
+  it("submits the input value on Enter", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(config.inputPlaceholder);
+    await user.type(input, "What is ProPGF?");
+    await user.keyboard("{Enter}");
+    expect(onSubmit).toHaveBeenCalledWith("What is ProPGF?");
+  });
+
+  it("submits when the search button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(config.inputPlaceholder);
+    await user.type(input, "Hello there");
+    await user.click(screen.getByLabelText("Ask the AI Assistant"));
+    expect(onSubmit).toHaveBeenCalledWith("Hello there");
+  });
+
+  it("ignores submits when the input is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const button = screen.getByLabelText("Ask the AI Assistant");
+    expect(button).toBeDisabled();
+    const input = screen.getByPlaceholderText(config.inputPlaceholder);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe("AskKarmaStart — chip click animation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  it("renders the flying chip clone immediately on click", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    const clone = screen.getByTestId("ask-karma-flying-chip");
+    expect(clone).toBeInTheDocument();
+    expect(clone).toHaveTextContent(config.exampleQuestions[0]);
+    // The container reflects the animation phase via a data attribute so
+    // tests (and future a11y/UX work) can hang behaviour off it.
+    expect(screen.getByText(config.heading).closest("[data-animation-phase]")).toHaveAttribute(
+      "data-animation-phase",
+      "flying"
+    );
+  });
+
+  it("blocks further chip clicks during the animation", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const first = screen.getByRole("button", { name: config.exampleQuestions[0] });
+    const second = screen.getByRole("button", { name: config.exampleQuestions[1] });
+    await user.click(first);
+    // Mid-animation: second chip is disabled.
+    expect(second).toBeDisabled();
+    await user.click(second);
+    // Advance through the full sequence — only the first text should submit.
+    await advanceChipAnimation(config.exampleQuestions[0]);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(config.exampleQuestions[0]);
+  });
+
+  it("auto-types the chip text into the input then calls onSubmit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const text = config.exampleQuestions[0];
+    await user.click(screen.getByRole("button", { name: text }));
+
+    // Flush RAFs + complete the fly so we enter the typing phase.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.FLY_DURATION_MS + 20);
+    });
+    const input = screen.getByPlaceholderText(config.inputPlaceholder) as HTMLInputElement;
+    expect(input).toHaveAttribute("readonly");
+
+    // Tick half the characters and verify the prefix accumulates in the input.
+    const halfChars = Math.max(1, Math.floor(text.length / 2));
+    for (let i = 0; i < halfChars; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.TYPE_SPEED_MS);
+      });
+    }
+    expect(input.value.length).toBeGreaterThan(0);
+    expect(input.value.length).toBeLessThan(text.length);
+    expect(text.startsWith(input.value)).toBe(true);
+
+    // Finish the remaining characters + the post-type pause and the submit.
+    for (let i = halfChars; i < text.length; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.TYPE_SPEED_MS);
+      });
+    }
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.POST_TYPE_PAUSE_MS + 30);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(text);
+    expect(screen.getByText(config.heading).closest("[data-animation-phase]")).toHaveAttribute(
+      "data-animation-phase",
+      "idle"
+    );
+  });
+
+  it("unmounts the flying chip clone after onArrive fires", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    expect(screen.getByTestId("ask-karma-flying-chip")).toBeInTheDocument();
+    // Flush RAFs and the fly duration so the parent transitions to "typing".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.FLY_DURATION_MS + 30);
+    });
+    expect(screen.queryByTestId("ask-karma-flying-chip")).not.toBeInTheDocument();
+  });
+
+  it("cleans up timers when unmounted mid-animation", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onSubmit = vi.fn();
+    const { unmount } = render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+    // Get into the typing phase, then unmount before the submit fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ASK_KARMA_ANIMATION.FLY_DURATION_MS + 30);
+    });
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
@@ -153,6 +153,66 @@ describe("AskKarmaStart — direct input submissions", () => {
     await user.keyboard("{Enter}");
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("caps free-text input length to prevent oversized prompts", () => {
+    render(<AskKarmaStart config={config} onSubmit={vi.fn()} />);
+    const input = screen.getByTestId("ask-karma-search-input");
+    // Hard cap surfaced via the HTML maxLength attribute so the browser
+    // itself rejects keystrokes/pastes past the limit. Value is intentional
+    // and tested so we notice if it changes silently.
+    expect(input).toHaveAttribute("maxLength", "500");
+  });
+});
+
+describe("AskKarmaStart — reduced motion", () => {
+  beforeEach(() => {
+    // Override the global matchMedia stub from __tests__/setup.ts so the
+    // hook reports the user preferring reduced motion.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    // Restore the default (matches: false) stub so other tests stay in the
+    // "motion-allowed" world.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("submits the chip text immediately without flying chip animation", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: config.exampleQuestions[0] }));
+
+    expect(onSubmit).toHaveBeenCalledWith(config.exampleQuestions[0]);
+    // Critical: the chip clone never renders — confirms the motion path
+    // was bypassed, not just visually suppressed.
+    expect(screen.queryByTestId("ask-karma-flying-chip")).not.toBeInTheDocument();
+  });
 });
 
 describe("AskKarmaStart — chip click animation", () => {

--- a/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
@@ -162,6 +162,20 @@ describe("AskKarmaStart — direct input submissions", () => {
     // and tested so we notice if it changes silently.
     expect(input).toHaveAttribute("maxLength", "500");
   });
+
+  it("ignores Enter while IME composition is active", async () => {
+    const { fireEvent } = await import("@testing-library/react");
+    const onSubmit = vi.fn();
+    render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
+    const input = screen.getByTestId("ask-karma-search-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "konnichiwa" } });
+    // IME composition active — Enter must NOT submit.
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+    // Now release composition and press Enter again — should submit.
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("konnichiwa");
+  });
 });
 
 describe("AskKarmaStart — reduced motion", () => {

--- a/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
@@ -31,7 +31,7 @@ vi.mock("@/components/ui/button", () => ({
 const config: AskKarmaConfig = {
   heading: "Ask us anything",
   subheading: "Learn how funding works.",
-  inputPlaceholder: "Questions? Ask the AI Assistant",
+  inputPlaceholder: "Questions? Ask the Karma Assistant",
   examplesIntro: "Some examples to get the juices flowing:",
   exampleQuestions: ["How do I submit a milestone?", "Why can't I access a project?"],
   featuredTopicsHeading: "Check out these featured topics",
@@ -48,7 +48,7 @@ const config: AskKarmaConfig = {
       cta: { label: "View Funded Projects", href: "/projects" },
     },
   ],
-  assistantTitle: "AI Assistant",
+  assistantTitle: "Karma Assistant",
   assistantSubtitle: "Here to help 24/7",
 };
 
@@ -138,7 +138,7 @@ describe("AskKarmaStart — direct input submissions", () => {
     render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
     const input = screen.getByPlaceholderText(config.inputPlaceholder);
     await user.type(input, "Hello there");
-    await user.click(screen.getByLabelText("Ask the AI Assistant"));
+    await user.click(screen.getByLabelText("Ask the Karma Assistant"));
     expect(onSubmit).toHaveBeenCalledWith("Hello there");
   });
 
@@ -146,7 +146,7 @@ describe("AskKarmaStart — direct input submissions", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<AskKarmaStart config={config} onSubmit={onSubmit} />);
-    const button = screen.getByLabelText("Ask the AI Assistant");
+    const button = screen.getByLabelText("Ask the Karma Assistant");
     expect(button).toBeDisabled();
     const input = screen.getByPlaceholderText(config.inputPlaceholder);
     await user.type(input, "   ");

--- a/__tests__/unit/features/ask-karma/config.test.ts
+++ b/__tests__/unit/features/ask-karma/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
+
+describe("getAskKarmaConfig", () => {
+  it("returns the default config when no tenant id is provided", () => {
+    const config = getAskKarmaConfig();
+    expect(config.heading).toBe("Ask us anything");
+    expect(config.exampleQuestions.length).toBeGreaterThan(0);
+    expect(config.featuredTopics.length).toBeGreaterThan(0);
+    expect(config.assistantTitle).toBe("AI Assistant");
+  });
+
+  it("returns the default config when the tenant id is unknown", () => {
+    const config = getAskKarmaConfig("not-a-real-tenant");
+    expect(config.heading).toBe("Ask us anything");
+  });
+
+  it("returns the default config for null or undefined", () => {
+    expect(getAskKarmaConfig(null)).toEqual(getAskKarmaConfig());
+    expect(getAskKarmaConfig(undefined)).toEqual(getAskKarmaConfig());
+  });
+
+  it("returns the filecoin-specific config when tenant id is 'filecoin'", () => {
+    const config = getAskKarmaConfig("filecoin");
+    // Filecoin example questions must include the bespoke "fil.one" prompt
+    // from the screenshot — this is the contract we wire from the spec.
+    expect(config.exampleQuestions.some((q) => q.toLowerCase().includes("fil.one"))).toBe(true);
+    expect(config.featuredTopics.some((t) => t.title.includes("ProPGF"))).toBe(true);
+  });
+
+  it("returns featured topics that are well-formed", () => {
+    const config = getAskKarmaConfig("filecoin");
+    for (const topic of config.featuredTopics) {
+      expect(topic.title).toBeTruthy();
+      expect(topic.icon).toBeTruthy();
+      // Every topic should expose at least one navigation surface — links OR a CTA.
+      const hasLinks = (topic.links?.length ?? 0) > 0;
+      const hasCta = Boolean(topic.cta);
+      expect(hasLinks || hasCta).toBe(true);
+    }
+  });
+});

--- a/__tests__/unit/features/ask-karma/config.test.ts
+++ b/__tests__/unit/features/ask-karma/config.test.ts
@@ -28,6 +28,21 @@ describe("getAskKarmaConfig", () => {
     expect(config.featuredTopics.some((t) => t.title.includes("ProPGF"))).toBe(true);
   });
 
+  it("returns the default config for a known tenant that has no override", () => {
+    // optimism is a known tenant id but isn't in TENANT_CONFIGS — should
+    // fall through to DEFAULT_CONFIG, not throw or return undefined.
+    const config = getAskKarmaConfig("optimism");
+    expect(config.heading).toBe("Ask us anything");
+    expect(config.assistantTitle).toBe("Karma Assistant");
+  });
+
+  it("returns the default config for an arbitrary community slug (not a known tenant)", () => {
+    // An unrecognized community slug must NOT match a tenant config by
+    // coincidence — the isKnownTenant guard is what enforces this.
+    const config = getAskKarmaConfig("some-random-community-uid-or-slug");
+    expect(config).toEqual(getAskKarmaConfig());
+  });
+
   it("returns featured topics that are well-formed", () => {
     const config = getAskKarmaConfig("filecoin");
     for (const topic of config.featuredTopics) {

--- a/__tests__/unit/features/ask-karma/config.test.ts
+++ b/__tests__/unit/features/ask-karma/config.test.ts
@@ -7,7 +7,7 @@ describe("getAskKarmaConfig", () => {
     expect(config.heading).toBe("Ask us anything");
     expect(config.exampleQuestions.length).toBeGreaterThan(0);
     expect(config.featuredTopics.length).toBeGreaterThan(0);
-    expect(config.assistantTitle).toBe("AI Assistant");
+    expect(config.assistantTitle).toBe("Karma Assistant");
   });
 
   it("returns the default config when the tenant id is unknown", () => {

--- a/__tests__/unit/features/ask-karma/featured-topic-card.test.tsx
+++ b/__tests__/unit/features/ask-karma/featured-topic-card.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FeaturedTopicCard } from "@/src/features/ask-karma/components/featured-topic-card";
+import type { AskKarmaTopic } from "@/src/features/ask-karma/types";
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    target,
+    rel,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    target?: string;
+    rel?: string;
+  }) => (
+    <a href={href} target={target} rel={rel}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    asChild: _asChild,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    variant?: string;
+    size?: string;
+  }) => <span {...props}>{children}</span>,
+}));
+
+const baseTopic: AskKarmaTopic = {
+  icon: "dollar",
+  title: "Open Funding Rounds",
+  description: "Browse active programs",
+  links: [{ label: "View open rounds", href: "/funding-opportunities" }],
+};
+
+describe("FeaturedTopicCard", () => {
+  it("renders title, description, and links", () => {
+    render(<FeaturedTopicCard topic={baseTopic} />);
+    expect(screen.getByRole("heading", { name: "Open Funding Rounds" })).toBeInTheDocument();
+    expect(screen.getByText("Browse active programs")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "View open rounds" });
+    expect(link).toHaveAttribute("href", "/funding-opportunities");
+  });
+
+  it("marks external links with target and rel attributes", () => {
+    render(
+      <FeaturedTopicCard
+        topic={{
+          ...baseTopic,
+          links: [{ label: "External", href: "https://example.com", isExternal: true }],
+        }}
+      />
+    );
+    const link = screen.getByRole("link", { name: "External" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not set target/rel for internal links", () => {
+    render(<FeaturedTopicCard topic={baseTopic} />);
+    const link = screen.getByRole("link", { name: "View open rounds" });
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+  });
+
+  it("renders a CTA when provided instead of links", () => {
+    render(
+      <FeaturedTopicCard
+        topic={{
+          icon: "trending-up",
+          title: "Track Active Projects",
+          cta: { label: "View Funded Projects", href: "/projects" },
+        }}
+      />
+    );
+    const cta = screen.getByRole("link", { name: "View Funded Projects" });
+    expect(cta).toHaveAttribute("href", "/projects");
+  });
+
+  it("renders without description if not provided", () => {
+    render(<FeaturedTopicCard topic={{ ...baseTopic, description: undefined }} />);
+    expect(screen.queryByText("Browse active programs")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Open Funding Rounds" })).toBeInTheDocument();
+  });
+
+  it("renders both links and CTA when both provided", () => {
+    render(
+      <FeaturedTopicCard
+        topic={{
+          ...baseTopic,
+          cta: { label: "View All", href: "/all" },
+        }}
+      />
+    );
+    expect(screen.getByRole("link", { name: "View open rounds" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View All" })).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/features/ask-karma/flying-chip.test.tsx
+++ b/__tests__/unit/features/ask-karma/flying-chip.test.tsx
@@ -1,0 +1,117 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FlyingChip, type FlyingChipRect } from "@/src/features/ask-karma/components/flying-chip";
+
+const startRect: FlyingChipRect = { left: 100, top: 200, width: 180, height: 32 };
+const endRect: FlyingChipRect = { left: 50, top: 80, width: 600, height: 48 };
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("FlyingChip", () => {
+  it("renders inside the document body with the chip text", () => {
+    render(
+      <FlyingChip
+        text="How do I submit a milestone?"
+        startRect={startRect}
+        endRect={endRect}
+        durationMs={200}
+        onArrive={vi.fn()}
+      />
+    );
+    const chip = screen.getByTestId("ask-karma-flying-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent("How do I submit a milestone?");
+    // Portal target: the chip lives directly under <body>, not inside the
+    // test container, so its parent should be document.body.
+    expect(chip.parentElement).toBe(document.body);
+  });
+
+  it("starts positioned at the source rect on mount", () => {
+    render(
+      <FlyingChip
+        text="hello"
+        startRect={startRect}
+        endRect={endRect}
+        durationMs={200}
+        onArrive={vi.fn()}
+      />
+    );
+    const chip = screen.getByTestId("ask-karma-flying-chip");
+    expect(chip.style.left).toBe(`${startRect.left}px`);
+    expect(chip.style.top).toBe(`${startRect.top}px`);
+    expect(chip.style.opacity).toBe("1");
+  });
+
+  it("transitions to the end position after the double-RAF commit", async () => {
+    render(
+      <FlyingChip
+        text="hello"
+        startRect={startRect}
+        endRect={endRect}
+        durationMs={200}
+        onArrive={vi.fn()}
+      />
+    );
+    // RAF in JSDOM is implemented via setTimeout(~16ms). Advancing a few
+    // frames flushes both the layout-commit RAF and the phase-flip RAF.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    const chip = screen.getByTestId("ask-karma-flying-chip");
+    // Ends up at the input's left edge + 12px padding.
+    expect(chip.style.left).toBe(`${endRect.left + 12}px`);
+    expect(chip.style.opacity).toBe("0");
+  });
+
+  it("invokes onArrive after the duration elapses", async () => {
+    const onArrive = vi.fn();
+    render(
+      <FlyingChip
+        text="hello"
+        startRect={startRect}
+        endRect={endRect}
+        durationMs={200}
+        onArrive={onArrive}
+      />
+    );
+    // First flush: RAFs fire → setPhase("end") → useEffect runs → 200ms timer scheduled
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(onArrive).not.toHaveBeenCalled();
+    // Second flush: fire the 200ms timer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(220);
+    });
+    expect(onArrive).toHaveBeenCalledTimes(1);
+  });
+
+  it("only calls onArrive once even when extra time elapses past the duration", async () => {
+    const onArrive = vi.fn();
+    render(
+      <FlyingChip
+        text="hello"
+        startRect={startRect}
+        endRect={endRect}
+        durationMs={150}
+        onArrive={onArrive}
+      />
+    );
+    // Same split as above: let RAFs fire and the duration timer schedule,
+    // then advance well past the duration. The arrivedRef guard ensures the
+    // callback fires exactly once even if the effect's cleanup is racy.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(onArrive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/features/ask-karma/use-prefers-reduced-motion.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-prefers-reduced-motion.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePrefersReducedMotion } from "@/src/features/ask-karma/hooks/use-prefers-reduced-motion";
+
+interface MockMediaQueryList {
+  matches: boolean;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+let mediaQueryList: MockMediaQueryList;
+let listeners: Array<(event: MediaQueryListEvent) => void>;
+
+beforeEach(() => {
+  listeners = [];
+  mediaQueryList = {
+    matches: false,
+    addEventListener: vi.fn((_evt: string, fn: (event: MediaQueryListEvent) => void) => {
+      listeners.push(fn);
+    }),
+    removeEventListener: vi.fn(),
+  };
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mediaQueryList));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("usePrefersReducedMotion", () => {
+  it("returns false when the user has not opted into reduced motion", () => {
+    mediaQueryList.matches = false;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when the user has opted into reduced motion", () => {
+    mediaQueryList.matches = true;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query changes", () => {
+    mediaQueryList.matches = false;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      // Simulate the OS toggling reduced motion on.
+      for (const fn of listeners) fn({ matches: true } as MediaQueryListEvent);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    unmount();
+    expect(mediaQueryList.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/app/ask-karma/error.tsx
+++ b/app/ask-karma/error.tsx
@@ -1,28 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
-import { errorManager } from "@/components/Utilities/errorManager";
-import { Button } from "@/components/ui/button";
+import { AskKarmaError } from "@/src/features/ask-karma/components/ask-karma-error";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function AskKarmaError({ error, reset }: ErrorProps) {
-  useEffect(() => {
-    errorManager("Ask Karma page error", error);
-  }, [error]);
-
-  return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col items-center gap-4 px-4 py-16 text-center">
-      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-        Something went wrong loading the assistant.
-      </h2>
-      <p className="text-sm text-zinc-600 dark:text-zinc-300">
-        Please try again. If the issue persists, refresh the page.
-      </p>
-      <Button onClick={reset}>Try again</Button>
-    </div>
-  );
+export default function AskKarmaRouteError({ error, reset }: ErrorProps) {
+  return <AskKarmaError error={error} reset={reset} errorLabel="Ask Karma page error" />;
 }

--- a/app/ask-karma/error.tsx
+++ b/app/ask-karma/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { Button } from "@/components/ui/button";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AskKarmaError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    errorManager("Ask Karma page error", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col items-center gap-4 px-4 py-16 text-center">
+      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+        Something went wrong loading the assistant.
+      </h2>
+      <p className="text-sm text-zinc-600 dark:text-zinc-300">
+        Please try again. If the issue persists, refresh the page.
+      </p>
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/app/ask-karma/loading.tsx
+++ b/app/ask-karma/loading.tsx
@@ -1,0 +1,31 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col gap-3">
+          <div className="h-9 w-2/3 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+          <div className="h-5 w-full max-w-xl animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+        </div>
+        <div className="h-12 w-full animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-8 w-48 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/ask-karma/loading.tsx
+++ b/app/ask-karma/loading.tsx
@@ -1,31 +1,5 @@
+import { AskKarmaLoading } from "@/src/features/ask-karma/components/ask-karma-loading";
+
 export default function Loading() {
-  return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
-      <div className="flex flex-col gap-10">
-        <div className="flex flex-col gap-3">
-          <div className="h-9 w-2/3 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
-          <div className="h-5 w-full max-w-xl animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
-        </div>
-        <div className="h-12 w-full animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
-        <div className="flex flex-wrap gap-2">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
-              key={idx}
-              className="h-8 w-48 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
-            />
-          ))}
-        </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
-              key={idx}
-              className="h-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800"
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+  return <AskKarmaLoading />;
 }

--- a/app/ask-karma/page.tsx
+++ b/app/ask-karma/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { AskKarmaPage } from "@/src/features/ask-karma/components/ask-karma-page";
 import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
 import { SITE_URL, twitterMeta } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 async function resolveTenant() {
@@ -20,11 +21,11 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: { canonical: "/ask-karma" },
+    alternates: { canonical: PAGES.ASK_KARMA },
     twitter: { ...twitterMeta, title, description },
     openGraph: {
       type: "website",
-      url: `${SITE_URL}/ask-karma`,
+      url: `${SITE_URL}${PAGES.ASK_KARMA}`,
       title,
       description,
     },
@@ -33,7 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function RootAskKarmaPage() {
   const { tenantId, communitySlug } = await resolveTenant();
-  const config = getAskKarmaConfig(tenantId, communitySlug ?? null);
+  const config = getAskKarmaConfig(tenantId);
 
   return <AskKarmaPage config={config} communityId={communitySlug} />;
 }

--- a/app/ask-karma/page.tsx
+++ b/app/ask-karma/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { AskKarmaPage } from "@/src/features/ask-karma/components/ask-karma-page";
+import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
+import { SITE_URL, twitterMeta } from "@/utilities/meta";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
+
+async function resolveTenant() {
+  const ctx = await getWhitelabelContext();
+  const tenantId = ctx.tenantConfig?.id ?? "karma";
+  const tenantName = ctx.tenantConfig?.name ?? "Karma";
+  const communitySlug = ctx.communitySlug ?? undefined;
+  return { tenantId, tenantName, communitySlug };
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { tenantName } = await resolveTenant();
+  const title = `Ask ${tenantName} — AI Assistant`;
+  const description = `Ask anything about ${tenantName} — funding rounds, project progress, milestones, and ecosystem insights.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: "/ask-karma" },
+    twitter: { ...twitterMeta, title, description },
+    openGraph: {
+      type: "website",
+      url: `${SITE_URL}/ask-karma`,
+      title,
+      description,
+    },
+  };
+}
+
+export default async function RootAskKarmaPage() {
+  const { tenantId, communitySlug } = await resolveTenant();
+  const config = getAskKarmaConfig(tenantId, communitySlug ?? null);
+
+  return <AskKarmaPage config={config} communityId={communitySlug} />;
+}

--- a/app/ask-karma/page.tsx
+++ b/app/ask-karma/page.tsx
@@ -14,7 +14,7 @@ async function resolveTenant() {
 
 export async function generateMetadata(): Promise<Metadata> {
   const { tenantName } = await resolveTenant();
-  const title = `Ask ${tenantName} — AI Assistant`;
+  const title = `Ask ${tenantName} — Karma Assistant`;
   const description = `Ask anything about ${tenantName} — funding rounds, project progress, milestones, and ecosystem insights.`;
 
   return {

--- a/app/community/[communityId]/(with-header)/ask-karma/error.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/error.tsx
@@ -1,28 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
-import { errorManager } from "@/components/Utilities/errorManager";
-import { Button } from "@/components/ui/button";
+import { AskKarmaError } from "@/src/features/ask-karma/components/ask-karma-error";
 
 interface ErrorProps {
   error: Error & { digest?: string };
   reset: () => void;
 }
 
-export default function CommunityAskKarmaError({ error, reset }: ErrorProps) {
-  useEffect(() => {
-    errorManager("Community ask-karma page error", error);
-  }, [error]);
-
-  return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col items-center gap-4 px-4 py-16 text-center">
-      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
-        Something went wrong loading the assistant.
-      </h2>
-      <p className="text-sm text-zinc-600 dark:text-zinc-300">
-        Please try again. If the issue persists, refresh the page.
-      </p>
-      <Button onClick={reset}>Try again</Button>
-    </div>
-  );
+export default function CommunityAskKarmaRouteError({ error, reset }: ErrorProps) {
+  return <AskKarmaError error={error} reset={reset} errorLabel="Community ask-karma page error" />;
 }

--- a/app/community/[communityId]/(with-header)/ask-karma/error.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { Button } from "@/components/ui/button";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function CommunityAskKarmaError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    errorManager("Community ask-karma page error", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col items-center gap-4 px-4 py-16 text-center">
+      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+        Something went wrong loading the assistant.
+      </h2>
+      <p className="text-sm text-zinc-600 dark:text-zinc-300">
+        Please try again. If the issue persists, refresh the page.
+      </p>
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/ask-karma/loading.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/loading.tsx
@@ -1,0 +1,31 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col gap-3">
+          <div className="h-9 w-2/3 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+          <div className="h-5 w-full max-w-xl animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+        </div>
+        <div className="h-12 w-full animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-8 w-48 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/ask-karma/loading.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/loading.tsx
@@ -1,31 +1,5 @@
+import { AskKarmaLoading } from "@/src/features/ask-karma/components/ask-karma-loading";
+
 export default function Loading() {
-  return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
-      <div className="flex flex-col gap-10">
-        <div className="flex flex-col gap-3">
-          <div className="h-9 w-2/3 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
-          <div className="h-5 w-full max-w-xl animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
-        </div>
-        <div className="h-12 w-full animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
-        <div className="flex flex-wrap gap-2">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
-              key={idx}
-              className="h-8 w-48 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
-            />
-          ))}
-        </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
-              key={idx}
-              className="h-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800"
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+  return <AskKarmaLoading />;
 }

--- a/app/community/[communityId]/(with-header)/ask-karma/page.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   }
 
   const communityName = community.details.name;
-  const title = `Ask ${communityName} — AI Assistant`;
+  const title = `Ask ${communityName} — Karma Assistant`;
   const description = `Ask anything about ${communityName} — funding rounds, project progress, milestones, and ecosystem insights.`;
 
   return {

--- a/app/community/[communityId]/(with-header)/ask-karma/page.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { AskKarmaPage } from "@/src/features/ask-karma/components/ask-karma-page";
+import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
+import { SITE_URL } from "@/utilities/meta";
+import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
+
+type Params = Promise<{
+  communityId: string;
+}>;
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const { communityId } = await params;
+  const community = await getCommunityDetails(communityId);
+
+  if (!community || !community.details?.name) {
+    notFound();
+  }
+
+  const communityName = community.details.name;
+  const title = `Ask ${communityName} — AI Assistant`;
+  const description = `Ask anything about ${communityName} — funding rounds, project progress, milestones, and ecosystem insights.`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/community/${communityId}/ask-karma`,
+    },
+    openGraph: {
+      type: "website",
+      url: `${SITE_URL}/community/${communityId}/ask-karma`,
+      title,
+      description,
+    },
+  };
+}
+
+export default async function CommunityAskKarmaPage({ params }: { params: Params }) {
+  const { communityId } = await params;
+  const community = await getCommunityDetails(communityId);
+
+  if (!community || !community.details?.name) {
+    notFound();
+  }
+
+  const config = getAskKarmaConfig(communityId, community.details.slug ?? communityId);
+
+  return <AskKarmaPage config={config} communityId={communityId} />;
+}

--- a/app/community/[communityId]/(with-header)/ask-karma/page.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { AskKarmaPage } from "@/src/features/ask-karma/components/ask-karma-page";
 import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
 import { SITE_URL } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
 
 type Params = Promise<{
@@ -20,16 +21,15 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const communityName = community.details.name;
   const title = `Ask ${communityName} — Karma Assistant`;
   const description = `Ask anything about ${communityName} — funding rounds, project progress, milestones, and ecosystem insights.`;
+  const canonical = PAGES.COMMUNITY.ASK_KARMA(communityId);
 
   return {
     title,
     description,
-    alternates: {
-      canonical: `/community/${communityId}/ask-karma`,
-    },
+    alternates: { canonical },
     openGraph: {
       type: "website",
-      url: `${SITE_URL}/community/${communityId}/ask-karma`,
+      url: `${SITE_URL}${canonical}`,
       title,
       description,
     },
@@ -44,7 +44,7 @@ export default async function CommunityAskKarmaPage({ params }: { params: Params
     notFound();
   }
 
-  const config = getAskKarmaConfig(communityId, community.details.slug ?? communityId);
+  const config = getAskKarmaConfig(communityId);
 
   return <AskKarmaPage config={config} communityId={communityId} />;
 }

--- a/components/DeferredLayoutComponents.tsx
+++ b/components/DeferredLayoutComponents.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 
 const Toaster = dynamic(() => import("react-hot-toast").then((mod) => mod.Toaster), { ssr: false });
 
@@ -63,6 +64,14 @@ export function DeferredLayoutComponents({ toasterConfig }: DeferredLayoutCompon
   // is what caused the profile-modal bug at app.filpgf.io (see issue
   // "fix-profile-on-app-filpgf"). The dialogs are loaded via next/dynamic
   // with ssr:false, so the chunk cost is paid only when first rendered.
+  const pathname = usePathname() ?? "";
+  // The ask-karma page is itself a full-screen chat surface; the floating
+  // bubble would be a redundant second entry point that shares the same
+  // Zustand store and would mirror whatever conversation is happening on
+  // the page. Hide it on ask-karma routes only.
+  const isAskKarmaRoute =
+    pathname === "/ask-karma" || /\/community\/[^/]+\/ask-karma$/.test(pathname);
+
   return (
     <>
       <Toaster {...toasterConfig} />
@@ -73,7 +82,7 @@ export function DeferredLayoutComponents({ toasterConfig }: DeferredLayoutCompon
       <ContributorProfileDialog />
       <ApiKeyManagementModal />
       <OnboardingDialog />
-      <AgentChatBubble />
+      {!isAskKarmaRoute && <AgentChatBubble />}
     </>
   );
 }

--- a/components/DeferredLayoutComponents.tsx
+++ b/components/DeferredLayoutComponents.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
+import { isAskKarmaPathname } from "@/utilities/pages";
 
 const Toaster = dynamic(() => import("react-hot-toast").then((mod) => mod.Toaster), { ssr: false });
 
@@ -64,13 +65,11 @@ export function DeferredLayoutComponents({ toasterConfig }: DeferredLayoutCompon
   // is what caused the profile-modal bug at app.filpgf.io (see issue
   // "fix-profile-on-app-filpgf"). The dialogs are loaded via next/dynamic
   // with ssr:false, so the chunk cost is paid only when first rendered.
-  const pathname = usePathname() ?? "";
   // The ask-karma page is itself a full-screen chat surface; the floating
   // bubble would be a redundant second entry point that shares the same
   // Zustand store and would mirror whatever conversation is happening on
   // the page. Hide it on ask-karma routes only.
-  const isAskKarmaRoute =
-    pathname === "/ask-karma" || /\/community\/[^/]+\/ask-karma$/.test(pathname);
+  const isAskKarmaRoute = isAskKarmaPathname(usePathname() ?? "");
 
   return (
     <>

--- a/src/features/ask-karma/components/ask-karma-chat.tsx
+++ b/src/features/ask-karma/components/ask-karma-chat.tsx
@@ -98,9 +98,16 @@ export function AskKarmaChat({
   const endRef = useRef<HTMLDivElement>(null);
   const lastContent = messages[messages.length - 1]?.content;
 
+  // During streaming, `lastContent` ticks on every token — smooth scrolling
+  // on each tick produces visible jank. Use instant (`"auto"`) scroll while
+  // streaming so the viewport keeps up with the stream, and smooth scroll
+  // when idle for normal message turnover.
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [lastContent]);
+    endRef.current?.scrollIntoView({
+      behavior: isStreaming ? "auto" : "smooth",
+      block: "end",
+    });
+  }, [isStreaming, lastContent, messages.length]);
 
   const lastMessage = messages[messages.length - 1];
   const showThinking = isStreaming && lastMessage?.role === "assistant" && !lastMessage.content;

--- a/src/features/ask-karma/components/ask-karma-chat.tsx
+++ b/src/features/ask-karma/components/ask-karma-chat.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { AlertCircleIcon, ArrowLeftIcon, SparklesIcon, UserIcon } from "lucide-react";
+import { memo, useEffect, useRef } from "react";
+import { MessageResponse } from "@/src/components/ai-elements/message-response";
+import type { ChatMessage } from "@/store/agentChat";
+import { cn } from "@/utilities/tailwind";
+import type { AskKarmaConfig } from "../types";
+import { AskKarmaInput } from "./ask-karma-input";
+
+function formatTime(timestamp: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(timestamp);
+}
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+}
+
+const MessageBubble = memo(function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <div
+      data-testid={`ask-karma-message-${message.role}`}
+      className={cn(
+        "flex w-full items-start gap-3",
+        "animate-in fade-in slide-in-from-bottom-2 duration-300 ease-out",
+        isUser ? "flex-row-reverse" : "flex-row"
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-transform duration-200",
+          "animate-in zoom-in-90 duration-200",
+          isUser
+            ? "bg-zinc-900 text-zinc-50 dark:bg-zinc-100 dark:text-zinc-900"
+            : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+        )}
+        aria-hidden="true"
+      >
+        {isUser ? <UserIcon className="h-4 w-4" /> : <SparklesIcon className="h-4 w-4" />}
+      </div>
+
+      <div className={cn("flex max-w-[80%] flex-col gap-1", isUser ? "items-end" : "items-start")}>
+        <div
+          className={cn(
+            "rounded-2xl px-4 py-3 text-sm leading-relaxed transition-shadow duration-200",
+            "shadow-sm hover:shadow-md",
+            isUser
+              ? "rounded-tr-sm bg-zinc-900 text-zinc-50 dark:bg-zinc-100 dark:text-zinc-900"
+              : "rounded-tl-sm border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50"
+          )}
+        >
+          {isUser ? (
+            <p className="whitespace-pre-wrap">{message.content}</p>
+          ) : (
+            <MessageResponse>{message.content}</MessageResponse>
+          )}
+        </div>
+        <time
+          className={cn(
+            "text-xs text-zinc-500 dark:text-zinc-400",
+            "animate-in fade-in duration-500",
+            isUser ? "pr-1 text-right" : "pl-1"
+          )}
+          style={{ animationDelay: "120ms", animationFillMode: "both" }}
+        >
+          {formatTime(message.timestamp)}
+        </time>
+      </div>
+    </div>
+  );
+});
+
+interface AskKarmaChatProps {
+  config: AskKarmaConfig;
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  error: string | null;
+  onSend: (text: string) => void;
+  onStop: () => void;
+  onBack: () => void;
+}
+
+export function AskKarmaChat({
+  config,
+  messages,
+  isStreaming,
+  error,
+  onSend,
+  onStop,
+  onBack,
+}: AskKarmaChatProps) {
+  const endRef = useRef<HTMLDivElement>(null);
+  const lastContent = messages[messages.length - 1]?.content;
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [lastContent]);
+
+  const lastMessage = messages[messages.length - 1];
+  const showThinking = isStreaming && lastMessage?.role === "assistant" && !lastMessage.content;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header
+        className={cn(
+          "flex items-center justify-between border-b border-zinc-200 pb-4 dark:border-zinc-800",
+          "animate-in fade-in slide-in-from-top-2 duration-300 ease-out"
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 transition-transform duration-300 hover:scale-105 dark:bg-emerald-900/40 dark:text-emerald-300"
+            aria-hidden="true"
+          >
+            <SparklesIcon className="h-5 w-5" />
+          </div>
+          <div className="flex flex-col">
+            <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+              {config.assistantTitle}
+            </h2>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">{config.assistantSubtitle}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onBack}
+          className={cn(
+            "group flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-emerald-700",
+            "transition-all duration-200 ease-out",
+            "hover:bg-emerald-50 hover:text-emerald-900 hover:gap-2",
+            "active:scale-95",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300",
+            "dark:text-emerald-400 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-200"
+          )}
+        >
+          <ArrowLeftIcon
+            className="h-4 w-4 transition-transform duration-200 group-hover:-translate-x-0.5"
+            aria-hidden="true"
+          />
+          Back to topics
+        </button>
+      </header>
+
+      <div className="flex flex-1 flex-col gap-6 overflow-y-auto py-6">
+        {messages.length === 0 && !isStreaming && (
+          <div
+            className={cn(
+              "flex flex-1 flex-col items-center justify-center gap-2 text-center",
+              "animate-in fade-in duration-500"
+            )}
+          >
+            <SparklesIcon className="h-8 w-8 text-emerald-500" aria-hidden="true" />
+            <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              Ask a question to get started.
+            </p>
+          </div>
+        )}
+
+        {messages.map((message) => (
+          <MessageBubble key={message.id} message={message} />
+        ))}
+
+        {showThinking && (
+          <div
+            className="flex items-start gap-3 animate-in fade-in duration-200"
+            data-testid="thinking-dots"
+          >
+            <div
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+              aria-hidden="true"
+            >
+              <SparklesIcon className="h-4 w-4" />
+            </div>
+            <div className="flex items-center gap-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-4 py-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:0ms]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:150ms]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:300ms]" />
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className={cn(
+              "flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700",
+              "animate-in fade-in slide-in-from-bottom-1 duration-300",
+              "dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300"
+            )}
+          >
+            <AlertCircleIcon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p>{error}</p>
+          </div>
+        )}
+
+        <div ref={endRef} />
+      </div>
+
+      <div
+        className={cn(
+          "border-t border-zinc-200 pt-4 dark:border-zinc-800",
+          "animate-in fade-in slide-in-from-bottom-2 duration-300 ease-out"
+        )}
+        style={{ animationDelay: "80ms", animationFillMode: "both" }}
+      >
+        <AskKarmaInput onSubmit={onSend} onStop={onStop} isStreaming={isStreaming} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/ask-karma/components/ask-karma-error.tsx
+++ b/src/features/ask-karma/components/ask-karma-error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { Button } from "@/components/ui/button";
+
+interface AskKarmaErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  /**
+   * Label used as the first arg to errorManager — distinguishes the root
+   * route from the community route in Sentry so each path's errors can be
+   * filtered separately. Kept short and stable.
+   */
+  errorLabel: string;
+}
+
+/**
+ * Shared error boundary content for both ask-karma route entries. The route
+ * `error.tsx` files thin-wrap this so they each get a stable Sentry label.
+ */
+export function AskKarmaError({ error, reset, errorLabel }: AskKarmaErrorProps) {
+  useEffect(() => {
+    errorManager(errorLabel, error);
+  }, [error, errorLabel]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col items-center gap-4 px-4 py-16 text-center">
+      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+        Something went wrong loading the assistant.
+      </h2>
+      <p className="text-sm text-zinc-600 dark:text-zinc-300">
+        Please try again. If the issue persists, refresh the page.
+      </p>
+      <Button onClick={reset}>Try again</Button>
+    </div>
+  );
+}

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -65,7 +65,7 @@ export function AskKarmaInput({
         onKeyDown={handleKeyDown}
         rows={1}
         placeholder={placeholder}
-        aria-label={placeholder}
+        aria-label="Message Karma Assistant"
         className={cn(
           "max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-sm",
           "text-zinc-900 placeholder:text-zinc-400 outline-none",

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -11,6 +11,10 @@ interface AskKarmaInputProps {
   placeholder?: string;
 }
 
+// Hard cap on a single chat turn. Generous (~1k tokens of English) but
+// prevents pasted-document-sized prompts from being submitted accidentally.
+const CHAT_INPUT_MAX_LENGTH = 4000;
+
 export function AskKarmaInput({
   onSubmit,
   onStop,
@@ -64,6 +68,7 @@ export function AskKarmaInput({
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
         rows={1}
+        maxLength={CHAT_INPUT_MAX_LENGTH}
         placeholder={placeholder}
         aria-label="Message Karma Assistant"
         className={cn(

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -40,6 +40,10 @@ export function AskKarmaInput({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      // CJK / IME users press Enter to confirm a composition candidate;
+      // without this guard, that confirmation also submits the half-typed
+      // message and breaks the input for those locales.
+      if (event.nativeEvent.isComposing) return;
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         send();

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { SendIcon, SquareIcon } from "lucide-react";
+import { type FormEvent, type KeyboardEvent, useCallback, useState } from "react";
+import { cn } from "@/utilities/tailwind";
+
+interface AskKarmaInputProps {
+  onSubmit: (text: string) => void;
+  onStop?: () => void;
+  isStreaming: boolean;
+  placeholder?: string;
+}
+
+export function AskKarmaInput({
+  onSubmit,
+  onStop,
+  isStreaming,
+  placeholder = "Type your message...",
+}: AskKarmaInputProps) {
+  const [value, setValue] = useState("");
+
+  const send = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed || isStreaming) return;
+    onSubmit(trimmed);
+    setValue("");
+  }, [isStreaming, onSubmit, value]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      send();
+    },
+    [send]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        send();
+      }
+    },
+    [send]
+  );
+
+  const canSend = value.trim().length > 0 && !isStreaming;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn(
+        "relative flex w-full items-end gap-2 rounded-xl border border-zinc-200 bg-white px-3 py-2",
+        "shadow-sm transition-all duration-200 ease-out",
+        "hover:border-zinc-300 hover:shadow-md",
+        "focus-within:border-emerald-400 focus-within:ring-2 focus-within:ring-emerald-200/60",
+        "focus-within:shadow-[0_0_0_4px_rgba(167,243,208,0.15)]",
+        "dark:border-zinc-800 dark:bg-zinc-900",
+        "dark:hover:border-zinc-700 dark:focus-within:border-emerald-700 dark:focus-within:ring-emerald-900/40"
+      )}
+    >
+      <textarea
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={handleKeyDown}
+        rows={1}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        className={cn(
+          "max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-sm",
+          "text-zinc-900 placeholder:text-zinc-400 outline-none",
+          "transition-colors duration-200",
+          "dark:text-zinc-50 dark:placeholder:text-zinc-500"
+        )}
+      />
+      {isStreaming && onStop ? (
+        <button
+          type="button"
+          onClick={onStop}
+          aria-label="Stop response"
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-full",
+            "bg-zinc-200 text-zinc-700 transition-all duration-200 ease-out",
+            "animate-in zoom-in-90 fade-in",
+            "hover:scale-110 hover:bg-zinc-300 active:scale-90",
+            "dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+          )}
+        >
+          <SquareIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={!canSend}
+          aria-label="Send message"
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-full transition-all duration-200 ease-out",
+            "active:scale-90 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100",
+            canSend
+              ? "bg-emerald-600 text-white shadow-sm hover:scale-110 hover:bg-emerald-700 hover:shadow-md dark:bg-emerald-500 dark:hover:bg-emerald-400"
+              : "bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+          )}
+        >
+          <SendIcon
+            className={cn(
+              "h-3.5 w-3.5 transition-transform duration-200",
+              canSend ? "group-active:rotate-12" : ""
+            )}
+            aria-hidden="true"
+          />
+        </button>
+      )}
+    </form>
+  );
+}

--- a/src/features/ask-karma/components/ask-karma-loading.tsx
+++ b/src/features/ask-karma/components/ask-karma-loading.tsx
@@ -1,0 +1,36 @@
+/**
+ * Shared loading skeleton for both ask-karma route entries (root and
+ * community-scoped). Mirrors the section layout of AskKarmaStart so the
+ * page doesn't reflow when content arrives.
+ */
+export function AskKarmaLoading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col gap-3">
+          <div className="h-9 w-2/3 animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+          <div className="h-5 w-full max-w-xl animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800" />
+        </div>
+        <div className="h-12 w-full animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-8 w-48 animate-pulse rounded-full bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders are stable for a single render
+              key={idx}
+              className="h-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -79,10 +79,16 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
           key="start"
           data-testid="ask-karma-start-view"
           data-view-state={view}
+          // While the start view is fading out (`leaving-start`), keep it
+          // visible for the exit animation but block any new clicks/edits
+          // — any input during that 220ms window would be discarded when
+          // the chat view mounts. aria-hidden so assistive tech also skips
+          // the disappearing subtree.
+          aria-hidden={view === "leaving-start"}
           className={cn(
             "py-8",
             view === "leaving-start"
-              ? "animate-out fade-out slide-out-to-top-2 duration-200"
+              ? "pointer-events-none animate-out fade-out slide-out-to-top-2 duration-200"
               : "animate-in fade-in slide-in-from-bottom-1 duration-300"
           )}
           style={isLeaving ? { animationFillMode: "forwards" } : undefined}
@@ -95,13 +101,17 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
           key="chat"
           data-testid="ask-karma-chat-view"
           data-view-state={view}
+          // Symmetric to leaving-start: lock interaction during the chat
+          // view's fade-out so a stray click on Back / Send during the
+          // 220ms exit can't double-fire.
+          aria-hidden={view === "leaving-chat"}
           className={cn(
             // 100dvh (dynamic viewport) avoids the iOS Safari quirk where
             // 100vh ignores the on-screen keyboard. Fallback min-h keeps
             // the layout sane on older browsers that don't support dvh.
             "h-[calc(100dvh-180px)] min-h-[520px] py-6",
             view === "leaving-chat"
-              ? "animate-out fade-out slide-out-to-bottom-2 duration-200"
+              ? "pointer-events-none animate-out fade-out slide-out-to-bottom-2 duration-200"
               : "animate-in fade-in slide-in-from-bottom-3 duration-300"
           )}
           style={isLeaving ? { animationFillMode: "forwards" } : undefined}

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAgentStream } from "@/hooks/useAgentStream";
+import { useAgentChatStore } from "@/store/agentChat";
+import { cn } from "@/utilities/tailwind";
+import type { AskKarmaConfig } from "../types";
+import { AskKarmaChat } from "./ask-karma-chat";
+import { AskKarmaStart } from "./ask-karma-start";
+
+export type AskKarmaView = "start" | "leaving-start" | "chat" | "leaving-chat";
+
+interface AskKarmaPageProps {
+  config: AskKarmaConfig;
+  communityId?: string;
+}
+
+// Keep this in sync with the exit animation durations on each view's
+// `animate-out duration-*` class. We mount the leaving view for this long
+// so its fade-out completes before we swap subtrees.
+const FADE_OUT_MS = 220;
+
+export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
+  const messages = useAgentChatStore((s) => s.messages);
+  const isStreaming = useAgentChatStore((s) => s.isStreaming);
+  const error = useAgentChatStore((s) => s.error);
+  const clearMessages = useAgentChatStore((s) => s.clearMessages);
+  const setAgentContext = useAgentChatStore((s) => s.setAgentContext);
+
+  const { sendMessage, abort } = useAgentStream();
+  const [view, setView] = useState<AskKarmaView>("start");
+  const transitionTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    clearMessages();
+    setAgentContext(communityId ? { communityId } : null);
+    return () => {
+      abort();
+      clearMessages();
+      setAgentContext(null);
+      if (transitionTimeout.current) {
+        clearTimeout(transitionTimeout.current);
+        transitionTimeout.current = null;
+      }
+    };
+  }, [communityId, clearMessages, setAgentContext, abort]);
+
+  const handleSubmit = useCallback(
+    (text: string) => {
+      if (!text || isStreaming) return;
+      if (view === "start") {
+        setView("leaving-start");
+        if (transitionTimeout.current) clearTimeout(transitionTimeout.current);
+        transitionTimeout.current = setTimeout(() => setView("chat"), FADE_OUT_MS);
+      }
+      sendMessage(text);
+    },
+    [isStreaming, sendMessage, view]
+  );
+
+  const handleBack = useCallback(() => {
+    abort();
+    setView("leaving-chat");
+    if (transitionTimeout.current) clearTimeout(transitionTimeout.current);
+    transitionTimeout.current = setTimeout(() => {
+      clearMessages();
+      setView("start");
+    }, FADE_OUT_MS);
+  }, [abort, clearMessages]);
+
+  const showStart = view === "start" || view === "leaving-start";
+  const showChat = view === "chat" || view === "leaving-chat";
+  const isLeaving = view === "leaving-start" || view === "leaving-chat";
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+      {showStart && (
+        <div
+          key="start"
+          data-testid="ask-karma-start-view"
+          data-view-state={view}
+          className={cn(
+            "py-8",
+            view === "leaving-start"
+              ? "animate-out fade-out slide-out-to-top-2 duration-200"
+              : "animate-in fade-in slide-in-from-bottom-1 duration-300"
+          )}
+          style={isLeaving ? { animationFillMode: "forwards" } : undefined}
+        >
+          <AskKarmaStart config={config} onSubmit={handleSubmit} />
+        </div>
+      )}
+      {showChat && (
+        <div
+          key="chat"
+          data-testid="ask-karma-chat-view"
+          data-view-state={view}
+          className={cn(
+            "h-[calc(100vh-180px)] min-h-[520px] py-6",
+            view === "leaving-chat"
+              ? "animate-out fade-out slide-out-to-bottom-2 duration-200"
+              : "animate-in fade-in slide-in-from-bottom-3 duration-300"
+          )}
+          style={isLeaving ? { animationFillMode: "forwards" } : undefined}
+        >
+          <AskKarmaChat
+            config={config}
+            messages={messages}
+            isStreaming={isStreaming}
+            error={error}
+            onSend={handleSubmit}
+            onStop={abort}
+            onBack={handleBack}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -96,7 +96,10 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
           data-testid="ask-karma-chat-view"
           data-view-state={view}
           className={cn(
-            "h-[calc(100vh-180px)] min-h-[520px] py-6",
+            // 100dvh (dynamic viewport) avoids the iOS Safari quirk where
+            // 100vh ignores the on-screen keyboard. Fallback min-h keeps
+            // the layout sane on older browsers that don't support dvh.
+            "h-[calc(100dvh-180px)] min-h-[520px] py-6",
             view === "leaving-chat"
               ? "animate-out fade-out slide-out-to-bottom-2 duration-200"
               : "animate-in fade-in slide-in-from-bottom-3 duration-300"

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -116,6 +116,10 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
+      // CJK / IME users press Enter to confirm a composition candidate;
+      // without this guard, that confirmation also submits the half-typed
+      // message and breaks the input for those locales.
+      if (event.nativeEvent.isComposing) return;
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         if (phase !== "idle") return;

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -11,9 +11,15 @@ import {
   useState,
 } from "react";
 import { cn } from "@/utilities/tailwind";
+import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 import type { AskKarmaConfig } from "../types";
 import { FeaturedTopicCard } from "./featured-topic-card";
 import { FlyingChip, type FlyingChipRect } from "./flying-chip";
+
+// Hard cap on free-text input. Roughly matches a generous tweet length and
+// well below the LLM's prompt window — protects against accidental paste of
+// a huge document into the search bar.
+const INPUT_MAX_LENGTH = 500;
 
 interface AskKarmaStartProps {
   config: AskKarmaConfig;
@@ -58,6 +64,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
   const [typedValue, setTypedValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const submitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // Drive the auto-type effect. Owns its own setInterval and a follow-up
   // setTimeout for the post-type pause. Both are cleaned up on unmount or
@@ -123,6 +130,14 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
   const handleChipClick = useCallback(
     (question: string, event: ReactMouseEvent<HTMLButtonElement>) => {
       if (phase !== "idle") return;
+      // Vestibular-safety: skip the fly+type animation entirely for users who
+      // have opted into reduced motion. The chip-fly is a 300ms+ viewport
+      // translation which is exactly the kind of motion `prefers-reduced-
+      // motion: reduce` is meant to suppress. Submit directly instead.
+      if (prefersReducedMotion) {
+        onSubmit(question);
+        return;
+      }
       const chipEl = event.currentTarget;
       const inputEl = inputRef.current;
       // Defensive fallback: if we can't measure either rect (e.g. JSDOM in
@@ -140,7 +155,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
       setTypedValue("");
       setPhase("flying");
     },
-    [onSubmit, phase]
+    [onSubmit, phase, prefersReducedMotion]
   );
 
   const handleFlyArrive = useCallback(() => {
@@ -181,6 +196,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
           }}
           onKeyDown={handleKeyDown}
           readOnly={inputDisabled}
+          maxLength={INPUT_MAX_LENGTH}
           placeholder={config.inputPlaceholder}
           aria-label="Ask Karma Assistant a question"
           data-testid="ask-karma-search-input"

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -182,7 +182,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
           onKeyDown={handleKeyDown}
           readOnly={inputDisabled}
           placeholder={config.inputPlaceholder}
-          aria-label={config.inputPlaceholder}
+          aria-label="Ask Karma Assistant a question"
           data-testid="ask-karma-search-input"
           className={cn(
             "w-full rounded-xl border border-zinc-200 bg-white px-4 py-3 pr-12 text-sm",

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -199,7 +199,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
         />
         <button
           type="submit"
-          aria-label="Ask the AI Assistant"
+          aria-label="Ask the Karma Assistant"
           className={cn(
             "absolute right-2 top-1/2 -translate-y-1/2",
             "flex h-8 w-8 items-center justify-center rounded-full",

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/utilities/tailwind";
+import type { AskKarmaConfig } from "../types";
+import { FeaturedTopicCard } from "./featured-topic-card";
+import { FlyingChip, type FlyingChipRect } from "./flying-chip";
+
+interface AskKarmaStartProps {
+  config: AskKarmaConfig;
+  onSubmit: (question: string) => void;
+}
+
+// Animation timing — tuned for a snappy ~1s click-to-chat handoff while
+// still reading as deliberate motion. Exported for tests so they can advance
+// fake timers by exactly the right amount.
+export const ASK_KARMA_ANIMATION = {
+  FLY_DURATION_MS: 350,
+  TYPE_SPEED_MS: 18,
+  POST_TYPE_PAUSE_MS: 150,
+} as const;
+
+type ChipAnimationPhase = "idle" | "flying" | "typing";
+
+// Stagger constants for the initial cascade — keep tight (~40-60ms per item)
+// so the introduction reads as one motion.
+const CHIP_STAGGER_MS = 40;
+const TOPIC_STAGGER_MS = 60;
+const SECTION_BASE_DELAY = {
+  heading: 0,
+  input: 80,
+  examplesIntro: 160,
+  chipsBase: 200,
+  featuredHeading: 280,
+  topicsBase: 340,
+} as const;
+
+function rectFromDOMRect(rect: DOMRect): FlyingChipRect {
+  return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+}
+
+export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
+  const [value, setValue] = useState("");
+  const [phase, setPhase] = useState<ChipAnimationPhase>("idle");
+  const [flyText, setFlyText] = useState("");
+  const [flyRects, setFlyRects] = useState<{ start: FlyingChipRect; end: FlyingChipRect } | null>(
+    null
+  );
+  const [typedValue, setTypedValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const submitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Drive the auto-type effect. Owns its own setInterval and a follow-up
+  // setTimeout for the post-type pause. Both are cleaned up on unmount or
+  // phase change so a stale interval can't keep ticking after the user has
+  // navigated away.
+  useEffect(() => {
+    if (phase !== "typing") return;
+    let index = 0;
+    setTypedValue("");
+    const interval = setInterval(() => {
+      index += 1;
+      setTypedValue(flyText.slice(0, index));
+      if (index >= flyText.length) {
+        clearInterval(interval);
+        submitTimerRef.current = setTimeout(() => {
+          submitTimerRef.current = null;
+          setPhase("idle");
+          onSubmit(flyText);
+        }, ASK_KARMA_ANIMATION.POST_TYPE_PAUSE_MS);
+      }
+    }, ASK_KARMA_ANIMATION.TYPE_SPEED_MS);
+    return () => {
+      clearInterval(interval);
+      if (submitTimerRef.current) {
+        clearTimeout(submitTimerRef.current);
+        submitTimerRef.current = null;
+      }
+    };
+  }, [phase, flyText, onSubmit]);
+
+  // Focus the input as soon as the typing phase begins so the native caret
+  // is visible while characters appear.
+  useEffect(() => {
+    if (phase === "typing") {
+      inputRef.current?.focus();
+    }
+  }, [phase]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (phase !== "idle") return;
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      onSubmit(trimmed);
+    },
+    [onSubmit, phase, value]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        if (phase !== "idle") return;
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        onSubmit(trimmed);
+      }
+    },
+    [onSubmit, phase, value]
+  );
+
+  const handleChipClick = useCallback(
+    (question: string, event: ReactMouseEvent<HTMLButtonElement>) => {
+      if (phase !== "idle") return;
+      const chipEl = event.currentTarget;
+      const inputEl = inputRef.current;
+      // Defensive fallback: if we can't measure either rect (e.g. JSDOM in
+      // an old test environment), short-circuit the animation and submit
+      // immediately rather than getting stuck in a half-state.
+      if (!inputEl) {
+        onSubmit(question);
+        return;
+      }
+      setFlyText(question);
+      setFlyRects({
+        start: rectFromDOMRect(chipEl.getBoundingClientRect()),
+        end: rectFromDOMRect(inputEl.getBoundingClientRect()),
+      });
+      setTypedValue("");
+      setPhase("flying");
+    },
+    [onSubmit, phase]
+  );
+
+  const handleFlyArrive = useCallback(() => {
+    setPhase("typing");
+  }, []);
+
+  // What renders in the input across phases:
+  //   idle    → user-controlled value
+  //   flying  → empty (the chip clone is still in flight)
+  //   typing  → progressively populated from typedValue
+  const displayValue = phase === "idle" ? value : phase === "flying" ? "" : typedValue;
+  const inputDisabled = phase !== "idle";
+  const submitDisabled = phase !== "idle" || displayValue.trim().length === 0;
+
+  return (
+    <div className="flex flex-col gap-10" data-animation-phase={phase}>
+      <section
+        className="animate-in fade-in slide-in-from-bottom-1 duration-500 flex flex-col gap-3"
+        style={{ animationDelay: `${SECTION_BASE_DELAY.heading}ms`, animationFillMode: "both" }}
+      >
+        <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+          {config.heading}
+        </h1>
+        <p className="text-base text-zinc-600 dark:text-zinc-300">{config.subheading}</p>
+      </section>
+
+      <form
+        onSubmit={handleSubmit}
+        className="animate-in fade-in slide-in-from-bottom-1 duration-500 relative"
+        style={{ animationDelay: `${SECTION_BASE_DELAY.input}ms`, animationFillMode: "both" }}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={displayValue}
+          onChange={(event) => {
+            if (phase === "idle") setValue(event.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          readOnly={inputDisabled}
+          placeholder={config.inputPlaceholder}
+          aria-label={config.inputPlaceholder}
+          data-testid="ask-karma-search-input"
+          className={cn(
+            "w-full rounded-xl border border-zinc-200 bg-white px-4 py-3 pr-12 text-sm",
+            "text-zinc-900 placeholder:text-zinc-400",
+            "shadow-sm transition-all duration-200",
+            "hover:border-zinc-300 hover:shadow-md",
+            "focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200/60",
+            "focus:shadow-[0_0_0_4px_rgba(167,243,208,0.15)]",
+            phase === "typing" && "border-emerald-400 ring-2 ring-emerald-200/60",
+            "dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50",
+            "dark:placeholder:text-zinc-500 dark:hover:border-zinc-700",
+            "dark:focus:border-emerald-700 dark:focus:ring-emerald-900/40"
+          )}
+        />
+        <button
+          type="submit"
+          aria-label="Ask the AI Assistant"
+          className={cn(
+            "absolute right-2 top-1/2 -translate-y-1/2",
+            "flex h-8 w-8 items-center justify-center rounded-full",
+            "transition-all duration-200 ease-out",
+            "hover:scale-110 active:scale-90",
+            "disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100",
+            !submitDisabled
+              ? "bg-emerald-600 text-white shadow-sm hover:bg-emerald-700 hover:shadow-md dark:bg-emerald-500 dark:hover:bg-emerald-400"
+              : "bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+          )}
+          disabled={submitDisabled}
+        >
+          <SearchIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </form>
+
+      <section className="flex flex-col gap-3">
+        <p
+          className="animate-in fade-in slide-in-from-bottom-1 duration-500 text-sm text-zinc-600 dark:text-zinc-300"
+          style={{
+            animationDelay: `${SECTION_BASE_DELAY.examplesIntro}ms`,
+            animationFillMode: "both",
+          }}
+        >
+          {config.examplesIntro}
+        </p>
+        <ul className="flex flex-wrap gap-2">
+          {config.exampleQuestions.map((question, idx) => (
+            <li
+              key={question}
+              className="animate-in fade-in zoom-in-95 slide-in-from-bottom-1 duration-300"
+              style={{
+                animationDelay: `${SECTION_BASE_DELAY.chipsBase + idx * CHIP_STAGGER_MS}ms`,
+                animationFillMode: "both",
+              }}
+            >
+              <button
+                type="button"
+                onClick={(event) => handleChipClick(question, event)}
+                disabled={phase !== "idle"}
+                className={cn(
+                  "rounded-full border border-zinc-200 bg-zinc-50 px-3.5 py-1.5 text-sm",
+                  "text-zinc-800 transition-all duration-200 ease-out",
+                  "hover:-translate-y-0.5 hover:scale-[1.02]",
+                  "hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-900 hover:shadow-sm",
+                  "active:translate-y-0 active:scale-100",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300",
+                  "disabled:cursor-default disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:scale-100 disabled:hover:bg-zinc-50 disabled:hover:border-zinc-200 disabled:hover:text-zinc-800 disabled:hover:shadow-none",
+                  "dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200",
+                  "dark:hover:border-emerald-800 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-100",
+                  "dark:disabled:hover:bg-zinc-900 dark:disabled:hover:border-zinc-800 dark:disabled:hover:text-zinc-200"
+                )}
+              >
+                {question}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2
+          className="animate-in fade-in slide-in-from-bottom-1 duration-500 text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50"
+          style={{
+            animationDelay: `${SECTION_BASE_DELAY.featuredHeading}ms`,
+            animationFillMode: "both",
+          }}
+        >
+          {config.featuredTopicsHeading}
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {config.featuredTopics.map((topic, idx) => (
+            <div
+              key={topic.title}
+              className="animate-in fade-in slide-in-from-bottom-2 duration-500"
+              style={{
+                animationDelay: `${SECTION_BASE_DELAY.topicsBase + idx * TOPIC_STAGGER_MS}ms`,
+                animationFillMode: "both",
+              }}
+            >
+              <FeaturedTopicCard topic={topic} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {phase === "flying" && flyRects && (
+        <FlyingChip
+          text={flyText}
+          startRect={flyRects.start}
+          endRect={flyRects.end}
+          durationMs={ASK_KARMA_ANIMATION.FLY_DURATION_MS}
+          onArrive={handleFlyArrive}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/ask-karma/components/featured-topic-card.tsx
+++ b/src/features/ask-karma/components/featured-topic-card.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utilities/tailwind";
+import type { AskKarmaTopic } from "../types";
+import { TopicIcon } from "./topic-icon";
+
+interface FeaturedTopicCardProps {
+  topic: AskKarmaTopic;
+}
+
+export function FeaturedTopicCard({ topic }: FeaturedTopicCardProps) {
+  return (
+    <article
+      className={cn(
+        "group relative flex h-full flex-col gap-4 overflow-hidden rounded-xl border border-zinc-200 bg-white p-6",
+        "transition-all duration-300 ease-out",
+        "hover:-translate-y-1 hover:border-emerald-200 hover:shadow-lg hover:shadow-emerald-100/50",
+        "dark:border-zinc-800 dark:bg-zinc-900",
+        "dark:hover:border-emerald-900/40 dark:hover:shadow-emerald-900/20"
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 h-px",
+          "bg-gradient-to-r from-transparent via-emerald-400/0 to-transparent",
+          "transition-all duration-500 group-hover:via-emerald-400/60"
+        )}
+      />
+
+      <div
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700",
+          "transition-all duration-300 ease-out",
+          "group-hover:scale-110 group-hover:rotate-3",
+          "dark:bg-emerald-900/40 dark:text-emerald-300"
+        )}
+      >
+        <TopicIcon name={topic.icon} className="h-5 w-5" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">{topic.title}</h3>
+        {topic.description && (
+          <p className="text-sm text-emerald-700 dark:text-emerald-400">{topic.description}</p>
+        )}
+      </div>
+
+      {topic.links && topic.links.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {topic.links.map((link) => (
+            <li key={`${link.label}-${link.href}`}>
+              <Link
+                href={link.href}
+                target={link.isExternal ? "_blank" : undefined}
+                rel={link.isExternal ? "noopener noreferrer" : undefined}
+                className={cn(
+                  "inline-flex items-center text-sm font-medium text-emerald-700",
+                  "underline-offset-4 transition-all duration-150",
+                  "hover:underline hover:translate-x-0.5",
+                  "dark:text-emerald-400"
+                )}
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {topic.cta && (
+        <div className="mt-auto pt-1">
+          <Button
+            variant="outline"
+            size="sm"
+            asChild
+            className="transition-all duration-200 hover:scale-[1.02] active:scale-100"
+          >
+            <Link
+              href={topic.cta.href}
+              target={topic.cta.isExternal ? "_blank" : undefined}
+              rel={topic.cta.isExternal ? "noopener noreferrer" : undefined}
+            >
+              {topic.cta.label}
+            </Link>
+          </Button>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/features/ask-karma/components/flying-chip.tsx
+++ b/src/features/ask-karma/components/flying-chip.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utilities/tailwind";
+
+export interface FlyingChipRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface FlyingChipProps {
+  text: string;
+  startRect: FlyingChipRect;
+  endRect: FlyingChipRect;
+  durationMs: number;
+  onArrive: () => void;
+}
+
+/**
+ * Renders a chip clone via a body portal that animates from `startRect` to
+ * `endRect` over `durationMs`. The clone fades out during the back half of
+ * the flight so the input it lands on can take over the visual.
+ *
+ * Two RAFs before flipping to the end position so the start position commits
+ * to the layout — without the double RAF, the browser collapses both styles
+ * into one paint and skips the transition.
+ */
+export function FlyingChip({ text, startRect, endRect, durationMs, onArrive }: FlyingChipProps) {
+  const [phase, setPhase] = useState<"start" | "end">("start");
+  const arrivedRef = useRef(false);
+
+  useLayoutEffect(() => {
+    let raf2: number | null = null;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setPhase("end"));
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2 !== null) cancelAnimationFrame(raf2);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (phase !== "end") return;
+    const timer = setTimeout(() => {
+      if (arrivedRef.current) return;
+      arrivedRef.current = true;
+      onArrive();
+    }, durationMs);
+    return () => clearTimeout(timer);
+  }, [phase, durationMs, onArrive]);
+
+  if (typeof document === "undefined") return null;
+
+  const isAtEnd = phase === "end";
+  // Land at the input's left edge with a 12px pad so the chip aligns with
+  // where the first typed character will appear, and vertically center it
+  // relative to the input.
+  const target: FlyingChipRect = isAtEnd
+    ? {
+        left: endRect.left + 12,
+        top: endRect.top + (endRect.height - startRect.height) / 2,
+        width: Math.max(40, Math.min(startRect.width * 0.85, endRect.width - 24)),
+        height: startRect.height,
+      }
+    : startRect;
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      data-testid="ask-karma-flying-chip"
+      className={cn(
+        "pointer-events-none fixed z-[9999] flex items-center overflow-hidden whitespace-nowrap",
+        "rounded-full border border-emerald-300 bg-emerald-50 px-3.5 py-1.5",
+        "text-sm font-medium text-emerald-900 shadow-lg shadow-emerald-300/40",
+        "dark:border-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-100 dark:shadow-emerald-900/40"
+      )}
+      style={{
+        left: target.left,
+        top: target.top,
+        width: target.width,
+        height: target.height,
+        opacity: isAtEnd ? 0 : 1,
+        transform: isAtEnd ? "scale(0.92)" : "scale(1)",
+        // The position/size animates over the full duration; opacity fades in
+        // the back 60% so the chip is fully visible during the launch and
+        // dissolves as it lands on the input.
+        transition: [
+          `left ${durationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `top ${durationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `width ${durationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `transform ${durationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          `opacity ${Math.round(durationMs * 0.6)}ms ease-out ${Math.round(durationMs * 0.4)}ms`,
+        ].join(", "),
+      }}
+    >
+      <span className="truncate">{text}</span>
+    </div>,
+    document.body
+  );
+}

--- a/src/features/ask-karma/components/topic-icon.tsx
+++ b/src/features/ask-karma/components/topic-icon.tsx
@@ -1,0 +1,36 @@
+import {
+  ArrowLeftIcon,
+  BarChart3Icon,
+  CompassIcon,
+  DollarSignIcon,
+  FileTextIcon,
+  InfoIcon,
+  Settings2Icon,
+  SparklesIcon,
+  TrendingUpIcon,
+  UsersIcon,
+} from "lucide-react";
+import type { AskKarmaTopicIcon } from "../types";
+
+const ICON_MAP = {
+  dollar: DollarSignIcon,
+  "trending-up": TrendingUpIcon,
+  settings: Settings2Icon,
+  document: FileTextIcon,
+  chart: BarChart3Icon,
+  back: ArrowLeftIcon,
+  sparkles: SparklesIcon,
+  info: InfoIcon,
+  users: UsersIcon,
+  compass: CompassIcon,
+} as const satisfies Record<AskKarmaTopicIcon, unknown>;
+
+interface TopicIconProps {
+  name: AskKarmaTopicIcon;
+  className?: string;
+}
+
+export function TopicIcon({ name, className }: TopicIconProps) {
+  const Icon = ICON_MAP[name] ?? SparklesIcon;
+  return <Icon className={className} aria-hidden="true" />;
+}

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -1,4 +1,4 @@
-import type { TenantId } from "@/src/infrastructure/types/tenant";
+import { isKnownTenant, type KnownTenantId } from "@/src/infrastructure/types/tenant";
 import type { AskKarmaConfig } from "./types";
 
 const DEFAULT_CONFIG: AskKarmaConfig = {
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
       title: "Open Funding Rounds",
       description: "Browse active programs accepting applications",
       links: [
+        // TODO(ask-karma): replace placeholder hrefs with real destinations
         { label: "View open rounds", href: "/funding-opportunities" },
         { label: "How applications work", href: "/" },
       ],
@@ -35,6 +36,7 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
       icon: "settings",
       title: "Project Management",
       links: [
+        // TODO(ask-karma): replace placeholder hrefs with real destinations
         { label: "Submit a milestone update", href: "/my-projects" },
         { label: "Update project profile", href: "/my-projects" },
         { label: "FAQs", href: "/" },
@@ -45,12 +47,12 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
   assistantSubtitle: "Here to help 24/7",
 };
 
-const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
+// Tenant-specific configs override DEFAULT_CONFIG. Shared boilerplate fields
+// (assistantTitle, subheading, etc.) flow through the spread so future
+// per-tenant configs stay minimal — override only what differs.
+const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
   filecoin: {
-    heading: "Ask us anything",
-    subheading: "Learn how funding works, track project progress, and discover ecosystem insights.",
-    inputPlaceholder: "Questions? Ask the Karma Assistant",
-    examplesIntro: "Some examples to get the juices flowing:",
+    ...DEFAULT_CONFIG,
     exampleQuestions: [
       "How do I submit a milestone update for my project?",
       "Why can't I access the project I am reviewing?",
@@ -59,12 +61,12 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
       "What is the typical payment timeline after invoice submission?",
       "Are there retrospective reports from previous funding rounds?",
     ],
-    featuredTopicsHeading: "Check out these featured topics",
     featuredTopics: [
       {
         icon: "dollar",
         title: "The Next ProPGF Round (General Track)",
         links: [
+          // TODO(ask-karma-filecoin): replace placeholder hrefs with real destinations
           { label: "Round 3 Announcement", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "Selection Committee", href: "https://filpgf.io/propgf", isExternal: true },
           {
@@ -84,6 +86,7 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
         icon: "settings",
         title: "Navigate filpgf.io",
         links: [
+          // TODO(ask-karma-filecoin): replace placeholder hrefs with real destinations
           { label: "ProPGF Grantee Guide", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "Milestone Reviewer Guide", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "FAQs", href: "https://filpgf.io/propgf", isExternal: true },
@@ -93,6 +96,7 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
         icon: "document",
         title: "Focus Areas",
         links: [
+          // TODO(ask-karma-filecoin): replace placeholder hrefs with real destinations
           { label: "Large Data Onboarding", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "Filecoin Onchain Cloud", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "Fil.one", href: "https://filpgf.io/propgf", isExternal: true },
@@ -102,6 +106,7 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
         icon: "chart",
         title: "Metrics and Strategy",
         links: [
+          // TODO(ask-karma-filecoin): replace placeholder hrefs with real destinations
           { label: "2026 Network Strategy", href: "https://filpgf.io/propgf", isExternal: true },
           { label: "ProPGF Project Impact", href: "https://filpgf.io/propgf", isExternal: true },
         ],
@@ -115,17 +120,18 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
         ],
       },
     ],
-    assistantTitle: "Karma Assistant",
-    assistantSubtitle: "Here to help 24/7",
   },
 };
 
-export function getAskKarmaConfig(
-  tenantId?: TenantId | string | null,
-  _communitySlug?: string | null
-): AskKarmaConfig {
-  if (tenantId && TENANT_CONFIGS[tenantId as TenantId]) {
-    return TENANT_CONFIGS[tenantId as TenantId] as AskKarmaConfig;
+/**
+ * Resolve the ask-karma config for a tenant. Accepts either a known tenant
+ * id or an arbitrary community slug — falls through to DEFAULT_CONFIG when
+ * the lookup key isn't a known tenant. The `isKnownTenant` type guard keeps
+ * the table lookup type-safe without an `as` cast.
+ */
+export function getAskKarmaConfig(lookupKey?: string | null): AskKarmaConfig {
+  if (lookupKey && isKnownTenant(lookupKey)) {
+    return TENANT_CONFIGS[lookupKey] ?? DEFAULT_CONFIG;
   }
   return DEFAULT_CONFIG;
 }

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -4,7 +4,7 @@ import type { AskKarmaConfig } from "./types";
 const DEFAULT_CONFIG: AskKarmaConfig = {
   heading: "Ask us anything",
   subheading: "Learn how funding works, track project progress, and discover ecosystem insights.",
-  inputPlaceholder: "Questions? Ask the AI Assistant",
+  inputPlaceholder: "Questions? Ask the Karma Assistant",
   examplesIntro: "Some examples to get the juices flowing:",
   exampleQuestions: [
     "How do I submit a milestone update for my project?",
@@ -41,7 +41,7 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
       ],
     },
   ],
-  assistantTitle: "AI Assistant",
+  assistantTitle: "Karma Assistant",
   assistantSubtitle: "Here to help 24/7",
 };
 
@@ -49,7 +49,7 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
   filecoin: {
     heading: "Ask us anything",
     subheading: "Learn how funding works, track project progress, and discover ecosystem insights.",
-    inputPlaceholder: "Questions? Ask the AI Assistant",
+    inputPlaceholder: "Questions? Ask the Karma Assistant",
     examplesIntro: "Some examples to get the juices flowing:",
     exampleQuestions: [
       "How do I submit a milestone update for my project?",
@@ -115,7 +115,7 @@ const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
         ],
       },
     ],
-    assistantTitle: "AI Assistant",
+    assistantTitle: "Karma Assistant",
     assistantSubtitle: "Here to help 24/7",
   },
 };

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -1,0 +1,131 @@
+import type { TenantId } from "@/src/infrastructure/types/tenant";
+import type { AskKarmaConfig } from "./types";
+
+const DEFAULT_CONFIG: AskKarmaConfig = {
+  heading: "Ask us anything",
+  subheading: "Learn how funding works, track project progress, and discover ecosystem insights.",
+  inputPlaceholder: "Questions? Ask the AI Assistant",
+  examplesIntro: "Some examples to get the juices flowing:",
+  exampleQuestions: [
+    "How do I submit a milestone update for my project?",
+    "Why can't I access the project I am reviewing?",
+    "Which metrics matter most when evaluating project impact?",
+    "What is the typical payment timeline after invoice submission?",
+    "Are there retrospective reports from previous funding rounds?",
+    "How do I apply to an open funding round?",
+  ],
+  featuredTopicsHeading: "Check out these featured topics",
+  featuredTopics: [
+    {
+      icon: "dollar",
+      title: "Open Funding Rounds",
+      description: "Browse active programs accepting applications",
+      links: [
+        { label: "View open rounds", href: "/funding-opportunities" },
+        { label: "How applications work", href: "/" },
+      ],
+    },
+    {
+      icon: "trending-up",
+      title: "Track Active Projects",
+      description: "Review the progress of funded projects",
+      cta: { label: "View Funded Projects", href: "/projects" },
+    },
+    {
+      icon: "settings",
+      title: "Project Management",
+      links: [
+        { label: "Submit a milestone update", href: "/my-projects" },
+        { label: "Update project profile", href: "/my-projects" },
+        { label: "FAQs", href: "/" },
+      ],
+    },
+  ],
+  assistantTitle: "AI Assistant",
+  assistantSubtitle: "Here to help 24/7",
+};
+
+const TENANT_CONFIGS: Partial<Record<TenantId, AskKarmaConfig>> = {
+  filecoin: {
+    heading: "Ask us anything",
+    subheading: "Learn how funding works, track project progress, and discover ecosystem insights.",
+    inputPlaceholder: "Questions? Ask the AI Assistant",
+    examplesIntro: "Some examples to get the juices flowing:",
+    exampleQuestions: [
+      "How do I submit a milestone update for my project?",
+      "Why can't I access the project I am reviewing?",
+      "Which metrics matter most when evaluating project impact?",
+      "How is ProPGF currently supporting fil.one?",
+      "What is the typical payment timeline after invoice submission?",
+      "Are there retrospective reports from previous funding rounds?",
+    ],
+    featuredTopicsHeading: "Check out these featured topics",
+    featuredTopics: [
+      {
+        icon: "dollar",
+        title: "The Next ProPGF Round (General Track)",
+        links: [
+          { label: "Round 3 Announcement", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "Selection Committee", href: "https://filpgf.io/propgf", isExternal: true },
+          {
+            label: "Retro from previous rounds",
+            href: "https://filpgf.io/propgf",
+            isExternal: true,
+          },
+        ],
+      },
+      {
+        icon: "trending-up",
+        title: "Track Active Projects",
+        description: "Review the progress of funded projects in ProPGF",
+        cta: { label: "View Funded Projects", href: "/projects" },
+      },
+      {
+        icon: "settings",
+        title: "Navigate filpgf.io",
+        links: [
+          { label: "ProPGF Grantee Guide", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "Milestone Reviewer Guide", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "FAQs", href: "https://filpgf.io/propgf", isExternal: true },
+        ],
+      },
+      {
+        icon: "document",
+        title: "Focus Areas",
+        links: [
+          { label: "Large Data Onboarding", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "Filecoin Onchain Cloud", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "Fil.one", href: "https://filpgf.io/propgf", isExternal: true },
+        ],
+      },
+      {
+        icon: "chart",
+        title: "Metrics and Strategy",
+        links: [
+          { label: "2026 Network Strategy", href: "https://filpgf.io/propgf", isExternal: true },
+          { label: "ProPGF Project Impact", href: "https://filpgf.io/propgf", isExternal: true },
+        ],
+      },
+      {
+        icon: "back",
+        title: "RetroPGF",
+        links: [
+          { label: "About RetroPGF", href: "https://www.fil-retropgf.io/", isExternal: true },
+          { label: "Past rounds", href: "https://www.fil-retropgf.io/", isExternal: true },
+        ],
+      },
+    ],
+    assistantTitle: "AI Assistant",
+    assistantSubtitle: "Here to help 24/7",
+  },
+};
+
+export function getAskKarmaConfig(
+  tenantId?: TenantId | string | null,
+  _communitySlug?: string | null
+): AskKarmaConfig {
+  if (tenantId && TENANT_CONFIGS[tenantId as TenantId]) {
+    return TENANT_CONFIGS[tenantId as TenantId] as AskKarmaConfig;
+  }
+  return DEFAULT_CONFIG;
+}

--- a/src/features/ask-karma/hooks/use-prefers-reduced-motion.ts
+++ b/src/features/ask-karma/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Reactive `prefers-reduced-motion` reader. Returns `true` when the user has
+ * opted into reduced motion via the OS or browser. Updates on changes.
+ *
+ * Local to the ask-karma feature because the only consumer right now is the
+ * chip-fly animation gate. Promote to `hooks/` if a third caller appears.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    setPrefersReduced(mediaQuery.matches);
+    const handler = (event: MediaQueryListEvent) => setPrefersReduced(event.matches);
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, []);
+
+  return prefersReduced;
+}

--- a/src/features/ask-karma/types.ts
+++ b/src/features/ask-karma/types.ts
@@ -1,0 +1,37 @@
+export type AskKarmaTopicIcon =
+  | "dollar"
+  | "trending-up"
+  | "settings"
+  | "document"
+  | "chart"
+  | "back"
+  | "sparkles"
+  | "info"
+  | "users"
+  | "compass";
+
+export interface AskKarmaLink {
+  label: string;
+  href: string;
+  isExternal?: boolean;
+}
+
+export interface AskKarmaTopic {
+  icon: AskKarmaTopicIcon;
+  title: string;
+  description?: string;
+  links?: AskKarmaLink[];
+  cta?: AskKarmaLink;
+}
+
+export interface AskKarmaConfig {
+  heading: string;
+  subheading: string;
+  inputPlaceholder: string;
+  examplesIntro: string;
+  exampleQuestions: string[];
+  featuredTopicsHeading: string;
+  featuredTopics: AskKarmaTopic[];
+  assistantTitle: string;
+  assistantSubtitle: string;
+}

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -160,6 +160,17 @@ export const PAGES = {
 };
 
 /**
+ * Detects pathnames that belong to the ask-karma feature — both the root
+ * `/ask-karma` route and the community-scoped `/community/<slug>/ask-karma`
+ * route. Lives next to the route constants so any rename here updates the
+ * detection automatically.
+ */
+const ASK_KARMA_COMMUNITY_PATTERN = /^\/community\/[^/]+\/ask-karma$/;
+export function isAskKarmaPathname(pathname: string): boolean {
+  return pathname === PAGES.ASK_KARMA || ASK_KARMA_COMMUNITY_PATTERN.test(pathname);
+}
+
+/**
  * First path segments under /community/[communityId]/ that should be rewritten
  * in whitelabel mode. Derived from PAGES.COMMUNITY route definitions and
  * filesystem route directories. This is the single source of truth — used by

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -39,6 +39,7 @@ export const PAGES = {
     REPORTS: (community: string) => `/community/${community}/reports`,
     REPORT_DETAIL: (community: string, runDate: string) =>
       `/community/${community}/reports/${encodeURIComponent(runDate)}`,
+    ASK_KARMA: (community: string) => `/community/${community}/ask-karma`,
   },
   MY_PROJECTS: `/my-projects`,
   MY_REVIEWS: `/my-reviews`,
@@ -155,6 +156,7 @@ export const PAGES = {
   FOR_PROJECTS: `/for-projects`,
   SEEDS: `/seeds`,
   SEEDS_FUND: `/seeds/fund`,
+  ASK_KARMA: `/ask-karma`,
 };
 
 /**
@@ -178,6 +180,7 @@ export const COMMUNITY_SUB_ROUTE_SEGMENTS: ReadonlySet<string> = new Set([
   "updates",
   // Direct route directories under /community/[communityId]/
   "admin",
+  "ask-karma",
   "karma-ai",
   "manage",
 ]);


### PR DESCRIPTION
## Summary

Adds a new tenant-aware **Ask Karma** page that pairs a curated start screen (example questions + featured topic cards) with a full-page chat surface backed by the existing `/v2/agent/stream` endpoint.

Three routes resolve to the same component with different configs:
- `karmahq.xyz/ask-karma` — default Karma config
- `karmahq.xyz/community/<id>/ask-karma` — community-scoped, picks tenant config by id
- `<whitelabel-domain>/ask-karma` — middleware rewrites to the community route, picks tenant config

Per-tenant content (heading, example chips, featured topics) lives in `src/features/ask-karma/config.ts`. Default + filecoin entries shipped; new tenants are a one-file addition.

## How the chip-to-chat flow works

Click an example chip and you get a grant-atlas-style sequence:

1. **Fly** (350ms): a chip clone is portal-mounted and CSS-transitioned from its source rect to the input's left edge, fading out as it lands.
2. **Type** (18ms × chars): the input goes `readOnly` and auto-focuses; the question is written character-by-character via `setInterval`.
3. **Pause** (150ms) so the user registers the full sentence.
4. **Submit + crossfade** (220ms): `onSubmit` fires, the parent's state machine fades the start view out and fades the chat view in. The user's message bubble is already there, assistant streams the answer.

## Implementation notes

- **No backend work.** Reuses `useAgentStream` + `useAgentChatStore` that already power the floating `AgentChatBubble`. The bubble is hidden on ask-karma routes (path check in `DeferredLayoutComponents`) to avoid two surfaces sharing one store.
- **No new animation library.** Uses Tailwind `animate-in`/`animate-out` from the existing `tailwindcss-animate` plus a hand-rolled portal clone for the fly animation. State-machine crossfade between start ↔ chat views (`start | leaving-start | chat | leaving-chat`).
- **Routing:** `ask-karma` added to `COMMUNITY_SUB_ROUTE_SEGMENTS` in `utilities/pages.ts` so the middleware rewrites whitelabel `/ask-karma` → `/community/<slug>/ask-karma`. `PAGES.ASK_KARMA` + `PAGES.COMMUNITY.ASK_KARMA` constants added.
- **Three states everywhere:** every page has `page.tsx` + `loading.tsx` + `error.tsx` per project convention.

## Tests

**59 tests across 8 files, all green:**

| File | Tests | Coverage |
|---|---|---|
| `config.test.ts` | 5 | tenant config resolution (default / unknown / nullish / filecoin) |
| `flying-chip.test.tsx` | 5 | portal mount, double-RAF commit, onArrive timing, once-only guard |
| `featured-topic-card.test.tsx` | 6 | links / external link attrs / CTA / no-description / both modes |
| `ask-karma-input.test.tsx` | 9 | Enter / Shift+Enter / click / whitespace / streaming / stop |
| `ask-karma-chat.test.tsx` | 8 | header, empty, user vs assistant, thinking dots, error, back, follow-up |
| `ask-karma-start.test.tsx` | 12 | static render + full chip animation phases + cleanup |
| `ask-karma-page.test.tsx` | 8 | state machine, store wiring, mount/unmount lifecycle |
| `ask-karma-pages.test.tsx` (smoke) | 6 | both routes + metadata + notFound branch |

Animation tests use `vi.useFakeTimers({ shouldAdvanceTime: true })` and advance through each phase boundary so React's setState → useEffect chain has a chance to schedule the next phase's timer. See the `advanceChipAnimation` helper in the start tests for the canonical pattern.

## Test plan

- [ ] `pnpm test __tests__/unit/features/ask-karma __tests__/integration/pages/smoke/ask-karma-pages.test.tsx` → 59/59
- [ ] `pnpm lint:fix` clean on the changed paths
- [ ] `pnpm dev` → visit `localhost:3000/ask-karma`: example chips fly into the input, auto-type, transition to chat
- [ ] Visit `localhost:3000/community/filecoin/ask-karma`: filecoin-specific examples (fil.one, ProPGF) appear; community header is present
- [ ] Click "Back to topics" in chat view: smooth fade back, messages cleared
- [ ] Press Enter in the start input directly (no chip): skips the fly animation, submits immediately
- [ ] Verify the floating chat bubble is hidden on `/ask-karma` and visible elsewhere
- [ ] Whitelabel: `app.filpgf.io/ask-karma` (or local equivalent) lands on the filecoin config without showing `/community/filecoin` in the URL

## Files

- `src/features/ask-karma/` — types, config, 7 components
- `app/ask-karma/` and `app/community/[communityId]/(with-header)/ask-karma/` — route trios
- `utilities/pages.ts` — `PAGES.ASK_KARMA` + segment registration
- `components/DeferredLayoutComponents.tsx` — hide the floating bubble on ask-karma routes
- `__tests__/unit/features/ask-karma/` + `__tests__/integration/pages/smoke/ask-karma-pages.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ask Karma pages (root + community), tenant/community-scoped configs, routing helpers, and route detection.
  * Introduced Ask Karma UI: start flow, flying-chip animation, chat view, input control, featured topic cards, icons, loading and shared error UIs.
  * Deferred layout now hides global chat bubble on Ask Karma routes.

* **Tests**
  * Added extensive integration and unit tests covering pages, chat, input, animations, config, hooks, and components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->