### PR TITLE
fix(applications): align textarea label weight with other form inputs

### DIFF
--- a/__tests__/components/Utilities/MarkdownEditor.test.tsx
+++ b/__tests__/components/Utilities/MarkdownEditor.test.tsx
@@ -127,6 +127,27 @@ describe("MarkdownEditor", () => {
 
       expect(screen.queryByRole("button", { name: /preview/i })).not.toBeInTheDocument();
     });
+
+    it("should render label with default bold class when labelClassName is not provided", () => {
+      render(<MarkdownEditor label="Test Label" id="test-editor" />);
+
+      const label = screen.getByText("Test Label", { selector: "label" });
+      expect(label).toHaveClass("font-bold");
+    });
+
+    it("should apply labelClassName when provided and drop the default", () => {
+      render(
+        <MarkdownEditor
+          label="Test Label"
+          id="test-editor"
+          labelClassName="text-sm font-medium leading-none"
+        />
+      );
+
+      const label = screen.getByText("Test Label", { selector: "label" });
+      expect(label).toHaveClass("font-medium");
+      expect(label).not.toHaveClass("font-bold");
+    });
   });
 
   describe("Character Limits", () => {

--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -36,6 +36,8 @@ interface MarkdownEditorProps {
   showCharacterCount?: boolean;
   /** Enable preview toggle button (default: true) */
   enablePreviewToggle?: boolean;
+  /** Override the label element's className. When omitted, a bold default is used. */
+  labelClassName?: string;
 }
 
 import "md-editor-rt/lib/style.css";
@@ -110,6 +112,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   maxLength = DEFAULT_MAX_LENGTH,
   showCharacterCount = false,
   enablePreviewToggle = true,
+  labelClassName,
 }) => {
   // md-editor-rt accesses `modelValue.length` synchronously inside its
   // CodeMirror input/paste/setValue handlers — if a caller (or RHF default)
@@ -205,7 +208,10 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
       {/* Header with label and preview toggle */}
       <div className="flex items-center justify-between mb-2">
         {label && (
-          <label htmlFor={safeId} className="block text-sm font-bold text-black dark:text-zinc-100">
+          <label
+            htmlFor={safeId}
+            className={labelClassName ?? "block text-sm font-bold text-black dark:text-zinc-100"}
+          >
             {label} {isRequired && <span className="text-red-500">*</span>}
           </label>
         )}

--- a/src/features/applications/components/ApplicationFormField.tsx
+++ b/src/features/applications/components/ApplicationFormField.tsx
@@ -188,6 +188,7 @@ export function ApplicationFormField({
               <div className="flex flex-col gap-2" data-field-id={question.id}>
                 <MarkdownEditor
                   label={question.label}
+                  labelClassName="text-sm font-medium leading-none"
                   placeholder={question.placeholder}
                   value={(field.value as string) || ""}
                   onChange={field.onChange}

--- a/src/features/applications/components/MilestoneItem.tsx
+++ b/src/features/applications/components/MilestoneItem.tsx
@@ -103,6 +103,7 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
 
       <MarkdownEditor
         label="Description"
+        labelClassName="text-sm font-medium leading-none"
         placeholder="Describe what will be accomplished in this milestone"
         value={milestone.description}
         onChange={(value) => handleFieldChange("description", value)}
@@ -144,6 +145,7 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
 
       <MarkdownEditor
         label="Completion Criteria"
+        labelClassName="text-sm font-medium leading-none"
         placeholder="Define criteria for milestone completion"
         value={milestone.completionCriteria || ""}
         onChange={(value) => handleFieldChange("completionCriteria", value)}


### PR DESCRIPTION
## Overview

Removes the bold styling on textarea field titles in application forms so they match every other input on the same form.

## Problem

On application forms (e.g. https://staging.karmahq.xyz/community/filecoin/programs/101105/apply), textarea field titles render in `font-bold` while every other input (text, email, number, select, checkbox, date, etc.) renders its label in `font-medium`. The bold weight made textarea titles visually inconsistent with the rest of the form.

The cause: textarea questions use `MarkdownEditor`, which renders its own raw `<label>` with the hardcoded class `block text-sm font-bold text-black dark:text-zinc-100` — whereas all other field types in `ApplicationFormField.tsx` use the shared Radix `<Label>` component (`text-sm font-medium leading-none`).

## Solution

Add an optional `labelClassName?: string` prop to `MarkdownEditor`. When provided, it replaces the default class entirely; when omitted, the existing bold default is preserved.

Then pass `labelClassName="text-sm font-medium leading-none"` from the three `MarkdownEditor` call sites inside the application-form feature:

1. The `textarea` case in `ApplicationFormField.tsx`
2. The "Description" `MarkdownEditor` in `MilestoneItem.tsx`
3. The "Completion Criteria" `MarkdownEditor` in `MilestoneItem.tsx`

## Why This Approach

`MarkdownEditor` is used in 57 files across the app (project updates, milestone dialogs, grant details, admin pages, etc.) — many of those callers may want the bold weight or have laid out their UIs around it. Changing the default would have a wide, untested blast radius.

A caller-controlled override keeps the change scoped to the application-form context, where the inconsistency was actually reported, without touching any of the other 54 usages.

## Testing Steps

1. `pnpm run dev` and open `http://localhost:3000/community/filecoin/programs/101105/apply`.
2. Confirm textarea field titles render in the same weight as the surrounding text/email/number inputs (medium, not bold).
3. Add a milestone question to a program and verify the milestone "Description" and "Completion Criteria" labels also render in medium weight, matching the milestone's "Title", "Due Date", and "Funding Requested" labels.
4. Open any other surface that uses `MarkdownEditor` (e.g. project update form, grant details, admin access-denied messages) and confirm the label is still bold there — the default is preserved.

## Technical Details

- 2 new unit tests in `__tests__/components/Utilities/MarkdownEditor.test.tsx` verify (a) the default label has `font-bold`, (b) a provided `labelClassName` is applied and the default is dropped.
- Full `MarkdownEditor.test.tsx` suite passes: 41/41.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (default behavior preserved for all existing callers)
- [x] Linting passes (Biome ran via pre-commit hook)
- [x] Typecheck passes (ran via pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Markdown editor labels now support customizable styling for consistent formatting across application forms and milestone items.

* **Tests**
  * Added comprehensive test coverage for markdown editor label styling behavior, verifying both default and custom style application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->