### PR TITLE
fix(project): include project owner in Updates and Impact edit authorization

### DIFF
--- a/__tests__/components/Milestone/MilestonesList.test.tsx
+++ b/__tests__/components/Milestone/MilestonesList.test.tsx
@@ -30,7 +30,7 @@ vi.mock("next/navigation", () => ({
 // Mock stores
 vi.mock("@/store", () => ({
   useOwnerStore: vi.fn((selector) => selector({ isOwner: false })),
-  useProjectStore: vi.fn((selector) => selector({ isProjectAdmin: false })),
+  useProjectStore: vi.fn((selector) => selector({ isProjectAdmin: false, isProjectOwner: false })),
 }));
 
 // Mock ActivityCard component

--- a/components/Milestone/MilestonesList.tsx
+++ b/components/Milestone/MilestonesList.tsx
@@ -9,7 +9,7 @@ import { Fragment, useCallback, useMemo, useState } from "react";
 import { ActivityCard } from "@/components/Shared/ActivityCard";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import type { StatusOptions } from "@/utilities/gapIndexerApi/getProjectObjectives";
 import { mergeDuplicateMilestones } from "@/utilities/milestones/mergeDuplicateMilestones";
@@ -87,10 +87,7 @@ export const MilestonesList = ({
   showAllTypes = false,
   totalItems,
 }: MilestonesListProps) => {
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
 
   // Extract unique grant UIDs for allocation lookup
   const grantUIDs = useMemo(() => {

--- a/components/Milestone/MilestonesList.tsx
+++ b/components/Milestone/MilestonesList.tsx
@@ -89,7 +89,8 @@ export const MilestonesList = ({
 }: MilestonesListProps) => {
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   // Extract unique grant UIDs for allocation lookup
   const grantUIDs = useMemo(() => {

--- a/components/Pages/Project/Activity.tsx
+++ b/components/Pages/Project/Activity.tsx
@@ -2,17 +2,15 @@ import { Tab } from "@headlessui/react";
 import { useParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import { ActivityList } from "@/components/Shared/ActivityList";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { useProjectImpacts } from "@/hooks/v2/useProjectImpacts";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { transformImpactsToMilestones } from "@/services/project-profile.service";
-import { useOwnerStore, useProjectStore } from "@/store";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { cn } from "@/utilities/tailwind";
 
 export const ProjectActivity = () => {
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isOwner = useOwnerStore((state) => state.isOwner);
+  const isAuthorized = useProjectAuthorization();
   const { projectId } = useParams();
 
   const { milestones = [] } = useProjectUpdates(projectId as string);
@@ -25,7 +23,6 @@ export const ProjectActivity = () => {
     const impactItems = transformImpactsToMilestones(impacts);
     return [...milestones, ...impactItems];
   }, [milestones, impacts]);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   // Count items by type for tabs
   const updatesCount = useMemo(

--- a/components/Pages/Project/Activity.tsx
+++ b/components/Pages/Project/Activity.tsx
@@ -5,12 +5,14 @@ import { ActivityList } from "@/components/Shared/ActivityList";
 import { useProjectImpacts } from "@/hooks/v2/useProjectImpacts";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { transformImpactsToMilestones } from "@/services/project-profile.service";
-import { useProjectStore } from "@/store";
+import { useOwnerStore, useProjectStore } from "@/store";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { cn } from "@/utilities/tailwind";
 
 export const ProjectActivity = () => {
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isOwner = useOwnerStore((state) => state.isOwner);
   const { projectId } = useParams();
 
   const { milestones = [] } = useProjectUpdates(projectId as string);
@@ -23,7 +25,7 @@ export const ProjectActivity = () => {
     const impactItems = transformImpactsToMilestones(impacts);
     return [...milestones, ...impactItems];
   }, [milestones, impacts]);
-  const isAuthorized = isProjectAdmin;
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   // Count items by type for tabs
   const updatesCount = useMemo(

--- a/components/Pages/Project/Impact/EmptyImpactScreen.tsx
+++ b/components/Pages/Project/Impact/EmptyImpactScreen.tsx
@@ -2,15 +2,11 @@ import { PlusIcon } from "@heroicons/react/20/solid";
 import Image from "next/image";
 import { useQueryState } from "nuqs";
 import type { FC } from "react";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { MESSAGES } from "@/utilities/messages";
 
 export const EmptyImpactScreen: FC = () => {
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isOwner = useOwnerStore((state) => state.isOwner);
-
-  const isAuthorized = isProjectAdmin || isOwner || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
   const [, changeTab] = useQueryState("tab");
   if (!isAuthorized) {
     return (

--- a/components/Pages/Project/Impact/EmptyImpactScreen.tsx
+++ b/components/Pages/Project/Impact/EmptyImpactScreen.tsx
@@ -7,9 +7,10 @@ import { MESSAGES } from "@/utilities/messages";
 
 export const EmptyImpactScreen: FC = () => {
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isOwner = useOwnerStore((state) => state.isOwner);
 
-  const isAuthorized = isProjectAdmin || isOwner;
+  const isAuthorized = isProjectAdmin || isOwner || isProjectOwner;
   const [, changeTab] = useQueryState("tab");
   if (!isAuthorized) {
     return (

--- a/components/Pages/Project/Impact/index.tsx
+++ b/components/Pages/Project/Impact/index.tsx
@@ -10,7 +10,8 @@ type ImpactComponentProps = {};
 export const ImpactComponent: FC<ImpactComponentProps> = () => {
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   const searchParams = useSearchParams();
   const grantScreen = searchParams?.get("tab");

--- a/components/Pages/Project/Impact/index.tsx
+++ b/components/Pages/Project/Impact/index.tsx
@@ -2,16 +2,13 @@
 import { useSearchParams } from "next/navigation";
 import type { FC } from "react";
 import { OutputsAndOutcomes } from "@/components/Pages/Project/Impact/OutputsAndOutcomes";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { AddImpactScreen } from "./AddImpactScreen";
 
 type ImpactComponentProps = {};
 
 export const ImpactComponent: FC<ImpactComponentProps> = () => {
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
 
   const searchParams = useSearchParams();
   const grantScreen = searchParams?.get("tab");

--- a/components/Pages/Project/ProjectWrapper/ProjectNavigation.tsx
+++ b/components/Pages/Project/ProjectWrapper/ProjectNavigation.tsx
@@ -92,7 +92,7 @@ export const ProjectNavigation = ({
   );
   const isSuperAdmin = permissions?.roles?.roles?.includes(Role.SUPER_ADMIN) ?? false;
 
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
   // Can set payout address: project member/owner/admin/super admin
   // Wait for permissions check to complete to avoid UI flicker
   const canSetPayoutAddress =

--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -56,7 +56,8 @@ export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) =>
 
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   // Derive active filters directly from URL params - no state synchronization needed
   const activeFilters = useMemo(() => {

--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -4,10 +4,11 @@ import { useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { MilestonesList } from "@/components/Milestone/MilestonesList";
 import { Button } from "@/components/Utilities/Button";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { useProjectImpacts } from "@/hooks/v2/useProjectImpacts";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { transformImpactsToMilestones } from "@/services/project-profile.service";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import { useProgressModalStore } from "@/store/modals/progress";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
@@ -54,10 +55,7 @@ export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) =>
 
   const { setIsProgressModalOpen, setProgressModalScreen } = useProgressModalStore();
 
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
 
   // Derive active filters directly from URL params - no state synchronization needed
   const activeFilters = useMemo(() => {

--- a/components/Pages/Project/Updates/Updates.tsx
+++ b/components/Pages/Project/Updates/Updates.tsx
@@ -16,7 +16,8 @@ export const UpdatesPage: FC = () => {
 
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   const { setIsProgressModalOpen, setProgressModalScreen } = useProgressModalStore();
 

--- a/components/Pages/Project/Updates/Updates.tsx
+++ b/components/Pages/Project/Updates/Updates.tsx
@@ -4,20 +4,18 @@ import Image from "next/image";
 import type { FC } from "react";
 import { ActivityList } from "@/components/Shared/ActivityList";
 import { Button } from "@/components/Utilities/Button";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { useProjectImpacts } from "@/hooks/v2/useProjectImpacts";
 import { useProjectUpdates } from "@/hooks/v2/useProjectUpdates";
 import { transformImpactsToMilestones } from "@/services/project-profile.service";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import { useProgressModalStore } from "@/store/modals/progress";
 import { MESSAGES } from "@/utilities/messages";
 
 export const UpdatesPage: FC = () => {
   const project = useProjectStore((state) => state.project);
 
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
 
   const { setIsProgressModalOpen, setProgressModalScreen } = useProgressModalStore();
 

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -2,13 +2,13 @@
 
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useMemo } from "react";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import {
   isMilestoneStatusFilter,
   type MilestoneStatusFilter,
 } from "@/services/milestone-status-filter.service";
 import { getActivityFilterType } from "@/services/project-profile.service";
-import { useOwnerStore, useProjectStore } from "@/store";
 import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
 import { ActivityFeed } from "../MainContent/ActivityFeed";
 import { ActivityFilters, type ActivityFilterType } from "../MainContent/ActivityFilters";
@@ -33,10 +33,7 @@ function parseIntParam(value: string | null): number | undefined {
  */
 export function UpdatesContent({ className }: UpdatesContentProps) {
   const { projectId } = useParams();
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -35,7 +35,8 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
   const { projectId } = useParams();
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();

--- a/components/Pages/Project/v2/Content/__tests__/UpdatesContent.test.tsx
+++ b/components/Pages/Project/v2/Content/__tests__/UpdatesContent.test.tsx
@@ -43,9 +43,11 @@ vi.mock("@/components/Pages/Project/v2/MainContent/ActivityFilters", () => ({
 
 // ─── Shared test helpers ───────────────────────────────────────────────────────
 
-function mockStores({ isOwner = false, isProjectAdmin = false } = {}) {
+function mockStores({ isOwner = false, isProjectAdmin = false, isProjectOwner = false } = {}) {
   (useOwnerStore as unknown as vi.Mock).mockImplementation((sel) => sel({ isOwner }));
-  (useProjectStore as unknown as vi.Mock).mockImplementation((sel) => sel({ isProjectAdmin }));
+  (useProjectStore as unknown as vi.Mock).mockImplementation((sel) =>
+    sel({ isProjectAdmin, isProjectOwner })
+  );
 }
 
 function mockProjectProfile(overrides: Record<string, unknown> = {}) {
@@ -90,6 +92,12 @@ describe("UpdatesContent — authorization", () => {
 
   it("passes isAuthorized=true when user is both owner and admin", () => {
     mockStores({ isOwner: true, isProjectAdmin: true });
+    render(<UpdatesContent />);
+    expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "true");
+  });
+
+  it("passes isAuthorized=true to ActivityFeed when user is project owner (not admin)", () => {
+    mockStores({ isProjectOwner: true });
     render(<UpdatesContent />);
     expect(screen.getByTestId("activity-feed")).toHaveAttribute("data-authorized", "true");
   });

--- a/components/Pages/Project/v2/MainContent/ImpactContent.tsx
+++ b/components/Pages/Project/v2/MainContent/ImpactContent.tsx
@@ -27,7 +27,8 @@ interface ImpactContentProps {
 export function ImpactContent({ className }: ImpactContentProps) {
   const isOwner = useOwnerStore((state) => state.isOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isAuthorized = isOwner || isProjectAdmin;
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
 
   const searchParams = useSearchParams();
   const grantScreen = searchParams?.get("tab");

--- a/components/Pages/Project/v2/MainContent/ImpactContent.tsx
+++ b/components/Pages/Project/v2/MainContent/ImpactContent.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { AddImpactScreen } from "@/components/Pages/Project/Impact/AddImpactScreen";
 import { OutputsAndOutcomes } from "@/components/Pages/Project/Impact/OutputsAndOutcomes";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { ImpactStatsSummary } from "./ImpactStatsSummary";
 
 interface ImpactContentProps {
@@ -25,10 +25,7 @@ interface ImpactContentProps {
  * alongside the project info, separated by a vertical divider.
  */
 export function ImpactContent({ className }: ImpactContentProps) {
-  const isOwner = useOwnerStore((state) => state.isOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isAuthorized = isOwner || isProjectAdmin || isProjectOwner;
+  const isAuthorized = useProjectAuthorization();
 
   const searchParams = useSearchParams();
   const grantScreen = searchParams?.get("tab");

--- a/components/Pages/Project/v2/__tests__/ImpactContent.test.tsx
+++ b/components/Pages/Project/v2/__tests__/ImpactContent.test.tsx
@@ -46,7 +46,7 @@ describe("ImpactContent", () => {
       return selector ? selector(state as never) : state;
     });
     mockUseProjectStore.mockImplementation((selector) => {
-      const state = { isProjectAdmin: false };
+      const state = { isProjectAdmin: false, isProjectOwner: false };
       return selector ? selector(state as never) : state;
     });
     mockUseSearchParams.mockReturnValue(new URLSearchParams());
@@ -94,7 +94,19 @@ describe("ImpactContent", () => {
 
     it("should show AddImpactScreen when project admin and tab=add-impact", () => {
       mockUseProjectStore.mockImplementation((selector) => {
-        const state = { isProjectAdmin: true };
+        const state = { isProjectAdmin: true, isProjectOwner: false };
+        return selector ? selector(state as never) : state;
+      });
+      mockUseSearchParams.mockReturnValue(new URLSearchParams("tab=add-impact"));
+
+      render(<ImpactContent />);
+
+      expect(screen.getByTestId("add-impact-screen")).toBeInTheDocument();
+    });
+
+    it("should show AddImpactScreen when project owner (not admin) and tab=add-impact", () => {
+      mockUseProjectStore.mockImplementation((selector) => {
+        const state = { isProjectAdmin: false, isProjectOwner: true };
         return selector ? selector(state as never) : state;
       });
       mockUseSearchParams.mockReturnValue(new URLSearchParams("tab=add-impact"));

--- a/hooks/__tests__/useProjectAuthorization.test.ts
+++ b/hooks/__tests__/useProjectAuthorization.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from "@testing-library/react";
+import { useProjectAuthorization } from "../useProjectAuthorization";
+
+vi.mock("@/store", () => ({
+  useOwnerStore: vi.fn(),
+  useProjectStore: vi.fn(),
+}));
+
+import { useOwnerStore, useProjectStore } from "@/store";
+
+const mockUseOwnerStore = useOwnerStore as unknown as vi.Mock;
+const mockUseProjectStore = useProjectStore as unknown as vi.Mock;
+
+function mockStores({ isOwner = false, isProjectAdmin = false, isProjectOwner = false } = {}) {
+  mockUseOwnerStore.mockImplementation((selector) => selector({ isOwner }));
+  mockUseProjectStore.mockImplementation((selector) =>
+    selector({ isProjectAdmin, isProjectOwner })
+  );
+}
+
+describe("useProjectAuthorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when the user has none of the ownership signals", () => {
+    mockStores();
+    const { result } = renderHook(() => useProjectAuthorization());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true for the global EAS resolver super-admin (isOwner)", () => {
+    mockStores({ isOwner: true });
+    const { result } = renderHook(() => useProjectAuthorization());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true for an on-chain project admin (isProjectAdmin)", () => {
+    mockStores({ isProjectAdmin: true });
+    const { result } = renderHook(() => useProjectAuthorization());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true for a project owner without admin rights (isProjectOwner)", () => {
+    // The regression case: email/embedded-wallet owners resolve only via isProjectOwner.
+    mockStores({ isProjectOwner: true });
+    const { result } = renderHook(() => useProjectAuthorization());
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/useProjectAuthorization.ts
+++ b/hooks/useProjectAuthorization.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useOwnerStore, useProjectStore } from "@/store";
+
+/**
+ * Whether the current user may edit/delete project content (milestones,
+ * updates, impact) on the project profile.
+ *
+ * Centralizes the three ownership signals that must stay in sync across every
+ * project view. Keeping them in one place prevents the drift that previously
+ * hid edit/delete controls from legitimate project owners:
+ * - `isOwner`        — global EAS resolver super-admin (not the project owner)
+ * - `isProjectAdmin` — on-chain `isAdmin()` result (no linked-wallet fallback)
+ * - `isProjectOwner` — ownership resolved via `compareAllWallets`, covering
+ *   email/embedded-wallet owners and multi-wallet accounts
+ */
+export function useProjectAuthorization(): boolean {
+  const isOwner = useOwnerStore((state) => state.isOwner);
+  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
+  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
+  return isOwner || isProjectAdmin || isProjectOwner;
+}


### PR DESCRIPTION
## Problem

Project owners reported losing the ability to **edit and delete milestones** (and impact entries) on the project profile — the controls simply disappeared from the UI.

Root cause: several project views computed edit authorization as:

```ts
const isAuthorized = isOwner || isProjectAdmin;   // (or, in the legacy Activity view, isProjectAdmin alone)
```

This omits `isProjectOwner`. Note:
- `isOwner` (from `useOwnerStore`) is the **global EAS resolver super-admin**, not the project owner.
- `isProjectAdmin` is set **only** from the on-chain `isAdmin()` check — it has **no linked-wallet/API fallback**.
- `isProjectOwner` is the flag that *does* resolve ownership via `compareAllWallets` (covering email/embedded-wallet owners and multi-wallet accounts).

So a legitimate project owner who is not separately registered as an on-chain admin — e.g. a Privy email-login owner whose active wallet is the embedded wallet — resolved to `isAuthorized = false`, and all edit/delete controls silently stopped rendering.

This was a latent gap: sibling components already do it correctly (`GrantDetailLayout.tsx`, `TeamContent.tsx`); these views were missed by the earlier `isProjectOwner` authorization fix.

## Fix

Authorize on `isOwner || isProjectAdmin || isProjectOwner` across all affected project views:

- `components/Pages/Project/v2/Content/UpdatesContent.tsx`
- `components/Pages/Project/v2/MainContent/ImpactContent.tsx`
- `components/Milestone/MilestonesList.tsx`
- `components/Pages/Project/Roadmap/index.tsx`
- `components/Pages/Project/Impact/index.tsx`
- `components/Pages/Project/Impact/EmptyImpactScreen.tsx`
- `components/Pages/Project/Updates/Updates.tsx`
- `components/Pages/Project/ProjectWrapper/ProjectNavigation.tsx`
- `components/Pages/Project/Activity.tsx` (legacy — previously checked `isProjectAdmin` alone; now also includes `isOwner` + `isProjectOwner`)

## Tests

- Updated store mocks in the affected suites to include `isProjectOwner`.
- Added regression tests for the **project-owner-but-not-admin** case in `UpdatesContent` and `ImpactContent`.
- Affected unit suites pass (UpdatesContent, ImpactContent, MilestonesList, ProjectNavigation, ProjectNavigationTabs); typecheck passes.

## Out of scope

The intermittent "No wallet connected" and first-load endpoint failures reported alongside this issue stem from a separate Privy/Wagmi auth-init race (no coordinated "auth ready → refetch" signal) and are **not** addressed here.
