### PR TITLE
feat: add Batch 3 - Apply Now to Filecoin ProPGF Grants dropdown

### DIFF
--- a/src/infrastructure/config/tenant-config.ts
+++ b/src/infrastructure/config/tenant-config.ts
@@ -320,6 +320,11 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
                 href: "https://app.filpgf.io/projects?programId=1039",
                 isExternal: true,
               },
+              {
+                label: "Batch 3 - Apply Now",
+                href: "https://app.filpgf.io/programs/1479/",
+                isExternal: true,
+              },
             ],
           },
           {


### PR DESCRIPTION
## Overview

Adds **Batch 3 - Apply Now** to the **Grants** subsection of the Filecoin community ProPGF dropdown.

## Problem

When signed in, the Filecoin ProPGF dropdown showed the old structure — "Batch 2 - Pods Track" was present but **Batch 3 was missing entirely**, unlike the public filpgf.io site. The signed-in (gap-app) navigation is driven by the static `filecoin` tenant config, which had not been updated for Batch 3.

## Solution

Add a `Batch 3 - Apply Now` item under `ProPGF → Grants` in the `filecoin` tenant navigation, linking to the live application program (`https://app.filpgf.io/programs/1479/`). Placed after the existing batches (Batch 1 → Batch 2 → Pods Track → Batch 3).

## Testing steps

1. Open the Filecoin community while signed in.
2. Open the **ProPGF** dropdown → **Grants**.
3. Confirm **Batch 3 - Apply Now** appears and links to `https://app.filpgf.io/programs/1479/`.

Resolves DEV-354 and the signed-in half of DEV-358. The public/signed-out (filpgf.io Hugo) half is handled in a companion PR on `show-karma/filecoin-grants`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Batch 3 - Apply Now" navigation link in the ProPGF Grants section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/show-karma/gap-app-v2/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->