### PR TITLE
feat(ask-karma): static "Ask Karma" metadata, drop tenant interpolation

### DIFF
--- a/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
@@ -97,8 +97,10 @@ describe("/ask-karma (root) page", () => {
     const { metadata } = await import("@/app/ask-karma/page");
     expect(metadata.title).toBe("Ask Karma");
     expect(metadata.alternates?.canonical).toBe("/ask-karma");
-    // Description must not include any tenant name.
-    expect(metadata.description).not.toMatch(/Filecoin|Optimism|Karma\s/i);
+    // Rule: no tenant-name interpolation in the description. "Karma" is
+    // intentionally NOT in this list — it's the product name, not a tenant,
+    // and is allowed in copy ("Ask Karma about …", etc.).
+    expect(metadata.description).not.toMatch(/Filecoin|Optimism/i);
   });
 });
 

--- a/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
@@ -90,17 +90,15 @@ describe("/ask-karma (root) page", () => {
     expect(props.config.exampleQuestions.some((q: string) => q.includes("fil.one"))).toBe(true);
   });
 
-  it("generateMetadata produces a tenant-aware title", async () => {
-    mockGetWhitelabelContext.mockResolvedValueOnce({
-      isWhitelabel: true,
-      communitySlug: "filecoin",
-      config: { domain: "app.filpgf.io", communitySlug: "filecoin", tenantId: "filecoin" },
-      tenantConfig: { id: "filecoin", name: "Filecoin" },
-    });
-    const { generateMetadata } = await import("@/app/ask-karma/page");
-    const meta = await generateMetadata();
-    expect(meta.title).toContain("Filecoin");
-    expect(meta.alternates?.canonical).toBe("/ask-karma");
+  it("metadata is static 'Ask Karma' even on a whitelabel surface", async () => {
+    // Tenant-agnostic by design: the agent is Karma regardless of
+    // which whitelabel the user arrived on. The on-page chrome still
+    // uses the community's branding — only the page metadata is fixed.
+    const { metadata } = await import("@/app/ask-karma/page");
+    expect(metadata.title).toBe("Ask Karma");
+    expect(metadata.alternates?.canonical).toBe("/ask-karma");
+    // Description must not include any tenant name.
+    expect(metadata.description).not.toMatch(/Filecoin|Optimism|Karma\s/i);
   });
 });
 
@@ -142,7 +140,9 @@ describe("/community/[communityId]/ask-karma (community) page", () => {
     vi.doUnmock("next/navigation");
   });
 
-  it("generateMetadata produces a community-aware title", async () => {
+  it("generateMetadata returns the static 'Ask Karma' title with a community-scoped canonical", async () => {
+    // Title is intentionally tenant-agnostic; only the canonical URL
+    // changes per community so search engines can dedupe per surface.
     vi.resetModules();
     vi.doMock("@/utilities/queries/v2/getCommunityData", () => ({
       getCommunityDetails: vi
@@ -155,8 +155,9 @@ describe("/community/[communityId]/ask-karma (community) page", () => {
     const meta = await generateMetadata({
       params: Promise.resolve({ communityId: "filecoin" }),
     });
-    expect(meta.title).toContain("Filecoin");
+    expect(meta.title).toBe("Ask Karma");
     expect(meta.alternates?.canonical).toBe("/community/filecoin/ask-karma");
+    expect(meta.description).not.toMatch(/Filecoin/i);
     vi.doUnmock("@/utilities/queries/v2/getCommunityData");
   });
 });

--- a/app/ask-karma/page.tsx
+++ b/app/ask-karma/page.tsx
@@ -5,35 +5,34 @@ import { SITE_URL, twitterMeta } from "@/utilities/meta";
 import { PAGES } from "@/utilities/pages";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
-async function resolveTenant() {
-  const ctx = await getWhitelabelContext();
-  const tenantId = ctx.tenantConfig?.id ?? "karma";
-  const tenantName = ctx.tenantConfig?.name ?? "Karma";
-  const communitySlug = ctx.communitySlug ?? undefined;
-  return { tenantId, tenantName, communitySlug };
-}
+// Metadata is intentionally tenant-agnostic. The agent that answers these
+// questions is Karma's regardless of which whitelabel surface the user
+// arrives from, so the title/description shouldn't read "Ask Filecoin" or
+// "Ask Optimism". Whitelabel branding still applies to the on-page chrome.
+const STATIC_TITLE = "Ask Karma";
+const STATIC_DESCRIPTION =
+  "Ask anything about funding rounds, project progress, milestones, and ecosystem insights.";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { tenantName } = await resolveTenant();
-  const title = `Ask ${tenantName} — AI Assistant`;
-  const description = `Ask anything about ${tenantName} — funding rounds, project progress, milestones, and ecosystem insights.`;
-
-  return {
-    title,
-    description,
-    alternates: { canonical: PAGES.ASK_KARMA },
-    twitter: { ...twitterMeta, title, description },
-    openGraph: {
-      type: "website",
-      url: `${SITE_URL}${PAGES.ASK_KARMA}`,
-      title,
-      description,
-    },
-  };
-}
+export const metadata: Metadata = {
+  title: STATIC_TITLE,
+  description: STATIC_DESCRIPTION,
+  alternates: { canonical: PAGES.ASK_KARMA },
+  twitter: { ...twitterMeta, title: STATIC_TITLE, description: STATIC_DESCRIPTION },
+  openGraph: {
+    type: "website",
+    url: `${SITE_URL}${PAGES.ASK_KARMA}`,
+    title: STATIC_TITLE,
+    description: STATIC_DESCRIPTION,
+  },
+};
 
 export default async function RootAskKarmaPage() {
-  const { tenantId, communitySlug } = await resolveTenant();
+  // Resolve the active community for the page component (drives the config
+  // lookup + the in-page communityId context). Independent from the static
+  // metadata above.
+  const ctx = await getWhitelabelContext();
+  const tenantId = ctx.tenantConfig?.id ?? "karma";
+  const communitySlug = ctx.communitySlug ?? undefined;
   const config = getAskKarmaConfig(tenantId);
 
   return <AskKarmaPage config={config} communityId={communitySlug} />;

--- a/app/community/[communityId]/(with-header)/ask-karma/page.tsx
+++ b/app/community/[communityId]/(with-header)/ask-karma/page.tsx
@@ -10,28 +10,35 @@ type Params = Promise<{
   communityId: string;
 }>;
 
+// Metadata is intentionally tenant-agnostic. The agent that answers these
+// questions is Karma's regardless of which community surface the user is
+// in, so the title/description shouldn't read "Ask Filecoin" etc. The
+// in-page chrome still uses the community's branding.
+const STATIC_TITLE = "Ask Karma";
+const STATIC_DESCRIPTION =
+  "Ask anything about funding rounds, project progress, milestones, and ecosystem insights.";
+
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { communityId } = await params;
+  // Still validate the community exists so an invalid slug 404s before
+  // we surface metadata for it — the page below will notFound() too,
+  // but Next.js calls generateMetadata first and we want the same
+  // behaviour from both code paths.
   const community = await getCommunityDetails(communityId);
-
   if (!community || !community.details?.name) {
     notFound();
   }
-
-  const communityName = community.details.name;
-  const title = `Ask ${communityName} — AI Assistant`;
-  const description = `Ask anything about ${communityName} — funding rounds, project progress, milestones, and ecosystem insights.`;
   const canonical = PAGES.COMMUNITY.ASK_KARMA(communityId);
 
   return {
-    title,
-    description,
+    title: STATIC_TITLE,
+    description: STATIC_DESCRIPTION,
     alternates: { canonical },
     openGraph: {
       type: "website",
       url: `${SITE_URL}${canonical}`,
-      title,
-      description,
+      title: STATIC_TITLE,
+      description: STATIC_DESCRIPTION,
     },
   };
 }


### PR DESCRIPTION
## Summary

The agent that powers `/ask-karma` is Karma's, full stop — there's no separate "Filecoin agent" or "Optimism agent" answering queries. The previous metadata read **"Ask Filecoin — AI Assistant"** on the filecoin surface (and equivalent for other tenants), which implied a fleet of tenant-specific agents that don't exist.

Both ask-karma routes now emit the same static metadata:

| Field | Value |
|---|---|
| `title` | `Ask Karma` |
| `description` | `Ask anything about funding rounds, project progress, milestones, and ecosystem insights.` |

Per-page canonical URLs stay distinct (`/ask-karma` vs `/community/<id>/ask-karma`) so search engines dedupe per surface, but the title/description are uniform.

## What is *not* changing

- Tenant theme colors on-page still apply
- Tenant-specific example questions / featured topics still render
- The community/whitelabel chrome (header, navigation) is unaffected
- `communityId` still flows into the client `<AskKarmaPage>` for the agent context

This is metadata-only.

## Files

- `app/ask-karma/page.tsx` — `generateMetadata` (async) replaced with a static `export const metadata` block. The tenant resolution in the default export remains; it still feeds `communityId` to the page component.
- `app/community/[communityId]/(with-header)/ask-karma/page.tsx` — `generateMetadata` still runs (it has to call `notFound()` for invalid community slugs) but returns the static strings.
- `__tests__/integration/pages/smoke/ask-karma-pages.test.tsx` — both metadata tests updated to assert the new fixed values and explicitly reject any tenant name in the description (`expect(meta.description).not.toMatch(/Filecoin/i)`).

## Test plan

- [x] `pnpm vitest run __tests__/integration/pages/smoke/ask-karma-pages.test.tsx` → 6/6
- [x] Biome clean on changed files
- [x] `tsc --noEmit` clean
- [ ] Manual: view source on `app.filpgf.io/ask-karma` → `<title>Ask Karma</title>`, no "Filecoin" anywhere in `<head>`
- [ ] Manual: `karmahq.xyz/community/optimism/ask-karma` → same
- [ ] Search-bar preview / OpenGraph sharing previews show "Ask Karma" everywhere

## Linked

[DEV-298](https://linear.app/showkarma/issue/DEV-298) — was shipped, this is post-ship polish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized Ask Karma page metadata to use consistent, static values across all configurations instead of dynamically generating tenant-specific titles and descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->