### PR TITLE
fix(rpc): derive chain RPC URLs from a single Alchemy key

### DIFF
--- a/__tests__/unit/utilities/rpcClient.test.ts
+++ b/__tests__/unit/utilities/rpcClient.test.ts
@@ -181,5 +181,61 @@ describe("rpcClient", () => {
 
       expect(url).toBe("https://optimism.llamarpc.com");
     });
+
+    it("prefers the Alchemy URL over a configured per-chain URL when the key is set", async () => {
+      vi.resetModules();
+      vi.doMock("@/utilities/enviromentVars", () => ({
+        envVars: {
+          ALCHEMY_KEY: "abc123-_KEY",
+          RPC: { CELO: "https://stale-embedded-key.example.com" },
+        },
+      }));
+
+      const { getRPCUrlByChainId } = await import("@/utilities/rpcClient");
+
+      expect(getRPCUrlByChainId(42220)).toBe("https://celo-mainnet.g.alchemy.com/v2/abc123-_KEY");
+    });
+
+    it("keeps the configured URL for chains Alchemy does not serve even when the key is set", async () => {
+      vi.resetModules();
+      vi.doMock("@/utilities/enviromentVars", () => ({
+        envVars: {
+          ALCHEMY_KEY: "abc123",
+          RPC: { LISK: "https://rpc-lisk.example.com" },
+        },
+      }));
+
+      const { getRPCUrlByChainId } = await import("@/utilities/rpcClient");
+
+      expect(getRPCUrlByChainId(1135)).toBe("https://rpc-lisk.example.com");
+    });
+  });
+
+  describe("buildAlchemyRpcUrl", () => {
+    it("builds the endpoint from chain subdomain and key", async () => {
+      vi.resetModules();
+      const { buildAlchemyRpcUrl } = await import("@/utilities/rpcClient");
+
+      expect(buildAlchemyRpcUrl(42220, "valid_KEY-123")).toBe(
+        "https://celo-mainnet.g.alchemy.com/v2/valid_KEY-123"
+      );
+    });
+
+    it("returns undefined for chains with no Alchemy endpoint", async () => {
+      vi.resetModules();
+      const { buildAlchemyRpcUrl } = await import("@/utilities/rpcClient");
+
+      expect(buildAlchemyRpcUrl(1135, "valid123")).toBeUndefined();
+    });
+
+    it.each(["", "   ", "not a key", "https://celo-mainnet.g.alchemy.com/v2/x"])(
+      "returns undefined for a missing or malformed key (%j)",
+      async (key) => {
+        vi.resetModules();
+        const { buildAlchemyRpcUrl } = await import("@/utilities/rpcClient");
+
+        expect(buildAlchemyRpcUrl(42220, key)).toBeUndefined();
+      }
+    );
   });
 });

--- a/utilities/enviromentVars.ts
+++ b/utilities/enviromentVars.ts
@@ -38,6 +38,7 @@ export const envVars = {
   PRIVY_APP_ID: process.env.NEXT_PUBLIC_PRIVY_APP_ID || "",
   ENV: process.env.NEXT_PUBLIC_ENV || "development",
   ZERODEV_PROJECT_ID: process.env.NEXT_PUBLIC_ZERODEV_PROJECT_ID || "",
+  ALCHEMY_KEY: process.env.NEXT_PUBLIC_ALCHEMY_KEY || "",
   ALCHEMY_POLICY_ID: process.env.NEXT_PUBLIC_ALCHEMY_POLICY_ID || "",
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "",
   // Karma platform-owned Telegram bot handle (without leading @).

--- a/utilities/rpcClient.ts
+++ b/utilities/rpcClient.ts
@@ -33,24 +33,64 @@ const DEFAULT_RPC_URLS_BY_CHAIN_ID: Partial<Record<number, string>> = {
   [scroll.id]: scroll.rpcUrls.default.http[0],
 };
 
+/**
+ * Alchemy network subdomains by chain ID. Chains absent here (e.g. Lisk, Sei)
+ * have no Alchemy endpoint and keep using their NEXT_PUBLIC_RPC_* URL. Deriving
+ * URLs from the single NEXT_PUBLIC_ALCHEMY_KEY keeps key rotation in one place
+ * and avoids stale keys getting embedded in per-chain RPC URLs.
+ */
+const ALCHEMY_SUBDOMAIN_BY_CHAIN_ID: Partial<Record<number, string>> = {
+  [mainnet.id]: "eth-mainnet",
+  [optimism.id]: "opt-mainnet",
+  [arbitrum.id]: "arb-mainnet",
+  [base.id]: "base-mainnet",
+  [polygon.id]: "polygon-mainnet",
+  [celo.id]: "celo-mainnet",
+  [scroll.id]: "scroll-mainnet",
+  [optimismSepolia.id]: "opt-sepolia",
+  [baseSepolia.id]: "base-sepolia",
+  [sepolia.id]: "eth-sepolia",
+};
+
+/**
+ * Alchemy keys are alphanumeric with optional `-`/`_`. Reject anything else so a
+ * malformed value (e.g. a full URL pasted into NEXT_PUBLIC_ALCHEMY_KEY) can't
+ * produce a broken endpoint that silently fails every request.
+ */
+const ALCHEMY_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
 const normalizeRPCUrl = (rpcUrl?: string): string | undefined => {
   const normalizedRpcUrl = rpcUrl?.trim();
   return normalizedRpcUrl ? normalizedRpcUrl : undefined;
 };
 
-const CHAIN_CONFIG: Record<string, { chain: Chain; rpcUrl: string | undefined }> = {
-  mainnet: { chain: mainnet, rpcUrl: envVars.RPC.MAINNET },
-  optimism: { chain: optimism, rpcUrl: envVars.RPC.OPTIMISM },
-  arbitrum: { chain: arbitrum, rpcUrl: envVars.RPC.ARBITRUM },
-  base: { chain: base, rpcUrl: envVars.RPC.BASE },
-  "base-sepolia": { chain: baseSepolia, rpcUrl: envVars.RPC.BASE_SEPOLIA },
-  celo: { chain: celo, rpcUrl: envVars.RPC.CELO },
-  lisk: { chain: lisk, rpcUrl: envVars.RPC.LISK },
-  "optimism-sepolia": { chain: optimismSepolia, rpcUrl: envVars.RPC.OPT_SEPOLIA },
-  polygon: { chain: polygon, rpcUrl: envVars.RPC.POLYGON },
-  scroll: { chain: scroll, rpcUrl: envVars.RPC.SCROLL },
-  sei: { chain: sei, rpcUrl: envVars.RPC.SEI },
-  sepolia: { chain: sepolia, rpcUrl: envVars.RPC.SEPOLIA },
+/**
+ * Build a chain's Alchemy RPC URL from the shared key alone. Returns undefined
+ * when the chain has no Alchemy endpoint or the key is missing/malformed, so
+ * callers fall through to the configured URL or the chain's public default.
+ */
+export const buildAlchemyRpcUrl = (chainId: number, key?: string): string | undefined => {
+  const subdomain = ALCHEMY_SUBDOMAIN_BY_CHAIN_ID[chainId];
+  const trimmedKey = key?.trim();
+  if (!subdomain || !trimmedKey || !ALCHEMY_KEY_PATTERN.test(trimmedKey)) {
+    return undefined;
+  }
+  return `https://${subdomain}.g.alchemy.com/v2/${trimmedKey}`;
+};
+
+const CHAIN_BY_NETWORK: Record<string, Chain> = {
+  mainnet,
+  optimism,
+  arbitrum,
+  base,
+  "base-sepolia": baseSepolia,
+  celo,
+  lisk,
+  "optimism-sepolia": optimismSepolia,
+  polygon,
+  scroll,
+  sei,
+  sepolia,
 };
 
 const clientCache = new Map<string, PublicClient>();
@@ -59,12 +99,12 @@ function getOrCreateClient(network: string): PublicClient | undefined {
   const existing = clientCache.get(network);
   if (existing) return existing;
 
-  const config = CHAIN_CONFIG[network];
-  if (!config) return undefined;
+  const chain = CHAIN_BY_NETWORK[network];
+  if (!chain) return undefined;
 
   const client = createPublicClient({
-    chain: config.chain,
-    transport: http(config.rpcUrl),
+    chain,
+    transport: http(getRPCUrlByChainId(chain.id)),
   });
 
   clientCache.set(network, client as PublicClient);
@@ -114,9 +154,17 @@ const getConfiguredRPCUrlByChainId = (chainId: number): string | undefined => {
   }
 };
 
+/**
+ * Resolve a chain's RPC URL. Precedence: Alchemy (built from the shared
+ * NEXT_PUBLIC_ALCHEMY_KEY) → explicit NEXT_PUBLIC_RPC_* override → public
+ * default. Alchemy wins so rotating the one key takes effect without having to
+ * also clear a stale per-chain URL.
+ */
 export const getRPCUrlByChainId = (chainId: number): string | undefined => {
   return (
-    normalizeRPCUrl(getConfiguredRPCUrlByChainId(chainId)) || DEFAULT_RPC_URLS_BY_CHAIN_ID[chainId]
+    buildAlchemyRpcUrl(chainId, envVars.ALCHEMY_KEY) ||
+    normalizeRPCUrl(getConfiguredRPCUrlByChainId(chainId)) ||
+    DEFAULT_RPC_URLS_BY_CHAIN_ID[chainId]
   );
 };
 


### PR DESCRIPTION
Community admins (observed on Celo) intermittently saw the **create-program / add-funding** UI gated, reporting they were "no longer admin" — though the wallet is still enlisted on-chain.

## Root cause
The frontend admin gate (`isCommunityAdminOf`) reads the on-chain resolver over the Celo RPC, and on any error returns `false` (admin treated as guest). That RPC came from `NEXT_PUBLIC_RPC_CELO`, which had the **Alchemy key embedded directly in the URL**. When the key was rotated/expired, every Celo read failed (401/403/429) and the gate silently closed. Separately, `NEXT_PUBLIC_ALCHEMY_KEY` was declared in the env schema but never wired to anything.

## Fix
- `getRPCUrlByChainId` is now the single source of truth and derives each chain's URL from the one `NEXT_PUBLIC_ALCHEMY_KEY` via an `ALCHEMY_SUBDOMAIN_BY_CHAIN_ID` data table (mirrors the existing `DEFAULT_RPC_URLS_BY_CHAIN_ID`). Precedence: **Alchemy key → per-chain `NEXT_PUBLIC_RPC_*` override → public default.** Alchemy wins so rotating the one key takes effect without having to clear a stale per-chain URL.
- The viem client path (`getOrCreateClient`) routes through the same resolver — one place to reason about.
- Wires `NEXT_PUBLIC_ALCHEMY_KEY` into `envVars` (was dead config).
- No chain-specific branches: chains Alchemy doesn't serve (Lisk, Sei) are just absent from the table and keep their existing URLs.

## Testing
- `rpcClient.test.ts`: 16 pass — Alchemy preference over a configured URL, malformed-key rejection, unmapped-chain pass-through.
- 47 admin-check tests (`isCommunityAdminOf`, `useCheckCommunityAdmin`, `useIsCommunityAdmin`) green; Biome + `tsc` clean.

## Companion / rollout
- Backend companion: show-karma/gap-indexer#1907 (routes the server-side admin check through a multi-RPC FallbackProvider).
- Ops: set `NEXT_PUBLIC_ALCHEMY_KEY` on Vercel (not the now-unused embedded `NEXT_PUBLIC_RPC_CELO`). Note this switches **all** Alchemy-mapped chains to the shared key — confirm those networks are enabled on the Alchemy app, or trim the table to Celo only.

> Pre-existing, unrelated: `pnpm run build` currently fails on `@stripe/crypto` / `agentation` module resolution; `tsc --noEmit` and the unit suite pass.