### PR TITLE
fix(sitemap): stop index from dropping child sitemaps on counts failure

### DIFF
--- a/__tests__/app/sitemaps/orphaned-chunk-route.test.ts
+++ b/__tests__/app/sitemaps/orphaned-chunk-route.test.ts
@@ -35,4 +35,9 @@ describe("app/sitemaps/[kind]/sitemap/[chunk] orphaned-chunk fallback", () => {
     const res = await call("grants", "sitemap.xml");
     expect(res.status).toBe(404);
   });
+
+  it.each(["0.xml", "01.xml"])("returns 404 for the non-positive chunk id %s", async (chunk) => {
+    const res = await call("grants", chunk);
+    expect(res.status).toBe(404);
+  });
 });

--- a/__tests__/app/sitemaps/orphaned-chunk-route.test.ts
+++ b/__tests__/app/sitemaps/orphaned-chunk-route.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/sitemaps/[kind]/sitemap/[chunk]/route";
+
+function call(kind: string, chunk: string) {
+  return GET(new Request("https://www.karmahq.xyz/sitemaps/test"), {
+    params: Promise.resolve({ kind, chunk }),
+  });
+}
+
+describe("app/sitemaps/[kind]/sitemap/[chunk] orphaned-chunk fallback", () => {
+  it("returns an empty 200 urlset for a known kind with a numeric chunk", async () => {
+    const res = await call("grants", "2.xml");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/xml");
+    const body = await res.text();
+    expect(body).toContain("<urlset");
+    expect(body).not.toContain("<url>");
+  });
+
+  it.each(["projects", "impacts", "grants", "milestones", "funding-programs"])(
+    "serves the %s kind",
+    async (kind) => {
+      const res = await call(kind, "9.xml");
+      expect(res.status).toBe(200);
+    }
+  );
+
+  it("returns 404 for an unknown kind", async () => {
+    const res = await call("unknown", "1.xml");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-numeric chunk filename", async () => {
+    const res = await call("grants", "sitemap.xml");
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/scripts/generate-sitemap.test.ts
+++ b/__tests__/scripts/generate-sitemap.test.ts
@@ -71,8 +71,11 @@ describe("generate-sitemap", () => {
     originalChildren.clear();
   });
 
-  it("falls back to a minimal sitemapindex when the indexer is unreachable", () => {
+  it("falls back to one chunk per kind on a cold start when the indexer is unreachable", () => {
     snapshot();
+    // Cold start: no prior index means there is no published floor to preserve.
+    if (fs.existsSync(INDEX_OUTPUT)) fs.unlinkSync(INDEX_OUTPUT);
+    if (fs.existsSync(ALIAS_OUTPUT)) fs.unlinkSync(ALIAS_OUTPUT);
 
     const xml = runScript({ NEXT_PUBLIC_GAP_INDEXER_URL: "http://127.0.0.1:9" });
 
@@ -82,6 +85,35 @@ describe("generate-sitemap", () => {
     expect(xml).toContain("https://www.karmahq.xyz/sitemaps/communities/sitemap.xml");
     // static + communities + 1 chunk per 5 kinds = 7
     expect(xml.match(/<sitemap>/g) ?? []).toHaveLength(7);
+  }, 30_000);
+
+  it("preserves the previously-published chunk count when counts are unavailable", () => {
+    snapshot();
+    // A transient /counts failure makes every kind look empty. Without the
+    // floor, grants would collapse from 2 chunks to 1 and grants/sitemap/2.xml
+    // — already crawled by Google — would 404. The prior index is the floor.
+    const priorIndex = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      "  <sitemap><loc>https://www.karmahq.xyz/sitemaps/static/sitemap.xml</loc></sitemap>",
+      "  <sitemap><loc>https://www.karmahq.xyz/sitemaps/communities/sitemap.xml</loc></sitemap>",
+      "  <sitemap><loc>https://www.karmahq.xyz/sitemaps/grants/sitemap/1.xml</loc></sitemap>",
+      "  <sitemap><loc>https://www.karmahq.xyz/sitemaps/grants/sitemap/2.xml</loc></sitemap>",
+      "</sitemapindex>",
+      "",
+    ].join("\n");
+    fs.mkdirSync(path.dirname(INDEX_OUTPUT), { recursive: true });
+    fs.writeFileSync(INDEX_OUTPUT, priorIndex, "utf-8");
+
+    const xml = runScript({ NEXT_PUBLIC_GAP_INDEXER_URL: "http://127.0.0.1:9" });
+
+    expect(xml).toContain("https://www.karmahq.xyz/sitemaps/grants/sitemap/1.xml");
+    expect(xml).toContain("https://www.karmahq.xyz/sitemaps/grants/sitemap/2.xml");
+    // Every chunk listed in the index must have a child file on disk (no 404).
+    expect(fs.existsSync(path.join(SITEMAPS_ROOT, "grants", "sitemap", "2.xml"))).toBe(true);
+    // Kinds with no prior entry still get exactly one chunk.
+    expect(xml).toContain("https://www.karmahq.xyz/sitemaps/projects/sitemap/1.xml");
+    expect(xml).not.toContain("https://www.karmahq.xyz/sitemaps/projects/sitemap/2.xml");
   }, 30_000);
 
   it("emits lastmod values without fractional seconds (Google parser strictness)", () => {

--- a/__tests__/scripts/generate-sitemap.test.ts
+++ b/__tests__/scripts/generate-sitemap.test.ts
@@ -116,6 +116,27 @@ describe("generate-sitemap", () => {
     expect(xml).not.toContain("https://www.karmahq.xyz/sitemaps/projects/sitemap/2.xml");
   }, 30_000);
 
+  it("ignores an out-of-range chunk number in a corrupt prior index", () => {
+    snapshot();
+    // A garbage chunk number must not become a loop bound. Without the cap this
+    // run would hang emitting billions of chunks; with it the entry is ignored
+    // and grants falls back to a single chunk.
+    const corruptIndex = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      "  <sitemap><loc>https://www.karmahq.xyz/sitemaps/grants/sitemap/999999999999.xml</loc></sitemap>",
+      "</sitemapindex>",
+      "",
+    ].join("\n");
+    fs.mkdirSync(path.dirname(INDEX_OUTPUT), { recursive: true });
+    fs.writeFileSync(INDEX_OUTPUT, corruptIndex, "utf-8");
+
+    const xml = runScript({ NEXT_PUBLIC_GAP_INDEXER_URL: "http://127.0.0.1:9" });
+
+    expect(xml).toContain("https://www.karmahq.xyz/sitemaps/grants/sitemap/1.xml");
+    expect(xml).not.toContain("https://www.karmahq.xyz/sitemaps/grants/sitemap/2.xml");
+  }, 30_000);
+
   it("emits lastmod values without fractional seconds (Google parser strictness)", () => {
     snapshot();
 

--- a/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
+++ b/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+// Child sitemap chunks for these kinds are pre-generated as static files under
+// `public/sitemaps/{kind}/sitemap/{n}.xml` at build time (see
+// `scripts/generate-sitemap.ts`). Next.js serves an existing `public/` file in
+// preference to this dynamic route, so this handler only ever runs for a chunk
+// that has NO static file — i.e. a chunk Google recorded from a previous build
+// but that the current index no longer lists.
+//
+// For those orphaned chunks we return an empty-but-valid urlset with HTTP 200
+// instead of a 404. Google Search Console treats a 404 on a previously-fetched
+// child sitemap as a "Couldn't fetch" error that lingers in the index
+// drilldown; an empty 200 is read as "0 URLs" and the chunk is dropped cleanly.
+const KIND_PATHS = new Set(["projects", "impacts", "grants", "milestones", "funding-programs"]);
+
+const CHUNK_FILENAME = /^\d+\.xml$/;
+
+const EMPTY_URLSET = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>
+`;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ kind: string; chunk: string }> }
+): Promise<NextResponse> {
+  const { kind, chunk } = await params;
+
+  if (!KIND_PATHS.has(kind) || !CHUNK_FILENAME.test(chunk)) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  return new NextResponse(EMPTY_URLSET, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
+++ b/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
@@ -13,7 +13,9 @@ import { NextResponse } from "next/server";
 // drilldown; an empty 200 is read as "0 URLs" and the chunk is dropped cleanly.
 const KIND_PATHS = new Set(["projects", "impacts", "grants", "milestones", "funding-programs"]);
 
-const CHUNK_FILENAME = /^\d+\.xml$/;
+// Positive chunk IDs only — the generator emits 1.xml, 2.xml, … never 0.xml or
+// zero-padded names, so those should 404 rather than return an empty 200.
+const CHUNK_FILENAME = /^[1-9]\d*\.xml$/;
 
 const EMPTY_URLSET = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -26,8 +26,8 @@ interface SitemapCounts {
 
 interface KindConfig {
   kind: SitemapKind;
-  total: number;
   path: string;
+  chunkCount: number;
   priority: number;
   changeFrequency: "daily" | "weekly" | "monthly";
 }
@@ -78,6 +78,34 @@ function logWarn(message: string): void {
 function computeChunkCount(total: number): number {
   if (total <= 0) return FALLBACK_CHUNKS_PER_KIND;
   return Math.ceil(total / SITEMAP_PAGE_SIZE);
+}
+
+/**
+ * Parses the chunk count previously published for each kind from an existing
+ * sitemap index. Used as a floor so a transient `/counts` failure (which makes
+ * every kind look empty) can never shrink the published chunk count: dropping
+ * a chunk would 404 child sitemaps Google has already crawled and recorded in
+ * its sitemap-index drilldown. Returns `{}` when the index is absent/unreadable.
+ */
+function readPublishedChunkCounts(indexPath: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  if (!fs.existsSync(indexPath)) return counts;
+
+  let content: string;
+  try {
+    content = fs.readFileSync(indexPath, "utf-8");
+  } catch {
+    return counts;
+  }
+
+  const pattern = /\/sitemaps\/([a-z-]+)\/sitemap\/(\d+)\.xml/g;
+  for (const match of content.matchAll(pattern)) {
+    const kindPath = match[1];
+    const chunk = Number.parseInt(match[2], 10);
+    if (!Number.isFinite(chunk)) continue;
+    counts[kindPath] = Math.max(counts[kindPath] ?? 0, chunk);
+  }
+  return counts;
 }
 
 function escapeXml(value: string): string {
@@ -177,8 +205,7 @@ function buildIndexXml(kindConfigs: KindConfig[]): string {
   entries.push(`${SITE_URL}/sitemaps/static/sitemap.xml`);
   entries.push(`${SITE_URL}/sitemaps/communities/sitemap.xml`);
 
-  for (const { path: kindPath, total } of kindConfigs) {
-    const chunkCount = computeChunkCount(total);
+  for (const { path: kindPath, chunkCount } of kindConfigs) {
     for (let i = 1; i <= chunkCount; i++) {
       entries.push(`${SITE_URL}/sitemaps/${kindPath}/sitemap/${i}.xml`);
     }
@@ -211,14 +238,13 @@ async function writeChildSitemaps(
 
   const jobs: Job[] = [];
   for (const config of kindConfigs) {
-    const chunkCount = computeChunkCount(config.total);
     // Reset the kind's output directory so stale chunks from a previous build
     // (when chunk count was higher) do not linger.
     const kindDir = path.join(PROJECT_ROOT, "public", "sitemaps", config.path, "sitemap");
     fs.rmSync(kindDir, { recursive: true, force: true });
     fs.mkdirSync(kindDir, { recursive: true });
 
-    for (let i = 1; i <= chunkCount; i++) {
+    for (let i = 1; i <= config.chunkCount; i++) {
       jobs.push({
         config,
         chunkId: i,
@@ -266,51 +292,59 @@ async function main() {
   const counts = baseUrl ? await fetchCounts(baseUrl) : null;
   if (!counts) {
     logWarn(
-      "[sitemap-gen] Using fallback counts (one chunk per kind). Build will succeed; Google will discover additional chunks on next deploy."
+      "[sitemap-gen] Counts unavailable — preserving the previously-published chunk count per kind so no child sitemap is dropped. Build will succeed."
     );
   }
+
+  const publicDir = path.join(PROJECT_ROOT, "public");
+  const indexPath = path.join(publicDir, "sitemap.xml");
+
+  // Floor each kind's chunk count at what the existing index already published.
+  // This is the durable guard against a transient `/counts` failure shrinking
+  // the index and 404-ing child sitemaps Google has already crawled.
+  const publishedFloor = readPublishedChunkCounts(indexPath);
+  const chunksFor = (kindPath: string, total: number): number =>
+    Math.max(computeChunkCount(total), publishedFloor[kindPath] ?? 0);
 
   const kindConfigs: KindConfig[] = [
     {
       kind: "projects",
-      total: counts?.projects ?? 0,
       path: "projects",
+      chunkCount: chunksFor("projects", counts?.projects ?? 0),
       priority: 0.8,
       changeFrequency: "daily",
     },
     {
       kind: "impacts",
-      total: counts?.impacts ?? 0,
       path: "impacts",
+      chunkCount: chunksFor("impacts", counts?.impacts ?? 0),
       priority: 0.7,
       changeFrequency: "weekly",
     },
     {
       kind: "grants",
-      total: counts?.grants ?? 0,
       path: "grants",
+      chunkCount: chunksFor("grants", counts?.grants ?? 0),
       priority: 0.6,
       changeFrequency: "weekly",
     },
     {
       kind: "milestones",
-      total: counts?.milestones ?? 0,
       path: "milestones",
+      chunkCount: chunksFor("milestones", counts?.milestones ?? 0),
       priority: 0.5,
       changeFrequency: "weekly",
     },
     {
       kind: "funding-programs",
-      total: counts?.fundingPrograms ?? 0,
       path: "funding-programs",
+      chunkCount: chunksFor("funding-programs", counts?.fundingPrograms ?? 0),
       priority: 0.6,
       changeFrequency: "weekly",
     },
   ];
 
   const indexXml = buildIndexXml(kindConfigs);
-  const publicDir = path.join(PROJECT_ROOT, "public");
-  const indexPath = path.join(publicDir, "sitemap.xml");
   fs.mkdirSync(publicDir, { recursive: true });
   fs.writeFileSync(indexPath, indexXml, "utf-8");
 

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -13,6 +13,11 @@ const COUNTS_RETRY_BACKOFF_MS = 1000;
 const URLS_RETRY_BACKOFF_MS = 750;
 const URLS_CONCURRENCY = 4;
 const FALLBACK_CHUNKS_PER_KIND = 1;
+// Sanity ceiling for a chunk number parsed from an existing index — ~100M URLs
+// at SITEMAP_PAGE_SIZE per chunk. Guards the chunk-emitting loops against a
+// corrupt or hand-edited index whose digits would otherwise drive an
+// effectively unbounded loop at build time.
+const MAX_REASONABLE_CHUNKS = 100_000;
 
 type SitemapKind = "projects" | "impacts" | "grants" | "milestones" | "funding-programs";
 
@@ -102,7 +107,7 @@ function readPublishedChunkCounts(indexPath: string): Record<string, number> {
   for (const match of content.matchAll(pattern)) {
     const kindPath = match[1];
     const chunk = Number.parseInt(match[2], 10);
-    if (!Number.isFinite(chunk)) continue;
+    if (!Number.isInteger(chunk) || chunk < 1 || chunk > MAX_REASONABLE_CHUNKS) continue;
     counts[kindPath] = Math.max(counts[kindPath] ?? 0, chunk);
   }
   return counts;


### PR DESCRIPTION
## Overview

The `sitemap-index.xml` periodically lists child sitemaps that 404 (e.g. `https://www.karmahq.xyz/sitemaps/grants/sitemap/2.xml`), which shows up as "Couldn't fetch" errors in the Google Search Console sitemap-index drilldown. This fixes the root cause and prevents previously-crawled chunks from ever 404-ing.

## Problem

The sitemap is regenerated on every build by `scripts/generate-sitemap.ts` (it runs before `next build`). It calls the indexer's `GET /v2/sitemap/counts` — a single request that fires 5 Mongo aggregations in parallel on a cold cache — to decide how many `…/N.xml` chunks to publish per kind.

When `/counts` times out (8s limit), `fetchCounts` returns `null` and **every kind collapses to 1 chunk**:

```ts
const counts = baseUrl ? await fetchCounts(baseUrl) : null;
// total: counts?.grants ?? 0  →  computeChunkCount(0) → 1 chunk
```

The child-sitemap writer then `fs.rmSync`-deletes the old `grants/sitemap/2.xml` (and `projects/2`, `milestones/2`, …). Google has already crawled those chunks and keeps them in its index drilldown, so it re-fetches them and gets a **404**. It also silently drops every URL beyond the first 1000 per kind.

Evidence: the live `/sitemap.xml` lists exactly 1 chunk each for projects, grants, **and** milestones simultaneously, while the committed index lists 2 each — a signature only a global `/counts` failure produces (a real data change can't drop all three to exactly 1 at once). The current live data actually spans projects ×4, grants ×3, milestones ×3, so production has been badly under-indexed, not just 404-ing one chunk.

## Solution

1. **Floor the chunk count** (`scripts/generate-sitemap.ts`): each kind's chunk count is now `max(computeChunkCount(liveTotal), previouslyPublishedCount)`, where the floor is parsed from the existing committed index. A transient `/counts` failure can no longer shrink the index or delete previously-published chunks. The index and the child files now derive from a single shared `chunkCount`, so they cannot drift apart within a build.
2. **Catch-all empty-200 route** (`app/sitemaps/[kind]/sitemap/[chunk]/route.ts`): returns an empty-but-valid `urlset` with HTTP 200 for any child chunk that has no static file. Next.js serves existing `public/` files in preference, so this only fires for a chunk Google remembers from a previous build — turning a GSC "Couldn't fetch" 404 into a clean "0 URLs, dropped".

The current `grants/2.xml` 404 self-heals on the next deploy: the committed index already lists it, so a healthy rebuild restores the file.

## Why This Approach

`/v2/sitemap/counts` and `/v2/sitemap` (URLs) read the same cached array in the indexer, so `counts` is a redundant, fragile input whose only job is to size the index — and whose failure was catastrophic. Rather than rewrite the whole pipeline to be dynamic (it deliberately pre-generates static files to control crawl cost and the GSC 1MB/5000-URL limits), flooring at the last-published count is a minimal, durable guard, and the catch-all makes any residual shrink harmless instead of an error.

## Testing Steps

1. `pnpm test __tests__/app/sitemaps/orphaned-chunk-route.test.ts` → 8/8 pass.
2. `pnpm test __tests__/scripts/generate-sitemap.test.ts` (CI/Linux) → includes a new regression test that seeds a prior 2-chunk index and asserts the count does not shrink when `/counts` is unavailable.
3. Manual (done): ran the generator against the real indexer → full 15-entry index, every listed chunk has a child file; ran against a dead indexer with a prior 2-chunk index → `grants` stayed at 2 chunks, `grants/sitemap/2.xml` written as a valid empty urlset (no 404).
4. **Preview-deploy check:** confirm `/sitemaps/grants/sitemap/1.xml` still returns the real ~1000-URL file (static wins) while `/sitemaps/grants/sitemap/99.xml` returns an empty 200 (the catch-all). This validates the public-file-precedence assumption.

## Technical Details

- `computeChunkCount` is unchanged; the floor is applied in `main()` via `readPublishedChunkCounts(indexPath)`, which regex-parses `/sitemaps/{kind}/sitemap/{n}.xml` from the existing index.
- Caveat: the floor is read from the committed index, which can lag the last deployed state. On a healthy build, live counts drive the result; the floor only matters on a `/counts` failure, and the catch-all route covers any chunk above the floor.

## Notes for reviewers

- `__tests__/scripts/generate-sitemap.test.ts` shells out to `npm` via `execFileSync`, which cannot spawn on Windows without the `.cmd` extension — so that suite does not run in a local Windows sandbox (it runs on Linux CI). The behavior it asserts was verified manually as described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fallback route handler that serves valid empty sitemaps for orphaned sitemap chunks instead of returning errors.

* **Bug Fixes**
  * Improved sitemap generation resilience when the indexer is unavailable—previously published sitemap chunks are now preserved rather than dropped.
  * Sitemap chunk counts are now floored to previously published values to prevent data loss across builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->