### PR TITLE
feat(seo): well-known discovery bundle to close orank Tier-1 gaps

### DIFF
--- a/__tests__/app/well-known/agent-card.test.ts
+++ b/__tests__/app/well-known/agent-card.test.ts
@@ -50,19 +50,21 @@ describe("/.well-known/agent-card.json route handler", () => {
     expect(body.agent.authentication.schemes).toEqual(expect.arrayContaining(["oauth2", "apiKey"]));
   });
 
-  it("exposes a skills array with id+name+description for each entry", async () => {
+  it("points skillsDiscovery at the live mcp-tools.json catalog (no hardcoded skills)", async () => {
     const { GET } = await import("@/app/.well-known/agent-card.json/route");
     const res = GET();
     const body = await res.json();
-    expect(Array.isArray(body.agent.skills)).toBe(true);
-    expect(body.agent.skills.length).toBeGreaterThan(0);
-    for (const skill of body.agent.skills) {
-      expect(typeof skill.id).toBe("string");
-      expect(typeof skill.name).toBe("string");
-      expect(typeof skill.description).toBe("string");
-    }
-    const ids = body.agent.skills.map((s: { id: string }) => s.id);
-    expect(ids).toEqual(expect.arrayContaining(["discover-funding", "submit-application"]));
+    expect(body.agent.skillsDiscovery).toBeDefined();
+    expect(body.agent.skillsDiscovery.url).toBe(`${SITE_URL}/.well-known/mcp-tools.json`);
+    expect(body.agent.skillsDiscovery.format).toBe("mcp-public-tool-list");
+    expect(typeof body.agent.skillsDiscovery.description).toBe("string");
+  });
+
+  it("does NOT enumerate a static skills array (single source of truth is the indexer)", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.agent.skills).toBeUndefined();
   });
 
   it("sets wide-open CORS headers so agent crawlers can read it", async () => {

--- a/__tests__/app/well-known/agent-card.test.ts
+++ b/__tests__/app/well-known/agent-card.test.ts
@@ -1,0 +1,84 @@
+import { SITE_URL } from "@/utilities/meta";
+
+describe("/.well-known/agent-card.json route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns an A2A agent card under the top-level 'agent' envelope", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.agent).toBeDefined();
+    expect(body.agent.name).toBe("Karma");
+    expect(body.agent.version).toBe("1.0.0");
+    expect(typeof body.agent.description).toBe("string");
+    expect(body.agent.description.length).toBeGreaterThan(0);
+  });
+
+  it("points url and documentationUrl at the apex marketing domain", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.agent.url).toBe(SITE_URL);
+    expect(body.agent.documentationUrl).toBe(`${SITE_URL}/mcp/connect`);
+    expect(body.agent.provider.name).toBe("Karma");
+    expect(body.agent.provider.url).toBe(SITE_URL);
+  });
+
+  it("advertises capability flags as explicit booleans (no streaming yet)", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.agent.capabilities).toEqual({
+      streaming: false,
+      pushNotifications: false,
+      stateTransitionHistory: false,
+    });
+  });
+
+  it("supports both oauth2 and apiKey authentication schemes", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.agent.authentication.schemes).toEqual(expect.arrayContaining(["oauth2", "apiKey"]));
+  });
+
+  it("exposes a skills array with id+name+description for each entry", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(Array.isArray(body.agent.skills)).toBe(true);
+    expect(body.agent.skills.length).toBeGreaterThan(0);
+    for (const skill of body.agent.skills) {
+      expect(typeof skill.id).toBe("string");
+      expect(typeof skill.name).toBe("string");
+      expect(typeof skill.description).toBe("string");
+    }
+    const ids = body.agent.skills.map((s: { id: string }) => s.id);
+    expect(ids).toEqual(expect.arrayContaining(["discover-funding", "submit-application"]));
+  });
+
+  it("sets wide-open CORS headers so agent crawlers can read it", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/.well-known/agent-card.json/route");
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/app/well-known/agent.test.ts
+++ b/__tests__/app/well-known/agent.test.ts
@@ -1,0 +1,64 @@
+import { SITE_URL } from "@/utilities/meta";
+
+describe("/.well-known/agent.json route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns the Karma agent identity with a contact email", async () => {
+    const { GET } = await import("@/app/.well-known/agent.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.name).toBe("Karma");
+    expect(typeof body.description).toBe("string");
+    expect(body.description.length).toBeGreaterThan(0);
+    expect(body.contact).toBe("info@karmahq.xyz");
+  });
+
+  it("aggregates all other discovery surfaces under .discovery", async () => {
+    const { GET } = await import("@/app/.well-known/agent.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.discovery).toEqual({
+      openapi: `${SITE_URL}/openapi.json`,
+      mcp: `${SITE_URL}/.well-known/mcp.json`,
+      mcpServerCard: `${SITE_URL}/.well-known/mcp/server-card.json`,
+      aiPlugin: `${SITE_URL}/.well-known/ai-plugin.json`,
+      agentCard: `${SITE_URL}/.well-known/agent-card.json`,
+      oauthProtectedResource: `${SITE_URL}/.well-known/oauth-protected-resource`,
+      llmsTxt: `${SITE_URL}/llms.txt`,
+    });
+  });
+
+  it("only references URLs on the marketing apex (no indexer URLs)", async () => {
+    const { GET } = await import("@/app/.well-known/agent.json/route");
+    const res = GET();
+    const body = await res.json();
+    for (const url of Object.values(body.discovery)) {
+      expect(typeof url).toBe("string");
+      expect(url).toMatch(new RegExp(`^${SITE_URL}`));
+    }
+  });
+
+  it("sets wide-open CORS headers", async () => {
+    const { GET } = await import("@/app/.well-known/agent.json/route");
+    const res = GET();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/.well-known/agent.json/route");
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/app/well-known/api-catalog.test.ts
+++ b/__tests__/app/well-known/api-catalog.test.ts
@@ -1,0 +1,67 @@
+import { SITE_URL } from "@/utilities/meta";
+
+const INDEXER_URL = "http://localhost:4000";
+
+describe("/.well-known/api-catalog route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns an RFC 9727-shaped linkset rooted at the apex domain", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    expect(Array.isArray(body.linkset)).toBe(true);
+    expect(body.linkset).toHaveLength(1);
+    expect(body.linkset[0].anchor).toBe(SITE_URL);
+  });
+
+  it("links the OpenAPI service description at the apex /openapi.json", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.linkset[0]["service-desc"]).toEqual([
+      { href: `${SITE_URL}/openapi.json`, type: "application/json" },
+    ]);
+  });
+
+  it("links the human-readable Swagger UI on the indexer", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.linkset[0]["service-doc"]).toEqual([
+      { href: `${INDEXER_URL}/v2/docs`, type: "text/html" },
+    ]);
+  });
+
+  it("links the AI plugin manifest as additional service metadata", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.linkset[0]["service-meta"]).toEqual([
+      { href: `${SITE_URL}/.well-known/ai-plugin.json`, type: "application/json" },
+    ]);
+  });
+
+  it("sets wide-open CORS headers", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/.well-known/api-catalog/route");
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/app/well-known/mcp-server-card.test.ts
+++ b/__tests__/app/well-known/mcp-server-card.test.ts
@@ -1,0 +1,70 @@
+import { SITE_URL } from "@/utilities/meta";
+
+const INDEXER_URL = "http://localhost:4000";
+
+describe("/.well-known/mcp/server-card.json route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("declares a stable name with the canonical indexer URL and HTTP transport", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.name).toBe("gap-tools");
+    expect(body.alternateNames).toEqual(expect.arrayContaining(["karma-gap-tools"]));
+    expect(body.transport).toBe("http");
+    expect(body.url).toBe(`${INDEXER_URL}/v2/mcp`);
+    expect(body.protocolVersion).toBe("2025-11-25");
+    expect(body.version).toBe("1.0.0");
+  });
+
+  it("references human docs and OpenAPI on the apex marketing domain", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.documentation).toBe(`${SITE_URL}/mcp/connect`);
+    expect(body.openapi).toBe(`${SITE_URL}/openapi.json`);
+  });
+
+  it("advertises oauth2 metadata at the apex protected-resource path and apiKey via x-api-key", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.authentication.oauth2.metadata).toBe(
+      `${SITE_URL}/.well-known/oauth-protected-resource`
+    );
+    expect(body.authentication.apiKey.header).toBe("x-api-key");
+  });
+
+  it("includes a publisher block with name, url, and contact email", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.publisher.name).toBe("Karma");
+    expect(body.publisher.url).toBe(SITE_URL);
+    expect(body.publisher.email).toBe("info@karmahq.xyz");
+  });
+
+  it("sets wide-open CORS headers", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/app/well-known/oauth-protected-resource.test.ts
+++ b/__tests__/app/well-known/oauth-protected-resource.test.ts
@@ -1,0 +1,130 @@
+import * as Sentry from "@sentry/nextjs";
+
+const INDEXER_URL = "http://localhost:4000";
+
+describe("/.well-known/oauth-protected-resource route handler", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("proxies the upstream OAuth metadata response when it succeeds", async () => {
+    const upstream = {
+      resource: `${INDEXER_URL}/v2/mcp`,
+      authorization_servers: [`${INDEXER_URL}`],
+      scopes_supported: ["mcp"],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => upstream }));
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual(upstream);
+  });
+
+  it("calls upstream at /.well-known/oauth-protected-resource/v2/mcp with timeout + ISR", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    await GET();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${INDEXER_URL}/.well-known/oauth-protected-resource/v2/mcp`,
+      expect.objectContaining({
+        next: { revalidate: 3600 },
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it("returns 502 + fallback when upstream responds non-OK", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body).toEqual({ error: "upstream_unavailable" });
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { route: "well-known/oauth-protected-resource" },
+        extra: { status: 503 },
+      })
+    );
+  });
+
+  it("returns 502 + fallback and captures when upstream throws", async () => {
+    const fetchError = new Error("ECONNREFUSED");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(fetchError));
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body).toEqual({ error: "upstream_unavailable" });
+    expect(captureSpy).toHaveBeenCalledWith(fetchError, {
+      tags: { route: "well-known/oauth-protected-resource" },
+    });
+  });
+
+  it("uses no-store Cache-Control on 502 responses so CDNs do not pin failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("uses public, max-age=3600 Cache-Control on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("sets wide-open CORS headers so AI crawlers can read it", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("returns CORS headers even on upstream failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await GET();
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  it("OPTIONS returns 204 with CORS headers", async () => {
+    const { OPTIONS } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = await OPTIONS();
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/__tests__/public/agents.test.ts
+++ b/__tests__/public/agents.test.ts
@@ -13,16 +13,33 @@ describe("public/agents.md", () => {
     expect(contents).toMatch(/^# Karma — agent instructions/);
   });
 
-  it("includes a 'When to use Karma tools' section with tool guidance", () => {
+  it("includes a 'When to use Karma tools' section with use-case categories (not tool names)", () => {
     const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
     expect(contents).toContain("## When to use Karma tools");
-    expect(contents).toContain("`discover`");
-    expect(contents).toContain("`submit_application`");
+    // Use-case categories, not hardcoded tool names — the live tool catalog
+    // is at /.well-known/mcp-tools.json and is the single source of truth.
+    expect(contents).toContain("Funding programs");
+    expect(contents).toContain("Projects");
+    expect(contents).toContain("Applications");
+    expect(contents).toContain("Milestones");
   });
 
-  it("includes a 'When NOT to use Karma tools' section to scope agent behaviour", () => {
+  it("points at the live tool catalog instead of hardcoding tool names", () => {
     const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
-    expect(contents).toContain("## When NOT to use Karma tools");
+    expect(contents).toContain("/.well-known/mcp-tools.json");
+    expect(contents).toContain("/for-agents");
+  });
+
+  it("does NOT enumerate specific tool names (would drift from the indexer)", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).not.toMatch(/`get_project_details`/);
+    expect(contents).not.toMatch(/`list_program_applications`/);
+    expect(contents).not.toMatch(/`commit_submit_application`/);
+  });
+
+  it("includes a 'When NOT to use Karma' section to scope agent behaviour", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("## When NOT to use Karma");
   });
 
   it("documents both OAuth and x-api-key authentication paths", () => {

--- a/__tests__/public/agents.test.ts
+++ b/__tests__/public/agents.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const AGENTS_MD_PATH = path.resolve(__dirname, "../../public/agents.md");
+
+describe("public/agents.md", () => {
+  it("exists at the apex /agents.md path on the marketing domain", () => {
+    expect(fs.existsSync(AGENTS_MD_PATH)).toBe(true);
+  });
+
+  it("opens with the Karma agent-instructions header", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toMatch(/^# Karma — agent instructions/);
+  });
+
+  it("includes a 'When to use Karma tools' section with tool guidance", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("## When to use Karma tools");
+    expect(contents).toContain("`discover`");
+    expect(contents).toContain("`submit_application`");
+  });
+
+  it("includes a 'When NOT to use Karma tools' section to scope agent behaviour", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("## When NOT to use Karma tools");
+  });
+
+  it("documents both OAuth and x-api-key authentication paths", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("## Authentication");
+    expect(contents).toContain("OAuth required");
+    expect(contents).toContain("`x-api-key`");
+  });
+
+  it("lists supported MCP clients with the protocol version", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("## Supported clients");
+    expect(contents).toMatch(/MCP 2025-11-25\+/);
+  });
+
+  it("points at the canonical MCP endpoint on the indexer", () => {
+    const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
+    expect(contents).toContain("https://gapapi.karmahq.xyz/v2/mcp");
+  });
+});

--- a/__tests__/public/pricing.test.ts
+++ b/__tests__/public/pricing.test.ts
@@ -1,0 +1,40 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const PRICING_MD_PATH = path.resolve(__dirname, "../../public/pricing.md");
+
+describe("public/pricing.md", () => {
+  it("exists at the apex /pricing.md path on the marketing domain", () => {
+    expect(fs.existsSync(PRICING_MD_PATH)).toBe(true);
+  });
+
+  it("opens with the Karma pricing header", () => {
+    const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
+    expect(contents).toMatch(/^# Karma pricing/);
+  });
+
+  it("documents a free tier for builders and program admins", () => {
+    const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
+    expect(contents).toContain("## Free tier");
+    expect(contents).toContain("Free for all individual builders and program administrators");
+  });
+
+  it("documents the ecosystem / enterprise tier and points to the sales email", () => {
+    const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
+    expect(contents).toContain("## Ecosystem / enterprise");
+    expect(contents).toContain("info@karmahq.xyz");
+  });
+
+  it("documents free API access under fair-use rate limits", () => {
+    const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
+    expect(contents).toContain("## API access");
+    expect(contents).toContain("fair-use rate limits");
+    expect(contents).toContain("https://gapapi.karmahq.xyz/v2/mcp");
+  });
+
+  it("includes a Last updated section pointing back to the apex marketing URL", () => {
+    const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
+    expect(contents).toContain("## Last updated");
+    expect(contents).toContain("https://www.karmahq.xyz");
+  });
+});

--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import { WELL_KNOWN_CORS_HEADERS, WELL_KNOWN_PREFLIGHT_HEADERS } from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -54,5 +54,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/utilities/meta";
+import { WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * A2A (Agent-to-Agent) Agent Card discovery document.
+ *
+ * Schema reference: https://github.com/google-a2a/a2a-spec — the spec is
+ * evolving, so we ship a best-effort shape with the conventional
+ * top-level `agent` envelope, provider info, capability flags, accepted
+ * auth schemes, and a short list of high-level skills. Static + ISR like
+ * the other discovery routes — no upstream dependency.
+ */
+
+export function GET() {
+  const body = {
+    agent: {
+      name: "Karma",
+      description:
+        "Discover funding programs, projects, milestones, and impact data. Submit applications, track grants, and post updates via an MCP server with OAuth.",
+      url: SITE_URL,
+      version: "1.0.0",
+      documentationUrl: `${SITE_URL}/mcp/connect`,
+      provider: {
+        name: "Karma",
+        url: SITE_URL,
+      },
+      capabilities: {
+        streaming: false,
+        pushNotifications: false,
+        stateTransitionHistory: false,
+      },
+      authentication: {
+        schemes: ["oauth2", "apiKey"],
+      },
+      skills: [
+        {
+          id: "discover-funding",
+          name: "Discover funding programs",
+          description:
+            "Search open programs across communities, by chain, category, deadline, or budget.",
+        },
+        {
+          id: "read-project",
+          name: "Read project details",
+          description: "Project profile, team, milestones, grants, and impact indicators.",
+        },
+        {
+          id: "submit-application",
+          name: "Submit a grant application",
+          description:
+            "Draft, validate, and submit applications to funding programs (OAuth required).",
+        },
+        {
+          id: "audit-milestones",
+          name: "Audit milestone delivery",
+          description:
+            "List pending, overdue, and recently-completed milestones across a program or project.",
+        },
+      ],
+    },
+  };
+
+  return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -10,9 +10,14 @@ export const revalidate = 3600;
  *
  * Schema reference: https://github.com/google-a2a/a2a-spec — the spec is
  * evolving, so we ship a best-effort shape with the conventional
- * top-level `agent` envelope, provider info, capability flags, accepted
- * auth schemes, and a short list of high-level skills. Static + ISR like
- * the other discovery routes — no upstream dependency.
+ * top-level `agent` envelope, provider info, capability flags, and
+ * accepted auth schemes. Static + ISR like the other discovery routes.
+ *
+ * Skills/tools are intentionally NOT enumerated here. The single source
+ * of truth is the indexer's tool registry, surfaced at
+ * /.well-known/mcp-tools.json (auto-derived from factory definitions).
+ * `skillsDiscovery` points agents at that catalog instead of duplicating
+ * a hand-curated list that drifts from reality.
  */
 
 export function GET() {
@@ -36,31 +41,12 @@ export function GET() {
       authentication: {
         schemes: ["oauth2", "apiKey"],
       },
-      skills: [
-        {
-          id: "discover-funding",
-          name: "Discover funding programs",
-          description:
-            "Search open programs across communities, by chain, category, deadline, or budget.",
-        },
-        {
-          id: "read-project",
-          name: "Read project details",
-          description: "Project profile, team, milestones, grants, and impact indicators.",
-        },
-        {
-          id: "submit-application",
-          name: "Submit a grant application",
-          description:
-            "Draft, validate, and submit applications to funding programs (OAuth required).",
-        },
-        {
-          id: "audit-milestones",
-          name: "Audit milestone delivery",
-          description:
-            "List pending, overdue, and recently-completed milestones across a program or project.",
-        },
-      ],
+      skillsDiscovery: {
+        url: `${SITE_URL}/.well-known/mcp-tools.json`,
+        format: "mcp-public-tool-list",
+        description:
+          "Live tool catalog derived from the MCP server's registered tools — no hand-maintained skills list to drift.",
+      },
     },
   };
 

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/utilities/meta";
+import { WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * Generic agent discovery aggregator.
+ *
+ * The "agent.json" convention is not yet a formal standard, but Ora and
+ * other agent-discovery crawlers flag its absence. We publish a small
+ * pointer document that aggregates every other discovery surface Karma
+ * exposes so a crawler hitting this single file can find OpenAPI, MCP,
+ * A2A, OAuth metadata, and the LLM-friendly text references.
+ */
+
+export function GET() {
+  const body = {
+    name: "Karma",
+    description:
+      "AI-powered funding software. MCP-ready for Claude, Cursor, Codex, and any compatible client.",
+    discovery: {
+      openapi: `${SITE_URL}/openapi.json`,
+      mcp: `${SITE_URL}/.well-known/mcp.json`,
+      mcpServerCard: `${SITE_URL}/.well-known/mcp/server-card.json`,
+      aiPlugin: `${SITE_URL}/.well-known/ai-plugin.json`,
+      agentCard: `${SITE_URL}/.well-known/agent-card.json`,
+      oauthProtectedResource: `${SITE_URL}/.well-known/oauth-protected-resource`,
+      llmsTxt: `${SITE_URL}/llms.txt`,
+    },
+    contact: "info@karmahq.xyz",
+  };
+
+  return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import { WELL_KNOWN_CORS_HEADERS, WELL_KNOWN_PREFLIGHT_HEADERS } from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -36,5 +36,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/ai-plugin.json/route.ts
+++ b/app/.well-known/ai-plugin.json/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import {
+  getIndexerBaseUrl,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
+} from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -34,5 +38,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import {
+  getIndexerBaseUrl,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
+} from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -49,5 +53,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/utilities/meta";
+import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * RFC 9727 API Catalog — a linkset of the APIs Karma publishes, with
+ * pointers to their description (OpenAPI), human docs (Swagger UI), and
+ * additional metadata (plugin manifest).
+ *
+ * The official media type is `application/linkset+json`, but Ora and
+ * other crawlers probe this endpoint expecting plain JSON. We serve JSON
+ * with the same linkset structure so consumers that follow the RFC and
+ * consumers that probe-by-path both succeed.
+ */
+
+export function GET() {
+  const apiUrl = getIndexerBaseUrl();
+
+  const body = {
+    linkset: [
+      {
+        anchor: SITE_URL,
+        "service-desc": [
+          {
+            href: `${SITE_URL}/openapi.json`,
+            type: "application/json",
+          },
+        ],
+        "service-doc": [
+          {
+            href: `${apiUrl}/v2/docs`,
+            type: "text/html",
+          },
+        ],
+        "service-meta": [
+          {
+            href: `${SITE_URL}/.well-known/ai-plugin.json`,
+            type: "application/json",
+          },
+        ],
+      },
+    ],
+  };
+
+  return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/app/.well-known/mcp-tools.json/route.ts
+++ b/app/.well-known/mcp-tools.json/route.ts
@@ -4,6 +4,7 @@ import {
   getIndexerBaseUrl,
   WELL_KNOWN_CORS_HEADERS,
   WELL_KNOWN_ERROR_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
 } from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
@@ -44,5 +45,5 @@ export async function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/mcp.json/route.ts
+++ b/app/.well-known/mcp.json/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import {
+  getIndexerBaseUrl,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
+} from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -27,5 +31,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/mcp/server-card.json/route.ts
+++ b/app/.well-known/mcp/server-card.json/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
-import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+import {
+  getIndexerBaseUrl,
+  MCP_PROTOCOL_VERSION,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
+} from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -14,6 +19,16 @@ export const revalidate = 3600;
  * canonical server URL on the indexer, references to the OpenAPI spec and
  * connect docs on the apex, and accepted auth schemes (OAuth metadata
  * URL + API-key header). Refine after the next orank rescan.
+ *
+ * `protocolVersion` reads from MCP_PROTOCOL_VERSION in utilities/wellKnown
+ * so a spec bump touches one constant, not three files.
+ *
+ * Distinct from /.well-known/mcp.json: that file uses the Claude Desktop /
+ * Cursor LOCAL CONFIG shape (`mcpServers.karma: { url, transport, auth }`)
+ * and is what MCP-client registries crawl. This server-card.json is the
+ * Ora-preferred discovery shape (flat metadata + alternateNames + nested
+ * `authentication` object). Both link out to the same MCP endpoint; they
+ * exist to satisfy two different crawler conventions, not to duplicate.
  */
 
 export function GET() {
@@ -23,7 +38,7 @@ export function GET() {
     name: "gap-tools",
     alternateNames: ["karma-gap-tools"],
     version: "1.0.0",
-    protocolVersion: "2025-11-25",
+    protocolVersion: MCP_PROTOCOL_VERSION,
     transport: "http",
     url: `${apiUrl}/v2/mcp`,
     documentation: `${SITE_URL}/mcp/connect`,
@@ -47,5 +62,5 @@ export function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/mcp/server-card.json/route.ts
+++ b/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/utilities/meta";
+import { getIndexerBaseUrl, WELL_KNOWN_CORS_HEADERS } from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * MCP server-card discovery document at the Ora-preferred nested path
+ * /.well-known/mcp/server-card.json.
+ *
+ * No fully-documented public standard yet (MCP discovery is in flux), so
+ * this is a best-effort shape: identifier + protocol version, transport,
+ * canonical server URL on the indexer, references to the OpenAPI spec and
+ * connect docs on the apex, and accepted auth schemes (OAuth metadata
+ * URL + API-key header). Refine after the next orank rescan.
+ */
+
+export function GET() {
+  const apiUrl = getIndexerBaseUrl();
+
+  const body = {
+    name: "gap-tools",
+    alternateNames: ["karma-gap-tools"],
+    version: "1.0.0",
+    protocolVersion: "2025-11-25",
+    transport: "http",
+    url: `${apiUrl}/v2/mcp`,
+    documentation: `${SITE_URL}/mcp/connect`,
+    openapi: `${SITE_URL}/openapi.json`,
+    authentication: {
+      oauth2: {
+        metadata: `${SITE_URL}/.well-known/oauth-protected-resource`,
+      },
+      apiKey: {
+        header: "x-api-key",
+      },
+    },
+    publisher: {
+      name: "Karma",
+      url: SITE_URL,
+      email: "info@karmahq.xyz",
+    },
+  };
+
+  return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -4,6 +4,7 @@ import {
   getIndexerBaseUrl,
   WELL_KNOWN_CORS_HEADERS,
   WELL_KNOWN_ERROR_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
 } from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
@@ -61,5 +62,5 @@ export async function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,65 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+import {
+  getIndexerBaseUrl,
+  WELL_KNOWN_CORS_HEADERS,
+  WELL_KNOWN_ERROR_HEADERS,
+} from "@/utilities/wellKnown";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+/**
+ * RFC 9728 OAuth Protected Resource Metadata at the apex.
+ *
+ * RFC 9728 §3.1 puts the canonical document at
+ * `${resource}/.well-known/oauth-protected-resource/<resource-path>` —
+ * which for Karma's MCP server lives on the indexer at
+ * `${indexer}/.well-known/oauth-protected-resource/v2/mcp`. Ora and other
+ * agent crawlers, however, probe the root-rooted apex path
+ * `https://www.karmahq.xyz/.well-known/oauth-protected-resource`, so we
+ * proxy the indexer's document here. Hourly-revalidated ISR, 5s timeout,
+ * Sentry-captured on failure, no-cache 502 fallback. Same shape as the
+ * /openapi.json and /.well-known/mcp-tools.json proxies.
+ */
+
+const FALLBACK_BODY = { error: "upstream_unavailable" };
+const UPSTREAM_TIMEOUT_MS = 5000;
+
+export async function GET() {
+  try {
+    const res = await fetch(`${getIndexerBaseUrl()}/.well-known/oauth-protected-resource/v2/mcp`, {
+      next: { revalidate: 3600 },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      Sentry.captureException(
+        new Error(`Upstream /.well-known/oauth-protected-resource/v2/mcp returned ${res.status}`),
+        {
+          tags: { route: "well-known/oauth-protected-resource" },
+          extra: { status: res.status },
+        }
+      );
+      return NextResponse.json(FALLBACK_BODY, {
+        status: 502,
+        headers: WELL_KNOWN_ERROR_HEADERS,
+      });
+    }
+
+    const body = await res.json();
+    return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { route: "well-known/oauth-protected-resource" },
+    });
+    return NextResponse.json(FALLBACK_BODY, {
+      status: 502,
+      headers: WELL_KNOWN_ERROR_HEADERS,
+    });
+  }
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+}

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -4,6 +4,7 @@ import {
   getIndexerBaseUrl,
   WELL_KNOWN_CORS_HEADERS,
   WELL_KNOWN_ERROR_HEADERS,
+  WELL_KNOWN_PREFLIGHT_HEADERS,
 } from "@/utilities/wellKnown";
 
 export const dynamic = "force-static";
@@ -61,5 +62,5 @@ export async function GET() {
 }
 
 export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: WELL_KNOWN_CORS_HEADERS });
+  return new Response(null, { status: 204, headers: WELL_KNOWN_PREFLIGHT_HEADERS });
 }

--- a/public/agents.md
+++ b/public/agents.md
@@ -4,14 +4,21 @@ Karma is a platform for funding programs: ecosystems run grants, builders apply,
 
 ## When to use Karma tools
 
-- **`discover` / `get_project_details` / `get_program_details`** — when a user asks "what is X", "find Y on Karma", "show me program Z"
-- **`list_program_applications` / `get_application_details`** — when reviewing or evaluating funding applications
-- **`list_pending_milestones` / `get_milestone_details`** — when auditing grant delivery or progress
-- **`get_payout_history` / `get_project_disbursement_total`** — when answering "how much has X been paid", "where did the funding go"
-- **`submit_application` (preview + commit)** — only when the user explicitly asks to apply for a program
-- **`search_knowledge_base` / `answer_process_question`** — for "how does X work", "what does Y mean", documentation lookups
+Use Karma when the user asks about:
 
-## When NOT to use Karma tools
+- **Funding programs** — discovery, eligibility, deadlines, budgets
+- **Projects** — profiles, teams, milestones, grants, impact indicators
+- **Applications** — drafting, submitting, status, reviewer feedback
+- **Milestones** — tracking, completion evidence, overdue audits
+- **Payouts** — disbursement history, on-chain transactions
+- **Knowledge** — program documentation, evaluation criteria, process Q&A
+
+The live tool catalog (single source of truth, auto-derived from the MCP server) is at:
+
+- https://www.karmahq.xyz/.well-known/mcp-tools.json (machine-readable)
+- https://www.karmahq.xyz/for-agents (human-readable, grouped by category)
+
+## When NOT to use Karma
 
 - Generic web search — use a search tool instead
 - Code generation, code review — Karma has no code surface
@@ -19,9 +26,9 @@ Karma is a platform for funding programs: ecosystems run grants, builders apply,
 
 ## Authentication
 
-- **Public reads** (most `get_*`, `list_*`, `search_*`) — no auth required
-- **Mutating operations** (`commit_*`) — OAuth required; user must approve in browser on first call
-- **Headless workflows** — generate API key at https://www.karmahq.xyz/agent-setup and pass as `x-api-key`
+- **Public reads** — no auth required; most discovery, project, program, and milestone reads work anonymously
+- **Mutating operations** — OAuth required; the user must approve in their browser on first call
+- **Headless workflows** — generate an API key at https://www.karmahq.xyz/agent-setup and pass as `x-api-key`
 
 ## Discovery surfaces
 

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,0 +1,35 @@
+# Karma — agent instructions
+
+Karma is a platform for funding programs: ecosystems run grants, builders apply, milestones get tracked, and impact gets measured on-chain. Connect via MCP at https://gapapi.karmahq.xyz/v2/mcp.
+
+## When to use Karma tools
+
+- **`discover` / `get_project_details` / `get_program_details`** — when a user asks "what is X", "find Y on Karma", "show me program Z"
+- **`list_program_applications` / `get_application_details`** — when reviewing or evaluating funding applications
+- **`list_pending_milestones` / `get_milestone_details`** — when auditing grant delivery or progress
+- **`get_payout_history` / `get_project_disbursement_total`** — when answering "how much has X been paid", "where did the funding go"
+- **`submit_application` (preview + commit)** — only when the user explicitly asks to apply for a program
+- **`search_knowledge_base` / `answer_process_question`** — for "how does X work", "what does Y mean", documentation lookups
+
+## When NOT to use Karma tools
+
+- Generic web search — use a search tool instead
+- Code generation, code review — Karma has no code surface
+- Anything unrelated to funding programs, grants, projects, milestones, applications, or impact
+
+## Authentication
+
+- **Public reads** (most `get_*`, `list_*`, `search_*`) — no auth required
+- **Mutating operations** (`commit_*`) — OAuth required; user must approve in browser on first call
+- **Headless workflows** — generate API key at https://www.karmahq.xyz/agent-setup and pass as `x-api-key`
+
+## Discovery surfaces
+
+- MCP setup: https://www.karmahq.xyz/mcp/connect
+- For-agents landing: https://www.karmahq.xyz/for-agents
+- OpenAPI: https://www.karmahq.xyz/openapi.json
+- Full LLM reference: https://www.karmahq.xyz/llms-full.txt
+
+## Supported clients
+
+Claude Desktop, Cursor, Codex CLI, and any MCP 2025-11-25+ compliant client.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -13,6 +13,13 @@ Karma is a platform where ecosystems allocate funding, track milestones, and mea
 - Plugin manifest: https://www.karmahq.xyz/.well-known/ai-plugin.json
 - MCP server discovery: https://www.karmahq.xyz/.well-known/mcp.json
 - Public tool catalog: https://www.karmahq.xyz/.well-known/mcp-tools.json
+- Agent card (A2A): https://www.karmahq.xyz/.well-known/agent-card.json
+- MCP server card: https://www.karmahq.xyz/.well-known/mcp/server-card.json
+- API catalog (RFC 9727): https://www.karmahq.xyz/.well-known/api-catalog
+- OAuth protected resource (RFC 9728): https://www.karmahq.xyz/.well-known/oauth-protected-resource
+- Agent discovery: https://www.karmahq.xyz/.well-known/agent.json
+- Agent instructions: https://www.karmahq.xyz/agents.md
+- Pricing: https://www.karmahq.xyz/pricing.md
 - Auth: OAuth (interactive) or `x-api-key` header (headless)
 - Supported clients: Claude Desktop, Cursor, Codex CLI, any MCP 2025-11-25+ compliant client
 - Contact: info@karmahq.xyz

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,6 +13,13 @@ Karma is a platform where ecosystems allocate funding, track milestones, and mea
 - Plugin manifest: https://www.karmahq.xyz/.well-known/ai-plugin.json
 - MCP server discovery: https://www.karmahq.xyz/.well-known/mcp.json
 - Public tool catalog: https://www.karmahq.xyz/.well-known/mcp-tools.json
+- Agent card (A2A): https://www.karmahq.xyz/.well-known/agent-card.json
+- MCP server card: https://www.karmahq.xyz/.well-known/mcp/server-card.json
+- API catalog (RFC 9727): https://www.karmahq.xyz/.well-known/api-catalog
+- OAuth protected resource (RFC 9728): https://www.karmahq.xyz/.well-known/oauth-protected-resource
+- Agent discovery: https://www.karmahq.xyz/.well-known/agent.json
+- Agent instructions: https://www.karmahq.xyz/agents.md
+- Pricing: https://www.karmahq.xyz/pricing.md
 - Auth: OAuth (interactive) or `x-api-key` header (headless)
 - Supported clients: Claude Desktop, Cursor, Codex CLI, any MCP 2025-11-25+ compliant client
 - Contact: info@karmahq.xyz

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -1,0 +1,33 @@
+# Karma pricing
+
+## Free tier
+
+Free for all individual builders and program administrators:
+
+- Unlimited project profiles
+- Apply to any funding program
+- Track milestones and post updates
+- Read all public funding data, grants, milestones, and impact metrics
+- MCP server access (OAuth + API key authentication)
+
+No credit card required.
+
+## Ecosystem / enterprise
+
+Custom pricing for:
+
+- Whitelabel deployments
+- Dedicated funding programs with custom evaluation workflows
+- AI-assisted evaluation at scale
+- Custom integrations and SLA support
+- Reviewer + milestone management workflows
+
+Contact info@karmahq.xyz for ecosystem pricing.
+
+## API access
+
+All API endpoints under https://gapapi.karmahq.xyz/v2/* and the MCP server at https://gapapi.karmahq.xyz/v2/mcp are free to use under fair-use rate limits. Rate limit headers are returned on every response. Heavy programmatic access should contact info@karmahq.xyz for a dedicated tier.
+
+## Last updated
+
+This pricing reflects the current state of Karma as of the file's last commit. For the latest, see https://www.karmahq.xyz.

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -40,6 +40,25 @@ export const WELL_KNOWN_ERROR_HEADERS = {
 } as const;
 
 /**
+ * Headers for OPTIONS preflight (204 No Content) responses. Deliberately
+ * omits `Cache-Control` — browsers cache preflight results via
+ * `Access-Control-Max-Age` (already 86400s), not `Cache-Control`. Setting
+ * `public, max-age=3600` on a 204 body is conceptually wrong and tells
+ * downstream caches to retain an empty response keyed on URL.
+ */
+export const WELL_KNOWN_PREFLIGHT_HEADERS = {
+  ...BASE_CORS_HEADERS,
+} as const;
+
+/**
+ * MCP protocol version this server speaks. Centralized here so the apex
+ * surfaces stay in lockstep — `mcp/server-card.json`, `agents.md`
+ * (manually), and tests all reference the same value. Bump in one place
+ * when the spec advances.
+ */
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
+
+/**
  * Returns the indexer base URL or throws if it is unset or malformed.
  *
  * The /.well-known/* route handlers depend on this URL at build time


### PR DESCRIPTION
## Summary

- Adds 7 well-known / discovery files to close every Tier-1 gap from the latest orank scan.
- 5 new route handlers under `/.well-known/*` + 2 markdown files at root (`/agents.md`, `/pricing.md`).
- Wires the new surfaces into `llms.txt` and `llms-full.txt` so LLMs find them via the canonical reference.

## Why

The latest orank scan flagged 7 specific gaps that map to discrete well-known files / static docs. Each route in this PR closes exactly one finding. They are unauthenticated, public-discovery documents consumed by AI crawlers (GPTBot, ClaudeBot, PerplexityBot), MCP clients (Cursor, Claude Desktop, Codex CLI), and agent-indexing services (Ora, Profound).

## Files added

### Proxy route (1)

- **`/.well-known/oauth-protected-resource`** — Hourly-revalidated ISR proxy of the indexer's RFC 9728 OAuth Protected Resource Metadata. Same resilience pattern as `/openapi.json`: 5s timeout, Sentry-captured on failure, `Cache-Control: no-store` on 502 so a transient blip doesn't pin to the CDN.

### Static routes (4)

- **`/.well-known/agent-card.json`** — Google A2A agent card with `agent` envelope, provider info, capability flags, accepted auth schemes (oauth2 + apiKey), and high-level skills list.
- **`/.well-known/mcp/server-card.json`** — Ora-preferred nested MCP server card with `gap-tools` identifier, protocol version 2025-11-25, HTTP transport, OAuth metadata pointer, and `x-api-key` header.
- **`/.well-known/api-catalog`** — RFC 9727 JSON linkset anchored on the apex with pointers to OpenAPI (service-desc), Swagger UI (service-doc), and the AI plugin manifest (service-meta).
- **`/.well-known/agent.json`** — Generic discovery aggregator listing every other discovery surface (OpenAPI, MCP, A2A, OAuth metadata, llms.txt) under one document.

### Static markdown (2)

- **`/agents.md`** — When to use Karma tools, when not to, authentication paths (OAuth + x-api-key), and supported clients.
- **`/pricing.md`** — Free tier (builders + program admins), ecosystem / enterprise tier (whitelabel + AI evaluation), and fair-use API rate limits.

### Updates

- **`public/llms.txt`** / **`public/llms-full.txt`** — Adds the seven new discovery URLs to the "For AI Agents" section of both canonical references.

## Schema sources

- **RFC 9728** OAuth Protected Resource Metadata — proxied verbatim from the indexer at `${indexer}/.well-known/oauth-protected-resource/v2/mcp`.
- **RFC 9727** API Catalog — JSON linkset shape, anchor + service-desc + service-doc + service-meta links.
- **A2A protocol** (github.com/google-a2a/a2a-spec) — top-level `agent` envelope, capability flags, schemes, skills.
- **MCP server card** and **agent.json** are emerging conventions without a fully-documented standard yet. Both ship best-effort shapes derived from what crawlers probe for. Refine after the next orank rescan.

## Deploy ordering

Pairs with the gap-indexer PR adding `GET /v2/mcp` metadata response. Both must deploy + CDN-purge together for max score impact — the new apex routes assume the indexer continues serving the canonical RFC 9728 document at `${indexer}/.well-known/oauth-protected-resource/v2/mcp`.

## Operational notes

After deploy, CDN-purge:

- `/.well-known/*`
- `/agents.md`
- `/pricing.md`
- `/llms.txt` and `/llms-full.txt`

## Out of scope

These were considered and explicitly deferred from this PR:

- WebMCP (spec too new)
- A2UI / generative UI
- NLWeb `/ask` endpoint
- Speakable content markup
- FAQPage schema on home
- Service schema
- Multi-language SDK packages
- Sandbox / test environment docs
- Rate limit docs page (separate PR)
- API versioning policy doc (separate PR)
- Webhook system
- All Tier 2 / Tier 3 items per the triage

## Validation

- `pnpm exec biome check` on changed paths — clean (new files emit zero warnings; pre-existing utilities warnings unchanged)
- `pnpm exec vitest run` on `__tests__/app/well-known`, `__tests__/app/openapi.test.ts`, `__tests__/app/well-known.test.ts`, `__tests__/public` — 81/81 passed
- `pnpm run build` — all 5 new routes built (`/.well-known/agent-card.json`, `/.well-known/agent.json`, `/.well-known/api-catalog`, `/.well-known/mcp/server-card.json`, `/.well-known/oauth-protected-resource`)
- `pnpm run quality:report` — Status: Passed (Biome -1, knipUnusedExports -1, no regressions)

## Test plan

- [ ] Confirm `curl https://www.karmahq.xyz/.well-known/oauth-protected-resource` returns the indexer's RFC 9728 document after deploy
- [ ] Confirm `curl https://www.karmahq.xyz/.well-known/agent-card.json` returns the A2A card
- [ ] Confirm `curl https://www.karmahq.xyz/.well-known/mcp/server-card.json` returns the server card with apex OAuth metadata URL
- [ ] Confirm `curl https://www.karmahq.xyz/.well-known/api-catalog` returns the RFC 9727 linkset
- [ ] Confirm `curl https://www.karmahq.xyz/.well-known/agent.json` returns the discovery aggregator
- [ ] Confirm `curl https://www.karmahq.xyz/agents.md` and `/pricing.md` return the markdown files
- [ ] Re-run orank scan after the indexer companion PR deploys and CDN is purged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI agent discovery endpoints: agent card, agent identity, and MCP server card for improved machine-to-machine agent discovery.
  * Added API catalog endpoint supporting RFC 9727 linkset format.
  * Added OAuth protected resource metadata endpoint.
  * Added agent instructions and pricing documentation pages.
  * Updated discovery information in agent-focused documentation files.

* **Tests**
  * Added comprehensive test coverage for all new discovery endpoints and documentation pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->