### PR TITLE
test(sentry): lock in transient auth.privy.io 'Failed to fetch' suppression (DEV-264)

### DIFF
--- a/__tests__/unit/utilities/sentry/transientErrors.test.ts
+++ b/__tests__/unit/utilities/sentry/transientErrors.test.ts
@@ -1,0 +1,50 @@
+import {
+  isAxiosAbortError,
+  isTransientNetworkError,
+} from "../../../../utilities/sentry/transientErrors";
+
+describe("isTransientNetworkError", () => {
+  it("suppresses the Privy 'Failed to fetch (auth.privy.io)' signature (DEV-264)", () => {
+    // The Privy SDK bootstrap fires a fetch to auth.privy.io. When the browser
+    // never gets a usable response (offline, DNS, TLS reset, ad-blocker /
+    // privacy extension blocking the host), it rejects with a bare
+    // `TypeError: Failed to fetch`. Sentry annotates the title with the host
+    // (`(auth.privy.io)`) but the underlying message is just "Failed to fetch".
+    // This is unactionable third-party noise and must be dropped in beforeSend.
+    expect(isTransientNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("matches the 'failed to fetch' message regardless of casing", () => {
+    expect(isTransientNetworkError(new Error("failed to fetch"))).toBe(true);
+    expect(isTransientNetworkError(new Error("FAILED TO FETCH"))).toBe(true);
+  });
+
+  it("matches other transient browser fetch failures", () => {
+    expect(isTransientNetworkError(new Error("Network Error"))).toBe(true);
+    expect(isTransientNetworkError(new Error("Load failed"))).toBe(true);
+  });
+
+  it("matches transient axios error codes without an HTTP response", () => {
+    expect(isTransientNetworkError({ code: "ERR_NETWORK" })).toBe(true);
+    expect(isTransientNetworkError({ code: "ETIMEDOUT" })).toBe(true);
+  });
+
+  it("does NOT suppress real HTTP errors that carry a response", () => {
+    // A 500 with "Failed to fetch" text still has an HTTP response attached —
+    // that IS actionable and must reach Sentry.
+    expect(isTransientNetworkError({ message: "Failed to fetch", response: { status: 500 } })).toBe(
+      false
+    );
+  });
+
+  it("does not over-match unrelated errors", () => {
+    expect(isTransientNetworkError(new Error("Something else broke"))).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+  });
+
+  it("treats cancellations as transient (abort during navigation/unmount)", () => {
+    expect(isAxiosAbortError({ code: "ERR_CANCELED" })).toBe(true);
+    expect(isTransientNetworkError({ name: "AbortError" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes DEV-264 (`TypeError: Failed to fetch (auth.privy.io)` on the program apply flow) and supersedes #1389.

The Sentry signature is an **unactionable transient third-party network failure** (offline, DNS, TLS reset, ad-blocker / privacy extension blocking the host — the event's frame is `frame_ant.js`, an extension). This error class is **already dropped** in `instrumentation-client.ts` `beforeSend` via `isTransientNetworkError`, which matches the `"failed to fetch"` message fragment. That filter (DEV-236) landed *after* both the single Sentry event and #1389 were created, so the issue is already handled on `main`.

`utilities/sentry/transientErrors.ts` had **zero** test coverage. This PR adds regression tests that lock in the behavior:
- `TypeError: Failed to fetch` (the DEV-264 signature) is treated as transient and suppressed
- real HTTP errors carrying a `response` are **not** suppressed (they stay actionable)
- existing code / abort / casing branches

## Why not #1389

#1389 deferred Privy boot on apply routes. That approach:
- leaves the Privy bridge `ready=false` forever on apply pages, so the navbar "Sign in" button never renders (infinite skeleton) and closed-program apply pages show an infinite "Checking permissions…" spinner — a regression worse than the original transient error
- is the wrong tool for a transient third-party fetch failure, and is redundant with the existing DEV-236 filter
- isn't resilient anyway (a user clicking "Sign in" still triggers the same `auth.privy.io` fetch)

## Testing

`pnpm exec vitest run --project unit __tests__/unit/utilities/sentry/transientErrors.test.ts` — 7 passing