### PR TITLE
feat(seo): Tier S AEO polish — schema fixes, trust anchors, robots tweaks, OAuth Sentry fix

### DIFF
--- a/__tests__/app/about.test.tsx
+++ b/__tests__/app/about.test.tsx
@@ -1,14 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import AboutPage, { metadata } from "@/app/about/page";
 
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: vi.fn().mockResolvedValue({ isWhitelabel: false }),
+}));
+
+async function renderAboutPage() {
+  const element = await AboutPage();
+  return render(element);
+}
+
 describe("app/about/page.tsx", () => {
-  it("renders the About Karma H1", () => {
-    render(<AboutPage />);
+  it("renders the About Karma H1", async () => {
+    await renderAboutPage();
     expect(screen.getByRole("heading", { level: 1, name: /about karma/i })).toBeInTheDocument();
   });
 
-  it("includes substantive body content (>500 chars)", () => {
-    const { container } = render(<AboutPage />);
+  it("includes substantive body content (>500 chars)", async () => {
+    const { container } = await renderAboutPage();
     expect(container.textContent?.length ?? 0).toBeGreaterThan(500);
   });
 
@@ -17,11 +26,27 @@ describe("app/about/page.tsx", () => {
     expect(canonical).toBe("/about");
   });
 
-  it("links to the MCP setup guide and the For AI Agents landing page", () => {
-    render(<AboutPage />);
+  it("links to the MCP setup guide and the For AI Agents landing page", async () => {
+    await renderAboutPage();
     const mcpLink = screen.getByRole("link", { name: /mcp setup guide/i });
     const forAgentsLink = screen.getByRole("link", { name: /for ai agents/i });
     expect(mcpLink.getAttribute("href")).toBe("/mcp/connect");
     expect(forAgentsLink.getAttribute("href")).toBe("/for-agents");
+  });
+});
+
+describe("app/about/page.tsx whitelabel gating", () => {
+  it("calls notFound() when rendered on a whitelabel tenant", async () => {
+    const { getWhitelabelContext } = await import("@/utilities/whitelabel-server");
+    (getWhitelabelContext as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      isWhitelabel: true,
+    });
+    const { notFound } = await import("next/navigation");
+
+    await AboutPage().catch(() => {
+      // notFound() throws a NEXT_HTTP_ERROR_FALLBACK; swallow it here.
+    });
+
+    expect(notFound).toHaveBeenCalled();
   });
 });

--- a/__tests__/app/about.test.tsx
+++ b/__tests__/app/about.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import AboutPage, { metadata } from "@/app/about/page";
+
+describe("app/about/page.tsx", () => {
+  it("renders the About Karma H1", () => {
+    render(<AboutPage />);
+    expect(screen.getByRole("heading", { level: 1, name: /about karma/i })).toBeInTheDocument();
+  });
+
+  it("includes substantive body content (>500 chars)", () => {
+    const { container } = render(<AboutPage />);
+    expect(container.textContent?.length ?? 0).toBeGreaterThan(500);
+  });
+
+  it("declares the canonical /about path in metadata", () => {
+    const canonical = (metadata.alternates?.canonical ?? "") as string;
+    expect(canonical).toBe("/about");
+  });
+
+  it("links to the MCP setup guide and the For AI Agents landing page", () => {
+    render(<AboutPage />);
+    const mcpLink = screen.getByRole("link", { name: /mcp setup guide/i });
+    const forAgentsLink = screen.getByRole("link", { name: /for ai agents/i });
+    expect(mcpLink.getAttribute("href")).toBe("/mcp/connect");
+    expect(forAgentsLink.getAttribute("href")).toBe("/for-agents");
+  });
+});

--- a/__tests__/app/contact.test.tsx
+++ b/__tests__/app/contact.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import ContactPage, { metadata } from "@/app/contact/page";
+
+describe("app/contact/page.tsx", () => {
+  it("renders the Contact Karma H1", () => {
+    render(<ContactPage />);
+    expect(screen.getByRole("heading", { level: 1, name: /contact karma/i })).toBeInTheDocument();
+  });
+
+  it("includes substantive body content (>500 chars)", () => {
+    const { container } = render(<ContactPage />);
+    expect(container.textContent?.length ?? 0).toBeGreaterThan(500);
+  });
+
+  it("declares the canonical /contact path in metadata", () => {
+    const canonical = (metadata.alternates?.canonical ?? "") as string;
+    expect(canonical).toBe("/contact");
+  });
+
+  it("exposes the info@karmahq.xyz contact mailto link", () => {
+    render(<ContactPage />);
+    const mailtoLink = screen.getByRole("link", { name: /info@karmahq\.xyz/i });
+    expect(mailtoLink.getAttribute("href")).toBe("mailto:info@karmahq.xyz");
+  });
+});

--- a/__tests__/app/contact.test.tsx
+++ b/__tests__/app/contact.test.tsx
@@ -1,14 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import ContactPage, { metadata } from "@/app/contact/page";
 
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: vi.fn().mockResolvedValue({ isWhitelabel: false }),
+}));
+
+async function renderContactPage() {
+  const element = await ContactPage();
+  return render(element);
+}
+
 describe("app/contact/page.tsx", () => {
-  it("renders the Contact Karma H1", () => {
-    render(<ContactPage />);
+  it("renders the Contact Karma H1", async () => {
+    await renderContactPage();
     expect(screen.getByRole("heading", { level: 1, name: /contact karma/i })).toBeInTheDocument();
   });
 
-  it("includes substantive body content (>500 chars)", () => {
-    const { container } = render(<ContactPage />);
+  it("includes substantive body content (>500 chars)", async () => {
+    const { container } = await renderContactPage();
     expect(container.textContent?.length ?? 0).toBeGreaterThan(500);
   });
 
@@ -17,9 +26,28 @@ describe("app/contact/page.tsx", () => {
     expect(canonical).toBe("/contact");
   });
 
-  it("exposes the info@karmahq.xyz contact mailto link", () => {
-    render(<ContactPage />);
-    const mailtoLink = screen.getByRole("link", { name: /info@karmahq\.xyz/i });
-    expect(mailtoLink.getAttribute("href")).toBe("mailto:info@karmahq.xyz");
+  it("exposes the info@karmahq.xyz contact mailto link", async () => {
+    await renderContactPage();
+    const mailtoLinks = screen.getAllByRole("link", { name: /info@karmahq\.xyz/i });
+    expect(mailtoLinks.length).toBeGreaterThanOrEqual(1);
+    expect(
+      mailtoLinks.some((link) => link.getAttribute("href")?.startsWith("mailto:info@karmahq.xyz"))
+    ).toBe(true);
+  });
+});
+
+describe("app/contact/page.tsx whitelabel gating", () => {
+  it("calls notFound() when rendered on a whitelabel tenant", async () => {
+    const { getWhitelabelContext } = await import("@/utilities/whitelabel-server");
+    (getWhitelabelContext as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      isWhitelabel: true,
+    });
+    const { notFound } = await import("next/navigation");
+
+    await ContactPage().catch(() => {
+      // notFound() throws a NEXT_HTTP_ERROR_FALLBACK; swallow it here.
+    });
+
+    expect(notFound).toHaveBeenCalled();
   });
 });

--- a/__tests__/app/robots.test.ts
+++ b/__tests__/app/robots.test.ts
@@ -4,8 +4,8 @@ import { SITE_URL } from "@/utilities/meta";
 describe("robots", () => {
   const result = robots();
 
-  it("should return 5 rule sets", () => {
-    expect(result.rules).toHaveLength(5);
+  it("should return 8 rule sets", () => {
+    expect(result.rules).toHaveLength(8);
   });
 
   it("should apply wildcard rule to all user agents", () => {
@@ -25,7 +25,7 @@ describe("robots", () => {
 
   it("should allow /.well-known/ for every AI crawler rule", () => {
     const rules = result.rules as Array<Record<string, unknown>>;
-    const aiCrawlers = ["GPTBot", "ClaudeBot", "PerplexityBot", "Google-Extended"];
+    const aiCrawlers = ["GPTBot", "ChatGPT-User", "ClaudeBot", "PerplexityBot", "Google-Extended"];
     for (const crawler of aiCrawlers) {
       const rule = rules.find((r) => r.userAgent === crawler);
       expect(rule?.allow).toContain("/.well-known/");
@@ -59,7 +59,7 @@ describe("robots", () => {
 
   describe("AI crawler rules", () => {
     const rules = result.rules as Array<Record<string, unknown>>;
-    const aiCrawlers = ["GPTBot", "ClaudeBot", "PerplexityBot", "Google-Extended"];
+    const aiCrawlers = ["GPTBot", "ChatGPT-User", "ClaudeBot", "PerplexityBot", "Google-Extended"];
 
     for (const crawler of aiCrawlers) {
       it(`should have a rule for ${crawler}`, () => {
@@ -67,9 +67,32 @@ describe("robots", () => {
         expect(rule).toBeDefined();
         expect(rule?.allow).toContain("/llms.txt");
         expect(rule?.allow).toContain("/llms-full.txt");
+        expect(rule?.allow).toContain("/agents.md");
         expect(rule?.disallow).toContain("/api/");
       });
     }
+  });
+
+  describe("training-only crawler blocks", () => {
+    const rules = result.rules as Array<Record<string, unknown>>;
+
+    it("should disallow the entire site for CCBot", () => {
+      const rule = rules.find((r) => r.userAgent === "CCBot");
+      expect(rule).toBeDefined();
+      expect(rule?.disallow).toContain("/");
+    });
+
+    it("should disallow the entire site for Bytespider", () => {
+      const rule = rules.find((r) => r.userAgent === "Bytespider");
+      expect(rule).toBeDefined();
+      expect(rule?.disallow).toContain("/");
+    });
+
+    it("should explicitly list ChatGPT-User as an allowed crawler", () => {
+      const rule = rules.find((r) => r.userAgent === "ChatGPT-User");
+      expect(rule).toBeDefined();
+      expect(rule?.allow).toContain("/");
+    });
   });
 
   describe("sitemaps", () => {

--- a/__tests__/app/well-known/agent-card.test.ts
+++ b/__tests__/app/well-known/agent-card.test.ts
@@ -22,6 +22,23 @@ describe("/.well-known/agent-card.json route handler", () => {
     expect(body.agent.description.length).toBeGreaterThan(0);
   });
 
+  it("also exposes name and description at the root for AEO crawlers (Ora)", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.name).toBe("Karma");
+    expect(typeof body.description).toBe("string");
+    expect(body.description.length).toBeGreaterThan(0);
+  });
+
+  it("keeps root-level and nested name/description in lockstep", async () => {
+    const { GET } = await import("@/app/.well-known/agent-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.name).toBe(body.agent.name);
+    expect(body.description).toBe(body.agent.description);
+  });
+
   it("points url and documentationUrl at the apex marketing domain", async () => {
     const { GET } = await import("@/app/.well-known/agent-card.json/route");
     const res = GET();

--- a/__tests__/app/well-known/api-catalog.test.ts
+++ b/__tests__/app/well-known/api-catalog.test.ts
@@ -49,6 +49,30 @@ describe("/.well-known/api-catalog route handler", () => {
     ]);
   });
 
+  it("exposes an 'item' array per RFC 9727 with at least 4 entries", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    const item = body.linkset[0].item;
+    expect(Array.isArray(item)).toBe(true);
+    expect(item.length).toBeGreaterThanOrEqual(4);
+    for (const entry of item) {
+      expect(typeof entry.href).toBe("string");
+      expect(typeof entry.type).toBe("string");
+    }
+  });
+
+  it("includes the apex OpenAPI, indexer docs, mcp.json, and mcp/server-card.json in 'item'", async () => {
+    const { GET } = await import("@/app/.well-known/api-catalog/route");
+    const res = GET();
+    const body = await res.json();
+    const hrefs = body.linkset[0].item.map((entry: { href: string }) => entry.href);
+    expect(hrefs).toContain(`${SITE_URL}/openapi.json`);
+    expect(hrefs).toContain(`${INDEXER_URL}/v2/docs`);
+    expect(hrefs).toContain(`${SITE_URL}/.well-known/mcp.json`);
+    expect(hrefs).toContain(`${SITE_URL}/.well-known/mcp/server-card.json`);
+  });
+
   it("sets wide-open CORS headers", async () => {
     const { GET } = await import("@/app/.well-known/api-catalog/route");
     const res = GET();

--- a/__tests__/app/well-known/mcp-server-card.test.ts
+++ b/__tests__/app/well-known/mcp-server-card.test.ts
@@ -25,6 +25,14 @@ describe("/.well-known/mcp/server-card.json route handler", () => {
     expect(body.version).toBe("1.0.0");
   });
 
+  it("exposes a top-level description so AEO crawlers (Ora) can index it", async () => {
+    const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(typeof body.description).toBe("string");
+    expect(body.description.length).toBeGreaterThan(0);
+  });
+
   it("references human docs and OpenAPI on the apex marketing domain", async () => {
     const { GET } = await import("@/app/.well-known/mcp/server-card.json/route");
     const res = GET();

--- a/__tests__/app/well-known/oauth-protected-resource.test.ts
+++ b/__tests__/app/well-known/oauth-protected-resource.test.ts
@@ -8,12 +8,6 @@ describe("/.well-known/oauth-protected-resource route handler", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.resetModules();
-    vi.unstubAllGlobals();
-    vi.clearAllMocks();
-  });
-
   it("returns 200 with a static RFC 9728 metadata document", async () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
     const res = GET();
@@ -88,19 +82,40 @@ describe("/.well-known/oauth-protected-resource route handler", () => {
     expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
     expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
   });
+});
 
-  // Placed last so the per-test doMock can't leak into other tests that
-  // rely on the global setup-mocks env (vi.doMock persists module cache
-  // overrides even when vi.resetModules() runs in beforeEach).
-  it("throws when NEXT_PUBLIC_GAP_OAUTH_URL is unset", async () => {
+// Isolated suite for the env-var-missing path. vi.doMock leaks across
+// tests within the same describe even with vi.resetModules() in
+// beforeEach, so the assertion lives in its own describe block with its
+// own lifecycle. This makes test order non-load-bearing.
+describe("/.well-known/oauth-protected-resource route handler — missing env", () => {
+  beforeEach(() => {
+    vi.resetModules();
     vi.doMock("@/utilities/enviromentVars", () => ({
       envVars: {
         NEXT_PUBLIC_GAP_INDEXER_URL: "http://localhost:4000",
         NEXT_PUBLIC_GAP_OAUTH_URL: "",
       },
     }));
-    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    expect(() => GET()).toThrow(/NEXT_PUBLIC_GAP_OAUTH_URL is not set/);
+  });
+
+  afterEach(() => {
     vi.doUnmock("@/utilities/enviromentVars");
+    vi.resetModules();
+  });
+
+  it("throws and tags the Sentry capture when NEXT_PUBLIC_GAP_OAUTH_URL is unset", async () => {
+    const Sentry = await import("@sentry/nextjs");
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+
+    expect(() => GET()).toThrow(/NEXT_PUBLIC_GAP_OAUTH_URL is not set/);
+    expect(captureSpy).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { route: "well-known/oauth-protected-resource" },
+      })
+    );
   });
 });

--- a/__tests__/app/well-known/oauth-protected-resource.test.ts
+++ b/__tests__/app/well-known/oauth-protected-resource.test.ts
@@ -1,130 +1,106 @@
-import * as Sentry from "@sentry/nextjs";
-
 const INDEXER_URL = "http://localhost:4000";
+const OAUTH_ISSUER = "https://oauth.test.karmahq.xyz";
 
 describe("/.well-known/oauth-protected-resource route handler", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    vi.resetModules();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  it("proxies the upstream OAuth metadata response when it succeeds", async () => {
-    const upstream = {
-      resource: `${INDEXER_URL}/v2/mcp`,
-      authorization_servers: [`${INDEXER_URL}`],
-      scopes_supported: ["mcp"],
-    };
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => upstream }));
-
+  it("returns 200 with a static RFC 9728 metadata document", async () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-    const body = await res.json();
+    const res = GET();
     expect(res.status).toBe(200);
-    expect(body).toEqual(upstream);
+    const body = await res.json();
+    expect(body).toBeDefined();
   });
 
-  it("calls upstream at /.well-known/oauth-protected-resource/v2/mcp with timeout + ISR", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("sets resource to the indexer's MCP endpoint", async () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    await GET();
+    const res = GET();
+    const body = await res.json();
+    expect(body.resource).toBe(`${INDEXER_URL}/v2/mcp`);
+  });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      `${INDEXER_URL}/.well-known/oauth-protected-resource/v2/mcp`,
-      expect.objectContaining({
-        next: { revalidate: 3600 },
-        signal: expect.any(AbortSignal),
-      })
+  it("advertises NEXT_PUBLIC_GAP_OAUTH_URL as the authorization server", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.authorization_servers).toEqual([OAUTH_ISSUER]);
+  });
+
+  it("advertises the mcp scope", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.scopes_supported).toEqual(["mcp"]);
+  });
+
+  it("advertises header-based bearer auth", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  it("advertises RS256 signing algorithm", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.resource_signing_alg_values_supported).toEqual(["RS256"]);
+  });
+
+  it("points resource_documentation at the authorization-server metadata path", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.resource_documentation).toBe(
+      `${OAUTH_ISSUER}/.well-known/oauth-authorization-server`
     );
   });
 
-  it("returns 502 + fallback when upstream responds non-OK", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
-    const captureSpy = vi.spyOn(Sentry, "captureException");
-
+  it("sets wide-open CORS headers so agent crawlers can read it", async () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-    const body = await res.json();
-
-    expect(res.status).toBe(502);
-    expect(body).toEqual({ error: "upstream_unavailable" });
-    expect(captureSpy).toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.objectContaining({
-        tags: { route: "well-known/oauth-protected-resource" },
-        extra: { status: 503 },
-      })
-    );
-  });
-
-  it("returns 502 + fallback and captures when upstream throws", async () => {
-    const fetchError = new Error("ECONNREFUSED");
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(fetchError));
-    const captureSpy = vi.spyOn(Sentry, "captureException");
-
-    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-    const body = await res.json();
-
-    expect(res.status).toBe(502);
-    expect(body).toEqual({ error: "upstream_unavailable" });
-    expect(captureSpy).toHaveBeenCalledWith(fetchError, {
-      tags: { route: "well-known/oauth-protected-resource" },
-    });
-  });
-
-  it("uses no-store Cache-Control on 502 responses so CDNs do not pin failures", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
-
-    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-  });
-
-  it("uses public, max-age=3600 Cache-Control on success", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
-
-    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
-  });
-
-  it("sets wide-open CORS headers so AI crawlers can read it", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
-
-    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-
+    const res = GET();
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
     expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
     expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
   });
 
-  it("returns CORS headers even on upstream failure", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
-
+  it("sets long-lived Cache-Control on success", async () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
-    const res = await GET();
-
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
-    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    const res = GET();
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
   });
 
   it("OPTIONS returns 204 with CORS headers", async () => {
     const { OPTIONS } = await import("@/app/.well-known/oauth-protected-resource/route");
     const res = await OPTIONS();
-
     expect(res.status).toBe(204);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
     expect(res.headers.get("Access-Control-Allow-Methods")).toContain("OPTIONS");
     expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+
+  // Placed last so the per-test doMock can't leak into other tests that
+  // rely on the global setup-mocks env (vi.doMock persists module cache
+  // overrides even when vi.resetModules() runs in beforeEach).
+  it("throws when NEXT_PUBLIC_GAP_OAUTH_URL is unset", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: {
+        NEXT_PUBLIC_GAP_INDEXER_URL: "http://localhost:4000",
+        NEXT_PUBLIC_GAP_OAUTH_URL: "",
+      },
+    }));
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    expect(() => GET()).toThrow(/NEXT_PUBLIC_GAP_OAUTH_URL is not set/);
+    vi.doUnmock("@/utilities/enviromentVars");
   });
 });

--- a/__tests__/components/Seo/OrganizationJsonLd.test.tsx
+++ b/__tests__/components/Seo/OrganizationJsonLd.test.tsx
@@ -67,6 +67,34 @@ describe("OrganizationJsonLd", () => {
       expect(schema.sameAs).toContain("https://github.com/show-karma");
       expect(schema.sameAs).not.toContain("https://twitter.com/karmahq_");
     });
+
+    it("should include LinkedIn and Crunchbase entity URLs in sameAs", () => {
+      const { container } = render(<OrganizationJsonLd />);
+      const schema = getOrganizationSchema(container);
+      expect(schema.sameAs).toContain("https://linkedin.com/company/karmahq");
+      expect(schema.sameAs).toContain("https://crunchbase.com/organization/karmahq");
+    });
+
+    it("should expose a customer-service contactPoint", () => {
+      const { container } = render(<OrganizationJsonLd />);
+      const schema = getOrganizationSchema(container);
+      expect(schema.contactPoint).toEqual({
+        "@type": "ContactPoint",
+        contactType: "customer service",
+        email: "info@karmahq.xyz",
+        areaServed: "Worldwide",
+        availableLanguage: ["English"],
+      });
+    });
+
+    it("should expose a PostalAddress with US country", () => {
+      const { container } = render(<OrganizationJsonLd />);
+      const schema = getOrganizationSchema(container);
+      expect(schema.address).toEqual({
+        "@type": "PostalAddress",
+        addressCountry: "US",
+      });
+    });
   });
 
   describe("WebApplication schema", () => {

--- a/__tests__/components/Seo/SpeakableJsonLd.test.tsx
+++ b/__tests__/components/Seo/SpeakableJsonLd.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "@testing-library/react";
 import { SpeakableJsonLd } from "@/components/Seo/SpeakableJsonLd";
-import { SITE_URL } from "@/utilities/meta";
 
 function extractJsonLd(container: HTMLElement): Record<string, unknown> {
   const script = container.querySelector('script[type="application/ld+json"]');
@@ -11,11 +10,14 @@ function extractJsonLd(container: HTMLElement): Record<string, unknown> {
 }
 
 describe("SpeakableJsonLd", () => {
-  it("renders a WebPage schema with @id pointing at the site root", () => {
+  it("renders a WebPage schema without a hardcoded @id", () => {
+    // The component ships in the root layout, i.e. on every page —
+    // pinning @id to a single URL would mis-attribute the speakable
+    // selectors. Crawlers infer the resource identity from the page URL.
     const { container } = render(<SpeakableJsonLd />);
     const schema = extractJsonLd(container);
     expect(schema["@type"]).toBe("WebPage");
-    expect(schema["@id"]).toBe(SITE_URL);
+    expect(schema["@id"]).toBeUndefined();
   });
 
   it("declares a SpeakableSpecification with a cssSelector array", () => {

--- a/__tests__/components/Seo/SpeakableJsonLd.test.tsx
+++ b/__tests__/components/Seo/SpeakableJsonLd.test.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import { SpeakableJsonLd } from "@/components/Seo/SpeakableJsonLd";
+import { SITE_URL } from "@/utilities/meta";
+
+function extractJsonLd(container: HTMLElement): Record<string, unknown> {
+  const script = container.querySelector('script[type="application/ld+json"]');
+  if (!script || !script.textContent) {
+    throw new Error("No JSON-LD script tag rendered");
+  }
+  return JSON.parse(script.textContent);
+}
+
+describe("SpeakableJsonLd", () => {
+  it("renders a WebPage schema with @id pointing at the site root", () => {
+    const { container } = render(<SpeakableJsonLd />);
+    const schema = extractJsonLd(container);
+    expect(schema["@type"]).toBe("WebPage");
+    expect(schema["@id"]).toBe(SITE_URL);
+  });
+
+  it("declares a SpeakableSpecification with a cssSelector array", () => {
+    const { container } = render(<SpeakableJsonLd />);
+    const schema = extractJsonLd(container);
+    const speakable = schema.speakable as Record<string, unknown>;
+    expect(speakable["@type"]).toBe("SpeakableSpecification");
+    expect(Array.isArray(speakable.cssSelector)).toBe(true);
+  });
+
+  it("targets the H1 and any data-speakable element on the page", () => {
+    const { container } = render(<SpeakableJsonLd />);
+    const schema = extractJsonLd(container);
+    const speakable = schema.speakable as { cssSelector: string[] };
+    expect(speakable.cssSelector).toContain("h1");
+    expect(speakable.cssSelector).toContain("[data-speakable]");
+  });
+
+  it("emits the @context required for Schema.org parsing", () => {
+    const { container } = render(<SpeakableJsonLd />);
+    const schema = extractJsonLd(container);
+    expect(schema["@context"]).toBe("https://schema.org");
+  });
+});

--- a/__tests__/setup-mocks.ts
+++ b/__tests__/setup-mocks.ts
@@ -51,6 +51,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/utilities/enviromentVars", () => ({
   envVars: {
     NEXT_PUBLIC_GAP_INDEXER_URL: "http://localhost:4000",
+    NEXT_PUBLIC_GAP_OAUTH_URL: "https://oauth.test.karmahq.xyz",
     NEXT_PUBLIC_ENV: "development",
     isDev: false,
     NEXT_PUBLIC_KARMA_API: "https://api.karmahq.xyz/api",

--- a/app/.well-known/agent-card.json/route.ts
+++ b/app/.well-known/agent-card.json/route.ts
@@ -21,11 +21,19 @@ export const revalidate = 3600;
  */
 
 export function GET() {
+  // Ora and similar AEO crawlers look at the root for `name` and
+  // `description`, while A2A consumers expect the nested `agent` envelope.
+  // We expose both — same values, no drift.
+  const name = "Karma";
+  const description =
+    "Discover funding programs, projects, milestones, and impact data. Submit applications, track grants, and post updates via an MCP server with OAuth.";
+
   const body = {
+    name,
+    description,
     agent: {
-      name: "Karma",
-      description:
-        "Discover funding programs, projects, milestones, and impact data. Submit applications, track grants, and post updates via an MCP server with OAuth.",
+      name,
+      description,
       url: SITE_URL,
       version: "1.0.0",
       documentationUrl: `${SITE_URL}/mcp/connect`,

--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -45,6 +45,24 @@ export function GET() {
             type: "application/json",
           },
         ],
+        item: [
+          {
+            href: `${SITE_URL}/openapi.json`,
+            type: "application/json",
+          },
+          {
+            href: `${apiUrl}/v2/docs`,
+            type: "text/html",
+          },
+          {
+            href: `${SITE_URL}/.well-known/mcp.json`,
+            type: "application/json",
+          },
+          {
+            href: `${SITE_URL}/.well-known/mcp/server-card.json`,
+            type: "application/json",
+          },
+        ],
       },
     ],
   };

--- a/app/.well-known/mcp/server-card.json/route.ts
+++ b/app/.well-known/mcp/server-card.json/route.ts
@@ -37,6 +37,8 @@ export function GET() {
   const body = {
     name: "gap-tools",
     alternateNames: ["karma-gap-tools"],
+    description:
+      "MCP server for Karma — discover funding programs, projects, milestones, grants, and impact data across 8 blockchain networks. Read-only public tools without auth; OAuth or API-key for mutations.",
     version: "1.0.0",
     protocolVersion: MCP_PROTOCOL_VERSION,
     transport: "http",

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import { envVars } from "@/utilities/enviromentVars";
 import {
@@ -26,10 +27,19 @@ export const revalidate = 3600;
 
 export function GET() {
   const issuer = envVars.NEXT_PUBLIC_GAP_OAUTH_URL;
-  if (!issuer || typeof issuer !== "string" || issuer.trim() === "") {
-    throw new Error(
+  if (!issuer || issuer.trim() === "") {
+    // Capture explicitly so Sentry alerts carry the route tag. The
+    // default unhandled-error capture wouldn't — and we'd lose the
+    // operational visibility the previous proxy route had via its
+    // upstream Sentry.captureException calls. With `force-static`
+    // this also surfaces a misconfigured env var at build time.
+    const err = new Error(
       "NEXT_PUBLIC_GAP_OAUTH_URL is not set. Required for /.well-known/oauth-protected-resource."
     );
+    Sentry.captureException(err, {
+      tags: { route: "well-known/oauth-protected-resource" },
+    });
+    throw err;
   }
   const resource = `${getIndexerBaseUrl()}/v2/mcp`;
 

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,9 +1,8 @@
-import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
+import { envVars } from "@/utilities/enviromentVars";
 import {
   getIndexerBaseUrl,
   WELL_KNOWN_CORS_HEADERS,
-  WELL_KNOWN_ERROR_HEADERS,
   WELL_KNOWN_PREFLIGHT_HEADERS,
 } from "@/utilities/wellKnown";
 
@@ -13,52 +12,37 @@ export const revalidate = 3600;
 /**
  * RFC 9728 OAuth Protected Resource Metadata at the apex.
  *
- * RFC 9728 §3.1 puts the canonical document at
- * `${resource}/.well-known/oauth-protected-resource/<resource-path>` —
- * which for Karma's MCP server lives on the indexer at
- * `${indexer}/.well-known/oauth-protected-resource/v2/mcp`. Ora and other
- * agent crawlers, however, probe the root-rooted apex path
- * `https://www.karmahq.xyz/.well-known/oauth-protected-resource`, so we
- * proxy the indexer's document here. Hourly-revalidated ISR, 5s timeout,
- * Sentry-captured on failure, no-cache 502 fallback. Same shape as the
- * /openapi.json and /.well-known/mcp-tools.json proxies.
+ * Served directly from gap-app-v2 rather than proxying gap-indexer's
+ * canonical endpoint. Rationale: the document is essentially static
+ * config (resource URL + authorization server URL + scopes + signing
+ * algs) — no per-request data — so the upstream round-trip is wasted
+ * cost. Previously we proxied, but the gap-indexer route silently
+ * 404'd in production (registration failed to take effect post-deploy)
+ * and fired a Sentry alert on every probe.
+ *
+ * Authorization server URL is sourced from NEXT_PUBLIC_GAP_OAUTH_URL.
+ * Resource URL is the MCP endpoint on the indexer.
  */
 
-const FALLBACK_BODY = { error: "upstream_unavailable" };
-const UPSTREAM_TIMEOUT_MS = 5000;
-
-export async function GET() {
-  try {
-    const res = await fetch(`${getIndexerBaseUrl()}/.well-known/oauth-protected-resource/v2/mcp`, {
-      next: { revalidate: 3600 },
-      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-    });
-
-    if (!res.ok) {
-      Sentry.captureException(
-        new Error(`Upstream /.well-known/oauth-protected-resource/v2/mcp returned ${res.status}`),
-        {
-          tags: { route: "well-known/oauth-protected-resource" },
-          extra: { status: res.status },
-        }
-      );
-      return NextResponse.json(FALLBACK_BODY, {
-        status: 502,
-        headers: WELL_KNOWN_ERROR_HEADERS,
-      });
-    }
-
-    const body = await res.json();
-    return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
-  } catch (err) {
-    Sentry.captureException(err, {
-      tags: { route: "well-known/oauth-protected-resource" },
-    });
-    return NextResponse.json(FALLBACK_BODY, {
-      status: 502,
-      headers: WELL_KNOWN_ERROR_HEADERS,
-    });
+export function GET() {
+  const issuer = envVars.NEXT_PUBLIC_GAP_OAUTH_URL;
+  if (!issuer || typeof issuer !== "string" || issuer.trim() === "") {
+    throw new Error(
+      "NEXT_PUBLIC_GAP_OAUTH_URL is not set. Required for /.well-known/oauth-protected-resource."
+    );
   }
+  const resource = `${getIndexerBaseUrl()}/v2/mcp`;
+
+  const body = {
+    resource,
+    authorization_servers: [issuer],
+    scopes_supported: ["mcp"],
+    bearer_methods_supported: ["header"],
+    resource_signing_alg_values_supported: ["RS256"],
+    resource_documentation: `${issuer}/.well-known/oauth-authorization-server`,
+  };
+
+  return NextResponse.json(body, { headers: WELL_KNOWN_CORS_HEADERS });
 }
 
 export async function OPTIONS() {

--- a/app/about/error.tsx
+++ b/app/about/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function AboutErrorBoundary({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-bold text-black dark:text-white">Something went wrong</h1>
+      <p className="mt-4 text-base text-zinc-700 dark:text-zinc-300">
+        The About page failed to load. This is usually temporary.
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/app/about/loading.tsx
+++ b/app/about/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="h-9 w-64 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      <div className="mt-6 space-y-3">
+        <div className="h-4 w-full animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-4 w-5/6 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-4 w-4/6 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+    </main>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { customMetadata } from "@/utilities/meta";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 export const metadata: Metadata = customMetadata({
-  title: "About",
+  title: "About Karma",
   description:
     "Karma is a platform that helps ecosystems allocate funding transparently and helps builders share progress, earn reputation, and get discovered.",
   path: "/about",
@@ -18,7 +20,13 @@ const styles = {
   a: "text-blue-500 underline",
 };
 
-export default function AboutPage() {
+export default async function AboutPage() {
+  // Karma-branded marketing copy — hide on whitelabel tenants so a
+  // partner's own /about isn't shadowed by ours. Matches the gate on
+  // OrganizationJsonLd in app/layout.tsx.
+  const { isWhitelabel } = await getWhitelabelContext();
+  if (isWhitelabel) notFound();
+
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
       <h1 className={styles.h1}>About Karma</h1>
@@ -84,7 +92,10 @@ export default function AboutPage() {
 
       <h2 className={styles.h2}>Contact</h2>
       <p className={styles.p}>
-        For partnership inquiries, support, or general questions: info@karmahq.xyz
+        For partnership inquiries, support, or general questions:{" "}
+        <a className={styles.a} href="mailto:info@karmahq.xyz">
+          info@karmahq.xyz
+        </a>
       </p>
     </main>
   );

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "About",
+  description:
+    "Karma is a platform that helps ecosystems allocate funding transparently and helps builders share progress, earn reputation, and get discovered.",
+  path: "/about",
+});
+
+const styles = {
+  h1: "text-3xl font-bold text-black dark:text-white",
+  h2: "text-xl font-bold text-black dark:text-white mt-8",
+  p: "text-base text-black dark:text-white mt-4",
+  ul: "list-disc list-inside mt-4 space-y-2",
+  li: "text-base text-zinc-700 dark:text-zinc-300",
+  a: "text-blue-500 underline",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className={styles.h1}>About Karma</h1>
+
+      <p className={styles.p}>
+        Karma is a platform that helps ecosystems allocate funding transparently and helps builders
+        share their progress, earn reputation, and get discovered for more opportunities. Funders
+        use Karma to coordinate grant programs end-to-end — from application intake through
+        milestone tracking, evaluation, payout, and impact reporting. Builders use it to publish
+        project profiles, claim grants, post updates, and prove delivery on-chain.
+      </p>
+
+      <h2 className={styles.h2}>What we do</h2>
+      <p className={styles.p}>
+        Karma turns the messy operational work of running a funding program — Google Forms,
+        Airtable, Discord, Notion, spreadsheet trackers — into one workflow:
+      </p>
+      <ul className={styles.ul}>
+        <li className={styles.li}>
+          <strong>Project profiles</strong> with verifiable on-chain attestations of milestones,
+          grants, and impact indicators
+        </li>
+        <li className={styles.li}>
+          <strong>Funding programs</strong> with configurable intake forms, reviewer workflows, and
+          AI-assisted evaluation
+        </li>
+        <li className={styles.li}>
+          <strong>Milestone tracking</strong> with completion attestations submitted by builders and
+          verified by funders
+        </li>
+        <li className={styles.li}>
+          <strong>Payout coordination</strong> across 8 blockchain networks (Optimism, Arbitrum One,
+          Polygon, Base, Celo, Scroll, Lisk, Sei) with multi-signature support and disbursement
+          auditing
+        </li>
+        <li className={styles.li}>
+          <strong>Impact measurement</strong> through self-reported indicators tied back to specific
+          funded work
+        </li>
+      </ul>
+
+      <h2 className={styles.h2}>How we are different</h2>
+      <p className={styles.p}>
+        Most grant operations today are stitched together from generic tools. Karma replaces that
+        stack with software designed specifically for funding-program workflows, with native
+        blockchain attestations for verifiable execution history. Public read access for anyone (no
+        sign-in to browse projects or programs); OAuth or API key for authenticated operations.
+      </p>
+
+      <h2 className={styles.h2}>For developers and AI agents</h2>
+      <p className={styles.p}>
+        Karma exposes an MCP (Model Context Protocol) server so AI agents can discover programs,
+        draft applications, audit milestones, and analyze impact data directly. See our{" "}
+        <Link className={styles.a} href="/mcp/connect">
+          MCP setup guide
+        </Link>{" "}
+        and the{" "}
+        <Link className={styles.a} href="/for-agents">
+          For AI Agents
+        </Link>{" "}
+        landing page.
+      </p>
+
+      <h2 className={styles.h2}>Contact</h2>
+      <p className={styles.p}>
+        For partnership inquiries, support, or general questions: info@karmahq.xyz
+      </p>
+    </main>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 export const metadata: Metadata = customMetadata({
@@ -80,11 +81,11 @@ export default async function AboutPage() {
       <p className={styles.p}>
         Karma exposes an MCP (Model Context Protocol) server so AI agents can discover programs,
         draft applications, audit milestones, and analyze impact data directly. See our{" "}
-        <Link className={styles.a} href="/mcp/connect">
+        <Link className={styles.a} href={PAGES.MCP_CONNECT}>
           MCP setup guide
         </Link>{" "}
         and the{" "}
-        <Link className={styles.a} href="/for-agents">
+        <Link className={styles.a} href={PAGES.FOR_AGENTS}>
           For AI Agents
         </Link>{" "}
         landing page.

--- a/app/contact/error.tsx
+++ b/app/contact/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function ContactErrorBoundary({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-bold text-black dark:text-white">Something went wrong</h1>
+      <p className="mt-4 text-base text-zinc-700 dark:text-zinc-300">
+        The Contact page failed to load. This is usually temporary.
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/app/contact/loading.tsx
+++ b/app/contact/loading.tsx
@@ -1,0 +1,11 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <div className="h-9 w-64 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      <div className="mt-6 space-y-3">
+        <div className="h-4 w-full animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-4 w-5/6 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      </div>
+    </main>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "Contact",
+  description:
+    "Contact Karma — partnership inquiries, support, security disclosures, and developer documentation.",
+  path: "/contact",
+});
+
+const styles = {
+  h1: "text-3xl font-bold text-black dark:text-white",
+  h2: "text-xl font-bold text-black dark:text-white mt-8",
+  p: "text-base text-black dark:text-white mt-4",
+  a: "text-blue-500 underline",
+};
+
+export default function ContactPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className={styles.h1}>Contact Karma</h1>
+
+      <h2 className={styles.h2}>General inquiries</h2>
+      <p className={styles.p}>
+        <a className={styles.a} href="mailto:info@karmahq.xyz">
+          info@karmahq.xyz
+        </a>{" "}
+        — partnerships, support, and general questions.
+      </p>
+
+      <h2 className={styles.h2}>Funders</h2>
+      <p className={styles.p}>
+        Running a grants program and want to use Karma? Email info@karmahq.xyz with details about
+        your ecosystem, program structure, and rough budget. We respond within 1-2 business days.
+      </p>
+
+      <h2 className={styles.h2}>Builders</h2>
+      <p className={styles.p}>
+        Looking to apply to a program? Browse open programs at{" "}
+        <Link className={styles.a} href="/funding-map">
+          Funding Map
+        </Link>
+        . To create your project profile, start at{" "}
+        <Link className={styles.a} href="/create-project-profile">
+          Create Project
+        </Link>
+        .
+      </p>
+
+      <h2 className={styles.h2}>Developers and AI agents</h2>
+      <p className={styles.p}>
+        Karma exposes a public REST API and MCP server. See the{" "}
+        <a
+          className={styles.a}
+          href="https://gapapi.karmahq.xyz/v2/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          API documentation
+        </a>{" "}
+        and the{" "}
+        <Link className={styles.a} href="/mcp/connect">
+          MCP setup guide
+        </Link>
+        .
+      </p>
+
+      <h2 className={styles.h2}>Reporting issues</h2>
+      <p className={styles.p}>
+        For security disclosures, email info@karmahq.xyz with subject &ldquo;Security:&rdquo;. For
+        platform bugs or feature requests, mention us at{" "}
+        <a
+          className={styles.a}
+          href="https://x.com/karmahq_"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          x.com/karmahq_
+        </a>{" "}
+        or open an issue on{" "}
+        <a
+          className={styles.a}
+          href="https://github.com/show-karma"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+
+      <h2 className={styles.h2}>Office hours</h2>
+      <p className={styles.p}>
+        Karma is a globally-distributed team — there is no single office. Communications happen
+        async via email and GitHub.
+      </p>
+    </main>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { customMetadata } from "@/utilities/meta";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 export const metadata: Metadata = customMetadata({
-  title: "Contact",
+  title: "Contact Karma",
   description:
     "Contact Karma — partnership inquiries, support, security disclosures, and developer documentation.",
   path: "/contact",
@@ -16,7 +18,10 @@ const styles = {
   a: "text-blue-500 underline",
 };
 
-export default function ContactPage() {
+export default async function ContactPage() {
+  const { isWhitelabel } = await getWhitelabelContext();
+  if (isWhitelabel) notFound();
+
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
       <h1 className={styles.h1}>Contact Karma</h1>
@@ -31,8 +36,12 @@ export default function ContactPage() {
 
       <h2 className={styles.h2}>Funders</h2>
       <p className={styles.p}>
-        Running a grants program and want to use Karma? Email info@karmahq.xyz with details about
-        your ecosystem, program structure, and rough budget. We respond within 1-2 business days.
+        Running a grants program and want to use Karma? Email{" "}
+        <a className={styles.a} href="mailto:info@karmahq.xyz">
+          info@karmahq.xyz
+        </a>{" "}
+        with details about your ecosystem, program structure, and rough budget. We respond within
+        1-2 business days.
       </p>
 
       <h2 className={styles.h2}>Builders</h2>
@@ -68,8 +77,11 @@ export default function ContactPage() {
 
       <h2 className={styles.h2}>Reporting issues</h2>
       <p className={styles.p}>
-        For security disclosures, email info@karmahq.xyz with subject &ldquo;Security:&rdquo;. For
-        platform bugs or feature requests, mention us at{" "}
+        For security disclosures, email{" "}
+        <a className={styles.a} href="mailto:info@karmahq.xyz?subject=Security%3A">
+          info@karmahq.xyz
+        </a>{" "}
+        with subject &ldquo;Security:&rdquo;. For platform bugs or feature requests, mention us at{" "}
         <a
           className={styles.a}
           href="https://x.com/karmahq_"
@@ -81,7 +93,7 @@ export default function ContactPage() {
         or open an issue on{" "}
         <a
           className={styles.a}
-          href="https://github.com/show-karma"
+          href="https://github.com/show-karma/gap-app-v2/issues"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { customMetadata } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 export const metadata: Metadata = customMetadata({
@@ -69,7 +70,7 @@ export default async function ContactPage() {
           API documentation
         </a>{" "}
         and the{" "}
-        <Link className={styles.a} href="/mcp/connect">
+        <Link className={styles.a} href={PAGES.MCP_CONNECT}>
           MCP setup guide
         </Link>
         .

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { ThemeProvider } from "next-themes";
 import { DeferredLayoutComponents } from "@/components/DeferredLayoutComponents";
 import { OrganizationJsonLd } from "@/components/Seo/OrganizationJsonLd";
+import { SpeakableJsonLd } from "@/components/Seo/SpeakableJsonLd";
 import { PermissionsProvider } from "@/components/Utilities/PermissionsProvider";
 import PrivyProviderWrapper from "@/components/Utilities/PrivyProviderWrapper";
 import { TenantStoreInitializer } from "@/components/Utilities/TenantStoreInitializer";
@@ -168,6 +169,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </PrivyProviderWrapper>
         </ThemeProvider>
         {!isWhitelabel && <OrganizationJsonLd />}
+        {!isWhitelabel && <SpeakableJsonLd />}
       </body>
     </html>
   );

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -11,23 +11,37 @@ export default function robots(): MetadataRoute.Robots {
       },
       {
         userAgent: "GPTBot",
-        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt"],
+        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt", "/agents.md"],
+        disallow: ["/api/", "/admin/", "/super-admin/", "/safe/"],
+      },
+      {
+        userAgent: "ChatGPT-User",
+        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt", "/agents.md"],
         disallow: ["/api/", "/admin/", "/super-admin/", "/safe/"],
       },
       {
         userAgent: "ClaudeBot",
-        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt"],
+        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt", "/agents.md"],
         disallow: ["/api/", "/admin/", "/super-admin/", "/safe/"],
       },
       {
         userAgent: "PerplexityBot",
-        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt"],
+        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt", "/agents.md"],
         disallow: ["/api/", "/admin/", "/super-admin/", "/safe/"],
       },
       {
         userAgent: "Google-Extended",
-        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt"],
+        allow: ["/", "/.well-known/", "/llms.txt", "/llms-full.txt", "/agents.md"],
         disallow: ["/api/", "/admin/", "/super-admin/", "/safe/"],
+      },
+      // Training-only crawlers: no answer-engine value, full disallow.
+      {
+        userAgent: "CCBot",
+        disallow: ["/"],
+      },
+      {
+        userAgent: "Bytespider",
+        disallow: ["/"],
       },
     ],
     sitemap: [`${SITE_URL}/sitemap.xml`],

--- a/app/sitemaps/static/sitemap.ts
+++ b/app/sitemaps/static/sitemap.ts
@@ -38,6 +38,8 @@ const staticPages = [
   "/knowledge/how-funders-use-project-profiles",
   "/mcp/connect",
   "/for-agents",
+  "/about",
+  "/contact",
   "/privacy-policy",
   "/terms-and-conditions",
   "/dashboard",

--- a/components/Seo/OrganizationJsonLd.tsx
+++ b/components/Seo/OrganizationJsonLd.tsx
@@ -9,7 +9,23 @@ const organizationSchema = {
   logo: `${SITE_URL}/logo/karma-logo.svg`,
   description: DEFAULT_DESCRIPTION,
   email: "info@karmahq.xyz",
-  sameAs: ["https://x.com/karmahq_", "https://github.com/show-karma"],
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "customer service",
+    email: "info@karmahq.xyz",
+    areaServed: "Worldwide",
+    availableLanguage: ["English"],
+  },
+  address: {
+    "@type": "PostalAddress",
+    addressCountry: "US",
+  },
+  sameAs: [
+    "https://x.com/karmahq_",
+    "https://github.com/show-karma",
+    "https://linkedin.com/company/karmahq",
+    "https://crunchbase.com/organization/karmahq",
+  ],
 };
 
 const webApplicationSchema = {

--- a/components/Seo/SpeakableJsonLd.tsx
+++ b/components/Seo/SpeakableJsonLd.tsx
@@ -15,7 +15,6 @@ export function SpeakableJsonLd() {
   return (
     <script
       type="application/ld+json"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data requires dangerouslySetInnerHTML
       dangerouslySetInnerHTML={{
         __html: safeJsonLdStringify(speakableSchema),
       }}

--- a/components/Seo/SpeakableJsonLd.tsx
+++ b/components/Seo/SpeakableJsonLd.tsx
@@ -1,0 +1,24 @@
+import { safeJsonLdStringify } from "@/utilities/jsonLd";
+import { SITE_URL } from "@/utilities/meta";
+
+const speakableSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": SITE_URL,
+  speakable: {
+    "@type": "SpeakableSpecification",
+    cssSelector: ["h1", "[data-speakable]"],
+  },
+};
+
+export function SpeakableJsonLd() {
+  return (
+    <script
+      type="application/ld+json"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data requires dangerouslySetInnerHTML
+      dangerouslySetInnerHTML={{
+        __html: safeJsonLdStringify(speakableSchema),
+      }}
+    />
+  );
+}

--- a/components/Seo/SpeakableJsonLd.tsx
+++ b/components/Seo/SpeakableJsonLd.tsx
@@ -1,10 +1,12 @@
 import { safeJsonLdStringify } from "@/utilities/jsonLd";
-import { SITE_URL } from "@/utilities/meta";
 
+// No `@id` — this component is mounted in the root layout and therefore
+// ships on every page. Pinning `@id` to a single URL (e.g. SITE_URL)
+// would tell crawlers that every page is the same resource, which is
+// semantically wrong. Crawlers infer the resource from the page URL.
 const speakableSchema = {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "@id": SITE_URL,
   speakable: {
     "@type": "SpeakableSpecification",
     cssSelector: ["h1", "[data-speakable]"],

--- a/e2e/tests/smoke/rbac-access-control.smoke.spec.ts
+++ b/e2e/tests/smoke/rbac-access-control.smoke.spec.ts
@@ -15,7 +15,10 @@ async function expectAccessBlocked(page: Page, originalPath: string): Promise<vo
 
   const showsDenialText = await page
     .getByText(
-      /sign in|connect wallet|log in|access denied|not authorized|forbidden|only.*admin.*can view|isnt.*admin|need to be an admin/i
+      // Covers both the legacy "Access Denied / not authorized" copy and the
+      // RBAC-aware copy introduced by PR #1441 ("You're almost there / needs
+      // a role your account doesn't have yet / Reach out to ... admin").
+      /sign in|connect wallet|log in|access denied|not authorized|forbidden|only.*admin.*can view|isnt.*admin|need to be an admin|almost there|needs a role|reach out to/i
     )
     .first()
     .waitFor({ timeout: 5000 })


### PR DESCRIPTION
## Summary

- 10 small AEO polish changes addressing trivial-fix gaps from orank's latest scan (current: 68/100)
- Fixes Sentry alert GAP-FRONTEND-21E by direct-serving OAuth protected-resource metadata from the apex (was proxying a gap-indexer endpoint that 404s in production)
- Projected score impact: 68 → ~77

## Why

[orank scan](https://ora.ai/scan/karmahq.xyz) flagged 9 specific Tier-S gaps that are each a single-line / single-file fix, plus 1 operational fix to silence a production Sentry alert. Bundled into one focused PR.

## What's new

| orank finding | Fix in this PR |
|---|---|
| `agent-card.json` "missing name, description" | Exposed both at root in addition to nested `agent` envelope |
| `mcp/server-card.json` "missing fields: description" | Added a description field |
| `api-catalog` "linkset[0] has no 'item' entries" | Added 4 `item` entries (RFC 9727) pointing at openapi.json, swagger UI, mcp.json, mcp/server-card.json |
| `Organization schema` missing `contactPoint` + `address` | Added both (customer-service email contact, country-only PostalAddress) |
| `JSON-LD entity linking (sameAs)` only github | Added LinkedIn + Crunchbase URLs to sameAs |
| `Speakable content markup` not detected | New `SpeakableJsonLd` component mounted globally; targets `h1` + `[data-speakable]` |
| `robots.txt AI policy quality` "consider blocking training-only crawlers" | Block CCBot + Bytespider; explicit ChatGPT-User allow |
| `Trust anchor pages` only /privacy verified | New /about (~1200 chars) and /contact (~800 chars) pages, both with proper metadata, loading + error states, sitemap entries |
| `Agent platform configs` could not locate AGENTS.md | AGENTS.md already exists as a symlink to CLAUDE.md at repo root (verified; no change needed) |

## Sentry alert resolved

GAP-FRONTEND-21E fires today because `/.well-known/oauth-protected-resource` proxies `gapapi.karmahq.xyz/.well-known/oauth-protected-resource/v2/mcp` which returns 404 in production despite the route being registered in gap-indexer's `app/modules/v2/api/routes/index.ts:602`. Most likely a silent Fastify plugin registration ordering issue — can't diagnose without prod logs.

This PR replaces the proxy with direct-serve from the apex. The RFC 9728 document is static config (resource URL, authorization server URL, scopes, signing alg) — no per-request data, no upstream needed. Sources `authorization_servers` from existing `NEXT_PUBLIC_GAP_OAUTH_URL` (= `https://oauth.karmahq.xyz`). Throws at build/request time if the env var is unset.

## Validation

- Biome: clean (3 initial warnings introduced by new code were fixed before final commit)
- TypeScript: clean (after `.next` cache cleared — stale type-check references unrelated)
- Tests: 106/106 pass across well-known + Seo + new about + new contact suites
- Build: succeeds, all new routes appear in build output
- Quality gate: ✅ Passed — no regressions vs main

## Deploy notes

- Purge CDN cache for `/.well-known/oauth-protected-resource`, `/.well-known/agent-card.json`, `/.well-known/mcp/server-card.json`, `/.well-known/api-catalog`, `/about`, `/contact` after deploy
- Confirm `NEXT_PUBLIC_GAP_OAUTH_URL` is set on the Vercel project (already in use; this PR just reads it for one more file)
- Re-run orank scan ~6h after deploy to let CDN warmup settle

## Out of scope

- Wikipedia/Wikidata entity (-4 + -2) — external, needs notability/press
- NPM/PyPI SDK (-3) — multi-week engineering project
- Webhooks (-2), Sandbox (-2), NLWeb /ask (-2), WebMCP (-2), A2UI (-2), cursor pagination (-1), CLI (-1) — substantial engineering, deferred
- Wikipedia article, third-party citations, comparison pages, MCP registry submissions — content / external work
- Tier B (gap-indexer OpenAPI improvements: operationIds, typed errors, Idempotency-Key, RFC 9598 rate-limit) — separate gap-indexer PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added About and Contact pages with company information and multiple contact options for different user types
  * Enhanced structured data markup with contact details and address information for improved search visibility

* **Improvements**
  * Updated search engine and AI crawler directives to support new content
  * Extended sitemap coverage with newly added pages
  * Implemented loading states and error boundaries for improved user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->