### PR TITLE
feat(ask-karma): thinking panel replaces empty assistant bubble

### DIFF
--- a/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
@@ -108,7 +108,7 @@ describe("AskKarmaChat", () => {
         onBack={vi.fn()}
       />
     );
-    expect(screen.getByTestId("thinking-dots")).toBeInTheDocument();
+    expect(screen.getByTestId("ask-karma-thinking")).toBeInTheDocument();
   });
 
   it("does not show thinking dots once the assistant has streamed content", () => {
@@ -126,7 +126,54 @@ describe("AskKarmaChat", () => {
         onBack={vi.fn()}
       />
     );
-    expect(screen.queryByTestId("thinking-dots")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ask-karma-thinking")).not.toBeInTheDocument();
+  });
+
+  it("does not render an empty bubble for an assistant placeholder", () => {
+    // The stream adds the assistant message to the store with content=""
+    // before tokens arrive. Without the suppression, a hollow rounded
+    // bubble would stack on top of the thinking panel.
+    const messages: ChatMessage[] = [
+      buildMsg({ id: "u1", role: "user", content: "Hi", timestamp: Date.now() }),
+      buildMsg({ id: "a1", role: "assistant", content: "", timestamp: Date.now() }),
+    ];
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={messages}
+        isStreaming={true}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    // User bubble still renders; assistant bubble does NOT.
+    expect(screen.getByTestId("ask-karma-message-user")).toBeInTheDocument();
+    expect(screen.queryByTestId("ask-karma-message-assistant")).not.toBeInTheDocument();
+    // Thinking panel takes the assistant's visual slot instead.
+    expect(screen.getByTestId("ask-karma-thinking")).toBeInTheDocument();
+  });
+
+  it("surfaces the configured assistant title in the thinking panel", () => {
+    render(
+      <AskKarmaChat
+        config={{ ...config, assistantTitle: "Filecoin Assistant" }}
+        messages={[buildMsg({ id: "a1", role: "assistant", content: "", timestamp: Date.now() })]}
+        isStreaming={true}
+        error={null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    const panel = screen.getByTestId("ask-karma-thinking");
+    // Tenant override flows through to the visible name + a11y label.
+    expect(panel).toHaveTextContent("Filecoin Assistant");
+    expect(panel).toHaveAttribute("aria-label", "Filecoin Assistant is thinking");
+    // <output> has implicit role="status" — query by role to confirm the
+    // a11y semantics regardless of whether the role is set explicitly.
+    expect(screen.getByRole("status")).toBe(panel);
   });
 
   it("renders error alert when error is present", () => {

--- a/src/features/ask-karma/components/ask-karma-chat.tsx
+++ b/src/features/ask-karma/components/ask-karma-chat.tsx
@@ -76,6 +76,49 @@ const MessageBubble = memo(function MessageBubble({ message }: MessageBubbleProp
   );
 });
 
+/**
+ * Streaming placeholder shown while the assistant has been added to the
+ * store but no tokens have arrived yet. Replaces the prior bare-dot
+ * indicator with a real attribution surface (avatar, agent name, status)
+ * so users know who is responding and what is happening.
+ *
+ * role="status" + aria-live="polite" let assistive tech announce the
+ * waiting state without interrupting current focus.
+ */
+function ThinkingPanel({ title }: { title: string }) {
+  return (
+    // <output> has implicit role="status" + aria-live="polite" — a native
+    // a11y signal that assistive tech announces the waiting state without
+    // interrupting focus. Cleaner than div + ARIA attributes.
+    <output
+      data-testid="ask-karma-thinking"
+      aria-label={`${title} is thinking`}
+      className="flex items-start gap-3 animate-in fade-in slide-in-from-bottom-1 duration-300"
+    >
+      <div
+        className="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+        aria-hidden="true"
+      >
+        <SparklesIcon className="h-4 w-4 animate-pulse" />
+        {/* Subtle outer-ring breathing pulse — communicates "working" without
+            shouting like a spinner would. */}
+        <span className="pointer-events-none absolute inset-0 rounded-full ring-2 ring-emerald-400/40 animate-ping" />
+      </div>
+      <div className="flex flex-col gap-1.5 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-4 py-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">{title}</span>
+          <span className="flex items-center gap-1" aria-hidden="true">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500 [animation-delay:0ms]" />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500 [animation-delay:150ms]" />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500 [animation-delay:300ms]" />
+          </span>
+        </div>
+        <span className="text-xs italic text-zinc-500 dark:text-zinc-400">thinking…</span>
+      </div>
+    </output>
+  );
+}
+
 interface AskKarmaChatProps {
   config: AskKarmaConfig;
   messages: ChatMessage[];
@@ -169,28 +212,17 @@ export function AskKarmaChat({
           </div>
         )}
 
-        {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
-        ))}
+        {messages.map((message) => {
+          // While the agent stream is warming up the assistant message
+          // exists with `content: ""` — rendering MessageBubble at that
+          // point produces a hollow rounded box stacked on top of the
+          // thinking panel. Skip the empty placeholder; the thinking
+          // panel below carries the visual.
+          if (message.role === "assistant" && !message.content) return null;
+          return <MessageBubble key={message.id} message={message} />;
+        })}
 
-        {showThinking && (
-          <div
-            className="flex items-start gap-3 animate-in fade-in duration-200"
-            data-testid="thinking-dots"
-          >
-            <div
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
-              aria-hidden="true"
-            >
-              <SparklesIcon className="h-4 w-4" />
-            </div>
-            <div className="flex items-center gap-1 rounded-2xl rounded-tl-sm border border-zinc-200 bg-white px-4 py-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:0ms]" />
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:150ms]" />
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-400 [animation-delay:300ms]" />
-            </div>
-          </div>
-        )}
+        {showThinking && <ThinkingPanel title={config.assistantTitle} />}
 
         {error && (
           <div


### PR DESCRIPTION
## Summary

Two related UX fixes on the ask-karma chat surface:

**1. The empty bubble bug** — when the user sent a question, the stream added an assistant message to the store with `content: ""` before any tokens arrived. The chat view rendered the bordered `MessageBubble` for that placeholder, then stacked the bare 3-dot indicator below it. Net result: a hollow rounded box on top of a row of dots.

**2. The thinking state was uninformative** — even setting the empty bubble aside, the bare 3-dot indicator gave no attribution. Compared to karmagrants' clear "Prospecting Agent · searching 140,221 filings…" pattern, ours felt anonymous.

## Changes

- `ask-karma-chat.tsx`: skip `MessageBubble` rendering when `role === "assistant" && !content`. New `ThinkingPanel` sub-component takes the placeholder's visual slot:
  - Sparkle avatar with `animate-pulse` + a soft `animate-ping` ring
  - Assistant title from `config.assistantTitle` (so Filecoin reads "Filecoin Assistant", default reads "Karma Assistant")
  - Three staggered emerald dots
  - Italic "thinking…" subtext
- Uses native `<output>` element — implicit `role="status"` + `aria-live="polite"`, labelled `"{title} is thinking"` so assistive tech announces the waiting state without interrupting focus

## Out of scope (deferred)

Full karmagrants-style tool-call list (✓ ✗ ⟳ icons + current activity string per tool) is parked for a follow-up. That requires extending `useAgentStream`'s SSE parser to track `tool_use` blocks from the Anthropic SDK events and threading that state through `ChatMessage` in the shared agent store — touches the existing floating bubble and needs broader testing. Marked as TODO in the [DEV-298](https://linear.app/showkarma/issue/DEV-298/) chain.

## Test plan

- [x] `pnpm vitest run __tests__/unit/features/ask-karma` → **70 / 70 pass** (2 new for empty-bubble suppression + tenant-title surfacing)
- [x] Biome clean on changed files
- [x] `tsc --noEmit` clean
- [ ] Manual: send a message on `/ask-karma`, observe no hollow box appears while waiting for first token. Confirm panel shows assistant title.
- [ ] Manual on `app.filpgf.io/ask-karma`: panel should say "Karma Assistant" (filecoin tenant inherits default `assistantTitle`)

## Linked

[DEV-298](https://linear.app/showkarma/issue/DEV-298/make-chatbot-interface-front-and-center-on-the-page) — same chatbot work; previous PR #1456 already merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an improved thinking panel with visual indicators while the AI generates responses.

* **Bug Fixes**
  * Eliminated temporary empty assistant message bubbles appearing during initial response streaming.

* **Accessibility**
  * Enhanced thinking panel with ARIA labels and semantic roles for improved screen reader support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->