### PR TITLE
feat(ask-karma): refresh Filecoin tenant copy (DEV-337, DEV-338)

### DIFF
--- a/__tests__/unit/features/ask-karma/config.test.ts
+++ b/__tests__/unit/features/ask-karma/config.test.ts
@@ -22,9 +22,10 @@ describe("getAskKarmaConfig", () => {
 
   it("returns the filecoin-specific config when tenant id is 'filecoin'", () => {
     const config = getAskKarmaConfig("filecoin");
-    // Filecoin example questions must include the bespoke "fil.one" prompt
-    // from the screenshot — this is the contract we wire from the spec.
-    expect(config.exampleQuestions.some((q) => q.toLowerCase().includes("fil.one"))).toBe(true);
+    // Filecoin overrides the default question list and surfaces a ProPGF
+    // card — keep these as the durable contract rather than pinning to
+    // specific copy that the customer iterates on.
+    expect(config.exampleQuestions).not.toEqual(getAskKarmaConfig().exampleQuestions);
     expect(config.featuredTopics.some((t) => t.title.includes("ProPGF"))).toBe(true);
   });
 

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -56,8 +56,6 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
     exampleQuestions: [
       "How do I submit a milestone update for my project?",
       "Why can't I access the project I am reviewing?",
-      "Which metrics matter most when evaluating project impact?",
-      "How is ProPGF currently supporting fil.one?",
       "What is the typical payment timeline after invoice submission?",
       "Are there retrospective reports from previous funding rounds?",
     ],
@@ -69,10 +67,9 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
           // No href → renders as "coming soon" (muted, non-interactive)
           { label: "Round 3 Announcement" },
           { label: "Selection Committee" },
-          // TODO(ask-karma-filecoin): replace placeholder href with real destination
           {
             label: "Retro from previous rounds",
-            href: "https://filpgf.io/propgf",
+            href: "https://www.filecoin.io/blog/reflections-from-propgf-batch-1-what-we-learned-about-funding-impact-in-the-filecoin-ecosystem",
             isExternal: true,
           },
         ],
@@ -100,22 +97,18 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
             href: "https://docs.gap.karmahq.xyz/how-to-guides/partners/filecoin/milestone-reviewer-guide",
             isExternal: true,
           },
-          // No href → greyed out ("coming soon")
-          { label: "FAQs" },
         ],
       },
       {
         icon: "document",
         title: "Focus Areas",
         links: [
-          // TODO(ask-karma-filecoin): replace placeholder href with real destination
-          { label: "Large Data Onboarding", href: "https://filpgf.io/propgf", isExternal: true },
           {
             label: "Filecoin Onchain Cloud",
             href: "https://filecoin.cloud/",
             isExternal: true,
           },
-          { label: "Fil.one", href: "https://fil.one", isExternal: true },
+          { label: "Fil.one", href: "https://fil.one/", isExternal: true },
         ],
       },
       {
@@ -127,8 +120,11 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
             href: "https://www.filecoin.io/blog/the-2026-filecoin-network-strategy",
             isExternal: true,
           },
-          // No href → greyed out ("coming soon")
-          { label: "ProPGF Project Impact" },
+          {
+            label: "Filecoin Data Portal",
+            href: "https://filecoindataportal.xyz/",
+            isExternal: true,
+          },
         ],
       },
       {
@@ -136,7 +132,11 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
         title: "RetroPGF",
         links: [
           { label: "About RetroPGF", href: "https://www.fil-retropgf.io/", isExternal: true },
-          { label: "Past rounds", href: "https://www.fil-retropgf.io/", isExternal: true },
+          {
+            label: "Past rounds",
+            href: "https://www.fil-retropgf.io/archive/round-2/",
+            isExternal: true,
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Refreshes the Filecoin-specific copy on `/ask-karma` to reflect what's actually shippable today. All changes are scoped to the `filecoin` entry inside `src/features/ask-karma/config.ts` — no component, type, or routing changes.

Closes [DEV-337](https://linear.app/showkarma/issue/DEV-337) and [DEV-338](https://linear.app/showkarma/issue/DEV-338) (both High priority, due 2026-05-22, requested by Erin O'Connor).

## Changes

**Suggested questions (DEV-338)** — removed two prompts that don't have good answers right now:
- ~~Which metrics matter most when evaluating project impact?~~
- ~~How is ProPGF currently supporting fil.one?~~

**Featured index cards (DEV-337):**

| Card | Change |
| --- | --- |
| The Next ProPGF Round | "Retro from previous rounds" → Filecoin.io reflections post (was placeholder URL). Round 3 / Selection Committee stay as "coming soon". |
| Navigate filpgf.io | Removed FAQs entry (not ready). |
| Focus Areas | Removed Large Data Onboarding (not ready). Filecoin Onchain Cloud and Fil.one unchanged. |
| Metrics and Strategy | Renamed "ProPGF Project Impact" → "Filecoin Data Portal" with real destination (`filecoindataportal.xyz`). |
| RetroPGF | "Past rounds" now points to `/archive/round-2/` instead of the homepage. |

**Test:** swapped the brittle "filecoin questions include `fil.one`" assertion for a durable "filecoin diverges from the default tenant" check, so future copy iteration doesn't bounce the test.

## Test plan

- [x] `pnpm test __tests__/unit/features/ask-karma/config.test.ts` → 7/7 pass
- [x] Biome check on the two edited files → clean
- [x] `tsc --noEmit` on the touched files → no errors
- [ ] Manually verify on Filecoin whitelabel (filpgf.io / `/community/filecoin`):
  - Suggested questions list shows 4 items, neither removed prompt appears
  - "Retro from previous rounds" opens the Filecoin.io blog post in a new tab
  - "Navigate filpgf.io" no longer shows FAQs
  - "Focus Areas" no longer shows Large Data Onboarding
  - "Metrics and Strategy" shows "Filecoin Data Portal" linking to filecoindataportal.xyz
  - RetroPGF "Past rounds" opens `/archive/round-2/`
- [ ] Cross-check `/ask-karma` on the default Karma tenant is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Filecoin configuration with revised example questions and featured topic links.
  * Added Filecoin Data Portal as a new external resource under Metrics and Strategy.
  * Updated navigation links and URLs for Filecoin-related topics, including "Past rounds" and "Focus Areas" sections.
  * Updated test assertions to verify Filecoin configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->