### PR TITLE
feat(seo): serve OpenAPI spec at apex /openapi.json for agent crawlers

### DIFF
--- a/__tests__/app/openapi.test.ts
+++ b/__tests__/app/openapi.test.ts
@@ -1,0 +1,117 @@
+import * as Sentry from "@sentry/nextjs";
+
+const INDEXER_URL = "http://localhost:4000";
+
+describe("/openapi.json route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("proxies the upstream /v2/docs/json response when it succeeds", async () => {
+    const upstream = {
+      openapi: "3.0.0",
+      info: { title: "Karma API", version: "2.0.0" },
+      paths: { "/v2/projects": {} },
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => upstream }));
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(upstream);
+  });
+
+  it("calls upstream with a 5s timeout and ISR revalidate hint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ paths: {} }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/app/openapi.json/route");
+    await GET();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${INDEXER_URL}/v2/docs/json`,
+      expect.objectContaining({
+        next: { revalidate: 3600 },
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it("returns 502 + minimal fallback when upstream responds non-OK", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toBe("upstream_unavailable");
+    expect(body.openapi).toBe("3.0.0");
+    expect(body.paths).toEqual({});
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { route: "openapi" } })
+    );
+  });
+
+  it("returns 502 + fallback and captures the error when upstream throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+
+    expect(res.status).toBe(502);
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { route: "openapi" } })
+    );
+  });
+
+  it("uses no-store Cache-Control on 502 responses so CDNs do not pin failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("uses public, max-age=3600 Cache-Control on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("sets wide-open CORS headers so AI crawlers can read it", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+
+    const { GET } = await import("@/app/openapi.json/route");
+    const res = await GET();
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/openapi.json/route");
+    const res = await OPTIONS();
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/app/well-known.test.ts
+++ b/__tests__/app/well-known.test.ts
@@ -23,11 +23,11 @@ describe("/.well-known/ai-plugin.json route handler", () => {
     expect(body.name_for_model).toBe("karma");
   });
 
-  it("points api.url at the indexer's OpenAPI spec", async () => {
+  it("points api.url at the apex openapi.json proxy", async () => {
     const { GET } = await import("@/app/.well-known/ai-plugin.json/route");
     const res = GET();
     const body = await res.json();
-    expect(body.api.url).toBe(`${INDEXER_URL}/v2/docs/json`);
+    expect(body.api.url).toBe(`${SITE_URL}/openapi.json`);
     expect(body.api.type).toBe("openapi");
   });
 

--- a/app/.well-known/ai-plugin.json/route.ts
+++ b/app/.well-known/ai-plugin.json/route.ts
@@ -23,7 +23,7 @@ export function GET() {
     },
     api: {
       type: "openapi",
-      url: `${apiUrl}/v2/docs/json`,
+      url: `${SITE_URL}/openapi.json`,
     },
     logo_url: `${SITE_URL}/logo/karma-logo.svg`,
     contact_email: "info@karmahq.xyz",

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -1,0 +1,65 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+import {
+  getIndexerBaseUrl,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_ERROR_HEADERS,
+} from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * Serves the indexer's OpenAPI spec from the marketing-domain apex so
+ * agent crawlers (Ora, Profound, etc.) that probe predictable paths
+ * like https://www.karmahq.xyz/openapi.json find it without having to
+ * walk the .well-known/ai-plugin.json manifest first.
+ *
+ * Hourly-revalidated ISR proxy of `${indexer}/v2/docs/json`. Same
+ * resilience pattern as /.well-known/mcp-tools.json: 5s timeout,
+ * Sentry-captured on failure, no-cache 502 fallback so CDNs don't
+ * pin a transient upstream blip for an hour.
+ */
+
+const FALLBACK_BODY = {
+  error: "upstream_unavailable",
+  openapi: "3.0.0",
+  info: { title: "Karma API", version: "unknown" },
+  paths: {},
+};
+const UPSTREAM_TIMEOUT_MS = 5000;
+
+export async function GET() {
+  try {
+    const res = await fetch(`${getIndexerBaseUrl()}/v2/docs/json`, {
+      next: { revalidate: 3600 },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      Sentry.captureException(new Error(`Upstream /v2/docs/json returned ${res.status}`), {
+        tags: { route: "openapi" },
+        extra: { status: res.status },
+      });
+      return NextResponse.json(FALLBACK_BODY, {
+        status: 502,
+        headers: WELL_KNOWN_ERROR_HEADERS,
+      });
+    }
+
+    const body = await res.json();
+    return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { route: "openapi" },
+    });
+    return NextResponse.json(FALLBACK_BODY, {
+      status: 502,
+      headers: WELL_KNOWN_ERROR_HEADERS,
+    });
+  }
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8,7 +8,7 @@ Karma is a platform where ecosystems allocate funding, track milestones, and mea
 - MCP endpoint: https://gapapi.karmahq.xyz/v2/mcp
 - Setup guide: https://www.karmahq.xyz/mcp/connect
 - For-agents overview: https://www.karmahq.xyz/for-agents
-- OpenAPI spec (JSON): https://gapapi.karmahq.xyz/v2/docs/json
+- OpenAPI spec (JSON): https://www.karmahq.xyz/openapi.json
 - API docs (Swagger UI): https://gapapi.karmahq.xyz/v2/docs
 - Plugin manifest: https://www.karmahq.xyz/.well-known/ai-plugin.json
 - MCP server discovery: https://www.karmahq.xyz/.well-known/mcp.json
@@ -116,7 +116,7 @@ Add your organization
 ## Developer Docs
 
 - [API Documentation](https://gapapi.karmahq.xyz/v2/docs): REST API docs for projects, communities, grants, and attestations
-- [OpenAPI JSON](https://gapapi.karmahq.xyz/v2/docs/json)
+- [OpenAPI JSON](https://www.karmahq.xyz/openapi.json)
 - Authentication: use Privy JWT in `Authorization: Bearer <token>` for protected endpoints
 - Public reads are available for key listing endpoints (projects, communities, grants)
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,7 +8,7 @@ Karma is a platform where ecosystems allocate funding, track milestones, and mea
 - MCP endpoint: https://gapapi.karmahq.xyz/v2/mcp
 - Setup guide: https://www.karmahq.xyz/mcp/connect
 - For-agents overview: https://www.karmahq.xyz/for-agents
-- OpenAPI spec (JSON): https://gapapi.karmahq.xyz/v2/docs/json
+- OpenAPI spec (JSON): https://www.karmahq.xyz/openapi.json
 - API docs (Swagger UI): https://gapapi.karmahq.xyz/v2/docs
 - Plugin manifest: https://www.karmahq.xyz/.well-known/ai-plugin.json
 - MCP server discovery: https://www.karmahq.xyz/.well-known/mcp.json
@@ -27,7 +27,7 @@ Karma is a platform where ecosystems allocate funding, track milestones, and mea
 
 ## Developer Docs
 - [API Documentation](https://gapapi.karmahq.xyz/v2/docs): REST API docs for projects, communities, grants, and attestations
-- [OpenAPI JSON](https://gapapi.karmahq.xyz/v2/docs/json)
+- [OpenAPI JSON](https://www.karmahq.xyz/openapi.json)
 
 ## Documentation
 - [Why Karma](https://docs.gap.karmahq.xyz): Overview — Why Karma

--- a/scripts/generate-llms-txt.ts
+++ b/scripts/generate-llms-txt.ts
@@ -42,7 +42,11 @@ const SITE_URL = "https://www.karmahq.xyz";
 const SITEMAP_URL = `${SITE_URL}/sitemap.xml`;
 const PROJECT_NAME = "Karma";
 const API_DOCS_URL = "https://gapapi.karmahq.xyz/v2/docs";
-const API_SPEC_URL = "https://gapapi.karmahq.xyz/v2/docs/json";
+// Apex proxy of the indexer's OpenAPI spec; agent crawlers (Ora, etc.)
+// probe predictable apex paths, so we publish under the marketing
+// domain rather than the API subdomain. Implementation lives in
+// app/openapi.json/route.ts and proxies ${gap-indexer}/v2/docs/json.
+const API_SPEC_URL = "https://www.karmahq.xyz/openapi.json";
 const FIRECRAWL_SCRAPE_URL =
   process.env.FIRECRAWL_SCRAPE_URL || "https://api.firecrawl.dev/v1/scrape";
 const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY || "";


### PR DESCRIPTION
## Summary

- Serves the indexer's OpenAPI spec at the marketing-domain apex (`https://www.karmahq.xyz/openapi.json`) so agent crawlers that probe predictable apex paths (Ora, Profound, etc.) find it without walking the `.well-known/ai-plugin.json` manifest first.
- Retargets every reference (`ai-plugin.json` `api.url`, `llms.txt`, `llms-full.txt`, `generate-llms-txt.ts`) at the new apex URL so the discovery chain stays on the marketing domain.
- Same resilience pattern as `/.well-known/mcp-tools.json`: 5s timeout, 1h ISR cache, Sentry-captured 502 fallback with `Cache-Control: no-store`.

## Why

[orank](https://ora.ai/scan/karmahq.xyz) currently reports:

> **OpenAPI spec published** — lost 7 of 7 pts (fail)
> Finding: No OpenAPI/Swagger specification found
> Fix: Publish an OpenAPI (Swagger) specification at `/openapi.json` or `/api/openapi.yaml`.

We already publish it at `gapapi.karmahq.xyz/v2/docs/json` — but Ora doesn't follow `ai-plugin.json` references; it probes path-based locations on the apex. This PR closes that 7-point gap by serving the spec at the path Ora actually looks at, while keeping the indexer as the single source of truth (the apex route is a proxy with ISR caching).

Once deployed, the "Scoped permissions" finding (another -5 pts) also resolves automatically — Ora can now discover the `securitySchemes` defined in the OpenAPI it can finally see.

## What's new

### Route handler
- \`app/openapi.json/route.ts\` — async server route, \`force-static\` + \`revalidate = 3600\`, 5s \`AbortSignal.timeout\`, Sentry capture on failure, 502 fallback with \`Cache-Control: no-store\`, wide-open CORS, OPTIONS preflight handler

### Reference updates (so the discovery chain stays on the apex)
- \`app/.well-known/ai-plugin.json/route.ts\` — \`api.url\` now points at \`\${SITE_URL}/openapi.json\`
- \`public/llms.txt\`, \`public/llms-full.txt\` — OpenAPI references swapped to apex URL
- \`scripts/generate-llms-txt.ts\` — \`API_SPEC_URL\` constant updated so future regenerations stay consistent

### Tests (8 new + 1 updated)
- \`__tests__/app/openapi.test.ts\` — proxy success, non-OK upstream, throw, timeout signal, ISR hint, Cache-Control branching, CORS headers, OPTIONS preflight
- \`__tests__/app/well-known.test.ts\` — \`api.url\` assertion updated to expect the apex URL

## Deploy notes

- Purge CDN cache for \`/openapi.json\` after merge so the first request doesn't return a stale 404
- After deploy, verify via:
  - \`curl -i https://www.karmahq.xyz/openapi.json | head -5\` (expect 200, application/json, Cache-Control: public, max-age=3600)
  - \`curl -i https://www.karmahq.xyz/.well-known/ai-plugin.json\` and confirm \`api.url\` resolves to a working spec
- Re-run the orank scan ~6h after deploy to let CDN warmup settle; expect Discovery + Auth & Access to jump by ~12 points combined

## Out of scope

- \`/api/openapi.yaml\` — \`robots.txt\` currently \`Disallow: /api/\`, so that path is invisible to crawlers. JSON at root is the right path.
- The "category share of voice" gap from orank — that's content/marketing work (comparison pages, "best X for Y" SEO), not infrastructure