### PR TITLE
fix(build): cap Turbopack build hangs with timeout + clean-cache retry

### DIFF
--- a/docs/adr/0001-turbopack-build-timeout-retry.md
+++ b/docs/adr/0001-turbopack-build-timeout-retry.md
@@ -52,7 +52,7 @@ Keep `next build --turbopack` (preserves build speed and parity with
    `timeout`; the shared `package.json` `build` script stays cross-platform so
    local builds on Windows/macOS are unaffected):
 
-   ```
+   ```bash
    timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )
    ```
 

--- a/docs/adr/0001-turbopack-build-timeout-retry.md
+++ b/docs/adr/0001-turbopack-build-timeout-retry.md
@@ -1,0 +1,97 @@
+# 1. Guard Turbopack production builds with a self-timeout and clean-cache retry
+
+Date: 2026-05-25
+
+## Status
+
+Accepted
+
+## Context
+
+Vercel deployments for `gap-app-v2` intermittently hung for ~45 minutes and
+then failed, with no error in the logs — the build appeared to "take 45
+minutes to realise it won't build". Investigation of the Vercel deployment
+history established what was actually happening:
+
+- The failed build (`dpl_Co68avDfBW7Rj178k56kUvizdPaP`) ran for **45.4 min**
+  and its log went **silent immediately after `Creating an optimized
+  production build …` (Turbopack)** — no compile error, just a stall.
+- The ~45-minute figure is **Vercel's hard max-build-duration killing a hung
+  process**, not the build detecting a problem. There was never an error to
+  surface; there was an infinite stall that got force-killed.
+- The hang was **non-deterministic**. Three builds on branch
+  `feat/oauth-mcp-consent-ui` hung in a ~1-hour window. Critically, commit
+  `664e3d7b` hung for 45 min (`dpl_Hc5WSKP8…`) and then, **redeployed ~18h
+  later with zero code changes, built in ~5 min and succeeded**
+  (`dpl_DxH3GaSw…`). Identical input, different outcome — which rules out a
+  code-level bug, a specific page, or a bad commit.
+- Builds use `next build --turbopack`. Turbopack's **production** compiler is
+  beta and has a documented history of intermittent silent hangs. The failed
+  builds ran on **Next 15.4.10**; the project has since moved to 15.5.16 and
+  the issue largely subsided — but production builds still use `--turbopack`,
+  so the risk remained armed.
+
+Two configuration smells made a hang worse than necessary:
+
+- `staticPageGenerationTimeout: 10000` (≈2.77 hours). The app has **no
+  `generateStaticParams`** and builds in ~5 min, so nothing approaches this.
+  It could not save a build inside Vercel's 45-min window — purely vestigial.
+- No upper bound on build duration below Vercel's 45-min platform ceiling.
+
+Because the root cause is non-deterministic instability in an upstream beta
+compiler, **it cannot be deterministically fixed from this repo.** The real
+choice is how to contain it.
+
+## Decision
+
+Keep `next build --turbopack` (preserves build speed and parity with
+`next dev --turbopack`), and **contain** the hang rather than eliminate it:
+
+1. **Self-timeout + clean-cache auto-retry**, applied only on Vercel via
+   `vercel.json` `buildCommand` (Vercel's Linux builders have GNU coreutils
+   `timeout`; the shared `package.json` `build` script stays cross-platform so
+   local builds on Windows/macOS are unaffected):
+
+   ```
+   timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )
+   ```
+
+   A hung build is killed at **15 min**, then rebuilt once on a **clean
+   `.next`** — which both leverages the observed "retry succeeds" behaviour and
+   clears a possibly-poisoned Turbopack cache (a leading hang suspect).
+
+2. **Lower `staticPageGenerationTimeout` from `10000` to `120`** in
+   `next.config.ts`, so a hung build-time fetch fails fast and names the page
+   instead of stalling silently.
+
+We explicitly did **not** switch the production build to the stable webpack
+compiler (which would eliminate the Turbopack-hang class entirely), to keep
+build speed and dev/build parity.
+
+## Consequences
+
+- A hang now costs at most ~30 min (15-min kill + clean cold rebuild) instead
+  of 45 min, and usually **self-heals with no human in the loop** — best case
+  ~23 min (15-min fail + ~8-min cold rebuild), worst case two 15-min fails →
+  hard failure surfaced fast. All paths stay under Vercel's 45-min ceiling.
+- The retry path does a **cold** rebuild (cache wiped), so it is slower than a
+  normal ~5-min build. If cold rebuilds ever approach 15 min, raise the second
+  attempt's budget (e.g. `1200s`); total still fits under 45 min.
+- Local `pnpm build` is unchanged on all platforms — the guard is Vercel-only.
+- This is **containment, not a cure.** The underlying Turbopack instability
+  lives upstream. Revisit if hangs recur on current Next: either bump Next
+  again or reconsider switching the production build to webpack. When Turbopack
+  `build` reaches GA and is stable, the timeout/retry wrapper can be removed.
+- `staticPageGenerationTimeout: 120` assumes no page legitimately needs >2 min
+  of build-time generation. True today (no `generateStaticParams`); if a future
+  page does heavy build-time fetching, fix the fetch rather than re-inflating
+  this value.
+
+## Evidence
+
+| Deployment | Commit | Duration | Result |
+|---|---|---|---|
+| `dpl_ERwy6Hu…` | `af40d6c6` | 45.6 min | ERROR (silent hang) |
+| `dpl_Co68avD…` | `00fb74c5` | 45.4 min | ERROR (silent hang) |
+| `dpl_Hc5WSKP8…` | `664e3d7b` | 45.2 min | ERROR (silent hang) |
+| `dpl_DxH3GaSw…` | `664e3d7b` (redeploy) | ~5.1 min | **READY** |

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,7 +21,11 @@ const removeImports = require("next-remove-imports")();
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  staticPageGenerationTimeout: 10000,
+  // Cap per-page static generation at 2 min. The app has no
+  // generateStaticParams and builds in ~5 min, so nothing legitimately
+  // approaches this — a longer stall means a hung build-time fetch that
+  // should fail fast and name the page, not silently burn the build.
+  staticPageGenerationTimeout: 120,
   // Standalone output produces a self-contained server.js bundle in
   // .next/standalone with traced node_modules. Cuts CI artifact size
   // from ~200MB to ~30-50MB and boots in ~2s vs ~25s for `pnpm start`.

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,6 @@
       "*": true
     }
   },
-  "ignoreCommand": "bash vercel-ignore.sh"
+  "ignoreCommand": "bash vercel-ignore.sh",
+  "buildCommand": "timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )"
 }


### PR DESCRIPTION
## Overview

Production builds occasionally hung in the Turbopack production compiler and were silently killed at Vercel's 45-minute max-build-duration — appearing to "take 45 minutes to realise it won't build". This caps that blast radius and lets most hangs self-heal automatically, without touching local builds.

## Problem

Investigation of the Vercel deployment history (project `gap-app-v2`) found:

- A failed build ran **45.4 min** and went **silent right after `Creating an optimized production build …` (Turbopack)** — no compile error, just a stall. The ~45-min figure is **Vercel's hard ceiling force-killing a hung process**, not the build detecting a problem.
- The hang is **non-deterministic**. Three builds on one branch hung in a ~1-hour window; commit `664e3d7b` hung 45 min and then, **redeployed ~18h later with zero code changes, built in ~5 min and succeeded**. Identical input, different outcome → not a code bug.
- Builds use `next build --turbopack`; Turbopack's **production** compiler is beta with a documented history of intermittent silent hangs. The failures were on Next 15.4.10 (since bumped to 15.5.16, which largely subsided it), but prod builds still use `--turbopack`, so the risk remained armed.

| Deployment | Commit | Duration | Result |
|---|---|---|---|
| `dpl_ERwy6Hu…` | `af40d6c6` | 45.6 min | ERROR (silent hang) |
| `dpl_Co68avD…` | `00fb74c5` | 45.4 min | ERROR (silent hang) |
| `dpl_Hc5WSKP8…` | `664e3d7b` | 45.2 min | ERROR (silent hang) |
| `dpl_DxH3GaSw…` | `664e3d7b` (redeploy) | ~5.1 min | **READY** |

## Solution

Contain the hang (rather than switch off beta Turbopack), guarding only Vercel so local `pnpm build` stays cross-platform:

- **`vercel.json`** — new `buildCommand`:
  ```
  timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )
  ```
  A hang is killed at **15 min**, then rebuilt once on a **clean `.next`** — leveraging the observed "retry succeeds" behaviour and clearing a possibly-poisoned Turbopack cache. `timeout` is GNU coreutils (present on Vercel's Linux builders, absent on Windows/macOS), so this lives in `vercel.json`, not `package.json`.
- **`next.config.ts`** — `staticPageGenerationTimeout: 10000` → `120`. The app has no `generateStaticParams` and builds in ~5 min, so the old ~2.77h value was vestigial; 120s makes a hung build-time fetch fail fast and name the page.
- **`docs/adr/0001-turbopack-build-timeout-retry.md`** — records the root cause, decision, and exit criteria.

## Impact

- A hang now costs at most ~30 min (15-min kill + cold rebuild) instead of 45, and usually **self-heals with no human** — all paths stay under Vercel's 45-min ceiling.
- The retry path is a **cold** rebuild (slower than ~5 min). If cold rebuilds ever approach 15 min, raise the second attempt to `1200s`.
- **Local builds unchanged** on all platforms; the guard is Vercel-only.
- This is **containment, not a cure** — the instability lives upstream in beta Turbopack. Revisit if hangs recur on current Next; drop the wrapper when Turbopack `build` is GA.

## Testing steps

1. Confirm `vercel.json` is valid JSON and the preview deployment for this branch builds green (it exercises the new `buildCommand`).
2. Verify local `pnpm build` is unaffected (no `timeout` in the `package.json` script).
3. Confirm the preview build completes well under 15 min (normal ~5 min).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision record documenting build reliability improvements and recovery strategies.

* **Chores**
  * Updated application build configuration to adjust static page generation timeout thresholds.
  * Enhanced Vercel deployment configuration with improved build timeout handling and automatic recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->