### PR TITLE
fix(sentry): drop transient indexer 504s from SSR Sentry signal

### DIFF
--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { isTransientNetworkError } from "@/utilities/sentry/transientErrors";
+import { isTransientHttpError, isTransientNetworkError } from "@/utilities/sentry/transientErrors";
 
 // Lazy import toast to avoid issues in server components
 let toast: typeof import("react-hot-toast").default | null = null;
@@ -82,6 +82,14 @@ export const errorManager = (
   // Query and surface to the user as an error UI, so drop them on the
   // floor for Sentry. See DEV-236 / GAP-FRONTEND-13P.
   if (isTransientNetworkError(error)) {
+    return;
+  }
+
+  // Transient upstream gateway failures (indexer 504/502/503/408). These
+  // crash SSR fetch paths with a minified, frontend-unactionable stack and
+  // are tracked on the infra/indexer side, not here. See DEV-271 /
+  // GAP-FRONTEND-1R1.
+  if (isTransientHttpError(error)) {
     return;
   }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
-import { isTransientNetworkError } from "./utilities/sentry/transientErrors";
+import { isTransientHttpError, isTransientNetworkError } from "./utilities/sentry/transientErrors";
 
 Sentry.init({
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
@@ -13,9 +13,12 @@ Sentry.init({
   integrations: [],
   // Defence in depth for transient Axios "Network Error" events that
   // bubble through code paths bypassing `errorManager` (raw React errors,
-  // third-party SDK fetches). See DEV-236 / GAP-FRONTEND-13P.
+  // third-party SDK fetches). See DEV-236 / GAP-FRONTEND-13P. Transient
+  // upstream gateway timeouts (504 etc.) get the same treatment — see
+  // DEV-271 / GAP-FRONTEND-1R1.
   beforeSend(event, hint) {
-    if (isTransientNetworkError(hint?.originalException)) {
+    const original = hint?.originalException;
+    if (isTransientNetworkError(original) || isTransientHttpError(original)) {
       return null;
     }
     return event;

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,11 +4,26 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
+import { isTransientHttpError, isTransientNetworkError } from "./utilities/sentry/transientErrors";
 
 Sentry.init({
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   ignoreErrors: sentryIgnoreErrors,
+  // Drop transient indexer outages that crash SSR. A 504 (and the rest of
+  // the 5xx gateway family) from `NEXT_PUBLIC_GAP_INDEXER_URL` during a
+  // server render bubbles up here as a minified `Request failed with status
+  // code 504` with no actionable first-party frame. The page still throws to
+  // its `error.tsx` retry boundary for the user — we just keep the unfixable
+  // (frontend-side) noise out of Sentry. Mirrors the client-side filter in
+  // `instrumentation-client.ts`. See DEV-271 / GAP-FRONTEND-1R1.
+  beforeSend(event, hint) {
+    const original = hint?.originalException;
+    if (isTransientNetworkError(original) || isTransientHttpError(original)) {
+      return null;
+    }
+    return event;
+  },
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 0.01,
 

--- a/utilities/sentry/__tests__/transientErrors.test.ts
+++ b/utilities/sentry/__tests__/transientErrors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAxiosAbortError, isTransientNetworkError } from "../transientErrors";
+import {
+  isAxiosAbortError,
+  isTransientHttpError,
+  isTransientNetworkError,
+} from "../transientErrors";
 
 describe("isTransientNetworkError", () => {
   it("detects axios Network Error with no response", () => {
@@ -36,6 +40,44 @@ describe("isTransientNetworkError", () => {
     );
     expect(isTransientNetworkError(null)).toBe(false);
     expect(isTransientNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("isTransientHttpError", () => {
+  it("detects an axios 504 by response.status", () => {
+    const err = {
+      message: "Request failed with status code 504",
+      response: { status: 504, data: {} },
+    };
+    expect(isTransientHttpError(err)).toBe(true);
+  });
+
+  it("detects the re-thrown SSR error by its axios message (no response attached)", () => {
+    // This is the exact DEV-271 shape: getGrantPrograms re-throws
+    // `new Error("Request failed with status code 504")`, which Next captures
+    // with no `.response`.
+    expect(isTransientHttpError(new Error("Request failed with status code 504"))).toBe(true);
+    expect(isTransientHttpError("Request failed with status code 504")).toBe(true);
+  });
+
+  it("detects the rest of the transient gateway family (502/503/408)", () => {
+    expect(isTransientHttpError({ status: 502 })).toBe(true);
+    expect(isTransientHttpError({ response: { status: 503 } })).toBe(true);
+    expect(isTransientHttpError(new Error("Request failed with status code 408"))).toBe(true);
+  });
+
+  it("does NOT match non-transient HTTP failures (4xx/5xx that are real bugs)", () => {
+    expect(isTransientHttpError({ response: { status: 500 } })).toBe(false);
+    expect(isTransientHttpError(new Error("Request failed with status code 400"))).toBe(false);
+    expect(isTransientHttpError({ response: { status: 404 } })).toBe(false);
+  });
+
+  it("does NOT match non-HTTP errors", () => {
+    expect(isTransientHttpError(new TypeError("Cannot read property 'x' of undefined"))).toBe(
+      false
+    );
+    expect(isTransientHttpError(null)).toBe(false);
+    expect(isTransientHttpError(undefined)).toBe(false);
   });
 });
 

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -29,6 +29,15 @@ const TRANSIENT_AXIOS_CODES = new Set([
 
 const ABORT_CODES = new Set(["ERR_CANCELED", "ABORT_ERR"]);
 
+// Upstream HTTP statuses that mean "the indexer/gateway was momentarily
+// unreachable", not "the frontend code is broken". A 504 (gateway timeout)
+// from the indexer during SSR surfaces as a minified `Request failed with
+// status code 504` server crash with no actionable first-party frame — the
+// only fix is on the infra/indexer side, so it's noise in the frontend
+// Sentry project. 502/503/408 share the same transient, retriable shape.
+// See DEV-271 / GAP-FRONTEND-1R1.
+const TRANSIENT_HTTP_STATUS = new Set([408, 502, 503, 504]);
+
 function getErrorMessage(error: unknown): string {
   if (!error) return "";
   if (typeof error === "string") return error;
@@ -54,6 +63,18 @@ function hasHttpResponse(error: unknown): boolean {
     "response" in error &&
     !!(error as { response?: unknown }).response
   );
+}
+
+// Pulls an HTTP status code off the various error shapes that reach Sentry:
+// an axios error (`error.response.status`), the `[null, error, null, status]`
+// tuple-style object some callers attach (`error.status`), or nothing.
+function getHttpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const response = (error as { response?: { status?: unknown } }).response;
+  if (response && typeof response.status === "number") return response.status;
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === "number") return status;
+  return undefined;
 }
 
 /**
@@ -83,4 +104,29 @@ export function isTransientNetworkError(error: unknown): boolean {
 
   const message = getErrorMessage(error).toLowerCase();
   return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
+/**
+ * True when the error is a transient upstream HTTP failure (gateway timeout
+ * / bad gateway / service unavailable / request timeout). Unlike
+ * `isTransientNetworkError`, these DO carry an HTTP response, so they need
+ * their own predicate. Used to keep the frontend Sentry project clean of
+ * indexer outages that crash SSR — the page still throws to its `error.tsx`
+ * retry boundary, we just don't page on the unactionable minified event.
+ * See DEV-271 / GAP-FRONTEND-1R1.
+ */
+export function isTransientHttpError(error: unknown): boolean {
+  if (!error) return false;
+
+  const status = getHttpStatus(error);
+  if (status !== undefined && TRANSIENT_HTTP_STATUS.has(status)) return true;
+
+  // SSR fetch failures bubble up as a re-thrown `Error` whose message is the
+  // axios default ("Request failed with status code 504") with no `response`
+  // attached — match the status off the message in that case.
+  const message = getErrorMessage(error).toLowerCase();
+  for (const code of TRANSIENT_HTTP_STATUS) {
+    if (message.includes(`status code ${code}`)) return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

Supersedes #1399. DEV-271 is a Sentry **signal** problem: indexer gateway timeouts during SSR surface as a minified `Request failed with status code 504` (`function c`) event with no actionable first-party frame, across an unknown set of routes (130 events, first seen 2026-01-27).

The root gap: `instrumentation-client.ts` already filters transient errors in `beforeSend` (DEV-236), but **`sentry.server.config.ts` had no `beforeSend` at all** — so SSR fetch failures were never filtered, regardless of route. This fixes it at that layer instead of patching a single page.

## Changes

- **`utilities/sentry/transientErrors.ts`** — new `isTransientHttpError()` detecting transient upstream statuses (504/502/503/408) via `response.status`, `status`, or the axios message string the re-thrown SSR error carries.
- **`sentry.server.config.ts`** — add the missing `beforeSend` filtering transient network + HTTP errors. Root fix: drops the minified SSR 504 noise from **every** route.
- **`instrumentation-client.ts`** — extend `beforeSend` for parity (client-side React Query 504s).
- **`components/Utilities/errorManager.tsx`** — early-return for transient HTTP errors, mirroring the existing transient-network guard.
- **Tests** — 6 new cases for the exact DEV-271 shape, the 502/503/408 family, and negatives (500/400/404 stay reported).

## Why not #1399

#1399 made `getGrantPrograms` return `[]` on 504 for one page. Problems:

1. **Doesn't fix the issue** — it still calls `errorManager(...)` before the 504 branch, so the Sentry event is still captured.
2. **Reverses a deliberate, CodeRabbit-MAJOR-reviewed decision** (commit `06a767979`): returning `[]` makes an outage indistinguishable from "no programs", letting admins save report configs with no `programIds`. Re-introduces that data-integrity bug for the most common outage.
3. **Wrong surface** — that page was created 2026-04-23 and only began throwing 2026-04-30; the issue was first seen 2026-01-27, so it can't account for the bulk of events. A per-page patch can't fix a route-unknown SSR 504.

## Behavior preserved

Pages still throw to their `error.tsx` retry boundary, so the user-facing outage UX is unchanged (retry CTA, not a silent empty list). We only keep the frontend-unfixable noise out of Sentry; indexer 504s are tracked on the infra/indexer side (same philosophy as DEV-236).

> Note: this fully drops 504s from the frontend Sentry project. If low-volume visibility is preferred, the `beforeSend` can sample instead of returning `null`.

## Verification

- `pnpm exec vitest run --project unit utilities/sentry __tests__/unit/utilities/sentry __tests__/infrastructure/sentry-ignore-errors.test.ts` — 19/19 pass
- `pnpm exec biome check` on all touched files — clean

Refs DEV-271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error handling to identify and suppress reporting for transient upstream gateway failures (408/502/503/504 HTTP statuses) across client and server environments.

* **Tests**
  * Added comprehensive test coverage for transient HTTP error detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->