### PR TITLE
chore(quality-gate): pin react-doctor and refresh baseline

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -462,20 +462,19 @@
   },
   "reactDoctor": {
     "score": 0,
-    "errors": 32,
-    "warnings": 10623,
+    "errors": 61,
+    "warnings": 3185,
     "byCategory": {
-      "Architecture": 8267,
-      "Correctness": 414,
-      "Performance": 657,
-      "Accessibility": 41,
-      "Next.js": 160,
-      "State & Effects": 195,
-      "TanStack Query": 35,
-      "Bundle Size": 2,
-      "Server": 13,
-      "Security": 5,
-      "Dead Code": 866
+      "Accessibility": 263,
+      "Architecture": 1165,
+      "Correctness": 393,
+      "Next.js": 143,
+      "State & Effects": 660,
+      "Server": 6,
+      "Performance": 575,
+      "TanStack Query": 29,
+      "Bundle Size": 9,
+      "Security": 3
     }
   }
 }

--- a/scripts/quality-gate.js
+++ b/scripts/quality-gate.js
@@ -63,6 +63,11 @@ const FLAGS = {
   },
 };
 
+// Pinned react-doctor version. The reactDoctor section of
+// quality-baseline.json is captured against this exact version — bump both in
+// the same (quality-baseline-labelled) PR, never independently.
+const REACT_DOCTOR_VERSION = "0.2.2";
+
 // ── utils ───────────────────────────────────────────────────────────────────
 const log = (...a) => console.log("[quality]", ...a);
 const warn = (...a) => console.warn("[quality:warn]", ...a);
@@ -229,7 +234,13 @@ function collectReactDoctor() {
   ensureDir(REPORT_DIR);
   const outPath = path.join(REPORT_DIR, "react-doctor.json");
   // react-doctor supports JSON output via --json flag.
-  const res = runCapture("npx", ["-y", "react-doctor@latest", ".", "--json"], { shell: false });
+  // Pin the version: `@latest` makes the gate non-deterministic — a new
+  // react-doctor release silently re-categorizes findings and inflates the
+  // error count, failing every PR with a regression that no PR introduced.
+  // The baseline is captured against this exact version; bump both together.
+  const res = runCapture("npx", ["-y", `react-doctor@${REACT_DOCTOR_VERSION}`, ".", "--json"], {
+    shell: false,
+  });
   let parsed = null;
   // Prefer stdout JSON, else any file it wrote.
   const start = res.stdout.indexOf("{");


### PR DESCRIPTION
## Problem

The quality gate runs `npx react-doctor@latest` over the whole repo and compares the error count to `quality-baseline.json`. Because the version is unpinned, every new react-doctor release silently re-categorizes findings and changes the count. The baseline was frozen on 2026-05-14 at **32 errors** (older version); react-doctor has since shipped **0.2.2**, which reports **61 errors** repo-wide.

Result: the gate reports `React Doctor errors 32 → 61 (+29)` as a regression on **every PR**, including ones that touch no React code (e.g. #1496, a Sentry-config change — verified 0 of the 61 errors touch its files).

## Fix

- **Pin** the package via a `REACT_DOCTOR_VERSION` constant (`0.2.2`) so the gate is deterministic. Documented to bump it and the baseline together.
- **Refresh** the baseline's `reactDoctor` section to the 0.2.2 output (errors 61, warnings 3185, current `byCategory`). All other baseline metrics are unchanged.

No application code changes.

## Verification

`pnpm quality --report-only` on this branch:

```
React Health   Baseline  Current  Δ
Errors         61        61       0
Warnings       3185      3184     -1
Biome          1277      1277     0
```

No regressions section → gate passes.

> Carries the `quality-baseline` label as required by `baseline-guard` for any change to `quality-baseline.json`.