### PR TITLE
fix: metric remove icon should only show with more than one entry

### DIFF
--- a/src/features/applications/components/MetricFieldArray.tsx
+++ b/src/features/applications/components/MetricFieldArray.tsx
@@ -31,7 +31,9 @@ export const MetricFieldArray: FC<MetricFieldArrayProps> = ({
   });
 
   const maxMetrics = question.validation?.maxMetrics ?? Number.POSITIVE_INFINITY;
-  const minMetrics = question.validation?.minMetrics ?? 0;
+  // Required fields keep at least one entry (matches the Zod schema), so the
+  // remove icon only appears once there is more than one metric.
+  const minMetrics = question.validation?.minMetrics ?? (question.required ? 1 : 0);
 
   const handleAddMetric = () => {
     const newMetric: MetricData = {

--- a/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
+++ b/src/features/applications/components/__tests__/MetricFieldArray.test.tsx
@@ -46,3 +46,30 @@ describe("MetricFieldArray — sequential sub-field edits", () => {
     expect(screen.getByTestId("metric-target-input-0")).toHaveValue("10,000 by Q4");
   });
 });
+
+describe("MetricFieldArray — remove icon visibility (required, no explicit min)", () => {
+  const requiredQuestion: ApplicationQuestion = {
+    id: "metrics",
+    type: "metric",
+    label: "Impact Metrics",
+    required: true,
+  };
+
+  function RequiredHarness() {
+    const { control } = useForm<ApplicationFormData>({
+      defaultValues: { metrics: [] } as Partial<ApplicationFormData>,
+    });
+    return <MetricFieldArray control={control} name="metrics" question={requiredQuestion} />;
+  }
+
+  it("hides the remove icon for a single metric and shows it once there is more than one", () => {
+    render(<RequiredHarness />);
+
+    fireEvent.click(screen.getByTestId("add-metric-btn"));
+    expect(screen.queryByTestId("remove-metric-btn-0")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("add-metric-btn"));
+    expect(screen.getByTestId("remove-metric-btn-0")).toBeInTheDocument();
+    expect(screen.getByTestId("remove-metric-btn-1")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Overview

Follow-up to #1522: the metric **remove (trash) icon** showed on a single metric entry, instead of only appearing once there is more than one. This fix was committed after #1522 had merged, so it never reached `main`.

## Problem

For a required Metrics field with no explicit minimum, the remove icon appeared even when only one metric was present — letting an applicant delete the sole entry of a required field (which the Zod schema then rejects on submit).

## Root cause

`MetricFieldArray` derived its minimum as `question.validation?.minMetrics ?? 0`, ignoring `required`. With a floor of `0`, `canRemove = fields.length > 0` is true for a single entry. Meanwhile `buildMetricSchema` already treats a required field as min 1 — so the UI and the validation disagreed.

## Solution

Default the minimum to **1 for required fields**, matching the schema:

```ts
const minMetrics = question.validation?.minMetrics ?? (question.required ? 1 : 0);
```

Now the remove icon appears only when there is more than one metric, and the last required entry can't be removed. Explicit `minMetrics`/`maxMetrics` from the builder are still respected.

## Testing Steps

1. Add a required Metrics field; open the apply form and add one metric → no remove icon.
2. Add a second metric → remove icons appear on all entries.
3. Remove down to one → its remove icon disappears.

Automated: new `MetricFieldArray` test asserts the single-vs-multiple remove-icon visibility. Tests + tsc + lint pass.

## Risk

Low. One-line behavior change in the metric field array, frontend-only, covered by a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Required metric fields now properly enforce minimum constraints, preventing users from removing all metrics from the form. The remove action is automatically disabled when only a single metric entry remains in fields marked as required.

## Tests
* Added comprehensive test suite verifying metric removal constraints work correctly for required questions, ensuring the remove option properly displays and hides based on metric count and field requirement status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->