### PR TITLE
feat(sitemap): emit per-kind sitemap indexes at root

### DIFF
--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -163,8 +163,15 @@ async function fetchUrls(
   return null;
 }
 
-function buildIndexXml(kindConfigs: KindConfig[]): string {
+function buildSitemapIndex(locs: string[]): string {
   const now = formatLastmod(new Date());
+  const items = locs
+    .map((loc) => `  <sitemap>\n    <loc>${loc}</loc>\n    <lastmod>${now}</lastmod>\n  </sitemap>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</sitemapindex>\n`;
+}
+
+function buildIndexXml(kindConfigs: KindConfig[]): string {
   const entries: string[] = [];
 
   entries.push(`${SITE_URL}/sitemaps/static/sitemap.xml`);
@@ -177,11 +184,16 @@ function buildIndexXml(kindConfigs: KindConfig[]): string {
     }
   }
 
-  const items = entries
-    .map((loc) => `  <sitemap>\n    <loc>${loc}</loc>\n    <lastmod>${now}</lastmod>\n  </sitemap>`)
-    .join("\n");
+  return buildSitemapIndex(entries);
+}
 
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</sitemapindex>\n`;
+function buildKindIndexXml(config: KindConfig): string {
+  const chunkCount = computeChunkCount(config.total);
+  const locs: string[] = [];
+  for (let i = 1; i <= chunkCount; i++) {
+    locs.push(`${SITE_URL}/sitemaps/${config.path}/sitemap/${i}.xml`);
+  }
+  return buildSitemapIndex(locs);
 }
 
 function buildUrlsetXml(urls: string[], priority: number, changeFrequency: string): string {
@@ -312,6 +324,14 @@ async function main() {
 
   const indexEntryCount = (indexXml.match(/<sitemap>/g) ?? []).length;
   logInfo(`[sitemap-gen] Wrote ${indexPath} (${indexEntryCount} entries)`);
+
+  for (const config of kindConfigs) {
+    const kindIndexXml = buildKindIndexXml(config);
+    const kindIndexPath = path.join(PROJECT_ROOT, "public", `sitemap-${config.path}.xml`);
+    fs.writeFileSync(kindIndexPath, kindIndexXml, "utf-8");
+    const kindEntries = (kindIndexXml.match(/<sitemap>/g) ?? []).length;
+    logInfo(`[sitemap-gen] Wrote ${kindIndexPath} (${kindEntries} entries)`);
+  }
 
   await writeChildSitemaps(baseUrl, kindConfigs);
 }

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -333,6 +333,17 @@ async function main() {
     logInfo(`[sitemap-gen] Wrote ${kindIndexPath} (${kindEntries} entries)`);
   }
 
+  const singletonIndexes: Array<{ name: string; loc: string }> = [
+    { name: "sitemap-static.xml", loc: `${SITE_URL}/sitemaps/static/sitemap.xml` },
+    { name: "sitemap-communities.xml", loc: `${SITE_URL}/sitemaps/communities/sitemap.xml` },
+  ];
+  for (const { name, loc } of singletonIndexes) {
+    const xml = buildSitemapIndex([loc]);
+    const outPath = path.join(PROJECT_ROOT, "public", name);
+    fs.writeFileSync(outPath, xml, "utf-8");
+    logInfo(`[sitemap-gen] Wrote ${outPath} (1 entries)`);
+  }
+
   await writeChildSitemaps(baseUrl, kindConfigs);
 }
 


### PR DESCRIPTION
## Summary
- Generates `public/sitemap-{kind}.xml` at build time for each chunked kind (projects, impacts, grants, milestones, funding-programs).
- Each is a sitemapindex listing that kind's `sitemaps/{kind}/sitemap/{i}.xml` chunks.
- Root `/sitemap.xml` is unchanged (still lists every chunk + the two un-chunked categories).

## Why
Lets us submit each category independently in Google Search Console to isolate which kind (if any) is the bad apple when the root index reports "Couldn't fetch". Pure probe — no behavior change on existing URLs.

## Test plan
- [ ] CI green
- [ ] After deploy: `curl -I https://www.karmahq.xyz/sitemap-projects.xml` returns 200 with `x-vercel-cache: HIT`
- [ ] Submit each new `sitemap-{kind}.xml` in GSC and observe per-kind fetch outcome