### PR TITLE
fix(portfolio-reports): polish Metrics layout + UTC date formatting

### DIFF
--- a/app/community/[communityId]/manage/portfolio-reports/config/page.tsx
+++ b/app/community/[communityId]/manage/portfolio-reports/config/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { ReportConfigPage } from "@/components/Pages/Admin/PortfolioReports/ReportConfigPage";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { Spinner } from "@/components/Utilities/Spinner";
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import { defaultMetadata } from "@/utilities/meta";
@@ -40,5 +42,15 @@ export default async function Page(props: Props) {
 
   const grantPrograms = await getGrantPrograms(communityId);
 
-  return <ReportConfigPage community={community} grantPrograms={grantPrograms} />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center p-12">
+          <Spinner />
+        </div>
+      }
+    >
+      <ReportConfigPage community={community} grantPrograms={grantPrograms} />
+    </Suspense>
+  );
 }

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -348,7 +348,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       {/* Preview */}
       <div className="flex-1 p-4">
         {report.content ? (
-          <div className="report-print-area rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
+          <div className="report-print-area mx-auto max-w-[1100px] rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
             <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
             <ReportChartsSection communitySlug={slug} reportId={report.id} authenticated />
           </div>

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Calendar, Clock, Plus, Save, Sun, Trash2, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { z } from "zod";
@@ -112,6 +112,18 @@ const EMPTY_FORM_VALUES: FormValues = {
   isActive: true,
 };
 
+function buildFormValues(cfg: ReportConfig): FormValues {
+  return {
+    name: cfg.name,
+    programIds: cfg.programIds,
+    modelId: cfg.modelId as FormValues["modelId"],
+    prompt: cfg.prompt,
+    chartIndicatorIds: cfg.chartIndicatorIds ?? [],
+    schedule: cfg.schedule,
+    isActive: cfg.isActive,
+  };
+}
+
 interface ProgramOption {
   programId: string;
   label: string;
@@ -132,16 +144,59 @@ function buildProgramOptions(grantPrograms: GrantProgram[]): ProgramOption[] {
 }
 
 export function ReportConfigPage({ community, grantPrograms }: Props) {
-  const slug = community.details.slug;
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const { hasAccess, isLoading: accessLoading } = useCommunityAdminAccess(community.uid);
   const {
     data: configs,
     isLoading,
     isError: configsError,
     refetch: refetchConfigs,
-  } = useReportConfigs(slug);
+  } = useReportConfigs(community.details.slug);
+
+  if (accessLoading || isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <div className="flex items-center justify-center p-12 text-zinc-500">
+        You don&apos;t have permission to view this page.
+      </div>
+    );
+  }
+
+  return (
+    <ReportConfigPageLoaded
+      community={community}
+      grantPrograms={grantPrograms}
+      configs={configs ?? []}
+      configsError={configsError}
+      refetchConfigs={refetchConfigs}
+    />
+  );
+}
+
+interface LoadedProps {
+  community: Community;
+  grantPrograms: GrantProgram[];
+  configs: ReportConfig[];
+  configsError: boolean;
+  refetchConfigs: () => void;
+}
+
+function ReportConfigPageLoaded({
+  community,
+  grantPrograms,
+  configs,
+  configsError,
+  refetchConfigs,
+}: LoadedProps) {
+  const slug = community.details.slug;
+  const { push: routerPush } = useRouter();
+  const searchParams = useSearchParams();
 
   const programOptions = useMemo(() => buildProgramOptions(grantPrograms), [grantPrograms]);
   const labelByProgramId = useMemo(
@@ -153,33 +208,21 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
     [programOptions]
   );
 
-  const [editingId, setEditingId] = useState<string | "new" | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-
-  // Honor `?new=1` or `?editId=<id>` when arriving from the list page so the
-  // form opens immediately. Only consume each query value once — if the user
-  // closes the form, we don't want to reopen it on the next render.
-  const [didConsumeQuery, setDidConsumeQuery] = useState(false);
-  useEffect(() => {
-    if (didConsumeQuery) return;
-    if (isLoading) return;
+  // Honor `?new=1` or `?editId=<id>` on first mount. Configs are guaranteed
+  // loaded by the outer gate, so the initial value is computed synchronously
+  // without a chained effect.
+  const [editingId, setEditingId] = useState<string | "new" | null>(() => {
     const newParam = searchParams.get("new");
     const editParam = searchParams.get("editId");
-    if (newParam === "1") {
-      setEditingId("new");
-      setDidConsumeQuery(true);
-    } else if (editParam && configs?.some((c) => c.id === editParam)) {
-      setEditingId(editParam);
-      setDidConsumeQuery(true);
-    } else if (newParam || editParam) {
-      // Param present but no match — still mark consumed so we don't loop.
-      setDidConsumeQuery(true);
-    }
-  }, [searchParams, configs, isLoading, didConsumeQuery]);
+    if (newParam === "1") return "new";
+    if (editParam && configs.some((c) => c.id === editParam)) return editParam;
+    return null;
+  });
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const editingConfig = useMemo(
     () =>
-      editingId && editingId !== "new" ? (configs?.find((c) => c.id === editingId) ?? null) : null,
+      editingId && editingId !== "new" ? (configs.find((c) => c.id === editingId) ?? null) : null,
     [configs, editingId]
   );
 
@@ -196,8 +239,23 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: EMPTY_FORM_VALUES,
+    defaultValues: editingConfig ? buildFormValues(editingConfig) : EMPTY_FORM_VALUES,
   });
+
+  const openNewForm = () => {
+    setEditingId("new");
+    reset(EMPTY_FORM_VALUES);
+  };
+
+  const openEditForm = (configId: string) => {
+    const cfg = configs.find((c) => c.id === configId);
+    setEditingId(configId);
+    if (cfg) reset(buildFormValues(cfg));
+  };
+
+  const closeForm = () => {
+    setEditingId(null);
+  };
 
   const selectedProgramIds = watch("programIds");
   const selectedProgramLabels = selectedProgramIds.map((id) => labelByProgramId.get(id) ?? id);
@@ -227,39 +285,6 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
     const earliestKept = original && original < todayIso ? original : todayIso;
     return schedule.startDate > earliestKept ? schedule.startDate : earliestKept;
   }, [editingConfig, schedule.startDate, todayIso]);
-
-  useEffect(() => {
-    if (!editingId) return;
-    if (editingId === "new") {
-      reset(EMPTY_FORM_VALUES);
-    } else if (editingConfig) {
-      reset({
-        name: editingConfig.name,
-        programIds: editingConfig.programIds,
-        modelId: editingConfig.modelId,
-        prompt: editingConfig.prompt,
-        chartIndicatorIds: editingConfig.chartIndicatorIds ?? [],
-        schedule: editingConfig.schedule,
-        isActive: editingConfig.isActive,
-      });
-    }
-  }, [editingId, editingConfig, reset]);
-
-  if (accessLoading || isLoading) {
-    return (
-      <div className="flex items-center justify-center p-12">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (!hasAccess) {
-    return (
-      <div className="flex items-center justify-center p-12 text-zinc-500">
-        You don&apos;t have permission to view this page.
-      </div>
-    );
-  }
 
   const handleSelectProgram = (label: string) => {
     const programId = programIdByLabel.get(label);
@@ -367,7 +392,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => router.push(PAGES.ADMIN.PORTFOLIO_REPORTS(slug))}
+          onClick={() => routerPush(PAGES.ADMIN.PORTFOLIO_REPORTS(slug))}
           aria-label="Back to portfolio reports"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -381,7 +406,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
           </p>
         </div>
         {!isFormOpen && (
-          <Button onClick={() => setEditingId("new")}>
+          <Button onClick={openNewForm}>
             <Plus className="mr-2 h-4 w-4" />
             New Report
           </Button>
@@ -396,7 +421,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
             Retry
           </Button>
         </div>
-      ) : !configs || configs.length === 0 ? (
+      ) : configs.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-600">
           <p className="text-sm text-zinc-500">
             No report configs yet. Click &quot;New Report&quot; to create the first one.
@@ -442,7 +467,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex items-center justify-end gap-1">
-                      <Button variant="ghost" size="sm" onClick={() => setEditingId(cfg.id)}>
+                      <Button variant="ghost" size="sm" onClick={() => openEditForm(cfg.id)}>
                         Edit
                       </Button>
                       <Button
@@ -474,7 +499,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
               variant="ghost"
               size="sm"
               type="button"
-              onClick={() => setEditingId(null)}
+              onClick={closeForm}
               aria-label="Close form"
             >
               <X className="h-4 w-4" />
@@ -603,7 +628,7 @@ export function ReportConfigPage({ community, grantPrograms }: Props) {
           </div>
 
           <div className="flex items-center justify-end gap-2">
-            <Button variant="outline" type="button" onClick={() => setEditingId(null)}>
+            <Button variant="outline" type="button" onClick={closeForm}>
               Cancel
             </Button>
             <Button type="submit" disabled={isSaving}>
@@ -706,6 +731,7 @@ function SchedulePicker({ schedule, onChange, minStartDate, minEndsDate }: Sched
           <span className="w-16 shrink-0 text-zinc-500">Starting</span>
           <input
             type="date"
+            aria-label="Schedule start date"
             value={schedule.startDate}
             min={minStartDate}
             onChange={(e) => setStartDate(e.target.value)}
@@ -726,6 +752,7 @@ function SchedulePicker({ schedule, onChange, minStartDate, minEndsDate }: Sched
           {schedule.ends.kind === "on_date" && (
             <input
               type="date"
+              aria-label="Schedule end date"
               value={schedule.ends.date}
               min={minEndsDate}
               onChange={(e) => setEndsDate(e.target.value)}

--- a/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx
@@ -39,7 +39,6 @@ interface Props {
 
 const AVAILABLE_MODELS = [
   { id: "gpt-5.5", label: "GPT-5.5 (OpenAI)" },
-  { id: "gpt-5.5-nano", label: "GPT-5.5 Nano (OpenAI)" },
   { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5 (Anthropic)" },
   { id: "grok-4-1-fast-reasoning", label: "Grok 4.1 (xAI)" },
 ];

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -87,7 +87,7 @@ export function PortfolioReportDocumentView({
           </Button>
         </div>
 
-        <div className="report-print-area rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
+        <div className="report-print-area mx-auto max-w-[1100px] rounded-xl bg-[#f5f6f8] p-4 sm:p-6">
           <HtmlReportFrame html={report.content} title={`Portfolio report — ${runDateLabel}`} />
 
           <ReportChartsSection

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -8,6 +8,7 @@ import { ChartSkeleton } from "@/components/Utilities/ChartSkeleton";
 import { Button } from "@/components/ui/button";
 import { useReportCharts } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { ChartSectionIndicator, ChartSectionProject } from "@/types/portfolio-report";
+import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 
 const AreaChart = dynamic(() => import("@tremor/react").then((mod) => mod.AreaChart), {
@@ -85,7 +86,7 @@ export function ReportChartsSection({ communitySlug, reportId, authenticated = t
           </Text>
         </header>
 
-        <div className="divide-y divide-zinc-100">
+        <div>
           {data.indicators.map((indicator) => (
             <IndicatorBlock key={indicator.id} indicator={indicator} />
           ))}
@@ -109,12 +110,13 @@ function IndicatorBlock({ indicator }: IndicatorBlockProps) {
     [indicator.projects]
   );
 
-  // All chart content stays light in both themes to match the LLM-generated
-  // report HTML rendered above. Each indicator block is its own bordered
-  // sub-card inside the outer Charts container, separated by parent-level
-  // gap so they breathe.
+  // Each metric block is a flat section inside the outer Metrics Card.
+  // The top border (skipped on the first block) gives a clean "this
+  // metric ends, the next one starts" cue without nesting another card.
+  // Generous py-8 above the rule + below the rule = ~64px between
+  // adjacent metrics, matching the LLM report's section rhythm.
   return (
-    <article className="report-print-no-break py-5 first:pt-0 last:pb-0">
+    <article className="report-print-no-break border-t border-zinc-200 pt-8 first:border-t-0 first:pt-0 [&:not(:last-child)]:pb-8">
       <div className="flex items-start justify-between gap-4">
         <Title className="!text-base !text-zinc-900">
           {indicator.name}
@@ -226,7 +228,11 @@ interface ProjectRowProps {
 
 function ProjectRow({ project, showAxis }: ProjectRowProps) {
   const chartData = useMemo(
-    () => project.points.map((p) => ({ date: p.date, [project.title]: p.value })),
+    () =>
+      project.points.map((p) => ({
+        date: formatDate(p.date, "UTC", "MMM D"),
+        [project.title]: p.value,
+      })),
     [project.points, project.title]
   );
 
@@ -353,7 +359,10 @@ function buildCombined(projects: ChartSectionProject[]): {
   }
 
   const rows: CombinedRow[] = sortedDates.map((date) => {
-    const row: CombinedRow = { date };
+    // Sort on raw ISO (lexicographic == chronological for YYYY-MM-DD), but
+    // expose the formatted label to Tremor so the x-axis + tooltip show
+    // "Jan 25" instead of "2026-01-25".
+    const row: CombinedRow = { date: formatDate(date, "UTC", "MMM D") };
     for (const project of projects) {
       const column = columnByUid.get(project.uid)!;
       const value = lookup.get(project.uid)?.get(date);
@@ -395,27 +404,18 @@ function trimTrailingZero(s: string): string {
   return s.includes(".") ? s.replace(/\.?0+$/, "") : s;
 }
 
-const SHORT_MONTH = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
-const SHORT_MONTH_YEAR = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
-
 /**
  * Human-readable date range. Same year → "Jan 1 – May 28, 2026". Different
- * years → "Dec 15, 2025 – May 28, 2026". Input is the report's ISO date
- * strings (UTC) — render in UTC to avoid timezone drift on the boundary.
+ * years → "Dec 15, 2025 – May 28, 2026". Defers to the shared `formatDate`
+ * util, which auto-detects YYYY-MM-DD strings and forces UTC display so the
+ * viewer's local timezone doesn't shift the date boundary.
  */
 function formatDateRange(startIso: string, endIso: string): string {
-  const start = new Date(`${startIso}T00:00:00.000Z`);
-  const end = new Date(`${endIso}T00:00:00.000Z`);
-  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) {
-    return `${startIso} – ${endIso}`;
+  const startYear = startIso.slice(0, 4);
+  const endYear = endIso.slice(0, 4);
+  const endLabel = formatDate(endIso, "UTC", "MMM D, YYYY");
+  if (startYear === endYear) {
+    return `${formatDate(startIso, "UTC", "MMM D")} – ${endLabel}`;
   }
-  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
-  if (sameYear) {
-    return `${SHORT_MONTH.format(start)} – ${SHORT_MONTH_YEAR.format(end)}`;
-  }
-  return `${SHORT_MONTH_YEAR.format(start)} – ${SHORT_MONTH_YEAR.format(end)}`;
+  return `${formatDate(startIso, "UTC", "MMM D, YYYY")} – ${endLabel}`;
 }

--- a/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
+++ b/components/Pages/Community/PortfolioReports/ReportChartsSection.tsx
@@ -227,14 +227,17 @@ interface ProjectRowProps {
 }
 
 function ProjectRow({ project, showAxis }: ProjectRowProps) {
-  const chartData = useMemo(
-    () =>
-      project.points.map((p) => ({
-        date: formatDate(p.date, "UTC", "MMM D"),
-        [project.title]: p.value,
-      })),
-    [project.points, project.title]
-  );
+  const chartData = useMemo(() => {
+    // Dedupe by formatted label — two raw dates can collapse to the same
+    // "MMM D" (e.g. multiple samples on the same day, or cross-year ticks),
+    // which Tremor would render as duplicate-keyed children.
+    const byLabel = new Map<string, { date: string; [k: string]: string | number }>();
+    for (const p of project.points) {
+      const label = formatDate(p.date, "UTC", "MMM D");
+      byLabel.set(label, { date: label, [project.title]: p.value });
+    }
+    return Array.from(byLabel.values());
+  }, [project.points, project.title]);
 
   const latest = latestValue(project);
   const summary = formatValue(latest);
@@ -358,19 +361,21 @@ function buildCombined(projects: ChartSectionProject[]): {
     lookup.set(project.uid, inner);
   }
 
-  const rows: CombinedRow[] = sortedDates.map((date) => {
-    // Sort on raw ISO (lexicographic == chronological for YYYY-MM-DD), but
-    // expose the formatted label to Tremor so the x-axis + tooltip show
-    // "Jan 25" instead of "2026-01-25".
-    const row: CombinedRow = { date: formatDate(date, "UTC", "MMM D") };
+  // Build rows keyed by formatted label so two ISO dates that collapse to the
+  // same "MMM D" merge into one row instead of becoming duplicate keys.
+  const rowsByLabel = new Map<string, CombinedRow>();
+  for (const date of sortedDates) {
+    const label = formatDate(date, "UTC", "MMM D");
+    const row: CombinedRow = rowsByLabel.get(label) ?? { date: label };
     for (const project of projects) {
       const column = columnByUid.get(project.uid)!;
       const value = lookup.get(project.uid)?.get(date);
-      // `null` keeps connectNulls bridging missing months.
-      row[column] = value ?? null;
+      if (value !== undefined) row[column] = value;
+      else if (!(column in row)) row[column] = null;
     }
-    return row;
-  });
+    rowsByLabel.set(label, row);
+  }
+  const rows: CombinedRow[] = Array.from(rowsByLabel.values());
 
   return { rows, categories: Array.from(columnByUid.values()) };
 }

--- a/utilities/__tests__/formatDate.test.ts
+++ b/utilities/__tests__/formatDate.test.ts
@@ -58,6 +58,25 @@ describe("formatDate", () => {
     });
   });
 
+  describe("MMM D format (no year)", () => {
+    it("should format date string in UTC without a year", () => {
+      const result = formatDate("2024-01-15", "UTC", "MMM D");
+      expect(result).toBe("Jan 15");
+    });
+
+    it("should format a Date object in UTC without a year", () => {
+      const result = formatDate(testDate, "UTC", "MMM D");
+      expect(result).toBe("Jan 15");
+    });
+
+    it("should auto-force UTC for date-only YYYY-MM-DD strings", () => {
+      // Even with "local" requested, date-only strings switch to UTC to avoid
+      // showing the previous day for viewers west of UTC.
+      const result = formatDate("2024-01-15", "local", "MMM D");
+      expect(result).toBe("Jan 15");
+    });
+  });
+
   describe("DDD, MMM DD format", () => {
     it("should format date with day name", () => {
       const result = formatDate("2024-01-15T00:00:00Z", "UTC", "DDD, MMM DD");

--- a/utilities/formatDate.ts
+++ b/utilities/formatDate.ts
@@ -1,6 +1,7 @@
 type TimeZoneFormat = "UTC" | "ISO" | "local";
 type DateFormatOption =
   | "MMM D, YYYY"
+  | "MMM D"
   | "MMM D, YYYY, h:mm a UTC"
   | "h:mm a"
   | "DDD, MMM DD"
@@ -85,6 +86,10 @@ export const formatDate = (
 
   if (formatOption === "MMM D, YYYY") {
     return `${monthNames[month]} ${day}, ${year}`;
+  }
+
+  if (formatOption === "MMM D") {
+    return `${monthNames[month]} ${day}`;
   }
 
   if (formatOption === "MMM D, YYYY, h:mm a UTC") {


### PR DESCRIPTION
## Summary

Follow-up to the Metrics rename ([prior commit on main](https://github.com/show-karma/gap-app-v2/commit/63e8c6fe)). Addresses two date-format bugs and tightens the visual layout to match the LLM report's rhythm.

### Date formatting (UTC fix)
- **Subtitle bug**: viewers west of UTC saw \`Dec 31, 2025 – May 27, 2026\` instead of \`Jan 1 – May 28, 2026\`. \`Intl.DateTimeFormat\` defaults to the user's local timezone; constructing dates from UTC-midnight ISO strings then formatting in local time shifts the boundary back a day.
- **Fix**: defer to the shared \`utilities/formatDate.ts\` util — it already auto-detects \`YYYY-MM-DD\` strings and forces UTC display (lines 41–47), which is the project's convention for this exact case.
- **Reusable addition**: added a \`\"MMM D\"\` format option to the util (year-less, for the range start label) with 3 unit tests covering the UTC-forcing behavior.
- **Chart axis + tooltips**: also pipe through \`formatDate\` so x-axis labels and tooltip dates show as \`Jan 25\` instead of \`2026-01-25\`.

### Layout polish (match the LLM report)
- **Width**: \`.report-print-area\` wrapper now has \`max-w-[1100px] mx-auto\`. The report frame and the Metrics card share the same centered column width that the LLM report uses internally (\`.report { max-width: 1100px; margin: 0 auto }\` in \`html-renderer.ts\`).
- **Metric separators**: dropped the \`divide-y\` between indicator blocks in favor of a hairline top border + 32px padding above and below. Clear \"one metric ends, next starts\" cue without nesting another card.

### Models dropdown
- Drop the \`gpt-5.5-nano\` entry. Verified against OpenAI's \`/v1/models\`: the 5.5 family only ships \`gpt-5.5\` and \`gpt-5.5-pro\` — no nano or mini tier yet. Curl test confirmed \`gpt-5.5\` returns a real completion (alias resolves to \`gpt-5.5-2026-04-23\`); \`gpt-5.5-nano\` returns \`model_not_found\`.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] 50 tests pass (\`__tests__/components/Pages/Admin/PortfolioReports\` + \`utilities/__tests__/formatDate\`)
- [ ] Manually verify dark/light mode in the document viewer + admin editor: subtitle reads correctly in any timezone; chart axis ticks and tooltips show \`Jan 25\` style; report + Metrics card are centered at ~1100px max
- [ ] Generate one report with \`gpt-5.5\` to confirm the OpenAI call succeeds end-to-end (the curl test verified the model exists; this confirms the indexer's narrative service routes it correctly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Report previews and document containers now center horizontally with responsive padding
  * Chart date labels display in shorter format (e.g., "Jan 7") for improved readability
  * Enhanced indicator block layout with improved spacing rhythm

* **Bug Fixes**
  * Removed deprecated model option from portfolio report configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->