### PR TITLE
feat(community): "Ask Karma" button + ⌘K shortcut route to /ask-karma

### DIFF
--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -3,14 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronLeftIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useParams, usePathname } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { HeaderStatsCards } from "@/components/Community/HeaderStatsCards";
 import { CommunityPageNavigator } from "@/components/Pages/Communities/CommunityPageNavigator";
 import { BorderBeam } from "@/components/ui/border-beam";
 import { useDominantColor } from "@/hooks/useDominantColor";
 import { layoutTheme } from "@/src/helper/theme";
-import { useAgentChatStore } from "@/store/agentChat";
 import type { Community } from "@/types/v2/community";
 import { communityColors } from "@/utilities/communityColors";
 import { PAGES } from "@/utilities/pages";
@@ -89,25 +88,18 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
   const params = useParams();
   const communityId = (params?.communityId as string) || community?.details?.slug || "";
   const [isMac, setIsMac] = useState(false);
-  const setChatOpen = useAgentChatStore((s) => s.setOpen);
-  const setAgentContext = useAgentChatStore((s) => s.setAgentContext);
+  const router = useRouter();
   const communityName = community?.details?.name || "";
 
-  const openKarmaAssistant = useCallback(() => {
-    if (communityId) {
-      setAgentContext({ communityId });
-    }
-    setChatOpen(true);
-    // Wait for the chat shell + input to mount before focusing.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const editor = document.querySelector<HTMLElement>(
-          '[role="textbox"][aria-label="Chat message"]'
-        );
-        editor?.focus();
-      });
-    });
-  }, [communityId, setAgentContext, setChatOpen]);
+  const openAskKarma = useCallback(() => {
+    // The dedicated /ask-karma page replaces the prior floating chat
+    // bubble for this entry point. We still want the keyboard shortcut
+    // and the visible "Ask Karma" pill to land users on the same surface
+    // so they get the full-page experience (start view + chat view +
+    // tool activity panel) rather than the bubble.
+    const target = communityId ? PAGES.COMMUNITY.ASK_KARMA(communityId) : PAGES.ASK_KARMA;
+    router.push(target);
+  }, [communityId, router]);
 
   useEffect(() => {
     if (typeof navigator !== "undefined") {
@@ -129,12 +121,12 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (mod && (e.key === "k" || e.key === "K")) {
         e.preventDefault();
-        openKarmaAssistant();
+        openAskKarma();
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isMac, openKarmaAssistant]);
+  }, [isMac, openAskKarma]);
   const { isWhitelabel, config } = useWhitelabel();
   const uid = (community as Community)?.uid?.toLowerCase() || "";
   const slug = community?.details?.slug?.toLowerCase() || "";
@@ -285,7 +277,7 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
         >
           <button
             type="button"
-            onClick={openKarmaAssistant}
+            onClick={openAskKarma}
             aria-label={`Ask Karma about ${communityName || "this community"}`}
             className="group relative overflow-hidden inline-flex items-center gap-2 pl-2.5 pr-3.5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-full text-[13px] font-medium text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)] transition-all"
           >

--- a/components/Community/Header.tsx
+++ b/components/Community/Header.tsx
@@ -12,7 +12,7 @@ import { useDominantColor } from "@/hooks/useDominantColor";
 import { layoutTheme } from "@/src/helper/theme";
 import type { Community } from "@/types/v2/community";
 import { communityColors } from "@/utilities/communityColors";
-import { PAGES } from "@/utilities/pages";
+import { isAskKarmaPathname, PAGES } from "@/utilities/pages";
 import { getCommunityStats } from "@/utilities/queries/v2/getCommunityData";
 import { cn } from "@/utilities/tailwind";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
@@ -89,6 +89,8 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
   const communityId = (params?.communityId as string) || community?.details?.slug || "";
   const [isMac, setIsMac] = useState(false);
   const router = useRouter();
+  const headerPathname = usePathname() ?? "";
+  const isOnAskKarma = isAskKarmaPathname(headerPathname);
   const communityName = community?.details?.name || "";
 
   const openAskKarma = useCallback(() => {
@@ -279,7 +281,20 @@ const NormalCommunityHeader = ({ community }: { community: Community }) => {
             type="button"
             onClick={openAskKarma}
             aria-label={`Ask Karma about ${communityName || "this community"}`}
-            className="group relative overflow-hidden inline-flex items-center gap-2 pl-2.5 pr-3.5 py-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-zinc-800 rounded-full text-[13px] font-medium text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)] transition-all"
+            // Active state when the user is already on the ask-karma page —
+            // mirrors the hover affordance so the pill reads as "you are
+            // here". `aria-current="page"` surfaces the same to assistive
+            // tech without depending on the visual treatment.
+            aria-current={isOnAskKarma ? "page" : undefined}
+            className={cn(
+              "group relative overflow-hidden inline-flex items-center gap-2 pl-2.5 pr-3.5 py-2",
+              "bg-white dark:bg-zinc-900 rounded-full text-[13px] font-medium",
+              "text-gray-900 dark:text-white shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
+              "transition-all",
+              isOnAskKarma
+                ? "border border-brand-500 shadow-[0_0_0_3px_rgba(46,209,168,0.12)]"
+                : "border border-gray-200 dark:border-zinc-800 hover:border-brand-500 hover:shadow-[0_0_0_3px_rgba(46,209,168,0.12)]"
+            )}
           >
             <Image
               src="/logo/logo-dark.png"

--- a/components/Pages/Communities/CommunityPageNavigator.tsx
+++ b/components/Pages/Communities/CommunityPageNavigator.tsx
@@ -63,6 +63,10 @@ const NAVIGATION_ITEMS: readonly NavigationItem[] = [
     path: (communityId: string) => PAGES.COMMUNITY.PROJECTS(communityId),
     title: () => "View funded projects",
     Icon: SquareUser,
+    // "View funded projects" is the default-active tab when no other tab
+    // claims the route — exclude every other community subpath, including
+    // /ask-karma, so visiting the assistant doesn't make this tab look
+    // selected.
     isActive: (pathname: string) =>
       !pathname.includes("/impact") &&
       !pathname.includes("/project-discovery") &&
@@ -71,7 +75,8 @@ const NAVIGATION_ITEMS: readonly NavigationItem[] = [
       !pathname.includes("/funding-opportunities") &&
       !pathname.includes("/browse-applications") &&
       !pathname.includes("/financials") &&
-      !pathname.includes("/reports"),
+      !pathname.includes("/reports") &&
+      !pathname.includes("/ask-karma"),
   },
   {
     id: "milestone-updates",


### PR DESCRIPTION
## Summary

Hook up the existing **"Ask Karma"** pill in the community header (and its ⌘K / Ctrl-K keyboard shortcut) to the dedicated `/community/<id>/ask-karma` page that landed in PR #1461. Previously both opened the floating chat bubble. The dedicated page is now the canonical surface (start screen + chat view + thinking-panel with tool activity), so the muscle memory carries over to the new UX.

Also fixes a subtle navigation bug: the **"View funded projects"** tab appeared selected when visiting `/ask-karma`. The tab uses a negative-match default ("active when no other tab claims the route"), and `/ask-karma` wasn't in the exclusion list.

## Changes

### `components/Community/Header.tsx`
- Drop the `useAgentChatStore` wiring — no more `setOpen(true)` / `setAgentContext({ communityId })` from this button
- Add `useRouter` from `next/navigation`
- New `openAskKarma` callback: `router.push(PAGES.COMMUNITY.ASK_KARMA(communityId))` (falls back to `PAGES.ASK_KARMA` when no community is in scope)
- Both the button onClick and the ⌘K / Ctrl-K shortcut handler share this single callback

### `components/Pages/Communities/CommunityPageNavigator.tsx`
- Extend the "View funded projects" negative-match list with `!pathname.includes("/ask-karma")` + a comment explaining the default-active semantics so the next person adding a route knows to update this list

## Test plan

- [x] `npx biome check` — clean on both files
- [x] `tsc --noEmit` — clean
- [ ] Manual: click "Ask Karma" pill on `/community/filecoin` → lands on `/community/filecoin/ask-karma`
- [ ] Manual: press ⌘K (Mac) or Ctrl-K on any community page → lands on the community's ask-karma route
- [ ] Manual: visit `/community/filecoin/ask-karma` → confirm the "View funded projects" tab is no longer highlighted (no tab should be highlighted on the ask-karma page)
- [ ] Manual: visit `/community/filecoin/projects` → "View funded projects" still correctly highlighted (regression check)
- [ ] Manual: visit `/community/filecoin/funding-opportunities` → that tab highlights, "View funded projects" does NOT (regression check)

## Out of scope

The floating `AgentChatBubble` itself is **not** removed — it still hangs from `DeferredLayoutComponents` for routes that aren't `/ask-karma`. This PR only repoints the visible community-header entry point. If we want to fully retire the bubble in favour of the page, that's a separate follow-up.

## Linked

[DEV-298](https://linear.app/showkarma/issue/DEV-298) — chatbot interface track.