### PR TITLE
fix(milestone): persist outputs and deliverables on project milestone completion

### DIFF
--- a/__tests__/unit/components/Forms/ProjectObjectiveCompletion.payload.test.ts
+++ b/__tests__/unit/components/Forms/ProjectObjectiveCompletion.payload.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildProjectObjectiveCompletionPayload } from "@/components/Forms/projectObjectiveCompletionPayload";
+import {
+  buildProjectObjectiveCompletionPayload,
+  projectObjectiveCompletionSchema,
+} from "@/components/Forms/projectObjectiveCompletionPayload";
 
 describe("buildProjectObjectiveCompletionPayload", () => {
   it("forwards outputs and deliverables onto the attestation payload", () => {
@@ -85,6 +88,32 @@ describe("buildProjectObjectiveCompletionPayload", () => {
 
     expect(payload.reason).toBe("shipped the work");
     expect(payload.proofOfWork).toBe("https://example.com/proof");
+  });
+
+  it("rejects whitespace-only values on required string fields", () => {
+    // Without .trim() before .min(1), "   " would pass the required check
+    // and a whitespace-only payload could be submitted on chain.
+    const result = projectObjectiveCompletionSchema.safeParse({
+      description: "",
+      proofOfWork: "",
+      outputs: [{ outputId: "   ", value: 1 }],
+      deliverables: [{ name: "   ", proof: "   " }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a proofOfWork URL with surrounding whitespace", () => {
+    // Form-side trim() lets validators run against the normalised value, so
+    // "  https://example.com  " is accepted rather than rejected as invalid URL.
+    const result = projectObjectiveCompletionSchema.safeParse({
+      description: "",
+      proofOfWork: "  https://example.com/proof  ",
+      outputs: [],
+      deliverables: [],
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("always stamps the project-milestone-completed type", () => {

--- a/__tests__/unit/components/Forms/ProjectObjectiveCompletion.payload.test.ts
+++ b/__tests__/unit/components/Forms/ProjectObjectiveCompletion.payload.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for `buildProjectObjectiveCompletionPayload`.
+ *
+ * The bug this guards against: the project-milestone completion form was
+ * dropping form-collected `outputs` and `deliverables` arrays on submit,
+ * so the resulting on-chain attestation had only `type/proofOfWork/reason`.
+ * Owners reported empty "Metrics" sections on completed milestone cards.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildProjectObjectiveCompletionPayload } from "@/components/Forms/projectObjectiveCompletionPayload";
+
+describe("buildProjectObjectiveCompletionPayload", () => {
+  it("forwards outputs and deliverables onto the attestation payload", () => {
+    const payload = buildProjectObjectiveCompletionPayload({
+      description: "Shipped the bridge",
+      proofOfWork: "https://example.com/proof",
+      outputs: [
+        {
+          outputId: "tps",
+          value: 1500,
+          proof: "https://example.com/tps",
+          startDate: "",
+          endDate: "",
+        },
+        {
+          outputId: "users",
+          value: "42",
+          proof: "",
+          startDate: "2026-01-01",
+          endDate: "2026-03-01",
+        },
+      ],
+      deliverables: [
+        { name: "Contract", proof: "https://etherscan.io/0xabc", description: "Deployed contract" },
+      ],
+    });
+
+    expect(payload).toEqual({
+      proofOfWork: "https://example.com/proof",
+      reason: "Shipped the bridge",
+      type: "project-milestone-completed",
+      outputs: [
+        {
+          outputId: "tps",
+          value: 1500,
+          proof: "https://example.com/tps",
+          startDate: "",
+          endDate: "",
+        },
+        {
+          outputId: "users",
+          value: "42",
+          proof: "",
+          startDate: "2026-01-01",
+          endDate: "2026-03-01",
+        },
+      ],
+      deliverables: [
+        { name: "Contract", proof: "https://etherscan.io/0xabc", description: "Deployed contract" },
+      ],
+    });
+  });
+
+  it("preserves empty outputs and deliverables arrays without losing them", () => {
+    const payload = buildProjectObjectiveCompletionPayload({
+      description: "",
+      proofOfWork: "",
+      outputs: [],
+      deliverables: [],
+    });
+
+    expect(payload.outputs).toEqual([]);
+    expect(payload.deliverables).toEqual([]);
+    expect(payload.type).toBe("project-milestone-completed");
+  });
+
+  it("trims whitespace on description and proofOfWork via sanitizeInput", () => {
+    const payload = buildProjectObjectiveCompletionPayload({
+      description: "  shipped the work  ",
+      proofOfWork: "  https://example.com/proof  ",
+      outputs: [],
+      deliverables: [],
+    });
+
+    expect(payload.reason).toBe("shipped the work");
+    expect(payload.proofOfWork).toBe("https://example.com/proof");
+  });
+
+  it("always stamps the project-milestone-completed type", () => {
+    const payload = buildProjectObjectiveCompletionPayload({
+      description: "anything",
+      proofOfWork: "https://example.com",
+      outputs: [{ outputId: "id", value: 1 }],
+      deliverables: [{ name: "n", proof: "https://example.com/p" }],
+    });
+
+    expect(payload.type).toBe("project-milestone-completed");
+  });
+});

--- a/components/Forms/ProjectObjectiveCompletion.tsx
+++ b/components/Forms/ProjectObjectiveCompletion.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { IProjectMilestoneStatus } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone";
 import { ProjectMilestone } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -162,16 +163,23 @@ export const ProjectObjectiveCompletionForm = ({
         return;
       }
 
+      // The SDK type is narrow (proofOfWork/reason/type), but `complete()`
+      // spreads the data into the JSON schema, so deliverables + outputs
+      // captured by the form below are persisted on chain. Without this,
+      // any metrics or deliverables the user filled in are silently dropped.
+      const completionPayload: IProjectMilestoneStatus & {
+        outputs: SchemaType["outputs"];
+        deliverables: SchemaType["deliverables"];
+      } = {
+        proofOfWork: sanitizeInput(data.proofOfWork),
+        reason: sanitizeInput(data.description),
+        type: `project-milestone-completed`,
+        outputs: data.outputs,
+        deliverables: data.deliverables,
+      };
+
       await objectiveInstance
-        .complete(
-          walletSigner,
-          {
-            proofOfWork: sanitizeInput(data.proofOfWork),
-            reason: sanitizeInput(data.description),
-            type: `project-milestone-completed`,
-          },
-          changeStepperStep
-        )
+        .complete(walletSigner, completionPayload, changeStepperStep)
         .then(async (res) => {
           let retries = 1000;
           changeStepperStep("indexing");

--- a/components/Forms/ProjectObjectiveCompletion.tsx
+++ b/components/Forms/ProjectObjectiveCompletion.tsx
@@ -1,13 +1,16 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { IProjectMilestoneStatus } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone";
 import { ProjectMilestone } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useAccount } from "wagmi";
-import { z } from "zod";
 import { OutputsSection } from "@/components/Forms/Outputs/OutputsSection";
+import {
+  buildProjectObjectiveCompletionPayload,
+  type ProjectObjectiveCompletionFormData as SchemaType,
+  projectObjectiveCompletionSchema as schema,
+} from "@/components/Forms/projectObjectiveCompletionPayload";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useGap } from "@/hooks/useGap";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
@@ -20,42 +23,12 @@ import { getProjectObjectives } from "@/utilities/gapIndexerApi/getProjectObject
 import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
 import { PAGES } from "@/utilities/pages";
-import { urlRegex } from "@/utilities/regexs/urlRegex";
-import { sanitizeInput } from "@/utilities/sanitize";
 import { getProjectById } from "@/utilities/sdk";
 import { SHARE_TEXTS } from "@/utilities/share/text";
 import { cn } from "@/utilities/tailwind";
 import { Button } from "../Utilities/Button";
 import { errorManager } from "../Utilities/errorManager";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
-
-const schema = z.object({
-  description: z.string().optional(),
-  proofOfWork: z
-    .string()
-    .refine((value) => urlRegex.test(value), {
-      message: "Please enter a valid URL",
-    })
-    .optional()
-    .or(z.literal("")),
-  outputs: z.array(
-    z.object({
-      outputId: z.string().min(1, "Output is required"),
-      value: z.union([z.number().min(0), z.string()]),
-      proof: z.string().optional(),
-      startDate: z.string().optional(),
-      endDate: z.string().optional(),
-    })
-  ),
-  deliverables: z.array(
-    z.object({
-      name: z.string().min(1, "Name is required"),
-      proof: z.string().min(1, "Proof is required"),
-      description: z.string().optional(),
-    })
-  ),
-});
-type SchemaType = z.infer<typeof schema>;
 
 const labelStyle = "text-slate-700 text-sm font-bold leading-tight dark:text-slate-200";
 
@@ -163,23 +136,8 @@ export const ProjectObjectiveCompletionForm = ({
         return;
       }
 
-      // The SDK type is narrow (proofOfWork/reason/type), but `complete()`
-      // spreads the data into the JSON schema, so deliverables + outputs
-      // captured by the form below are persisted on chain. Without this,
-      // any metrics or deliverables the user filled in are silently dropped.
-      const completionPayload: IProjectMilestoneStatus & {
-        outputs: SchemaType["outputs"];
-        deliverables: SchemaType["deliverables"];
-      } = {
-        proofOfWork: sanitizeInput(data.proofOfWork),
-        reason: sanitizeInput(data.description),
-        type: `project-milestone-completed`,
-        outputs: data.outputs,
-        deliverables: data.deliverables,
-      };
-
       await objectiveInstance
-        .complete(walletSigner, completionPayload, changeStepperStep)
+        .complete(walletSigner, buildProjectObjectiveCompletionPayload(data), changeStepperStep)
         .then(async (res) => {
           let retries = 1000;
           changeStepperStep("indexing");

--- a/components/Forms/projectObjectiveCompletionPayload.ts
+++ b/components/Forms/projectObjectiveCompletionPayload.ts
@@ -1,0 +1,63 @@
+import type { IProjectMilestoneStatus } from "@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone";
+import { z } from "zod";
+import { urlRegex } from "@/utilities/regexs/urlRegex";
+import { sanitizeInput } from "@/utilities/sanitize";
+
+/**
+ * Form schema shared between the React form component and the on-chain payload
+ * builder below. Kept in its own module so unit tests for the payload builder
+ * can import without pulling in the heavy SDK / React form transitive graph.
+ */
+export const projectObjectiveCompletionSchema = z.object({
+  description: z.string().optional(),
+  proofOfWork: z
+    .string()
+    .refine((value) => urlRegex.test(value), {
+      message: "Please enter a valid URL",
+    })
+    .optional()
+    .or(z.literal("")),
+  outputs: z.array(
+    z.object({
+      outputId: z.string().min(1, "Output is required"),
+      value: z.union([z.number().min(0), z.string()]),
+      proof: z.string().optional(),
+      startDate: z.string().optional(),
+      endDate: z.string().optional(),
+    })
+  ),
+  deliverables: z.array(
+    z.object({
+      name: z.string().min(1, "Name is required"),
+      proof: z.string().min(1, "Proof is required"),
+      description: z.string().optional(),
+    })
+  ),
+});
+
+export type ProjectObjectiveCompletionFormData = z.infer<typeof projectObjectiveCompletionSchema>;
+
+export type ProjectObjectiveCompletionPayload = IProjectMilestoneStatus & {
+  outputs: ProjectObjectiveCompletionFormData["outputs"];
+  deliverables: ProjectObjectiveCompletionFormData["deliverables"];
+};
+
+/**
+ * Builds the on-chain attestation payload for a project milestone completion.
+ *
+ * The SDK type `IProjectMilestoneStatus` is narrow (proofOfWork/reason/type),
+ * but `ProjectMilestone.complete` spreads the data object into the JSON schema,
+ * so any extra keys are persisted. Earlier this site only forwarded the three
+ * narrow fields, silently dropping the `outputs` and `deliverables` arrays
+ * the form collects — completed milestones then rendered with empty Metrics
+ * sections. Always route through this builder to keep that contract intact.
+ */
+export const buildProjectObjectiveCompletionPayload = (
+  data: ProjectObjectiveCompletionFormData
+): ProjectObjectiveCompletionPayload => ({
+  proofOfWork: sanitizeInput(data.proofOfWork),
+  reason: sanitizeInput(data.description),
+  type: "project-milestone-completed",
+  outputs: data.outputs,
+  deliverables: data.deliverables,
+});

--- a/components/Forms/projectObjectiveCompletionPayload.ts
+++ b/components/Forms/projectObjectiveCompletionPayload.ts
@@ -12,14 +12,15 @@ export const projectObjectiveCompletionSchema = z.object({
   description: z.string().optional(),
   proofOfWork: z
     .string()
-    .refine((value) => urlRegex.test(value), {
+    .trim()
+    .refine((value) => value === "" || urlRegex.test(value), {
       message: "Please enter a valid URL",
     })
     .optional()
     .or(z.literal("")),
   outputs: z.array(
     z.object({
-      outputId: z.string().min(1, "Output is required"),
+      outputId: z.string().trim().min(1, "Output is required"),
       value: z.union([z.number().min(0), z.string()]),
       proof: z.string().optional(),
       startDate: z.string().optional(),
@@ -28,8 +29,8 @@ export const projectObjectiveCompletionSchema = z.object({
   ),
   deliverables: z.array(
     z.object({
-      name: z.string().min(1, "Name is required"),
-      proof: z.string().min(1, "Proof is required"),
+      name: z.string().trim().min(1, "Name is required"),
+      proof: z.string().trim().min(1, "Proof is required"),
       description: z.string().optional(),
     })
   ),
@@ -37,7 +38,9 @@ export const projectObjectiveCompletionSchema = z.object({
 
 export type ProjectObjectiveCompletionFormData = z.infer<typeof projectObjectiveCompletionSchema>;
 
-export type ProjectObjectiveCompletionPayload = IProjectMilestoneStatus & {
+// Internal — the type the payload builder returns. Kept module-local so knip
+// doesn't flag it as an unused export; nothing outside this module needs it.
+type ProjectObjectiveCompletionPayload = IProjectMilestoneStatus & {
   outputs: ProjectObjectiveCompletionFormData["outputs"];
   deliverables: ProjectObjectiveCompletionFormData["deliverables"];
 };


### PR DESCRIPTION
## Summary

When a project owner marks a project milestone complete, the form's `outputs[]` (metrics) and `deliverables[]` arrays were being silently dropped on submit. Only `proofOfWork`, `reason`, and `type` ever made it to the on-chain attestation. The resulting "completed" card on the project page therefore showed no metrics — and an empty `reason` rendered the `—` placeholder users were seeing.

## Problem

`components/Forms/ProjectObjectiveCompletion.tsx`:
- Schema (L41–55) collects `outputs[]` + `deliverables[]` via `<OutputsSection>` and `useFieldArray`.
- Form UI binds and validates those fields.
- Submit handler (old L165-174) passed only `{ proofOfWork, reason, type }` to `objectiveInstance.complete()`.

The SDK (`karma-gap-sdk/core/class/entities/ProjectMilestone.ts:152-156`) spreads the data object into the JSON schema, so the on-chain schema already accepts arbitrary keys — the gap was purely in the form's submit handler.

### Evidence (production indexer, read-only)

Two completed Tower Exchange project milestones have completion data keys: `['type', 'proofOfWork', 'reason']` and zero deliverables/outputs, despite the owner reporting that he filled metrics + deliverables in. The data shape confirms the form-side drop.

## Fix

Forward both arrays in the completion payload. A narrow intersection type captures the actual shape the SDK persists without using `as any`:

```ts
const completionPayload: IProjectMilestoneStatus & {
  outputs: SchemaType["outputs"];
  deliverables: SchemaType["deliverables"];
} = {
  proofOfWork: sanitizeInput(data.proofOfWork),
  reason: sanitizeInput(data.description),
  type: "project-milestone-completed",
  outputs: data.outputs,
  deliverables: data.deliverables,
};
```

## Test plan

- [ ] Mark a project milestone complete with at least one deliverable and one metric (output) — the completed card now shows both, no empty "Metrics" / em-dash placeholder.
- [ ] Mark complete with no outputs/deliverables — still works; arrays are persisted as empty.
- [ ] Existing already-completed milestones are unchanged (this only affects future completions).
- [ ] `pnpm lint:fix` and `tsc --noEmit` pass.

## Out of scope

- The grant-milestone form (`hooks/useMilestone.ts`) already passes `deliverables`. No change there.
- This PR does not migrate or backfill existing on-chain attestations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Milestone completion form now preserves outputs and deliverables in attestations and enforces the completion type.
* **Improvements**
  * Form payloads are validated and sanitized (trims description/proof, accepts empty proof or URL).
* **Tests**
  * Added unit tests covering payload construction, preservation of arrays, sanitization, and type stamping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->