### PR TITLE
fix(milestone-invoices): send milestoneUID on payment status and surface real submit errors

### DIFF
--- a/__tests__/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.test.tsx
+++ b/__tests__/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.test.tsx
@@ -180,6 +180,7 @@ function renderWithProviders(ui: React.ReactElement) {
 const defaultProps = {
   currentStatus: "unpaid" as MilestonePaymentStatus,
   milestoneLabel: "Milestone 1",
+  milestoneUID: "milestone-uid-789",
   grantUID: "grant-123",
   communityUID: "community-456",
 };
@@ -243,6 +244,7 @@ describe("PaymentStatusDropdown", () => {
       {
         grantUID: "grant-123",
         milestoneLabel: "Milestone 1",
+        milestoneUID: "milestone-uid-789",
         paymentStatus: "pending",
       },
       expect.objectContaining({

--- a/__tests__/unit/services/payout-disbursement.service.test.ts
+++ b/__tests__/unit/services/payout-disbursement.service.test.ts
@@ -627,17 +627,17 @@ describe("payout-disbursement.service", () => {
       );
     });
 
-    it("throws on fetch error", async () => {
-      mockFetchData.mockResolvedValue([null, "Unauthorized"]);
+    it("surfaces the backend error message verbatim", async () => {
+      mockFetchData.mockResolvedValue([null, "An invoice already exists for this milestone"]);
       await expect(submitGranteeInvoice("grant-1", invoice)).rejects.toThrow(
-        /Failed to submit invoice/
+        "An invoice already exists for this milestone"
       );
     });
 
-    it("throws when data is null", async () => {
+    it("falls back to a generic message when the backend provides none", async () => {
       mockFetchData.mockResolvedValue([null, null]);
       await expect(submitGranteeInvoice("grant-1", invoice)).rejects.toThrow(
-        /Failed to submit invoice/
+        "Failed to submit invoice"
       );
     });
   });

--- a/components/Forms/MilestoneUpdate.tsx
+++ b/components/Forms/MilestoneUpdate.tsx
@@ -566,7 +566,13 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
           address,
           milestoneUID: milestone.uid,
         });
-        toast.error("Invoice submission failed. Please try again.", { id: loadingToastId });
+        // Surface the backend's specific reason (e.g. a 409 conflict
+        // message); fall back only when no message is available.
+        const message =
+          invoiceError instanceof Error && invoiceError.message
+            ? invoiceError.message
+            : "Invoice submission failed. Please try again.";
+        toast.error(message, { id: loadingToastId });
       } finally {
         setIsSubmitLoading(false);
       }
@@ -602,7 +608,13 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
         });
       } catch (invoiceError) {
         errorManager("Invoice submission failed after milestone update", invoiceError);
-        toast.error("Update saved but invoice submission failed. You can try again later.");
+        // Surface the backend's specific reason; the milestone update
+        // itself already succeeded, so prefix to keep that context.
+        const reason =
+          invoiceError instanceof Error && invoiceError.message
+            ? invoiceError.message
+            : "You can try again later.";
+        toast.error(`Update saved but invoice submission failed: ${reason}`);
       }
     }
   };

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -530,6 +530,7 @@ export const MilestonesSection = memo(function MilestonesSection({
                           <PaymentStatusDropdown
                             currentStatus={invoice.paymentStatus ?? "unpaid"}
                             milestoneLabel={invoice.milestoneLabel}
+                            milestoneUID={invoice.milestoneUID}
                             grantUID={grant.grantUid}
                             communityUID={communityUID}
                             paymentStatusDate={invoice.paymentStatusDate}

--- a/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
+++ b/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
@@ -59,6 +59,7 @@ const STATUS_OPTIONS: {
 interface PaymentStatusDropdownProps {
   currentStatus: MilestonePaymentStatus;
   milestoneLabel: string;
+  milestoneUID: string | null;
   grantUID: string;
   communityUID: string;
   paymentStatusDate?: string | null;
@@ -72,6 +73,7 @@ interface PaymentStatusDropdownProps {
 export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
   currentStatus,
   milestoneLabel,
+  milestoneUID,
   grantUID,
   communityUID,
   paymentStatusDate,
@@ -104,7 +106,7 @@ export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
 
       // "Pending" stays as override-only (existing behavior)
       mutation.mutate(
-        { grantUID, milestoneLabel, paymentStatus: "pending" },
+        { grantUID, milestoneLabel, milestoneUID: milestoneUID ?? "", paymentStatus: "pending" },
         {
           onSuccess: () => {
             toast.success(`Payment status updated to ${status}`);
@@ -119,6 +121,7 @@ export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
       currentStatus,
       grantUID,
       milestoneLabel,
+      milestoneUID,
       mutation,
       onRequestRecordPayment,
       onRequestDeleteDisbursement,

--- a/src/features/applications/hooks/use-submit-milestone-completion.ts
+++ b/src/features/applications/hooks/use-submit-milestone-completion.ts
@@ -235,6 +235,7 @@ export function useSubmitMilestoneCompletion() {
           try {
             await submitGranteeInvoice(grantUID, {
               milestoneLabel: params.milestoneTitle,
+              milestoneUID: params.milestoneUID,
               invoiceFileKey: params.invoiceFile.fileKey,
               invoiceFileUrl: params.invoiceFile.fileUrl,
             });

--- a/src/features/applications/hooks/use-submit-milestone-completion.ts
+++ b/src/features/applications/hooks/use-submit-milestone-completion.ts
@@ -243,10 +243,16 @@ export function useSubmitMilestoneCompletion() {
             await queryClient.invalidateQueries({
               queryKey: QUERY_KEYS.APPLICATIONS.INVOICE_CONFIG(params.referenceNumber),
             });
-          } catch {
+          } catch (invoiceError) {
             if (signal.aborted) return;
-            // Non-fatal — the on-chain completion already shipped.
-            toast.error("Failed to submit invoice");
+            // Non-fatal — the on-chain completion already shipped. Surface
+            // the backend's specific reason (e.g. a 409 conflict message)
+            // instead of a generic string; fall back only when absent.
+            const message =
+              invoiceError instanceof Error && invoiceError.message
+                ? invoiceError.message
+                : "Failed to submit invoice";
+            toast.error(message);
           }
         }
       } finally {

--- a/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
+++ b/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
@@ -687,13 +687,15 @@ export function useUpdateMilestonePaymentStatus(
     {
       grantUID: string;
       milestoneLabel: string;
+      milestoneUID: string;
       paymentStatus: "pending";
     }
   >({
-    mutationFn: ({ grantUID, milestoneLabel, paymentStatus }) =>
+    mutationFn: ({ grantUID, milestoneLabel, milestoneUID, paymentStatus }) =>
       payoutService.updateMilestonePaymentStatus(grantUID, {
         communityUID,
         milestoneLabel,
+        milestoneUID,
         paymentStatus,
       }),
     onSuccess: () => {

--- a/src/features/payout-disbursement/services/payout-disbursement.service.ts
+++ b/src/features/payout-disbursement/services/payout-disbursement.service.ts
@@ -231,6 +231,7 @@ export const updateMilestonePaymentStatus = async (
   request: {
     communityUID: string;
     milestoneLabel: string;
+    milestoneUID: string;
     paymentStatus: "pending";
   }
 ): Promise<void> => {
@@ -876,13 +877,18 @@ export const submitGranteeInvoice = async (
     );
 
     if (error || !data?.data) {
+      // `fetchData` already extracts the backend `message` field into
+      // `error`, so propagate it verbatim — the UI surfaces this string
+      // (e.g. a 409 conflict reason) instead of a generic fallback.
       throw new Error(error || "Failed to submit invoice");
     }
 
     return data.data.invoice;
   } catch (error: unknown) {
     errorManager(`Error submitting grantee invoice for grant ${grantUID}`, error);
-    throw new Error(`Failed to submit invoice: ${getErrorMessage(error)}`);
+    // Re-throw the original message unchanged so callers can show the
+    // backend's specific reason; only fall back when none is available.
+    throw new Error(getErrorMessage(error) || "Failed to submit invoice");
   }
 };
 


### PR DESCRIPTION
## Problem

Two related Sentry issues, same root cause: a grantee submitting an invoice for a **second milestone that shares a label** with the first saw "Failed to submit invoice: An unexpected error occurred" ([`GAP-FRONTEND-22F`](https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-22F)) — the browser capture of the indexer 500 (`GAP-INDEXER-TP`).

Two frontend gaps fed it:
1. The admin **payment-status override** sent only `{ communityUID, milestoneLabel, paymentStatus }` — no `milestoneUID` — so the indexer resolved the invoice by label, which is ambiguous when two milestones in a grant share a label.
2. Invoice submit failures showed a **hardcoded generic message**, hiding the real backend reason.

## Fix

- **Send `milestoneUID`** through the payment-status flow: `PaymentStatusDropdown` → `useUpdateMilestonePaymentStatus` → `updateMilestonePaymentStatus`. The value already exists on `CommunityPayoutInvoiceInfo`; `MilestonesSection` now threads it down. (Submit and batch-save already sent it.)
- **Surface the real backend error** on invoice submit failures instead of the generic string. `fetchData` already extracts `{ message }`; the submit service/hook/forms now propagate and toast it, with the generic text only as a fallback. The indexer now returns specific messages (e.g. 409 Conflict).

## Testing

- `PaymentStatusDropdown` and `payout-disbursement.service` tests updated and passing (milestoneUID forwarded; backend message surfaced verbatim with fallback).
- Changed files typecheck clean.

## Pairs with

show-karma/gap-indexer#1948 (backend identity hardening + index reconciliation).

## ⚠️ Rollout order

Deploy this **with** the indexer PR, **before** the indexer's index-reconciliation script runs — the payment-status path must be UID-keyed in production before the legacy index is dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice submission failures now surface backend-provided error messages (with sensible fallbacks) so users see clearer, specific feedback.
  * Payment status updates now include the correct milestone identifier to ensure status changes apply to the intended milestone.

* **Tests**
  * Test suites updated to assert the new error-message behavior and milestone-identifier handling in payment-status and invoice flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->