### PR TITLE
fix: metric intake sub-fields clear each other on edit

### DIFF
--- a/src/features/applications/components/MetricFieldArray.tsx
+++ b/src/features/applications/components/MetricFieldArray.tsx
@@ -6,8 +6,8 @@ import type { Control, FieldPath, UseFormTrigger } from "react-hook-form";
 import { Controller, useFieldArray } from "react-hook-form";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Button } from "@/components/ui/button";
+import type { ApplicationFormData } from "@/features/applications/types";
 import type { ApplicationQuestion, MetricData } from "@/types/whitelabel-entities";
-import type { ApplicationFormData } from "../types";
 import { MetricItem } from "./MetricItem";
 
 interface MetricFieldArrayProps {

--- a/src/features/applications/components/MetricFieldArray.tsx
+++ b/src/features/applications/components/MetricFieldArray.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import pluralize from "pluralize";
-import { type FC, useCallback } from "react";
+import type { FC } from "react";
 import type { Control, FieldPath, UseFormTrigger } from "react-hook-form";
 import { Controller, useFieldArray } from "react-hook-form";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
@@ -33,7 +33,7 @@ export const MetricFieldArray: FC<MetricFieldArrayProps> = ({
   const maxMetrics = question.validation?.maxMetrics ?? Number.POSITIVE_INFINITY;
   const minMetrics = question.validation?.minMetrics ?? 0;
 
-  const handleAddMetric = useCallback(() => {
+  const handleAddMetric = () => {
     const newMetric: MetricData = {
       metric: "",
       dataSource: "",
@@ -41,17 +41,14 @@ export const MetricFieldArray: FC<MetricFieldArrayProps> = ({
       target: "",
     };
     append(newMetric as never);
-  }, [append]);
+  };
 
-  const handleRemoveMetric = useCallback(
-    async (index: number) => {
-      remove(index);
-      if (trigger) {
-        await trigger(name as FieldPath<ApplicationFormData>);
-      }
-    },
-    [remove, trigger, name]
-  );
+  const handleRemoveMetric = async (index: number) => {
+    remove(index);
+    if (trigger) {
+      await trigger(name as FieldPath<ApplicationFormData>);
+    }
+  };
 
   const canAddMore = fields.length < maxMetrics;
   const canRemove = fields.length > minMetrics;
@@ -82,26 +79,14 @@ export const MetricFieldArray: FC<MetricFieldArrayProps> = ({
 
             <div className="space-y-4" data-testid="metrics-list">
               {fields.map((field, index) => (
-                <Controller
+                <MetricItem
                   key={field.id}
-                  name={`${name}.${index}` as FieldPath<ApplicationFormData>}
+                  index={index}
+                  namePrefix={name}
                   control={control}
-                  render={({ field: metricField, fieldState }) => (
-                    <MetricItem
-                      index={index}
-                      metric={metricField.value as MetricData}
-                      onUpdate={metricField.onChange}
-                      onRemove={() => handleRemoveMetric(index)}
-                      canRemove={canRemove}
-                      disabled={disabled}
-                      errors={
-                        fieldState.error as unknown as Record<
-                          string,
-                          { message?: string } | undefined
-                        >
-                      }
-                    />
-                  )}
+                  canRemove={canRemove}
+                  disabled={disabled}
+                  onRemove={() => handleRemoveMetric(index)}
                 />
               ))}
             </div>

--- a/src/features/applications/components/MetricItem.tsx
+++ b/src/features/applications/components/MetricItem.tsx
@@ -1,43 +1,35 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
-import { type FC, memo } from "react";
+import type { FC } from "react";
+import { type Control, Controller, type FieldPath } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import type { MetricData } from "@/types/whitelabel-entities";
+import type { ApplicationFormData } from "../types";
 
 interface MetricItemProps {
   index: number;
-  metric: MetricData;
-  onUpdate: (data: MetricData) => void;
+  namePrefix: string;
+  control: Control<ApplicationFormData>;
   onRemove: () => void;
   canRemove: boolean;
   disabled?: boolean;
-  errors?: {
-    metric?: { message?: string };
-    dataSource?: { message?: string };
-    howItsMeasured?: { message?: string };
-    target?: { message?: string };
-  };
 }
 
-export const MetricItem: FC<MetricItemProps> = memo(function MetricItem({
+// Each sub-field is registered independently so editing one never rewrites the
+// others (avoids the stale-object-spread data loss).
+export const MetricItem: FC<MetricItemProps> = ({
   index,
-  metric,
-  onUpdate,
+  namePrefix,
+  control,
   onRemove,
   canRemove,
   disabled = false,
-  errors,
-}) {
-  const handleFieldChange = (field: keyof MetricData, value: string) => {
-    onUpdate({
-      ...metric,
-      [field]: value,
-    });
-  };
+}) => {
+  const subFieldName = (sub: string) =>
+    `${namePrefix}.${index}.${sub}` as FieldPath<ApplicationFormData>;
 
   return (
     <div
@@ -61,66 +53,94 @@ export const MetricItem: FC<MetricItemProps> = memo(function MetricItem({
         )}
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor={`metric-name-${index}`}>Metric *</Label>
-        <Input
-          id={`metric-name-${index}`}
-          placeholder="e.g., Monthly active users"
-          value={metric.metric || ""}
-          onChange={(e) => handleFieldChange("metric", e.target.value)}
-          disabled={disabled}
-          data-testid={`metric-name-input-${index}`}
-        />
-        {errors?.metric?.message && (
-          <p className="text-sm text-destructive">{errors.metric.message}</p>
+      <Controller
+        name={subFieldName("metric")}
+        control={control}
+        render={({ field, fieldState }) => (
+          <div className="space-y-2">
+            <Label htmlFor={`metric-name-${index}`}>Metric *</Label>
+            <Input
+              id={`metric-name-${index}`}
+              placeholder="e.g., Monthly active users"
+              value={(field.value as string) || ""}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              disabled={disabled}
+              data-testid={`metric-name-input-${index}`}
+            />
+            {fieldState.error?.message && (
+              <p className="text-sm text-destructive">{fieldState.error.message}</p>
+            )}
+          </div>
         )}
-      </div>
+      />
 
-      <div className="space-y-2">
-        <Label htmlFor={`metric-data-source-${index}`}>Data Source *</Label>
-        <Input
-          id={`metric-data-source-${index}`}
-          placeholder="e.g., Dune Analytics dashboard"
-          value={metric.dataSource || ""}
-          onChange={(e) => handleFieldChange("dataSource", e.target.value)}
-          disabled={disabled}
-          data-testid={`metric-data-source-input-${index}`}
-        />
-        {errors?.dataSource?.message && (
-          <p className="text-sm text-destructive">{errors.dataSource.message}</p>
+      <Controller
+        name={subFieldName("dataSource")}
+        control={control}
+        render={({ field, fieldState }) => (
+          <div className="space-y-2">
+            <Label htmlFor={`metric-data-source-${index}`}>Data Source *</Label>
+            <Input
+              id={`metric-data-source-${index}`}
+              placeholder="e.g., Dune Analytics dashboard"
+              value={(field.value as string) || ""}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              disabled={disabled}
+              data-testid={`metric-data-source-input-${index}`}
+            />
+            {fieldState.error?.message && (
+              <p className="text-sm text-destructive">{fieldState.error.message}</p>
+            )}
+          </div>
         )}
-      </div>
+      />
 
-      <div className="space-y-2">
-        <Label htmlFor={`metric-how-measured-${index}`}>How It's Measured *</Label>
-        <Textarea
-          id={`metric-how-measured-${index}`}
-          placeholder="e.g., Count of unique wallet addresses interacting with the contract each month"
-          value={metric.howItsMeasured || ""}
-          onChange={(e) => handleFieldChange("howItsMeasured", e.target.value)}
-          disabled={disabled}
-          rows={3}
-          data-testid={`metric-how-measured-input-${index}`}
-        />
-        {errors?.howItsMeasured?.message && (
-          <p className="text-sm text-destructive">{errors.howItsMeasured.message}</p>
+      <Controller
+        name={subFieldName("howItsMeasured")}
+        control={control}
+        render={({ field, fieldState }) => (
+          <div className="space-y-2">
+            <Label htmlFor={`metric-how-measured-${index}`}>How It's Measured *</Label>
+            <Textarea
+              id={`metric-how-measured-${index}`}
+              placeholder="e.g., Count of unique wallet addresses interacting with the contract each month"
+              value={(field.value as string) || ""}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              disabled={disabled}
+              rows={3}
+              data-testid={`metric-how-measured-input-${index}`}
+            />
+            {fieldState.error?.message && (
+              <p className="text-sm text-destructive">{fieldState.error.message}</p>
+            )}
+          </div>
         )}
-      </div>
+      />
 
-      <div className="space-y-2">
-        <Label htmlFor={`metric-target-${index}`}>Target *</Label>
-        <Input
-          id={`metric-target-${index}`}
-          placeholder="e.g., 10,000 monthly active users by Q4"
-          value={metric.target || ""}
-          onChange={(e) => handleFieldChange("target", e.target.value)}
-          disabled={disabled}
-          data-testid={`metric-target-input-${index}`}
-        />
-        {errors?.target?.message && (
-          <p className="text-sm text-destructive">{errors.target.message}</p>
+      <Controller
+        name={subFieldName("target")}
+        control={control}
+        render={({ field, fieldState }) => (
+          <div className="space-y-2">
+            <Label htmlFor={`metric-target-${index}`}>Target *</Label>
+            <Input
+              id={`metric-target-${index}`}
+              placeholder="e.g., 10,000 monthly active users by Q4"
+              value={(field.value as string) || ""}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              disabled={disabled}
+              data-testid={`metric-target-input-${index}`}
+            />
+            {fieldState.error?.message && (
+              <p className="text-sm text-destructive">{fieldState.error.message}</p>
+            )}
+          </div>
         )}
-      </div>
+      />
     </div>
   );
-});
+};

--- a/src/features/applications/components/MetricItem.tsx
+++ b/src/features/applications/components/MetricItem.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import type { ApplicationFormData } from "../types";
+import type { ApplicationFormData } from "@/features/applications/types";
 
 interface MetricItemProps {
   index: number;

--- a/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
+++ b/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import type { ApplicationQuestion } from "@/types/whitelabel-entities";
+import type { ApplicationFormData } from "../../types";
+import { MetricFieldArray } from "../MetricFieldArray";
+
+const question: ApplicationQuestion = {
+  id: "metrics",
+  type: "metric",
+  label: "Impact Metrics",
+  required: true,
+  validation: { minMetrics: 1, maxMetrics: 5 },
+};
+
+function Harness() {
+  const { control } = useForm<ApplicationFormData>({
+    defaultValues: { metrics: [] } as Partial<ApplicationFormData>,
+  });
+  return <MetricFieldArray control={control} name="metrics" question={question} />;
+}
+
+describe("MetricFieldArray — sequential sub-field edits", () => {
+  it("retains earlier sub-fields when a later one is edited", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByTestId("add-metric-btn"));
+
+    // Fill the four sub-fields in order, mirroring how a user types.
+    fireEvent.change(screen.getByTestId("metric-name-input-0"), {
+      target: { value: "Monthly active users" },
+    });
+    fireEvent.change(screen.getByTestId("metric-data-source-input-0"), {
+      target: { value: "Dune analytics" },
+    });
+    fireEvent.change(screen.getByTestId("metric-how-measured-input-0"), {
+      target: { value: "Count of unique users" },
+    });
+    fireEvent.change(screen.getByTestId("metric-target-input-0"), {
+      target: { value: "10,000 by Q4" },
+    });
+
+    // Editing the Target must not clear the earlier fields.
+    expect(screen.getByTestId("metric-name-input-0")).toHaveValue("Monthly active users");
+    expect(screen.getByTestId("metric-data-source-input-0")).toHaveValue("Dune analytics");
+    expect(screen.getByTestId("metric-how-measured-input-0")).toHaveValue("Count of unique users");
+    expect(screen.getByTestId("metric-target-input-0")).toHaveValue("10,000 by Q4");
+  });
+});

--- a/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
+++ b/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";
+import type { ApplicationFormData } from "@/features/applications/types";
 import type { ApplicationQuestion } from "@/types/whitelabel-entities";
-import type { ApplicationFormData } from "../../types";
 import { MetricFieldArray } from "../MetricFieldArray";
 
 const question: ApplicationQuestion = {

--- a/src/features/applications/components/__tests__/MetricItem.test.tsx
+++ b/src/features/applications/components/__tests__/MetricItem.test.tsx
@@ -1,77 +1,72 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { MetricData } from "@/types/whitelabel-entities";
+import { useForm } from "react-hook-form";
+import type { ApplicationFormData } from "../../types";
 import { MetricItem } from "../MetricItem";
 
+const mockOnRemove = vi.fn();
+
+interface HarnessProps {
+  canRemove?: boolean;
+  disabled?: boolean;
+  defaultValues?: Record<string, unknown>;
+}
+
+function Harness({ canRemove = true, disabled = false, defaultValues }: HarnessProps) {
+  const { control } = useForm<ApplicationFormData>({
+    defaultValues: (defaultValues ?? {
+      metrics: [{ metric: "", dataSource: "", howItsMeasured: "", target: "" }],
+    }) as Partial<ApplicationFormData>,
+  });
+  return (
+    <MetricItem
+      index={0}
+      namePrefix="metrics"
+      control={control}
+      canRemove={canRemove}
+      disabled={disabled}
+      onRemove={mockOnRemove}
+    />
+  );
+}
+
 describe("MetricItem", () => {
-  const mockMetric: MetricData = {
-    metric: "Monthly active users",
-    dataSource: "Dune Analytics dashboard",
-    howItsMeasured: "Unique wallets interacting with the contract",
-    target: "10,000 by Q4",
-  };
-
-  const mockOnUpdate = vi.fn();
-  const mockOnRemove = vi.fn();
-
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render all four metric sub-fields", () => {
+  it("renders all four sub-fields with their values", () => {
     render(
-      <MetricItem
-        index={0}
-        metric={mockMetric}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        canRemove={true}
+      <Harness
+        defaultValues={{
+          metrics: [
+            {
+              metric: "Monthly active users",
+              dataSource: "Dune analytics",
+              howItsMeasured: "Unique wallets",
+              target: "10,000 by Q4",
+            },
+          ],
+        }}
       />
     );
 
     expect(screen.getByText("Metric 1")).toBeInTheDocument();
     expect(screen.getByTestId("metric-name-input-0")).toHaveValue("Monthly active users");
-    expect(screen.getByTestId("metric-data-source-input-0")).toHaveValue(
-      "Dune Analytics dashboard"
-    );
-    expect(screen.getByTestId("metric-how-measured-input-0")).toHaveValue(
-      "Unique wallets interacting with the contract"
-    );
+    expect(screen.getByTestId("metric-data-source-input-0")).toHaveValue("Dune analytics");
+    expect(screen.getByTestId("metric-how-measured-input-0")).toHaveValue("Unique wallets");
     expect(screen.getByTestId("metric-target-input-0")).toHaveValue("10,000 by Q4");
   });
 
-  it("should call onUpdate with the changed sub-field, preserving the rest", () => {
-    render(
-      <MetricItem
-        index={0}
-        metric={mockMetric}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        canRemove={true}
-      />
-    );
+  it("calls onRemove when the remove button is clicked", () => {
+    render(<Harness />);
 
-    fireEvent.change(screen.getByTestId("metric-target-input-0"), {
-      target: { value: "25,000 by Q4" },
-    });
+    fireEvent.click(screen.getByTestId("remove-metric-btn-0"));
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metric: "Monthly active users",
-        target: "25,000 by Q4",
-      })
-    );
+    expect(mockOnRemove).toHaveBeenCalledTimes(1);
   });
 
-  it("should hide the remove button when canRemove is false", () => {
-    render(
-      <MetricItem
-        index={0}
-        metric={mockMetric}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        canRemove={false}
-      />
-    );
+  it("hides the remove button when canRemove is false", () => {
+    render(<Harness canRemove={false} />);
 
     expect(screen.queryByTestId("remove-metric-btn-0")).not.toBeInTheDocument();
   });

--- a/src/features/applications/components/__tests__/MetricItem.test.tsx
+++ b/src/features/applications/components/__tests__/MetricItem.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";
-import type { ApplicationFormData } from "../../types";
+import type { ApplicationFormData } from "@/features/applications/types";
 import { MetricItem } from "../MetricItem";
 
 const mockOnRemove = vi.fn();


### PR DESCRIPTION
## Overview

Fixes a data-loss bug in the **Metrics** intake field (added in #1518): editing one sub-field clears the others.

This fix was committed after #1518 had already been merged, so it never landed on `main` — hence this follow-up PR.

## Problem

In the live application form, filling a metric entry and then editing a later sub-field wipes the earlier ones. Repro:

1. Add a Metrics field to an intake form; open the public apply page.
2. In one metric, type **Metric** = "Monthly active users", **Data Source** = "Dune analytics", **How It's Measured** = "Count of unique users".
3. Type anything in **Target** → the first three fields clear.

## Root cause

`MetricItem` rebuilt the entire entry object on every keystroke from a `metric` prop:

```ts
onUpdate({ ...metric, [field]: value });
```

That `metric` prop goes stale between sequential sub-field edits (and the `React.memo` wrapper made it easier to hit), so a later edit writes back an out-of-date object and overwrites the earlier values.

## Solution

Register **each sub-field with its own `Controller`** (`control` + `namePrefix`) instead of spreading a whole-object prop. An edit now only ever touches that one leaf — the same pattern the legacy `MetricInput` (post-approval / admin-edit path) already uses. Removes the stale-object spread, the `metric`/`onUpdate`/`errors` prop plumbing, and the `React.memo` indirection.

## Testing Steps

1. Run the apply form repro above — all four sub-fields now persist independently.
2. Edit any field in any order; none clear the others.
3. Submit — values save as before.

Automated:
- New `MetricFieldArray` integration test types into all four sub-fields in sequence and asserts they all survive.
- `MetricItem` tests updated for the control-based API.
- `MetricFieldArray`, `MetricItem`, `MetricInput`, and metric-schema suites pass; `tsc` + lint clean.

## Risk

Low. Frontend-only, scoped to the metric intake field components. No backend or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured metric input components for improved form integration and streamlined data handling.

* **Tests**
  * Added comprehensive test coverage for metric field array and item management, including field editing and removal interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->