### PR TITLE
feat(knowledge-base): add optional citation link for Google Doc sources

### DIFF
--- a/__tests__/components/Admin/KnowledgeBasePage/AddSourceDialog.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/AddSourceDialog.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { AddSourceDialog } from "@/components/Pages/Admin/KnowledgeBasePage/AddSourceDialog";
+import { useCreateKnowledgeSource } from "@/hooks/knowledge-base/useKnowledgeSourceMutations";
+import "@testing-library/jest-dom";
+
+// DEV-342: coverage for the Citation link field — visibility per kind and
+// its presence in the create payload. The mutation hook is mocked; we
+// assert what `mutateAsync` receives.
+
+vi.mock("@/hooks/knowledge-base/useKnowledgeSourceMutations", () => ({
+  useCreateKnowledgeSource: vi.fn(),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockCreate = useCreateKnowledgeSource as ReturnType<typeof vi.fn>;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function renderDialog() {
+  return render(
+    <AddSourceDialog communityIdOrSlug="filecoin" open onOpenChange={() => undefined} />,
+    { wrapper: Wrapper }
+  );
+}
+
+describe("AddSourceDialog citation URL (DEV-342)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the citation link field for the default gdrive_file kind", () => {
+    mockCreate.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    renderDialog();
+
+    expect(screen.getByLabelText(/citation link/i)).toBeInTheDocument();
+  });
+
+  it("hides the citation link field when a non-Google-Doc kind is selected", async () => {
+    mockCreate.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    renderDialog();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("radio", { name: /web page/i }));
+
+    expect(screen.queryByLabelText(/citation link/i)).not.toBeInTheDocument();
+  });
+
+  it("includes citationUrl in the create payload when filled for a Google Doc", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockCreate.mockReturnValue({ mutateAsync, isPending: false });
+    renderDialog();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), "Handbook");
+    await user.type(
+      screen.getByLabelText(/google doc url or id/i),
+      "https://docs.google.com/document/d/abc/edit"
+    );
+    await user.type(screen.getByLabelText(/citation link/i), "https://public.example.com/handbook");
+    await user.click(screen.getByRole("button", { name: /add source/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "gdrive_file",
+          citationUrl: "https://public.example.com/handbook",
+        })
+      );
+    });
+  });
+
+  it("omits citationUrl when the field is left empty", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockCreate.mockReturnValue({ mutateAsync, isPending: false });
+    renderDialog();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), "Handbook");
+    await user.type(
+      screen.getByLabelText(/google doc url or id/i),
+      "https://docs.google.com/document/d/abc/edit"
+    );
+    await user.click(screen.getByRole("button", { name: /add source/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(mutateAsync.mock.calls[0][0].citationUrl).toBeUndefined();
+  });
+});

--- a/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/EditSourceDialog.test.tsx
@@ -45,6 +45,7 @@ const createSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource
   goal: "old purpose",
   syncIntervalMin: 1440,
   followLinks: false,
+  citationUrl: null,
   lastSyncedAt: "2026-04-26T00:00:00.000Z",
   lastSyncStatus: "success",
   lastSyncError: null,
@@ -312,6 +313,71 @@ describe("EditSourceDialog", () => {
         expect(mutateAsync).toHaveBeenCalledWith({
           sourceId: "src-1",
           patch: { goal: null },
+        });
+      });
+    });
+  });
+
+  describe("citation URL (DEV-342)", () => {
+    it("does NOT show the citation link field for url kind", () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(createSource({ kind: "url" }));
+
+      expect(screen.queryByLabelText(/citation link/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the citation link field for gdrive_file kind", () => {
+      mockEdit.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+      renderDialog(createSource({ kind: "gdrive_file", externalId: "doc-1234" }));
+
+      expect(screen.getByLabelText(/citation link/i)).toBeInTheDocument();
+    });
+
+    it("commits a citation-URL change directly without the re-sync confirmation", async () => {
+      // DEV-342: the override is display-only — editing it must bypass the
+      // confirmation modal and patch immediately, unlike goal/externalId.
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(createSource({ kind: "gdrive_file", externalId: "doc-1234" }));
+
+      const user = userEvent.setup();
+      await user.type(
+        screen.getByLabelText(/citation link/i),
+        "https://public.example.com/handbook"
+      );
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /apply re-sync changes/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { citationUrl: "https://public.example.com/handbook" },
+        });
+      });
+    });
+
+    it("clears citation URL to null when the field is emptied", async () => {
+      const mutateAsync = vi.fn().mockResolvedValue(undefined);
+      mockEdit.mockReturnValue({ mutateAsync, isPending: false });
+      renderDialog(
+        createSource({
+          kind: "gdrive_file",
+          externalId: "doc-1234",
+          citationUrl: "https://public.example.com/handbook",
+        })
+      );
+
+      const user = userEvent.setup();
+      await user.clear(screen.getByDisplayValue("https://public.example.com/handbook"));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mutateAsync).toHaveBeenCalledWith({
+          sourceId: "src-1",
+          patch: { citationUrl: null },
         });
       });
     });

--- a/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
+++ b/__tests__/components/Admin/KnowledgeBasePage/SourceRow.test.tsx
@@ -49,6 +49,7 @@ const createSource = (overrides: Partial<KnowledgeSource> = {}): KnowledgeSource
   goal: null,
   syncIntervalMin: 1440,
   followLinks: false,
+  citationUrl: null,
   lastSyncedAt: "2026-04-26T00:00:00.000Z",
   lastSyncStatus: "success",
   lastSyncError: null,

--- a/components/Pages/Admin/KnowledgeBasePage/AddSourceDialog.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/AddSourceDialog.tsx
@@ -79,6 +79,9 @@ export function AddSourceDialog({ communityIdOrSlug, open, onOpenChange, initial
   // kind === "gdrive_file"; we hide the toggle for other kinds and clear
   // the value on kind changes so a stale `true` can't sneak in.
   const [followLinks, setFollowLinks] = useState(false);
+  // DEV-342: optional public citation link. Only valid on Google Docs —
+  // hidden and cleared for other kinds (backend rejects it with 422).
+  const [citationUrl, setCitationUrl] = useState("");
   const create = useCreateKnowledgeSource(communityIdOrSlug);
 
   // On open, seed the kind from `initialKind` (quick-pick) or fall back to the
@@ -92,6 +95,7 @@ export function AddSourceDialog({ communityIdOrSlug, open, onOpenChange, initial
       setTitle("");
       setGoal("");
       setFollowLinks(false);
+      setCitationUrl("");
     }
   }, [open, initialKind]);
 
@@ -101,7 +105,10 @@ export function AddSourceDialog({ communityIdOrSlug, open, onOpenChange, initial
   // with what we'd send.
   const handleKindChange = (nextKind: KnowledgeSourceKind) => {
     setKind(nextKind);
-    if (nextKind !== "gdrive_file") setFollowLinks(false);
+    if (nextKind !== "gdrive_file") {
+      setFollowLinks(false);
+      setCitationUrl("");
+    }
   };
 
   const canSubmit = externalId.trim().length > 0 && title.trim().length > 0 && !create.isPending;
@@ -123,6 +130,10 @@ export function AddSourceDialog({ communityIdOrSlug, open, onOpenChange, initial
         // accepts false universally), but omitting keeps the request
         // payload tight and aligned with the visible UI state.
         followLinks: kind === "gdrive_file" ? followLinks : undefined,
+        // DEV-342: only Google Docs accept a citation override; omit it
+        // otherwise. Empty input means "no public link" (cite by title).
+        citationUrl:
+          kind === "gdrive_file" && citationUrl.trim().length > 0 ? citationUrl.trim() : undefined,
       });
       toast.success("Knowledge source added.");
       onOpenChange(false);
@@ -253,6 +264,25 @@ export function AddSourceDialog({ communityIdOrSlug, open, onOpenChange, initial
                     </span>
                   </div>
                 </FormField>
+
+                {kind === "gdrive_file" && (
+                  <FormField
+                    label="Citation link (optional)"
+                    hint="Public URL to link in chat citations. If empty, this Google Doc is cited by title with no link — its Drive URL is never shown."
+                    htmlFor="kb-citation-url"
+                  >
+                    <input
+                      id="kb-citation-url"
+                      type="url"
+                      value={citationUrl}
+                      onChange={(e) => setCitationUrl(e.target.value)}
+                      placeholder="https://example.com/published-handbook"
+                      maxLength={2048}
+                      spellCheck={false}
+                      className="h-9 w-full rounded-md border border-stone-300 bg-white px-3 font-mono text-[12.5px] text-stone-900 placeholder-stone-400 transition focus:border-sky-500 focus:outline-none focus:ring-[3px] focus:ring-sky-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-600 dark:focus:border-sky-400 dark:focus:ring-sky-400/20"
+                    />
+                  </FormField>
+                )}
 
                 {kind === "gdrive_file" && (
                   <FollowLinksToggle checked={followLinks} onChange={setFollowLinks} />

--- a/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
+++ b/components/Pages/Admin/KnowledgeBasePage/EditSourceDialog.tsx
@@ -37,9 +37,15 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
   const [externalId, setExternalId] = useState("");
   const [goal, setGoal] = useState("");
   const [followLinks, setFollowLinks] = useState(false);
+  // DEV-342: optional public citation link. Editing it is display-only —
+  // it never triggers a re-sync, so it stays out of `requiresConfirmation`.
+  const [citationUrl, setCitationUrl] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const edit = useEditKnowledgeSource(communityIdOrSlug);
+
+  // DEV-342: the citation override only applies to Google Doc sources.
+  const isGoogleDocSource = source?.kind === "gdrive_file" || source?.kind === "gdrive_folder";
 
   // Hydrate from `source` only when the dialog opens or the row identity
   // changes (different sourceId). Depending on the source object reference
@@ -55,6 +61,7 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
       setExternalId(source.externalId);
       setGoal(source.goal ?? "");
       setFollowLinks(source.followLinks);
+      setCitationUrl(source.citationUrl ?? "");
     }
     if (!open) {
       // Clear any in-flight confirmation modal when the parent closes —
@@ -67,6 +74,7 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
   const trimmedTitle = title.trim();
   const trimmedExternalId = externalId.trim();
   const trimmedGoal = goal.trim();
+  const trimmedCitationUrl = citationUrl.trim();
 
   // Tri-state goal: original null + empty string → no change, original
   // string + empty string → clear (null), original string + new string
@@ -79,6 +87,15 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
     return trimmedGoal.length > 0 ? trimmedGoal : null;
   }, [source, trimmedGoal]);
 
+  // DEV-342: same tri-state as goal — empty input clears the override to
+  // null; an unchanged value is a no-op.
+  const citationUrlForPatch: string | null | "unchanged" = useMemo(() => {
+    if (!source) return "unchanged";
+    const original = source.citationUrl ?? "";
+    if (trimmedCitationUrl === original) return "unchanged";
+    return trimmedCitationUrl.length > 0 ? trimmedCitationUrl : null;
+  }, [source, trimmedCitationUrl]);
+
   const changes = useMemo<EditChanges | null>(() => {
     if (!source) return null;
     return {
@@ -87,15 +104,17 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
       externalIdChanged: trimmedExternalId !== source.externalId && trimmedExternalId.length > 0,
       followLinksTurnedOn: followLinks && !source.followLinks,
       followLinksTurnedOff: !followLinks && source.followLinks,
+      citationUrlChanged: citationUrlForPatch !== "unchanged",
     };
-  }, [source, trimmedTitle, goalForPatch, trimmedExternalId, followLinks]);
+  }, [source, trimmedTitle, goalForPatch, trimmedExternalId, followLinks, citationUrlForPatch]);
 
   const hasAnyChange = changes
     ? changes.titleChanged ||
       changes.goalChanged ||
       changes.externalIdChanged ||
       changes.followLinksTurnedOn ||
-      changes.followLinksTurnedOff
+      changes.followLinksTurnedOff ||
+      changes.citationUrlChanged
     : false;
 
   const requiresConfirmation = changes
@@ -122,6 +141,11 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
     if (changes.externalIdChanged) patch.externalId = trimmedExternalId;
     if (changes.followLinksTurnedOn || changes.followLinksTurnedOff) {
       patch.followLinks = followLinks;
+    }
+    if (changes.citationUrlChanged) {
+      // Narrow off the "unchanged" sentinel — the branch guarantees it's
+      // `string | null` here.
+      patch.citationUrl = citationUrlForPatch as string | null;
     }
     return patch;
   };
@@ -267,6 +291,25 @@ export function EditSourceDialog({ communityIdOrSlug, source, open, onOpenChange
                     </div>
                   </FormField>
 
+                  {isGoogleDocSource && (
+                    <FormField
+                      label="Citation link (optional)"
+                      hint="Public URL to link in chat citations. If empty, this Google Doc is cited by title with no link — its Drive URL is never shown. Saved instantly; no re-sync."
+                      htmlFor="kb-edit-citation-url"
+                    >
+                      <input
+                        id="kb-edit-citation-url"
+                        type="url"
+                        value={citationUrl}
+                        onChange={(e) => setCitationUrl(e.target.value)}
+                        placeholder="https://example.com/published-handbook"
+                        maxLength={2048}
+                        spellCheck={false}
+                        className="h-9 w-full rounded-md border border-stone-300 bg-white px-3 font-mono text-[12.5px] text-stone-900 placeholder-stone-400 transition focus:border-sky-500 focus:outline-none focus:ring-[3px] focus:ring-sky-500/20 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-600 dark:focus:border-sky-400 dark:focus:ring-sky-400/20"
+                      />
+                    </FormField>
+                  )}
+
                   {source.kind === "gdrive_file" && (
                     <FollowLinksToggle checked={followLinks} onChange={setFollowLinks} />
                   )}
@@ -307,6 +350,8 @@ interface EditChanges {
   externalIdChanged: boolean;
   followLinksTurnedOn: boolean;
   followLinksTurnedOff: boolean;
+  // DEV-342: display-only — deliberately excluded from requiresConfirmation.
+  citationUrlChanged: boolean;
 }
 
 // ── Locked kind badge ───────────────────────────────────────────────────────

--- a/hooks/knowledge-base/useKnowledgeSourceMutations.ts
+++ b/hooks/knowledge-base/useKnowledgeSourceMutations.ts
@@ -131,6 +131,11 @@ function applyPatch(source: KnowledgeSource, patch: UpdateKnowledgeSourceInput):
       syncIntervalMin: patch.syncIntervalMin,
     }),
     ...(patch.followLinks !== undefined && { followLinks: patch.followLinks }),
+    // DEV-342: tri-state like `goal` — present (incl. null) applies, absent
+    // leaves the override unchanged.
+    ...(Object.hasOwn(patch, "citationUrl") && {
+      citationUrl: patch.citationUrl ?? null,
+    }),
   };
 }
 

--- a/types/v2/knowledge-base.ts
+++ b/types/v2/knowledge-base.ts
@@ -32,6 +32,11 @@ export interface KnowledgeSource {
   // ingests Google Docs linked from the parent doc as additional
   // documents under the same source (depth=1, no recursion).
   followLinks: boolean;
+  // DEV-342: optional public link used when citing this source in Ask
+  // Karma. For Google Docs the raw docs.google.com URL is never cited —
+  // the doc links only via this override (top-level document only);
+  // absent it, it is cited by title with no link.
+  citationUrl: string | null;
   lastSyncedAt: string | null;
   lastSyncStatus: KnowledgeSyncStatus | null;
   lastSyncError: string | null;
@@ -66,6 +71,9 @@ export interface CreateKnowledgeSourceInput {
   // DEV-192: opt-in only when kind === "gdrive_file". Backend rejects
   // with 422 if set true on any other kind.
   followLinks?: boolean;
+  // DEV-342: optional public citation link. Only valid on Google Doc
+  // kinds — backend returns 422 if set on any other kind.
+  citationUrl?: string | null;
 }
 
 export interface UpdateKnowledgeSourceInput {
@@ -82,6 +90,9 @@ export interface UpdateKnowledgeSourceInput {
   paused?: boolean;
   syncIntervalMin?: number;
   followLinks?: boolean;
+  // DEV-342: set the public citation link, or `null` to clear it. Only
+  // valid on Google Doc kinds. Display-only — never triggers a re-sync.
+  citationUrl?: string | null;
 }
 
 export const KNOWLEDGE_SOURCE_KIND_LABELS: Record<KnowledgeSourceKind, string> = {


### PR DESCRIPTION
## Overview

Surfaces the DEV-342 citation override in the admin knowledge-base UI. For **Google Doc sources**, admins can set an optional public **Citation link**; when empty, the doc is cited by title with no link in Ask Karma (its `docs.google.com` URL is never shown).

Linear: DEV-342

> Pairs with the gap-indexer PR that implements the backend resolution and the `citation_url` column. The field is rejected by the API on non-Google-Docs kinds, which is why the input is shown for Google Doc kinds only.

## Changes

- **Types:** `citationUrl` on `KnowledgeSource` and on the create/update inputs.
- **AddSourceDialog:** Citation link input shown only when kind is `gdrive_file`; cleared on kind change; included in the create payload only when non-empty.
- **EditSourceDialog:** input shown for Google Doc kinds; editing it is a **direct save** — deliberately excluded from the re-sync confirmation modal because it is display-only. Tri-state (empty clears to `null`).
- **Optimistic update:** `applyPatch` projects `citationUrl` (tri-state, mirroring `goal`) so the cached row updates instantly.

## UX

- Hint: *"Public URL to link in chat citations. If empty, this Google Doc is cited by title with no link — its Drive URL is never shown."*
- Non-Google sources are unaffected (no input, behavior unchanged).

## Testing

- `__tests__/.../AddSourceDialog.test.tsx` (new): field visibility per kind, payload inclusion/omission.
- `__tests__/.../EditSourceDialog.test.tsx`: field visibility, **direct-save without the re-sync modal**, clear-to-null.
- All KnowledgeBasePage tests pass (47); Biome + `tsc --noEmit` clean for touched files.

> `pnpm run build` not run here — it is blocked by the pre-existing `@stripe/crypto` / `agentation` module-resolution failures unrelated to this change.
