### PR TITLE
fix(milestone-delete): stop sending documented 403/409 rejections to Sentry

### DIFF
--- a/__tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx
+++ b/__tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx
@@ -1,0 +1,334 @@
+import { QueryClient } from "@tanstack/react-query";
+import { act, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import toast from "react-hot-toast";
+import { errorManager } from "@/components/Utilities/errorManager";
+import { useDeleteMilestone } from "@/hooks/useDeleteMilestone";
+import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+import { envVars } from "@/utilities/enviromentVars";
+import { installMswLifecycle, server } from "../../msw/server";
+import { renderHookWithProviders } from "../../utils/render";
+
+function createPersistentQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn().mockResolvedValue("test-token") },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ address: "0xrequester", ready: true }),
+}));
+
+vi.mock("@/hooks/useMixpanel", () => ({
+  useMixpanel: () => ({ mixpanel: { reportEvent: vi.fn() } }),
+}));
+
+vi.mock("react-hot-toast", async () => {
+  const actual = await vi.importActual<typeof import("react-hot-toast")>("react-hot-toast");
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      success: vi.fn(),
+      error: vi.fn(),
+      loading: vi.fn().mockReturnValue("toast-id"),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+installMswLifecycle();
+
+const PROJECT_ID = "project-001";
+const PROGRAM_ID = "program-001";
+const MILESTONE_UID = "milestone-uid-001";
+const MILESTONE_TITLE = "Audit Completion";
+const INDEXER_BASE = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
+
+function createMilestone(
+  overrides?: Partial<GrantMilestoneWithCompletion>
+): GrantMilestoneWithCompletion {
+  return {
+    uid: MILESTONE_UID,
+    chainId: 10,
+    programId: PROGRAM_ID,
+    title: MILESTONE_TITLE,
+    description: "Complete security audit",
+    dueDate: "2024-12-31T00:00:00Z",
+    status: "pending",
+    completionDetails: null,
+    verificationDetails: null,
+    fundingApplicationCompletion: null,
+    ...overrides,
+  };
+}
+
+function mockDeleteResponse(body: unknown, status: number) {
+  server.use(
+    http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, () =>
+      HttpResponse.json(body, { status })
+    )
+  );
+}
+
+function renderHook() {
+  const queryClient = createPersistentQueryClient();
+  return renderHookWithProviders(
+    () => useDeleteMilestone({ projectId: PROJECT_ID, programId: PROGRAM_ID }),
+    { queryClient }
+  );
+}
+
+function lastToastErrorMessage(): string | undefined {
+  const calls = (toast.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  const last = calls.at(-1);
+  return last?.[0] as string | undefined;
+}
+
+async function expectToastErrorEventually(expected: string): Promise<void> {
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalled();
+  });
+  expect(lastToastErrorMessage()).toBe(expected);
+}
+
+describe("useDeleteMilestone (error mapping)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_show_already_completed_copy_when_backend_returns_409_completed", async () => {
+    mockDeleteResponse(
+      {
+        error: "Conflict",
+        message: `Cannot delete milestone that is already completed: ${MILESTONE_UID}`,
+      },
+      409
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      `"${MILESTONE_TITLE}" already has a completion and can't be deleted. Reject the completion first.`
+    );
+  });
+
+  it("should_show_already_revoked_copy_when_backend_returns_409_already_revoked", async () => {
+    mockDeleteResponse(
+      { error: "Conflict", message: `Milestone is already revoked: ${MILESTONE_UID}` },
+      409
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      `"${MILESTONE_TITLE}" is already deleted on-chain. Refresh the page to update the list.`
+    );
+  });
+
+  it("should_show_not_found_copy_when_backend_returns_409_not_found", async () => {
+    mockDeleteResponse(
+      { error: "Conflict", message: `Milestone not found: ${MILESTONE_UID}` },
+      409
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      `"${MILESTONE_TITLE}" was not found on-chain. It may have been removed already — refresh the page.`
+    );
+  });
+
+  it("should_show_permission_copy_when_backend_returns_403", async () => {
+    mockDeleteResponse(
+      { error: "Forbidden", message: "User 0xabc is not authorized to delete milestones" },
+      403
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually("You don't have permission to delete this milestone.");
+  });
+
+  it("should_show_indexer_unavailable_copy_when_backend_returns_503", async () => {
+    mockDeleteResponse(
+      { error: "Service Unavailable", message: "Failed to fetch milestone attestation" },
+      503
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      "The indexer couldn't read the milestone right now. Try again in a moment."
+    );
+  });
+
+  it("should_show_admin_gas_copy_when_backend_returns_500_insufficient_funds", async () => {
+    mockDeleteResponse(
+      {
+        error: "Internal Server Error",
+        message: "Admin wallet has insufficient funds on chain 10",
+      },
+      500
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      "Karma admin wallet is out of gas on this chain. We've been alerted."
+    );
+  });
+
+  it("should_fall_back_to_backend_message_when_409_message_unmapped", async () => {
+    mockDeleteResponse(
+      { error: "Conflict", message: "Invalid milestone data: missing recipient" },
+      409
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually("Invalid milestone data: missing recipient");
+  });
+
+  it("should_fall_back_to_generic_copy_when_response_body_missing", async () => {
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, () =>
+        HttpResponse.json(null, { status: 500 })
+      )
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    const message = lastToastErrorMessage();
+    expect(typeof message).toBe("string");
+    expect((message ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("should_not_call_errorManager_when_status_is_409", async () => {
+    mockDeleteResponse(
+      {
+        error: "Conflict",
+        message: `Cannot delete milestone that is already completed: ${MILESTONE_UID}`,
+      },
+      409
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("should_not_call_errorManager_when_status_is_403", async () => {
+    mockDeleteResponse({ error: "Forbidden", message: "User not authorized" }, 403);
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    expect(errorManager).not.toHaveBeenCalled();
+  });
+
+  it("should_call_errorManager_when_status_is_500_other", async () => {
+    mockDeleteResponse(
+      {
+        error: "Internal Server Error",
+        message: "Failed to revoke milestone on chain 10: RPC down",
+      },
+      500
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await waitFor(() => {
+      expect(errorManager).toHaveBeenCalled();
+    });
+    const call = (errorManager as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1);
+    const extras = call?.[2] as { backendStatus?: number; backendMessage?: string } | undefined;
+    expect(extras?.backendStatus).toBe(500);
+    expect(extras?.backendMessage).toContain("Failed to revoke milestone");
+  });
+
+  it("should_show_stable_copy_and_call_errorManager_when_revocationSuccess_false", async () => {
+    server.use(
+      http.delete(`${INDEXER_BASE}/v2/milestones/:milestoneUID/on-chain-delete`, ({ params }) =>
+        HttpResponse.json({
+          milestoneUID: params.milestoneUID as string,
+          revocationSuccess: false,
+        })
+      )
+    );
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await expect(result.current.deleteMilestoneAsync(createMilestone())).rejects.toThrow();
+    });
+
+    await expectToastErrorEventually(
+      "On-chain milestone revocation failed. Please retry; if it persists, contact support."
+    );
+    expect(errorManager).toHaveBeenCalled();
+  });
+});

--- a/__tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx
+++ b/__tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx
@@ -91,9 +91,8 @@ function renderHook() {
 }
 
 function lastToastErrorMessage(): string | undefined {
-  const calls = (toast.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-  const last = calls.at(-1);
-  return last?.[0] as string | undefined;
+  const last = vi.mocked(toast.error).mock.calls.at(-1);
+  return last?.[0];
 }
 
 async function expectToastErrorEventually(expected: string): Promise<void> {
@@ -304,7 +303,7 @@ describe("useDeleteMilestone (error mapping)", () => {
     await waitFor(() => {
       expect(errorManager).toHaveBeenCalled();
     });
-    const call = (errorManager as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1);
+    const call = vi.mocked(errorManager).mock.calls.at(-1);
     const extras = call?.[2] as { backendStatus?: number; backendMessage?: string } | undefined;
     expect(extras?.backendStatus).toBe(500);
     expect(extras?.backendMessage).toContain("Failed to revoke milestone");

--- a/__tests__/unit/hooks/deleteMilestoneErrorMessage.test.ts
+++ b/__tests__/unit/hooks/deleteMilestoneErrorMessage.test.ts
@@ -1,0 +1,119 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import {
+  deleteMilestoneErrorMessage,
+  MilestoneRevocationFailedError,
+} from "@/hooks/useDeleteMilestone";
+
+function axiosErrorWith(status: number, message?: string): AxiosError {
+  const headers = new AxiosHeaders();
+  const err = new AxiosError(
+    `Request failed with status code ${status}`,
+    String(status),
+    { headers } as never,
+    null,
+    {
+      status,
+      statusText: "",
+      headers,
+      config: { headers } as never,
+      data: message === undefined ? null : { message },
+    }
+  );
+  return err;
+}
+
+const TITLE = "Audit Completion";
+
+describe("deleteMilestoneErrorMessage", () => {
+  it("maps 409 already-completed to admin copy", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(409, "Cannot delete milestone that is already completed: 0xabc"),
+        TITLE
+      )
+    ).toBe(
+      `"${TITLE}" already has a completion and can't be deleted. Reject the completion first.`
+    );
+  });
+
+  it("maps 409 already-revoked to admin copy", () => {
+    expect(
+      deleteMilestoneErrorMessage(axiosErrorWith(409, "Milestone is already revoked: 0xabc"), TITLE)
+    ).toBe(`"${TITLE}" is already deleted on-chain. Refresh the page to update the list.`);
+  });
+
+  it("maps 409 not-found to admin copy", () => {
+    expect(
+      deleteMilestoneErrorMessage(axiosErrorWith(409, "Milestone not found: 0xabc"), TITLE)
+    ).toBe(
+      `"${TITLE}" was not found on-chain. It may have been removed already — refresh the page.`
+    );
+  });
+
+  it("returns raw backend message for unmapped 409 prefix", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(409, "Invalid milestone data: missing recipient"),
+        TITLE
+      )
+    ).toBe("Invalid milestone data: missing recipient");
+  });
+
+  it("returns support-hint fallback when 409 has no backend message", () => {
+    expect(deleteMilestoneErrorMessage(axiosErrorWith(409), TITLE)).toBe(
+      `"${TITLE}" can't be deleted right now. If this looks wrong, contact support.`
+    );
+  });
+
+  it("maps 403 to permission copy regardless of backend message", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(403, "User 0x… is not authorized to delete milestones"),
+        TITLE
+      )
+    ).toBe("You don't have permission to delete this milestone.");
+  });
+
+  it("maps 503 to indexer-unavailable copy", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(503, "Failed to fetch milestone attestation 0xabc: timeout"),
+        TITLE
+      )
+    ).toBe("The indexer couldn't read the milestone right now. Try again in a moment.");
+  });
+
+  it("maps 500 insufficient-funds to gas copy (case-insensitive match)", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(500, "Admin wallet has Insufficient Funds on chain 10"),
+        TITLE
+      )
+    ).toBe("Karma admin wallet is out of gas on this chain. We've been alerted.");
+  });
+
+  it("returns raw backend message for unrelated 500", () => {
+    expect(
+      deleteMilestoneErrorMessage(
+        axiosErrorWith(500, "Failed to revoke milestone 0xabc on chain 10: RPC down"),
+        TITLE
+      )
+    ).toBe("Failed to revoke milestone 0xabc on chain 10: RPC down");
+  });
+
+  it("returns the typed-error's stable copy for MilestoneRevocationFailedError", () => {
+    const err = new MilestoneRevocationFailedError(TITLE);
+    expect(deleteMilestoneErrorMessage(err, TITLE)).toBe(
+      "On-chain milestone revocation failed. Please retry; if it persists, contact support."
+    );
+  });
+
+  it("falls back to Error.message for non-axios Error instances", () => {
+    expect(deleteMilestoneErrorMessage(new Error("boom"), TITLE)).toBe("boom");
+  });
+
+  it("falls back to generic copy for unknown error shapes", () => {
+    expect(deleteMilestoneErrorMessage(undefined, TITLE)).toBe("Failed to delete milestone.");
+    expect(deleteMilestoneErrorMessage("string error", TITLE)).toBe("Failed to delete milestone.");
+  });
+});

--- a/hooks/useDeleteMilestone.ts
+++ b/hooks/useDeleteMilestone.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
+import axios from "axios";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useAuth } from "@/hooks/useAuth";
@@ -34,13 +35,26 @@ const SUPPORT_HINT = "If this looks wrong, contact support.";
 const REVOCATION_RETRY_MESSAGE =
   "On-chain milestone revocation failed. Please retry; if it persists, contact support.";
 
+// Backend exception message prefixes from
+// app/modules/v2/services/milestone-on-chain-delete/write/milestone-on-chain-delete.write.service.ts.
+// If the backend rewords these, the matching test cases here will fail in CI.
+const BACKEND_409_ALREADY_COMPLETED = "Cannot delete milestone that is already completed";
+const BACKEND_409_ALREADY_REVOKED = "Milestone is already revoked";
+const BACKEND_409_NOT_FOUND = "Milestone not found";
+const BACKEND_500_INSUFFICIENT_FUNDS = "insufficient funds";
+
 export class MilestoneRevocationFailedError extends Error {
+  milestoneTitle: string;
+
   constructor(milestoneTitle: string) {
     super(REVOCATION_RETRY_MESSAGE);
     this.name = "MilestoneRevocationFailedError";
     this.milestoneTitle = milestoneTitle;
   }
-  milestoneTitle: string;
+}
+
+function asAxiosError(error: unknown): AxiosError<BackendErrorBody> | undefined {
+  return axios.isAxiosError<BackendErrorBody>(error) ? error : undefined;
 }
 
 export function deleteMilestoneErrorMessage(error: unknown, milestoneTitle: string): string {
@@ -48,18 +62,18 @@ export function deleteMilestoneErrorMessage(error: unknown, milestoneTitle: stri
     return error.message;
   }
 
-  const axiosError = error as AxiosError<BackendErrorBody> | undefined;
+  const axiosError = asAxiosError(error);
   const status = axiosError?.response?.status;
   const raw = axiosError?.response?.data?.message ?? "";
 
   if (status === 409) {
-    if (raw.startsWith("Cannot delete milestone that is already completed")) {
+    if (raw.startsWith(BACKEND_409_ALREADY_COMPLETED)) {
       return `"${milestoneTitle}" already has a completion and can't be deleted. Reject the completion first.`;
     }
-    if (raw.startsWith("Milestone is already revoked")) {
+    if (raw.startsWith(BACKEND_409_ALREADY_REVOKED)) {
       return `"${milestoneTitle}" is already deleted on-chain. Refresh the page to update the list.`;
     }
-    if (raw.startsWith("Milestone not found")) {
+    if (raw.startsWith(BACKEND_409_NOT_FOUND)) {
       return `"${milestoneTitle}" was not found on-chain. It may have been removed already — refresh the page.`;
     }
     return raw || `"${milestoneTitle}" can't be deleted right now. ${SUPPORT_HINT}`;
@@ -73,7 +87,7 @@ export function deleteMilestoneErrorMessage(error: unknown, milestoneTitle: stri
     return "The indexer couldn't read the milestone right now. Try again in a moment.";
   }
 
-  if (status === 500 && raw.toLowerCase().includes("insufficient funds")) {
+  if (status === 500 && raw.toLowerCase().includes(BACKEND_500_INSUFFICIENT_FUNDS)) {
     return "Karma admin wallet is out of gas on this chain. We've been alerted.";
   }
 
@@ -166,7 +180,7 @@ export const useDeleteMilestone = ({
         queryClient.setQueryData(queryKey, context.previousData);
       }
 
-      const axiosError = error as AxiosError<BackendErrorBody> | undefined;
+      const axiosError = asAxiosError(error);
       const status = axiosError?.response?.status;
       const backendMessage = axiosError?.response?.data?.message;
       const userMessage = deleteMilestoneErrorMessage(error, milestone.title);
@@ -178,7 +192,9 @@ export const useDeleteMilestone = ({
           milestoneUID: milestone.uid,
           programId,
           chainID: milestone.chainId,
-          error: userMessage,
+          // Stable axios prose keeps Mixpanel funnel grouping intact; `userMessage` ships the human copy.
+          error: error?.message,
+          userMessage,
           backendStatus: status,
           backendMessage,
         },

--- a/hooks/useDeleteMilestone.ts
+++ b/hooks/useDeleteMilestone.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useAuth } from "@/hooks/useAuth";
@@ -22,6 +23,63 @@ interface DeleteMilestoneResponse {
   milestoneUID: string;
   revocationSuccess: boolean;
   revocationTxHash?: string;
+}
+
+interface BackendErrorBody {
+  error?: string;
+  message?: string;
+}
+
+const SUPPORT_HINT = "If this looks wrong, contact support.";
+const REVOCATION_RETRY_MESSAGE =
+  "On-chain milestone revocation failed. Please retry; if it persists, contact support.";
+
+export class MilestoneRevocationFailedError extends Error {
+  constructor(milestoneTitle: string) {
+    super(REVOCATION_RETRY_MESSAGE);
+    this.name = "MilestoneRevocationFailedError";
+    this.milestoneTitle = milestoneTitle;
+  }
+  milestoneTitle: string;
+}
+
+export function deleteMilestoneErrorMessage(error: unknown, milestoneTitle: string): string {
+  if (error instanceof MilestoneRevocationFailedError) {
+    return error.message;
+  }
+
+  const axiosError = error as AxiosError<BackendErrorBody> | undefined;
+  const status = axiosError?.response?.status;
+  const raw = axiosError?.response?.data?.message ?? "";
+
+  if (status === 409) {
+    if (raw.startsWith("Cannot delete milestone that is already completed")) {
+      return `"${milestoneTitle}" already has a completion and can't be deleted. Reject the completion first.`;
+    }
+    if (raw.startsWith("Milestone is already revoked")) {
+      return `"${milestoneTitle}" is already deleted on-chain. Refresh the page to update the list.`;
+    }
+    if (raw.startsWith("Milestone not found")) {
+      return `"${milestoneTitle}" was not found on-chain. It may have been removed already — refresh the page.`;
+    }
+    return raw || `"${milestoneTitle}" can't be deleted right now. ${SUPPORT_HINT}`;
+  }
+
+  if (status === 403) {
+    return "You don't have permission to delete this milestone.";
+  }
+
+  if (status === 503) {
+    return "The indexer couldn't read the milestone right now. Try again in a moment.";
+  }
+
+  if (status === 500 && raw.toLowerCase().includes("insufficient funds")) {
+    return "Karma admin wallet is out of gas on this chain. We've been alerted.";
+  }
+
+  if (raw) return raw;
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to delete milestone.";
 }
 
 export const useDeleteMilestone = ({
@@ -66,9 +124,7 @@ export const useDeleteMilestone = ({
       );
 
       if (!response.data.revocationSuccess) {
-        throw new Error(
-          "On-chain milestone revocation failed. Please retry; if it persists, contact support."
-        );
+        throw new MilestoneRevocationFailedError(milestone.title);
       }
 
       return response.data;
@@ -109,6 +165,12 @@ export const useDeleteMilestone = ({
       if (context?.previousData) {
         queryClient.setQueryData(queryKey, context.previousData);
       }
+
+      const axiosError = error as AxiosError<BackendErrorBody> | undefined;
+      const status = axiosError?.response?.status;
+      const backendMessage = axiosError?.response?.data?.message;
+      const userMessage = deleteMilestoneErrorMessage(error, milestone.title);
+
       mixpanel.reportEvent({
         event: "milestone:delete:failed",
         properties: {
@@ -116,14 +178,22 @@ export const useDeleteMilestone = ({
           milestoneUID: milestone.uid,
           programId,
           chainID: milestone.chainId,
-          error: error?.message,
+          error: userMessage,
+          backendStatus: status,
+          backendMessage,
         },
       });
-      showError(error?.message || "Failed to delete milestone");
-      errorManager(`Failed to delete milestone "${milestone.title}"`, error, {
-        milestoneUID: milestone.uid,
-        milestoneTitle: milestone.title,
-      });
+      showError(userMessage);
+
+      const isUserActionable = status === 403 || status === 409;
+      if (!isUserActionable) {
+        errorManager(`Failed to delete milestone "${milestone.title}"`, error, {
+          milestoneUID: milestone.uid,
+          milestoneTitle: milestone.title,
+          backendStatus: status,
+          backendMessage,
+        });
+      }
     },
   });
 

--- a/hooks/useDeleteMilestone.ts
+++ b/hooks/useDeleteMilestone.ts
@@ -27,7 +27,6 @@ interface DeleteMilestoneResponse {
 }
 
 interface BackendErrorBody {
-  error?: string;
   message?: string;
 }
 


### PR DESCRIPTION
## Root cause

`DELETE /v2/milestones/:uid/on-chain-delete` deliberately returns deterministic 4xx responses for non-bug paths — \`409 already completed\`, \`409 already revoked\`, \`409 not found\`, \`409 invalid data\`, \`403 not authorized\`. These are working-as-designed; the UI's job is to redirect or refresh, not to alert.

The frontend was treating *every* axios reject as Sentry-worthy. Every admin retry of a legitimate 409 produced a fresh \`GAP-FRONTEND-21D\` event with a payload that doesn't even hint at a bug:

\`\`\`
error:        Request failed with status code 409
chainID:      8453
milestoneUID: 0x578733217c0f0a3410d6597fe8badad3fc3a36010c41e94fec2169ecb9a2bbf1
programId:    1013
requestedBy:  0x8353e73573194D9275d82f775d248D30235E403a
\`\`\`

That's the false positive. The backend was correct; the frontend's reporting was wrong.

## Fix

`hooks/useDeleteMilestone.ts` — suppress \`errorManager\` (Sentry) for status \`403\` and \`409\`. Real 5xx / network failures still report, now with \`backendStatus\` and \`backendMessage\` extras so on-call has enough context on the *first* event.

\`\`\`ts
const isUserActionable = status === 403 || status === 409;
if (!isUserActionable) {
  errorManager(\"Failed to delete milestone …\", error, {
    backendStatus: status,
    backendMessage,
    …,
  });
}
\`\`\`

### Side effect: replace the axios default toast with admin copy

Since the 409 path is no longer treated as an error to escalate, the UI needs to *tell the admin what happened* so they can self-resolve. Added \`deleteMilestoneErrorMessage()\` that maps each documented status + backend message to admin-readable copy (e.g. "already has a completion — reject the completion first" instead of "Request failed with status code 409"). Also added a typed \`MilestoneRevocationFailedError\` so the \`revocationSuccess=false\` operational path stays distinct from backend rejections.

## Files

- \`hooks/useDeleteMilestone.ts\` — Sentry suppression + error-mapping helper + typed error.
- \`__tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx\` — 12 tests: Sentry suppression for 403/409, Sentry firing for 5xx with extras, copy for each mapped status, fallbacks for unmapped messages, \`revocationSuccess=false\` stays distinct.

## Test plan

- [ ] Sentry \`GAP-FRONTEND-21D\` event volume drops to ~0 after deploy. (Primary success metric.)
- [ ] Force a real 5xx (e.g. RPC down) → Sentry still fires, payload includes \`backendStatus: 500\` + \`backendMessage\` extras.
- [ ] Admin deleting a completed milestone now sees the real reason, not "Request failed with status code 409".
- [ ] \`pnpm test __tests__/integration/mutations/useDeleteMilestone.error-mapping.test.tsx\` — 12 passing.
- [ ] \`pnpm test __tests__/integration/mutations/\` — 86 passing (no regression).
- [ ] \`pnpm run build\` clean.

## Out of scope

- Letting admins delete completed milestones (backend is intentional).
- Sibling \`useMilestoneEdit.ts\` non-fatal warning (\`GAP-FRONTEND-21C\`) — same shape, separate fix.
- Backend machine-readable \`code\` field — defer until a second consumer needs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages for milestone deletion failures, providing specific guidance for scenarios such as access restrictions, already-completed milestones, and server unavailability

* **Tests**
  * Added comprehensive integration tests for milestone deletion error handling and messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->