### PR TITLE
chore(seo): expose child sitemaps in robots.txt

### DIFF
--- a/__tests__/app/robots.test.ts
+++ b/__tests__/app/robots.test.ts
@@ -96,12 +96,23 @@ describe("robots", () => {
   });
 
   describe("sitemaps", () => {
-    it("should reference only the main sitemap index", () => {
-      expect(result.sitemap).toContain(`${SITE_URL}/sitemap.xml`);
+    const expected = [
+      `${SITE_URL}/sitemap.xml`,
+      `${SITE_URL}/sitemaps/static/sitemap.xml`,
+      `${SITE_URL}/sitemaps/communities/sitemap.xml`,
+      `${SITE_URL}/sitemaps/projects/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/grants/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/impacts/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/milestones/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/funding-programs/sitemap/1.xml`,
+    ];
+
+    it.each(expected)("should reference %s", (url) => {
+      expect(result.sitemap).toContain(url);
     });
 
-    it("should list exactly 1 sitemap entry", () => {
-      expect(result.sitemap).toHaveLength(1);
+    it("should list all child sitemaps alongside the index", () => {
+      expect(result.sitemap).toHaveLength(expected.length);
     });
   });
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -44,7 +44,16 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/"],
       },
     ],
-    sitemap: [`${SITE_URL}/sitemap.xml`],
+    sitemap: [
+      `${SITE_URL}/sitemap.xml`,
+      `${SITE_URL}/sitemaps/static/sitemap.xml`,
+      `${SITE_URL}/sitemaps/communities/sitemap.xml`,
+      `${SITE_URL}/sitemaps/projects/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/grants/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/impacts/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/milestones/sitemap/1.xml`,
+      `${SITE_URL}/sitemaps/funding-programs/sitemap/1.xml`,
+    ],
     host: SITE_URL,
   };
 }


### PR DESCRIPTION
## Summary
- Adds all child sitemap URLs (static, communities, projects, grants, impacts, milestones, funding-programs) as separate `Sitemap:` entries in robots.txt
- Gives Googlebot a redundant discovery path independent of the root sitemap index, which has been stuck in "Couldn't fetch" in Search Console
- Updates the robots test to assert all 8 sitemap entries

## Why
Search Console has not processed our root sitemap index even though the server returns valid XML (HTTP 200, fast response, multi-region CDN HIT). Listing the child sitemaps directly in robots.txt gives Google an alternate discovery channel while we wait for the index to be re-processed.

## Test plan
- [x] `pnpm vitest run __tests__/app/robots.test.ts` (28/28 pass)
- [ ] After deploy: verify `https://karmahq.xyz/robots.txt` lists all 8 sitemap entries
- [ ] Monitor GSC for child-sitemap discovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple sitemap entries for comprehensive search engine indexing coverage across static pages, communities, projects, grants, impacts, milestones, and funding programs.

* **Tests**
  * Expanded test coverage to validate sitemap behavior and ensure all expected entries are properly included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->