### PR TITLE
fix(sitemap): reduce page size to 1000 for GSC compatibility

### DIFF
--- a/app/sitemaps/probe-1k/sitemap.ts
+++ b/app/sitemaps/probe-1k/sitemap.ts
@@ -1,9 +1,0 @@
-import type { MetadataRoute } from "next";
-import { buildSitemapEntries, fetchSitemapUrls } from "@/utilities/sitemap";
-
-// Probe sitemap: serves first 1000 project URLs to test whether GSC
-// fetches succeed at this size (vs. the 5000-URL default that fails).
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const urls = await fetchSitemapUrls("projects", 1, 1000);
-  return buildSitemapEntries(urls, { priority: 0.8, changeFrequency: "daily" });
-}

--- a/app/sitemaps/static/sitemap.ts
+++ b/app/sitemaps/static/sitemap.ts
@@ -42,10 +42,9 @@ const staticPages = [
   "/contact",
   "/privacy-policy",
   "/terms-and-conditions",
-  "/dashboard",
 ];
 
-const lowPriorityPages = ["/privacy-policy", "/terms-and-conditions", "/dashboard"];
+const lowPriorityPages = ["/privacy-policy", "/terms-and-conditions"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = formatSitemapLastmod();

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -2,7 +2,11 @@ import type { MetadataRoute } from "next";
 import { envVars } from "@/utilities/enviromentVars";
 import { INDEXER } from "@/utilities/indexer";
 
-export const SITEMAP_PAGE_SIZE = 5000;
+// Google Search Console fails to fetch sitemaps above ~1MB / 5000 URLs in
+// practice, despite the official 50MB / 50,000 URL limit. Probes confirmed
+// 1000 URLs (~170KB) and 2664 URLs (~470KB) succeed; 5000 URLs (~1.35MB)
+// returns "Sitemap could not be read".
+export const SITEMAP_PAGE_SIZE = 1000;
 
 type SitemapKind = "projects" | "impacts" | "grants" | "milestones" | "funding-programs";
 


### PR DESCRIPTION
## Summary
- Reduces \`SITEMAP_PAGE_SIZE\` from 5000 → 1000
- Removes temporary \`/sitemaps/probe-1k\` test route (no longer needed)

## Problem
Google Search Console reported \"Couldn't fetch / Sitemap could not be read\" for every 5000-URL child sitemap, despite valid XML, correct \`<lastmod>\` formatting (PR #1466), and HTTP 200 responses.

## Diagnosis
Submitted a 1000-URL probe sitemap alongside the existing 5000-URL ones. Result:

| Sitemap | URLs | Size | GSC |
|---|---|---|---|
| probe-1k | 1000 | 173 KB | ✅ Success |
| projects/sitemap/2.xml | 2664 | 470 KB | ✅ Success |
| projects/sitemap/1.xml | 5000 | 1.35 MB | ❌ Could not be read |
| grants/sitemap/1.xml | 5000 | 1.24 MB | ❌ Could not be read |
| milestones/sitemap/1.xml | 5000 | 1.35 MB | ❌ Could not be read |

Resubmission confirmed: Google fetched the failing sitemaps fresh (Last read = today) and still rejected them. GSC has a practical fetch limit somewhere between 470 KB and 1.35 MB regardless of the official 50 MB / 50k URL documentation.

## Solution
1000-URL chunks keep every sitemap under ~250 KB, well within the proven-working range. Chunk count grows but Google's stated soft cap is 50k sitemaps per site — we are nowhere near it.

## Test plan
- [ ] Merge & deploy
- [ ] Verify \`/sitemaps/projects/sitemap/1.xml\` (and others) now serve ~1000 URLs each
- [ ] Resubmit previously-failing sitemaps to GSC
- [ ] Confirm Success status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified sitemap pagination to reduce URLs per file from 5000 to 1000, improving delivery reliability.
  * Removed the probe sitemap to streamline the overall sitemap structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->