### PR TITLE
chore(sitemap): add 1k-URL probe for GSC fetch testing

### DIFF
--- a/app/sitemaps/probe-1k/sitemap.ts
+++ b/app/sitemaps/probe-1k/sitemap.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from "next";
+import { buildSitemapEntries, fetchSitemapUrls } from "@/utilities/sitemap";
+
+// Probe sitemap: serves first 1000 project URLs to test whether GSC
+// fetches succeed at this size (vs. the 5000-URL default that fails).
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const urls = await fetchSitemapUrls("projects", 1, 1000);
+  return buildSitemapEntries(urls, { priority: 0.8, changeFrequency: "daily" });
+}


### PR DESCRIPTION
## Summary
- Adds `/sitemaps/probe-1k/sitemap.xml` serving the first 1000 project URLs
- Isolation test for ongoing Google Search Console "Couldn't fetch" issue: in-prod 5000-URL sitemaps all fail, <200-URL ones all succeed
- Temporary — will remove once root cause is confirmed

## Test plan
- [ ] Merge & deploy
- [ ] Submit probe URL to GSC
- [ ] If success → confirms 5000 is over the size threshold; ship `SITEMAP_PAGE_SIZE: 5000 → 1000` fix
- [ ] If fail → size isn't the issue; investigate response headers / content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added testing infrastructure for sitemap generation at scale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->