### PR TITLE
feat(non-profits): narrative linkify + feedback, hero-transition, a11y (Phase 6)

### DIFF
--- a/src/features/non-profits/__tests__/linkify-narrative.test.ts
+++ b/src/features/non-profits/__tests__/linkify-narrative.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { linkifyNarrative } from "../lib/linkify-narrative";
+import type { RankedEntity } from "../types/philanthropy";
+
+function entity(overrides: Partial<RankedEntity> & { id: string; name: string }): RankedEntity {
+  return {
+    entityType: "foundation",
+    id: overrides.id,
+    name: overrides.name,
+    description: null,
+    ein: null,
+    location: null,
+    totalAssets: null,
+    amount: null,
+    date: null,
+    filingYear: null,
+    foundationId: null,
+    foundationName: null,
+    nonprofitId: null,
+    nonprofitName: null,
+    scores: { semantic: 0, amount: 0, recency: 0, composite: 0 },
+    ...overrides,
+  };
+}
+
+describe("linkifyNarrative", () => {
+  it("returns the input when there are no entities", () => {
+    expect(linkifyNarrative("hello world", [])).toBe("hello world");
+  });
+
+  it("links an exact case-insensitive match", () => {
+    const entities = [entity({ id: "f1", name: "Ford Foundation" })];
+    expect(linkifyNarrative("The Ford Foundation funds work.", entities)).toContain(
+      "[The Ford Foundation](/non-profits/foundations/f1)"
+    );
+  });
+
+  it("links when narrative has punctuation the entity name lacks", () => {
+    const entities = [entity({ id: "walton", name: "Alice L Walton Foundation" })];
+    const result = linkifyNarrative("the Alice L. Walton Foundation in Bentonville", entities);
+    expect(result).toContain("the [Alice L. Walton Foundation](/non-profits/foundations/walton)");
+  });
+
+  it("does not include a lowercase leading article in the anchor", () => {
+    const entities = [entity({ id: "ford", name: "Ford Foundation" })];
+    const result = linkifyNarrative("Grants from the Ford Foundation support work.", entities);
+    expect(result).toContain("the [Ford Foundation](/non-profits/foundations/ford)");
+    expect(result).not.toContain("[the Ford Foundation]");
+  });
+
+  it("links when the entity name has a leading 'The' and the narrative drops it", () => {
+    const entities = [entity({ id: "kresge", name: "THE KRESGE FOUNDATION" })];
+    const result = linkifyNarrative("The Kresge Foundation in Troy.", entities);
+    expect(result).toContain("[The Kresge Foundation](/non-profits/foundations/kresge)");
+  });
+
+  it("links when the entity has a trailing 'Inc' the narrative drops", () => {
+    const entities = [entity({ id: "casey", name: "Annie E Casey Foundation Inc" })];
+    const result = linkifyNarrative("the Annie E. Casey Foundation is based", entities);
+    expect(result).toContain("the [Annie E. Casey Foundation](/non-profits/foundations/casey)");
+  });
+
+  it("prefers longer names when two candidates share a suffix", () => {
+    const entities = [
+      entity({ id: "short", name: "Ford Foundation" }),
+      entity({ id: "long", name: "Henry Ford Foundation" }),
+    ];
+    const result = linkifyNarrative("The Henry Ford Foundation supports work.", entities);
+    expect(result).toContain("/non-profits/foundations/long");
+    expect(result).not.toContain("/non-profits/foundations/short");
+  });
+
+  it("does not double-link overlapping mentions", () => {
+    const entities = [entity({ id: "f1", name: "Ford Foundation" })];
+    const result = linkifyNarrative("Ford Foundation and Ford Foundation", entities);
+    const linkCount = result.match(/\/non-profits\/foundations\/f1/g)?.length ?? 0;
+    expect(linkCount).toBe(2);
+  });
+
+  it("skips single-word entity names to avoid false positives", () => {
+    const entities = [entity({ id: "f1", name: "Foundation" })];
+    expect(linkifyNarrative("This Foundation is great.", entities)).toBe(
+      "This Foundation is great."
+    );
+  });
+
+  it("produces correct path for each entity type", () => {
+    const foundations = [entity({ id: "x", name: "Test Foundation", entityType: "foundation" })];
+    const nonprofits = [entity({ id: "x", name: "Test Nonprofit", entityType: "nonprofit" })];
+    const grants = [entity({ id: "x", name: "Test Grant", entityType: "grant" })];
+
+    expect(linkifyNarrative("Test Foundation", foundations)).toContain(
+      "/non-profits/foundations/x"
+    );
+    expect(linkifyNarrative("Test Nonprofit", nonprofits)).toContain("/non-profits/nonprofits/x");
+    expect(linkifyNarrative("Test Grant", grants)).toContain("/non-profits/grants/x");
+  });
+
+  it("handles a realistic narrative with mixed name variations", () => {
+    const entities = [
+      entity({ id: "ford", name: "THE FORD FOUNDATION" }),
+      entity({ id: "arnold", name: "LAURA AND JOHN ARNOLD FOUNDATION" }),
+      entity({ id: "walton", name: "Alice L Walton Foundation" }),
+      entity({ id: "kresge", name: "THE KRESGE FOUNDATION" }),
+      entity({ id: "mott", name: "CHARLES STEWART MOTT FOUNDATION" }),
+    ];
+    const narrative =
+      "The Ford Foundation leads. The Laura and John Arnold Foundation follows, " +
+      "as does the Alice L. Walton Foundation, the Kresge Foundation, and the " +
+      "Charles Stewart Mott Foundation.";
+
+    const result = linkifyNarrative(narrative, entities);
+    expect(result).toContain("/non-profits/foundations/ford");
+    expect(result).toContain("/non-profits/foundations/arnold");
+    expect(result).toContain("/non-profits/foundations/walton");
+    expect(result).toContain("/non-profits/foundations/kresge");
+    expect(result).toContain("/non-profits/foundations/mott");
+  });
+});

--- a/src/features/non-profits/components/bookmarks-drawer.tsx
+++ b/src/features/non-profits/components/bookmarks-drawer.tsx
@@ -12,7 +12,7 @@ import { Building2, ChevronRight, HandCoins, Landmark, X } from "lucide-react";
 import Link from "next/link";
 import pluralize from "pluralize";
 import type React from "react";
-import { memo, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import {
@@ -101,6 +101,28 @@ export function BookmarksDrawer({ open, onClose }: { open: boolean; onClose: () 
   const { data: items = [], isLoading, isError } = useResearchTray();
   const { mutateAsync: clearAll, isPending: isClearing } = useClearResearchTray();
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Escape key closes the drawer.
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  // Move focus into the drawer when it opens.
+  useEffect(() => {
+    if (open) {
+      closeButtonRef.current?.focus();
+    }
+  }, [open]);
 
   return (
     <>
@@ -140,12 +162,14 @@ export function BookmarksDrawer({ open, onClose }: { open: boolean; onClose: () 
                 type="button"
                 onClick={() => setConfirmClearOpen(true)}
                 disabled={isClearing}
+                aria-label="Clear all bookmarks"
                 className="text-xs text-zinc-400 transition-colors hover:text-zinc-600 dark:hover:text-zinc-300 disabled:opacity-50"
               >
                 Clear all
               </button>
             )}
             <button
+              ref={closeButtonRef}
               type="button"
               onClick={onClose}
               aria-label="Close bookmarks"

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -20,15 +20,12 @@ import {
   Bookmark,
   BookmarkCheck,
   Building2,
-  Check,
   ChevronDown,
   Clock,
   HandCoins,
   Landmark,
   MapPin,
   Sparkles,
-  Wrench,
-  X,
 } from "lucide-react";
 import Link from "next/link";
 import pluralize from "pluralize";
@@ -43,7 +40,6 @@ import {
   ConversationScrollButton,
 } from "@/src/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/src/components/ai-elements/message";
-import { MessageResponse } from "@/src/components/ai-elements/message-response";
 import {
   PromptInput,
   PromptInputBody,
@@ -62,12 +58,16 @@ import {
   useResearchTray,
 } from "../hooks/use-research-tray";
 import { searchHistoryService } from "../services/search-history.service";
+import type { FieldRect, PageTransitionFields } from "../store/page-transition";
+import { usePageTransitionStore } from "../store/page-transition";
 import { type ChatTurn, EMPTY_MESSAGES, usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 import type { PhilanthropyEntityType, RankedEntity } from "../types/philanthropy";
 import { AttachmentsPanel } from "./attachments-panel";
 import { BookmarksDrawer } from "./bookmarks-drawer";
 import { ConnectorNudge } from "./connector-nudge";
+import { NarrativeBlock } from "./narrative-block";
+import { ProgressView } from "./progress-view";
 import { SearchHistoryPanel } from "./search-history-panel";
 
 // ── Entity presentation constants ──────────────────────────────────────────
@@ -158,10 +158,6 @@ function getEntityHref(entity: RankedEntity, searchId?: string): string {
   }
 }
 
-function formatToolName(tool: string): string {
-  return tool.replace(/^mcp__[^_]+__/, "").replace(/_/g, " ");
-}
-
 // ── Sub-components ──────────────────────────────────────────────────────────
 
 const CompactEntityCard = memo(function CompactEntityCard({
@@ -173,24 +169,55 @@ const CompactEntityCard = memo(function CompactEntityCard({
 }) {
   const Icon = ENTITY_ICON[entity.entityType];
   const href = getEntityHref(entity, searchId);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const setTransition = usePageTransitionStore((s) => s.set);
 
   const meta: string[] = [];
   if (entity.totalAssets) meta.push(`$${formatCurrency(entity.totalAssets)} assets`);
   if (entity.amount) meta.push(`$${formatCurrency(entity.amount)} grant`);
   if (entity.location) meta.push(entity.location);
 
+  const handleLinkClick = useCallback(() => {
+    if (!cardRef.current) return;
+    const fieldEls = cardRef.current.querySelectorAll<HTMLElement>("[data-field]");
+    const collected: Partial<PageTransitionFields> & { name?: FieldRect } = {};
+    for (const el of fieldEls) {
+      const key = el.dataset.field as keyof PageTransitionFields | undefined;
+      if (!key) continue;
+      const rect = el.getBoundingClientRect();
+      const entry: FieldRect = {
+        text: el.textContent?.trim() ?? "",
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      };
+      collected[key] = entry;
+    }
+    if (collected.name) {
+      setTransition(entity.id, entity.entityType, collected as PageTransitionFields);
+    }
+  }, [entity.id, entity.entityType, setTransition]);
+
   return (
-    <div className="group relative flex items-start gap-3 rounded-lg border border-zinc-200 bg-white p-3 transition-all hover:border-zinc-300 hover:bg-zinc-50 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 dark:hover:bg-zinc-800">
-      <Link href={href} className="contents">
+    <div
+      ref={cardRef}
+      className="group relative flex items-start gap-3 rounded-lg border border-zinc-200 bg-white p-3 transition-all hover:border-zinc-300 hover:bg-zinc-50 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
+    >
+      <Link href={href} className="contents" onClick={handleLinkClick}>
         <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
           <Icon className="size-4" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
-            <p className="truncate text-sm font-medium text-zinc-900 group-hover:text-brand-emphasis dark:text-zinc-100">
+            <p
+              data-field="name"
+              className="truncate text-sm font-medium text-zinc-900 group-hover:text-brand-emphasis dark:text-zinc-100"
+            >
               {entity.name ?? "Unnamed"}
             </p>
             <span
+              data-field="badge"
               className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ENTITY_BADGE_CLASS[entity.entityType]}`}
             >
               {ENTITY_LABEL[entity.entityType]}
@@ -205,8 +232,13 @@ const CompactEntityCard = memo(function CompactEntityCard({
             <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
               {meta.map((m, i) => (
                 <span key={`${entity.id}-meta-${i}`} className="inline-flex items-center gap-1">
-                  {i === meta.length - 1 && entity.location === m && <MapPin className="size-3" />}
-                  {m}
+                  {i === meta.length - 1 && entity.location === m && (
+                    <>
+                      <MapPin className="size-3" />
+                      <span data-field="location">{m}</span>
+                    </>
+                  )}
+                  {!(i === meta.length - 1 && entity.location === m) && m}
                 </span>
               ))}
             </div>
@@ -245,67 +277,6 @@ function EntityList({ entities, searchId }: { entities: RankedEntity[]; searchId
   );
 }
 
-function ProgressView({ progress }: { progress: NonNullable<ChatTurn["progress"]> }) {
-  const { toolHistory, latestThought, matchedNames } = progress;
-  const hasAnything = toolHistory.length > 0 || latestThought !== null || matchedNames.length > 0;
-
-  if (!hasAnything) {
-    return (
-      <div className="inline-flex items-center gap-1.5 text-xs text-zinc-400">
-        <Spinner className="size-3" />
-        searching 140,221 filings…
-      </div>
-    );
-  }
-
-  return (
-    <div className="mt-1 flex flex-col gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/50">
-      {toolHistory.length > 0 && (
-        <ul className="flex flex-col gap-1">
-          {toolHistory.map((entry, i) => (
-            <li
-              key={`${entry.tool}-${i}`}
-              className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400"
-            >
-              <span className="flex size-4 shrink-0 items-center justify-center">
-                {entry.status === "running" && <Spinner className="size-3" />}
-                {entry.status === "completed" && (
-                  <Check className="size-3 text-emerald-600 dark:text-emerald-400" />
-                )}
-                {entry.status === "failed" && (
-                  <X className="size-3 text-red-600 dark:text-red-400" />
-                )}
-              </span>
-              <Wrench className="size-3 shrink-0 text-zinc-400" />
-              <span className="font-mono">{formatToolName(entry.tool)}</span>
-            </li>
-          ))}
-        </ul>
-      )}
-      {latestThought && (
-        <p className="text-xs italic text-zinc-500 dark:text-zinc-400">{latestThought}</p>
-      )}
-      {matchedNames.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {matchedNames.slice(0, 12).map((name) => (
-            <span
-              key={name}
-              className="rounded-full bg-brand px-2 py-0.5 text-[10px] font-medium text-white dark:bg-brand/20 dark:text-brand-subtle"
-            >
-              {name}
-            </span>
-          ))}
-          {matchedNames.length > 12 && (
-            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
-              +{matchedNames.length - 12} more
-            </span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
 const AssistantTurn = memo(function AssistantTurn({
   turn,
   searchId,
@@ -338,7 +309,14 @@ const AssistantTurn = memo(function AssistantTurn({
           </div>
         )}
         {isStreaming && turn.progress && <ProgressView progress={turn.progress} />}
-        {hasNarrative && <MessageResponse>{turn.narrative}</MessageResponse>}
+        {hasNarrative && (
+          <NarrativeBlock
+            narrative={turn.narrative}
+            entities={[...turn.entities]}
+            traceId={turn.traceId}
+            status={turn.status}
+          />
+        )}
         {turn.entities.length > 0 && (
           <EntityList entities={[...turn.entities]} searchId={searchId} />
         )}

--- a/src/features/non-profits/components/foundation-detail.tsx
+++ b/src/features/non-profits/components/foundation-detail.tsx
@@ -1,17 +1,9 @@
 "use client";
 
 /**
- * Foundation detail page component — ported from
- * grant-atlas src/features/grant-atlas/components/foundation-detail.tsx.
- *
- * Key adaptations from grant-atlas:
- * - TanStack Router `Link` → Next.js `Link` from next/link
- * - PAGES.FOUNDATION/NONPROFIT/GRANT → NON_PROFITS_PAGES.*
- * - ~/... imports → @/... imports
- * - brand-* color classes already exist in gap-app-v2's tailwind.config.js
- * - Sort state is client-local `useState` (not URL params)
- * - searchId flows via `useSearchParams` (read only)
- * - Not-found is rendered inline (no server-side notFound())
+ * Foundation detail page component — ported from grant-atlas.
+ * Key adaptations: Next.js Link, NON_PROFITS_PAGES constants, @/ imports,
+ * client-local sort state, searchId via useSearchParams, inline not-found.
  */
 
 import "@/src/features/non-profits/styles/non-profits-detail.css";
@@ -36,7 +28,7 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
-import { motion } from "motion/react";
+import { MotionConfig, motion } from "motion/react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import pluralize from "pluralize";
@@ -1224,172 +1216,174 @@ export function FoundationDetail({ id }: { id: string }) {
   );
 
   return (
-    <div className="w-full">
-      {/* Hero header */}
-      <div className="animate-entrance" style={{ animationDelay: "0s" }}>
-        {foundationLoading ? (
-          <HeroSkeleton />
-        ) : (
-          <FoundationHero
-            id={id}
-            name={foundation?.name ?? ""}
-            ein={foundation?.ein ?? ""}
-            location={foundation?.location ?? null}
-            description={foundation?.description ?? null}
-            latestFilingYear={latestFinancials?.filingYear}
-            breadcrumbs={
-              <PageBreadcrumbs
-                currentLabel={foundation?.name ?? "Foundation"}
-                searchId={searchId}
-              />
-            }
-          />
-        )}
-      </div>
+    <MotionConfig reducedMotion="user">
+      <div className="w-full">
+        {/* Hero header */}
+        <div className="animate-entrance" style={{ animationDelay: "0s" }}>
+          {foundationLoading ? (
+            <HeroSkeleton />
+          ) : (
+            <FoundationHero
+              id={id}
+              name={foundation?.name ?? ""}
+              ein={foundation?.ein ?? ""}
+              location={foundation?.location ?? null}
+              description={foundation?.description ?? null}
+              latestFilingYear={latestFinancials?.filingYear}
+              breadcrumbs={
+                <PageBreadcrumbs
+                  currentLabel={foundation?.name ?? "Foundation"}
+                  searchId={searchId}
+                />
+              }
+            />
+          )}
+        </div>
 
-      {/* Stat cards grid */}
-      <div
-        className="animate-entrance border-b border-zinc-200 bg-zinc-50 px-4 py-6 dark:border-zinc-800 dark:bg-zinc-950"
-        style={{ animationDelay: "0.07s" }}
-      >
-        {foundationLoading || financialsLoading ? (
-          <StatGridSkeleton />
-        ) : (
-          <FoundationStatGrid
-            selectedFinancials={selectedFinancials}
-            totalAssets={foundation?.totalAssets}
-            grantsCount={filteredGrants?.length}
-            totalGrantAmount={totalGrantAmount}
-            grantsLoading={grantsLoading}
-            officersCount={filteredOfficers?.length}
-            officersLoading={officersLoading}
-            availableYears={sortedYears}
-            selectedYear={selectedYear}
-            onYearChange={setSelectedYear}
-          />
-        )}
-      </div>
-
-      {/* Mobile tab bar — visible below xl */}
-      <div
-        className="animate-entrance sticky top-0 z-10 border-b border-zinc-200 bg-white px-4 xl:hidden dark:border-zinc-800 dark:bg-zinc-950"
-        style={{ animationDelay: `${2 * 0.07}s` }}
-      >
-        <nav className="flex gap-1" aria-label="Data sections">
-          {mobileTabs.map((tab) => (
-            <button
-              key={tab.key}
-              type="button"
-              onClick={() => setMobileTab(tab.key)}
-              className={`flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-3 text-sm font-medium transition-colors ${
-                mobileTab === tab.key
-                  ? "border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400"
-                  : "border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
-              }`}
-            >
-              {tab.icon}
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-      </div>
-
-      {/* Mobile tabbed content — visible below xl */}
-      <div
-        className="animate-entrance px-4 py-6 xl:hidden"
-        style={{ animationDelay: `${3 * 0.07}s` }}
-      >
-        {mobileTab === "grants" && grantsTable}
-        {mobileTab === "officers" && officersTable}
-        {mobileTab === "financials" && financialsTable}
-      </div>
-
-      {/* Desktop side-by-side layout — visible at xl and above */}
-      <div
-        className="animate-entrance hidden px-4 py-6 xl:block"
-        style={{ animationDelay: `${3 * 0.07}s` }}
-      >
-        {/* Collapsed section pills — visible when a section is expanded */}
-        <motion.div
-          initial={false}
-          animate={{ height: expanded ? "auto" : 0, opacity: expanded ? 1 : 0 }}
-          transition={{ duration: 0.35, ease: [0.25, 0.1, 0.25, 1] }}
-          className="overflow-hidden"
+        {/* Stat cards grid */}
+        <div
+          className="animate-entrance border-b border-zinc-200 bg-zinc-50 px-4 py-6 dark:border-zinc-800 dark:bg-zinc-950"
+          style={{ animationDelay: "0.07s" }}
         >
-          <div className="mb-4 flex gap-2">
-            {mobileTabs
-              .filter((tab) => tab.key !== expanded)
-              .map((tab) => (
-                <button
-                  key={tab.key}
-                  type="button"
-                  onClick={() => setExpanded(tab.key)}
-                  className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-sm font-medium text-zinc-600 transition-all hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
-                >
-                  {tab.icon}
-                  {tab.label}
-                  <Maximize2 className="ml-1 size-3 text-zinc-400" />
-                </button>
-              ))}
+          {foundationLoading || financialsLoading ? (
+            <StatGridSkeleton />
+          ) : (
+            <FoundationStatGrid
+              selectedFinancials={selectedFinancials}
+              totalAssets={foundation?.totalAssets}
+              grantsCount={filteredGrants?.length}
+              totalGrantAmount={totalGrantAmount}
+              grantsLoading={grantsLoading}
+              officersCount={filteredOfficers?.length}
+              officersLoading={officersLoading}
+              availableYears={sortedYears}
+              selectedYear={selectedYear}
+              onYearChange={setSelectedYear}
+            />
+          )}
+        </div>
+
+        {/* Mobile tab bar — visible below xl */}
+        <div
+          className="animate-entrance sticky top-0 z-10 border-b border-zinc-200 bg-white px-4 xl:hidden dark:border-zinc-800 dark:bg-zinc-950"
+          style={{ animationDelay: `${2 * 0.07}s` }}
+        >
+          <nav className="flex gap-1" aria-label="Data sections">
+            {mobileTabs.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setMobileTab(tab.key)}
+                className={`flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-3 text-sm font-medium transition-colors ${
+                  mobileTab === tab.key
+                    ? "border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400"
+                    : "border-transparent text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                }`}
+              >
+                {tab.icon}
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        {/* Mobile tabbed content — visible below xl */}
+        <div
+          className="animate-entrance px-4 py-6 xl:hidden"
+          style={{ animationDelay: `${3 * 0.07}s` }}
+        >
+          {mobileTab === "grants" && grantsTable}
+          {mobileTab === "officers" && officersTable}
+          {mobileTab === "financials" && financialsTable}
+        </div>
+
+        {/* Desktop side-by-side layout — visible at xl and above */}
+        <div
+          className="animate-entrance hidden px-4 py-6 xl:block"
+          style={{ animationDelay: `${3 * 0.07}s` }}
+        >
+          {/* Collapsed section pills — visible when a section is expanded */}
+          <motion.div
+            initial={false}
+            animate={{ height: expanded ? "auto" : 0, opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.35, ease: [0.25, 0.1, 0.25, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="mb-4 flex gap-2">
+              {mobileTabs
+                .filter((tab) => tab.key !== expanded)
+                .map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setExpanded(tab.key)}
+                    className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-sm font-medium text-zinc-600 transition-all hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                  >
+                    {tab.icon}
+                    {tab.label}
+                    <Maximize2 className="ml-1 size-3 text-zinc-400" />
+                  </button>
+                ))}
+            </div>
+          </motion.div>
+
+          <div className="flex gap-6 xl:flex-row">
+            {/* Grants column */}
+            <motion.div
+              initial={false}
+              animate={{
+                flex: expanded === "grants" ? "1 1 100%" : expanded ? "0 0 0%" : "1 1 60%",
+                opacity: expanded && expanded !== "grants" ? 0 : 1,
+              }}
+              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+              className="min-w-0 overflow-hidden"
+            >
+              {grantsTable}
+            </motion.div>
+
+            {/* Officers + Financials column */}
+            <motion.div
+              initial={false}
+              animate={{
+                flex:
+                  expanded === "officers" || expanded === "financials"
+                    ? "1 1 100%"
+                    : expanded
+                      ? "0 0 0%"
+                      : "1 1 40%",
+                opacity: expanded === "grants" ? 0 : 1,
+              }}
+              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+              className="flex min-w-0 flex-col gap-6 overflow-hidden"
+            >
+              <motion.div
+                initial={false}
+                animate={{
+                  height: expanded === "financials" ? 0 : "auto",
+                  opacity: expanded === "financials" ? 0 : 1,
+                  marginBottom: expanded === "financials" ? 0 : undefined,
+                }}
+                transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+                className="overflow-hidden"
+              >
+                {officersTable}
+              </motion.div>
+
+              <motion.div
+                initial={false}
+                animate={{
+                  height: expanded === "officers" ? 0 : "auto",
+                  opacity: expanded === "officers" ? 0 : 1,
+                }}
+                transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+                className="overflow-hidden"
+              >
+                {financialsTable}
+              </motion.div>
+            </motion.div>
           </div>
-        </motion.div>
-
-        <div className="flex gap-6 xl:flex-row">
-          {/* Grants column */}
-          <motion.div
-            initial={false}
-            animate={{
-              flex: expanded === "grants" ? "1 1 100%" : expanded ? "0 0 0%" : "1 1 60%",
-              opacity: expanded && expanded !== "grants" ? 0 : 1,
-            }}
-            transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
-            className="min-w-0 overflow-hidden"
-          >
-            {grantsTable}
-          </motion.div>
-
-          {/* Officers + Financials column */}
-          <motion.div
-            initial={false}
-            animate={{
-              flex:
-                expanded === "officers" || expanded === "financials"
-                  ? "1 1 100%"
-                  : expanded
-                    ? "0 0 0%"
-                    : "1 1 40%",
-              opacity: expanded === "grants" ? 0 : 1,
-            }}
-            transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
-            className="flex min-w-0 flex-col gap-6 overflow-hidden"
-          >
-            <motion.div
-              initial={false}
-              animate={{
-                height: expanded === "financials" ? 0 : "auto",
-                opacity: expanded === "financials" ? 0 : 1,
-                marginBottom: expanded === "financials" ? 0 : undefined,
-              }}
-              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
-              className="overflow-hidden"
-            >
-              {officersTable}
-            </motion.div>
-
-            <motion.div
-              initial={false}
-              animate={{
-                height: expanded === "officers" ? 0 : "auto",
-                opacity: expanded === "officers" ? 0 : 1,
-              }}
-              transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
-              className="overflow-hidden"
-            >
-              {financialsTable}
-            </motion.div>
-          </motion.div>
         </div>
       </div>
-    </div>
+    </MotionConfig>
   );
 }

--- a/src/features/non-profits/components/narrative-block.tsx
+++ b/src/features/non-profits/components/narrative-block.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { MessageResponse } from "@/src/components/ai-elements/message-response";
+import { useSubmitFeedback } from "../hooks/use-feedback";
+import { linkifyNarrative } from "../lib/linkify-narrative";
+import type { ChatTurn } from "../store/philanthropy";
+import type { RankedEntity } from "../types/philanthropy";
+
+interface NarrativeBlockProps {
+  narrative: string;
+  entities: RankedEntity[];
+  traceId: string | null;
+  status: ChatTurn["status"];
+}
+
+export const NarrativeBlock = memo(function NarrativeBlock({
+  narrative,
+  entities,
+  traceId,
+  status,
+}: NarrativeBlockProps) {
+  const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
+  const [commentOpen, setCommentOpen] = useState(false);
+  const [comment, setComment] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const { mutate: submitFeedback, isPending: isSending } = useSubmitFeedback();
+
+  // Reset feedback UI whenever the traceId changes (new search).
+  useEffect(() => {
+    setFeedback(null);
+    setCommentOpen(false);
+    setComment("");
+    setSubmitted(false);
+  }, [traceId]);
+
+  const linked = useMemo(
+    () => (entities.length > 0 ? linkifyNarrative(narrative, entities) : narrative),
+    [narrative, entities]
+  );
+
+  const showFeedback = Boolean(traceId) && status === "done";
+
+  const handleThumbsUp = useCallback(() => {
+    if (!traceId || isSending || feedback === "up") return;
+    setFeedback("up");
+    setCommentOpen(false);
+    submitFeedback(
+      { traceId, value: 1 },
+      {
+        onSuccess: () => setSubmitted(true),
+      }
+    );
+  }, [traceId, isSending, feedback, submitFeedback]);
+
+  const handleThumbsDown = useCallback(() => {
+    if (!traceId || isSending) return;
+    if (feedback === "down") {
+      setCommentOpen((v) => !v);
+      return;
+    }
+    setFeedback("down");
+    setCommentOpen(true);
+    setSubmitted(false);
+  }, [traceId, isSending, feedback]);
+
+  const handleSubmitComment = useCallback(() => {
+    if (!traceId || isSending) return;
+    submitFeedback(
+      { traceId, value: -1, comment },
+      {
+        onSuccess: () => {
+          setSubmitted(true);
+          setCommentOpen(false);
+          setComment("");
+        },
+      }
+    );
+  }, [traceId, isSending, submitFeedback, comment]);
+
+  const handleCancelComment = useCallback(() => {
+    setCommentOpen(false);
+    setComment("");
+    if (!submitted) setFeedback(null);
+  }, [submitted]);
+
+  return (
+    <div>
+      <MessageResponse>{linked}</MessageResponse>
+      {showFeedback && (
+        <div className="mt-2">
+          {submitted && (
+            <output className="mb-2 block text-xs text-brand dark:text-brand-subtle">
+              Thanks for your feedback!
+            </output>
+          )}
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleThumbsUp}
+              aria-label="Helpful"
+              aria-pressed={feedback === "up"}
+              disabled={isSending}
+              className={`rounded-lg p-1.5 transition-colors ${
+                feedback === "up"
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              }`}
+            >
+              <ThumbsUp className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={handleThumbsDown}
+              aria-label="Not helpful"
+              aria-pressed={feedback === "down"}
+              disabled={isSending}
+              className={`rounded-lg p-1.5 transition-colors ${
+                feedback === "down"
+                  ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              }`}
+            >
+              <ThumbsDown className="size-3.5" />
+            </button>
+          </div>
+          {commentOpen && traceId && (
+            <div className="mt-2 rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+              <label
+                htmlFor={`feedback-comment-${traceId}`}
+                className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
+              >
+                What went wrong? (optional)
+              </label>
+              <textarea
+                id={`feedback-comment-${traceId}`}
+                value={comment}
+                onChange={(e) => setComment(e.target.value.slice(0, 2000))}
+                rows={2}
+                maxLength={2000}
+                placeholder="Tell us what was missing or inaccurate..."
+                className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
+              />
+              <div className="mt-2 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleCancelComment}
+                  className="rounded-md px-2.5 py-1 text-xs text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSubmitComment}
+                  disabled={isSending}
+                  className="rounded-md bg-brand px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
+                >
+                  {isSending ? "Sending..." : "Submit"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/features/non-profits/components/progress-view.tsx
+++ b/src/features/non-profits/components/progress-view.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Check, Wrench, X } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import type { ChatTurn } from "../store/philanthropy";
+
+function formatToolName(tool: string): string {
+  return tool.replace(/^mcp__[^_]+__/, "").replace(/_/g, " ");
+}
+
+export function ProgressView({ progress }: { progress: NonNullable<ChatTurn["progress"]> }) {
+  const { toolHistory, latestThought, matchedNames } = progress;
+  const hasAnything = toolHistory.length > 0 || latestThought !== null || matchedNames.length > 0;
+
+  if (!hasAnything) {
+    return (
+      <div className="inline-flex items-center gap-1.5 text-xs text-zinc-400">
+        <Spinner className="size-3" />
+        searching 140,221 filings…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-1 flex flex-col gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900/50">
+      {toolHistory.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {toolHistory.map((entry, i) => (
+            <li
+              key={`${entry.tool}-${i}`}
+              className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400"
+            >
+              <span className="flex size-4 shrink-0 items-center justify-center">
+                {entry.status === "running" && <Spinner className="size-3" />}
+                {entry.status === "completed" && (
+                  <Check className="size-3 text-emerald-600 dark:text-emerald-400" />
+                )}
+                {entry.status === "failed" && (
+                  <X className="size-3 text-red-600 dark:text-red-400" />
+                )}
+              </span>
+              <Wrench className="size-3 shrink-0 text-zinc-400" />
+              <span className="font-mono">{formatToolName(entry.tool)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {latestThought && (
+        <p className="text-xs italic text-zinc-500 dark:text-zinc-400">{latestThought}</p>
+      )}
+      {matchedNames.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {matchedNames.slice(0, 12).map((name) => (
+            <span
+              key={name}
+              className="rounded-full bg-brand px-2 py-0.5 text-[10px] font-medium text-white dark:bg-brand/20 dark:text-brand-subtle"
+            >
+              {name}
+            </span>
+          ))}
+          {matchedNames.length > 12 && (
+            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+              +{matchedNames.length - 12} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/non-profits/components/search-history-panel.tsx
+++ b/src/features/non-profits/components/search-history-panel.tsx
@@ -11,7 +11,7 @@
 import { Clock, Trash2, X } from "lucide-react";
 import Link from "next/link";
 import pluralize from "pluralize";
-import { memo, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import {
@@ -60,6 +60,20 @@ export function SearchHistoryPanel({ open, onClose }: { open: boolean; onClose: 
   const { data: entries = [], isLoading, isError } = useSearchHistoryList();
   const { mutateAsync: clearAll, isPending: isClearing } = useClearSearchHistory();
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
+
+  // Escape key closes the panel.
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
 
   if (!open) return null;
 

--- a/src/features/non-profits/hooks/use-feedback.ts
+++ b/src/features/non-profits/hooks/use-feedback.ts
@@ -1,0 +1,20 @@
+import { useMutation } from "@tanstack/react-query";
+import { resultToPromise } from "../lib/result-to-promise";
+import { philanthropyService } from "../services/philanthropy.service";
+
+interface FeedbackVariables {
+  traceId: string;
+  value: 1 | -1;
+  comment?: string;
+}
+
+/**
+ * Hook for submitting narrative feedback (thumbs up / thumbs down).
+ * Feedback is best-effort and fire-and-forget — no cache invalidation.
+ */
+export function useSubmitFeedback() {
+  return useMutation({
+    mutationFn: ({ traceId, value, comment }: FeedbackVariables) =>
+      resultToPromise(philanthropyService.submitFeedback(traceId, value, comment)),
+  });
+}

--- a/src/features/non-profits/lib/linkify-narrative.ts
+++ b/src/features/non-profits/lib/linkify-narrative.ts
@@ -1,0 +1,183 @@
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import type { RankedEntity } from "../types/philanthropy";
+
+const PUNCTUATION = /[.,'"()[\]{}!?;:]/g;
+const LEADING_ARTICLES = new Set(["the", "a", "an"]);
+const TRAILING_NOISE = new Set([
+  "inc",
+  "incorporated",
+  "llc",
+  "ltd",
+  "co",
+  "corp",
+  "corporation",
+  "company",
+]);
+
+interface Token {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+  readonly norm: string;
+}
+
+interface EntityCandidate {
+  readonly entity: RankedEntity;
+  readonly tokens: readonly string[];
+}
+
+interface Match {
+  readonly start: number;
+  readonly end: number;
+  readonly entity: RankedEntity;
+}
+
+function normalizeToken(raw: string): string {
+  return raw.toLowerCase().replace(PUNCTUATION, "");
+}
+
+function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  const re = /\S+/g;
+  let match: RegExpExecArray | null = re.exec(source);
+  while (match !== null) {
+    const norm = normalizeToken(match[0]);
+    if (norm) {
+      tokens.push({
+        text: match[0],
+        start: match.index,
+        end: match.index + match[0].length,
+        norm,
+      });
+    }
+    match = re.exec(source);
+  }
+  return tokens;
+}
+
+function canonicalizeEntityName(name: string): string[] {
+  const tokens = name.split(/\s+/).map(normalizeToken).filter(Boolean);
+
+  // Drop leading article(s): "The Ford Foundation" → "Ford Foundation"
+  while (tokens.length > 1 && LEADING_ARTICLES.has(tokens[0])) {
+    tokens.shift();
+  }
+
+  // Drop trailing legal-entity noise while keeping at least 2 tokens of signal:
+  // "Annie E Casey Foundation Inc" → "Annie E Casey Foundation"
+  while (tokens.length > 2 && TRAILING_NOISE.has(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+
+  return tokens;
+}
+
+function getEntityPath(entity: RankedEntity): string {
+  switch (entity.entityType) {
+    case "foundation":
+      return NON_PROFITS_PAGES.FOUNDATION(entity.id);
+    case "nonprofit":
+      return NON_PROFITS_PAGES.NONPROFIT(entity.id);
+    case "grant":
+      return NON_PROFITS_PAGES.GRANT(entity.id);
+  }
+}
+
+function inExistingMarkdownLink(source: string, index: number): boolean {
+  // Heuristic: if the next `]` before the next `[` is followed by `(`,
+  // we are inside an existing [text](url) link. Fast scan.
+  const close = source.indexOf("]", index);
+  if (close === -1) return false;
+  const open = source.indexOf("[", index);
+  if (open !== -1 && open < close) return false;
+  return source[close + 1] === "(";
+}
+
+/**
+ * Wraps entity mentions in a narrative with markdown links to their detail pages.
+ *
+ * Matching is tolerant to casing, punctuation, leading articles ("The ..."),
+ * and trailing legal-entity suffixes ("... Inc"). Longest entity names are
+ * preferred and matches cannot overlap.
+ */
+export function linkifyNarrative(narrative: string, entities: readonly RankedEntity[]): string {
+  if (!narrative || entities.length === 0) return narrative;
+
+  const candidates: EntityCandidate[] = [];
+  const seen = new Set<string>();
+  for (const entity of entities) {
+    if (!entity.name) continue;
+    const tokens = canonicalizeEntityName(entity.name);
+    if (tokens.length < 2) continue; // avoid single-word false positives
+    const key = tokens.join(" ");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    candidates.push({ entity, tokens });
+  }
+  if (candidates.length === 0) return narrative;
+
+  // Prefer longer names first so "Ford Foundation" doesn't shadow
+  // "Henry Ford Foundation".
+  candidates.sort((a, b) => b.tokens.length - a.tokens.length);
+
+  const narrativeTokens = tokenize(narrative);
+  const used = new Array<boolean>(narrativeTokens.length).fill(false);
+  const matches: Match[] = [];
+
+  for (let i = 0; i < narrativeTokens.length; i++) {
+    if (used[i]) continue;
+
+    // Let the match optionally start with a skippable leading article.
+    // Only include it in the anchor when capitalized ("The Ford Foundation").
+    // A lowercase "the" is part of surrounding prose, not the proper name,
+    // so we skip over it without pulling it into the link.
+    const hasLeadingArticle = LEADING_ARTICLES.has(narrativeTokens[i].norm);
+    const leadingArticleCapitalized = hasLeadingArticle && /^[A-Z]/.test(narrativeTokens[i].text);
+    const bodyStart = hasLeadingArticle ? i + 1 : i;
+    const anchorStart = leadingArticleCapitalized ? i : bodyStart;
+
+    for (const candidate of candidates) {
+      const lastIndex = bodyStart + candidate.tokens.length - 1;
+      if (lastIndex >= narrativeTokens.length) continue;
+
+      let matched = true;
+      for (let k = 0; k < candidate.tokens.length; k++) {
+        if (narrativeTokens[bodyStart + k].norm !== candidate.tokens[k]) {
+          matched = false;
+          break;
+        }
+      }
+      if (!matched) continue;
+
+      let overlapping = false;
+      for (let k = anchorStart; k <= lastIndex; k++) {
+        if (used[k]) {
+          overlapping = true;
+          break;
+        }
+      }
+      if (overlapping) break;
+
+      matches.push({
+        start: narrativeTokens[anchorStart].start,
+        end: narrativeTokens[lastIndex].end,
+        entity: candidate.entity,
+      });
+      for (let k = anchorStart; k <= lastIndex; k++) used[k] = true;
+      break;
+    }
+  }
+
+  if (matches.length === 0) return narrative;
+
+  // Apply in reverse so earlier indices stay valid.
+  matches.sort((a, b) => b.start - a.start);
+
+  let result = narrative;
+  for (const m of matches) {
+    if (inExistingMarkdownLink(result, m.start)) continue;
+    const anchor = result.slice(m.start, m.end);
+    result = `${result.slice(0, m.start)}[${anchor}](${getEntityPath(m.entity)})${result.slice(m.end)}`;
+  }
+  return result;
+}

--- a/src/features/non-profits/services/philanthropy.service.ts
+++ b/src/features/non-profits/services/philanthropy.service.ts
@@ -87,4 +87,19 @@ export const philanthropyService = {
   getGrant(id: string): ResultAsync<Grant, AppError> {
     return apiFetch(NON_PROFITS_API.PHILANTHROPY.GRANTS.GET(id), GrantSchema);
   },
+
+  submitFeedback(
+    traceId: string,
+    value: number,
+    comment?: string
+  ): ResultAsync<{ success: boolean }, AppError> {
+    const body = {
+      traceId,
+      value,
+      comment: comment?.trim() || undefined,
+    };
+    return apiFetch(NON_PROFITS_API.PHILANTHROPY.FEEDBACK, z.unknown(), "POST", body).map(() => ({
+      success: true,
+    }));
+  },
 };

--- a/src/features/non-profits/store/page-transition.ts
+++ b/src/features/non-profits/store/page-transition.ts
@@ -19,7 +19,7 @@ export interface FieldRect {
   height: number;
 }
 
-interface PageTransitionFields {
+export interface PageTransitionFields {
   name: FieldRect;
   badge?: FieldRect;
   location?: FieldRect;

--- a/src/features/non-profits/styles/non-profits-detail.css
+++ b/src/features/non-profits/styles/non-profits-detail.css
@@ -23,3 +23,9 @@
 .animate-entrance {
   animation: entrance-fade-in 0.45s cubic-bezier(0.25, 0.1, 0.25, 1) both;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-entrance {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 6 of the grant-atlas → gap-app-v2 `/non-profits/` migration. Adds the remaining narrative enhancements, finishes the hero-transition wiring, and hardens accessibility. Speech/TTS was intentionally dropped per scope decision.

### What's included

1. **Narrative linkify + feedback** (`NarrativeBlock`)
   - `linkify-narrative.ts` wraps entity mentions in the AI narrative with markdown links to the matching foundation/nonprofit/grant detail pages (tolerant to casing, punctuation, leading articles, trailing legal suffixes; longest-name-first, non-overlapping).
   - Thumbs-up / thumbs-down feedback via `useSubmitFeedback` (`useMutation` → `POST /v2/agent/rating`), with an optional comment box on thumbs-down.
   - `aria-label` / `aria-pressed` on the controls; resets on new `traceId`.

2. **Hero-transition card wiring** (`CompactEntityCard`)
   - On result-card click, captures `data-field` bounding rects (name/badge/location) into the page-transition store so the detail page can animate from the card.

3. **ProgressView extraction**
   - Streaming progress UI moved out of `chat-view-client.tsx` into its own component (keeps the file under the size budget).

4. **Accessibility hardening**
   - `prefers-reduced-motion` respected on the foundation detail page (`MotionConfig reducedMotion="user"` + CSS media query disabling `.animate-entrance`).
   - Escape-to-close + focus management on the bookmarks drawer and search-history panel.

### Scope decisions
- **Speech/TTS:** skipped (not ported).
- **Narrative card:** linkify + feedback added (vs. plain text).
- **Legacy table/grid views:** kept as currently implemented; not re-ported.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `quality-gate.js` (full, incl. knip) — zero regressions
- [x] `vitest` unit suite for `/non-profits/` green (incl. 11 new linkify tests)
- [ ] CI green on PR