### PR TITLE
fix(workflows): make pr-demo-video resilient when JSON report omits video attachments

### DIFF
--- a/.github/workflows/pr-demo-video.yml
+++ b/.github/workflows/pr-demo-video.yml
@@ -128,40 +128,79 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p demo-output
-          REPORT="e2e-demos-results/report.json"
-          if [ ! -f "$REPORT" ]; then
-            echo "No Playwright JSON report — nothing to publish"
-            echo "count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Resolve (demo-name, video-path) pairs from the JSON report so we
-          # don't have to guess the spec name from Playwright's output dir.
-          node -e '
-            const fs = require("fs");
-            const path = require("path");
-            const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-            const out = [];
-            const walk = (suites) => {
-              for (const s of suites || []) {
-                for (const spec of s.specs || []) {
-                  const file = spec.file || s.file || "";
-                  const name = path.basename(file).replace(/\.demo\.ts$/, "");
-                  for (const t of spec.tests || []) {
-                    for (const res of t.results || []) {
-                      for (const a of res.attachments || []) {
-                        if (a.name === "video" && a.path) {
-                          out.push(name + "\t" + a.path);
+          REPORT="e2e-demos-report.json"
+          RESULTS_DIR="e2e-demos-results"
+
+          # Primary path: resolve (demo-name, video-path) pairs from the JSON
+          # report so we don't have to guess the spec name from Playwright's
+          # output dir. Some Playwright/reporter combinations don't include
+          # video attachments for passing tests, so we keep a filesystem
+          # fallback below.
+          if [ -f "$REPORT" ]; then
+            node -e '
+              const fs = require("fs");
+              const path = require("path");
+              const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              const out = [];
+              const walk = (suites) => {
+                for (const s of suites || []) {
+                  for (const spec of s.specs || []) {
+                    const file = spec.file || s.file || "";
+                    const name = path.basename(file).replace(/\.demo\.ts$/, "");
+                    for (const t of spec.tests || []) {
+                      for (const res of t.results || []) {
+                        for (const a of res.attachments || []) {
+                          const isVideo =
+                            a.name === "video" ||
+                            (a.contentType && a.contentType.startsWith("video/"));
+                          if (isVideo && a.path) {
+                            out.push(name + "\t" + a.path);
+                          }
                         }
                       }
                     }
                   }
+                  if (s.suites) walk(s.suites);
                 }
-                if (s.suites) walk(s.suites);
-              }
-            };
-            walk(r.suites || []);
-            process.stdout.write(out.join("\n"));
-          ' "$REPORT" > /tmp/demo-manifest.tsv
+              };
+              walk(r.suites || []);
+              process.stdout.write(out.join("\n"));
+            ' "$REPORT" > /tmp/demo-manifest.tsv
+          else
+            echo "No Playwright JSON report at $REPORT — using filesystem fallback"
+            : > /tmp/demo-manifest.tsv
+          fi
+
+          if [ ! -s /tmp/demo-manifest.tsv ] && [ -d "$RESULTS_DIR" ]; then
+            echo "JSON report had no video attachments — scanning $RESULTS_DIR for *.webm"
+            # Playwright writes one subdir per (spec, test, project) under
+            # outputDir, each containing video.webm. The subdir name starts
+            # with the kebab-cased spec filename, which is what we use to
+            # name the MP4 and look up the description.
+            shopt -s nullglob
+            for webm in "$RESULTS_DIR"/*/*.webm; do
+              dir=$(basename "$(dirname "$webm")")
+              # Match the longest spec name that prefixes the dir name.
+              best=""
+              for spec in e2e/demos/*.demo.ts; do
+                stem=$(basename "$spec" .demo.ts)
+                case "$dir" in
+                  "$stem"-*|"$stem")
+                    if [ ${#stem} -gt ${#best} ]; then best="$stem"; fi
+                    ;;
+                esac
+              done
+              if [ -z "$best" ]; then
+                echo "No matching spec for $dir — skipping"
+                continue
+              fi
+              printf '%s\t%s\n' "$best" "$webm" >> /tmp/demo-manifest.tsv
+            done
+            shopt -u nullglob
+          fi
+
+          echo "Manifest contents:"
+          cat /tmp/demo-manifest.tsv || true
 
           count=0
           while IFS=$'\t' read -r name webm; do
@@ -178,6 +217,17 @@ jobs:
           done < /tmp/demo-manifest.tsv
           echo "count=$count" >> "$GITHUB_OUTPUT"
           ls -la demo-output
+
+      - name: Upload demo diagnostics
+        if: always() && steps.detect.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-diagnostics
+          path: |
+            e2e-demos-report.json
+            e2e-demos-results/**
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Push videos to pr-demo-assets branch
         if: steps.detect.outputs.exists == 'true' && steps.convert.outputs.count != '0'

--- a/e2e/demos/playwright.config.ts
+++ b/e2e/demos/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   retries: 0,
   reporter: [
     ["list"],
-    ["json", { outputFile: path.resolve(__dirname, "../../e2e-demos-results/report.json") }],
+    ["json", { outputFile: path.resolve(__dirname, "../../e2e-demos-report.json") }],
   ],
   outputDir: path.resolve(__dirname, "../../e2e-demos-results"),
 


### PR DESCRIPTION
## Summary

The first run of `pr-demo-video.yml` on `main` ([run 26128390905](https://github.com/show-karma/gap-app-v2/actions/runs/26128390905/job/76847635915)) completed cleanly — demo test passed in 6.5s — but no PR comment was ever posted. Cause: the Playwright JSON report's `attachments` array contained no entry with `name === "video"`, so the walker in `Convert recordings to MP4` produced an empty manifest, `count=0` was set, and every downstream step (push to `pr-demo-assets`, build comment body, post comment) was gated off.

This PR makes the workflow resilient to that failure mode and adds the diagnostics we'd need to debug the next one without another code push.

## Changes

- **`e2e/demos/playwright.config.ts`** — moved JSON `outputFile` to `e2e-demos-report.json` (sibling of `outputDir`, not nested inside it). Co-locating the report with the per-test artifact subdirs that Playwright creates inside `outputDir` invites edge cases between report serialization and outputDir cleanup.

- **`.github/workflows/pr-demo-video.yml`**:
  - Walker now also matches `contentType: video/*` in addition to `name === "video"`, so future Playwright versions that re-label video attachments still get picked up.
  - Filesystem fallback: when the JSON walker yields an empty manifest, scan `e2e-demos-results/**/*.webm` and map each video's parent-dir prefix back to a spec file in `e2e/demos/` (longest-prefix wins, so e.g. `team-email-display-extra` wouldn't collide with `team-email`).
  - New `Upload demo diagnostics` step always uploads `e2e-demos-report.json` + `e2e-demos-results/**` as an artifact, so the next time something goes sideways we can inspect the actual report shape without modifying the workflow.

## Verification

- Unit-tested the Node walker locally against a fake report containing `name: "video"`, `contentType: "video/mp4"` (no name), and a `trace` attachment. Walker correctly returns both videos and skips the trace.
- Unit-tested the bash fallback against a fake `e2e-demos-results/` with two test directories. Both mapped to the right spec stem via longest-prefix matching.

## Test plan

- [ ] After merge, observe the next `pr-demo-video` workflow run on `main`
- [ ] Confirm `Convert recordings to MP4` reports `count >= 1` and `demo-output/` contains an mp4
- [ ] Confirm the merged PR receives a `## Feature demo` comment with embedded video
- [ ] Inspect the `demo-diagnostics` artifact to verify which path won (JSON report vs filesystem fallback); if the JSON path consistently succeeds in subsequent runs, the fallback can be pruned in a follow-up