### PR TITLE
fix(applications): evaluate live form values, not a stale render snapshot

### DIFF
--- a/src/features/applications/components/ApplicationForm.tsx
+++ b/src/features/applications/components/ApplicationForm.tsx
@@ -60,6 +60,7 @@ export function ApplicationForm({
     control,
     handleSubmit: formHandleSubmit,
     watch,
+    getValues,
     trigger,
   } = useApplicationForm(questions, { initialData });
 
@@ -246,9 +247,13 @@ export function ApplicationForm({
     }
 
     setScoringState("pending");
+    // Read live values imperatively. `formState.data` is a getValues() snapshot
+    // frozen at the last render, and RHF Controller fields don't re-render this
+    // component on input — so it would evaluate stale (pre-edit) values.
+    const liveData = getValues();
     const evaluationData: Record<string, unknown> = {};
     questions.forEach((question) => {
-      const value = formState.data[question.id];
+      const value = liveData[question.id];
       if (value !== undefined && value !== null && value !== "") {
         evaluationData[question.label || question.id] = value;
       }

--- a/src/features/applications/components/__tests__/ApplicationForm.evaluation.test.tsx
+++ b/src/features/applications/components/__tests__/ApplicationForm.evaluation.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ApplicationQuestion, IFormSchema } from "@/types/whitelabel-entities";
+import { ApplicationForm } from "../ApplicationForm";
+
+const mockAuthState = vi.hoisted(() => ({
+  authenticated: true,
+  login: vi.fn(),
+}));
+
+const mockAIEvaluation = vi.hoisted(() => ({
+  triggerEvaluation: vi.fn(),
+  clearEvaluation: vi.fn(),
+  error: null as string | null,
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock("@/hooks/useRealTimeAIEvaluation", () => ({
+  useRealTimeAIEvaluation: () => ({
+    evaluation: null,
+    evaluationResponse: null,
+    isLoading: false,
+    error: mockAIEvaluation.error,
+    triggerEvaluation: mockAIEvaluation.triggerEvaluation,
+    clearEvaluation: mockAIEvaluation.clearEvaluation,
+  }),
+}));
+
+const PROGRAM_ID = "program-1";
+
+const questions = [
+  {
+    id: "requestedAmount",
+    type: "text",
+    label: "Requested amount",
+    required: false,
+  } as ApplicationQuestion,
+];
+
+const aiEvaluationFormSchema = {
+  questions: [],
+  aiConfig: { enableRealTimeEvaluation: true },
+} as IFormSchema;
+
+describe("ApplicationForm real-time evaluation payload", () => {
+  beforeEach(() => {
+    mockAuthState.authenticated = true;
+    mockAIEvaluation.triggerEvaluation.mockReset();
+    mockAIEvaluation.clearEvaluation.mockReset();
+    mockAIEvaluation.triggerEvaluation.mockResolvedValue(undefined);
+    mockAIEvaluation.error = null;
+    window.sessionStorage.clear();
+  });
+
+  // Regression: editing an already-submitted application and re-running the
+  // real-time evaluation must score the *edited* value. Previously handleScore
+  // read a getValues() snapshot frozen at the last render (formState.data), and
+  // RHF Controller fields don't re-render the parent on input — so it scored the
+  // original submitted value instead of the new one.
+  it("evaluates the latest edited field value, not the originally submitted one", async () => {
+    render(
+      <ApplicationForm
+        programId={PROGRAM_ID}
+        questions={questions}
+        formSchema={aiEvaluationFormSchema}
+        initialData={{ requestedAmount: "10" }}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requested amount")).toHaveValue("10");
+    });
+
+    fireEvent.change(screen.getByLabelText("Requested amount"), {
+      target: { value: "500000" },
+    });
+
+    fireEvent.click(screen.getByTestId("get-ai-feedback-btn"));
+
+    await waitFor(() => {
+      expect(mockAIEvaluation.triggerEvaluation).toHaveBeenCalledWith({
+        "Requested amount": "500000",
+      });
+    });
+  });
+});

--- a/src/features/applications/hooks/use-application-form.ts
+++ b/src/features/applications/hooks/use-application-form.ts
@@ -88,6 +88,7 @@ export function useApplicationForm(
     control,
     handleSubmit,
     watch,
+    getValues,
     trigger,
 
     formState: {


### PR DESCRIPTION
## Problem

When an applicant edits an already-submitted application and clicks **Evaluate** to re-run the real-time AI evaluation, the evaluation scores the **originally-submitted** values instead of the edited ones.

Reproduced: an application was submitted with a requested amount of `10`, then edited to `500000` and re-evaluated. The feedback was generated against `10` — so it missed that the amount should be flagged against the new `500000`.

## Root cause

`handleScore` (the Evaluate button handler) built its payload from `formState.data`, which is a `getValues()` snapshot captured **during render** in `useApplicationForm`. Form fields render through react-hook-form `<Controller>`s, which deliberately do **not** re-render the parent `ApplicationForm` on input. So the snapshot stayed frozen at the values from the last render — the originally-submitted data — and the evaluation (and the `aiEvaluation` later attached on submit) was computed against stale values.

For contrast, the submit path already used react-hook-form's live values via `formHandleSubmit(handleSubmit)`, and login read live values via `watch()`. Evaluate was the odd one out.

## Fix

- Expose `getValues` from `useApplicationForm`.
- `handleScore` now reads live values via `getValues()` at click time instead of the frozen `formState.data` snapshot.

## Tests

- New regression test (`ApplicationForm.evaluation.test.tsx`) reproduces the edit-then-evaluate flow: edits `10` → `500000`, clicks Evaluate, asserts the payload carries `500000`. Verified it **fails** against the old code and **passes** with the fix.
- All existing `ApplicationForm` and `useApplicationForm` tests pass (25/25).
- `tsc --noEmit` and Biome are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI evaluation to use real-time form values instead of stale data, ensuring edited inputs are accurately evaluated.

* **Tests**
  * Added regression test for real-time AI evaluation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->