### PR TITLE
feat(access-denied): per-community Access Denied page messages

### DIFF
--- a/__tests__/components/ui/AccessDenied.test.tsx
+++ b/__tests__/components/ui/AccessDenied.test.tsx
@@ -14,6 +14,21 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
+const mockUseAccessDeniedMessages = vi.fn();
+vi.mock("@/hooks/useAccessDeniedMessages", () => ({
+  useAccessDeniedMessages: (...args: unknown[]) => mockUseAccessDeniedMessages(...args),
+}));
+
+vi.mock("next/dynamic", () => ({
+  // Replace dynamic-loaded MarkdownPreview with a synchronous stub that
+  // surfaces the source so we can assert substitution + raw-token
+  // pass-through without bundling Streamdown into the test runner.
+  default: () =>
+    function MockMarkdown({ source }: { source: string }) {
+      return <div data-testid="markdown-mock">{source}</div>;
+    },
+}));
+
 const mockUsePermissionContext = vi.fn(() => ({
   roles: { primaryRole: "GUEST", roles: ["GUEST"], reviewerTypes: [] },
   isLoading: false,
@@ -39,6 +54,12 @@ const mockUseAuth = useAuth as vi.MockedFunction<typeof useAuth>;
 describe("AccessDenied", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no per-community overrides — preserves legacy
+    // behavior for tests that don't pass `communitySlug`.
+    mockUseAccessDeniedMessages.mockReturnValue({
+      data: { unauthenticatedMessage: null, forbiddenMessage: null },
+      isLoading: false,
+    });
   });
 
   describe("when not authenticated", () => {
@@ -49,10 +70,12 @@ describe("AccessDenied", () => {
       } as ReturnType<typeof useAuth>);
     });
 
-    it("renders with default title and message", () => {
+    it("renders the unauthenticated default copy", () => {
       render(<AccessDenied />);
-      expect(screen.getByText("Access Denied")).toBeInTheDocument();
-      expect(screen.getByText("You don't have permission to view this page.")).toBeInTheDocument();
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe(
+        "**Sign in to continue**\n\nThis area is reserved for folks with the right access. Pop in and we'll take it from there."
+      );
     });
 
     it("shows Sign In button when not authenticated", () => {
@@ -89,6 +112,22 @@ describe("AccessDenied", () => {
     it("shows Go to Home button when authenticated", () => {
       render(<AccessDenied />);
       expect(screen.getByRole("button", { name: /go to home/i })).toBeInTheDocument();
+    });
+
+    it("renders the forbidden default copy with the community name when provided", () => {
+      render(<AccessDenied communityName="Filecoin" />);
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe(
+        "**You're almost there**\n\nYou're signed in, but this page needs a role your account doesn't have yet. Reach out to a Filecoin admin and they can get you set up."
+      );
+    });
+
+    it("falls back to a generic 'community admin' phrasing when communityName is missing", () => {
+      render(<AccessDenied />);
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe(
+        "**You're almost there**\n\nYou're signed in, but this page needs a role your account doesn't have yet. Reach out to a community admin and they can get you set up."
+      );
     });
 
     it("navigates to default returnUrl ('/') when button clicked", async () => {
@@ -131,6 +170,91 @@ describe("AccessDenied", () => {
     it("renders custom message", () => {
       render(<AccessDenied message="You need admin privileges." />);
       expect(screen.getByText("You need admin privileges.")).toBeInTheDocument();
+    });
+  });
+
+  describe("per-community custom messages", () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        authenticated: false,
+        login: mockLogin,
+      } as ReturnType<typeof useAuth>);
+    });
+
+    it("renders the unauthenticated override with substituted tokens when not signed in", () => {
+      mockUseAccessDeniedMessages.mockReturnValue({
+        data: {
+          unauthenticatedMessage: "Welcome to **{{communityName}}** — sign in!",
+          forbiddenMessage: "should-not-show",
+        },
+        isLoading: false,
+      });
+
+      render(<AccessDenied communitySlug="octant" communityName="Octant" />);
+
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe("Welcome to **Octant** — sign in!");
+      expect(screen.queryByText("You don't have permission to view this page.")).toBeNull();
+    });
+
+    it("falls back to the default body when the unauthenticated override is null", () => {
+      mockUseAccessDeniedMessages.mockReturnValue({
+        data: { unauthenticatedMessage: null, forbiddenMessage: "irrelevant" },
+        isLoading: false,
+      });
+
+      render(<AccessDenied communitySlug="octant" communityName="Octant" />);
+
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe(
+        "**Sign in to continue**\n\nThis area is reserved for folks with the right access. Pop in and we'll take it from there."
+      );
+    });
+
+    it("uses the forbidden override and substitutes currentRoles when authenticated", () => {
+      mockUseAuth.mockReturnValue({
+        authenticated: true,
+        login: mockLogin,
+      } as ReturnType<typeof useAuth>);
+      mockUsePermissionContext.mockReturnValue({
+        roles: {
+          primaryRole: "PROGRAM_REVIEWER",
+          roles: ["PROGRAM_REVIEWER"],
+          reviewerTypes: [],
+        },
+        isLoading: false,
+      });
+      mockUseAccessDeniedMessages.mockReturnValue({
+        data: {
+          unauthenticatedMessage: null,
+          forbiddenMessage: "Need {{requiredRoles}}; you have {{currentRoles}}.",
+        },
+        isLoading: false,
+      });
+
+      render(
+        <AccessDenied
+          communitySlug="octant"
+          communityName="Octant"
+          requiredRoles={["COMMUNITY_ADMIN"] as unknown as string[]}
+        />
+      );
+
+      const md = screen.getByTestId("markdown-mock");
+      expect(md.textContent).toBe("Need Community Admin; you have Program Reviewer.");
+    });
+
+    it("renders the skeleton while the override is loading", () => {
+      mockUseAccessDeniedMessages.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      });
+
+      const { container } = render(<AccessDenied communitySlug="octant" />);
+
+      // Skeleton uses animate-pulse — no body copy or markdown stub.
+      expect(container.querySelector(".animate-pulse")).not.toBeNull();
+      expect(screen.queryByTestId("markdown-mock")).toBeNull();
     });
   });
 });

--- a/__tests__/hooks/useAccessDeniedMessages.test.tsx
+++ b/__tests__/hooks/useAccessDeniedMessages.test.tsx
@@ -7,7 +7,6 @@ vi.mock("@/utilities/fetchData", () => ({
 }));
 
 import { useAccessDeniedMessages } from "@/hooks/useAccessDeniedMessages";
-import { INDEXER } from "@/utilities/indexer";
 
 describe("useAccessDeniedMessages", () => {
   beforeEach(() => {
@@ -25,7 +24,7 @@ describe("useAccessDeniedMessages", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(mockFetchData).toHaveBeenCalledWith(
-      INDEXER.COMMUNITY.CONFIG.ACCESS_DENIED_MESSAGES("octant"),
+      "/v2/community-configs/octant/access-denied-messages",
       "GET",
       {},
       {},

--- a/__tests__/hooks/useAccessDeniedMessages.test.tsx
+++ b/__tests__/hooks/useAccessDeniedMessages.test.tsx
@@ -1,0 +1,72 @@
+import { waitFor } from "@testing-library/react";
+import { renderHookWithProviders } from "@/__tests__/utils/render";
+
+const mockFetchData = vi.fn();
+vi.mock("@/utilities/fetchData", () => ({
+  default: (...args: unknown[]) => mockFetchData(...args),
+}));
+
+import { useAccessDeniedMessages } from "@/hooks/useAccessDeniedMessages";
+import { INDEXER } from "@/utilities/indexer";
+
+describe("useAccessDeniedMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hits the public endpoint without auth", async () => {
+    mockFetchData.mockResolvedValue([
+      { unauthenticatedMessage: "hi", forbiddenMessage: "bye" },
+      null,
+    ]);
+
+    const { result } = renderHookWithProviders(() => useAccessDeniedMessages("octant"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      INDEXER.COMMUNITY.CONFIG.ACCESS_DENIED_MESSAGES("octant"),
+      "GET",
+      {},
+      {},
+      {},
+      false // authenticated flag MUST be false — endpoint is public
+    );
+    expect(result.current.data).toEqual({
+      unauthenticatedMessage: "hi",
+      forbiddenMessage: "bye",
+    });
+  });
+
+  it("returns nulls when fetch errors (caller falls back to default body)", async () => {
+    mockFetchData.mockResolvedValue([null, "404"]);
+
+    const { result } = renderHookWithProviders(() => useAccessDeniedMessages("nope"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual({
+      unauthenticatedMessage: null,
+      forbiddenMessage: null,
+    });
+  });
+
+  it("returns nulls without fetching when slug is empty", async () => {
+    const { result } = renderHookWithProviders(() => useAccessDeniedMessages(""));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockFetchData).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual({
+      unauthenticatedMessage: null,
+      forbiddenMessage: null,
+    });
+  });
+
+  it("does not fetch when explicitly disabled", async () => {
+    renderHookWithProviders(() => useAccessDeniedMessages("octant", false));
+    // give React Query a tick — would have called fetchData by now if enabled
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockFetchData).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/utilities/accessDeniedTemplate.test.ts
+++ b/__tests__/utilities/accessDeniedTemplate.test.ts
@@ -1,0 +1,106 @@
+import {
+  substituteAccessDeniedTemplate,
+  validateAccessDeniedTemplate,
+} from "@/utilities/accessDeniedTemplate";
+
+const baseVars = {
+  communityName: "Octant",
+  communitySlug: "octant",
+  appUrl: "https://app.example",
+  requiredRoles: "Admin",
+  currentRoles: "Reviewer",
+};
+
+describe("substituteAccessDeniedTemplate", () => {
+  it("substitutes all known tokens", () => {
+    expect(
+      substituteAccessDeniedTemplate(
+        "Welcome to {{communityName}} ({{communitySlug}}). Visit {{appUrl}}. Need {{requiredRoles}}; have {{currentRoles}}.",
+        baseVars
+      )
+    ).toBe("Welcome to Octant (octant). Visit https://app.example. Need Admin; have Reviewer.");
+  });
+
+  it("tolerates whitespace inside the braces", () => {
+    expect(substituteAccessDeniedTemplate("hi {{ communityName }}", baseVars)).toBe("hi Octant");
+  });
+
+  it("leaves currentRoles literal when null (unauthenticated scenario)", () => {
+    expect(
+      substituteAccessDeniedTemplate("Need {{requiredRoles}}; have {{currentRoles}}.", {
+        ...baseVars,
+        currentRoles: null,
+      })
+    ).toBe("Need Admin; have {{currentRoles}}.");
+  });
+
+  it("leaves unknown tokens literal", () => {
+    expect(substituteAccessDeniedTemplate("Hi {{nope}}!", baseVars)).toBe("Hi {{nope}}!");
+  });
+
+  it("returns the source unchanged when there are no tokens", () => {
+    expect(substituteAccessDeniedTemplate("plain text", baseVars)).toBe("plain text");
+  });
+
+  it("does NOT recursively substitute substituted values", () => {
+    // If communityName itself contained {{appUrl}}, the second-pass
+    // substitution would let an admin inject tokens through their
+    // display name. The single-pass replace prevents this.
+    expect(
+      substituteAccessDeniedTemplate("name={{communityName}}", {
+        ...baseVars,
+        communityName: "{{appUrl}}",
+      })
+    ).toBe("name={{appUrl}}");
+  });
+});
+
+describe("validateAccessDeniedTemplate", () => {
+  it("returns empty result for null/undefined/empty", () => {
+    expect(validateAccessDeniedTemplate(null, "unauthenticated")).toEqual({
+      unknownTokens: [],
+      disallowedTokens: [],
+    });
+    expect(validateAccessDeniedTemplate(undefined, "forbidden")).toEqual({
+      unknownTokens: [],
+      disallowedTokens: [],
+    });
+    expect(validateAccessDeniedTemplate("", "unauthenticated")).toEqual({
+      unknownTokens: [],
+      disallowedTokens: [],
+    });
+  });
+
+  it("accepts the full vocabulary in forbidden scenario", () => {
+    expect(
+      validateAccessDeniedTemplate(
+        "{{communityName}} {{communitySlug}} {{appUrl}} {{requiredRoles}} {{currentRoles}}",
+        "forbidden"
+      )
+    ).toEqual({ unknownTokens: [], disallowedTokens: [] });
+  });
+
+  it("flags currentRoles as disallowed in unauthenticated scenario", () => {
+    const result = validateAccessDeniedTemplate(
+      "Need {{requiredRoles}}; have {{currentRoles}}.",
+      "unauthenticated"
+    );
+    expect(result.unknownTokens).toEqual([]);
+    expect(result.disallowedTokens).toEqual(["currentRoles"]);
+  });
+
+  it("flags unknown tokens regardless of scenario", () => {
+    const result = validateAccessDeniedTemplate("hello {{nope}} {{alsoNope}}", "forbidden");
+    expect(result.unknownTokens.sort()).toEqual(["alsoNope", "nope"]);
+    expect(result.disallowedTokens).toEqual([]);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    const result = validateAccessDeniedTemplate(
+      "{{nope}} again {{nope}} and {{currentRoles}} {{currentRoles}}",
+      "unauthenticated"
+    );
+    expect(result.unknownTokens).toEqual(["nope"]);
+    expect(result.disallowedTokens).toEqual(["currentRoles"]);
+  });
+});

--- a/app/community/[communityId]/manage/access-denied-messages/error.tsx
+++ b/app/community/[communityId]/manage/access-denied-messages/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useEffect } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { Link } from "@/src/components/navigation/Link";
+
+export default function AccessDeniedMessagesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    errorManager(`Access Denied Messages page error: ${error.message}`, error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading the Access Denied page settings. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/access-denied-messages/loading.tsx
+++ b/app/community/[communityId]/manage/access-denied-messages/loading.tsx
@@ -1,0 +1,14 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: <output> is for form calculation results, not loading spinners
+    <div
+      role="status"
+      aria-label="Loading Access Denied page settings"
+      className="flex items-center justify-center min-h-screen"
+    >
+      <Spinner />
+    </div>
+  );
+}

--- a/app/community/[communityId]/manage/access-denied-messages/page.tsx
+++ b/app/community/[communityId]/manage/access-denied-messages/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { AccessDeniedMessagesPage } from "@/components/Pages/Admin/AccessDeniedMessagesPage";
+import { customMetadata } from "@/utilities/meta";
+import { getCommunityDetails } from "@/utilities/queries/v2/community";
+
+export const metadata: Metadata = customMetadata({
+  title: "Access Denied Page",
+});
+
+interface Props {
+  params: Promise<{ communityId: string }>;
+}
+
+export default async function Page(props: Props) {
+  const { communityId } = await props.params;
+  const community = await getCommunityDetails(communityId);
+
+  if (!community) {
+    notFound();
+  }
+
+  return <AccessDeniedMessagesPage community={community} />;
+}

--- a/app/community/[communityId]/manage/program-scores/page.tsx
+++ b/app/community/[communityId]/manage/program-scores/page.tsx
@@ -25,7 +25,13 @@ export default function ProgramScoresPage() {
   }
 
   if (!hasAccess) {
-    return <AccessDenied {...communityAdminDenial(community?.details?.name)} />;
+    return (
+      <AccessDenied
+        {...communityAdminDenial(community?.details?.name)}
+        communitySlug={community?.details?.slug || community?.uid}
+        communityName={community?.details?.name}
+      />
+    );
   }
 
   return (

--- a/app/community/[communityId]/manage/send-email/page.tsx
+++ b/app/community/[communityId]/manage/send-email/page.tsx
@@ -128,7 +128,7 @@ export default function SendEmailPage() {
   }
 
   if (!hasAccess) {
-    return <AccessDenied {...communityAdminDenial()} />;
+    return <AccessDenied {...communityAdminDenial()} communitySlug={communityId} />;
   }
 
   return <SendEmailContent communityId={communityId} />;

--- a/components/Manage/ManageBreadcrumbs.tsx
+++ b/components/Manage/ManageBreadcrumbs.tsx
@@ -34,6 +34,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   "kyc-settings": "KYC/KYB Settings",
   "notification-settings": "Notification Settings",
   "knowledge-base": "Knowledge Base",
+  "access-denied-messages": "Access Denied Page",
   impact: "Impact",
 };
 

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -83,6 +83,8 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
     return (
       <AccessDenied
         {...manageLayoutDenial(community?.details?.name)}
+        communitySlug={communityId}
+        communityName={community?.details?.name}
         cta={{ label: "Go to Community", href: PAGES.COMMUNITY.ALL_GRANTS(communityId) }}
       />
     );

--- a/components/Manage/ManageSidebar.tsx
+++ b/components/Manage/ManageSidebar.tsx
@@ -174,6 +174,7 @@ const NAV_GROUPS: NavGroup[] = [
         matchSegment: "access-denied-messages",
         label: "Access Denied Page",
         icon: ShieldAlert,
+        communityAdminOnly: true,
       },
     ],
   },

--- a/components/Manage/ManageSidebar.tsx
+++ b/components/Manage/ManageSidebar.tsx
@@ -15,6 +15,7 @@ import {
   Home,
   LayoutGrid,
   Mail,
+  ShieldAlert,
   Tag,
   TrendingUp,
 } from "lucide-react";
@@ -167,6 +168,12 @@ const NAV_GROUPS: NavGroup[] = [
         matchSegment: "knowledge-base",
         label: "Knowledge Base",
         icon: BookOpen,
+      },
+      {
+        href: PAGES.ADMIN.ACCESS_DENIED_MESSAGES,
+        matchSegment: "access-denied-messages",
+        label: "Access Denied Page",
+        icon: ShieldAlert,
       },
     ],
   },

--- a/components/Pages/Admin/AccessDeniedMessagesPage.tsx
+++ b/components/Pages/Admin/AccessDeniedMessagesPage.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { Check, Loader2, RotateCcw } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/Utilities/Button";
+import { Spinner } from "@/components/Utilities/Spinner";
+import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+import { useCommunityConfig, useCommunityConfigMutation } from "@/hooks/useCommunityConfig";
+import { AccessDenied } from "@/src/components/ui/AccessDenied";
+import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
+import type { Community } from "@/types/v2/community";
+import {
+  ACCESS_DENIED_DEFAULT_MESSAGES,
+  ACCESS_DENIED_TEMPLATE_VARIABLES,
+  type AccessDeniedScenario,
+  substituteAccessDeniedTemplate,
+  validateAccessDeniedTemplate,
+} from "@/utilities/accessDeniedTemplate";
+import { envVars } from "@/utilities/enviromentVars";
+
+// 500-char cap mirrors backend `ACCESS_DENIED_MESSAGE_MAX_CHARS`. Keep in
+// sync with gap-indexer/.../community-config.update.body.api.request.ts.
+const MAX_CHARS = 500;
+
+// Heavy editor + markdown libs — lazy-load so the rest of /manage doesn't
+// pay for them on every page.
+const MarkdownEditor = dynamic(
+  () => import("@/components/Utilities/MarkdownEditor").then((m) => m.MarkdownEditor),
+  { ssr: false }
+);
+const MarkdownPreview = dynamic(
+  () => import("@/components/Utilities/MarkdownPreview").then((m) => m.MarkdownPreview),
+  { ssr: false }
+);
+
+interface ScenarioMeta {
+  scenario: AccessDeniedScenario;
+  title: string;
+  description: string;
+  fieldKey: "accessDeniedUnauthenticatedMessage" | "accessDeniedForbiddenMessage";
+}
+
+const SCENARIOS: ReadonlyArray<ScenarioMeta> = [
+  {
+    scenario: "unauthenticated",
+    title: "When a visitor is not signed in",
+    description:
+      "Shown above the Sign In button when someone hits a gated page without an active session.",
+    fieldKey: "accessDeniedUnauthenticatedMessage",
+  },
+  {
+    scenario: "forbidden",
+    title: "When a signed-in user lacks the right role",
+    description:
+      "Shown to authenticated visitors who don't have a role that satisfies the page's requirement.",
+    fieldKey: "accessDeniedForbiddenMessage",
+  },
+];
+
+interface AccessDeniedMessagesPageProps {
+  community: Community;
+}
+
+export function AccessDeniedMessagesPage({ community }: AccessDeniedMessagesPageProps) {
+  const communitySlug = community.details?.slug || community.uid;
+  const { hasAccess, isLoading: loadingAdmin } = useCommunityAdminAccess(community.uid);
+  const { data: config, isLoading, error } = useCommunityConfig(communitySlug);
+
+  if (loadingAdmin || isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <AccessDenied
+        {...communityAdminDenial(community.details?.name)}
+        communitySlug={communitySlug}
+        communityName={community.details?.name}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 p-4 dark:bg-red-900/20">
+        <p className="text-red-600 dark:text-red-400">
+          Failed to load community configuration. Please try again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <AccessDeniedMessagesPageContent
+      community={community}
+      communitySlug={communitySlug}
+      initial={{
+        unauthenticated: config?.accessDeniedUnauthenticatedMessage ?? null,
+        forbidden: config?.accessDeniedForbiddenMessage ?? null,
+      }}
+    />
+  );
+}
+
+interface InitialValues {
+  unauthenticated: string | null;
+  forbidden: string | null;
+}
+
+function AccessDeniedMessagesPageContent({
+  community,
+  communitySlug,
+  initial,
+}: {
+  community: Community;
+  communitySlug: string;
+  initial: InitialValues;
+}) {
+  const { mutate: saveConfig, isPending: isSaving } = useCommunityConfigMutation();
+  // Prefill with the Karma default copy when no override is saved so admins
+  // can edit-in-place instead of starting from a blank textarea.
+  const baselineUnauth = initial.unauthenticated ?? ACCESS_DENIED_DEFAULT_MESSAGES.unauthenticated;
+  const baselineForbidden = initial.forbidden ?? ACCESS_DENIED_DEFAULT_MESSAGES.forbidden;
+  const [unauth, setUnauth] = useState<string>(baselineUnauth);
+  const [forbidden, setForbidden] = useState<string>(baselineForbidden);
+
+  const unauthValidation = useMemo(
+    () => validateAccessDeniedTemplate(unauth, "unauthenticated"),
+    [unauth]
+  );
+  const forbiddenValidation = useMemo(
+    () => validateAccessDeniedTemplate(forbidden, "forbidden"),
+    [forbidden]
+  );
+
+  const unauthError = formatValidationError(unauthValidation, unauth.length);
+  const forbiddenError = formatValidationError(forbiddenValidation, forbidden.length);
+  const hasError = Boolean(unauthError) || Boolean(forbiddenError);
+
+  const isDirty = unauth !== baselineUnauth || forbidden !== baselineForbidden;
+
+  const handleSave = () => {
+    if (hasError) return;
+    // Treat empty OR unchanged-from-default as "no override" so we don't
+    // freeze the current default copy into the DB the moment an admin opens
+    // the page and hits Save.
+    const normalize = (value: string, scenario: AccessDeniedScenario): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      if (trimmed === ACCESS_DENIED_DEFAULT_MESSAGES[scenario].trim()) return null;
+      return value;
+    };
+    saveConfig(
+      {
+        slug: communitySlug,
+        config: {
+          accessDeniedUnauthenticatedMessage: normalize(unauth, "unauthenticated"),
+          accessDeniedForbiddenMessage: normalize(forbidden, "forbidden"),
+        },
+      },
+      {
+        onSuccess: () => toast.success("Access Denied messages saved"),
+        onError: (err) => toast.error(err.message || "Failed to save"),
+      }
+    );
+  };
+
+  const handleReset = () => {
+    setUnauth(baselineUnauth);
+    setForbidden(baselineForbidden);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="pb-2">
+        <h1 className="text-xl font-bold text-stone-900 dark:text-zinc-100">Access Denied Page</h1>
+        <p className="mt-1 text-sm text-stone-500 dark:text-zinc-400">
+          Customize the Markdown shown on the Access Denied page for{" "}
+          {community.details?.name || "this community"}. Leave a field empty to fall back to the
+          default Karma copy.
+        </p>
+      </div>
+
+      <TokenReferencePanel />
+
+      {SCENARIOS.map((meta) => {
+        const isUnauth = meta.scenario === "unauthenticated";
+        const value = isUnauth ? unauth : forbidden;
+        const setValue = isUnauth ? setUnauth : setForbidden;
+        const validationError = isUnauth ? unauthError : forbiddenError;
+        return (
+          <MessageEditorSection
+            key={meta.scenario}
+            meta={meta}
+            communityName={community.details?.name ?? ""}
+            communitySlug={communitySlug}
+            value={value}
+            onChange={setValue}
+            errorMessage={validationError}
+          />
+        );
+      })}
+
+      <div className="mt-6 flex justify-end gap-2">
+        {isDirty && !isSaving ? (
+          <Button type="button" variant="secondary" onClick={handleReset}>
+            <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+            Discard
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving || hasError}
+          aria-disabled={!isDirty || isSaving || hasError}
+          aria-label="Save Access Denied messages"
+        >
+          {isSaving ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Check className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function formatValidationError(
+  result: { unknownTokens: readonly string[]; disallowedTokens: readonly string[] },
+  length: number
+): string | null {
+  if (length > MAX_CHARS) {
+    return `Message exceeds the ${MAX_CHARS}-character limit (${length}).`;
+  }
+  if (result.unknownTokens.length > 0) {
+    const list = result.unknownTokens.map((t) => `{{${t}}}`).join(", ");
+    return `Unknown template token(s): ${list}.`;
+  }
+  if (result.disallowedTokens.length > 0) {
+    const list = result.disallowedTokens.map((t) => `{{${t}}}`).join(", ");
+    return `Token(s) not allowed in this scenario: ${list}.`;
+  }
+  return null;
+}
+
+function MessageEditorSection({
+  meta,
+  communityName,
+  communitySlug,
+  value,
+  onChange,
+  errorMessage,
+}: {
+  meta: ScenarioMeta;
+  communityName: string;
+  communitySlug: string;
+  value: string;
+  onChange: (next: string) => void;
+  errorMessage: string | null;
+}) {
+  const previewSource = useMemo(() => {
+    if (!value.trim()) return "";
+    return substituteAccessDeniedTemplate(value, {
+      communityName: communityName || "Your Community",
+      communitySlug,
+      appUrl: envVars.VERCEL_URL || "https://gap.karmahq.xyz",
+      requiredRoles: "Community Admin",
+      currentRoles: meta.scenario === "forbidden" ? "Reviewer" : null,
+    });
+  }, [value, communityName, communitySlug, meta.scenario]);
+
+  return (
+    <section
+      aria-labelledby={`section-${meta.scenario}`}
+      className="space-y-3 rounded-xl border border-stone-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div>
+        <h2
+          id={`section-${meta.scenario}`}
+          className="text-sm font-semibold text-stone-900 dark:text-zinc-100"
+        >
+          {meta.title}
+        </h2>
+        <p className="mt-0.5 text-xs text-stone-500 dark:text-zinc-400">{meta.description}</p>
+      </div>
+
+      <MarkdownEditor
+        id={`access-denied-${meta.scenario}`}
+        value={value}
+        onChange={onChange}
+        maxLength={MAX_CHARS}
+        showCharacterCount
+        enablePreviewToggle={false}
+        height={220}
+        placeholder="Enter Markdown. Leave empty to use Karma's default message."
+        error={errorMessage ?? undefined}
+        aria-describedby={`hint-${meta.scenario}`}
+      />
+
+      <p id={`hint-${meta.scenario}`} className="text-xs text-stone-500 dark:text-zinc-400">
+        Allowed tokens:{" "}
+        {ACCESS_DENIED_TEMPLATE_VARIABLES[meta.scenario].map((t) => (
+          <code
+            key={t}
+            className="mx-0.5 rounded border border-stone-200 bg-stone-50 px-1 py-0.5 text-[11px] text-stone-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+          >{`{{${t}}}`}</code>
+        ))}
+      </p>
+
+      {previewSource ? (
+        <div>
+          <p className="mb-1.5 text-xs font-medium text-stone-600 dark:text-zinc-400">Preview</p>
+          <div className="rounded-lg border border-stone-200 bg-stone-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+            <MarkdownPreview source={previewSource} variant="inline" />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function TokenReferencePanel() {
+  return (
+    <div className="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-xs leading-relaxed dark:border-blue-900/40 dark:bg-blue-950/30">
+      <p className="font-semibold text-blue-900 dark:text-blue-200">Template tokens</p>
+      <ul className="mt-1.5 list-disc space-y-0.5 pl-5 text-blue-900/90 dark:text-blue-100/90">
+        <li>
+          <code>{`{{communityName}}`}</code> — the community's display name
+        </li>
+        <li>
+          <code>{`{{communitySlug}}`}</code> — the URL slug for the community
+        </li>
+        <li>
+          <code>{`{{appUrl}}`}</code> — the Karma app base URL
+        </li>
+        <li>
+          <code>{`{{requiredRoles}}`}</code> — the role(s) the page requires
+        </li>
+        <li>
+          <code>{`{{currentRoles}}`}</code> — the visitor's current roles (forbidden message only)
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/KnowledgeBasePage.tsx
@@ -89,6 +89,8 @@ export function KnowledgeBasePage({ community }: Props) {
         <AccessDenied
           title="Knowledge base access required"
           {...communityAdminDenial(community.details?.name)}
+          communitySlug={community.details?.slug || community.uid}
+          communityName={community.details?.name}
         />
       </PageFrame>
     );

--- a/components/Pages/Admin/KycSettingsPage.tsx
+++ b/components/Pages/Admin/KycSettingsPage.tsx
@@ -135,6 +135,8 @@ export function KycSettingsPage({ community }: KycSettingsPageProps) {
       <AccessDenied
         title="KYC settings access required"
         {...communityAdminDenial(community.details?.name)}
+        communitySlug={community.details?.slug || community.uid}
+        communityName={community.details?.name}
       />
     );
   }

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -749,6 +749,7 @@ function MilestonesReviewPageContent({
       <AccessDenied
         title="Milestone review access required"
         {...milestoneReviewDenial()}
+        communitySlug={communityId}
         cta={{ label: "Back to Milestones Report", href: PAGES.ADMIN.MILESTONES(communityId) }}
       />
     );

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -90,7 +90,13 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   }
 
   if (!hasAccess) {
-    return <AccessDenied {...communityAdminDenial(community.details?.name)} />;
+    return (
+      <AccessDenied
+        {...communityAdminDenial(community.details?.name)}
+        communitySlug={community.details?.slug || community.uid}
+        communityName={community.details?.name}
+      />
+    );
   }
 
   if (!report) {

--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -205,10 +205,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
       {/* Header with label and preview toggle */}
       <div className="flex items-center justify-between mb-2">
         {label && (
-          <label
-            htmlFor={safeId}
-            className="block text-sm font-bold text-black dark:text-zinc-100"
-          >
+          <label htmlFor={safeId} className="block text-sm font-bold text-black dark:text-zinc-100">
             {label} {isRequired && <span className="text-red-500">*</span>}
           </label>
         )}

--- a/hooks/useAccessDeniedMessages.ts
+++ b/hooks/useAccessDeniedMessages.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+/**
+ * Per-community Markdown overrides for the AccessDenied page body.
+ * Either field is null when the admin has not customized it; render
+ * the hard-coded fallback in that case. See
+ * gap-indexer/docs/adr/0001-per-community-access-denied-messages.md.
+ */
+export interface AccessDeniedMessages {
+  unauthenticatedMessage: string | null;
+  forbiddenMessage: string | null;
+}
+
+/**
+ * PUBLIC read — distinct from `useCommunityConfig` because the latter
+ * hits the admin-gated endpoint and would 401/403 the AccessDenied
+ * audience (anonymous visitors and signed-in users without the
+ * required role). Falls back to nulls when slug is empty, the
+ * endpoint 404s, or the fetch errors — the caller is expected to
+ * render the hard-coded default body in those cases.
+ */
+export const useAccessDeniedMessages = (
+  slugOrUid: string | null | undefined,
+  enabled: boolean = true
+) => {
+  return useQuery<AccessDeniedMessages>({
+    queryKey: ["access-denied-messages", slugOrUid ?? ""],
+    queryFn: async () => {
+      if (!slugOrUid) {
+        return { unauthenticatedMessage: null, forbiddenMessage: null };
+      }
+      const [data, error] = await fetchData(
+        INDEXER.COMMUNITY.CONFIG.ACCESS_DENIED_MESSAGES(slugOrUid),
+        "GET",
+        {},
+        {},
+        {},
+        false // public — no auth header
+      );
+      if (error || !data) {
+        return { unauthenticatedMessage: null, forbiddenMessage: null };
+      }
+      return {
+        unauthenticatedMessage: data.unauthenticatedMessage ?? null,
+        forbiddenMessage: data.forbiddenMessage ?? null,
+      };
+    },
+    enabled,
+    // Static-ish copy — admins change it rarely, anonymous visitors
+    // benefit most from aggressive caching.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 1,
+  });
+};

--- a/hooks/useAccessDeniedMessages.ts
+++ b/hooks/useAccessDeniedMessages.ts
@@ -1,6 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import fetchData from "@/utilities/fetchData";
-import { INDEXER } from "@/utilities/indexer";
+
+// Public endpoint — no auth header. Returns per-community Markdown
+// overrides for the AccessDenied page body. Lives here (not in
+// INDEXER) because it's the only caller — keeps the umbrella
+// constants file from growing past its size budget.
+const ACCESS_DENIED_MESSAGES_URL = (s: string) =>
+  `/v2/community-configs/${s}/access-denied-messages`;
 
 /**
  * Per-community Markdown overrides for the AccessDenied page body.
@@ -8,7 +14,7 @@ import { INDEXER } from "@/utilities/indexer";
  * the hard-coded fallback in that case. See
  * gap-indexer/docs/adr/0001-per-community-access-denied-messages.md.
  */
-export interface AccessDeniedMessages {
+interface AccessDeniedMessages {
   unauthenticatedMessage: string | null;
   forbiddenMessage: string | null;
 }
@@ -32,7 +38,7 @@ export const useAccessDeniedMessages = (
         return { unauthenticatedMessage: null, forbiddenMessage: null };
       }
       const [data, error] = await fetchData(
-        INDEXER.COMMUNITY.CONFIG.ACCESS_DENIED_MESSAGES(slugOrUid),
+        ACCESS_DENIED_MESSAGES_URL(slugOrUid),
         "GET",
         {},
         {},

--- a/hooks/useCommunityConfig.ts
+++ b/hooks/useCommunityConfig.ts
@@ -27,6 +27,14 @@ export interface CommunityConfig {
   telegramEnabled?: boolean;
   slackWebhookUrls?: string[];
   slackEnabled?: boolean;
+  /**
+   * Per-community Markdown overrides for the AccessDenied page body.
+   * `undefined` = don't touch on PUT; `null` = clear back to default.
+   * Token contract enforced server-side. See
+   * gap-indexer/docs/adr/0001-per-community-access-denied-messages.md.
+   */
+  accessDeniedUnauthenticatedMessage?: string | null;
+  accessDeniedForbiddenMessage?: string | null;
 }
 
 export const useCommunityConfig = (slug: string, enabled: boolean = true) => {
@@ -95,6 +103,10 @@ export const useCommunityConfigMutation = () => {
     onSettled: (_, __, { slug }) => {
       // Always refetch after error or success to ensure we have the latest
       queryClient.invalidateQueries({ queryKey: ["community-config", slug] });
+      // Public AccessDenied cache lives under a separate key; invalidate
+      // it too so the editor preview + any open AccessDenied pages pick
+      // up the new messages without a hard reload.
+      queryClient.invalidateQueries({ queryKey: ["access-denied-messages", slug] });
     },
   });
 };

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -1,12 +1,25 @@
 "use client";
 
 import { AlertTriangle, LogIn } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { useAccessDeniedMessages } from "@/hooks/useAccessDeniedMessages";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { isValidRole, ROLE_LABELS, Role } from "@/src/core/rbac/types";
+import {
+  ACCESS_DENIED_DEFAULT_MESSAGES,
+  substituteAccessDeniedTemplate,
+} from "@/utilities/accessDeniedTemplate";
+import { envVars } from "@/utilities/enviromentVars";
+
+const MarkdownPreview = dynamic(
+  () => import("@/components/Utilities/MarkdownPreview").then((m) => m.MarkdownPreview),
+  { ssr: false }
+);
 
 interface AccessDeniedCta {
   label: string;
@@ -18,10 +31,18 @@ interface AccessDeniedProps {
   message?: string;
   returnUrl?: string;
   requiredRoles?: ReadonlyArray<Role | string>;
-  contactLabel?: string;
   currentRolesOverride?: ReadonlyArray<Role>;
   isLoading?: boolean;
   cta?: AccessDeniedCta;
+  /**
+   * When provided, fetch the per-community Markdown overrides for the
+   * AccessDenied body (public endpoint) and render the matching
+   * scenario string instead of the hard-coded copy. Null/empty
+   * messages fall back to the existing default so existing callers
+   * keep working without changes.
+   */
+  communitySlug?: string;
+  communityName?: string;
 }
 
 function formatList(items: ReadonlyArray<string>): string {
@@ -60,90 +81,118 @@ function DenialSkeleton() {
 
 interface DenialBodyProps {
   authenticated: boolean;
-  requiredRoles?: ReadonlyArray<Role | string>;
-  requiredList: string | null;
-  currentRolesOverride?: ReadonlyArray<Role>;
-  detectedRoles: ReadonlyArray<Role>;
-  contactLabel?: string;
   message?: string;
+  customMessage?: string | null;
+  communityName?: string;
 }
 
-function DenialBody({
-  authenticated,
-  requiredRoles,
-  requiredList,
-  currentRolesOverride,
-  detectedRoles,
-  contactLabel,
-  message,
-}: DenialBodyProps) {
-  if (!requiredList) {
-    return (
-      <p className="text-muted-foreground mb-8">
-        {message ?? "You don't have permission to view this page."}
-      </p>
-    );
-  }
+// Fallback noun when no community context is available. Kept here
+// (not at the call site) so every default branch reads the same.
+const COMMUNITY_FALLBACK = "community";
 
-  const roleWord = requiredRoles && requiredRoles.length === 1 ? "role" : "roles";
-
-  if (!authenticated) {
-    return (
-      <p className="text-muted-foreground mb-8">
-        You need to sign in to view this page. This page requires {requiredList} {roleWord}.
-      </p>
-    );
-  }
-
-  const currentRoles =
-    currentRolesOverride ?? detectedRoles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
-  const currentList =
-    currentRoles.length > 0
-      ? formatList(currentRoles.map((r) => ROLE_LABELS[r]))
-      : ROLE_LABELS[Role.NONE];
-
+function CustomMarkdownBody({ source }: { source: string }) {
   return (
-    <p className="text-muted-foreground mb-8">
-      You don&apos;t have access to this page. You need {requiredList} {roleWord}. Your account has:{" "}
-      {currentList}.{contactLabel ? ` Please contact ${contactLabel}.` : ""}
-    </p>
+    <div className="text-muted-foreground mb-8 text-left" data-testid="access-denied-custom">
+      <MarkdownPreview source={source} variant="inline" />
+    </div>
   );
 }
 
+function DenialBody({ authenticated, message, customMessage, communityName }: DenialBodyProps) {
+  if (customMessage) {
+    return <CustomMarkdownBody source={customMessage} />;
+  }
+  if (message) {
+    return <p className="text-muted-foreground mb-8">{message}</p>;
+  }
+  const communityLabel = communityName ?? COMMUNITY_FALLBACK;
+  const fallback = authenticated
+    ? substituteAccessDeniedTemplate(ACCESS_DENIED_DEFAULT_MESSAGES.forbidden, {
+        communityName: communityLabel,
+        communitySlug: "",
+        appUrl: "",
+        requiredRoles: "",
+        currentRoles: "",
+      })
+    : ACCESS_DENIED_DEFAULT_MESSAGES.unauthenticated;
+  return <CustomMarkdownBody source={fallback} />;
+}
+
 export function AccessDenied({
-  title = "Access Denied",
+  title,
   message,
   returnUrl = "/",
   requiredRoles,
-  contactLabel,
   currentRolesOverride,
   isLoading,
   cta,
+  communitySlug,
+  communityName,
 }: AccessDeniedProps) {
   const { authenticated, login } = useAuth();
   const router = useRouter();
   const { roles: detectedRoles, isLoading: isRbacLoading } = usePermissionContext();
-
-  if (isLoading || isRbacLoading) {
-    return <DenialSkeleton />;
-  }
+  const { data: customMessages, isLoading: isCustomLoading } = useAccessDeniedMessages(
+    communitySlug,
+    !!communitySlug
+  );
 
   const requiredList =
     requiredRoles && requiredRoles.length > 0 ? formatList(requiredRoles.map(labelFor)) : null;
 
+  const customMessage = useMemo(() => {
+    if (!communitySlug || !customMessages) return null;
+    const raw = authenticated
+      ? customMessages.forbiddenMessage
+      : customMessages.unauthenticatedMessage;
+    if (!raw) return null;
+    const visibleRoles =
+      currentRolesOverride ??
+      detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
+    return substituteAccessDeniedTemplate(raw, {
+      communityName: communityName ?? "",
+      communitySlug,
+      appUrl: envVars.VERCEL_URL,
+      requiredRoles: requiredList ?? "",
+      currentRoles: authenticated
+        ? visibleRoles.length > 0
+          ? formatList(visibleRoles.map((r) => ROLE_LABELS[r]))
+          : ROLE_LABELS[Role.NONE]
+        : null,
+    });
+  }, [
+    communitySlug,
+    communityName,
+    customMessages,
+    authenticated,
+    currentRolesOverride,
+    detectedRoles.roles,
+    requiredList,
+  ]);
+
+  if (isLoading || isRbacLoading || (communitySlug && isCustomLoading)) {
+    return <DenialSkeleton />;
+  }
+
   const handleClick = () => {
-    if (cta) {
-      router.push(cta.href);
-      return;
-    }
     if (!authenticated) {
       login();
+      return;
+    }
+    if (cta) {
+      router.push(cta.href);
       return;
     }
     router.push(returnUrl);
   };
 
-  const buttonLabel = cta?.label ?? (authenticated ? "Go to Home" : "Sign In");
+  // `cta` is a post-login redirect target — only honor it once the visitor is
+  // signed in. Unauthenticated users always see the Sign In button.
+  const buttonLabel = authenticated ? (cta?.label ?? "Go to Home") : "Sign In";
+  // The title is part of the Markdown body (bold first line), so we only
+  // render a separate h1 when a caller explicitly passes `title` — e.g.
+  // page-specific headings like "Faucet admin access required".
+  const resolvedTitle = title ?? null;
 
   return (
     <div className="w-full mx-auto py-16 flex items-center justify-center min-h-[calc(100vh-8rem)]">
@@ -155,15 +204,12 @@ export function AccessDenied({
             </div>
           </div>
 
-          <h1 className="text-2xl font-bold mb-4">{title}</h1>
+          {resolvedTitle ? <h1 className="text-2xl font-bold mb-4">{resolvedTitle}</h1> : null}
           <DenialBody
             authenticated={authenticated}
-            requiredRoles={requiredRoles}
-            requiredList={requiredList}
-            currentRolesOverride={currentRolesOverride}
-            detectedRoles={detectedRoles.roles}
-            contactLabel={contactLabel}
             message={message}
+            customMessage={customMessage}
+            communityName={communityName}
           />
 
           <Button type="button" onClick={handleClick}>

--- a/src/components/ui/AccessDenied.tsx
+++ b/src/components/ui/AccessDenied.tsx
@@ -150,7 +150,7 @@ export function AccessDenied({
       currentRolesOverride ??
       detectedRoles.roles.filter((r) => r !== Role.GUEST && r !== Role.NONE);
     return substituteAccessDeniedTemplate(raw, {
-      communityName: communityName ?? "",
+      communityName: communityName ?? COMMUNITY_FALLBACK,
       communitySlug,
       appUrl: envVars.VERCEL_URL,
       requiredRoles: requiredList ?? "",

--- a/src/components/ui/access-denied-presets.ts
+++ b/src/components/ui/access-denied-presets.ts
@@ -2,21 +2,15 @@ import { Role } from "@/src/core/rbac/types";
 
 interface DenialPreset {
   requiredRoles: ReadonlyArray<Role | string>;
-  contactLabel: string;
 }
 
-function communityContact(communityName?: string | null): string {
-  return `a community administrator of ${communityName ?? "this community"}`;
-}
-
-export function communityAdminDenial(communityName?: string | null): DenialPreset {
+export function communityAdminDenial(_communityName?: string | null): DenialPreset {
   return {
     requiredRoles: [Role.COMMUNITY_ADMIN, Role.SUPER_ADMIN],
-    contactLabel: communityContact(communityName),
   };
 }
 
-export function manageLayoutDenial(communityName?: string | null): DenialPreset {
+export function manageLayoutDenial(_communityName?: string | null): DenialPreset {
   return {
     requiredRoles: [
       Role.COMMUNITY_ADMIN,
@@ -25,11 +19,10 @@ export function manageLayoutDenial(communityName?: string | null): DenialPreset 
       Role.REGISTRY_ADMIN,
       "Community Owner",
     ],
-    contactLabel: communityContact(communityName),
   };
 }
 
-export function milestoneReviewDenial(communityName?: string | null): DenialPreset {
+export function milestoneReviewDenial(_communityName?: string | null): DenialPreset {
   return {
     requiredRoles: [
       Role.COMMUNITY_ADMIN,
@@ -37,13 +30,11 @@ export function milestoneReviewDenial(communityName?: string | null): DenialPres
       Role.PROGRAM_REVIEWER,
       "Contract Owner",
     ],
-    contactLabel: communityContact(communityName),
   };
 }
 
 export function faucetAdminDenial(): DenialPreset {
   return {
     requiredRoles: [Role.SUPER_ADMIN],
-    contactLabel: "the platform team",
   };
 }

--- a/utilities/accessDeniedTemplate.ts
+++ b/utilities/accessDeniedTemplate.ts
@@ -13,7 +13,7 @@
  * the substitution then leaves `{{currentRoles}}` literal, matching
  * the backend validator behavior for that scenario.
  */
-export interface AccessDeniedTemplateVars {
+interface AccessDeniedTemplateVars {
   communityName: string;
   communitySlug: string;
   appUrl: string;
@@ -52,7 +52,7 @@ export const ACCESS_DENIED_DEFAULT_MESSAGES: Record<AccessDeniedScenario, string
     "**You're almost there**\n\nYou're signed in, but this page needs a role your account doesn't have yet. Reach out to a {{communityName}} admin and they can get you set up.",
 };
 
-export interface AccessDeniedTemplateValidationResult {
+interface AccessDeniedTemplateValidationResult {
   readonly unknownTokens: readonly string[];
   readonly disallowedTokens: readonly string[];
 }

--- a/utilities/accessDeniedTemplate.ts
+++ b/utilities/accessDeniedTemplate.ts
@@ -1,0 +1,117 @@
+/**
+ * Mustache-style `{{var}}` substitution for per-community AccessDenied
+ * messages. Closed vocabulary; the backend validator
+ * (`validateAccessDeniedTemplate`) rejects unknown tokens at write
+ * time so we only need to substitute what's known. Unknown tokens at
+ * render time are left literal — never silently deleted — so a
+ * downgraded backend (validator removed) still shows the admin
+ * exactly what they typed instead of an invisible gap.
+ *
+ * Scenario contract — `{{currentRoles}}` is only meaningful when the
+ * visitor is signed in (forbidden scenario). Callers MUST pass
+ * `currentRoles: null` when rendering the unauthenticated message;
+ * the substitution then leaves `{{currentRoles}}` literal, matching
+ * the backend validator behavior for that scenario.
+ */
+export interface AccessDeniedTemplateVars {
+  communityName: string;
+  communitySlug: string;
+  appUrl: string;
+  requiredRoles: string;
+  currentRoles: string | null;
+}
+
+const TOKEN_RE = /\{\{\s*([A-Za-z0-9_]+)\s*\}\}/g;
+
+export type AccessDeniedScenario = "unauthenticated" | "forbidden";
+
+/**
+ * Closed vocabulary per scenario. Mirrors
+ * `gap-indexer/app/modules/v2/domain/services/access-denied-template.domain.service.ts`
+ * so admins get the same inline errors the backend would emit on save.
+ * Keep both lists in sync when adding tokens on either side.
+ */
+export const ACCESS_DENIED_TEMPLATE_VARIABLES = {
+  unauthenticated: ["communityName", "communitySlug", "appUrl", "requiredRoles"],
+  forbidden: ["communityName", "communitySlug", "appUrl", "requiredRoles", "currentRoles"],
+} as const satisfies Record<AccessDeniedScenario, readonly string[]>;
+
+/**
+ * Default Markdown rendered by `<AccessDenied />` when a community has no
+ * override saved. Exported so the admin editor can prefill the fields with
+ * the same copy admins see in production — letting them tweak the default
+ * instead of staring at an empty textarea.
+ *
+ * Keep these strings in sync with the fallback branches in
+ * `src/components/ui/AccessDenied.tsx`.
+ */
+export const ACCESS_DENIED_DEFAULT_MESSAGES: Record<AccessDeniedScenario, string> = {
+  unauthenticated:
+    "**Sign in to continue**\n\nThis area is reserved for folks with the right access. Pop in and we'll take it from there.",
+  forbidden:
+    "**You're almost there**\n\nYou're signed in, but this page needs a role your account doesn't have yet. Reach out to a {{communityName}} admin and they can get you set up.",
+};
+
+export interface AccessDeniedTemplateValidationResult {
+  readonly unknownTokens: readonly string[];
+  readonly disallowedTokens: readonly string[];
+}
+
+const EMPTY_VALIDATION: AccessDeniedTemplateValidationResult = Object.freeze({
+  unknownTokens: Object.freeze([]),
+  disallowedTokens: Object.freeze([]),
+});
+
+export function validateAccessDeniedTemplate(
+  template: string | null | undefined,
+  scenario: AccessDeniedScenario
+): AccessDeniedTemplateValidationResult {
+  if (!template) return EMPTY_VALIDATION;
+
+  const allowed = new Set<string>(ACCESS_DENIED_TEMPLATE_VARIABLES[scenario]);
+  const allKnown = new Set<string>([
+    ...ACCESS_DENIED_TEMPLATE_VARIABLES.unauthenticated,
+    ...ACCESS_DENIED_TEMPLATE_VARIABLES.forbidden,
+  ]);
+
+  const unknown = new Set<string>();
+  const disallowed = new Set<string>();
+
+  for (const match of template.matchAll(TOKEN_RE)) {
+    const name = match[1];
+    if (!allKnown.has(name)) {
+      unknown.add(name);
+      continue;
+    }
+    if (!allowed.has(name)) {
+      disallowed.add(name);
+    }
+  }
+
+  return {
+    unknownTokens: Array.from(unknown),
+    disallowedTokens: Array.from(disallowed),
+  };
+}
+
+export function substituteAccessDeniedTemplate(
+  template: string,
+  vars: AccessDeniedTemplateVars
+): string {
+  return template.replace(TOKEN_RE, (match, name: string) => {
+    switch (name) {
+      case "communityName":
+        return vars.communityName;
+      case "communitySlug":
+        return vars.communitySlug;
+      case "appUrl":
+        return vars.appUrl;
+      case "requiredRoles":
+        return vars.requiredRoles;
+      case "currentRoles":
+        return vars.currentRoles ?? match;
+      default:
+        return match;
+    }
+  });
+}

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -708,6 +708,11 @@ export const INDEXER = {
       UPDATE: (slug: string) => `/v2/community-configs/${slug}`,
       TELEGRAM_PAIR_START: (slug: string) => `/v2/community-configs/${slug}/telegram-pair/start`,
       TELEGRAM_PAIR_VERIFY: (slug: string) => `/v2/community-configs/${slug}/telegram-pair/verify`,
+      // Public endpoint — no auth required. Returns per-community
+      // Markdown overrides for the AccessDenied page body. See
+      // gap-indexer/docs/adr/0001-per-community-access-denied-messages.md.
+      ACCESS_DENIED_MESSAGES: (slugOrUid: string) =>
+        `/v2/community-configs/${slugOrUid}/access-denied-messages`,
     },
   },
   GRANTS: {

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -708,11 +708,6 @@ export const INDEXER = {
       UPDATE: (slug: string) => `/v2/community-configs/${slug}`,
       TELEGRAM_PAIR_START: (slug: string) => `/v2/community-configs/${slug}/telegram-pair/start`,
       TELEGRAM_PAIR_VERIFY: (slug: string) => `/v2/community-configs/${slug}/telegram-pair/verify`,
-      // Public endpoint — no auth required. Returns per-community
-      // Markdown overrides for the AccessDenied page body. See
-      // gap-indexer/docs/adr/0001-per-community-access-denied-messages.md.
-      ACCESS_DENIED_MESSAGES: (slugOrUid: string) =>
-        `/v2/community-configs/${slugOrUid}/access-denied-messages`,
     },
   },
   GRANTS: {

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -111,6 +111,8 @@ export const PAGES = {
     NOTIFICATION_SETTINGS: (community: string) =>
       `/community/${community}/manage/notification-settings`,
     KNOWLEDGE_BASE: (community: string) => `/community/${community}/manage/knowledge-base`,
+    ACCESS_DENIED_MESSAGES: (community: string) =>
+      `/community/${community}/manage/access-denied-messages`,
     PROGRAM_SCORES: (community: string) => `/community/${community}/manage/program-scores`,
     SEND_EMAIL: (community: string) => `/community/${community}/manage/send-email`,
     PORTFOLIO_REPORTS: (community: string) => `/community/${community}/manage/portfolio-reports`,


### PR DESCRIPTION
## Summary
- Adds a `/community/[id]/manage/access-denied-messages` admin page where community admins can edit the Markdown shown on the Access Denied page for two scenarios: unauthenticated visitors and authenticated users without the required role.
- `AccessDenied` component now accepts `communitySlug` / `communityName` and renders per-community overrides (with `{{var}}` template substitution) when present, falling back to the existing defaults.
- All manage pages that use `AccessDenied` (program-scores, send-email, KnowledgeBase, KycSettings, MilestonesReview, PortfolioReports, ManageLayoutShell) wired to pass the community context.
- New `useAccessDeniedMessages` hook + `useCommunityConfig` PUT integration.
- Adds the new entry to ManageSidebar / ManageBreadcrumbs.

## Depends on
- Backend: https://github.com/show-karma/gap-indexer/pull/1817 — must ship first (introduces the two fields + public endpoint).

## Test plan
- [x] `pnpm test` passes (new tests for `useAccessDeniedMessages`, `accessDeniedTemplate`, `AccessDenied`)
- [x] As community admin, edit both messages, save, reload -> values persist
- [x] Sign out, visit `/community/<slug>` -> custom unauthenticated Markdown renders
- [x] Sign in with insufficient role -> custom forbidden Markdown renders
- [x] Empty / default values fall back to existing presets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New admin page for managing customizable access-denied messages per community with Markdown rendering and template token substitution ({{communityName}}, {{requiredRoles}}, {{currentRoles}}).
  * Added "Access Denied Page" navigation option in admin settings sidebar.
  * Enhanced AccessDenied component to display community-aware, customizable messages with loading and error states.

* **Tests**
  * Comprehensive test suites added for access-denied messaging system, template validation, and substitution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->