### PR TITLE
fix(community-updates): align cards and table views to same milestone set

### DIFF
--- a/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
+++ b/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for community milestone validity filtering and sorting.
+ *
+ * The cards view and the table view of the community Updates page consume the
+ * same API payload. Both must drop invalid milestones (missing uid, status,
+ * title, or project slug) so the two views render the exact same set of items.
+ * `isValidMilestone` is the shared predicate that guarantees that parity.
+ */
+
+import type { CommunityMilestoneUpdate } from "@/types/community-updates";
+import {
+  isValidMilestone,
+  sortCommunityMilestones,
+} from "@/utilities/sorting/communityMilestoneSort";
+
+function createMilestone(
+  overrides: Partial<CommunityMilestoneUpdate> = {}
+): CommunityMilestoneUpdate {
+  return {
+    uid: "milestone-1",
+    communityUID: "community-1",
+    status: "pending",
+    details: {
+      title: "Milestone title",
+      description: "Description",
+      dueDate: "2026-01-01T00:00:00.000Z",
+    },
+    project: {
+      uid: "project-1",
+      details: {
+        data: {
+          title: "Project title",
+          slug: "project-slug",
+        },
+      },
+    },
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isValidMilestone", () => {
+  it("accepts a fully populated milestone", () => {
+    expect(isValidMilestone(createMilestone())).toBe(true);
+  });
+
+  it.each([
+    ["missing uid", { uid: "" }],
+    ["missing status", { status: undefined as unknown as "pending" }],
+  ])("rejects a milestone %s", (_label, overrides) => {
+    expect(isValidMilestone(createMilestone(overrides as Partial<CommunityMilestoneUpdate>))).toBe(
+      false
+    );
+  });
+
+  it("rejects a milestone with no details title", () => {
+    const milestone = createMilestone();
+    milestone.details = { ...milestone.details, title: "" };
+    expect(isValidMilestone(milestone)).toBe(false);
+  });
+
+  it("rejects a milestone whose project has no slug", () => {
+    const milestone = createMilestone();
+    milestone.project = {
+      ...milestone.project,
+      details: { data: { title: "Project title", slug: "" } },
+    };
+    expect(isValidMilestone(milestone)).toBe(false);
+  });
+
+  it("rejects non-object input", () => {
+    expect(isValidMilestone(null)).toBe(false);
+    expect(isValidMilestone(undefined)).toBe(false);
+    expect(isValidMilestone("milestone")).toBe(false);
+  });
+});
+
+describe("sortCommunityMilestones", () => {
+  it("filters out invalid milestones from the result", () => {
+    const valid = createMilestone({ uid: "valid" });
+    const invalid = createMilestone({ uid: "" });
+
+    const result = sortCommunityMilestones([valid, invalid], "all", "community-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe("valid");
+  });
+
+  it("orders pending milestones before completed ones for the 'all' filter", () => {
+    const completed = createMilestone({ uid: "completed", status: "completed" });
+    const pending = createMilestone({ uid: "pending", status: "pending" });
+
+    const result = sortCommunityMilestones([completed, pending], "all", "community-1");
+
+    expect(result.map((m) => m.uid)).toEqual(["pending", "completed"]);
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(
+      sortCommunityMilestones(
+        undefined as unknown as CommunityMilestoneUpdate[],
+        "all",
+        "community-1"
+      )
+    ).toEqual([]);
+  });
+});

--- a/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
+++ b/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
@@ -47,7 +47,10 @@ describe("isValidMilestone", () => {
 
   it.each([
     ["missing uid", { uid: "" }],
+    ["whitespace-only uid", { uid: "   " }],
+    ["non-string uid", { uid: 123 as unknown as string }],
     ["missing status", { status: undefined as unknown as "pending" }],
+    ["unsupported status value", { status: "in_progress" as unknown as "pending" }],
   ])("rejects a milestone %s", (_label, overrides) => {
     expect(isValidMilestone(createMilestone(overrides as Partial<CommunityMilestoneUpdate>))).toBe(
       false
@@ -57,6 +60,12 @@ describe("isValidMilestone", () => {
   it("rejects a milestone with no details title", () => {
     const milestone = createMilestone();
     milestone.details = { ...milestone.details, title: "" };
+    expect(isValidMilestone(milestone)).toBe(false);
+  });
+
+  it("rejects a milestone whose title is whitespace only", () => {
+    const milestone = createMilestone();
+    milestone.details = { ...milestone.details, title: "   " };
     expect(isValidMilestone(milestone)).toBe(false);
   });
 

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -21,7 +21,10 @@ import { useCommunityProjectUpdates } from "@/hooks/useCommunityProjectUpdates";
 import { useCommunityUpdatesView } from "@/hooks/useCommunityUpdatesView";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { findProjectOptionBySlugOrUid, projectsToOptions } from "@/utilities/project-lookup";
-import { sortCommunityMilestones } from "@/utilities/sorting/communityMilestoneSort";
+import {
+  isValidMilestone,
+  sortCommunityMilestones,
+} from "@/utilities/sorting/communityMilestoneSort";
 
 type FilterOption = "all" | "pending" | "completed" | "past_due";
 
@@ -142,7 +145,11 @@ export default function CommunityUpdatesPage() {
     return sortCommunityMilestones([...data.payload], selectedFilter, communityId);
   }, [data?.payload, selectedFilter, communityId]);
 
-  const tableData = useMemo(() => data?.payload ?? [], [data?.payload]);
+  // Table view: keep the server order, but apply the same validity filter as
+  // the cards view so both views show the exact same set of milestones.
+  // Milestones missing a project slug/title come from the indexer; tracked in
+  // show-karma/super-gap#37.
+  const tableData = useMemo(() => (data?.payload ?? []).filter(isValidMilestone), [data?.payload]);
 
   const displayedData = isTableView ? tableData : cardsData;
 

--- a/utilities/sorting/communityMilestoneSort.ts
+++ b/utilities/sorting/communityMilestoneSort.ts
@@ -8,13 +8,16 @@ type FilterOption = "all" | "pending" | "completed" | "past_due";
 export function isValidMilestone(item: unknown): item is CommunityMilestoneUpdate {
   if (!item || typeof item !== "object") return false;
   const milestone = item as Record<string, unknown>;
-  if (!milestone.uid || !milestone.status) return false;
+  if (typeof milestone.uid !== "string" || milestone.uid.trim() === "") return false;
+  if (milestone.status !== "pending" && milestone.status !== "completed") return false;
   const details = milestone.details as Record<string, unknown> | undefined;
-  if (!details?.title) return false;
+  const title = details?.title;
+  if (typeof title !== "string" || title.trim() === "") return false;
   const project = milestone.project as Record<string, unknown> | undefined;
   const projectDetails = project?.details as Record<string, unknown> | undefined;
   const projectData = projectDetails?.data as Record<string, unknown> | undefined;
-  if (!projectData?.slug) return false;
+  const slug = projectData?.slug;
+  if (typeof slug !== "string" || slug.trim() === "") return false;
   return true;
 }
 

--- a/utilities/sorting/communityMilestoneSort.ts
+++ b/utilities/sorting/communityMilestoneSort.ts
@@ -5,7 +5,7 @@ type FilterOption = "all" | "pending" | "completed" | "past_due";
 /**
  * Validates if a milestone item has all required fields
  */
-function isValidMilestone(item: unknown): item is CommunityMilestoneUpdate {
+export function isValidMilestone(item: unknown): item is CommunityMilestoneUpdate {
   if (!item || typeof item !== "object") return false;
   const milestone = item as Record<string, unknown>;
   if (!milestone.uid || !milestone.status) return false;


### PR DESCRIPTION
@
## Summary

The community Updates page renders the same data in two views — cards (`/updates`) and table (`/updates?view=table`). They were showing **different items** for the same dataset.

## Problem

Both views consume the same payload from `useCommunityProjectUpdates`, but processed it differently:

- **Cards** ran the payload through `sortCommunityMilestones`, which silently drops any milestone failing `isValidMilestone` (missing `uid`, `status`, `details.title`, or `project.details.data.slug`).
- **Table** rendered the raw payload, so those "invalid" milestones appeared only in the table.

With no `sortBy` in the URL, both views fetch identical data, so the divergence came entirely from the cards-only validity filter.

## Solution

- Export the shared `isValidMilestone` guard from `utilities/sorting/communityMilestoneSort.ts`.
- Apply it to `tableData` in the page so both views render the exact same set.
- Add unit tests covering the validity filter and the sort ordering.

The deeper question — *why the indexer returns milestones without a project slug/title* — is tracked separately in show-karma/super-gap#37. This PR only makes the two views consistent.

## Testing Steps

1. Open a community with milestones whose projects lack a slug (or use a community with >0 milestones).
2. Compare `/<community>/updates` and `/<community>/updates?view=table`.
3. Both views now list the same milestones.

Automated:
- `pnpm test:unit __tests__/unit/utilities/sorting/communityMilestoneSort.test.ts` (9 tests)
- `tsc --noEmit` clean, Biome clean.

## Risk

Low. Change is confined to the community updates page and a now-exported pure guard. No API or data-layer changes.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent milestone filtering on the community updates page—both table and card views now consistently exclude invalid or incomplete milestones from display.

* **Tests**
  * Added comprehensive test suite for milestone validation and sorting utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->