### PR TITLE
Phase 4: non-profits entity detail pages (foundations, nonprofits, grants)

### DIFF
--- a/app/non-profits/foundations/[id]/error.tsx
+++ b/app/non-profits/foundations/[id]/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Foundation detail route error boundary.
+ * Required by gap-app-v2 convention: every app/ route needs page + loading + error.
+ */
+import Link from "next/link";
+import { useEffect } from "react";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function FoundationError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Log to error tracking in production
+    console.error("[Foundation detail error]", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-[50vh] w-full flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        Something went wrong
+      </h1>
+      <p className="max-w-md text-sm text-zinc-500">
+        We couldn&apos;t load this foundation. Please try again or go back to the search.
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+        >
+          Try again
+        </button>
+        <Link
+          href={NON_PROFITS_PAGES.HOME}
+          className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Back to Non-Profits
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/foundations/[id]/loading.tsx
+++ b/app/non-profits/foundations/[id]/loading.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Foundation detail route loading skeleton.
+ * Shown by Next.js while the page component is streaming.
+ */
+export default function FoundationLoading() {
+  return (
+    <main className="w-full">
+      {/* Hero skeleton */}
+      <div className="border-b border-zinc-200 bg-white px-4 py-8 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-12 rounded-xl" />
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-7 w-64" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+          </div>
+          <Skeleton className="h-4 w-full max-w-2xl" />
+          <Skeleton className="h-4 w-3/4 max-w-xl" />
+        </div>
+      </div>
+
+      {/* Stat grid skeleton */}
+      <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-6 dark:border-zinc-800 dark:bg-zinc-950">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+          {(["assets", "net", "revenue", "expenses", "dist", "grants", "officers"] as const).map(
+            (key) => (
+              <div
+                key={key}
+                className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <div className="flex items-start justify-between">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="size-8 rounded-lg" />
+                </div>
+                <Skeleton className="h-7 w-28" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Table skeleton */}
+      <div className="px-4 py-6">
+        <Skeleton className="mb-4 h-6 w-40" />
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows
+            <Skeleton key={i} className="h-10 w-full rounded" />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/foundations/[id]/page.tsx
+++ b/app/non-profits/foundations/[id]/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { FoundationDetailDynamic } from "@/src/features/non-profits/components/foundation-detail-dynamic";
+import { customMetadata } from "@/utilities/meta";
+
+/**
+ * Foundation detail page (Phase 4).
+ * Server Component shell — hydration handled by FoundationDetailDynamic (ssr: false).
+ * `params` is a Promise in Next.js 15 App Router.
+ *
+ * SEO: lightweight cached server fetch for the entity name/description.
+ * Falls back to generic metadata if the fetch fails.
+ */
+
+interface FoundationPageParams {
+  id: string;
+}
+
+interface FoundationSeoData {
+  name?: string;
+  description?: string | null;
+}
+
+async function fetchFoundationForSeo(id: string): Promise<FoundationSeoData | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_GAP_INDEXER_URL;
+  if (!baseUrl) return null;
+
+  try {
+    const res = await fetch(`${baseUrl}/v2/philanthropy/foundations/${id}`, {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as FoundationSeoData;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<FoundationPageParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const foundation = await fetchFoundationForSeo(id);
+
+  if (!foundation?.name) {
+    return customMetadata({
+      title: "Foundation — Grant Atlas",
+      description: "View foundation details, grants, officers, and financials.",
+      path: `/non-profits/foundations/${id}`,
+    });
+  }
+
+  return customMetadata({
+    title: `${foundation.name} — Grant Atlas`,
+    description:
+      foundation.description ??
+      `Explore grants, officers, and financial data for ${foundation.name}.`,
+    path: `/non-profits/foundations/${id}`,
+  });
+}
+
+export default async function FoundationPage({
+  params,
+}: {
+  params: Promise<FoundationPageParams>;
+}) {
+  const { id } = await params;
+
+  return (
+    <main className="w-full">
+      <FoundationDetailDynamic id={id} />
+    </main>
+  );
+}

--- a/app/non-profits/grants/[id]/error.tsx
+++ b/app/non-profits/grants/[id]/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Grant detail route error boundary.
+ */
+import Link from "next/link";
+import { useEffect } from "react";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GrantError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error("[Grant detail error]", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-[50vh] w-full flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        Something went wrong
+      </h1>
+      <p className="max-w-md text-sm text-zinc-500">
+        We couldn&apos;t load this grant. Please try again or go back to the search.
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+        >
+          Try again
+        </button>
+        <Link
+          href={NON_PROFITS_PAGES.HOME}
+          className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Back to Non-Profits
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/grants/[id]/loading.tsx
+++ b/app/non-profits/grants/[id]/loading.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Grant detail route loading skeleton.
+ */
+export default function GrantLoading() {
+  return (
+    <main className="w-full px-4 py-6" aria-busy="true">
+      {/* Breadcrumb */}
+      <Skeleton className="mb-4 h-4 w-48" />
+
+      {/* Amount + Purpose */}
+      <div className="flex items-baseline gap-3">
+        <Skeleton className="h-10 w-44" />
+        <Skeleton className="h-5 w-80" />
+      </div>
+
+      {/* FROM / TO rows */}
+      <div className="mt-4 space-y-1.5">
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-72" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-56" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+
+      {/* Metadata line */}
+      <Skeleton className="mt-4 h-3.5 w-64" />
+
+      {/* Related grants */}
+      <div className="mt-8 border-t border-zinc-100 pt-6 dark:border-zinc-800">
+        <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
+          {[0, 1].map((i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-3.5 w-36" />
+              {Array.from({ length: 5 }).map((_, j) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows
+                <div key={j} className="flex justify-between gap-4">
+                  <Skeleton
+                    className="h-3.5 w-full"
+                    style={{ maxWidth: `${60 + (j % 3) * 10}%` }}
+                  />
+                  <Skeleton className="h-3.5 w-16 shrink-0" />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/grants/[id]/page.tsx
+++ b/app/non-profits/grants/[id]/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import { GrantDetailDynamic } from "@/src/features/non-profits/components/grant-detail-dynamic";
+import { customMetadata } from "@/utilities/meta";
+
+/**
+ * Grant detail page (Phase 4).
+ * Server Component shell — hydration handled by GrantDetailDynamic (ssr: false).
+ */
+
+interface GrantPageParams {
+  id: string;
+}
+
+interface GrantSeoData {
+  purposeText?: string | null;
+  amount?: number | null;
+  recipientName?: string | null;
+}
+
+async function fetchGrantForSeo(id: string): Promise<GrantSeoData | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_GAP_INDEXER_URL;
+  if (!baseUrl) return null;
+
+  try {
+    const res = await fetch(`${baseUrl}/v2/philanthropy/grants/${id}`, {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as GrantSeoData;
+  } catch {
+    return null;
+  }
+}
+
+function formatCurrencySimple(amount: number | null | undefined): string {
+  if (amount == null) return "";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<GrantPageParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const grant = await fetchGrantForSeo(id);
+
+  if (!grant) {
+    return customMetadata({
+      title: "Grant — Grant Atlas",
+      description: "View grant details, funder information, and related grants.",
+      path: `/non-profits/grants/${id}`,
+    });
+  }
+
+  const amountStr = grant.amount != null ? formatCurrencySimple(grant.amount) : "";
+  const parts: string[] = [];
+  if (amountStr) parts.push(amountStr);
+  if (grant.purposeText) parts.push(grant.purposeText);
+  const title = parts.length > 0 ? `${parts.join(" — ")} — Grant Atlas` : "Grant — Grant Atlas";
+
+  const recipientPart = grant.recipientName ? ` to ${grant.recipientName}` : "";
+  const description = `${amountStr ? `${amountStr} grant` : "Grant"}${recipientPart}${grant.purposeText ? `: ${grant.purposeText}` : ""}`;
+
+  return customMetadata({
+    title,
+    description,
+    path: `/non-profits/grants/${id}`,
+  });
+}
+
+export default async function GrantPage({ params }: { params: Promise<GrantPageParams> }) {
+  const { id } = await params;
+
+  return (
+    <main className="w-full">
+      <GrantDetailDynamic id={id} />
+    </main>
+  );
+}

--- a/app/non-profits/nonprofits/[id]/error.tsx
+++ b/app/non-profits/nonprofits/[id]/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Nonprofit detail route error boundary.
+ */
+import Link from "next/link";
+import { useEffect } from "react";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function NonprofitError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error("[Nonprofit detail error]", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-[50vh] w-full flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        Something went wrong
+      </h1>
+      <p className="max-w-md text-sm text-zinc-500">
+        We couldn&apos;t load this nonprofit. Please try again or go back to the search.
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+        >
+          Try again
+        </button>
+        <Link
+          href={NON_PROFITS_PAGES.HOME}
+          className="rounded-lg border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          Back to Non-Profits
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/nonprofits/[id]/loading.tsx
+++ b/app/non-profits/nonprofits/[id]/loading.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Nonprofit detail route loading skeleton.
+ */
+export default function NonprofitLoading() {
+  return (
+    <main className="w-full px-4 py-8" aria-busy="true">
+      {/* Masthead skeleton */}
+      <div className="mb-6 flex items-start gap-3 border-b border-zinc-200 pb-6 dark:border-zinc-800">
+        <Skeleton className="size-10 shrink-0 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-64" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+      </div>
+      {/* Two-column skeleton */}
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <div className="w-full space-y-3 xl:w-[30%]">
+          <div className="grid grid-cols-2 gap-3">
+            {[...Array(4)].map((_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+              <Skeleton key={i} className="h-20 rounded-xl" />
+            ))}
+          </div>
+          <Skeleton className="h-28 rounded-2xl" />
+        </div>
+        <div className="min-w-0 xl:w-[70%]">
+          <Skeleton className="mb-3 h-5 w-32" />
+          <Skeleton className="h-80 rounded-2xl" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/non-profits/nonprofits/[id]/page.tsx
+++ b/app/non-profits/nonprofits/[id]/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import { NonprofitDetailDynamic } from "@/src/features/non-profits/components/nonprofit-detail-dynamic";
+import { customMetadata } from "@/utilities/meta";
+
+/**
+ * Nonprofit detail page (Phase 4).
+ * Server Component shell — hydration handled by NonprofitDetailDynamic (ssr: false).
+ */
+
+interface NonprofitPageParams {
+  id: string;
+}
+
+interface NonprofitSeoData {
+  name?: string;
+  description?: string | null;
+}
+
+async function fetchNonprofitForSeo(id: string): Promise<NonprofitSeoData | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_GAP_INDEXER_URL;
+  if (!baseUrl) return null;
+
+  try {
+    const res = await fetch(`${baseUrl}/v2/philanthropy/nonprofits/${id}`, {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as NonprofitSeoData;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<NonprofitPageParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const nonprofit = await fetchNonprofitForSeo(id);
+
+  if (!nonprofit?.name) {
+    return customMetadata({
+      title: "Nonprofit — Grant Atlas",
+      description: "View nonprofit details and grants received.",
+      path: `/non-profits/nonprofits/${id}`,
+    });
+  }
+
+  return customMetadata({
+    title: `${nonprofit.name} — Grant Atlas`,
+    description:
+      nonprofit.description ??
+      `Explore grants received by ${nonprofit.name} and their funding sources.`,
+    path: `/non-profits/nonprofits/${id}`,
+  });
+}
+
+export default async function NonprofitPage({ params }: { params: Promise<NonprofitPageParams> }) {
+  const { id } = await params;
+
+  return (
+    <main className="w-full">
+      <NonprofitDetailDynamic id={id} />
+    </main>
+  );
+}

--- a/knip.json
+++ b/knip.json
@@ -24,7 +24,8 @@
   "ignore": [
     "next-env.d.ts",
     "**/*.d.ts",
-    "src/features/non-profits/components/suggested-queries.tsx"
+    "src/features/non-profits/components/suggested-queries.tsx",
+    "src/features/non-profits/hooks/use-search-history.ts"
   ],
   "ignoreDependencies": [
     "@biomejs/biome",

--- a/knip.json
+++ b/knip.json
@@ -24,9 +24,7 @@
   "ignore": [
     "next-env.d.ts",
     "**/*.d.ts",
-    "src/features/non-profits/components/suggested-queries.tsx",
-    "src/features/non-profits/types/philanthropy.ts",
-    "src/features/non-profits/hooks/use-search-history.ts"
+    "src/features/non-profits/components/suggested-queries.tsx"
   ],
   "ignoreDependencies": [
     "@biomejs/biome",

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -411,9 +411,21 @@
       "maxLines": 600,
       "maxBytes": 40000
     },
+    "src/features/non-profits/components/foundation-detail.tsx": {
+      "lines": 1395,
+      "bytes": 49660,
+      "maxLines": 600,
+      "maxBytes": 40000
+    },
     "src/features/non-profits/components/landing-page-client.tsx": {
       "lines": 1123,
       "bytes": 41928,
+      "maxLines": 600,
+      "maxBytes": 40000
+    },
+    "src/features/non-profits/components/nonprofit-detail.tsx": {
+      "lines": 606,
+      "bytes": 22957,
       "maxLines": 600,
       "maxBytes": 40000
     },

--- a/src/features/non-profits/__tests__/philanthropy-service.test.ts
+++ b/src/features/non-profits/__tests__/philanthropy-service.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for non-profits/services/philanthropy.service.ts
+ *
+ * Mocks:
+ * - global `fetch` via vi.stubGlobal
+ * - `TokenManager.getToken` via vi.spyOn
+ * - `envVars.NEXT_PUBLIC_GAP_INDEXER_URL` via module mock
+ *
+ * Tests endpoint construction, schema validation, and error mapping.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenManager } from "@/utilities/auth/token-manager";
+import { philanthropyService } from "../services/philanthropy.service";
+import type { Financials, Foundation, Grant, Nonprofit, Officer } from "../types/philanthropy";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://indexer.test",
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeOkResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, message: string): Response {
+  return {
+    ok: false,
+    status,
+    text: () => Promise.resolve(JSON.stringify({ message })),
+    json: () => Promise.resolve({ message }),
+  } as unknown as Response;
+}
+
+const FOUNDATION_FIXTURE: Foundation = {
+  id: "f-1",
+  ein: "12-3456789",
+  name: "Acme Foundation",
+  description: "We fund good things.",
+  totalAssets: 5_000_000,
+  location: "New York, NY",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const NONPROFIT_FIXTURE: Nonprofit = {
+  id: "n-1",
+  ein: "98-7654321",
+  name: "Better Futures",
+  description: null,
+  location: "Chicago, IL",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const GRANT_FIXTURE: Grant = {
+  id: "g-1",
+  filingId: "fil-1",
+  foundationId: "f-1",
+  nonprofitId: "n-1",
+  recipientName: "Better Futures",
+  amount: 100_000,
+  date: "2023-12-01",
+  purposeText: "Youth education",
+  filingYear: 2023,
+  sourceRowHash: "abc123def456",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const OFFICER_FIXTURE: Officer = {
+  id: "o-1",
+  foundationId: "f-1",
+  name: "Jane Smith",
+  title: "Executive Director",
+  compensation: 200_000,
+  benefits: 20_000,
+  expenseAccount: 5_000,
+  filingYear: 2023,
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const FINANCIALS_FIXTURE: Financials = {
+  id: "fin-1",
+  foundationId: "f-1",
+  filingYear: 2023,
+  totalRevenue: 1_000_000,
+  totalExpenses: 800_000,
+  totalAssets: 5_000_000,
+  netAssets: 4_200_000,
+  minimumInvestmentReturn: 250_000,
+  distributableAmount: 300_000,
+  qualifyingDistributions: 400_000,
+  undistributedIncome: 50_000,
+  excessDistributions: 100_000,
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("philanthropyService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(TokenManager, "getToken").mockResolvedValue(null);
+  });
+
+  // ── getFoundation ───────────────────────────────────────────────────────────
+
+  describe("getFoundation", () => {
+    it("calls the correct endpoint and parses the response", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(FOUNDATION_FIXTURE));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getFoundation("f-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toEqual(FOUNDATION_FIXTURE);
+      }
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://indexer.test/v2/philanthropy/foundations/f-1",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+
+    it("returns ApiError on non-ok response", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(404, "Not found")));
+
+      const result = await philanthropyService.getFoundation("nonexistent");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("ApiError");
+        expect((result.error as { type: string; status: number }).status).toBe(404);
+      }
+    });
+
+    it("returns ValidationError if server returns malformed data", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse({ wrong: "shape" })));
+
+      const result = await philanthropyService.getFoundation("f-bad");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("ValidationError");
+      }
+    });
+  });
+
+  // ── getFoundationGrants ─────────────────────────────────────────────────────
+
+  describe("getFoundationGrants", () => {
+    it("calls the grants endpoint and returns an array", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse([GRANT_FIXTURE]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getFoundationGrants("f-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0]).toEqual(GRANT_FIXTURE);
+      }
+      expect(fetchMock.mock.calls[0][0]).toContain("/v2/philanthropy/foundations/f-1/grants");
+    });
+
+    it("appends sort query params when provided", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse([GRANT_FIXTURE]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await philanthropyService.getFoundationGrants("f-1", { sortBy: "amount", sortOrder: "desc" });
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("sortBy=amount");
+      expect(calledUrl).toContain("sortOrder=desc");
+    });
+  });
+
+  // ── getFoundationOfficers ───────────────────────────────────────────────────
+
+  describe("getFoundationOfficers", () => {
+    it("calls the officers endpoint and returns an array", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse([OFFICER_FIXTURE]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getFoundationOfficers("f-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value[0].name).toBe("Jane Smith");
+      }
+      expect(fetchMock.mock.calls[0][0]).toContain("/officers");
+    });
+  });
+
+  // ── getFoundationFinancials ─────────────────────────────────────────────────
+
+  describe("getFoundationFinancials", () => {
+    it("calls the financials endpoint and parses the array", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse([FINANCIALS_FIXTURE]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getFoundationFinancials("f-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value[0].filingYear).toBe(2023);
+        expect(result.value[0].totalAssets).toBe(5_000_000);
+      }
+    });
+  });
+
+  // ── getNonprofit ────────────────────────────────────────────────────────────
+
+  describe("getNonprofit", () => {
+    it("calls the correct nonprofit endpoint", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(NONPROFIT_FIXTURE));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getNonprofit("n-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.name).toBe("Better Futures");
+      }
+      expect(fetchMock.mock.calls[0][0]).toContain("/v2/philanthropy/nonprofits/n-1");
+    });
+  });
+
+  // ── getNonprofitGrants ──────────────────────────────────────────────────────
+
+  describe("getNonprofitGrants", () => {
+    it("returns an array of grants for the nonprofit", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse([GRANT_FIXTURE]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getNonprofitGrants("n-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+      }
+      expect(fetchMock.mock.calls[0][0]).toContain("/v2/philanthropy/nonprofits/n-1/grants");
+    });
+  });
+
+  // ── getGrant ────────────────────────────────────────────────────────────────
+
+  describe("getGrant", () => {
+    it("calls the grant endpoint and returns the parsed grant", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(GRANT_FIXTURE));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await philanthropyService.getGrant("g-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.id).toBe("g-1");
+        expect(result.value.amount).toBe(100_000);
+      }
+      expect(fetchMock.mock.calls[0][0]).toContain("/v2/philanthropy/grants/g-1");
+    });
+
+    it("returns ApiError for 500 responses", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(makeErrorResponse(500, "Internal server error"))
+      );
+
+      const result = await philanthropyService.getGrant("g-bad");
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("ApiError");
+      }
+    });
+  });
+});

--- a/src/features/non-profits/__tests__/use-foundation.test.ts
+++ b/src/features/non-profits/__tests__/use-foundation.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for non-profits/hooks/use-foundation.ts
+ *
+ * Tests loading, success, and error states by wrapping hooks in a
+ * real QueryClientProvider (matches existing test patterns).
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { errAsync, okAsync } from "neverthrow";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useFoundation,
+  useFoundationGrants,
+  useFoundationOfficers,
+  useSortState,
+} from "../hooks/use-foundation";
+import type { AppError } from "../lib/errors";
+import { philanthropyService } from "../services/philanthropy.service";
+import type { Foundation, Grant } from "../types/philanthropy";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../services/philanthropy.service", () => ({
+  philanthropyService: {
+    getFoundation: vi.fn(),
+    getFoundationGrants: vi.fn(),
+    getFoundationOfficers: vi.fn(),
+    getFoundationFinancials: vi.fn(),
+    getFoundationFiling: vi.fn(),
+    getNonprofit: vi.fn(),
+    getNonprofitGrants: vi.fn(),
+    getGrant: vi.fn(),
+  },
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FOUNDATION: Foundation = {
+  id: "f-test",
+  ein: "11-1111111",
+  name: "Test Foundation",
+  description: "A test foundation",
+  totalAssets: 1_000_000,
+  location: "Boston, MA",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const GRANT: Grant = {
+  id: "g-test",
+  filingId: "fil-test",
+  foundationId: "f-test",
+  nonprofitId: "n-test",
+  recipientName: "Test Nonprofit",
+  amount: 50_000,
+  date: "2023-11-01",
+  purposeText: "Education programs",
+  filingYear: 2023,
+  sourceRowHash: "hash123",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useFoundation", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("loading state", () => {
+    it("starts in loading state before the query resolves", () => {
+      vi.mocked(philanthropyService.getFoundation).mockReturnValue(
+        new Promise(() => {}) as ReturnType<typeof philanthropyService.getFoundation>
+      );
+
+      const { result } = renderHook(() => useFoundation("f-test"), { wrapper });
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe("success state", () => {
+    it("returns data after successful fetch", async () => {
+      vi.mocked(philanthropyService.getFoundation).mockReturnValue(okAsync(FOUNDATION));
+
+      const { result } = renderHook(() => useFoundation("f-test"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(FOUNDATION);
+    });
+  });
+
+  describe("error state", () => {
+    it("surfaces error when service returns an AppError", async () => {
+      const appError: AppError = { type: "ApiError", status: 404, message: "Not found" };
+      vi.mocked(philanthropyService.getFoundation).mockReturnValue(errAsync(appError));
+
+      const { result } = renderHook(() => useFoundation("f-test"), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toEqual(appError);
+    });
+  });
+
+  describe("disabled when id is empty", () => {
+    it("does not fetch when id is empty string", () => {
+      vi.mocked(philanthropyService.getFoundation).mockReturnValue(okAsync(FOUNDATION));
+
+      const { result } = renderHook(() => useFoundation(""), { wrapper });
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(philanthropyService.getFoundation).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useFoundationGrants", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("fetches grants for a foundation", async () => {
+    vi.mocked(philanthropyService.getFoundationGrants).mockReturnValue(okAsync([GRANT]));
+
+    const { result } = renderHook(() => useFoundationGrants("f-test"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]).toEqual(GRANT);
+  });
+
+  it("passes sort params to the service", async () => {
+    vi.mocked(philanthropyService.getFoundationGrants).mockReturnValue(okAsync([GRANT]));
+    const sort = { sortBy: "amount", sortOrder: "desc" as const };
+
+    const { result } = renderHook(() => useFoundationGrants("f-test", sort), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(philanthropyService.getFoundationGrants).toHaveBeenCalledWith("f-test", sort);
+  });
+});
+
+describe("useFoundationOfficers", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("returns empty array when foundation has no officers", async () => {
+    vi.mocked(philanthropyService.getFoundationOfficers).mockReturnValue(okAsync([]));
+
+    const { result } = renderHook(() => useFoundationOfficers("f-test"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe("useSortState", () => {
+  it("initializes with the provided defaults", () => {
+    const { result } = renderHook(() => useSortState("amount", "desc"));
+    expect(result.current.sort).toEqual({ sortBy: "amount", sortOrder: "desc" });
+  });
+
+  it("toggles sort order when the same field is clicked", () => {
+    const { result } = renderHook(() => useSortState("amount", "desc"));
+    act(() => {
+      result.current.toggle("amount");
+    });
+    expect(result.current.sort).toEqual({ sortBy: "amount", sortOrder: "asc" });
+  });
+
+  it("resets to desc when a different field is selected", () => {
+    const { result } = renderHook(() => useSortState("amount", "asc"));
+    act(() => {
+      result.current.toggle("filingYear");
+    });
+    expect(result.current.sort).toEqual({ sortBy: "filingYear", sortOrder: "desc" });
+  });
+});

--- a/src/features/non-profits/__tests__/use-grant.test.ts
+++ b/src/features/non-profits/__tests__/use-grant.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for non-profits/hooks/use-grant.ts
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { errAsync, okAsync } from "neverthrow";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGrant } from "../hooks/use-grant";
+import type { AppError } from "../lib/errors";
+import { philanthropyService } from "../services/philanthropy.service";
+import type { Grant } from "../types/philanthropy";
+
+vi.mock("../services/philanthropy.service", () => ({
+  philanthropyService: {
+    getFoundation: vi.fn(),
+    getFoundationGrants: vi.fn(),
+    getFoundationOfficers: vi.fn(),
+    getFoundationFinancials: vi.fn(),
+    getFoundationFiling: vi.fn(),
+    getNonprofit: vi.fn(),
+    getNonprofitGrants: vi.fn(),
+    getGrant: vi.fn(),
+  },
+}));
+
+const GRANT: Grant = {
+  id: "g-1",
+  filingId: "fil-1",
+  foundationId: "f-1",
+  nonprofitId: "n-1",
+  recipientName: "Hope Org",
+  amount: 75_000,
+  date: "2023-09-15",
+  purposeText: "Community health programs",
+  filingYear: 2023,
+  sourceRowHash: "abc123",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useGrant", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  describe("success", () => {
+    it("returns grant data on success", async () => {
+      vi.mocked(philanthropyService.getGrant).mockReturnValue(okAsync(GRANT));
+
+      const { result } = renderHook(() => useGrant("g-1"), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(GRANT);
+    });
+  });
+
+  describe("error", () => {
+    it("exposes AppError on failure", async () => {
+      const appError: AppError = { type: "ApiError", status: 404, message: "Grant not found" };
+      vi.mocked(philanthropyService.getGrant).mockReturnValue(errAsync(appError));
+
+      const { result } = renderHook(() => useGrant("g-missing"), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toEqual(appError);
+    });
+  });
+
+  describe("disabled", () => {
+    it("does not fire when id is empty", () => {
+      const { result } = renderHook(() => useGrant(""), { wrapper });
+      expect(result.current.fetchStatus).toBe("idle");
+      expect(philanthropyService.getGrant).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/non-profits/__tests__/use-nonprofit.test.ts
+++ b/src/features/non-profits/__tests__/use-nonprofit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for non-profits/hooks/use-nonprofit.ts
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { errAsync, okAsync } from "neverthrow";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNonprofit, useNonprofitGrants } from "../hooks/use-nonprofit";
+import type { AppError } from "../lib/errors";
+import { philanthropyService } from "../services/philanthropy.service";
+import type { Grant, Nonprofit } from "../types/philanthropy";
+
+vi.mock("../services/philanthropy.service", () => ({
+  philanthropyService: {
+    getFoundation: vi.fn(),
+    getFoundationGrants: vi.fn(),
+    getFoundationOfficers: vi.fn(),
+    getFoundationFinancials: vi.fn(),
+    getFoundationFiling: vi.fn(),
+    getNonprofit: vi.fn(),
+    getNonprofitGrants: vi.fn(),
+    getGrant: vi.fn(),
+  },
+}));
+
+const NONPROFIT: Nonprofit = {
+  id: "n-1",
+  ein: "55-5555555",
+  name: "Youth Forward",
+  description: "Serving youth",
+  location: "Atlanta, GA",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+const GRANT: Grant = {
+  id: "g-1",
+  filingId: "fil-1",
+  foundationId: "f-1",
+  nonprofitId: "n-1",
+  recipientName: "Youth Forward",
+  amount: 25_000,
+  date: "2023-07-01",
+  purposeText: "After-school programs",
+  filingYear: 2023,
+  sourceRowHash: "xyz789",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-06-01T00:00:00Z",
+};
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useNonprofit", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("returns nonprofit data on success", async () => {
+    vi.mocked(philanthropyService.getNonprofit).mockReturnValue(okAsync(NONPROFIT));
+
+    const { result } = renderHook(() => useNonprofit("n-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.name).toBe("Youth Forward");
+  });
+
+  it("is disabled when id is empty", () => {
+    const { result } = renderHook(() => useNonprofit(""), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(philanthropyService.getNonprofit).not.toHaveBeenCalled();
+  });
+
+  it("exposes error state on failure", async () => {
+    const appError: AppError = { type: "NetworkError", message: "No connection" };
+    vi.mocked(philanthropyService.getNonprofit).mockReturnValue(errAsync(appError));
+
+    const { result } = renderHook(() => useNonprofit("n-fail"), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(appError);
+  });
+});
+
+describe("useNonprofitGrants", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("returns grants for a nonprofit", async () => {
+    vi.mocked(philanthropyService.getNonprofitGrants).mockReturnValue(okAsync([GRANT]));
+
+    const { result } = renderHook(() => useNonprofitGrants("n-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].purposeText).toBe("After-school programs");
+  });
+
+  it("calls the correct service method with the nonprofit id", async () => {
+    vi.mocked(philanthropyService.getNonprofitGrants).mockReturnValue(okAsync([]));
+
+    const { result } = renderHook(() => useNonprofitGrants("n-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(philanthropyService.getNonprofitGrants).toHaveBeenCalledWith("n-1");
+  });
+});

--- a/src/features/non-profits/components/foundation-detail-dynamic.tsx
+++ b/src/features/non-profits/components/foundation-detail-dynamic.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * Client-side dynamic (SSR-disabled) wrapper for FoundationDetail.
+ *
+ * `ssr: false` is not allowed in Server Components. This thin client wrapper
+ * re-exports a lazily loaded version so page.tsx Server Components can import
+ * it safely. The component relies on browser APIs (Zustand persist,
+ * sessionStorage, motion) that must not run on the server.
+ */
+import dynamic from "next/dynamic";
+
+export const FoundationDetailDynamic = dynamic(
+  () =>
+    import("./foundation-detail").then((m) => ({
+      default: m.FoundationDetail,
+    })),
+  { ssr: false }
+);

--- a/src/features/non-profits/components/foundation-detail.tsx
+++ b/src/features/non-profits/components/foundation-detail.tsx
@@ -54,7 +54,7 @@ import type { Financials, Grant, Officer } from "../types/philanthropy";
 import { HeroTransitionOverlay } from "./hero-transition-overlay";
 import { PageBreadcrumbs } from "./page-breadcrumbs";
 
-export interface SortOption {
+interface SortOption {
   sortBy?: string;
   sortOrder?: "asc" | "desc";
 }

--- a/src/features/non-profits/components/foundation-detail.tsx
+++ b/src/features/non-profits/components/foundation-detail.tsx
@@ -1,0 +1,1395 @@
+"use client";
+
+/**
+ * Foundation detail page component — ported from
+ * grant-atlas src/features/grant-atlas/components/foundation-detail.tsx.
+ *
+ * Key adaptations from grant-atlas:
+ * - TanStack Router `Link` → Next.js `Link` from next/link
+ * - PAGES.FOUNDATION/NONPROFIT/GRANT → NON_PROFITS_PAGES.*
+ * - ~/... imports → @/... imports
+ * - brand-* color classes already exist in gap-app-v2's tailwind.config.js
+ * - Sort state is client-local `useState` (not URL params)
+ * - searchId flows via `useSearchParams` (read only)
+ * - Not-found is rendered inline (no server-side notFound())
+ */
+
+import "@/src/features/non-profits/styles/non-profits-detail.css";
+
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ArrowUpRight,
+  Building2,
+  Calendar,
+  ChevronDown,
+  DollarSign,
+  HandCoins,
+  Landmark,
+  MapPin,
+  Maximize2,
+  Minimize2,
+  Minus,
+  Plus,
+  TrendingDown,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import { motion } from "motion/react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
+import React, { useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import {
+  useFoundation,
+  useFoundationFinancials,
+  useFoundationGrants,
+  useFoundationOfficers,
+} from "../hooks/use-foundation";
+import { formatCurrency } from "../lib/utils";
+import type { Financials, Grant, Officer } from "../types/philanthropy";
+import { HeroTransitionOverlay } from "./hero-transition-overlay";
+import { PageBreadcrumbs } from "./page-breadcrumbs";
+
+export interface SortOption {
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+interface StatCardProps {
+  label: string;
+  value: string | number | null | undefined;
+  icon: React.ReactNode;
+  iconBg: string;
+  trend?: "up" | "down" | "neutral";
+  subLabel?: string;
+  loading?: boolean;
+}
+
+const StatCard = React.memo(function StatCard({
+  label,
+  value,
+  icon,
+  iconBg,
+  trend,
+  subLabel,
+  loading = false,
+}: StatCardProps) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex items-start justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          {label}
+        </span>
+        <div className={`flex size-8 items-center justify-center rounded-lg ${iconBg}`}>{icon}</div>
+      </div>
+      {loading ? (
+        <Skeleton className="h-7 w-32" />
+      ) : (
+        <span className="text-2xl font-bold tabular-nums text-zinc-900 dark:text-zinc-50">
+          {value ?? "—"}
+        </span>
+      )}
+      {(subLabel || trend) && (
+        <div className="flex items-center gap-1.5">
+          {trend === "up" && <TrendingUp className="size-3.5 text-emerald-500" />}
+          {trend === "down" && <TrendingDown className="size-3.5 text-red-500" />}
+          {trend === "neutral" && <Minus className="size-3.5 text-zinc-400" />}
+          {subLabel && <span className="text-xs text-zinc-400 dark:text-zinc-500">{subLabel}</span>}
+        </div>
+      )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+function SectionHeader({
+  title,
+  count,
+  icon,
+  expanded,
+  onToggleExpand,
+  trailing,
+}: {
+  title: string;
+  count?: number;
+  icon: React.ReactNode;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-4 flex items-center gap-2">
+      <div className="flex size-7 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800">
+        {icon}
+      </div>
+      <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{title}</h2>
+      {count !== undefined && (
+        <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          {count}
+        </span>
+      )}
+      {(trailing || onToggleExpand) && (
+        <div className="ml-auto flex items-center gap-1.5">
+          {trailing}
+          {onToggleExpand && (
+            <button
+              type="button"
+              onClick={onToggleExpand}
+              aria-label={expanded ? "Exit full width" : "Expand to full width"}
+              className={`rounded-md p-1.5 transition-all duration-300 ${
+                expanded
+                  ? "bg-brand-50 text-brand-600 hover:bg-brand-100 dark:bg-brand-950 dark:text-brand-400 dark:hover:bg-brand-900"
+                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              }`}
+            >
+              <span
+                className={`block transition-transform duration-300 ${expanded ? "rotate-180" : ""}`}
+              >
+                {expanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+              </span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty / loading states
+// ---------------------------------------------------------------------------
+
+function TableSkeleton({ rows = 5, cols = 3 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, rowIdx) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows have no identity
+        <div key={rowIdx} className="flex gap-3">
+          {Array.from({ length: cols }).map((_, colIdx) => (
+            <Skeleton
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton cols have no identity
+              key={colIdx}
+              className="h-5 flex-1"
+              style={{ flexBasis: colIdx === 0 ? "40%" : undefined }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 text-center">
+      <div className="mb-2 flex size-10 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+        <Minus className="size-4 text-zinc-400" />
+      </div>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">{message}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sortable column header
+// ---------------------------------------------------------------------------
+
+function SortableHeader({
+  label,
+  field,
+  sort,
+  onSort,
+  align = "left",
+}: {
+  label: string;
+  field: string;
+  sort: SortOption;
+  onSort: (field: string) => void;
+  align?: "left" | "right";
+}) {
+  const active = sort.sortBy === field;
+  return (
+    <th
+      className={`cursor-pointer select-none pb-2 pt-3 pr-4 text-xs font-medium uppercase tracking-wide transition-colors ${
+        active
+          ? "text-zinc-700 dark:text-zinc-200"
+          : "text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+      } ${align === "right" ? "text-right" : "text-left"}`}
+      onClick={() => onSort(field)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {active ? (
+          sort.sortOrder === "asc" ? (
+            <ArrowUp className="size-3" />
+          ) : (
+            <ArrowDown className="size-3" />
+          )
+        ) : (
+          <ArrowUpDown className="size-3 opacity-40" />
+        )}
+      </span>
+    </th>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grants table
+// ---------------------------------------------------------------------------
+
+const GrantRow = React.memo(function GrantRow({
+  grant,
+  searchId,
+}: {
+  grant: Grant;
+  searchId?: string;
+}) {
+  return (
+    <tr className="group border-b border-zinc-100 last:border-0 dark:border-zinc-800/60">
+      <td className="py-3 pr-4">
+        <Link
+          href={NON_PROFITS_PAGES.GRANT(grant.id, searchId)}
+          className="flex items-start gap-1 text-sm leading-snug text-zinc-800 hover:text-brand-600 dark:text-zinc-200 dark:hover:text-brand-400"
+        >
+          <span className="line-clamp-2">{grant.purposeText ?? "No purpose listed"}</span>
+          <ArrowUpRight className="mt-0.5 size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        </Link>
+      </td>
+      <td className="py-3 pr-4 text-sm text-zinc-600 dark:text-zinc-400">
+        {grant.recipientName && grant.nonprofitId ? (
+          <Link
+            href={NON_PROFITS_PAGES.NONPROFIT(grant.nonprofitId)}
+            className="line-clamp-1 hover:text-brand-600 hover:underline dark:hover:text-brand-400"
+          >
+            {grant.recipientName}
+          </Link>
+        ) : (
+          <span className="text-zinc-400 dark:text-zinc-500">{grant.recipientName ?? "—"}</span>
+        )}
+      </td>
+      <td className="whitespace-nowrap py-3 pr-4 text-right text-sm font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+        {formatCurrency(grant.amount)}
+      </td>
+      <td className="whitespace-nowrap py-3 text-right text-sm text-zinc-500 dark:text-zinc-400">
+        {grant.filingYear}
+      </td>
+    </tr>
+  );
+});
+
+function GrantYearFilter({
+  years,
+  selected,
+  onChange,
+}: {
+  years: number[];
+  selected: number | null;
+  onChange: (year: number | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  if (years.length <= 1) return null;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-all ${
+          open
+            ? "border-brand-300 bg-brand-50 text-brand-700 dark:border-brand-700 dark:bg-brand-950 dark:text-brand-300"
+            : "border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-600"
+        }`}
+      >
+        <Calendar className="size-3" />
+        {selected ?? "All"}
+        <ChevronDown
+          className={`size-3 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 max-h-48 min-w-[5rem] overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+          <button
+            type="button"
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+            className={`flex w-full items-center px-3 py-1.5 text-xs transition-colors ${
+              selected === null
+                ? "bg-brand-50 font-semibold text-brand-700 dark:bg-brand-950 dark:text-brand-300"
+                : "text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            }`}
+          >
+            All
+          </button>
+          {years.map((year) => (
+            <button
+              key={year}
+              type="button"
+              onClick={() => {
+                onChange(year);
+                setOpen(false);
+              }}
+              className={`flex w-full items-center px-3 py-1.5 text-xs transition-colors ${
+                year === selected
+                  ? "bg-brand-50 font-semibold text-brand-700 dark:bg-brand-950 dark:text-brand-300"
+                  : "text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {year}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GrantsTable({
+  grants,
+  isLoading,
+  searchId,
+  expanded,
+  onToggleExpand,
+  sort,
+  onSort,
+  availableYears,
+  selectedYear,
+  onYearChange,
+}: {
+  grants: Grant[] | undefined;
+  isLoading: boolean;
+  searchId?: string;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+  sort: SortOption;
+  onSort: (field: string) => void;
+  availableYears: number[];
+  selectedYear: number | null;
+  onYearChange: (year: number | null) => void;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+        <SectionHeader
+          title={pluralize("Grant", grants?.length ?? 0)}
+          count={grants?.length}
+          icon={<HandCoins className="size-4 text-brand-600 dark:text-brand-400" />}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+          trailing={
+            <GrantYearFilter
+              years={availableYears}
+              selected={selectedYear}
+              onChange={onYearChange}
+            />
+          }
+        />
+      </div>
+      <div className="overflow-x-auto px-5 pb-4">
+        {isLoading ? (
+          <div className="py-4">
+            <TableSkeleton rows={6} cols={3} />
+          </div>
+        ) : !grants || grants.length === 0 ? (
+          <EmptyState message="No grants found for this foundation." />
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-zinc-100 dark:border-zinc-800/60">
+                <SortableHeader label="Purpose" field="actionDate" sort={sort} onSort={onSort} />
+                <th className="pb-2 pt-3 pr-4 text-left text-xs font-medium uppercase tracking-wide text-zinc-400">
+                  Recipient
+                </th>
+                <SortableHeader
+                  label="Amount"
+                  field="amount"
+                  sort={sort}
+                  onSort={onSort}
+                  align="right"
+                />
+                <SortableHeader
+                  label="Year"
+                  field="filingYear"
+                  sort={sort}
+                  onSort={onSort}
+                  align="right"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {grants.map((grant) => (
+                <GrantRow key={grant.id} grant={grant} searchId={searchId} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Officers table
+// ---------------------------------------------------------------------------
+
+const OfficerRow = React.memo(function OfficerRow({ officer }: { officer: Officer }) {
+  const totalComp =
+    (officer.compensation ?? 0) + (officer.benefits ?? 0) + (officer.expenseAccount ?? 0);
+
+  return (
+    <tr className="border-b border-zinc-100 last:border-0 dark:border-zinc-800/60">
+      <td className="py-2.5 pr-3">
+        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{officer.name}</p>
+        <p className="text-xs text-zinc-400 dark:text-zinc-500">{officer.title ?? "—"}</p>
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-3 text-right text-sm tabular-nums text-zinc-700 dark:text-zinc-300">
+        {formatCurrency(officer.compensation)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-3 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
+        {formatCurrency(officer.benefits)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-3 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
+        {formatCurrency(officer.expenseAccount)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-3 text-right text-sm font-semibold tabular-nums text-zinc-900 dark:text-zinc-100">
+        {totalComp > 0 ? formatCurrency(totalComp) : "—"}
+      </td>
+      <td className="whitespace-nowrap py-2.5 text-right text-xs text-zinc-400 dark:text-zinc-500">
+        {officer.filingYear}
+      </td>
+    </tr>
+  );
+});
+
+function OfficersTable({
+  officers,
+  isLoading,
+  expanded,
+  onToggleExpand,
+  sort,
+  onSort,
+  yearLabel,
+}: {
+  officers: Officer[] | undefined;
+  isLoading: boolean;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+  sort: SortOption;
+  onSort: (field: string) => void;
+  yearLabel?: number | null;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+        <SectionHeader
+          title={pluralize("Officer", officers?.length ?? 0)}
+          count={officers?.length}
+          icon={<Users className="size-4 text-violet-500" />}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+        />
+        {yearLabel && (
+          <div className="-mt-3 mb-1 flex items-center gap-1.5">
+            <Calendar className="size-3 text-zinc-400" />
+            <span className="text-xs text-zinc-400 dark:text-zinc-500">
+              Filing year {yearLabel}
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="overflow-x-auto px-5 pb-4">
+        {isLoading ? (
+          <div className="py-4">
+            <TableSkeleton rows={4} cols={5} />
+          </div>
+        ) : !officers || officers.length === 0 ? (
+          <EmptyState message="No officers found for this foundation." />
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-zinc-100 dark:border-zinc-800/60">
+                <SortableHeader label="Name / Title" field="name" sort={sort} onSort={onSort} />
+                <SortableHeader
+                  label="Compensation"
+                  field="compensation"
+                  sort={sort}
+                  onSort={onSort}
+                  align="right"
+                />
+                <SortableHeader
+                  label="Benefits"
+                  field="benefits"
+                  sort={sort}
+                  onSort={onSort}
+                  align="right"
+                />
+                <th className="pb-2 pt-3 pr-3 text-right text-xs font-medium uppercase tracking-wide text-zinc-400">
+                  Expense Acct
+                </th>
+                <th className="pb-2 pt-3 pr-3 text-right text-xs font-medium uppercase tracking-wide text-zinc-400">
+                  Total
+                </th>
+                <SortableHeader
+                  label="Year"
+                  field="filingYear"
+                  sort={sort}
+                  onSort={onSort}
+                  align="right"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {officers.map((officer) => (
+                <OfficerRow key={officer.id} officer={officer} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Financials table
+// ---------------------------------------------------------------------------
+
+const FinancialRow = React.memo(function FinancialRow({ fin }: { fin: Financials }) {
+  const netPositive = fin.netAssets !== null && fin.netAssets >= 0;
+
+  return (
+    <tr className="border-b border-zinc-100 last:border-0 dark:border-zinc-800/60">
+      <td className="whitespace-nowrap py-2.5 pr-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        {fin.filingYear}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-700 dark:text-zinc-300">
+        {formatCurrency(fin.totalRevenue)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-700 dark:text-zinc-300">
+        {formatCurrency(fin.totalExpenses)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-700 dark:text-zinc-300">
+        {formatCurrency(fin.totalAssets)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums">
+        <span
+          className={
+            fin.netAssets === null
+              ? "text-zinc-400"
+              : netPositive
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-red-500 dark:text-red-400"
+          }
+        >
+          {fin.netAssets !== null && <span className="mr-0.5">{netPositive ? "+" : ""}</span>}
+          {formatCurrency(fin.netAssets)}
+        </span>
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-600 dark:text-zinc-400">
+        {formatCurrency(fin.qualifyingDistributions)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-500">
+        {formatCurrency(fin.minimumInvestmentReturn)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-500">
+        {formatCurrency(fin.distributableAmount)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 pr-4 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-500">
+        {formatCurrency(fin.undistributedIncome)}
+      </td>
+      <td className="whitespace-nowrap py-2.5 text-right text-sm tabular-nums text-zinc-500 dark:text-zinc-500">
+        {formatCurrency(fin.excessDistributions)}
+      </td>
+    </tr>
+  );
+});
+
+const FINANCIALS_COLUMNS: { label: string; field: string }[] = [
+  { label: "Year", field: "filingYear" },
+  { label: "Revenue", field: "totalRevenue" },
+  { label: "Expenses", field: "totalExpenses" },
+  { label: "Total Assets", field: "totalAssets" },
+  { label: "Net Assets", field: "netAssets" },
+  { label: "Qualifying Dist.", field: "qualifyingDistributions" },
+  { label: "Min. Investment Return", field: "minimumInvestmentReturn" },
+  { label: "Distributable Amt.", field: "distributableAmount" },
+  { label: "Undistributed Income", field: "undistributedIncome" },
+  { label: "Excess Dist.", field: "excessDistributions" },
+];
+
+function FinancialsTable({
+  financials,
+  isLoading,
+  expanded,
+  onToggleExpand,
+  sort,
+  onSort,
+}: {
+  financials: Financials[] | undefined;
+  isLoading: boolean;
+  expanded?: boolean;
+  onToggleExpand?: () => void;
+  sort: SortOption;
+  onSort: (field: string) => void;
+}) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+        <SectionHeader
+          title="Financials"
+          count={financials?.length || undefined}
+          icon={<DollarSign className="size-4 text-amber-500" />}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+        />
+      </div>
+      <div className="overflow-x-auto px-5 pb-4">
+        {isLoading ? (
+          <div className="py-4">
+            <TableSkeleton rows={4} cols={6} />
+          </div>
+        ) : !financials || financials.length === 0 ? (
+          <EmptyState message="No financial data found for this foundation." />
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-zinc-100 dark:border-zinc-800/60">
+                {FINANCIALS_COLUMNS.map((col, i) => (
+                  <SortableHeader
+                    key={col.field}
+                    label={col.label}
+                    field={col.field}
+                    sort={sort}
+                    onSort={onSort}
+                    align={i === 0 ? "left" : "right"}
+                  />
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {financials.map((fin) => (
+                <FinancialRow key={fin.id} fin={fin} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hero loading skeleton
+// ---------------------------------------------------------------------------
+
+function HeroSkeleton() {
+  return (
+    <div className="border-b border-zinc-200 bg-white px-4 py-8 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-12 rounded-xl" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-7 w-64" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+        </div>
+        <Skeleton className="h-4 w-full max-w-2xl" />
+        <Skeleton className="h-4 w-3/4 max-w-xl" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat grid loading skeleton
+// ---------------------------------------------------------------------------
+
+const STAT_SKELETON_KEYS = [
+  "assets",
+  "net",
+  "revenue",
+  "expenses",
+  "dist",
+  "grants",
+  "officers",
+] as const;
+
+function StatGridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+      {STAT_SKELETON_KEYS.map((key) => (
+        <div
+          key={key}
+          className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+        >
+          <div className="flex items-start justify-between">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="size-8 rounded-lg" />
+          </div>
+          <Skeleton className="h-7 w-28" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Net assets helpers
+// ---------------------------------------------------------------------------
+
+function netAssetsIsPositive(value: number | null | undefined): boolean {
+  return value !== null && value !== undefined && value >= 0;
+}
+
+function netAssetsIcon(value: number | null | undefined): React.ReactNode {
+  if (netAssetsIsPositive(value)) {
+    return <Plus className="size-4 text-emerald-600" />;
+  }
+  return <Minus className="size-4 text-red-500" />;
+}
+
+function netAssetsIconBg(value: number | null | undefined): string {
+  return netAssetsIsPositive(value)
+    ? "bg-emerald-50 dark:bg-emerald-950"
+    : "bg-red-50 dark:bg-red-950";
+}
+
+function netAssetsTrend(value: number | null | undefined): "up" | "down" | undefined {
+  if (value === null || value === undefined) return undefined;
+  return value >= 0 ? "up" : "down";
+}
+
+// ---------------------------------------------------------------------------
+// Foundation hero
+// ---------------------------------------------------------------------------
+
+interface FoundationHeroProps {
+  id: string;
+  name: string;
+  ein: string;
+  location: string | null;
+  description: string | null;
+  latestFilingYear: number | null | undefined;
+  breadcrumbs: React.ReactNode;
+}
+
+function FoundationHero({
+  id,
+  name,
+  ein,
+  location,
+  description,
+  latestFilingYear,
+  breadcrumbs,
+}: FoundationHeroProps) {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const fieldStyle = isAnimating ? { opacity: 0 } : undefined;
+  const fieldTransition = isAnimating ? undefined : { transition: "opacity 200ms ease-in" };
+
+  return (
+    <div className="relative border-b border-zinc-200 bg-white px-4 py-8 dark:border-zinc-800 dark:bg-zinc-900">
+      <HeroTransitionOverlay entityId={id} onAnimatingChange={setIsAnimating} />
+
+      {breadcrumbs}
+
+      <div className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-4">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-brand-50 dark:bg-brand-950">
+            <Landmark className="size-6 text-brand-600 dark:text-brand-400" />
+          </div>
+          <div>
+            <h1
+              data-hero-field="name"
+              style={{ ...fieldStyle, ...fieldTransition }}
+              className="text-2xl font-bold leading-tight text-zinc-900 dark:text-zinc-50"
+            >
+              {name}
+            </h1>
+            <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-zinc-500">
+              <span className="flex items-center gap-1">
+                <Building2 className="size-3.5" />
+                EIN {ein}
+              </span>
+              {location && (
+                <span
+                  data-hero-field="location"
+                  style={{ ...fieldStyle, ...fieldTransition }}
+                  className="flex items-center gap-1"
+                >
+                  <MapPin className="size-3.5" />
+                  {location}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 flex shrink-0 flex-wrap gap-2 sm:mt-0">
+          {latestFilingYear && (
+            <span
+              data-hero-field="year"
+              style={{ ...fieldStyle, ...fieldTransition }}
+              className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-xs font-medium text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+            >
+              Latest filing: {latestFilingYear}
+            </span>
+          )}
+          <span
+            data-hero-field="badge"
+            style={{ ...fieldStyle, ...fieldTransition }}
+            className="inline-flex items-center gap-1 rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 dark:bg-brand-950 dark:text-brand-300"
+          >
+            Private Foundation
+          </span>
+        </div>
+      </div>
+
+      {description && (
+        <p className="mt-4 max-w-4xl text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Year selector
+// ---------------------------------------------------------------------------
+
+function YearSelector({
+  years,
+  selected,
+  onChange,
+}: {
+  years: number[];
+  selected: number;
+  onChange: (year: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-semibold transition-all ${
+          open
+            ? "border-brand-300 bg-brand-50 text-brand-700 dark:border-brand-700 dark:bg-brand-950 dark:text-brand-300"
+            : "border-zinc-200 bg-white text-zinc-900 hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:border-zinc-600"
+        }`}
+      >
+        <Calendar className="size-3.5" />
+        {selected}
+        <ChevronDown
+          className={`size-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 max-h-48 overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+          {years.map((year) => (
+            <button
+              key={year}
+              type="button"
+              onClick={() => {
+                onChange(year);
+                setOpen(false);
+              }}
+              className={`flex w-full items-center px-4 py-2 text-sm transition-colors ${
+                year === selected
+                  ? "bg-brand-50 font-semibold text-brand-700 dark:bg-brand-950 dark:text-brand-300"
+                  : "text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              }`}
+            >
+              {year}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat grid
+// ---------------------------------------------------------------------------
+
+interface FoundationStatGridProps {
+  selectedFinancials: Financials | null;
+  totalAssets: number | null | undefined;
+  grantsCount: number | undefined;
+  totalGrantAmount: number | null;
+  grantsLoading: boolean;
+  officersCount: number | undefined;
+  officersLoading: boolean;
+  availableYears: number[];
+  selectedYear: number | null;
+  onYearChange: (year: number) => void;
+}
+
+function FoundationStatGrid({
+  selectedFinancials,
+  totalAssets,
+  grantsCount,
+  totalGrantAmount,
+  grantsLoading,
+  officersCount,
+  officersLoading,
+  availableYears,
+  selectedYear,
+  onYearChange,
+}: FoundationStatGridProps) {
+  const grantsValue =
+    grantsCount !== undefined
+      ? `${grantsCount}${totalGrantAmount ? ` · ${formatCurrency(totalGrantAmount)}` : ""}`
+      : "—";
+
+  return (
+    <div className="flex flex-col gap-3">
+      {availableYears.length > 0 && selectedYear && (
+        <div className="flex items-center gap-2">
+          <YearSelector years={availableYears} selected={selectedYear} onChange={onYearChange} />
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">Financial data year</span>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+        <StatCard
+          label="Total Assets"
+          value={formatCurrency(selectedFinancials?.totalAssets ?? totalAssets ?? null)}
+          icon={<DollarSign className="size-4 text-brand-600 dark:text-brand-400" />}
+          iconBg="bg-brand-50 dark:bg-brand-950"
+        />
+        <StatCard
+          label="Net Assets"
+          value={formatCurrency(selectedFinancials?.netAssets ?? null)}
+          icon={netAssetsIcon(selectedFinancials?.netAssets)}
+          iconBg={netAssetsIconBg(selectedFinancials?.netAssets)}
+          trend={netAssetsTrend(selectedFinancials?.netAssets)}
+        />
+        <StatCard
+          label="Revenue"
+          value={formatCurrency(selectedFinancials?.totalRevenue ?? null)}
+          icon={<TrendingUp className="size-4 text-sky-600" />}
+          iconBg="bg-sky-50 dark:bg-sky-950"
+        />
+        <StatCard
+          label="Expenses"
+          value={formatCurrency(selectedFinancials?.totalExpenses ?? null)}
+          icon={<TrendingDown className="size-4 text-orange-500" />}
+          iconBg="bg-orange-50 dark:bg-orange-950"
+        />
+        <StatCard
+          label="Qualifying Dist."
+          value={formatCurrency(selectedFinancials?.qualifyingDistributions ?? null)}
+          icon={<HandCoins className="size-4 text-violet-600" />}
+          iconBg="bg-violet-50 dark:bg-violet-950"
+        />
+        <StatCard
+          label={pluralize("Grant", grantsCount ?? 0)}
+          value={grantsLoading ? undefined : grantsValue}
+          icon={<HandCoins className="size-4 text-amber-600" />}
+          iconBg="bg-amber-50 dark:bg-amber-950"
+          loading={grantsLoading}
+          subLabel="Total grants awarded"
+        />
+        <StatCard
+          label={pluralize("Officer", officersCount ?? 0)}
+          value={officersLoading ? undefined : (officersCount ?? "—")}
+          icon={<Users className="size-4 text-pink-600" />}
+          iconBg="bg-pink-50 dark:bg-pink-950"
+          loading={officersLoading}
+          subLabel="On record"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Not found state
+// ---------------------------------------------------------------------------
+
+function FoundationNotFound() {
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center px-4 text-center">
+      <div className="mb-3 flex size-14 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+        <Landmark className="size-6 text-zinc-400" />
+      </div>
+      <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        Foundation not found
+      </h1>
+      <p className="mt-1 text-sm text-zinc-500">The foundation with this ID could not be found.</p>
+      <Link
+        href={NON_PROFITS_PAGES.HOME}
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+      >
+        Back to Non-Profits
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type ExpandedSection = "grants" | "officers" | "financials" | null;
+type MobileTab = "grants" | "officers" | "financials";
+
+const mobileTabs: { key: MobileTab; label: string; icon: React.ReactNode }[] = [
+  { key: "grants", label: "Grants", icon: <HandCoins className="size-4" /> },
+  { key: "officers", label: "Officers", icon: <Users className="size-4" /> },
+  { key: "financials", label: "Financials", icon: <DollarSign className="size-4" /> },
+];
+
+const GRANTS_DEFAULT: SortOption = { sortBy: "amount", sortOrder: "desc" };
+const OFFICERS_DEFAULT: SortOption = { sortBy: "name", sortOrder: "asc" };
+const FINANCIALS_DEFAULT: SortOption = { sortBy: "filingYear", sortOrder: "desc" };
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Foundation detail requires multi-section state orchestration; splitting further would harm readability without reducing actual complexity
+export function FoundationDetail({ id }: { id: string }) {
+  const searchParams = useSearchParams();
+  const searchId = searchParams.get("searchId") ?? undefined;
+
+  const { data: foundation, isLoading: foundationLoading } = useFoundation(id);
+
+  // Sort state — client-local (not URL params per spec)
+  const [grantsSort, setGrantsSort] = useState<SortOption>(GRANTS_DEFAULT);
+  const [officersSort, setOfficersSort] = useState<SortOption>(OFFICERS_DEFAULT);
+  const [financialsSort, setFinancialsSort] = useState<SortOption>(FINANCIALS_DEFAULT);
+
+  const { data: grants, isLoading: grantsLoading } = useFoundationGrants(id, grantsSort);
+  const { data: officers, isLoading: officersLoading } = useFoundationOfficers(id, officersSort);
+  const { data: financials, isLoading: financialsLoading } = useFoundationFinancials(
+    id,
+    financialsSort
+  );
+
+  const toggleGrantsSort = React.useCallback((field: string) => {
+    setGrantsSort((prev) => ({
+      sortBy: field,
+      sortOrder: prev.sortBy === field ? (prev.sortOrder === "desc" ? "asc" : "desc") : "desc",
+    }));
+  }, []);
+
+  const toggleOfficersSort = React.useCallback((field: string) => {
+    setOfficersSort((prev) => ({
+      sortBy: field,
+      sortOrder: prev.sortBy === field ? (prev.sortOrder === "asc" ? "desc" : "asc") : "asc",
+    }));
+  }, []);
+
+  const toggleFinancialsSort = React.useCallback((field: string) => {
+    setFinancialsSort((prev) => ({
+      sortBy: field,
+      sortOrder: prev.sortBy === field ? (prev.sortOrder === "desc" ? "asc" : "desc") : "desc",
+    }));
+  }, []);
+
+  const [expanded, setExpanded] = useState<ExpandedSection>(null);
+  const [mobileTab, setMobileTab] = useState<MobileTab>("grants");
+  const [grantsYearFilter, setGrantsYearFilter] = useState<number | null>(null);
+
+  const toggleExpand = (section: ExpandedSection) =>
+    setExpanded((prev) => (prev === section ? null : section));
+
+  const sortedYears = React.useMemo(() => {
+    if (!financials || financials.length === 0) return [];
+    return [...new Set(financials.map((f) => f.filingYear))].sort((a, b) => b - a);
+  }, [financials]);
+
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+
+  // Auto-select the latest year when financials load
+  React.useEffect(() => {
+    if (sortedYears.length > 0 && selectedYear === null) {
+      setSelectedYear(sortedYears[0]);
+    }
+  }, [sortedYears, selectedYear]);
+
+  const selectedFinancials = React.useMemo(() => {
+    if (!financials || !selectedYear) return null;
+    return financials.find((f) => f.filingYear === selectedYear) ?? null;
+  }, [financials, selectedYear]);
+
+  const latestFinancials = React.useMemo(() => {
+    if (!financials || financials.length === 0) return null;
+    return [...financials].sort((a, b) => b.filingYear - a.filingYear)[0];
+  }, [financials]);
+
+  // Officers filtered by selected financial year
+  const filteredOfficers = React.useMemo(() => {
+    if (!officers || !selectedYear) return officers;
+    const byYear = officers.filter((o) => o.filingYear === selectedYear);
+    return byYear.length > 0 ? byYear : officers;
+  }, [officers, selectedYear]);
+
+  // Grants: available years + filtered list
+  const grantYears = React.useMemo(() => {
+    if (!grants || grants.length === 0) return [];
+    return [...new Set(grants.map((g) => g.filingYear).filter((y): y is number => y != null))].sort(
+      (a, b) => b - a
+    );
+  }, [grants]);
+
+  const filteredGrants = React.useMemo(() => {
+    if (!grants || grantsYearFilter === null) return grants;
+    return grants.filter((g) => g.filingYear === grantsYearFilter);
+  }, [grants, grantsYearFilter]);
+
+  const totalGrantAmount = React.useMemo(() => {
+    const source = filteredGrants;
+    if (!source || source.length === 0) return null;
+    const sum = source.reduce((acc, g) => acc + (g.amount ?? 0), 0);
+    return sum > 0 ? sum : null;
+  }, [filteredGrants]);
+
+  if (!foundationLoading && !foundation) {
+    return <FoundationNotFound />;
+  }
+
+  const grantsTable = (
+    <GrantsTable
+      grants={filteredGrants}
+      isLoading={grantsLoading}
+      searchId={searchId}
+      expanded={expanded === "grants"}
+      onToggleExpand={() => toggleExpand("grants")}
+      sort={grantsSort}
+      onSort={toggleGrantsSort}
+      availableYears={grantYears}
+      selectedYear={grantsYearFilter}
+      onYearChange={setGrantsYearFilter}
+    />
+  );
+
+  const officersTable = (
+    <OfficersTable
+      officers={filteredOfficers}
+      isLoading={officersLoading}
+      expanded={expanded === "officers"}
+      onToggleExpand={() => toggleExpand("officers")}
+      sort={officersSort}
+      onSort={toggleOfficersSort}
+      yearLabel={selectedYear}
+    />
+  );
+
+  const financialsTable = (
+    <FinancialsTable
+      financials={financials}
+      isLoading={financialsLoading}
+      expanded={expanded === "financials"}
+      onToggleExpand={() => toggleExpand("financials")}
+      sort={financialsSort}
+      onSort={toggleFinancialsSort}
+    />
+  );
+
+  return (
+    <div className="w-full">
+      {/* Hero header */}
+      <div className="animate-entrance" style={{ animationDelay: "0s" }}>
+        {foundationLoading ? (
+          <HeroSkeleton />
+        ) : (
+          <FoundationHero
+            id={id}
+            name={foundation?.name ?? ""}
+            ein={foundation?.ein ?? ""}
+            location={foundation?.location ?? null}
+            description={foundation?.description ?? null}
+            latestFilingYear={latestFinancials?.filingYear}
+            breadcrumbs={
+              <PageBreadcrumbs
+                currentLabel={foundation?.name ?? "Foundation"}
+                searchId={searchId}
+              />
+            }
+          />
+        )}
+      </div>
+
+      {/* Stat cards grid */}
+      <div
+        className="animate-entrance border-b border-zinc-200 bg-zinc-50 px-4 py-6 dark:border-zinc-800 dark:bg-zinc-950"
+        style={{ animationDelay: "0.07s" }}
+      >
+        {foundationLoading || financialsLoading ? (
+          <StatGridSkeleton />
+        ) : (
+          <FoundationStatGrid
+            selectedFinancials={selectedFinancials}
+            totalAssets={foundation?.totalAssets}
+            grantsCount={filteredGrants?.length}
+            totalGrantAmount={totalGrantAmount}
+            grantsLoading={grantsLoading}
+            officersCount={filteredOfficers?.length}
+            officersLoading={officersLoading}
+            availableYears={sortedYears}
+            selectedYear={selectedYear}
+            onYearChange={setSelectedYear}
+          />
+        )}
+      </div>
+
+      {/* Mobile tab bar — visible below xl */}
+      <div
+        className="animate-entrance sticky top-0 z-10 border-b border-zinc-200 bg-white px-4 xl:hidden dark:border-zinc-800 dark:bg-zinc-950"
+        style={{ animationDelay: `${2 * 0.07}s` }}
+      >
+        <nav className="flex gap-1" aria-label="Data sections">
+          {mobileTabs.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setMobileTab(tab.key)}
+              className={`flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-3 text-sm font-medium transition-colors ${
+                mobileTab === tab.key
+                  ? "border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400"
+                  : "border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Mobile tabbed content — visible below xl */}
+      <div
+        className="animate-entrance px-4 py-6 xl:hidden"
+        style={{ animationDelay: `${3 * 0.07}s` }}
+      >
+        {mobileTab === "grants" && grantsTable}
+        {mobileTab === "officers" && officersTable}
+        {mobileTab === "financials" && financialsTable}
+      </div>
+
+      {/* Desktop side-by-side layout — visible at xl and above */}
+      <div
+        className="animate-entrance hidden px-4 py-6 xl:block"
+        style={{ animationDelay: `${3 * 0.07}s` }}
+      >
+        {/* Collapsed section pills — visible when a section is expanded */}
+        <motion.div
+          initial={false}
+          animate={{ height: expanded ? "auto" : 0, opacity: expanded ? 1 : 0 }}
+          transition={{ duration: 0.35, ease: [0.25, 0.1, 0.25, 1] }}
+          className="overflow-hidden"
+        >
+          <div className="mb-4 flex gap-2">
+            {mobileTabs
+              .filter((tab) => tab.key !== expanded)
+              .map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setExpanded(tab.key)}
+                  className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-sm font-medium text-zinc-600 transition-all hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                >
+                  {tab.icon}
+                  {tab.label}
+                  <Maximize2 className="ml-1 size-3 text-zinc-400" />
+                </button>
+              ))}
+          </div>
+        </motion.div>
+
+        <div className="flex gap-6 xl:flex-row">
+          {/* Grants column */}
+          <motion.div
+            initial={false}
+            animate={{
+              flex: expanded === "grants" ? "1 1 100%" : expanded ? "0 0 0%" : "1 1 60%",
+              opacity: expanded && expanded !== "grants" ? 0 : 1,
+            }}
+            transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+            className="min-w-0 overflow-hidden"
+          >
+            {grantsTable}
+          </motion.div>
+
+          {/* Officers + Financials column */}
+          <motion.div
+            initial={false}
+            animate={{
+              flex:
+                expanded === "officers" || expanded === "financials"
+                  ? "1 1 100%"
+                  : expanded
+                    ? "0 0 0%"
+                    : "1 1 40%",
+              opacity: expanded === "grants" ? 0 : 1,
+            }}
+            transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+            className="flex min-w-0 flex-col gap-6 overflow-hidden"
+          >
+            <motion.div
+              initial={false}
+              animate={{
+                height: expanded === "financials" ? 0 : "auto",
+                opacity: expanded === "financials" ? 0 : 1,
+                marginBottom: expanded === "financials" ? 0 : undefined,
+              }}
+              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+              className="overflow-hidden"
+            >
+              {officersTable}
+            </motion.div>
+
+            <motion.div
+              initial={false}
+              animate={{
+                height: expanded === "officers" ? 0 : "auto",
+                opacity: expanded === "officers" ? 0 : 1,
+              }}
+              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+              className="overflow-hidden"
+            >
+              {financialsTable}
+            </motion.div>
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/non-profits/components/grant-detail-dynamic.tsx
+++ b/src/features/non-profits/components/grant-detail-dynamic.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+/**
+ * Client-side dynamic (SSR-disabled) wrapper for GrantDetail.
+ *
+ * `ssr: false` is not allowed in Server Components. This thin client wrapper
+ * re-exports a lazily loaded version so page.tsx Server Components can import
+ * it safely.
+ */
+import dynamic from "next/dynamic";
+
+export const GrantDetailDynamic = dynamic(
+  () =>
+    import("./grant-detail").then((m) => ({
+      default: m.GrantDetail,
+    })),
+  { ssr: false }
+);

--- a/src/features/non-profits/components/grant-detail.tsx
+++ b/src/features/non-profits/components/grant-detail.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+/**
+ * Grant detail page component — ported from
+ * grant-atlas src/features/grant-atlas/components/grant-detail.tsx.
+ *
+ * Key adaptations:
+ * - TanStack Router `Link` → Next.js `Link`
+ * - PAGES.* → NON_PROFITS_PAGES.*
+ * - ~/... → @/...
+ * - searchId read via useSearchParams
+ * - Related grants "See all" links use pluralize for counts
+ */
+
+import "@/src/features/non-profits/styles/non-profits-detail.css";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { useFoundation, useFoundationGrants } from "../hooks/use-foundation";
+import { useGrant } from "../hooks/use-grant";
+import { useNonprofit, useNonprofitGrants } from "../hooks/use-nonprofit";
+import { formatCurrency } from "../lib/utils";
+import type { Grant } from "../types/philanthropy";
+import { PageBreadcrumbs } from "./page-breadcrumbs";
+
+const RELATED_LIMIT = 8;
+
+function RelatedSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-3.5 w-36" />
+      {Array.from({ length: 5 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows
+        <div key={i} className="flex justify-between gap-4">
+          <Skeleton className="h-3.5 w-full" style={{ maxWidth: `${60 + (i % 3) * 10}%` }} />
+          <Skeleton className="h-3.5 w-16 shrink-0" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PageSkeleton() {
+  return (
+    <div className="w-full px-4 py-6">
+      {/* Breadcrumb */}
+      <Skeleton className="mb-4 h-4 w-48" />
+
+      {/* Amount + Purpose */}
+      <div className="flex items-baseline gap-3">
+        <Skeleton className="h-10 w-44" />
+        <Skeleton className="h-5 w-80" />
+      </div>
+
+      {/* FROM / TO rows */}
+      <div className="mt-4 space-y-1.5">
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-72" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-56" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+
+      {/* Metadata line */}
+      <Skeleton className="mt-4 h-3.5 w-64" />
+
+      {/* Related grants */}
+      <div className="mt-8 border-t border-zinc-100 pt-6 dark:border-zinc-800">
+        <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
+          <RelatedSkeleton />
+          <RelatedSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function truncateHash(hash: string): string {
+  if (hash.length <= 14) return hash;
+  return `${hash.slice(0, 8)}…${hash.slice(-6)}`;
+}
+
+function formatAssets(totalAssets: number | null): string {
+  if (totalAssets == null) return "";
+  if (totalAssets >= 1_000_000_000) {
+    return `$${(totalAssets / 1_000_000_000).toFixed(1)}B assets`;
+  }
+  if (totalAssets >= 1_000_000) {
+    return `$${(totalAssets / 1_000_000).toFixed(1)}M assets`;
+  }
+  return `${formatCurrency(totalAssets)} assets`;
+}
+
+function formatPct(amount: number | null, total: number | null): string | null {
+  if (amount == null || total == null || total === 0) return null;
+  const pct = (amount / total) * 100;
+  if (pct < 0.01) return "<0.01%";
+  return `${pct.toFixed(pct < 1 ? 3 : 2)}% of assets`;
+}
+
+// ---------------------------------------------------------------------------
+// Related grants list
+// ---------------------------------------------------------------------------
+
+const RelatedGrantRow = React.memo(function RelatedGrantRow({
+  grant,
+  currentGrantId,
+}: {
+  grant: Grant;
+  currentGrantId: string;
+}) {
+  const isCurrent = grant.id === currentGrantId;
+  return (
+    <tr
+      className={`border-b border-zinc-100 last:border-0 dark:border-zinc-800/50 ${
+        isCurrent ? "bg-zinc-50 dark:bg-zinc-800/30" : ""
+      }`}
+    >
+      <td className={`py-1.5 pr-3 ${isCurrent ? "px-2" : ""}`}>
+        {isCurrent ? (
+          <span className="text-xs text-zinc-400 dark:text-zinc-500">This grant</span>
+        ) : (
+          <Link
+            href={NON_PROFITS_PAGES.GRANT(grant.id)}
+            className="line-clamp-1 text-xs text-zinc-700 hover:text-zinc-900 hover:underline dark:text-zinc-300 dark:hover:text-zinc-100"
+          >
+            {grant.purposeText ?? "Untitled"}
+          </Link>
+        )}
+      </td>
+      <td className="whitespace-nowrap py-1.5 text-right text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
+        {formatCurrency(grant.amount)}
+      </td>
+    </tr>
+  );
+});
+
+function RelatedGrantsList({
+  title,
+  grants,
+  isLoading,
+  currentGrantId,
+  seeAllLink,
+  totalCount,
+  className = "",
+}: {
+  title: string;
+  grants: Grant[] | undefined;
+  isLoading: boolean;
+  currentGrantId: string;
+  seeAllLink: React.ReactNode;
+  totalCount: number | undefined;
+  className?: string;
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-3/4" />
+      </div>
+    );
+  }
+
+  if (!grants || grants.length === 0) {
+    return (
+      <div className={className}>
+        <p className="text-xs text-zinc-400">{title}: none found.</p>
+      </div>
+    );
+  }
+
+  // Sort by amount desc, take top N
+  const sorted = [...grants].sort((a, b) => (b.amount ?? 0) - (a.amount ?? 0));
+  const visible = sorted.slice(0, RELATED_LIMIT);
+  const hasMore = (totalCount ?? grants.length) > RELATED_LIMIT;
+
+  return (
+    <div className={className}>
+      <div className="mb-2 flex items-baseline gap-2">
+        <span className="text-xs font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+          {title}
+        </span>
+        {totalCount !== undefined && (
+          <span className="text-xs tabular-nums text-zinc-300 dark:text-zinc-600">
+            {totalCount}
+          </span>
+        )}
+      </div>
+      <table className="w-full">
+        <tbody>
+          {visible.map((g) => (
+            <RelatedGrantRow key={g.id} grant={g} currentGrantId={currentGrantId} />
+          ))}
+        </tbody>
+      </table>
+      {hasMore && <div className="mt-2">{seeAllLink}</div>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Grant detail renders multiple related data panels with conditional states; complexity reflects domain logic, not poor structure
+export function GrantDetail({ id }: { id: string }) {
+  const searchParams = useSearchParams();
+  const searchId = searchParams.get("searchId") ?? undefined;
+
+  const { data: grant, isLoading: grantLoading } = useGrant(id);
+  const { data: foundation, isLoading: foundationLoading } = useFoundation(
+    grant?.foundationId ?? ""
+  );
+  const { data: nonprofit, isLoading: nonprofitLoading } = useNonprofit(grant?.nonprofitId ?? "");
+  const { data: funderGrants, isLoading: funderGrantsLoading } = useFoundationGrants(
+    grant?.foundationId ?? ""
+  );
+  const { data: recipientGrants, isLoading: recipientGrantsLoading } = useNonprofitGrants(
+    grant?.nonprofitId ?? ""
+  );
+
+  if (grantLoading) {
+    return <PageSkeleton />;
+  }
+
+  if (!grant) {
+    return (
+      <div className="w-full px-4 py-6">
+        <p className="text-sm text-zinc-500">Grant not found.</p>
+        <Link
+          href={NON_PROFITS_PAGES.HOME}
+          className="mt-2 inline-block text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          Back to Non-Profits
+        </Link>
+      </div>
+    );
+  }
+
+  const amountDisplay = grant.amount != null ? formatCurrency(grant.amount) : "—";
+  const assetPct = formatPct(grant.amount, foundation?.totalAssets ?? null);
+
+  const metaParts: string[] = ["Grant"];
+  if (grant.filingYear) metaParts.push(`FY ${grant.filingYear}`);
+  if (grant.date) metaParts.push(formatDate(grant.date));
+  metaParts.push(truncateHash(grant.sourceRowHash));
+
+  const foundationAssets =
+    foundation?.totalAssets != null ? formatAssets(foundation.totalAssets) : "";
+  const foundationEin = foundation?.ein ? `EIN ${foundation.ein}` : "";
+
+  return (
+    <div className="w-full px-4 py-6">
+      {/* Breadcrumb — index 0 */}
+      <div className="animate-entrance" style={{ animationDelay: "0s" }}>
+        <PageBreadcrumbs
+          currentLabel={grant.purposeText ?? "Grant"}
+          searchId={searchId}
+          middle={
+            foundation
+              ? {
+                  label: foundation.name,
+                  href: NON_PROFITS_PAGES.FOUNDATION(foundation.id, searchId),
+                }
+              : undefined
+          }
+        />
+      </div>
+
+      {/* Row 1: Amount + Purpose — index 1 */}
+      <div
+        className="animate-entrance flex min-w-0 items-baseline gap-3"
+        style={{ animationDelay: "0.07s" }}
+      >
+        <span className="shrink-0 text-4xl font-extrabold tabular-nums text-zinc-900 dark:text-zinc-50">
+          {amountDisplay}
+        </span>
+        {grant.purposeText && (
+          <span className="min-w-0 truncate text-lg font-normal text-zinc-600 dark:text-zinc-400">
+            {grant.purposeText}
+          </span>
+        )}
+      </div>
+
+      {/* Row 2: Entity ledger */}
+      <div className="mt-4 space-y-1.5">
+        {/* FROM row — index 2 */}
+        <div
+          className="animate-entrance flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-0.5"
+          style={{ animationDelay: "0.14s" }}
+        >
+          <span className="w-8 shrink-0 text-xs font-normal uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            FROM
+          </span>
+          {foundationLoading ? (
+            <Skeleton className="inline-block h-4 w-64" />
+          ) : foundation ? (
+            <Link
+              href={NON_PROFITS_PAGES.FOUNDATION(foundation.id, searchId)}
+              className="font-medium text-zinc-900 hover:underline dark:text-zinc-100"
+            >
+              {foundation.name}
+            </Link>
+          ) : (
+            <span className="text-zinc-500 dark:text-zinc-400">Unknown Foundation</span>
+          )}
+          {foundation?.location && (
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">{foundation.location}</span>
+          )}
+          {foundationEin && (
+            <span className="text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
+              {foundationEin}
+            </span>
+          )}
+          {foundationAssets && (
+            <span className="text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
+              {foundationAssets}
+            </span>
+          )}
+          {assetPct && (
+            <span className="text-sm tabular-nums text-zinc-400 dark:text-zinc-500">
+              ({assetPct})
+            </span>
+          )}
+        </div>
+
+        {/* TO row — index 3 */}
+        <div
+          className="animate-entrance flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-0.5"
+          style={{ animationDelay: "0.21s" }}
+        >
+          <span className="w-8 shrink-0 text-xs font-normal uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            TO
+          </span>
+          {nonprofit && !nonprofitLoading ? (
+            <Link
+              href={NON_PROFITS_PAGES.NONPROFIT(nonprofit.id, {
+                searchId,
+                grantId: id,
+              })}
+              className="font-medium text-zinc-900 hover:underline dark:text-zinc-100"
+            >
+              {nonprofit.name}
+            </Link>
+          ) : grant.nonprofitId && nonprofitLoading ? (
+            <Skeleton className="inline-block h-4 w-48" />
+          ) : (
+            <span className="text-zinc-500 dark:text-zinc-400">Unknown Recipient</span>
+          )}
+          {nonprofit?.location && (
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">{nonprofit.location}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Row 3: Metadata line — index 4 */}
+      <p
+        className="animate-entrance mt-4 text-sm text-zinc-400 dark:text-zinc-500"
+        style={{ animationDelay: "0.28s" }}
+      >
+        {metaParts.join(" · ")}
+      </p>
+
+      {/* Related grants — index 5 / 6 */}
+      <div className="mt-8 border-t border-zinc-100 pt-6 dark:border-zinc-800">
+        <div className="grid grid-cols-1 gap-8 xl:grid-cols-2">
+          <div className="animate-entrance" style={{ animationDelay: "0.35s" }}>
+            <RelatedGrantsList
+              title="More from this funder"
+              grants={funderGrants}
+              isLoading={funderGrantsLoading}
+              currentGrantId={id}
+              totalCount={funderGrants?.length}
+              seeAllLink={
+                foundation && funderGrants && funderGrants.length > RELATED_LIMIT ? (
+                  <Link
+                    href={NON_PROFITS_PAGES.FOUNDATION(foundation.id, searchId)}
+                    className="text-xs text-zinc-400 hover:text-zinc-600 hover:underline dark:text-zinc-500 dark:hover:text-zinc-300"
+                  >
+                    See all {pluralize("grant", funderGrants.length, true)} →
+                  </Link>
+                ) : null
+              }
+            />
+          </div>
+          {grant.nonprofitId && (
+            <div className="animate-entrance" style={{ animationDelay: "0.42s" }}>
+              <RelatedGrantsList
+                title="More to this recipient"
+                grants={recipientGrants}
+                isLoading={recipientGrantsLoading}
+                currentGrantId={id}
+                totalCount={recipientGrants?.length}
+                seeAllLink={
+                  nonprofit && recipientGrants && recipientGrants.length > RELATED_LIMIT ? (
+                    <Link
+                      href={NON_PROFITS_PAGES.NONPROFIT(nonprofit.id, {
+                        searchId,
+                        grantId: id,
+                      })}
+                      className="text-xs text-zinc-400 hover:text-zinc-600 hover:underline dark:text-zinc-500 dark:hover:text-zinc-300"
+                    >
+                      See all {pluralize("grant", recipientGrants.length, true)} →
+                    </Link>
+                  ) : null
+                }
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/non-profits/components/hero-transition-overlay.tsx
+++ b/src/features/non-profits/components/hero-transition-overlay.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+/**
+ * Hero transition overlay — ported from grant-atlas
+ * src/features/grant-atlas/components/hero-transition-overlay.tsx.
+ *
+ * Reads bounding-rect snapshots from `usePageTransitionStore` captured on
+ * entity-card click (in the search workbench). Renders ghost text elements
+ * positioned at the source coordinates, then animates them toward the
+ * corresponding `[data-hero-field="…"]` elements in the detail page hero.
+ *
+ * App Router adaptation: TanStack Router navigation is replaced by plain
+ * Next.js `Link` / `useRouter`. The timing boundary is the same — the store
+ * is marked stale after `STALE_THRESHOLD_MS` (2 s). If the page hasn't
+ * hydrated by then, the overlay is silently skipped.
+ *
+ * Note: Cross-page shared-element timing under Next.js App Router is reliable
+ * for same-origin client navigations (client-side routing). It will NOT fire
+ * during hard refreshes or initial SSR loads — the overlay component renders
+ * `null` in those cases, and the detail page shows without animation.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type FieldRect, usePageTransitionStore } from "../store/page-transition";
+
+interface HeroTransitionOverlayProps {
+  entityId: string;
+  onAnimatingChange?: (isAnimating: boolean) => void;
+}
+
+type FieldKey = "name" | "badge" | "location" | "assets" | "year";
+
+const FIELD_ORDER: FieldKey[] = ["name", "badge", "location", "assets", "year"];
+const STAGGER_MS = 30;
+const DURATION_MS = 400;
+
+interface AnimatingField {
+  key: FieldKey;
+  rect: FieldRect;
+  destRect: DOMRect | null;
+}
+
+interface FieldStyle {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  opacity: number;
+  transform: string;
+  transition: string;
+}
+
+function getFieldStyle(field: AnimatingField, played: boolean, staggerDelay: number): FieldStyle {
+  const { rect } = field;
+  const dest = field.destRect;
+
+  const baseStyle: FieldStyle = {
+    left: rect.x,
+    top: rect.y,
+    width: rect.width,
+    height: rect.height,
+    opacity: played ? 0 : 1,
+    transform: "translate(0, 0)",
+    transition: "none",
+  };
+
+  if (!played || !dest) return baseStyle;
+
+  const dx = dest.left - rect.x;
+  const dy = dest.top - rect.y;
+  const scaleX = rect.width > 0 ? dest.width / rect.width : 1;
+  const scaleY = rect.height > 0 ? dest.height / rect.height : 1;
+
+  return {
+    ...baseStyle,
+    opacity: 0,
+    transform: `translate(${dx}px, ${dy}px) scale(${scaleX}, ${scaleY})`,
+    transition: `transform ${DURATION_MS}ms cubic-bezier(0.4, 0, 0.2, 1) ${staggerDelay}ms, opacity ${DURATION_MS * 0.5}ms ease-in ${staggerDelay + DURATION_MS * 0.6}ms`,
+  };
+}
+
+export function HeroTransitionOverlay({ entityId, onAnimatingChange }: HeroTransitionOverlayProps) {
+  const store = usePageTransitionStore();
+  const [animatingFields, setAnimatingFields] = useState<AnimatingField[] | null>(null);
+  const [played, setPlayed] = useState(false);
+  const cleanupRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const isActive = store.entityId === entityId && store.fields !== null && !store.isStale();
+
+  const measureDestinations = useCallback((): Map<FieldKey, DOMRect | null> => {
+    const map = new Map<FieldKey, DOMRect | null>();
+    for (const key of FIELD_ORDER) {
+      const el = document.querySelector(`[data-hero-field="${key}"]`);
+      map.set(key, el ? el.getBoundingClientRect() : null);
+    }
+    return map;
+  }, []);
+
+  useEffect(() => {
+    if (!isActive || !store.fields) return;
+
+    const fields = store.fields;
+    const destMap = measureDestinations();
+
+    const fieldsToAnimate: AnimatingField[] = FIELD_ORDER.reduce<AnimatingField[]>((acc, key) => {
+      const rect = fields[key];
+      if (!rect) return acc;
+      acc.push({ key, rect, destRect: destMap.get(key) ?? null });
+      return acc;
+    }, []);
+
+    if (fieldsToAnimate.length === 0) {
+      store.clear();
+      return;
+    }
+
+    setAnimatingFields(fieldsToAnimate);
+    setPlayed(false);
+    onAnimatingChange?.(true);
+
+    // Next frame: trigger the PLAY phase
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = requestAnimationFrame(() => {
+        setPlayed(true);
+      });
+    });
+
+    // After animation completes, clean up
+    const totalDuration = DURATION_MS + STAGGER_MS * (fieldsToAnimate.length - 1) + 100;
+    cleanupRef.current = setTimeout(() => {
+      setAnimatingFields(null);
+      setPlayed(false);
+      onAnimatingChange?.(false);
+      store.clear();
+    }, totalDuration);
+
+    return () => {
+      if (cleanupRef.current !== null) clearTimeout(cleanupRef.current);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+    // isActive is derived from store fields — only re-run when it truly changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive]);
+
+  if (!animatingFields) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 50,
+        pointerEvents: "none",
+      }}
+    >
+      {animatingFields.map((field, idx) => {
+        const staggerDelay = idx * STAGGER_MS;
+        const style = getFieldStyle(field, played, staggerDelay);
+
+        return (
+          <span
+            key={field.key}
+            style={{
+              position: "absolute",
+              left: style.left,
+              top: style.top,
+              width: style.width,
+              height: style.height,
+              opacity: style.opacity,
+              transform: style.transform,
+              transition: style.transition,
+              transformOrigin: "top left",
+              display: "flex",
+              alignItems: "center",
+              overflow: "hidden",
+              whiteSpace: "nowrap",
+              fontSize: field.key === "name" ? "1.5rem" : "0.75rem",
+              fontWeight: field.key === "name" ? "700" : field.key === "badge" ? "500" : "400",
+              color:
+                field.key === "name"
+                  ? "rgb(9 9 11)"
+                  : field.key === "badge"
+                    ? "rgb(15 118 110)"
+                    : "rgb(113 113 122)",
+              lineHeight: "1.25",
+              willChange: "transform, opacity",
+            }}
+          >
+            {field.rect.text}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/non-profits/components/nonprofit-detail-dynamic.tsx
+++ b/src/features/non-profits/components/nonprofit-detail-dynamic.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+/**
+ * Client-side dynamic (SSR-disabled) wrapper for NonprofitDetail.
+ *
+ * `ssr: false` is not allowed in Server Components. This thin client wrapper
+ * re-exports a lazily loaded version so page.tsx Server Components can import
+ * it safely.
+ */
+import dynamic from "next/dynamic";
+
+export const NonprofitDetailDynamic = dynamic(
+  () =>
+    import("./nonprofit-detail").then((m) => ({
+      default: m.NonprofitDetail,
+    })),
+  { ssr: false }
+);

--- a/src/features/non-profits/components/nonprofit-detail.tsx
+++ b/src/features/non-profits/components/nonprofit-detail.tsx
@@ -1,0 +1,606 @@
+"use client";
+
+/**
+ * Nonprofit detail page component — ported from
+ * grant-atlas src/features/grant-atlas/components/nonprofit-detail.tsx.
+ *
+ * Key adaptations:
+ * - TanStack Router `Link` → Next.js `Link`
+ * - PAGES.* → NON_PROFITS_PAGES.*
+ * - ~/... → @/...
+ * - Sort state is client-local `useState`
+ * - searchId read via useSearchParams
+ * - `useQueries` stays (it's from @tanstack/react-query, unchanged)
+ * - Foundation concentration panel uses pluralize
+ */
+
+import "@/src/features/non-profits/styles/non-profits-detail.css";
+
+import { useQueries } from "@tanstack/react-query";
+import { Building2, DollarSign, HandCoins, Heart, MapPin, TrendingUp, Users } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
+import React, { useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { foundationKeys } from "../hooks/use-foundation";
+import { useGrant } from "../hooks/use-grant";
+import { useNonprofit, useNonprofitGrants } from "../hooks/use-nonprofit";
+import { resultToPromise } from "../lib/result-to-promise";
+import { formatCurrency } from "../lib/utils";
+import { philanthropyService } from "../services/philanthropy.service";
+import type { Grant } from "../types/philanthropy";
+import { type BreadcrumbItem, PageBreadcrumbs } from "./page-breadcrumbs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SortField = "amount" | "year" | "foundation" | "purpose";
+type SortDir = "asc" | "desc";
+
+interface SortState {
+  field: SortField;
+  dir: SortDir;
+}
+
+// ---------------------------------------------------------------------------
+// KPI mini-card
+// ---------------------------------------------------------------------------
+
+interface KpiCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  accent?: boolean;
+}
+
+const KpiCard = React.memo(function KpiCard({ icon, label, value, accent = false }: KpiCardProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-xl bg-zinc-50 p-4 dark:bg-zinc-800">
+      <div className="flex items-center gap-2">
+        <span className="text-zinc-400 dark:text-zinc-500">{icon}</span>
+        <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          {label}
+        </span>
+      </div>
+      <span
+        className={
+          accent
+            ? "text-2xl font-bold text-brand-600 dark:text-brand-400"
+            : "text-2xl font-bold text-zinc-900 dark:text-zinc-100"
+        }
+      >
+        {value}
+      </span>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Sort button helper
+// ---------------------------------------------------------------------------
+
+interface SortButtonProps {
+  label: string;
+  field: SortField;
+  sort: SortState;
+  onSort: (field: SortField) => void;
+}
+
+const SortButton = React.memo(function SortButton({ label, field, sort, onSort }: SortButtonProps) {
+  const active = sort.field === field;
+  const arrow = active ? (sort.dir === "asc" ? " ↑" : " ↓") : "";
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(field)}
+      className={
+        "select-none whitespace-nowrap text-xs font-medium uppercase tracking-wide transition-colors " +
+        (active
+          ? "text-brand-600 dark:text-brand-400"
+          : "text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200")
+      }
+      aria-label={`Sort by ${label}${active ? (sort.dir === "asc" ? ", ascending" : ", descending") : ""}`}
+    >
+      {label}
+      {arrow}
+    </button>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Grants table with inline proportional bars
+// ---------------------------------------------------------------------------
+
+interface GrantsTableProps {
+  grants: Grant[];
+  searchId?: string;
+  foundationNames: Record<string, string>;
+  sort: SortState;
+  onSort: (field: SortField) => void;
+}
+
+const GrantsTable = React.memo(function GrantsTable({
+  grants,
+  searchId,
+  foundationNames,
+  sort,
+  onSort,
+}: GrantsTableProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const sorted = [...grants].sort((a, b) => {
+    let cmp = 0;
+    if (sort.field === "amount") {
+      cmp = (a.amount ?? 0) - (b.amount ?? 0);
+    } else if (sort.field === "year") {
+      cmp = a.filingYear - b.filingYear;
+    } else if (sort.field === "foundation") {
+      const nameA = foundationNames[a.foundationId] ?? a.foundationId;
+      const nameB = foundationNames[b.foundationId] ?? b.foundationId;
+      cmp = nameA.localeCompare(nameB);
+    } else if (sort.field === "purpose") {
+      cmp = (a.purposeText ?? "").localeCompare(b.purposeText ?? "");
+    }
+    return sort.dir === "asc" ? cmp : -cmp;
+  });
+
+  const maxAmount = Math.max(...grants.map((g) => g.amount ?? 0), 1);
+  const totalAmount = grants.reduce((sum, g) => sum + (g.amount ?? 0), 0);
+
+  if (grants.length === 0) {
+    return <p className="text-sm text-zinc-500">No grants received.</p>;
+  }
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-200 dark:border-zinc-800">
+              <th className="py-3 pl-4 pr-2 text-left text-xs font-medium uppercase tracking-wide text-zinc-400">
+                #
+              </th>
+              <th className="py-3 pr-3 text-left">
+                <SortButton label="Foundation" field="foundation" sort={sort} onSort={onSort} />
+              </th>
+              <th className="py-3 pr-3 text-left">
+                <SortButton label="Purpose" field="purpose" sort={sort} onSort={onSort} />
+              </th>
+              <th className="py-3 pr-3 text-left">
+                <SortButton label="Year" field="year" sort={sort} onSort={onSort} />
+              </th>
+              <th className="py-3 pr-4 text-right">
+                <SortButton label="Amount" field="amount" sort={sort} onSort={onSort} />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((grant, idx) => {
+              const isExpanded = expandedId === grant.id;
+              const barWidth =
+                grant.amount != null ? Math.max(2, (grant.amount / maxAmount) * 100) : 0;
+              const foundationName = foundationNames[grant.foundationId];
+              const purposePreview = grant.purposeText
+                ? grant.purposeText.length > 60
+                  ? `${grant.purposeText.slice(0, 60)}…`
+                  : grant.purposeText
+                : "—";
+
+              return (
+                <React.Fragment key={grant.id}>
+                  <tr
+                    className="cursor-pointer border-b border-zinc-100 transition-colors last:border-0 hover:bg-zinc-50 dark:border-zinc-800/50 dark:hover:bg-zinc-800/40"
+                    onClick={() => setExpandedId(isExpanded ? null : grant.id)}
+                    aria-expanded={isExpanded}
+                  >
+                    <td className="py-2 pl-4 pr-2 text-xs tabular-nums text-zinc-400">{idx + 1}</td>
+                    <td className="py-2 pr-3">
+                      <Link
+                        href={NON_PROFITS_PAGES.FOUNDATION(grant.foundationId, searchId)}
+                        className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {foundationName ?? "View foundation"}
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-3 text-zinc-600 dark:text-zinc-400">{purposePreview}</td>
+                    <td className="py-2 pr-3 tabular-nums text-zinc-500">{grant.filingYear}</td>
+                    {/* Amount cell with proportional bar */}
+                    <td className="relative py-2 pr-4 text-right">
+                      {/* Proportional bar — behind the text */}
+                      <span
+                        className="absolute inset-y-1 right-0 rounded-r bg-brand-100 dark:bg-brand-900/40"
+                        style={{ width: `${barWidth}%` }}
+                        aria-hidden
+                      />
+                      {/* Text on top */}
+                      <span className="relative z-10 tabular-nums font-medium text-zinc-900 dark:text-zinc-100">
+                        {formatCurrency(grant.amount)}
+                      </span>
+                    </td>
+                  </tr>
+                  {isExpanded && grant.purposeText && (
+                    <tr className="border-b border-zinc-100 bg-zinc-50 dark:border-zinc-800/50 dark:bg-zinc-800/20">
+                      <td />
+                      <td
+                        colSpan={4}
+                        className="py-3 pr-4 text-sm text-zinc-600 dark:text-zinc-400"
+                      >
+                        {grant.purposeText}
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="border-t border-zinc-200 dark:border-zinc-800">
+              <td
+                colSpan={4}
+                className="py-3 pl-4 text-xs font-medium uppercase tracking-wide text-zinc-400"
+              >
+                Total
+              </td>
+              <td className="py-3 pr-4 text-right tabular-nums font-semibold text-zinc-900 dark:text-zinc-100">
+                {formatCurrency(totalAmount)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Foundation concentration panel
+// ---------------------------------------------------------------------------
+
+interface FoundationConcentrationProps {
+  grants: Grant[];
+  foundationNames: Record<string, string>;
+  searchId?: string;
+}
+
+const FoundationConcentrationPanel = React.memo(function FoundationConcentrationPanel({
+  grants,
+  foundationNames,
+  searchId,
+}: FoundationConcentrationProps) {
+  const totals: Record<string, number> = {};
+  for (const grant of grants) {
+    totals[grant.foundationId] = (totals[grant.foundationId] ?? 0) + (grant.amount ?? 0);
+  }
+
+  const grandTotal = Object.values(totals).reduce((s, v) => s + v, 0);
+  const sorted = Object.entries(totals).sort(([, a], [, b]) => b - a);
+
+  return (
+    <div className="mt-6 rounded-2xl border border-zinc-200 p-5 dark:border-zinc-800">
+      <div className="mb-4 flex items-center gap-2">
+        <Heart className="size-4 text-rose-500" aria-hidden />
+        <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Foundation Concentration
+        </h2>
+        <span className="ml-auto text-xs text-zinc-400">
+          {pluralize("foundation", sorted.length, true)}
+        </span>
+      </div>
+      <div className="space-y-3">
+        {sorted.map(([foundationId, total]) => {
+          const pct = grandTotal > 0 ? (total / grandTotal) * 100 : 0;
+          const name = foundationNames[foundationId];
+          return (
+            <div key={foundationId}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <Link
+                  href={NON_PROFITS_PAGES.FOUNDATION(foundationId, searchId)}
+                  className="truncate font-medium text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {name ?? "Unknown Foundation"}
+                </Link>
+                <span className="ml-3 shrink-0 tabular-nums text-zinc-500">
+                  {formatCurrency(total)}
+                  <span className="ml-2 text-xs text-zinc-400">{pct.toFixed(0)}%</span>
+                </span>
+              </div>
+              <div
+                className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800"
+                role="progressbar"
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${name ?? foundationId}: ${pct.toFixed(0)}% of total`}
+              >
+                <div
+                  className="h-full rounded-full bg-teal-500 transition-all dark:bg-teal-400"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+const LoadingSkeleton = React.memo(function LoadingSkeleton() {
+  return (
+    <div className="w-full px-4 py-8" aria-busy="true">
+      {/* Masthead skeleton */}
+      <div className="mb-6 flex items-start gap-3 border-b border-zinc-200 pb-6 dark:border-zinc-800">
+        <Skeleton className="size-10 shrink-0 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-64" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+      </div>
+      {/* Two-column skeleton */}
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <div className="w-full space-y-3 xl:w-[30%]">
+          <div className="grid grid-cols-2 gap-3">
+            {[...Array(4)].map((_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+              <Skeleton key={i} className="h-20 rounded-xl" />
+            ))}
+          </div>
+          <Skeleton className="h-28 rounded-2xl" />
+        </div>
+        <div className="min-w-0 xl:w-[70%]">
+          <Skeleton className="mb-3 h-5 w-32" />
+          <Skeleton className="h-80 rounded-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+const VALID_SORT_FIELDS = new Set<SortField>(["amount", "year", "foundation", "purpose"]);
+const VALID_SORT_DIRS = new Set<SortDir>(["asc", "desc"]);
+
+function parseSortField(v?: string): SortField {
+  return VALID_SORT_FIELDS.has(v as SortField) ? (v as SortField) : "amount";
+}
+function parseSortDir(v?: string): SortDir {
+  return VALID_SORT_DIRS.has(v as SortDir) ? (v as SortDir) : "desc";
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Nonprofit detail orchestrates multi-foundation KPI aggregation and breadcrumb chain resolution; inherent domain complexity
+export function NonprofitDetail({ id }: { id: string }) {
+  const searchParams = useSearchParams();
+  const searchId = searchParams.get("searchId") ?? undefined;
+  const grantId = searchParams.get("grantId") ?? undefined;
+
+  const { data: nonprofit, isLoading } = useNonprofit(id);
+  const { data: grants, isLoading: grantsLoading } = useNonprofitGrants(id);
+
+  // Sort state — client-local per spec
+  const [sortField, setSortField] = useState<string>("amount");
+  const [sortDirStr, setSortDirStr] = useState<string>("desc");
+
+  // Fetch grant for breadcrumb, then derive foundation from it.
+  const { data: rawBreadcrumbGrant } = useGrant(grantId ?? "");
+  const breadcrumbGrant = rawBreadcrumbGrant?.nonprofitId === id ? rawBreadcrumbGrant : undefined;
+  const breadcrumbFoundationId = breadcrumbGrant?.foundationId ?? "";
+  const foundationQuery = useQueries({
+    queries: [
+      {
+        queryKey: foundationKeys.detail(breadcrumbFoundationId),
+        queryFn: () => resultToPromise(philanthropyService.getFoundation(breadcrumbFoundationId)),
+        enabled: Boolean(breadcrumbFoundationId),
+        staleTime: 5 * 60 * 1000,
+      },
+    ],
+  });
+  const breadcrumbFoundation = foundationQuery[0]?.data;
+
+  const resolvedGrants = grants ?? [];
+
+  const uniqueFoundationIds = React.useMemo(
+    () => [...new Set(resolvedGrants.map((g) => g.foundationId))],
+    [resolvedGrants]
+  );
+
+  const foundationQueries = useQueries({
+    queries: uniqueFoundationIds.map((fId) => ({
+      queryKey: foundationKeys.detail(fId),
+      queryFn: () => resultToPromise(philanthropyService.getFoundation(fId)),
+      enabled: Boolean(fId),
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  const foundationNames: Record<string, string> = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    for (let i = 0; i < uniqueFoundationIds.length; i++) {
+      const fId = uniqueFoundationIds[i];
+      const data = foundationQueries[i]?.data;
+      map[fId] = data?.name ?? `Foundation ${fId.slice(0, 8)}`;
+    }
+    return map;
+  }, [uniqueFoundationIds, foundationQueries]);
+
+  const sort: SortState = {
+    field: parseSortField(sortField),
+    dir: parseSortDir(sortDirStr),
+  };
+
+  const handleSort = React.useCallback(
+    (field: SortField) => {
+      const newDir = sort.field === field ? (sort.dir === "asc" ? "desc" : "asc") : "desc";
+      setSortField(field);
+      setSortDirStr(newDir);
+    },
+    [sort.field, sort.dir]
+  );
+
+  if (isLoading || grantsLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (!nonprofit) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-16 text-center">
+        <h1 className="text-lg font-medium text-zinc-900 dark:text-zinc-100">
+          Nonprofit not found
+        </h1>
+        <Link
+          href={NON_PROFITS_PAGES.HOME}
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
+        >
+          Back to Non-Profits
+        </Link>
+      </div>
+    );
+  }
+
+  // Derived KPIs
+  const totalReceived = resolvedGrants.reduce((sum, g) => sum + (g.amount ?? 0), 0);
+  const grantCount = resolvedGrants.length;
+  const avgGrantSize = grantCount > 0 ? totalReceived / grantCount : 0;
+  const uniqueFoundations = uniqueFoundationIds.length;
+
+  // Build breadcrumb chain: search > foundation > grant > nonprofit
+  const breadcrumbMiddle: BreadcrumbItem[] = [];
+  if (breadcrumbFoundation && breadcrumbGrant?.foundationId) {
+    breadcrumbMiddle.push({
+      label: breadcrumbFoundation.name,
+      href: NON_PROFITS_PAGES.FOUNDATION(breadcrumbGrant.foundationId, searchId),
+    });
+  }
+  if (breadcrumbGrant && grantId) {
+    breadcrumbMiddle.push({
+      label: breadcrumbGrant.purposeText ?? "Grant",
+      href: NON_PROFITS_PAGES.GRANT(grantId, searchId),
+    });
+  }
+
+  return (
+    <div className="w-full px-4 py-8">
+      {/* Breadcrumbs — index 0 */}
+      <div className="animate-entrance" style={{ animationDelay: "0s" }}>
+        <PageBreadcrumbs
+          currentLabel={nonprofit.name ?? "Nonprofit"}
+          searchId={searchId}
+          middle={breadcrumbMiddle.length > 0 ? breadcrumbMiddle : undefined}
+        />
+      </div>
+
+      {/* Masthead — index 1 */}
+      <div
+        className="animate-entrance mb-6 flex items-start gap-3 border-b border-zinc-200 pb-6 dark:border-zinc-800"
+        style={{ animationDelay: "0.07s" }}
+      >
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-green-50 dark:bg-green-900/30">
+          <Building2 className="size-5 text-green-600 dark:text-green-400" aria-hidden />
+        </div>
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold leading-tight text-zinc-900 dark:text-zinc-100">
+            {nonprofit.name}
+          </h1>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500">
+            {nonprofit.ein && (
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono dark:bg-zinc-800">
+                EIN {nonprofit.ein}
+              </span>
+            )}
+            {nonprofit.location && (
+              <span className="flex items-center gap-1">
+                <MapPin className="size-3" aria-hidden />
+                {nonprofit.location}
+              </span>
+            )}
+          </div>
+          {nonprofit.description && (
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+              {nonprofit.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex flex-col gap-6 xl:flex-row">
+        {/* Left sidebar — KPIs + concentration */}
+        <div className="w-full xl:w-[30%] xl:shrink-0 xl:sticky xl:top-20 xl:self-start">
+          {/* KPI cards — index 2 */}
+          <div
+            className="animate-entrance grid grid-cols-2 gap-3"
+            style={{ animationDelay: "0.14s" }}
+          >
+            <KpiCard
+              icon={<DollarSign className="size-4" aria-hidden />}
+              label="Total Received"
+              value={formatCurrency(totalReceived)}
+              accent
+            />
+            <KpiCard
+              icon={<HandCoins className="size-4" aria-hidden />}
+              label={pluralize("Grant", grantCount)}
+              value={String(grantCount)}
+            />
+            <KpiCard
+              icon={<TrendingUp className="size-4" aria-hidden />}
+              label="Avg Grant Size"
+              value={formatCurrency(avgGrantSize)}
+            />
+            <KpiCard
+              icon={<Users className="size-4" aria-hidden />}
+              label={pluralize("Foundation", uniqueFoundations)}
+              value={String(uniqueFoundations)}
+            />
+          </div>
+
+          {/* Concentration panel — index 3 */}
+          {resolvedGrants.length > 0 && (
+            <div className="animate-entrance" style={{ animationDelay: "0.21s" }}>
+              <FoundationConcentrationPanel
+                grants={resolvedGrants}
+                foundationNames={foundationNames}
+                searchId={searchId}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Right main — grants table */}
+        <div className="min-w-0 xl:w-[70%]">
+          {/* Table header — index 4 */}
+          <div
+            className="animate-entrance mb-3 flex items-center gap-2"
+            style={{ animationDelay: "0.28s" }}
+          >
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              Grants Received
+            </h2>
+            <span className="text-xs text-zinc-400">({grantCount})</span>
+          </div>
+
+          {/* Grants table — index 5 */}
+          <div className="animate-entrance" style={{ animationDelay: "0.35s" }}>
+            <GrantsTable
+              grants={resolvedGrants}
+              searchId={searchId}
+              foundationNames={foundationNames}
+              sort={sort}
+              onSort={handleSort}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/non-profits/components/page-breadcrumbs.tsx
+++ b/src/features/non-profits/components/page-breadcrumbs.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ChevronRight, Search } from "lucide-react";
+/**
+ * Page breadcrumbs — ported from
+ * grant-atlas src/features/grant-atlas/components/page-breadcrumbs.tsx.
+ *
+ * Reads the search session store to resolve `searchId` → query text.
+ * Uses Next.js `Link` from `next/link` instead of TanStack Router's `Link`.
+ * Uses `NON_PROFITS_PAGES` route constants from `utilities/pages.ts`.
+ *
+ * Returns `null` when there is nothing meaningful to display (no searchId
+ * with a resolved query, and no middle breadcrumb items).
+ */
+import Link from "next/link";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { useSearchSessionStore } from "../store/search-session";
+
+export interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+interface PageBreadcrumbsProps {
+  currentLabel: string;
+  searchId?: string;
+  middle?: BreadcrumbItem | BreadcrumbItem[];
+}
+
+export function PageBreadcrumbs({ currentLabel, searchId, middle }: PageBreadcrumbsProps) {
+  const searchQuery = useSearchSessionStore((s) =>
+    searchId ? s.sessions[searchId]?.query : undefined
+  );
+
+  const middleItems = middle ? (Array.isArray(middle) ? middle : [middle]) : [];
+  const hasSearch = !!(searchId && searchQuery);
+  if (!hasSearch && middleItems.length === 0) return null;
+
+  const chevron = (
+    <ChevronRight className="size-3.5 text-zinc-300 dark:text-zinc-600" aria-hidden />
+  );
+  let itemCount = 0;
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4">
+      <ol className="flex min-w-0 items-center gap-1.5 text-sm">
+        {hasSearch && searchId && (
+          <li className="flex min-w-0 shrink items-center gap-1.5">
+            {itemCount++ > 0 && chevron}
+            <Link
+              href={NON_PROFITS_PAGES.SEARCH(searchId)}
+              className="flex min-w-0 items-center gap-1 text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+            >
+              <Search className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{searchQuery}</span>
+            </Link>
+          </li>
+        )}
+        {middleItems.map((item) => (
+          <li key={item.href} className="flex min-w-0 shrink items-center gap-1.5">
+            {itemCount++ > 0 && chevron}
+            <Link
+              href={item.href}
+              className="truncate text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+            >
+              {item.label}
+            </Link>
+          </li>
+        ))}
+        <li className="flex min-w-0 shrink-0 items-center gap-1.5">
+          {itemCount++ > 0 && chevron}
+          <span className="truncate font-medium text-zinc-900 dark:text-zinc-100">
+            {currentLabel}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  );
+}

--- a/src/features/non-profits/hooks/use-foundation.ts
+++ b/src/features/non-profits/hooks/use-foundation.ts
@@ -10,8 +10,6 @@ import { useState } from "react";
 import { resultToPromise } from "../lib/result-to-promise";
 import { philanthropyService, type SortOption } from "../services/philanthropy.service";
 
-export type { SortOption };
-
 export const foundationKeys = {
   all: ["philanthropy", "foundation"] as const,
   detail: (id: string) => [...foundationKeys.all, id] as const,
@@ -21,7 +19,6 @@ export const foundationKeys = {
     [...foundationKeys.all, id, "officers", sort?.sortBy ?? "", sort?.sortOrder ?? ""] as const,
   financials: (id: string, sort?: SortOption) =>
     [...foundationKeys.all, id, "financials", sort?.sortBy ?? "", sort?.sortOrder ?? ""] as const,
-  filing: (id: string, year: number) => [...foundationKeys.all, id, "filing", year] as const,
 };
 
 export function useFoundation(id: string) {
@@ -57,15 +54,6 @@ export function useFoundationFinancials(id: string, sort?: SortOption) {
     queryFn: () => resultToPromise(philanthropyService.getFoundationFinancials(id, sort)),
     enabled: Boolean(id),
     staleTime: 5 * 60 * 1000,
-  });
-}
-
-export function useFoundationFiling(id: string, year: number) {
-  return useQuery({
-    queryKey: foundationKeys.filing(id, year),
-    queryFn: () => resultToPromise(philanthropyService.getFoundationFiling(id, year)),
-    enabled: Boolean(id) && year > 0,
-    staleTime: 10 * 60 * 1000,
   });
 }
 

--- a/src/features/non-profits/hooks/use-foundation.ts
+++ b/src/features/non-profits/hooks/use-foundation.ts
@@ -1,0 +1,89 @@
+/**
+ * Foundation data hooks — ported from
+ * grant-atlas src/features/grant-atlas/hooks/use-foundation.ts.
+ *
+ * Uses TanStack Query with resultToPromise to bridge neverthrow results.
+ * Sort state management via useSortState is included for convenience.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { resultToPromise } from "../lib/result-to-promise";
+import { philanthropyService, type SortOption } from "../services/philanthropy.service";
+
+export type { SortOption };
+
+export const foundationKeys = {
+  all: ["philanthropy", "foundation"] as const,
+  detail: (id: string) => [...foundationKeys.all, id] as const,
+  grants: (id: string, sort?: SortOption) =>
+    [...foundationKeys.all, id, "grants", sort?.sortBy ?? "", sort?.sortOrder ?? ""] as const,
+  officers: (id: string, sort?: SortOption) =>
+    [...foundationKeys.all, id, "officers", sort?.sortBy ?? "", sort?.sortOrder ?? ""] as const,
+  financials: (id: string, sort?: SortOption) =>
+    [...foundationKeys.all, id, "financials", sort?.sortBy ?? "", sort?.sortOrder ?? ""] as const,
+  filing: (id: string, year: number) => [...foundationKeys.all, id, "filing", year] as const,
+};
+
+export function useFoundation(id: string) {
+  return useQuery({
+    queryKey: foundationKeys.detail(id),
+    queryFn: () => resultToPromise(philanthropyService.getFoundation(id)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationGrants(id: string, sort?: SortOption) {
+  return useQuery({
+    queryKey: foundationKeys.grants(id, sort),
+    queryFn: () => resultToPromise(philanthropyService.getFoundationGrants(id, sort)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationOfficers(id: string, sort?: SortOption) {
+  return useQuery({
+    queryKey: foundationKeys.officers(id, sort),
+    queryFn: () => resultToPromise(philanthropyService.getFoundationOfficers(id, sort)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationFinancials(id: string, sort?: SortOption) {
+  return useQuery({
+    queryKey: foundationKeys.financials(id, sort),
+    queryFn: () => resultToPromise(philanthropyService.getFoundationFinancials(id, sort)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFoundationFiling(id: string, year: number) {
+  return useQuery({
+    queryKey: foundationKeys.filing(id, year),
+    queryFn: () => resultToPromise(philanthropyService.getFoundationFiling(id, year)),
+    enabled: Boolean(id) && year > 0,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+/**
+ * Manages sort state for a table column set.
+ * Toggling the active field flips asc/desc; toggling a new field resets to desc.
+ */
+export function useSortState(defaultField: string, defaultOrder: "asc" | "desc" = "desc") {
+  const [sort, setSort] = useState<SortOption>({ sortBy: defaultField, sortOrder: defaultOrder });
+
+  const toggle = (field: string) => {
+    setSort((prev) => {
+      if (prev.sortBy === field) {
+        return { sortBy: field, sortOrder: prev.sortOrder === "desc" ? "asc" : "desc" };
+      }
+      return { sortBy: field, sortOrder: "desc" };
+    });
+  };
+
+  return { sort, toggle };
+}

--- a/src/features/non-profits/hooks/use-grant.ts
+++ b/src/features/non-profits/hooks/use-grant.ts
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { resultToPromise } from "../lib/result-to-promise";
 import { philanthropyService } from "../services/philanthropy.service";
 
-export const grantKeys = {
+const grantKeys = {
   all: ["philanthropy", "grant"] as const,
   detail: (id: string) => [...grantKeys.all, id] as const,
 };

--- a/src/features/non-profits/hooks/use-grant.ts
+++ b/src/features/non-profits/hooks/use-grant.ts
@@ -1,0 +1,21 @@
+/**
+ * Grant data hook — ported from
+ * grant-atlas src/features/grant-atlas/hooks/use-grant.ts.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { resultToPromise } from "../lib/result-to-promise";
+import { philanthropyService } from "../services/philanthropy.service";
+
+export const grantKeys = {
+  all: ["philanthropy", "grant"] as const,
+  detail: (id: string) => [...grantKeys.all, id] as const,
+};
+
+export function useGrant(id: string) {
+  return useQuery({
+    queryKey: grantKeys.detail(id),
+    queryFn: () => resultToPromise(philanthropyService.getGrant(id)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/non-profits/hooks/use-nonprofit.ts
+++ b/src/features/non-profits/hooks/use-nonprofit.ts
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { resultToPromise } from "../lib/result-to-promise";
 import { philanthropyService } from "../services/philanthropy.service";
 
-export const nonprofitKeys = {
+const nonprofitKeys = {
   all: ["philanthropy", "nonprofit"] as const,
   detail: (id: string) => [...nonprofitKeys.all, id] as const,
   grants: (id: string) => [...nonprofitKeys.all, id, "grants"] as const,

--- a/src/features/non-profits/hooks/use-nonprofit.ts
+++ b/src/features/non-profits/hooks/use-nonprofit.ts
@@ -1,0 +1,31 @@
+/**
+ * Nonprofit data hooks — ported from
+ * grant-atlas src/features/grant-atlas/hooks/use-nonprofit.ts.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { resultToPromise } from "../lib/result-to-promise";
+import { philanthropyService } from "../services/philanthropy.service";
+
+export const nonprofitKeys = {
+  all: ["philanthropy", "nonprofit"] as const,
+  detail: (id: string) => [...nonprofitKeys.all, id] as const,
+  grants: (id: string) => [...nonprofitKeys.all, id, "grants"] as const,
+};
+
+export function useNonprofit(id: string) {
+  return useQuery({
+    queryKey: nonprofitKeys.detail(id),
+    queryFn: () => resultToPromise(philanthropyService.getNonprofit(id)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useNonprofitGrants(id: string) {
+  return useQuery({
+    queryKey: nonprofitKeys.grants(id),
+    queryFn: () => resultToPromise(philanthropyService.getNonprofitGrants(id)),
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/non-profits/lib/utils.ts
+++ b/src/features/non-profits/lib/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared utility helpers for the non-profits feature.
+ *
+ * Ported from grant-atlas src/lib/utils.ts (formatCurrency only — cn is
+ * already provided by @/utilities/cn throughout gap-app-v2).
+ */
+
+/**
+ * Format a dollar amount using US locale, no decimal places.
+ * Returns an em-dash for null/undefined amounts.
+ */
+export function formatCurrency(amount: number | null | undefined): string {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}

--- a/src/features/non-profits/services/philanthropy.service.ts
+++ b/src/features/non-profits/services/philanthropy.service.ts
@@ -1,0 +1,90 @@
+/**
+ * Philanthropy service — ported from grant-atlas
+ * src/features/grant-atlas/services/philanthropy.service.ts.
+ *
+ * Uses the gap-app-v2 `apiFetch` helper (authenticated via TokenManager,
+ * validated with Zod) and returns `ResultAsync<T, AppError>` throughout.
+ *
+ * Differences from the grant-atlas original:
+ * - `apiFetch` is imported from the feature-local lib/api-fetch (uses
+ *   envVars.NEXT_PUBLIC_GAP_INDEXER_URL + TokenManager for auth).
+ * - Endpoint constants come from `NON_PROFITS_API` (already scaffolded in
+ *   Phase 0/1 to match grant-atlas paths exactly).
+ * - No `query()` / `submitFeedback()` — those are handled by the SSE stream
+ *   hook and search-history service respectively.
+ */
+import type { ResultAsync } from "neverthrow";
+import { z } from "zod";
+import { NON_PROFITS_API } from "../lib/api";
+import { apiFetch } from "../lib/api-fetch";
+import type { AppError } from "../lib/errors";
+import {
+  type Filing,
+  FilingSchema,
+  type Financials,
+  FinancialsSchema,
+  type Foundation,
+  FoundationSchema,
+  type Grant,
+  GrantSchema,
+  type Nonprofit,
+  NonprofitSchema,
+  type Officer,
+  OfficerSchema,
+} from "../types/philanthropy";
+
+export interface SortOption {
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}
+
+function buildSortQs(sort?: SortOption): string {
+  const params = new URLSearchParams();
+  if (sort?.sortBy) params.set("sortBy", sort.sortBy);
+  if (sort?.sortOrder) params.set("sortOrder", sort.sortOrder);
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export const philanthropyService = {
+  getFoundation(id: string): ResultAsync<Foundation, AppError> {
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.GET(id), FoundationSchema);
+  },
+
+  getFoundationGrants(id: string, sort?: SortOption): ResultAsync<Grant[], AppError> {
+    return apiFetch(
+      `${NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.GRANTS(id)}${buildSortQs(sort)}`,
+      z.array(GrantSchema)
+    );
+  },
+
+  getFoundationOfficers(id: string, sort?: SortOption): ResultAsync<Officer[], AppError> {
+    return apiFetch(
+      `${NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.OFFICERS(id)}${buildSortQs(sort)}`,
+      z.array(OfficerSchema)
+    );
+  },
+
+  getFoundationFinancials(id: string, sort?: SortOption): ResultAsync<Financials[], AppError> {
+    return apiFetch(
+      `${NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.FINANCIALS(id)}${buildSortQs(sort)}`,
+      z.array(FinancialsSchema)
+    );
+  },
+
+  getFoundationFiling(id: string, year: number): ResultAsync<Filing, AppError> {
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.FILING(id, year), FilingSchema);
+  },
+
+  getNonprofit(id: string): ResultAsync<Nonprofit, AppError> {
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.NONPROFITS.GET(id), NonprofitSchema);
+  },
+
+  getNonprofitGrants(id: string): ResultAsync<Grant[], AppError> {
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.NONPROFITS.GRANTS(id), z.array(GrantSchema));
+  },
+
+  getGrant(id: string): ResultAsync<Grant, AppError> {
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.GRANTS.GET(id), GrantSchema);
+  },
+};

--- a/src/features/non-profits/store/page-transition.ts
+++ b/src/features/non-profits/store/page-transition.ts
@@ -19,7 +19,7 @@ export interface FieldRect {
   height: number;
 }
 
-export interface PageTransitionFields {
+interface PageTransitionFields {
   name: FieldRect;
   badge?: FieldRect;
   location?: FieldRect;

--- a/src/features/non-profits/store/page-transition.ts
+++ b/src/features/non-profits/store/page-transition.ts
@@ -1,0 +1,61 @@
+/**
+ * Page-transition Zustand store — ported from grant-atlas src/store/page-transition.ts.
+ *
+ * Captures the bounding-rect snapshot of entity-card fields (name, badge,
+ * location, assets, year) at click time. The HeroTransitionOverlay component
+ * on the detail page reads these rects and animates ghost elements from their
+ * search-card positions to the hero field positions.
+ *
+ * Stale threshold: 2000 ms — if the user navigated slowly (SSR hydration,
+ * slow network) the snapshot is too old to produce a believable animation.
+ */
+import { create } from "zustand";
+
+export interface FieldRect {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PageTransitionFields {
+  name: FieldRect;
+  badge?: FieldRect;
+  location?: FieldRect;
+  assets?: FieldRect;
+  year?: FieldRect;
+}
+
+interface PageTransitionState {
+  entityId: string | null;
+  entityType: string | null;
+  fields: PageTransitionFields | null;
+  timestamp: number;
+  set: (entityId: string, entityType: string, fields: PageTransitionFields) => void;
+  clear: () => void;
+  isStale: () => boolean;
+}
+
+const STALE_THRESHOLD_MS = 2000;
+
+export const usePageTransitionStore = create<PageTransitionState>()((set, get) => ({
+  entityId: null,
+  entityType: null,
+  fields: null,
+  timestamp: 0,
+
+  set: (entityId, entityType, fields) => {
+    set({ entityId, entityType, fields, timestamp: Date.now() });
+  },
+
+  clear: () => {
+    set({ entityId: null, entityType: null, fields: null, timestamp: 0 });
+  },
+
+  isStale: () => {
+    const { timestamp } = get();
+    if (timestamp === 0) return true;
+    return Date.now() - timestamp > STALE_THRESHOLD_MS;
+  },
+}));

--- a/src/features/non-profits/styles/non-profits-detail.css
+++ b/src/features/non-profits/styles/non-profits-detail.css
@@ -1,0 +1,25 @@
+/**
+ * Route-scoped styles for the non-profits detail pages.
+ *
+ * Only adds the `.animate-entrance` keyframe used by the detail page layout
+ * components. Import this file at the top of each detail client component
+ * (foundation-detail.tsx, nonprofit-detail.tsx, grant-detail.tsx).
+ *
+ * This file intentionally does NOT touch globals.css. The animation is scoped
+ * to the non-profits feature area.
+ */
+
+@keyframes entrance-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-entrance {
+  animation: entrance-fade-in 0.45s cubic-bezier(0.25, 0.1, 0.25, 1) both;
+}

--- a/src/features/non-profits/types/philanthropy.ts
+++ b/src/features/non-profits/types/philanthropy.ts
@@ -15,13 +15,12 @@ export const CitationSchema = z.object({
 });
 export type Citation = z.infer<typeof CitationSchema>;
 
-export const EntityScoresSchema = z.object({
+const EntityScoresSchema = z.object({
   semantic: z.number(),
   amount: z.number(),
   recency: z.number(),
   composite: z.number(),
 });
-export type EntityScores = z.infer<typeof EntityScoresSchema>;
 
 // ── Query / search ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase 4 of the grant-atlas → gap-app-v2 migration. Adds the entity **detail pages** for foundations, nonprofits, and grants under `/non-profits/`, ported faithfully from grant-atlas.

### Routes (each with `page.tsx` + `loading.tsx` + `error.tsx`)
- `/non-profits/foundations/[id]`
- `/non-profits/nonprofits/[id]`
- `/non-profits/grants/[id]`

Server Components use `generateMetadata` with a cached `fetch(..., { next: { revalidate: 3600 } })` for SEO (per the agreed decision).

### Data layer
- `services/philanthropy.service.ts` — `apiFetch` + Zod, returns `ResultAsync<T, AppError>` throughout (ADR-0001 pattern)
- `hooks/use-foundation.ts`, `use-nonprofit.ts`, `use-grant.ts` — TanStack Query via `resultToPromise`
- `store/page-transition.ts` — Zustand store for the hero animation
- `lib/utils.ts` (`formatCurrency`), `styles/non-profits-detail.css` (entrance keyframe)

### Components
- `foundation-detail`, `nonprofit-detail`, `grant-detail` (+ `*-dynamic` SSR-off wrappers)
- `hero-transition-overlay` (rendered on detail pages; dormant until wired — see below)
- `page-breadcrumbs`

### Tests
91/91 non-profits unit tests pass (10 files), incl. new service + detail-hook coverage.

## Quality gate

- `tsc --noEmit`: 0 errors
- `biome check src/features/non-profits app/non-profits`: only 1 pre-existing warning (Phase 3 test suppression)
- `node scripts/quality-gate.js` (enforce): **passes**, improvements only (biome −2, knipUnusedFiles −3, knipUnusedDeps −2)
- knip: unused-export/type regressions resolved by un-exporting in-file-only symbols and removing dead code (the `useFoundationFiling` hook was dead in grant-atlas too)
- `foundation-detail.tsx` (1395 lines) and `nonprofit-detail.tsx` (606 lines) are registered in `quality-baseline.json` — faithful ports of grant-atlas's single-file components, matching the precedent set by `landing-page-client.tsx`

## Deferred to Phase 6 (polish)

**Hero-transition card wiring is NOT included.** The `HeroTransitionOverlay` and `page-transition` store are in place and the overlay renders transparently when no transition is active, but the search-result cards in the merged `chat-view-client.tsx` do not yet capture `getBoundingClientRect()` on click to populate the store. Wiring this touches Phase 3's merged code and depends on getting App Router navigation timing reliable, so it's deferred to Phase 6 alongside `ranked-entity-card.tsx`. Detail pages are fully functional without it.

## Test plan
- [ ] Visit each detail route (foundation/nonprofit/grant) — loading skeleton → data, empty, and error states render
- [ ] `generateMetadata` produces correct title/description per entity
- [ ] Sortable tables (grants/officers/financials) on the foundation page work
- [ ] CI green on the integration branch