### PR TITLE
feat(filecoin): clean up ProPGF navbar links and social label

### DIFF
--- a/__tests__/navbar/unit/whitelabel-navbar-social-labels.test.tsx
+++ b/__tests__/navbar/unit/whitelabel-navbar-social-labels.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Unit Tests: WhitelabelNavbar social link labels
+ * Verifies that a tenant can override the default "Twitter" social link label
+ * via navigation.socialLinkLabels (e.g. Filecoin shows "Social"), while tenants
+ * without an override keep the default label.
+ */
+
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+// NOTE: the social links are asserted via the mobile menu (plain conditional render).
+// The desktop "Resources" dropdown is a Radix DropdownMenu using setPointerCapture,
+// which does not open under jsdom, so it can't be exercised in unit tests here.
+import { WhitelabelNavbar } from "@/src/components/navbar/whitelabel-navbar";
+import type { TenantConfig } from "@/src/infrastructure/types/tenant";
+import { getAuthFixture } from "../fixtures/auth-fixtures";
+import {
+  cleanupAfterEach,
+  createMockPermissions,
+  createMockUsePrivy,
+  createMockUseTheme,
+  renderWithProviders,
+} from "../utils/test-helpers";
+
+// Mutable tenant ref so each test can supply its own navigation config.
+const _tenantRef = vi.hoisted(() => ({ tenant: null as TenantConfig | null }));
+
+vi.mock("@/store/tenant", () => ({
+  useTenantSafe: vi.fn(() => _tenantRef.tenant),
+}));
+
+function buildTenant(navigation: Partial<TenantConfig["navigation"]>): TenantConfig {
+  return {
+    id: "filpgf",
+    name: "Fil PGF",
+    theme: { primaryColor: "#0090FF", secondaryColor: "#E5F3FF", mode: "light" } as any,
+    assets: { logo: "/images/filpgf-logo.png" } as any,
+    karmaAssets: {} as any,
+    navigation: {
+      header: { shouldHaveTitle: true, title: "Fil PGF" },
+      items: [],
+      showBrowseApplications: true,
+      ...navigation,
+    } as any,
+    seo: {} as any,
+    chainId: 314,
+    claimGrants: {} as any,
+  };
+}
+
+function renderNavbar() {
+  const authFixture = getAuthFixture("unauthenticated");
+  renderWithProviders(<WhitelabelNavbar />, {
+    mockUsePrivy: createMockUsePrivy(authFixture.authState),
+    mockPermissions: createMockPermissions(authFixture.permissions),
+    mockUseTheme: createMockUseTheme("light"),
+  });
+}
+
+describe("WhitelabelNavbar social link labels", () => {
+  afterEach(() => {
+    cleanupAfterEach();
+  });
+
+  it('renders the overridden label ("Social") when socialLinkLabels.twitter is set', async () => {
+    _tenantRef.tenant = buildTenant({
+      socialLinks: { twitter: "https://x.com/Filecoin" },
+      socialLinkLabels: { twitter: "Social" },
+    });
+
+    renderNavbar();
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Social" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("link", { name: "Twitter" })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the default "Twitter" label when no override is provided', async () => {
+    _tenantRef.tenant = buildTenant({
+      socialLinks: { twitter: "https://x.com/optimism" },
+    });
+
+    renderNavbar();
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Twitter" })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("link", { name: "Social" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/navbar/whitelabel-navbar.tsx
+++ b/src/components/navbar/whitelabel-navbar.tsx
@@ -27,7 +27,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "@/src/components/navigation/Link";
-import type { NavDropdown, NavItem } from "@/src/infrastructure/types/tenant";
+import type { NavDropdown, NavItem, TenantNavigation } from "@/src/infrastructure/types/tenant";
 import { useTenantSafe } from "@/store/tenant";
 import { karmaLinks } from "@/utilities/karma/karma";
 import { cn } from "@/utilities/tailwind";
@@ -62,47 +62,54 @@ interface SocialLinkItem {
   href: string;
 }
 
+function buildSocialLinks(
+  socialLinks: TenantNavigation["socialLinks"],
+  labels: TenantNavigation["socialLinkLabels"]
+): SocialLinkItem[] {
+  return [
+    socialLinks?.twitter && {
+      key: "twitter",
+      label: labels?.twitter ?? "Twitter",
+      href: socialLinks.twitter,
+    },
+    socialLinks?.discord && {
+      key: "discord",
+      label: labels?.discord ?? "Discord",
+      href: socialLinks.discord,
+    },
+    socialLinks?.github && {
+      key: "github",
+      label: labels?.github ?? "GitHub",
+      href: socialLinks.github,
+    },
+    socialLinks?.telegram && {
+      key: "telegram",
+      label: labels?.telegram ?? "Telegram",
+      href: socialLinks.telegram,
+    },
+    socialLinks?.docs && {
+      key: "docs",
+      label: labels?.docs ?? "Docs",
+      href: socialLinks.docs,
+    },
+    {
+      key: "skills",
+      label: "Skills",
+      href: karmaLinks.skills,
+    },
+  ].filter((link): link is SocialLinkItem => Boolean(link));
+}
+
 export function WhitelabelNavbar() {
   const tenant = useTenantSafe();
   const { authenticated } = useAuth();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const tenantSocialLinks = tenant?.navigation?.socialLinks;
+  const tenantSocialLinkLabels = tenant?.navigation?.socialLinkLabels;
   const socialLinks = useMemo<SocialLinkItem[]>(
-    () =>
-      [
-        tenantSocialLinks?.twitter && {
-          key: "twitter",
-          label: "Twitter",
-          href: tenantSocialLinks.twitter,
-        },
-        tenantSocialLinks?.discord && {
-          key: "discord",
-          label: "Discord",
-          href: tenantSocialLinks.discord,
-        },
-        tenantSocialLinks?.github && {
-          key: "github",
-          label: "GitHub",
-          href: tenantSocialLinks.github,
-        },
-        tenantSocialLinks?.telegram && {
-          key: "telegram",
-          label: "Telegram",
-          href: tenantSocialLinks.telegram,
-        },
-        tenantSocialLinks?.docs && {
-          key: "docs",
-          label: "Docs",
-          href: tenantSocialLinks.docs,
-        },
-        {
-          key: "skills",
-          label: "Skills",
-          href: karmaLinks.skills,
-        },
-      ].filter((link): link is SocialLinkItem => Boolean(link)),
-    [tenantSocialLinks]
+    () => buildSocialLinks(tenantSocialLinks, tenantSocialLinkLabels),
+    [tenantSocialLinks, tenantSocialLinkLabels]
   );
 
   if (!tenant) {

--- a/src/infrastructure/config/tenant-config.ts
+++ b/src/infrastructure/config/tenant-config.ts
@@ -342,11 +342,6 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
               },
             ],
           },
-          {
-            label: "Payout process",
-            href: "https://docs.google.com/document/d/1WIyL8zj1ToTEVujRvCV6E4mlle5srwLP3DhEarWn3Ug/edit?usp=sharing",
-            isExternal: true,
-          },
           { label: "Financials", href: "/community/filecoin/financials" },
         ],
       },
@@ -361,7 +356,6 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
             href: "https://github.com/filecoin-project/community/discussions",
             isExternal: true,
           },
-          { label: "Community", href: "https://filecoin.io/community", isExternal: true },
         ],
       },
     ],
@@ -369,6 +363,9 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
       twitter: "https://twitter.com/Filecoin",
       discord: "https://discord.gg/yeQ2hcd2TD",
       github: "https://github.com/filecoin-project",
+    },
+    socialLinkLabels: {
+      twitter: "Social",
     },
   },
   "for-the-world": {

--- a/src/infrastructure/types/tenant.ts
+++ b/src/infrastructure/types/tenant.ts
@@ -109,6 +109,14 @@ export interface TenantNavigation {
     paragraph?: string;
     farcaster?: string;
   };
+  /** Per-tenant label overrides for social links (e.g. show "Social" instead of "Twitter"). */
+  socialLinkLabels?: {
+    twitter?: string;
+    discord?: string;
+    github?: string;
+    docs?: string;
+    telegram?: string;
+  };
 }
 
 export interface HeroStat {


### PR DESCRIPTION
## Overview

Filecoin (ProPGF) website cleanups requested in DEV-336. Scoped to the navbar items that live in `gap-app-v2`.

Resolves the in-app portion of [DEV-336](https://linear.app/showkarma/issue/DEV-336/erin-oconnor-website-updates).

## Changes

1. **Removed "Payout process"** from the ProPGF dropdown — it only linked to a stale "ProPGF Batch 2 - Payout & Milestone Process Guide" Google Doc, which should no longer be the source link.
2. **Removed "Community"** from the "More" dropdown — pointed to a broken `filecoin.io/community` link.
3. **"Twitter" → "Social" (Filecoin only)** — the Resources social link now reads "Social" since the account is on X. Implemented as a config-driven, per-tenant `socialLinkLabels` override so every other whitelabel tenant keeps "Twitter".

## Implementation notes

- Added optional `socialLinkLabels` to `TenantNavigation`; the navbar resolves each label as `labels?.<key> ?? "<default>"`.
- Extracted the social-link list into a module-level `buildSocialLinks()` helper to keep the override logic out of the component render.

## Testing

- New unit test `whitelabel-navbar-social-labels.test.tsx`: override renders "Social"; default renders "Twitter".
- Full navbar suite passes (668 tests).
- `pnpm lint:fix` exits clean and `pnpm run build` succeeds.

## Out of scope

Items 4–6 of the ticket edit the **Overview page at `https://filpgf.io/propgf`** (the "Reach out to Sejal" block, the follow-up blog copy, and the Telegram/Slack text). That content lives in the separate `filpgf.io` codebase, not in any super-gap submodule, so it must be handled there as a separate change. This PR should not close DEV-336 on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social link labels in the navbar are now customizable per tenant configuration, enabling branded alternatives to default labels (e.g., replacing "Twitter" with "Social" for Twitter, Discord, GitHub, Telegram, and Docs links).

* **Tests**
  * Added unit tests validating tenant-configurable social link label behavior in the navbar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->