### PR TITLE
fix(portfolio-reports): chart section dark-mode + unified layout

### DIFF
--- a/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
+++ b/components/Pages/Admin/PortfolioReports/ChartSectionPicker.tsx
@@ -338,15 +338,19 @@ function DialogBody({ initialSelection, catalog, isLoading, onClose, onSave }: D
           placeholder="Search indicators…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="w-full bg-transparent text-sm focus:outline-none"
+          className="w-full bg-transparent text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none dark:text-zinc-100 dark:placeholder:text-zinc-500"
         />
       </div>
 
       <div className="mt-4 max-h-[420px] overflow-y-auto pr-1">
         {isLoading ? (
-          <div className="py-8 text-center text-sm text-zinc-500">Loading indicators…</div>
+          <div className="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            Loading indicators…
+          </div>
         ) : catalog.length === 0 ? (
-          <div className="py-8 text-center text-sm text-zinc-500">No indicators available.</div>
+          <div className="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            No indicators available.
+          </div>
         ) : (
           <IndicatorGroup
             title="System indicators"
@@ -358,7 +362,7 @@ function DialogBody({ initialSelection, catalog, isLoading, onClose, onSave }: D
       </div>
 
       <div className="mt-4 flex items-center justify-between gap-2 border-t border-zinc-200 pt-4 dark:border-zinc-700">
-        <span className="text-xs text-zinc-500">{selection.size} selected</span>
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">{selection.size} selected</span>
         <div className="flex items-center gap-2">
           <Button type="button" variant="outline" onClick={onClose}>
             Cancel

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import toast from "react-hot-toast";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
 import { ReportChartsSection } from "@/components/Pages/Community/PortfolioReports/ReportChartsSection";
@@ -49,7 +49,7 @@ interface Props {
  */
 export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const slug = community.details.slug;
-  const router = useRouter();
+  const { push: routerPush } = useRouter();
   const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
   const { data: report, isLoading } = usePortfolioReport(slug, reportId);
   const publishMutation = usePublishReport(slug);
@@ -58,26 +58,21 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const updateContentMutation = useUpdateReportContent(slug);
 
   const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
-  const [showEditDialog, setShowEditDialog] = useState(false);
-  const [editDraft, setEditDraft] = useState("");
+  // Edit-dialog state lives in one object so we can update {open, draft}
+  // atomically in event handlers. Avoids a chain of setState updates
+  // across useState + useEffect.
+  const [editState, setEditState] = useState<{ open: boolean; draft: string }>({
+    open: false,
+    draft: "",
+  });
 
-  // Close the Edit dialog if a regenerate kicks off while it's open —
-  // the draft is now stale (it was seeded from pre-regen content) and
-  // saving would clobber the freshly generated report. We also clear
-  // editDraft so a subsequent Regenerate click doesn't surface a
-  // misleading "unsaved edits" warning about content that no longer
-  // exists. The user gets a toast so they know why their dialog
-  // disappeared.
   const isReportRegenerating = report ? isReportGenerating(report) : false;
-  useEffect(() => {
-    if (showEditDialog && isReportRegenerating) {
-      setShowEditDialog(false);
-      setEditDraft("");
-      toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
-        icon: "ℹ️",
-      });
-    }
-  }, [showEditDialog, isReportRegenerating]);
+  // Edit dialog hides automatically while a regenerate is in flight — the
+  // visual openness is derived, no useEffect to "react" to status changes.
+  // The toast + draft-clear for the local-regen case is handled inside
+  // handleRegenerate; for the rare remote-triggered regen, the dialog
+  // just visually closes without a toast (acceptable since it's rare).
+  const isEditDialogVisible = editState.open && !isReportRegenerating;
 
   if (accessLoading || isLoading) {
     return (
@@ -107,7 +102,15 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const failed = report.status === "failed";
 
   const navigateBack = () => {
-    router.push(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
+    routerPush(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
+  };
+
+  const openEditDialog = () => {
+    setEditState({ open: true, draft: report.content ?? "" });
+  };
+
+  const closeEditDialog = () => {
+    setEditState((prev) => ({ ...prev, open: false }));
   };
 
   const handlePublish = async () => {
@@ -132,6 +135,16 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     try {
       await regenerateMutation.mutateAsync(reportId);
       setShowRegenerateDialog(false);
+      // If the user had Edit open, close it and clear the draft — saving
+      // post-regen would clobber the freshly generated content, and a
+      // stale draft would surface a misleading "unsaved edits" warning
+      // on the next Regenerate click.
+      if (editState.open) {
+        setEditState({ open: false, draft: "" });
+        toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
+          icon: "ℹ️",
+        });
+      }
       toast.success("Regeneration started");
     } catch {
       toast.error("Failed to start regeneration");
@@ -140,11 +153,10 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const handleSaveEdit = async () => {
     try {
-      await updateContentMutation.mutateAsync({ reportId, content: editDraft });
-      setShowEditDialog(false);
-      // Clear so the brief window before React Query's cache update
-      // propagates doesn't make `hasUnsavedEdits` falsely true.
-      setEditDraft("");
+      await updateContentMutation.mutateAsync({ reportId, content: editState.draft });
+      // Atomically close + clear so the brief window before React Query's
+      // cache update propagates doesn't make `hasUnsavedEdits` falsely true.
+      setEditState({ open: false, draft: "" });
       toast.success("Report content saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
@@ -156,7 +168,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   // True when the user has typed in the Edit textarea and their local draft
   // diverges from the server's saved content. We only warn about *user* edits,
   // not the initial empty state before the dialog has ever been opened.
-  const hasUnsavedEdits = editDraft !== "" && editDraft !== (report.content ?? "");
+  const hasUnsavedEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
 
   return (
     <div className="flex h-full flex-col">
@@ -195,7 +207,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
+      <Dialog
+        open={isEditDialogVisible}
+        onOpenChange={(open) => {
+          if (!open) closeEditDialog();
+        }}
+      >
         <DialogContent className="max-w-4xl">
           <DialogHeader>
             <DialogTitle>Edit report content</DialogTitle>
@@ -206,22 +223,24 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           </DialogHeader>
           <textarea
             className="h-[60vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
-            value={editDraft}
-            onChange={(event) => setEditDraft(event.target.value)}
+            value={editState.draft}
+            onChange={(event) => setEditState((prev) => ({ ...prev, draft: event.target.value }))}
             spellCheck={false}
             aria-label="Report HTML content"
           />
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setShowEditDialog(false)}
+              onClick={closeEditDialog}
               disabled={updateContentMutation.isPending}
             >
               Cancel
             </Button>
             <Button
               onClick={handleSaveEdit}
-              disabled={updateContentMutation.isPending || editDraft === (report.content ?? "")}
+              disabled={
+                updateContentMutation.isPending || editState.draft === (report.content ?? "")
+              }
             >
               {updateContentMutation.isPending ? "Saving…" : "Save"}
             </Button>
@@ -257,10 +276,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => {
-              setEditDraft(report.content ?? "");
-              setShowEditDialog(true);
-            }}
+            onClick={openEditDialog}
             disabled={generating || !report.content}
           >
             <Pencil className="mr-1 h-3 w-3" />

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -332,7 +332,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       {/* Preview */}
       <div className="flex-1 p-4">
         {report.content ? (
-          <div className="report-print-area">
+          <div className="report-print-area rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
             <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
             <ReportChartsSection communitySlug={slug} reportId={report.id} authenticated />
           </div>

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -87,7 +87,7 @@ export function PortfolioReportDocumentView({
           </Button>
         </div>
 
-        <div className="report-print-area">
+        <div className="report-print-area rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
           <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
 
           <ReportChartsSection

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -96,7 +96,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
   );
 
   return (
-    <Card className="report-print-no-break">
+    <Card className="report-print-no-break bg-white dark:bg-zinc-800">
       <div className="flex items-start justify-between gap-4">
         <Title className="!text-base">
           {indicator.name}
@@ -110,7 +110,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
       </div>
 
       {projectsWithData.length === 0 ? (
-        <Text className="mt-4 !text-sm text-zinc-500">
+        <Text className="mt-4 !text-sm text-zinc-500 dark:text-zinc-400">
           No datapoints recorded for the selected projects in this date range.
         </Text>
       ) : viewMode === "rows" ? (
@@ -226,7 +226,7 @@ function ProjectRow({ project, showAxis }: ProjectRowProps) {
         title={project.title}
       >
         <span className="truncate font-medium">{project.title}</span>
-        <span className="ml-2 text-xs font-normal text-zinc-500 dark:text-zinc-400">{summary}</span>
+        <span className="ml-2 text-xs font-normal text-zinc-500 dark:text-zinc-300">{summary}</span>
       </div>
       <div className="flex-1">
         <AreaChart
@@ -265,7 +265,9 @@ function CombinedView({ projects }: CombinedViewProps) {
 
   if (rows.length === 0) {
     return (
-      <Text className="mt-4 !text-sm text-zinc-500">No comparable datapoints across projects.</Text>
+      <Text className="mt-4 !text-sm text-zinc-500 dark:text-zinc-400">
+        No comparable datapoints across projects.
+      </Text>
     );
   }
 

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -35,7 +35,7 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
 
   if (isLoading) {
     return (
-      <section className="mt-8" aria-label="Report charts">
+      <section className="mt-4" aria-label="Report charts">
         <Card className="bg-white">
           <Title className="!text-xl !text-zinc-900">Charts</Title>
           <div className="mt-4">
@@ -48,7 +48,7 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
 
   if (isError) {
     return (
-      <section className="mt-8" aria-label="Report charts">
+      <section className="mt-4" aria-label="Report charts">
         <Card className="bg-white">
           <Title className="!text-xl !text-zinc-900">Charts</Title>
           <Text className="mt-2 !text-sm !text-zinc-500">Couldn&apos;t load charts.</Text>

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -36,7 +36,7 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
   if (isLoading) {
     return (
       <section className="mt-8 space-y-4" aria-label="Report charts">
-        <Title className="!text-xl">Charts</Title>
+        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
         <ChartSkeleton height="h-48" />
       </section>
     );
@@ -45,8 +45,10 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
   if (isError) {
     return (
       <section className="mt-8" aria-label="Report charts">
-        <Title className="!text-xl">Charts</Title>
-        <Text className="mt-2 !text-sm text-zinc-500">Couldn&apos;t load charts.</Text>
+        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
+        <Text className="mt-2 !text-sm !text-zinc-500 dark:!text-zinc-400">
+          Couldn&apos;t load charts.
+        </Text>
         <Button
           variant="outline"
           size="sm"
@@ -68,8 +70,8 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
   return (
     <section className="mt-8 space-y-6" aria-label="Report charts">
       <header>
-        <Title className="!text-xl">Charts</Title>
-        <Text className="!text-sm">
+        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
+        <Text className="!text-sm !text-zinc-500 dark:!text-zinc-400">
           Data from {data.startDate} to {data.endDate}
         </Text>
       </header>
@@ -98,7 +100,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
   return (
     <Card className="report-print-no-break bg-white dark:bg-zinc-800">
       <div className="flex items-start justify-between gap-4">
-        <Title className="!text-base">
+        <Title className="!text-base !text-zinc-900 dark:!text-zinc-100">
           {indicator.name}
           {indicator.unit && (
             <span className="ml-2 text-sm font-normal text-zinc-500 dark:text-zinc-400">
@@ -110,7 +112,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
       </div>
 
       {projectsWithData.length === 0 ? (
-        <Text className="mt-4 !text-sm text-zinc-500 dark:text-zinc-400">
+        <Text className="mt-4 !text-sm !text-zinc-500 dark:!text-zinc-400">
           No datapoints recorded for the selected projects in this date range.
         </Text>
       ) : viewMode === "rows" ? (
@@ -265,7 +267,7 @@ function CombinedView({ projects }: CombinedViewProps) {
 
   if (rows.length === 0) {
     return (
-      <Text className="mt-4 !text-sm text-zinc-500 dark:text-zinc-400">
+      <Text className="mt-4 !text-sm !text-zinc-500 dark:!text-zinc-400">
         No comparable datapoints across projects.
       </Text>
     );

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -35,9 +35,13 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
 
   if (isLoading) {
     return (
-      <section className="mt-8 space-y-4" aria-label="Report charts">
-        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
-        <ChartSkeleton height="h-48" />
+      <section className="mt-8" aria-label="Report charts">
+        <Card className="bg-white">
+          <Title className="!text-xl !text-zinc-900">Charts</Title>
+          <div className="mt-4">
+            <ChartSkeleton height="h-48" />
+          </div>
+        </Card>
       </section>
     );
   }
@@ -45,20 +49,20 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
   if (isError) {
     return (
       <section className="mt-8" aria-label="Report charts">
-        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
-        <Text className="mt-2 !text-sm !text-zinc-500 dark:!text-zinc-400">
-          Couldn&apos;t load charts.
-        </Text>
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-3"
-          onClick={() => refetch()}
-          disabled={isFetching}
-        >
-          <RefreshCw className={cn("mr-1 h-3 w-3", isFetching && "animate-spin")} />
-          {isFetching ? "Retrying…" : "Retry"}
-        </Button>
+        <Card className="bg-white">
+          <Title className="!text-xl !text-zinc-900">Charts</Title>
+          <Text className="mt-2 !text-sm !text-zinc-500">Couldn&apos;t load charts.</Text>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RefreshCw className={cn("mr-1 h-3 w-3", isFetching && "animate-spin")} />
+            {isFetching ? "Retrying…" : "Retry"}
+          </Button>
+        </Card>
       </section>
     );
   }
@@ -67,29 +71,38 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
     return null;
   }
 
+  // One outer Card wraps the whole Charts section so it reads as a single
+  // "document" block — matching the LLM-generated report HTML above it,
+  // which is always rendered light inside its Shadow DOM. Individual
+  // indicator blocks are simple bordered <article>s inside the same card.
   return (
-    <section className="mt-8 space-y-6" aria-label="Report charts">
-      <header>
-        <Title className="!text-xl !text-zinc-900 dark:!text-zinc-100">Charts</Title>
-        <Text className="!text-sm !text-zinc-500 dark:!text-zinc-400">
-          Data from {data.startDate} to {data.endDate}
-        </Text>
-      </header>
+    <section className="mt-8" aria-label="Report charts">
+      <Card className="bg-white">
+        <header className="mb-6">
+          <Title className="!text-xl !text-zinc-900">Charts</Title>
+          <Text className="!text-sm !text-zinc-500">
+            Data from {data.startDate} to {data.endDate}
+          </Text>
+        </header>
 
-      {data.indicators.map((indicator) => (
-        <IndicatorCard key={indicator.id} indicator={indicator} />
-      ))}
+        <div>
+          {data.indicators.map((indicator, idx) => (
+            <IndicatorBlock key={indicator.id} indicator={indicator} isFirst={idx === 0} />
+          ))}
+        </div>
+      </Card>
     </section>
   );
 }
 
 type ViewMode = "rows" | "combined";
 
-interface IndicatorCardProps {
+interface IndicatorBlockProps {
   indicator: ChartSectionIndicator;
+  isFirst: boolean;
 }
 
-function IndicatorCard({ indicator }: IndicatorCardProps) {
+function IndicatorBlock({ indicator, isFirst }: IndicatorBlockProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("rows");
 
   const projectsWithData = useMemo(
@@ -97,22 +110,26 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
     [indicator.projects]
   );
 
+  // All chart content stays light in both themes to match the LLM-generated
+  // report HTML rendered above (which is always light inside its Shadow
+  // DOM). Indicator blocks are siblings inside one outer Card, separated
+  // by a top border so they read as document subsections.
   return (
-    <Card className="report-print-no-break bg-white dark:bg-zinc-800">
+    <article
+      className={cn("report-print-no-break", isFirst ? "" : "mt-6 border-t border-zinc-100 pt-6")}
+    >
       <div className="flex items-start justify-between gap-4">
-        <Title className="!text-base !text-zinc-900 dark:!text-zinc-100">
+        <Title className="!text-base !text-zinc-900">
           {indicator.name}
           {indicator.unit && (
-            <span className="ml-2 text-sm font-normal text-zinc-500 dark:text-zinc-400">
-              ({indicator.unit})
-            </span>
+            <span className="ml-2 text-sm font-normal text-zinc-500">({indicator.unit})</span>
           )}
         </Title>
         {projectsWithData.length > 0 && <ViewModeToggle value={viewMode} onChange={setViewMode} />}
       </div>
 
       {projectsWithData.length === 0 ? (
-        <Text className="mt-4 !text-sm !text-zinc-500 dark:!text-zinc-400">
+        <Text className="mt-4 !text-sm !text-zinc-500">
           No datapoints recorded for the selected projects in this date range.
         </Text>
       ) : viewMode === "rows" ? (
@@ -120,7 +137,7 @@ function IndicatorCard({ indicator }: IndicatorCardProps) {
       ) : (
         <CombinedView projects={projectsWithData} />
       )}
-    </Card>
+    </article>
   );
 }
 
@@ -134,7 +151,7 @@ function ViewModeToggle({ value, onChange }: ViewModeToggleProps) {
     <div
       role="toolbar"
       aria-label="Chart layout"
-      className="report-print-hide inline-flex flex-shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 dark:border-zinc-700 dark:bg-zinc-900"
+      className="report-print-hide inline-flex flex-shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5"
     >
       <ToggleButton
         active={value === "rows"}
@@ -174,9 +191,7 @@ function ToggleButton({
       onClick={onClick}
       className={cn(
         "inline-flex h-7 w-7 items-center justify-center rounded transition-colors",
-        active
-          ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100"
-          : "text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+        active ? "bg-zinc-100 text-zinc-900" : "text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700"
       )}
     >
       {children}
@@ -197,7 +212,7 @@ function RowsView({ projects }: RowsViewProps) {
   );
 
   return (
-    <ul className="mt-4 divide-y divide-zinc-100 dark:divide-zinc-800">
+    <ul className="mt-4 divide-y divide-zinc-100">
       {sorted.map((project, idx) => (
         <ProjectRow key={project.uid} project={project} showAxis={idx === sorted.length - 1} />
       ))}
@@ -223,12 +238,9 @@ function ProjectRow({ project, showAxis }: ProjectRowProps) {
 
   return (
     <li className={cn("flex items-center gap-4", showAxis ? "pt-2 pb-1" : "py-2")}>
-      <div
-        className="min-w-0 flex-shrink-0 basis-52 text-sm text-zinc-800 dark:text-zinc-100"
-        title={project.title}
-      >
+      <div className="min-w-0 flex-shrink-0 basis-52 text-sm text-zinc-800" title={project.title}>
         <span className="truncate font-medium">{project.title}</span>
-        <span className="ml-2 text-xs font-normal text-zinc-500 dark:text-zinc-300">{summary}</span>
+        <span className="ml-2 text-xs font-normal text-zinc-500">{summary}</span>
       </div>
       <div className="flex-1">
         <AreaChart
@@ -267,7 +279,7 @@ function CombinedView({ projects }: CombinedViewProps) {
 
   if (rows.length === 0) {
     return (
-      <Text className="mt-4 !text-sm !text-zinc-500 dark:!text-zinc-400">
+      <Text className="mt-4 !text-sm !text-zinc-500">
         No comparable datapoints across projects.
       </Text>
     );

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -85,9 +85,9 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
           </Text>
         </header>
 
-        <div>
-          {data.indicators.map((indicator, idx) => (
-            <IndicatorBlock key={indicator.id} indicator={indicator} isFirst={idx === 0} />
+        <div className="space-y-4">
+          {data.indicators.map((indicator) => (
+            <IndicatorBlock key={indicator.id} indicator={indicator} />
           ))}
         </div>
       </Card>
@@ -99,10 +99,9 @@ type ViewMode = "rows" | "combined";
 
 interface IndicatorBlockProps {
   indicator: ChartSectionIndicator;
-  isFirst: boolean;
 }
 
-function IndicatorBlock({ indicator, isFirst }: IndicatorBlockProps) {
+function IndicatorBlock({ indicator }: IndicatorBlockProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("rows");
 
   const projectsWithData = useMemo(
@@ -111,13 +110,11 @@ function IndicatorBlock({ indicator, isFirst }: IndicatorBlockProps) {
   );
 
   // All chart content stays light in both themes to match the LLM-generated
-  // report HTML rendered above (which is always light inside its Shadow
-  // DOM). Indicator blocks are siblings inside one outer Card, separated
-  // by a top border so they read as document subsections.
+  // report HTML rendered above. Each indicator block is its own bordered
+  // sub-card inside the outer Charts container, separated by parent-level
+  // gap so they breathe.
   return (
-    <article
-      className={cn("report-print-no-break", isFirst ? "" : "mt-6 border-t border-zinc-100 pt-6")}
-    >
+    <article className="report-print-no-break rounded-lg border border-zinc-200 bg-white p-5">
       <div className="flex items-start justify-between gap-4">
         <Title className="!text-base !text-zinc-900">
           {indicator.name}


### PR DESCRIPTION
## Summary

Follow-up to [#1528](https://github.com/show-karma/gap-app-v2/pull/1528). Addresses two related issues spotted after merge:

1. **Dark theme broken for the Charts section** — Tremor's \`<Card>\` doesn't auto-adapt and the Title/Text dark-mode tokens didn't resolve, so project names and metric titles were invisible (white-on-white) in dark mode.
2. **Visual seam between the report and the Charts section** — the report HTML renders inside a Shadow DOM with \`#f5f6f8\` background; the surrounding wrapper had no bg, so in dark mode the dark page color showed through the gap as a black band between the two surfaces.

## Approach

**Charts now always render light**, matching the LLM-generated report HTML above them. The report is a "document" surface — it stays light in both themes intentionally (and the PDF/print path depends on it). Extending that to the charts gives:

- One visually consistent "document" block (report + charts together)
- Zero dark-mode-fighting code
- Print/PDF output looks the same as on-screen

## Changes

### One unified Charts container
- Single outer \`<Card className="bg-white">\` wraps the whole Charts section — "Charts" title + per-indicator blocks live inside.
- Per-indicator blocks converted from nested Cards to bordered \`<article>\` sub-cards with \`space-y-4\` between them.
- Each block keeps \`report-print-no-break\` so individual metrics don't split across PDF pages.

### Always-light theming inside the Charts surface
- Removed every \`dark:\` variant from the chart UI.
- Forced explicit zinc colors with \`!important\` on Tremor's \`<Title>\` / \`<Text>\` (Tremor's own dark tokens don't resolve in this Tailwind setup).
- Toggle button + project rows + dividers all use single-theme colors.

### Picker stays theme-aware
- \`ChartSectionPicker\` is part of the admin config form (not the report) — it keeps full dark-mode coverage.
- Added missing dark variants on the "Loading indicators…", "No indicators available.", "N selected" counter, and search input placeholder.

### Continuous page surface
- \`.report-print-area\` wrapper now has \`bg-[#f5f6f8] rounded-xl p-4 sm:p-6\` — same bg as the report's Shadow DOM uses internally. Report + Charts sit on one continuous surface; no dark page bleed in the gap.
- Charts section top margin tightened (\`mt-8\` → \`mt-4\`) to match the cadence between the report's own internal cards.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] 21 unit tests pass in \`__tests__/components/Pages/Admin/PortfolioReports/\`
- [ ] Manually verify in **dark mode**: report and Charts section visually share one light "page" surface; metric names + project labels + summary values + view-mode toggle all readable; picker dialog still adapts to dark theme.
- [ ] Verify in **light mode**: no visual regression; report + charts still feel like one document.
- [ ] Click "Export PDF" — output unchanged (we already render light in print).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced dark mode support across portfolio report components with improved text styling for search inputs and empty states
  * Updated preview and print area styling with rounded corners, light gray backgrounds, and responsive padding
  * Redesigned charts section layout with improved card-based components for loading, error, and success states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->