### PR TITLE
fix(sitemap): strip fractional seconds from child sitemap lastmod

### DIFF
--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildSitemapEntries, formatSitemapLastmod } from "@/utilities/sitemap";
+
+describe("formatSitemapLastmod", () => {
+  it("strips fractional seconds from ISO timestamps (Google parser strictness)", () => {
+    const fixed = new Date("2026-05-20T14:43:55.227Z");
+    expect(formatSitemapLastmod(fixed)).toBe("2026-05-20T14:43:55Z");
+  });
+
+  it("leaves whole-second timestamps unchanged", () => {
+    const fixed = new Date("2026-05-20T14:43:55.000Z");
+    expect(formatSitemapLastmod(fixed)).toBe("2026-05-20T14:43:55Z");
+  });
+
+  it("defaults to now with second precision", () => {
+    expect(formatSitemapLastmod()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+});
+
+describe("buildSitemapEntries", () => {
+  it("emits lastModified without fractional seconds for every entry", () => {
+    const entries = buildSitemapEntries(["https://www.karmahq.xyz/project/a"], {
+      priority: 0.8,
+      changeFrequency: "daily",
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].lastModified).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(entries[0].lastModified).not.toMatch(/\.\d{3}Z$/);
+  });
+});

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
+import { formatSitemapLastmod } from "@/utilities/sitemap";
 
 const communitySubPages = [
   "funding-opportunities",
@@ -12,7 +13,7 @@ const communitySubPages = [
 ] as const;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date().toISOString();
+  const now = formatSitemapLastmod();
 
   return chosenCommunities().flatMap((community) => {
     const identifier = community.slug || community.uid;

--- a/app/sitemaps/static/sitemap.ts
+++ b/app/sitemaps/static/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/utilities/meta";
+import { formatSitemapLastmod } from "@/utilities/sitemap";
 
 const staticPages = [
   "",
@@ -43,9 +44,10 @@ const staticPages = [
 const lowPriorityPages = ["/privacy-policy", "/terms-and-conditions", "/dashboard"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = formatSitemapLastmod();
   return staticPages.map((path) => ({
     url: `${SITE_URL}${path}`,
-    lastModified: new Date().toISOString(),
+    lastModified,
     changeFrequency: path === "" ? "daily" : lowPriorityPages.includes(path) ? "yearly" : "weekly",
     priority:
       path === ""

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -64,6 +64,12 @@ export async function fetchSitemapUrls(
   }
 }
 
+// Google's sitemap parser rejects W3C Datetime values with fractional seconds.
+// Emit second-precision ISO 8601 instead of the default `.toISOString()`.
+export function formatSitemapLastmod(date: Date = new Date()): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
 export function buildSitemapEntries(
   urls: string[],
   options: {
@@ -71,7 +77,7 @@ export function buildSitemapEntries(
     changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
   }
 ): MetadataRoute.Sitemap {
-  const lastModified = new Date().toISOString();
+  const lastModified = formatSitemapLastmod();
   return urls.map((url) => ({
     url,
     lastModified,


### PR DESCRIPTION
## Problem

GSC keeps reporting "Couldn't fetch" on `/sitemap.xml` even after #1446, #1448, and #1450. The root sitemap is fine — but Google walks into the child sitemaps and chokes on millisecond-precision `<lastmod>` values:

```
$ curl -s https://www.karmahq.xyz/sitemaps/projects/sitemap/1.xml | head
…
<lastmod>2026-05-20T14:43:55.227Z</lastmod>
```

#1446 only stripped fractional seconds on the root sitemap; the per-kind child sitemaps (static, communities, projects, impacts, grants, milestones, funding-programs) still emit `new Date().toISOString()`.

## Solution

Add `formatSitemapLastmod(date?)` in `utilities/sitemap.ts` — `.toISOString().replace(/\.\d{3}Z$/, "Z")` — and use it from all child sitemap builders:

- `app/sitemaps/static/sitemap.ts`
- `app/sitemaps/communities/sitemap.ts`
- `utilities/sitemap.ts` → `buildSitemapEntries` (used by projects/impacts/grants/milestones/funding-programs)

After deploy, every `<lastmod>` in every sitemap will be second-precision.

## Testing

- New unit tests in `__tests__/utilities/sitemap.test.ts` cover the helper and `buildSitemapEntries`.
- Existing root-sitemap test (`__tests__/scripts/generate-sitemap.test.ts`) continues to pass.

## Post-merge steps

1. Wait for prod deploy.
2. Spot-check `curl https://www.karmahq.xyz/sitemaps/projects/sitemap/1.xml | head` — confirm no `.XXXZ` in `<lastmod>`.
3. In GSC, remove `/sitemap.xml` and resubmit (forces a fresh fetch — GSC caches its own errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for sitemap timestamp formatting utilities.

* **Chores**
  * Standardized sitemap timestamp formatting across all sitemap entries to remove fractional seconds for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->