### PR TITLE
feat(ask-karma): wire docs URLs + grey out two filecoin entries

### DIFF
--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -90,10 +90,18 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
         icon: "settings",
         title: "Navigate filpgf.io",
         links: [
-          // TODO(ask-karma-filecoin): replace placeholder hrefs with real destinations
-          { label: "ProPGF Grantee Guide", href: "https://filpgf.io/propgf", isExternal: true },
-          { label: "Milestone Reviewer Guide", href: "https://filpgf.io/propgf", isExternal: true },
-          { label: "FAQs", href: "https://filpgf.io/propgf", isExternal: true },
+          {
+            label: "ProPGF Grantee Guide",
+            href: "https://docs.gap.karmahq.xyz/how-to-guides/partners/filecoin/propgf-grantee-guide",
+            isExternal: true,
+          },
+          {
+            label: "Milestone Reviewer Guide",
+            href: "https://docs.gap.karmahq.xyz/how-to-guides/partners/filecoin/milestone-reviewer-guide",
+            isExternal: true,
+          },
+          // No href → greyed out ("coming soon")
+          { label: "FAQs" },
         ],
       },
       {
@@ -119,8 +127,8 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
             href: "https://www.filecoin.io/blog/the-2026-filecoin-network-strategy",
             isExternal: true,
           },
-          // TODO(ask-karma-filecoin): replace placeholder href with real destination
-          { label: "ProPGF Project Impact", href: "https://filpgf.io/propgf", isExternal: true },
+          // No href → greyed out ("coming soon")
+          { label: "ProPGF Project Impact" },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Four more filecoin tenant link updates on the ask-karma start page, continuing the URL fill-in from PR #1461.

### Wired up

| Entry | New destination |
|---|---|
| ProPGF Grantee Guide | `docs.gap.karmahq.xyz/how-to-guides/partners/filecoin/propgf-grantee-guide` |
| Milestone Reviewer Guide | `docs.gap.karmahq.xyz/how-to-guides/partners/filecoin/milestone-reviewer-guide` |

### Greyed out (no destination yet)

| Entry | Topic |
|---|---|
| FAQs | Navigate filpgf.io |
| ProPGF Project Impact | Metrics and Strategy |

Both render via the existing "coming soon" path — `{ label: "FAQs" }` with no `href` produces a muted, non-interactive `<span aria-disabled="true">` instead of a link.

### Cleanup

Removed the `TODO(ask-karma-filecoin)` comments from both affected topics — every entry in `Navigate filpgf.io` and `Metrics and Strategy` is now either a real link or an explicit "coming soon".

## Test plan

- [x] `pnpm vitest run __tests__/unit/features/ask-karma/config.test.ts` → 7/7 pass
- [x] Biome clean on `config.ts`
- [x] `tsc --noEmit` clean
- [ ] Manual: visit `localhost:3008/community/filecoin/ask-karma` → ProPGF Grantee Guide and Milestone Reviewer Guide link to the new docs URLs; FAQs and ProPGF Project Impact appear in muted text and are non-clickable

## Remaining placeholders

Still pointing at `filpgf.io/propgf`:
- `Retro from previous rounds` (under "The Next ProPGF Round")
- `Large Data Onboarding` (under "Focus Areas")

Send URLs whenever you have them and I'll wire those in too.

## Linked

[DEV-298](https://linear.app/showkarma/issue/DEV-298) — chatbot interface track.