### PR TITLE
fix(profile): stop validating an incomplete contributor form on load

### DIFF
--- a/__tests__/components/Dialogs/ContributorProfileDialog.test.tsx
+++ b/__tests__/components/Dialogs/ContributorProfileDialog.test.tsx
@@ -114,8 +114,9 @@ vi.mock("@/hooks/useAuth", () => ({
 }));
 
 const mockRefetchProfile = vi.fn().mockResolvedValue({ data: undefined });
+let mockProfileValue: { data?: Record<string, unknown> } | undefined;
 vi.mock("@/hooks/useContributorProfile", () => ({
-  useContributorProfile: () => ({ profile: undefined, refetch: mockRefetchProfile }),
+  useContributorProfile: () => ({ profile: mockProfileValue, refetch: mockRefetchProfile }),
 }));
 
 const mockRefetchTeamProfiles = vi.fn();
@@ -208,6 +209,7 @@ vi.mock("@/constants/brand", () => ({ PROJECT_NAME: "Karma GAP" }));
 describe("ContributorProfileDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProfileValue = undefined;
     mockSetupChainAndWallet.mockResolvedValue({
       gapClient: { findSchema: vi.fn(() => ({ uid: "0xschema" })) },
       walletSigner: {},
@@ -293,6 +295,29 @@ describe("ContributorProfileDialog", () => {
         })
       );
       // No validation error should be present on the happy path.
+      expect(screen.queryByText("This name is too short")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("profile load with a missing name (Sentry GAP-FRONTEND-222/225)", () => {
+    it("populates a name-less profile on load without surfacing a validation error", async () => {
+      // A real contributor profile that has no `name` yet. Populating the form on
+      // load must use reset() (no validation) — validating the partially-filled
+      // state is what previously threw "name: expected string, received
+      // undefined". The global unhandled-rejection guard also fails this test if
+      // that throw resurfaces.
+      mockProfileValue = { data: { name: "", github: "https://github.com/test" } };
+
+      render(<ContributorProfileDialog />);
+
+      // The profile-load effect ran (github populated from the profile)...
+      await waitFor(() => {
+        expect(
+          (screen.getByPlaceholderText("Ex: https://github.com/johndoe") as HTMLInputElement).value
+        ).toBe("https://github.com/test");
+      });
+
+      // ...and loading alone did not trigger validation of the empty name.
       expect(screen.queryByText("This name is too short")).not.toBeInTheDocument();
     });
   });

--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -91,7 +91,6 @@ export const ContributorProfileDialog: FC = () => {
   const { smartWalletAddress, setupChainAndWallet } = useSetupChainAndWallet();
   const {
     register,
-    setValue,
     handleSubmit,
     reset,
     formState: { errors, isValid },
@@ -99,6 +98,14 @@ export const ContributorProfileDialog: FC = () => {
     resolver: zodResolver(profileSchema),
     reValidateMode: "onChange",
     mode: "onChange",
+    defaultValues: {
+      name: "",
+      aboutMe: "",
+      github: "",
+      twitter: "",
+      linkedin: "",
+      farcaster: "",
+    },
   });
   const [isLoading, setIsLoading] = useState(false);
   const { startAttestation, showLoading, showSuccess, showError, dismiss, changeStepperStep } =
@@ -253,31 +260,25 @@ export const ContributorProfileDialog: FC = () => {
     }
   };
 
-  // Update form values when profile data is loaded
+  // Populate form values when profile data loads. Use reset() to set everything
+  // in a single batch WITHOUT validating a partially-filled state. The previous
+  // per-field setValue(..., { shouldValidate: true }) calls validated the whole
+  // form while `name` was still empty, surfacing a "name: expected string,
+  // received undefined" error (Sentry GAP-FRONTEND-222/225).
   useEffect(() => {
     if (profile?.data) {
-      setValue("aboutMe", profile.data.aboutMe, {
-        shouldValidate: true,
-      });
-      setValue("github", profile.data.github, {
-        shouldValidate: true,
-      });
-      setValue("linkedin", profile.data.linkedin, {
-        shouldValidate: true,
-      });
-      setValue("twitter", profile.data.twitter, {
-        shouldValidate: true,
-      });
-      setValue("name", profile.data.name || "", {
-        shouldValidate: !!profile.data.name,
-      });
-      setValue("farcaster", profile.data.farcaster, {
-        shouldValidate: !!profile.data.farcaster,
+      reset({
+        name: profile.data.name || "",
+        aboutMe: profile.data.aboutMe || "",
+        github: profile.data.github || "",
+        twitter: profile.data.twitter || "",
+        linkedin: profile.data.linkedin || "",
+        farcaster: profile.data.farcaster || "",
       });
     } else {
       reset();
     }
-  }, [profile, setValue, reset]);
+  }, [profile, reset]);
 
   return (
     <Transition appear show={isOpen} as={Fragment}>


### PR DESCRIPTION
## Summary
Hardens the source of the `name`-undefined crash (Sentry **GAP-FRONTEND-222/225**) so the globally-mounted contributor profile form never validates a partially-filled state. Builds on #1505 (the Zod v4 resolver fix, already merged).

## Problem
`ContributorProfileDialog` is rendered on every authenticated page (via `DeferredLayoutComponents`). When a contributor profile loaded, its effect populated the form with repeated `setValue(..., { shouldValidate: true })` calls **while `name` was still empty**, validating an incomplete form. That produced a `name: expected string, received undefined` ZodError on page load, surfaced as an **unhandled promise rejection** (Sentry 222/225, and the repo-wide `smoke` failure).

#1505 stopped the resolver from *throwing*; this removes the premature validation at the source so the form doesn't produce spurious errors on load either.

## Solution
- Populate the form in a single `reset({...})` (which does **not** validate) instead of six `setValue(..., { shouldValidate: true })` calls.
- Add `defaultValues` so the form is never in an undefined state.

## Testing steps
- New test: loading a profile with a missing `name` populates the form (asserts the GitHub field fills) **without** surfacing the "This name is too short" error — fails on the old per-field-validate code, passes now. The global unhandled-rejection guard also fails the test if the throw resurfaces.
- `ContributorProfileDialog.test.tsx`: 6/6 pass. `tsc --noEmit`: 0 errors.

## Risk
Low. `reset()` is the idiomatic way to load values into React Hook Form; valid-profile behavior is unchanged (happy-path test still passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation error messages displaying incorrectly when loading contributor profile information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->