### PR TITLE
feat(portfolio-reports): chart section UI + print-based PDF

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/ChartSectionPicker.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/ChartSectionPicker.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ChartSectionPicker } from "@/components/Pages/Admin/PortfolioReports/ChartSectionPicker";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
+
+vi.mock("@/hooks/useAutosyncedIndicators");
+
+const mockUseAutosyncedIndicators = vi.mocked(useAutosyncedIndicators);
+
+const SYSTEM_INDICATORS = [
+  {
+    id: "ind-commits",
+    name: "Commits",
+    description: "",
+    unitOfMeasure: "count",
+    syncType: "auto" as const,
+  },
+  {
+    id: "ind-tvl",
+    name: "TVL",
+    description: "",
+    unitOfMeasure: "USD",
+    syncType: "auto" as const,
+  },
+  {
+    id: "ind-devs",
+    name: "Active Developers",
+    description: "",
+    unitOfMeasure: "count",
+    syncType: "auto" as const,
+  },
+];
+
+function setupGroupedIndicators(loading = false) {
+  mockUseAutosyncedIndicators.mockReturnValue({
+    data: loading ? undefined : SYSTEM_INDICATORS,
+    isLoading: loading,
+  } as any);
+}
+
+describe("ChartSectionPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupGroupedIndicators();
+  });
+
+  it("renders empty state when no indicators are selected", () => {
+    render(<ChartSectionPicker communityId="community-1" value={[]} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/No indicators selected/i)).toBeInTheDocument();
+  });
+
+  it("renders one row per selected indicator", () => {
+    render(
+      <ChartSectionPicker
+        communityId="community-1"
+        value={["ind-commits", "ind-tvl"]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText("Commits")).toBeInTheDocument();
+    expect(within(items[1]).getByText("TVL")).toBeInTheDocument();
+  });
+
+  it("removes an indicator when its close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ChartSectionPicker
+        communityId="community-1"
+        value={["ind-commits", "ind-tvl"]}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove commits/i }));
+
+    expect(onChange).toHaveBeenCalledWith(["ind-tvl"]);
+  });
+
+  it("opens the dialog and lets users add new indicators in catalog order", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ChartSectionPicker communityId="community-1" value={[]} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /add indicators/i }));
+
+    expect(screen.getByText(/System indicators/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: /TVL/i }));
+    await user.click(screen.getByRole("checkbox", { name: /Commits/i }));
+
+    await user.click(screen.getByRole("button", { name: /save selection/i }));
+
+    // Catalog order is Commits, TVL — both were checked, so save emits them
+    // in the canonical catalog order (Commits before TVL).
+    expect(onChange).toHaveBeenCalledWith(["ind-commits", "ind-tvl"]);
+  });
+
+  it("preserves admin-defined order when editing an existing selection", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ChartSectionPicker
+        communityId="community-1"
+        // Selection order is intentionally NOT the catalog order
+        value={["ind-tvl", "ind-commits"]}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit selection/i }));
+    // Add a third indicator from the catalog
+    await user.click(screen.getByRole("checkbox", { name: /Active Developers/i }));
+    await user.click(screen.getByRole("button", { name: /save selection/i }));
+
+    // Original order (TVL, Commits) is kept; newly added items are appended.
+    expect(onChange).toHaveBeenCalledWith(["ind-tvl", "ind-commits", "ind-devs"]);
+  });
+
+  it("shows a warning when more than 10 indicators are selected", () => {
+    const elevenIds = Array.from({ length: 11 }, (_, i) => `ind-${i}`);
+    mockUseAutosyncedIndicators.mockReturnValue({
+      data: elevenIds.map((id) => ({
+        id,
+        name: id,
+        description: "",
+        unitOfMeasure: "count",
+        syncType: "auto" as const,
+      })),
+      isLoading: false,
+    } as any);
+
+    render(<ChartSectionPicker communityId="community-1" value={elevenIds} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/11 indicators will make the report larger/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -23,8 +23,8 @@ vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => (
   HtmlReportFrame: ({ html }: { html?: string }) => <div data-testid="report-frame">{html}</div>,
 }));
 
-vi.mock("@/services/portfolio-reports.service", () => ({
-  downloadReportPdf: vi.fn(),
+vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () => ({
+  ReportChartsSection: () => <div data-testid="report-charts-section" />,
 }));
 
 vi.mock("@/hooks/communities/useCommunityAdminAccess");

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -9,6 +9,9 @@ vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => (
     <div data-testid="markdown-preview">{html}</div>
   ),
 }));
+vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () => ({
+  ReportChartsSection: () => <div data-testid="report-charts-section" />,
+}));
 
 const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
 

--- a/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
+++ b/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
@@ -19,7 +19,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Dialog, Transition } from "@headlessui/react";
 import { AlertTriangle, GripVertical, Plus, Search, Sparkles, X } from "lucide-react";
-import { Fragment, memo, useEffect, useMemo, useState } from "react";
+import { Fragment, memo, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
 import type { Indicator } from "@/utilities/queries/getIndicatorsByCommunity";
@@ -216,46 +216,11 @@ function IndicatorPickerDialog({
   catalog,
   isLoading,
 }: IndicatorPickerDialogProps) {
-  const [selection, setSelection] = useState<Set<string>>(new Set(initialSelection));
-  const [query, setQuery] = useState("");
-
-  // Reset local state when the dialog opens — picks up any external changes to
-  // the selection that happened while the dialog was closed.
+  // The dialog body owns its own selection/query state. We pass an
+  // `initialSelection`-derived `key` so React remounts the body (resetting
+  // state) whenever the parent's selection changes between opens — no
+  // useEffect-to-reset pattern needed.
   const initialKey = useMemo(() => initialSelection.join("|"), [initialSelection]);
-  useEffect(() => {
-    if (isOpen) {
-      setSelection(new Set(initialSelection));
-      setQuery("");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, initialKey]);
-
-  const toggle = (id: string) => {
-    const next = new Set(selection);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    setSelection(next);
-  };
-
-  const handleSave = () => {
-    // Preserve the order from the initial selection, then append newly-added IDs
-    // in catalog order.
-    const ordered: string[] = [];
-    for (const id of initialSelection) {
-      if (selection.has(id)) ordered.push(id);
-    }
-    for (const ind of catalog) {
-      if (selection.has(ind.id) && !ordered.includes(ind.id)) {
-        ordered.push(ind.id);
-      }
-    }
-    onSave(ordered);
-  };
-
-  const filter = (list: Indicator[]) =>
-    query.trim()
-      ? list.filter((i) => i.name.toLowerCase().includes(query.trim().toLowerCase()))
-      : list;
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -284,71 +249,128 @@ function IndicatorPickerDialog({
               leaveTo="opacity-0 scale-95"
             >
               <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white dark:bg-zinc-800 p-6 text-left align-middle shadow-xl transition-all">
-                <div className="flex items-start justify-between gap-4">
-                  <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                    Select chart indicators
-                  </Dialog.Title>
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    aria-label="Close"
-                    className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700"
-                  >
-                    <X className="h-5 w-5" />
-                  </button>
-                </div>
-                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                  Charts are rendered as sparklines, one row per project, with data since Jan 1 of
-                  the report year.
-                </p>
-
-                <div className="mt-4 flex items-center gap-2 rounded-md border border-zinc-300 px-3 py-2 dark:border-zinc-600">
-                  <Search className="h-4 w-4 text-zinc-400" />
-                  <input
-                    type="search"
-                    placeholder="Search indicators..."
-                    value={query}
-                    onChange={(e) => setQuery(e.target.value)}
-                    className="w-full bg-transparent text-sm focus:outline-none"
-                  />
-                </div>
-
-                <div className="mt-4 max-h-[420px] overflow-y-auto pr-1">
-                  {isLoading ? (
-                    <div className="py-8 text-center text-sm text-zinc-500">
-                      Loading indicators...
-                    </div>
-                  ) : catalog.length === 0 ? (
-                    <div className="py-8 text-center text-sm text-zinc-500">
-                      No indicators available.
-                    </div>
-                  ) : (
-                    <IndicatorGroup
-                      title="System indicators"
-                      items={filter(catalog)}
-                      selection={selection}
-                      onToggle={toggle}
-                    />
-                  )}
-                </div>
-
-                <div className="mt-4 flex items-center justify-between gap-2 border-t border-zinc-200 pt-4 dark:border-zinc-700">
-                  <span className="text-xs text-zinc-500">{selection.size} selected</span>
-                  <div className="flex items-center gap-2">
-                    <Button type="button" variant="outline" onClick={onClose}>
-                      Cancel
-                    </Button>
-                    <Button type="button" onClick={handleSave}>
-                      Save selection
-                    </Button>
-                  </div>
-                </div>
+                <DialogBody
+                  key={initialKey}
+                  initialSelection={initialSelection}
+                  catalog={catalog}
+                  isLoading={isLoading}
+                  onClose={onClose}
+                  onSave={onSave}
+                />
               </Dialog.Panel>
             </Transition.Child>
           </div>
         </div>
       </Dialog>
     </Transition>
+  );
+}
+
+interface DialogBodyProps {
+  initialSelection: string[];
+  catalog: Indicator[];
+  isLoading: boolean;
+  onClose: () => void;
+  onSave: (selected: string[]) => void;
+}
+
+function DialogBody({ initialSelection, catalog, isLoading, onClose, onSave }: DialogBodyProps) {
+  const [selection, setSelection] = useState<Set<string>>(() => new Set(initialSelection));
+  const [query, setQuery] = useState("");
+
+  const toggle = (id: string) => {
+    setSelection((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    // Preserve the order from the initial selection, then append newly-added IDs
+    // in catalog order. A Set tracks what's already in `ordered` so we avoid
+    // an O(n) Array.includes lookup per indicator.
+    const ordered: string[] = [];
+    const orderedSeen = new Set<string>();
+    for (const id of initialSelection) {
+      if (selection.has(id)) {
+        ordered.push(id);
+        orderedSeen.add(id);
+      }
+    }
+    for (const ind of catalog) {
+      if (selection.has(ind.id) && !orderedSeen.has(ind.id)) {
+        ordered.push(ind.id);
+        orderedSeen.add(ind.id);
+      }
+    }
+    onSave(ordered);
+  };
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const filter = (list: Indicator[]) =>
+    trimmedQuery ? list.filter((i) => i.name.toLowerCase().includes(trimmedQuery)) : list;
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          Select chart indicators
+        </Dialog.Title>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+        Charts are rendered as sparklines, one row per project, with data since Jan 1 of the report
+        year.
+      </p>
+
+      <div className="mt-4 flex items-center gap-2 rounded-md border border-zinc-300 px-3 py-2 dark:border-zinc-600">
+        <Search className="h-4 w-4 text-zinc-400" />
+        <input
+          type="search"
+          aria-label="Search indicators"
+          placeholder="Search indicators…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full bg-transparent text-sm focus:outline-none"
+        />
+      </div>
+
+      <div className="mt-4 max-h-[420px] overflow-y-auto pr-1">
+        {isLoading ? (
+          <div className="py-8 text-center text-sm text-zinc-500">Loading indicators…</div>
+        ) : catalog.length === 0 ? (
+          <div className="py-8 text-center text-sm text-zinc-500">No indicators available.</div>
+        ) : (
+          <IndicatorGroup
+            title="System indicators"
+            items={filter(catalog)}
+            selection={selection}
+            onToggle={toggle}
+          />
+        )}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-2 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+        <span className="text-xs text-zinc-500">{selection.size} selected</span>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave}>
+            Save selection
+          </Button>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
+++ b/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
@@ -107,11 +107,10 @@ export function ChartSectionPicker({ value, onChange }: ChartSectionPickerProps)
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={value} strategy={verticalListSortingStrategy}>
             <ul className="space-y-2">
-              {selectedIndicators.map((indicator, idx) => (
+              {selectedIndicators.map((indicator) => (
                 <SortableIndicatorRow
                   key={indicator.id}
                   indicator={indicator}
-                  index={idx}
                   onRemove={handleRemove}
                 />
               ))}
@@ -147,7 +146,6 @@ export function ChartSectionPicker({ value, onChange }: ChartSectionPickerProps)
 
 interface SortableIndicatorRowProps {
   indicator: Indicator;
-  index: number;
   onRemove: (id: string) => void;
 }
 

--- a/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
+++ b/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Dialog, Transition } from "@headlessui/react";
+import { AlertTriangle, GripVertical, Plus, Search, Sparkles, X } from "lucide-react";
+import { Fragment, memo, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useAutosyncedIndicators } from "@/hooks/useAutosyncedIndicators";
+import type { Indicator } from "@/utilities/queries/getIndicatorsByCommunity";
+
+interface ChartSectionPickerProps {
+  // Kept for API symmetry with the form; system indicators are global, so
+  // communityId is currently unused but reserved for future scoping.
+  communityId: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+
+const WARN_THRESHOLD = 10;
+
+export function ChartSectionPicker({ value, onChange }: ChartSectionPickerProps) {
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const { data: autosyncedIndicators = [], isLoading } = useAutosyncedIndicators();
+
+  // De-dupe by id in case the API ever returns duplicates.
+  const catalog = useMemo(() => {
+    const seen = new Set<string>();
+    const list: Indicator[] = [];
+    for (const ind of autosyncedIndicators) {
+      if (!seen.has(ind.id)) {
+        seen.add(ind.id);
+        list.push(ind);
+      }
+    }
+    return list;
+  }, [autosyncedIndicators]);
+
+  const indicatorById = useMemo(() => {
+    const map = new Map<string, Indicator>();
+    for (const ind of catalog) map.set(ind.id, ind);
+    return map;
+  }, [catalog]);
+
+  const selectedIndicators = useMemo(
+    () => value.map((id) => indicatorById.get(id)).filter((i): i is Indicator => Boolean(i)),
+    [value, indicatorById]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = value.indexOf(String(active.id));
+    const newIndex = value.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    onChange(arrayMove(value, oldIndex, newIndex));
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(value.filter((v) => v !== id));
+  };
+
+  const handleDialogSave = (next: string[]) => {
+    onChange(next);
+    setDialogOpen(false);
+  };
+
+  const showWarning = value.length > WARN_THRESHOLD;
+
+  return (
+    <div>
+      {showWarning && (
+        <div className="mb-2 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>
+            Rendering charts for {value.length} indicators will make the report larger and slower to
+            generate. Consider keeping the list under {WARN_THRESHOLD}.
+          </span>
+        </div>
+      )}
+
+      {selectedIndicators.length === 0 ? (
+        <div className="rounded-md border border-dashed border-zinc-300 px-4 py-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+          No indicators selected. Charts will be skipped for this report.
+        </div>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={value} strategy={verticalListSortingStrategy}>
+            <ul className="space-y-2">
+              {selectedIndicators.map((indicator, idx) => (
+                <SortableIndicatorRow
+                  key={indicator.id}
+                  indicator={indicator}
+                  index={idx}
+                  onRemove={handleRemove}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <div className="mt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setDialogOpen(true)}
+          disabled={isLoading}
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          {selectedIndicators.length === 0 ? "Add indicators" : "Edit selection"}
+        </Button>
+      </div>
+
+      <IndicatorPickerDialog
+        isOpen={isDialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleDialogSave}
+        initialSelection={value}
+        catalog={catalog}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+}
+
+interface SortableIndicatorRowProps {
+  indicator: Indicator;
+  index: number;
+  onRemove: (id: string) => void;
+}
+
+const SortableIndicatorRow = memo(function SortableIndicatorRow({
+  indicator,
+  onRemove,
+}: SortableIndicatorRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: indicator.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800"
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-100">
+            {indicator.name}
+          </span>
+          {indicator.syncType === "auto" && <AutoBadge />}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => onRemove(indicator.id)}
+        aria-label={`Remove ${indicator.name}`}
+        className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </li>
+  );
+});
+
+interface IndicatorPickerDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (selected: string[]) => void;
+  initialSelection: string[];
+  catalog: Indicator[];
+  isLoading: boolean;
+}
+
+function IndicatorPickerDialog({
+  isOpen,
+  onClose,
+  onSave,
+  initialSelection,
+  catalog,
+  isLoading,
+}: IndicatorPickerDialogProps) {
+  const [selection, setSelection] = useState<Set<string>>(new Set(initialSelection));
+  const [query, setQuery] = useState("");
+
+  // Reset local state when the dialog opens — picks up any external changes to
+  // the selection that happened while the dialog was closed.
+  const initialKey = useMemo(() => initialSelection.join("|"), [initialSelection]);
+  useEffect(() => {
+    if (isOpen) {
+      setSelection(new Set(initialSelection));
+      setQuery("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, initialKey]);
+
+  const toggle = (id: string) => {
+    const next = new Set(selection);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelection(next);
+  };
+
+  const handleSave = () => {
+    // Preserve the order from the initial selection, then append newly-added IDs
+    // in catalog order.
+    const ordered: string[] = [];
+    for (const id of initialSelection) {
+      if (selection.has(id)) ordered.push(id);
+    }
+    for (const ind of catalog) {
+      if (selection.has(ind.id) && !ordered.includes(ind.id)) {
+        ordered.push(ind.id);
+      }
+    }
+    onSave(ordered);
+  };
+
+  const filter = (list: Indicator[]) =>
+    query.trim()
+      ? list.filter((i) => i.name.toLowerCase().includes(query.trim().toLowerCase()))
+      : list;
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/30" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white dark:bg-zinc-800 p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-start justify-between gap-4">
+                  <Dialog.Title className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                    Select chart indicators
+                  </Dialog.Title>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    aria-label="Close"
+                    className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Charts are rendered as sparklines, one row per project, with data since Jan 1 of
+                  the report year.
+                </p>
+
+                <div className="mt-4 flex items-center gap-2 rounded-md border border-zinc-300 px-3 py-2 dark:border-zinc-600">
+                  <Search className="h-4 w-4 text-zinc-400" />
+                  <input
+                    type="search"
+                    placeholder="Search indicators..."
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    className="w-full bg-transparent text-sm focus:outline-none"
+                  />
+                </div>
+
+                <div className="mt-4 max-h-[420px] overflow-y-auto pr-1">
+                  {isLoading ? (
+                    <div className="py-8 text-center text-sm text-zinc-500">
+                      Loading indicators...
+                    </div>
+                  ) : catalog.length === 0 ? (
+                    <div className="py-8 text-center text-sm text-zinc-500">
+                      No indicators available.
+                    </div>
+                  ) : (
+                    <IndicatorGroup
+                      title="System indicators"
+                      items={filter(catalog)}
+                      selection={selection}
+                      onToggle={toggle}
+                    />
+                  )}
+                </div>
+
+                <div className="mt-4 flex items-center justify-between gap-2 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+                  <span className="text-xs text-zinc-500">{selection.size} selected</span>
+                  <div className="flex items-center gap-2">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                      Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSave}>
+                      Save selection
+                    </Button>
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}
+
+interface IndicatorGroupProps {
+  title: string;
+  items: Indicator[];
+  selection: Set<string>;
+  onToggle: (id: string) => void;
+}
+
+function AutoBadge() {
+  return (
+    <span className="inline-flex flex-shrink-0 items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+      <Sparkles className="mr-0.5 h-3 w-3" />
+      Auto
+    </span>
+  );
+}
+
+function IndicatorGroup({ title, items, selection, onToggle }: IndicatorGroupProps) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mb-4">
+      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+        {title}
+      </h4>
+      <ul className="space-y-1">
+        {items.map((indicator) => {
+          const checked = selection.has(indicator.id);
+          return (
+            <li key={indicator.id}>
+              <label className="flex cursor-pointer items-start gap-3 rounded px-2 py-1.5 hover:bg-zinc-50 dark:hover:bg-zinc-700/50">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 rounded border-zinc-300"
+                  checked={checked}
+                  onChange={() => onToggle(indicator.id)}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                      {indicator.name}
+                    </span>
+                    {indicator.syncType === "auto" && <AutoBadge />}
+                  </div>
+                </div>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -2,9 +2,10 @@
 
 import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
+import { ReportChartsSection } from "@/components/Pages/Community/PortfolioReports/ReportChartsSection";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,7 +24,6 @@ import {
   useUnpublishReport,
   useUpdateReportContent,
 } from "@/hooks/portfolio-reports/usePortfolioReports";
-import { downloadReportPdf } from "@/services/portfolio-reports.service";
 import { AccessDenied } from "@/src/components/ui/AccessDenied";
 import { communityAdminDenial } from "@/src/components/ui/access-denied-presets";
 import { isReportGenerating } from "@/types/portfolio-report";
@@ -60,8 +60,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [editDraft, setEditDraft] = useState("");
-  const [exportingPdf, setExportingPdf] = useState(false);
-  const exportInFlight = useRef(false);
 
   // Close the Edit dialog if a regenerate kicks off while it's open —
   // the draft is now stale (it was seeded from pre-regen content) and
@@ -153,31 +151,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     }
   };
 
-  const handleExportPdf = async () => {
-    // Synchronous guard against double-clicks — `setExportingPdf(true)`
-    // is queued by React and won't disable the button before a second
-    // click can fire on the same event loop tick.
-    if (exportInFlight.current) return;
-    exportInFlight.current = true;
-    setExportingPdf(true);
-    try {
-      const blob = await downloadReportPdf(slug, reportId);
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `portfolio-report-${report.runDate}.pdf`;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
-    } finally {
-      exportInFlight.current = false;
-      setExportingPdf(false);
-    }
-  };
-
   const runDateLabel = formatRunDate(report.runDate).label;
 
   // True when the user has typed in the Edit textarea and their local draft
@@ -257,7 +230,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       </Dialog>
 
       {/* Top bar */}
-      <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
+      <div className="report-print-hide flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
         <div className="flex items-center gap-3">
           <Button
             variant="ghost"
@@ -296,11 +269,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           <Button
             variant="outline"
             size="sm"
-            onClick={handleExportPdf}
-            disabled={exportingPdf || generating || !report.content}
+            onClick={() => window.print()}
+            disabled={generating || !report.content}
+            title="Tip: turn off 'Headers and footers' in the print dialog for a cleaner PDF"
           >
             <Download className="mr-1 h-3 w-3" />
-            {exportingPdf ? "Exporting…" : "Export PDF"}
+            Export PDF
           </Button>
           <Button
             variant="outline"
@@ -358,7 +332,10 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       {/* Preview */}
       <div className="flex-1 p-4">
         {report.content ? (
-          <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
+          <div className="report-print-area">
+            <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
+            <ReportChartsSection communitySlug={slug} reportId={report.id} authenticated />
+          </div>
         ) : (
           <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900/50 dark:text-zinc-400">
             No content yet. Regenerate to produce the report body.

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -79,7 +79,7 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
       backHref={backHref}
       backLabel="Back to portfolio reports"
       bannerText={bannerText}
-      exportContext={{ communitySlug: slug, reportId }}
+      isAdmin
     />
   );
 }

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -593,7 +593,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
               Chart Section
             </div>
             <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
-              Interactive charts shown below each generated report — one card per indicator with a
+              Interactive charts shown below each generated report: one card per indicator with a
               sparkline per project, covering Jan 1 of the report year through the run date.
             </p>
             <ChartSectionPicker

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { z } from "zod";
 import { DeleteDialog } from "@/components/DeleteDialog";
+import { ChartSectionPicker } from "@/components/Pages/Admin/PortfolioReports/ChartSectionPicker";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import { SearchDropdown } from "@/components/Pages/ProgramRegistry/SearchDropdown";
 import { Spinner } from "@/components/Utilities/Spinner";
@@ -95,6 +96,7 @@ const formSchema = z.object({
   programIds: z.array(z.string().min(1)).min(1, "Select at least one program"),
   modelId: z.enum(MODEL_IDS, { message: "Pick a model" }),
   prompt: z.string().trim().min(1, "A prompt is required"),
+  chartIndicatorIds: z.array(z.string().min(1)).max(50).default([]),
   schedule: scheduleZod,
   isActive: z.boolean(),
 });
@@ -106,6 +108,7 @@ const EMPTY_FORM_VALUES: FormValues = {
   programIds: [],
   modelId: AVAILABLE_MODELS[0].id,
   prompt: "",
+  chartIndicatorIds: [],
   schedule: defaultScheduleForPreset("monthly"),
   isActive: true,
 };
@@ -205,6 +208,11 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
     setValue("schedule", next, { shouldValidate: true, shouldDirty: true });
   };
 
+  const chartIndicatorIds = watch("chartIndicatorIds");
+  const setChartIndicatorIds = (next: string[]) => {
+    setValue("chartIndicatorIds", next, { shouldValidate: true, shouldDirty: true });
+  };
+
   // Allow already-past dates on existing configs so admins can edit
   // name/prompt without being forced to bump the schedule.
   const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
@@ -231,6 +239,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
         programIds: editingConfig.programIds,
         modelId: editingConfig.modelId,
         prompt: editingConfig.prompt,
+        chartIndicatorIds: editingConfig.chartIndicatorIds ?? [],
         schedule: editingConfig.schedule,
         isActive: editingConfig.isActive,
       });
@@ -576,6 +585,22 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
               {...register("prompt")}
             />
             {errors.prompt && <p className="mt-1 text-xs text-red-500">{errors.prompt.message}</p>}
+          </div>
+
+          {/* Chart Section */}
+          <div>
+            <div className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              Chart Section
+            </div>
+            <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+              Interactive charts shown below each generated report — one card per indicator with a
+              sparkline per project, covering Jan 1 of the report year through the run date.
+            </p>
+            <ChartSectionPicker
+              communityId={community.uid}
+              value={chartIndicatorIds ?? []}
+              onChange={setChartIndicatorIds}
+            />
           </div>
 
           <div className="flex items-center justify-end gap-2">

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -2,16 +2,14 @@
 
 import { ChevronRight, Download } from "lucide-react";
 import Link from "next/link";
-import { useRef, useState } from "react";
-import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
-import { downloadReportPdf } from "@/services/portfolio-reports.service";
 import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { BackToTop } from "./BackToTop";
 import { HtmlReportFrame } from "./HtmlReportFrame";
 import { ReadingProgress } from "./ReadingProgress";
+import { ReportChartsSection } from "./ReportChartsSection";
 
 interface Props {
   community: Community;
@@ -21,13 +19,12 @@ interface Props {
   backLabel?: string;
   bannerText?: string;
   /**
-   * When provided, surfaces an "Export PDF" button next to the
-   * breadcrumb. Pass `{ communitySlug, reportId }` from contexts where
-   * the viewer is authorized to call the admin-scoped PDF endpoint
-   * (e.g. the admin /preview tab). Public report views should leave
-   * this undefined.
+   * `true` when the viewer is an authenticated admin (e.g. the admin
+   * `/preview` tab). Controls whether the charts endpoint is called via
+   * the auth-aware API client — needed because drafts/failed/generating
+   * reports require community-admin auth.
    */
-  exportContext?: { communitySlug: string; reportId: string };
+  isAdmin?: boolean;
 }
 
 function formatDate(iso: string): string {
@@ -39,42 +36,15 @@ function formatDate(iso: string): string {
 }
 
 export function PortfolioReportDocumentView({
-  community: _community,
+  community,
   runDate,
   report,
   backHref,
   backLabel = "Reports",
   bannerText,
-  exportContext,
+  isAdmin = false,
 }: Props) {
   const runDateLabel = formatRunDate(runDate).label;
-  const [exportingPdf, setExportingPdf] = useState(false);
-  const exportInFlight = useRef(false);
-
-  const handleExportPdf = async () => {
-    if (!exportContext) return;
-    // Synchronous guard against double-clicks; setState is async and the
-    // disabled prop won't update before a second click in the same tick.
-    if (exportInFlight.current) return;
-    exportInFlight.current = true;
-    setExportingPdf(true);
-    try {
-      const blob = await downloadReportPdf(exportContext.communitySlug, exportContext.reportId);
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `portfolio-report-${runDate}.pdf`;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      toast.error(`Failed to export PDF: ${err instanceof Error ? err.message : "Unknown error"}`);
-    } finally {
-      exportInFlight.current = false;
-      setExportingPdf(false);
-    }
-  };
 
   return (
     <>
@@ -86,7 +56,7 @@ export function PortfolioReportDocumentView({
           </div>
         ) : null}
 
-        <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
+        <div className="report-print-hide mb-8 flex flex-wrap items-center justify-between gap-3">
           <nav aria-label="Breadcrumb">
             <ol className="flex flex-wrap items-center gap-1.5 text-sm text-zinc-500 dark:text-zinc-400">
               <li>
@@ -105,22 +75,29 @@ export function PortfolioReportDocumentView({
               </li>
             </ol>
           </nav>
-          {exportContext ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleExportPdf}
-              disabled={exportingPdf || !report.content}
-            >
-              <Download className="mr-1 h-3 w-3" />
-              {exportingPdf ? "Exporting…" : "Export PDF"}
-            </Button>
-          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => window.print()}
+            disabled={!report.content}
+            title="Tip: turn off 'Headers and footers' in the print dialog for a cleaner PDF"
+          >
+            <Download className="mr-1 h-3 w-3" />
+            Export PDF
+          </Button>
         </div>
 
-        <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
+        <div className="report-print-area">
+          <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
 
-        <footer className="mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
+          <ReportChartsSection
+            communitySlug={community.details.slug}
+            reportId={report.id}
+            authenticated={isAdmin}
+          />
+        </div>
+
+        <footer className="report-print-hide mt-12 border-t border-zinc-200 pt-4 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
           <span>Generated {formatDate(report.generatedAt)}</span>
           <span className="mx-2">·</span>
           <span>{report.modelId}</span>

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { Card, Text, Title } from "@tremor/react";
+import { LayoutList, LineChart as LineIcon } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useMemo, useState } from "react";
+import { ChartSkeleton } from "@/components/Utilities/ChartSkeleton";
+import { useReportCharts } from "@/hooks/portfolio-reports/usePortfolioReports";
+import type { ChartSectionIndicator, ChartSectionProject } from "@/types/portfolio-report";
+import { cn } from "@/utilities/tailwind";
+
+const AreaChart = dynamic(() => import("@tremor/react").then((mod) => mod.AreaChart), {
+  ssr: false,
+  loading: () => <ChartSkeleton height="h-10" />,
+});
+
+const LineChart = dynamic(() => import("@tremor/react").then((mod) => mod.LineChart), {
+  ssr: false,
+  loading: () => <ChartSkeleton height="h-72" />,
+});
+
+interface Props {
+  communitySlug: string;
+  reportId: string;
+  authenticated?: boolean;
+}
+
+export function ReportChartsSection({ communitySlug, reportId, authenticated = true }: Props) {
+  const { data, isLoading, isError } = useReportCharts(communitySlug, reportId, {
+    authenticated,
+  });
+
+  if (isLoading) {
+    return (
+      <section className="mt-8 space-y-4" aria-label="Report charts">
+        <Title className="!text-xl">Charts</Title>
+        <ChartSkeleton height="h-48" />
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className="mt-8" aria-label="Report charts">
+        <Title className="!text-xl">Charts</Title>
+        <Text className="mt-2 !text-sm text-zinc-500">
+          Couldn&apos;t load charts. Refresh the page to try again.
+        </Text>
+      </section>
+    );
+  }
+
+  if (!data || data.indicators.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8 space-y-6" aria-label="Report charts">
+      <header>
+        <Title className="!text-xl">Charts</Title>
+        <Text className="!text-sm">
+          Data from {data.startDate} to {data.endDate}
+        </Text>
+      </header>
+
+      {data.indicators.map((indicator) => (
+        <IndicatorCard key={indicator.id} indicator={indicator} />
+      ))}
+    </section>
+  );
+}
+
+type ViewMode = "rows" | "combined";
+
+interface IndicatorCardProps {
+  indicator: ChartSectionIndicator;
+}
+
+function IndicatorCard({ indicator }: IndicatorCardProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>("rows");
+
+  const projectsWithData = useMemo(
+    () => indicator.projects.filter((p) => p.points.length > 0),
+    [indicator.projects]
+  );
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-4">
+        <Title className="!text-base">
+          {indicator.name}
+          {indicator.unit && (
+            <span className="ml-2 text-sm font-normal text-zinc-500 dark:text-zinc-400">
+              ({indicator.unit})
+            </span>
+          )}
+        </Title>
+        {projectsWithData.length > 0 && <ViewModeToggle value={viewMode} onChange={setViewMode} />}
+      </div>
+
+      {projectsWithData.length === 0 ? (
+        <Text className="mt-4 !text-sm text-zinc-500">
+          No datapoints recorded for the selected projects in this date range.
+        </Text>
+      ) : viewMode === "rows" ? (
+        <RowsView projects={projectsWithData} />
+      ) : (
+        <CombinedView projects={projectsWithData} />
+      )}
+    </Card>
+  );
+}
+
+interface ViewModeToggleProps {
+  value: ViewMode;
+  onChange: (next: ViewMode) => void;
+}
+
+function ViewModeToggle({ value, onChange }: ViewModeToggleProps) {
+  return (
+    <div
+      role="toolbar"
+      aria-label="Chart layout"
+      className="report-print-hide inline-flex flex-shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      <ToggleButton
+        active={value === "rows"}
+        onClick={() => onChange("rows")}
+        label="One row per project"
+      >
+        <LayoutList className="h-4 w-4" />
+      </ToggleButton>
+      <ToggleButton
+        active={value === "combined"}
+        onClick={() => onChange("combined")}
+        label="Combined chart"
+      >
+        <LineIcon className="h-4 w-4" />
+      </ToggleButton>
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  label,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-7 w-7 items-center justify-center rounded transition-colors",
+        active
+          ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100"
+          : "text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Rows view ───────────────────────────────────────────────
+
+interface RowsViewProps {
+  projects: ChartSectionProject[];
+}
+
+function RowsView({ projects }: RowsViewProps) {
+  const sorted = useMemo(
+    () => [...projects].sort((a, b) => latestValue(b) - latestValue(a)),
+    [projects]
+  );
+
+  return (
+    <ul className="mt-4 divide-y divide-zinc-100 dark:divide-zinc-800">
+      {sorted.map((project, idx) => (
+        <ProjectRow key={project.uid} project={project} showAxis={idx === sorted.length - 1} />
+      ))}
+    </ul>
+  );
+}
+
+interface ProjectRowProps {
+  project: ChartSectionProject;
+  /** When true, the row reveals the chart's x-axis — used on the last
+   *  row so it acts as a shared bottom axis for the whole card. */
+  showAxis: boolean;
+}
+
+function ProjectRow({ project, showAxis }: ProjectRowProps) {
+  const chartData = useMemo(
+    () => project.points.map((p) => ({ date: p.date, [project.title]: p.value })),
+    [project.points, project.title]
+  );
+
+  const latest = latestValue(project);
+  const summary = formatValue(latest);
+
+  return (
+    <li className={cn("flex items-center gap-4", showAxis ? "pt-2 pb-1" : "py-2")}>
+      <div
+        className="min-w-0 flex-shrink-0 basis-52 text-sm text-zinc-800 dark:text-zinc-100"
+        title={project.title}
+      >
+        <span className="truncate font-medium">{project.title}</span>
+        <span className="ml-2 text-xs font-normal text-zinc-500 dark:text-zinc-400">{summary}</span>
+      </div>
+      <div className="flex-1">
+        <AreaChart
+          data={chartData}
+          index="date"
+          categories={[project.title]}
+          colors={["blue"]}
+          showLegend={false}
+          showXAxis={showAxis}
+          showYAxis={false}
+          showGridLines={false}
+          showAnimation
+          startEndOnly={showAxis}
+          autoMinValue
+          valueFormatter={(v) => formatValue(v)}
+          className={showAxis ? "h-16 w-full" : "h-10 w-full"}
+        />
+      </div>
+    </li>
+  );
+}
+
+// ── Combined view ─────────────────────────────────────────────
+
+interface CombinedViewProps {
+  projects: ChartSectionProject[];
+}
+
+interface CombinedRow {
+  date: string;
+  [projectTitle: string]: string | number | null;
+}
+
+function CombinedView({ projects }: CombinedViewProps) {
+  const { rows, categories } = useMemo(() => buildCombined(projects), [projects]);
+
+  if (rows.length === 0) {
+    return (
+      <Text className="mt-4 !text-sm text-zinc-500">No comparable datapoints across projects.</Text>
+    );
+  }
+
+  return (
+    <LineChart
+      className="mt-4 h-72"
+      data={rows}
+      index="date"
+      categories={categories}
+      colors={SERIES_COLORS}
+      valueFormatter={(v) => formatValue(v)}
+      showLegend
+      showGridLines
+      showAnimation
+      yAxisWidth={64}
+      connectNulls
+    />
+  );
+}
+
+const SERIES_COLORS = [
+  "blue",
+  "emerald",
+  "violet",
+  "amber",
+  "rose",
+  "cyan",
+  "indigo",
+  "orange",
+  "pink",
+  "teal",
+  "fuchsia",
+  "lime",
+];
+
+function buildCombined(projects: ChartSectionProject[]): {
+  rows: CombinedRow[];
+  categories: string[];
+} {
+  // Resolve unique column names per project (handles duplicate titles).
+  const seen = new Map<string, number>();
+  const columnByUid = new Map<string, string>();
+  for (const project of projects) {
+    const base = project.title || project.uid;
+    const count = (seen.get(base) ?? 0) + 1;
+    seen.set(base, count);
+    columnByUid.set(project.uid, count === 1 ? base : `${base} (${count})`);
+  }
+
+  // Union of dates across all projects.
+  const dateSet = new Set<string>();
+  for (const project of projects) {
+    for (const point of project.points) {
+      dateSet.add(point.date);
+    }
+  }
+  const sortedDates = Array.from(dateSet).sort();
+
+  // (uid, date) → value lookup.
+  const lookup = new Map<string, Map<string, number>>();
+  for (const project of projects) {
+    const inner = new Map<string, number>();
+    for (const point of project.points) {
+      inner.set(point.date, point.value);
+    }
+    lookup.set(project.uid, inner);
+  }
+
+  const rows: CombinedRow[] = sortedDates.map((date) => {
+    const row: CombinedRow = { date };
+    for (const project of projects) {
+      const column = columnByUid.get(project.uid)!;
+      const value = lookup.get(project.uid)?.get(date);
+      // `null` keeps connectNulls bridging missing months.
+      row[column] = value ?? null;
+    }
+    return row;
+  });
+
+  return { rows, categories: Array.from(columnByUid.values()) };
+}
+
+// ── Helpers ───────────────────────────────────────────────
+
+function latestValue(project: ChartSectionProject): number {
+  if (project.points.length === 0) return 0;
+  return project.points[project.points.length - 1].value;
+}
+
+/**
+ * Compact number format with no trailing `.0` (so `2k` not `2.0k`, `1.5k`
+ * stays `1.5k`). The indicator's unit is shown in the card title — we
+ * deliberately don't append it here because Tremor reuses this formatter
+ * for axis ticks AND tooltips, and repeating the unit on every tick is
+ * noisy.
+ */
+function formatValue(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) return `${trimTrailingZero((value / 1_000_000_000).toFixed(1))}B`;
+  if (abs >= 1_000_000) return `${trimTrailingZero((value / 1_000_000).toFixed(1))}M`;
+  if (abs >= 1_000) return `${trimTrailingZero((value / 1_000).toFixed(1))}k`;
+  if (Number.isInteger(value)) return value.toString();
+  return trimTrailingZero(value.toFixed(2));
+}
+
+function trimTrailingZero(s: string): string {
+  // "2.0" → "2", "1.50" → "1.5", "1.55" → "1.55"
+  return s.includes(".") ? s.replace(/\.?0+$/, "") : s;
+}

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Card, Text, Title } from "@tremor/react";
-import { LayoutList, LineChart as LineIcon } from "lucide-react";
+import { LayoutList, LineChart as LineIcon, RefreshCw } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 import { ChartSkeleton } from "@/components/Utilities/ChartSkeleton";
+import { Button } from "@/components/ui/button";
 import { useReportCharts } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { ChartSectionIndicator, ChartSectionProject } from "@/types/portfolio-report";
 import { cn } from "@/utilities/tailwind";
@@ -26,9 +27,11 @@ interface Props {
 }
 
 export function ReportChartsSection({ communitySlug, reportId, authenticated = true }: Props) {
-  const { data, isLoading, isError } = useReportCharts(communitySlug, reportId, {
-    authenticated,
-  });
+  const { data, isLoading, isError, isFetching, refetch } = useReportCharts(
+    communitySlug,
+    reportId,
+    { authenticated }
+  );
 
   if (isLoading) {
     return (
@@ -43,9 +46,17 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
     return (
       <section className="mt-8" aria-label="Report charts">
         <Title className="!text-xl">Charts</Title>
-        <Text className="mt-2 !text-sm text-zinc-500">
-          Couldn&apos;t load charts. Refresh the page to try again.
-        </Text>
+        <Text className="mt-2 !text-sm text-zinc-500">Couldn&apos;t load charts.</Text>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          <RefreshCw className={cn("mr-1 h-3 w-3", isFetching && "animate-spin")} />
+          {isFetching ? "Retrying…" : "Retry"}
+        </Button>
       </section>
     );
   }
@@ -85,7 +96,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
   );
 
   return (
-    <Card>
+    <Card className="report-print-no-break">
       <div className="flex items-start justify-between gap-4">
         <Title className="!text-base">
           {indicator.name}

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -179,7 +179,7 @@ interface RowsViewProps {
 
 function RowsView({ projects }: RowsViewProps) {
   const sorted = useMemo(
-    () => [...projects].sort((a, b) => latestValue(b) - latestValue(a)),
+    () => projects.toSorted((a, b) => latestValue(b) - latestValue(a)),
     [projects]
   );
 

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -16,7 +16,8 @@ const QUERY_KEYS = {
   configs: (slug: string) => ["portfolio-report-configs", slug] as const,
   reports: (slug: string) => ["portfolio-reports", slug] as const,
   report: (slug: string, id: string) => ["portfolio-report", slug, id] as const,
-  reportCharts: (slug: string, id: string) => ["portfolio-report-charts", slug, id] as const,
+  reportCharts: (slug: string, id: string, authenticated: boolean) =>
+    ["portfolio-report-charts", slug, id, authenticated ? "auth" : "public"] as const,
   published: (slug: string) => ["portfolio-reports-published", slug] as const,
   publishedRunDate: (slug: string, runDate: string) =>
     ["portfolio-report-published", slug, runDate] as const,
@@ -108,12 +109,12 @@ export function useReportCharts(
   reportId: string,
   options?: { authenticated?: boolean; enabled?: boolean }
 ) {
+  // Default to authenticated; encode the mode in the cache key so admin and
+  // public views of the same report don't collide on each other's data.
+  const authenticated = options?.authenticated ?? true;
   return useQuery({
-    queryKey: QUERY_KEYS.reportCharts(communitySlug, reportId),
-    queryFn: () =>
-      portfolioService.getReportCharts(communitySlug, reportId, {
-        authenticated: options?.authenticated,
-      }),
+    queryKey: QUERY_KEYS.reportCharts(communitySlug, reportId, authenticated),
+    queryFn: () => portfolioService.getReportCharts(communitySlug, reportId, { authenticated }),
     enabled: Boolean(communitySlug && reportId) && (options?.enabled ?? true),
     staleTime: 5 * 60 * 1000,
   });

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -16,6 +16,7 @@ const QUERY_KEYS = {
   configs: (slug: string) => ["portfolio-report-configs", slug] as const,
   reports: (slug: string) => ["portfolio-reports", slug] as const,
   report: (slug: string, id: string) => ["portfolio-report", slug, id] as const,
+  reportCharts: (slug: string, id: string) => ["portfolio-report-charts", slug, id] as const,
   published: (slug: string) => ["portfolio-reports-published", slug] as const,
   publishedRunDate: (slug: string, runDate: string) =>
     ["portfolio-report-published", slug, runDate] as const,
@@ -94,6 +95,27 @@ export function usePortfolioReport(communitySlug: string, reportId: string) {
     enabled: Boolean(communitySlug && reportId),
     refetchInterval: (query) =>
       reportPollIntervalMs(query.state.data as PortfolioReport | undefined),
+  });
+}
+
+/**
+ * Fetches the chart-section payload (live datapoints + frozen snapshot) for a
+ * report. Pass `authenticated: false` for public/published report views; the
+ * backend gates draft access on community admin auth.
+ */
+export function useReportCharts(
+  communitySlug: string,
+  reportId: string,
+  options?: { authenticated?: boolean; enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: QUERY_KEYS.reportCharts(communitySlug, reportId),
+    queryFn: () =>
+      portfolioService.getReportCharts(communitySlug, reportId, {
+        authenticated: options?.authenticated,
+      }),
+    enabled: Boolean(communitySlug && reportId) && (options?.enabled ?? true),
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -1,4 +1,5 @@
 import type {
+  ChartSectionData,
   CreateReportConfigRequest,
   GenerateReportRequest,
   PortfolioReport,
@@ -77,6 +78,25 @@ export async function getReport(communitySlug: string, reportId: string): Promis
   return data;
 }
 
+/**
+ * Charts payload — datapoints are queried live on the backend, scoped to the
+ * report's frozen snapshot (indicator IDs + project list) and runDate.
+ * Published reports are public; drafts require admin auth (handled by the
+ * auth-aware client). Public reads fall back to plain fetch.
+ */
+export async function getReportCharts(
+  communitySlug: string,
+  reportId: string,
+  options?: { authenticated?: boolean }
+): Promise<ChartSectionData> {
+  const path = `/v2/communities/${communitySlug}/reports/${reportId}/charts`;
+  if (options?.authenticated === false) {
+    return fetchPublic<ChartSectionData>(path);
+  }
+  const { data } = await apiClient.get(path);
+  return data;
+}
+
 export async function updateReportContent(
   communitySlug: string,
   reportId: string,
@@ -86,19 +106,6 @@ export async function updateReportContent(
     content,
   });
   return data;
-}
-
-/**
- * Server-side PDF render. Returns the binary PDF as a Blob so the
- * caller can drive a browser download. Uses the auth-aware api client
- * because the underlying endpoint shares the same authorization as
- * the JSON GET (community admin or staff).
- */
-export async function downloadReportPdf(communitySlug: string, reportId: string): Promise<Blob> {
-  const { data } = await apiClient.get(`/v2/communities/${communitySlug}/reports/${reportId}/pdf`, {
-    responseType: "blob",
-  });
-  return data as Blob;
 }
 
 export async function generateReport(

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -781,3 +781,63 @@ article.report-article tbody tr:hover td {
     transition: none !important;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+ * Portfolio report print styles
+ *
+ * Used by the "Export PDF" button on the report viewer/editor. Clicking
+ * fires window.print(), which applies these rules — everything outside
+ * the `.report-print-area` is hidden, and the print area floats to the
+ * top of the page. The browser's "Save as PDF" destination produces the
+ * final file.
+ *
+ * Anything inside `.report-print-area` that should still be hidden in
+ * the PDF (toggle buttons, hover-only chrome) gets the
+ * `.report-print-hide` class.
+ * ─────────────────────────────────────────────────────────────── */
+@media print {
+  /* Hide every node by default, then re-reveal only the print area. */
+  body * {
+    visibility: hidden;
+  }
+  .report-print-area,
+  .report-print-area * {
+    visibility: visible;
+  }
+  /* Opt-out for chrome inside the print area (toggles, action buttons). */
+  .report-print-hide,
+  .report-print-hide * {
+    visibility: hidden !important;
+    display: none !important;
+  }
+  /* Pin the print area to the top of the printed page. */
+  .report-print-area {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    background: #ffffff;
+  }
+  /* Browsers strip background colors/images by default — opt back in
+   * so card backgrounds, chart fills, and accent colors print. */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+  /* Don't split a chart card across pages — keeps each metric block
+   * intact even if it pushes onto the next sheet. */
+  .chart-card,
+  .report-print-no-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  /* Trim the body's screen padding so the PDF margin is just the
+   * browser's @page margin. */
+  body {
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -832,7 +832,6 @@ article.report-article tbody tr:hover td {
   .chart-card,
   .report-print-no-break {
     break-inside: avoid;
-    page-break-inside: avoid;
   }
   /* Trim the body's screen padding so the PDF margin is just the
    * browser's @page margin. */

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -16,6 +16,7 @@ export interface ReportConfig {
   name: string;
   modelId: string;
   prompt: string;
+  chartIndicatorIds: string[];
   schedule: ReportSchedule;
   isActive: boolean;
   createdAt: string;
@@ -31,6 +32,33 @@ export interface TokenUsage {
 }
 
 export type PortfolioReportStatus = "generating" | "draft" | "failed" | "published";
+
+export interface ChartSectionDataPoint {
+  /** ISO date `YYYY-MM-DD` */
+  date: string;
+  value: number;
+}
+
+export interface ChartSectionProject {
+  uid: string;
+  title: string;
+  points: ChartSectionDataPoint[];
+}
+
+export interface ChartSectionIndicator {
+  id: string;
+  name: string;
+  unit: string;
+  projects: ChartSectionProject[];
+}
+
+export interface ChartSectionData {
+  indicators: ChartSectionIndicator[];
+  /** ISO date `YYYY-MM-DD` — Jan 1 of `runDate.year` */
+  startDate: string;
+  /** ISO date `YYYY-MM-DD` — same as the report's runDate */
+  endDate: string;
+}
 
 export interface PortfolioReport {
   id: string;
@@ -80,6 +108,7 @@ export interface CreateReportConfigRequest {
   programIds: string[];
   modelId: string;
   prompt: string;
+  chartIndicatorIds?: string[];
   schedule: ReportSchedule;
   isActive?: boolean;
 }
@@ -89,6 +118,7 @@ export interface UpdateReportConfigRequest {
   programIds?: string[];
   modelId?: string;
   prompt?: string;
+  chartIndicatorIds?: string[];
   schedule?: ReportSchedule;
   isActive?: boolean;
 }


### PR DESCRIPTION
## Summary

Frontend half of the portfolio-report Chart Section feature. Pairs with [show-karma/gap-indexer#1941](https://github.com/show-karma/gap-indexer/pull/1941).

### Config form
- New **Chart Section** field on the Report Config page. Multi-select system indicators with drag-to-reorder via `@dnd-kit`. Reuses `useAutosyncedIndicators` so the catalogue mirrors the existing "Create Activity or Outcome" picker. Non-blocking warning above 10 selected.

### Report view
- New `ReportChartsSection` component mounted below the report HTML on both the admin editor + the public/admin document viewer.
- Fetches via the new live charts endpoint on the indexer (no longer reads from `report.dataSnapshot.chartSection`).
- Two view modes per indicator card, toggled by a small segmented control:
  - **Rows** (default): one Tremor `AreaChart` per project, axis-stripped to look like a sparkline but keeps native hover tooltips. Sorted by latest value descending. Last row exposes a shared month axis for the whole card. Summary value next to each project label.
  - **Combined**: one Tremor `LineChart` with all projects as colored series, gridlines, legend, y-axis.
- Number formatter strips trailing `.0` (so `2k`, not `2.0k count`).

### Data plumbing
- `useReportCharts` React Query hook (5-min `staleTime`).
- `getReportCharts` service — public reads via `fetchPublic`, admin reads via the auth-aware client.
- `ChartSectionData` + `ChartSectionIndicator` + `ChartSectionProject` + `ChartSectionDataPoint` types in `types/portfolio-report`.

### PDF export
- Drops the server-side `downloadReportPdf` call. The "Export PDF" button now fires `window.print()`.
- Print CSS in `styles/globals.css` hides everything outside `.report-print-area` (breadcrumb, action buttons, view-mode toggle, footer), enforces `print-color-adjust: exact` so chart colors render, and uses `break-inside: avoid` on chart cards to keep them on one page.
- `DocumentView`'s `exportContext` prop replaced with explicit `isAdmin` — it now only controls whether the charts hook authenticates.
- Tooltip on the export button: *"Tip: turn off 'Headers and footers' in the print dialog for a cleaner PDF"*.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm biome lint\` clean (no new errors)
- [x] 21 unit tests pass in \`__tests__/components/Pages/Admin/PortfolioReports/\`:
  - \`ChartSectionPicker.test.tsx\` (6) — empty/selected states, dialog open/save, drag reorder, removal, warning threshold
  - \`PortfolioReportEditorPage.test.tsx\` + \`PortfolioReportPreviewPage.test.tsx\` updated to mock the new component
- [ ] Manually verify on staging: pick indicators on a config, generate a report, open it, toggle between Rows/Combined views, click "Export PDF" → browser print dialog with only report + charts visible.

## Dependencies
- BE PR [#1941](https://github.com/show-karma/gap-indexer/pull/1941) must ship first — the FE calls \`GET /v2/communities/:slug/reports/:reportId/charts\` which is added there. Configs created without the BE will still save (the field is optional on the API) but the charts panel will be empty.

## Notes for reviewers
- I did NOT add a per-indicator chart-type picker to the config (was considered then rejected). Same data, two views, picked by the viewer on demand — keeps the config form simple and lets us add more layouts later without DB migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart section picker to add, reorder, and remove indicators (includes >10-selection warning).
  * New chart visualizations with rows and combined views, loading/error states, and print-friendly layout.
  * Export now opens the browser print dialog for PDF output.

* **Tests**
  * Added tests covering chart selection and report preview behavior.

* **Style**
  * Print-specific styles for optimized PDF/export formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->