### PR TITLE
refactor(community-updates): rely on server-side default ordering

### DIFF
--- a/__tests__/integration/pages/smoke/remaining-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/remaining-pages.test.tsx
@@ -273,10 +273,6 @@ vi.mock("@/utilities/project-lookup", () => ({
   projectsToOptions: () => [],
 }));
 
-vi.mock("@/utilities/sorting/communityMilestoneSort", () => ({
-  sortCommunityMilestones: (m: unknown[]) => m,
-}));
-
 vi.mock("@/utilities/fundingPlatformUrls", () => ({
   getProgramApplyUrl: (cId: string, pId: string) => `/c/${cId}/p/${pId}`,
 }));

--- a/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
+++ b/__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts
@@ -1,17 +1,15 @@
 /**
- * Tests for community milestone validity filtering and sorting.
+ * Tests for community milestone validity filtering.
  *
  * The cards view and the table view of the community Updates page consume the
  * same API payload. Both must drop invalid milestones (missing uid, status,
  * title, or project slug) so the two views render the exact same set of items.
  * `isValidMilestone` is the shared predicate that guarantees that parity.
+ * Sort order is handled server-side in gap-indexer.
  */
 
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
-import {
-  isValidMilestone,
-  sortCommunityMilestones,
-} from "@/utilities/sorting/communityMilestoneSort";
+import { isValidMilestone } from "@/utilities/sorting/communityMilestoneSort";
 
 function createMilestone(
   overrides: Partial<CommunityMilestoneUpdate> = {}
@@ -82,36 +80,5 @@ describe("isValidMilestone", () => {
     expect(isValidMilestone(null)).toBe(false);
     expect(isValidMilestone(undefined)).toBe(false);
     expect(isValidMilestone("milestone")).toBe(false);
-  });
-});
-
-describe("sortCommunityMilestones", () => {
-  it("filters out invalid milestones from the result", () => {
-    const valid = createMilestone({ uid: "valid" });
-    const invalid = createMilestone({ uid: "" });
-
-    const result = sortCommunityMilestones([valid, invalid], "all", "community-1");
-
-    expect(result).toHaveLength(1);
-    expect(result[0].uid).toBe("valid");
-  });
-
-  it("orders pending milestones before completed ones for the 'all' filter", () => {
-    const completed = createMilestone({ uid: "completed", status: "completed" });
-    const pending = createMilestone({ uid: "pending", status: "pending" });
-
-    const result = sortCommunityMilestones([completed, pending], "all", "community-1");
-
-    expect(result.map((m) => m.uid)).toEqual(["pending", "completed"]);
-  });
-
-  it("returns an empty array for non-array input", () => {
-    expect(
-      sortCommunityMilestones(
-        undefined as unknown as CommunityMilestoneUpdate[],
-        "all",
-        "community-1"
-      )
-    ).toEqual([]);
   });
 });

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -21,10 +21,7 @@ import { useCommunityProjectUpdates } from "@/hooks/useCommunityProjectUpdates";
 import { useCommunityUpdatesView } from "@/hooks/useCommunityUpdatesView";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { findProjectOptionBySlugOrUid, projectsToOptions } from "@/utilities/project-lookup";
-import {
-  isValidMilestone,
-  sortCommunityMilestones,
-} from "@/utilities/sorting/communityMilestoneSort";
+import { isValidMilestone } from "@/utilities/sorting/communityMilestoneSort";
 
 type FilterOption = "all" | "pending" | "completed" | "past_due";
 
@@ -138,20 +135,14 @@ export default function CommunityUpdatesPage() {
     sortOrder: isTableView && sortBy ? sortOrder : undefined,
   });
 
-  // Cards view: apply the existing client-side sort.
-  // Table view: render the server order untouched.
-  const cardsData = useMemo(() => {
-    if (!data?.payload) return [];
-    return sortCommunityMilestones([...data.payload], selectedFilter, communityId);
-  }, [data?.payload, selectedFilter, communityId]);
-
-  // Table view: keep the server order, but apply the same validity filter as
-  // the cards view so both views show the exact same set of milestones.
-  // Milestones missing a project slug/title come from the indexer; tracked in
-  // show-karma/super-gap#37.
-  const tableData = useMemo(() => (data?.payload ?? []).filter(isValidMilestone), [data?.payload]);
-
-  const displayedData = isTableView ? tableData : cardsData;
+  // Server is authoritative for ordering (see gap-indexer
+  // MilestoneReadService.compareDefault) so both views render the same payload.
+  // The validity filter is a defensive guard against milestones missing a
+  // project slug/title from the indexer; tracked in show-karma/super-gap#37.
+  const displayedData = useMemo(
+    () => (data?.payload ?? []).filter(isValidMilestone),
+    [data?.payload]
+  );
 
   // Fetch payout configs for grants on the current page to show allocation amounts
   const { allocationMap } = useCommunityMilestoneAllocations(displayedData);

--- a/app/community/[communityId]/(with-header)/updates/page.tsx
+++ b/app/community/[communityId]/(with-header)/updates/page.tsx
@@ -123,8 +123,10 @@ export default function CommunityUpdatesPage() {
     setCurrentPage(1);
   }, [selectedProgramId, selectedProjectId, sortBy, sortOrder]);
 
-  // Fetch community updates from API using custom hook.
-  // Sort params are sent only in table view; cards view keeps existing behavior.
+  // Fetch community updates from API using custom hook. Explicit sort params
+  // are sent only when the user has clicked a table column header; otherwise
+  // the indexer applies the canonical community-updates default order, which
+  // both views render unchanged.
   const { data, isLoading, error } = useCommunityProjectUpdates(communityId, {
     page: currentPage,
     limit: ITEMS_PER_PAGE,

--- a/hooks/useCommunityUpdatesView.ts
+++ b/hooks/useCommunityUpdatesView.ts
@@ -41,7 +41,8 @@ interface CommunityUpdatesViewState {
 export function useCommunityUpdatesView(): CommunityUpdatesViewState {
   const [view, setViewQuery] = useQueryState<UpdatesView>("view", {
     defaultValue: "cards",
-    serialize: (value) => (value === "table" ? "table" : ""),
+    clearOnDefault: true,
+    serialize: (value) => (value === "table" ? "table" : "cards"),
     parse: (value) => (value === "table" ? "table" : "cards"),
   });
 

--- a/utilities/sorting/communityMilestoneSort.ts
+++ b/utilities/sorting/communityMilestoneSort.ts
@@ -1,10 +1,9 @@
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 
-type FilterOption = "all" | "pending" | "completed" | "past_due";
-
-/**
- * Validates if a milestone item has all required fields
- */
+// Sort order for community milestone updates lives on the indexer
+// (gap-indexer MilestoneReadService.compareDefault). This file only
+// retains the defensive validity guard for milestones missing required
+// fields from the indexer — tracked in show-karma/super-gap#37.
 export function isValidMilestone(item: unknown): item is CommunityMilestoneUpdate {
   if (!item || typeof item !== "object") return false;
   const milestone = item as Record<string, unknown>;
@@ -19,80 +18,4 @@ export function isValidMilestone(item: unknown): item is CommunityMilestoneUpdat
   const slug = projectData?.slug;
   if (typeof slug !== "string" || slug.trim() === "") return false;
   return true;
-}
-
-/**
- * Safely converts a date string to timestamp, returning a fallback for invalid dates
- */
-function getTimestamp(dateString: string | null | undefined, fallback: number): number {
-  if (!dateString) return fallback;
-  const timestamp = new Date(dateString).getTime();
-  return Number.isNaN(timestamp) ? fallback : timestamp;
-}
-
-/**
- * Compare function for sorting pending milestones by due date (ascending)
- */
-function comparePending(a: CommunityMilestoneUpdate, b: CommunityMilestoneUpdate): number {
-  const aDueDate = getTimestamp(a.details.dueDate, Number.MAX_SAFE_INTEGER);
-  const bDueDate = getTimestamp(b.details.dueDate, Number.MAX_SAFE_INTEGER);
-  return aDueDate - bDueDate;
-}
-
-/**
- * Compare function for sorting completed milestones by update date (descending)
- */
-function compareCompleted(a: CommunityMilestoneUpdate, b: CommunityMilestoneUpdate): number {
-  const aUpdated = getTimestamp(a.updatedAt, 0);
-  const bUpdated = getTimestamp(b.updatedAt, 0);
-  return bUpdated - aUpdated;
-}
-
-/**
- * Sorts community milestone updates based on the selected filter
- */
-export function sortCommunityMilestones(
-  milestones: CommunityMilestoneUpdate[],
-  filter: FilterOption,
-  communityId: string
-): CommunityMilestoneUpdate[] {
-  // Validate array input
-  if (!Array.isArray(milestones)) {
-    console.error("Invalid milestones array", { communityId, milestones });
-    return [];
-  }
-
-  try {
-    // Filter out invalid items
-    const validMilestones = milestones.filter(isValidMilestone);
-
-    // Sort based on filter
-    return [...validMilestones].sort((a, b) => {
-      if (filter === "all") {
-        // For "all": pending first, then completed
-        const aCompleted = a.status === "completed";
-        const bCompleted = b.status === "completed";
-
-        if (aCompleted !== bCompleted) {
-          return aCompleted ? 1 : -1; // Pending first
-        }
-
-        // If both same status, use appropriate sort
-        return aCompleted ? compareCompleted(a, b) : comparePending(a, b);
-      }
-
-      // For specific filters, use appropriate comparison
-      if (filter === "pending" || filter === "past_due") {
-        return comparePending(a, b);
-      }
-      return compareCompleted(a, b);
-    });
-  } catch (error) {
-    console.error("Error sorting community updates:", error, {
-      communityId,
-      milestonesLength: milestones.length,
-    });
-    // Return filtered but unsorted data as fallback
-    return milestones.filter(isValidMilestone);
-  }
 }


### PR DESCRIPTION
## Summary

The community updates page's cards view used to re-sort the API payload client-side (`utilities/sorting/communityMilestoneSort.ts`), while the table view rendered the server order untouched. The two views drifted, and the per-page client sort meant pagination was incoherent across pages.

This PR removes the client-side sort and lets the indexer be authoritative for ordering — the cards and table views now render the same payload.

Depends on **show-karma/gap-indexer#1906**, which adds `MilestoneReadService.compareDefault` so the server returns milestones in the same canonical order the cards view used to apply locally.

## Change set

- `app/community/[communityId]/(with-header)/updates/page.tsx` — drop the cards-vs-table branching; both views render the API payload, filtered only by `isValidMilestone`.
- `utilities/sorting/communityMilestoneSort.ts` — delete `sortCommunityMilestones` and its helpers (`comparePending`, `compareCompleted`, `getTimestamp`, the `FilterOption` type). Keep `isValidMilestone` as a defensive guard for milestones missing required fields from the indexer — tracked in show-karma/super-gap#37.
- `__tests__/unit/utilities/sorting/communityMilestoneSort.test.ts` — drop the `sortCommunityMilestones` test block.
- `__tests__/integration/pages/smoke/remaining-pages.test.tsx` — drop the now-unused `vi.mock` for the deleted helper.

## Test plan

- [x] Biome lint + format clean on the changed files
- [x] `isValidMilestone` tests pass (10/10)
- [x] Updates-page smoke test passes
- [ ] Local smoke-tested against the Filecoin community: cards view at `/community/filecoin/updates` and table view at `/community/filecoin/updates?view=table` show identical 25-item ordered lists. Verified across default, `?filter=completed`, page 2, view toggle, and column-header sort scenarios.
- [ ] Coordinate deploy with show-karma/gap-indexer#1906 so the new server default ships first (otherwise the frontend will render the old default ordering)

## Note on page contents shifting

Because the rule is now applied globally instead of per-page, page 1 of the cards view may contain different milestones than before (specifically, more pending-only items). This is the intended fix for the global-ordering bug — same data, different page boundaries.