### PR TITLE
fix(auth): heal Privy/Wagmi hydration race for wallet display and data fetching

### DIFF
--- a/__tests__/navbar/unit/navbar-user-menu.test.tsx
+++ b/__tests__/navbar/unit/navbar-user-menu.test.tsx
@@ -629,4 +629,27 @@ describe("NavbarUserMenu", () => {
       expect(followSection).toBeInTheDocument();
     });
   });
+
+  describe("Wallet Hydration (Privy↔Wagmi gap)", () => {
+    it("shows the skeleton instead of 'No wallet connected' while an authenticated user's wallet is still hydrating", () => {
+      // authenticated=true, but `user` and `wallets[0].address` haven't resolved
+      // yet (the deferred-SDK race). The menu must not render a blank avatar or
+      // claim "No wallet connected" for an actually-connected user.
+      _localRefs.navPermsState.current.isLoggedIn = true;
+      _localRefs.navPermsState.current.address = undefined;
+      _localRefs.navPermsState.current.ready = true;
+      _localRefs.authState.current.authenticated = true;
+      _localRefs.authState.current.address = undefined;
+      _localRefs.authState.current.user = null;
+
+      renderWithProviders(<NavbarUserMenu />, {
+        mockUseAuth: createMockUseAuth(_localRefs.authState.current),
+      });
+
+      expect(screen.queryByText("No wallet connected")).not.toBeInTheDocument();
+      // The skeleton replaces the menu entirely — no menubar or avatar yet.
+      expect(screen.queryByRole("menubar")).not.toBeInTheDocument();
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/__tests__/unit/hooks/useAuth.auth-ready-barrier.test.tsx
+++ b/__tests__/unit/hooks/useAuth.auth-ready-barrier.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @file Tests for the useAuth auth-ready refetch barrier
+ * @description Privy/Wagmi hydrate the wallet asynchronously, so `authenticated`
+ * flips true before `wallets[0].address` is populated. useAuth invalidates
+ * queries once when the address first resolves so requests that ran during the
+ * gap (empty/401) refetch with auth now ready. Kept in a focused module to keep
+ * useAuth.test.tsx under the file-size budget.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
+
+// Undo the global mock of useAuth from __tests__/navbar/setup.ts
+vi.unmock("@/hooks/useAuth");
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: vi.fn(() => ({ isWhitelabel: false, whitelabelConfig: null })),
+}));
+
+vi.mock("@/store/modals/projectCreate", () => ({
+  useProjectCreateModalStore: {
+    getState: vi.fn(() => ({ isProjectCreateModalOpen: false })),
+  },
+}));
+
+vi.mock("@/utilities/auth/compare-all-wallets", () => ({
+  compareAllWallets: vi.fn(() => true),
+}));
+
+vi.mock("@/utilities/pages", () => ({
+  PAGES: { DASHBOARD: "/dashboard" },
+}));
+
+vi.mock("@wagmi/core", () => ({
+  watchAccount: vi.fn(() => vi.fn()),
+}));
+
+const mockQueryClientInvalidate = vi.fn();
+
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: {
+    clear: vi.fn(),
+    invalidateQueries: (...args: unknown[]) => mockQueryClientInvalidate(...args),
+  },
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn().mockResolvedValue("token"),
+    setPrivyInstance: vi.fn(),
+    clearCache: vi.fn(),
+  },
+}));
+
+// Mutable bridge state that useAuth reads from. Typed loosely (not as Privy's
+// full User/ConnectedWallet) so tests can set minimal fixtures without `any`.
+interface MockBridgeState {
+  ready: boolean;
+  authenticated: boolean;
+  user: { id?: string; wallet?: { address: string } } | null;
+  login: () => void;
+  logout: () => void;
+  getAccessToken: () => Promise<string | null>;
+  connectWallet: () => void;
+  wallets: Array<{ address: string; chainId?: string }>;
+  isConnected: boolean;
+}
+
+const mockBridgeState: MockBridgeState = {
+  ready: true,
+  authenticated: false,
+  user: null,
+  login: vi.fn(),
+  logout: vi.fn(),
+  getAccessToken: vi.fn().mockResolvedValue("token"),
+  connectWallet: vi.fn(),
+  wallets: [],
+  isConnected: false,
+};
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => mockBridgeState,
+}));
+
+function setBridgeState(overrides: Partial<typeof mockBridgeState>) {
+  Object.assign(mockBridgeState, overrides);
+}
+
+function resetBridgeState() {
+  Object.assign(mockBridgeState, {
+    ready: true,
+    authenticated: false,
+    user: null,
+    wallets: [],
+    isConnected: false,
+  });
+}
+
+describe("useAuth - auth-ready refetch barrier", () => {
+  const mockPrivyUser = {
+    id: "user-123",
+    wallet: { address: "0x1234567890123456789012345678901234567890" },
+  };
+  const mockWallet = {
+    address: "0x1234567890123456789012345678901234567890",
+    chainId: "eip155:10",
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  beforeEach(() => {
+    mockQueryClientInvalidate.mockClear();
+  });
+
+  afterEach(() => {
+    resetBridgeState();
+  });
+
+  it("invalidates queries when the wallet address resolves after auth (Privy↔Wagmi gap)", async () => {
+    // Authenticated, but wallets[0].address has not hydrated yet.
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: mockPrivyUser,
+      wallets: [],
+      isConnected: false,
+    });
+    const { rerender } = renderHook(() => useAuth(), { wrapper });
+
+    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
+
+    // Wallet hydrates → address becomes available.
+    setBridgeState({ wallets: [mockWallet], isConnected: true });
+    await act(async () => {
+      rerender();
+    });
+
+    expect(mockQueryClientInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate when the address is already present at mount", async () => {
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: mockPrivyUser,
+      wallets: [mockWallet],
+      isConnected: true,
+    });
+    const { rerender } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -106,11 +106,13 @@ vi.mock("@/utilities/wagmi/privy-config", () => ({
 }));
 
 const mockQueryClientClear = vi.fn();
+const mockQueryClientInvalidate = vi.fn();
 const mockClearCache = vi.fn();
 
 vi.mock("@/utilities/query-client", () => ({
   queryClient: {
     clear: (...args: unknown[]) => mockQueryClientClear(...args),
+    invalidateQueries: (...args: unknown[]) => mockQueryClientInvalidate(...args),
     removeQueries: vi.fn(),
   },
 }));
@@ -187,6 +189,65 @@ describe("useAuth - Query Key Consistency", () => {
       expect(Array.isArray(QUERY_KEYS.AUTH.CONTRACT_OWNER("test", 1))).toBe(true);
       expect(Array.isArray(QUERY_KEYS.COMMUNITY.IS_ADMIN("uid", 1, "addr", {}))).toBe(true);
     });
+  });
+});
+
+describe("useAuth - Auth-ready refetch barrier", () => {
+  const mockPrivyUser = {
+    id: "user-123",
+    wallet: { address: "0x1234567890123456789012345678901234567890" },
+  };
+  const mockWallet = {
+    address: "0x1234567890123456789012345678901234567890",
+    chainId: "eip155:10",
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  beforeEach(() => {
+    mockQueryClientInvalidate.mockClear();
+  });
+
+  afterEach(() => {
+    resetBridgeState();
+  });
+
+  it("invalidates queries when the wallet address resolves after auth (Privy↔Wagmi gap)", async () => {
+    // Authenticated, but wallets[0].address has not hydrated yet.
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: mockPrivyUser,
+      wallets: [],
+      isConnected: false,
+    });
+    const { rerender } = renderHook(() => useAuth(), { wrapper });
+
+    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
+
+    // Wallet hydrates → address becomes available.
+    setBridgeState({ wallets: [mockWallet], isConnected: true });
+    await act(async () => {
+      rerender();
+    });
+
+    expect(mockQueryClientInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate when the address is already present at mount", async () => {
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: mockPrivyUser,
+      wallets: [mockWallet],
+      isConnected: true,
+    });
+    const { rerender } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      rerender();
+    });
+
+    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -106,14 +106,12 @@ vi.mock("@/utilities/wagmi/privy-config", () => ({
 }));
 
 const mockQueryClientClear = vi.fn();
-const mockQueryClientInvalidate = vi.fn();
 const mockClearCache = vi.fn();
 
 vi.mock("@/utilities/query-client", () => ({
   queryClient: {
     clear: (...args: unknown[]) => mockQueryClientClear(...args),
-    invalidateQueries: (...args: unknown[]) => mockQueryClientInvalidate(...args),
-    removeQueries: vi.fn(),
+    invalidateQueries: vi.fn(),
   },
 }));
 
@@ -189,65 +187,6 @@ describe("useAuth - Query Key Consistency", () => {
       expect(Array.isArray(QUERY_KEYS.AUTH.CONTRACT_OWNER("test", 1))).toBe(true);
       expect(Array.isArray(QUERY_KEYS.COMMUNITY.IS_ADMIN("uid", 1, "addr", {}))).toBe(true);
     });
-  });
-});
-
-describe("useAuth - Auth-ready refetch barrier", () => {
-  const mockPrivyUser = {
-    id: "user-123",
-    wallet: { address: "0x1234567890123456789012345678901234567890" },
-  };
-  const mockWallet = {
-    address: "0x1234567890123456789012345678901234567890",
-    chainId: "eip155:10",
-  };
-  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
-
-  beforeEach(() => {
-    mockQueryClientInvalidate.mockClear();
-  });
-
-  afterEach(() => {
-    resetBridgeState();
-  });
-
-  it("invalidates queries when the wallet address resolves after auth (Privy↔Wagmi gap)", async () => {
-    // Authenticated, but wallets[0].address has not hydrated yet.
-    setBridgeState({
-      ready: true,
-      authenticated: true,
-      user: mockPrivyUser,
-      wallets: [],
-      isConnected: false,
-    });
-    const { rerender } = renderHook(() => useAuth(), { wrapper });
-
-    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
-
-    // Wallet hydrates → address becomes available.
-    setBridgeState({ wallets: [mockWallet], isConnected: true });
-    await act(async () => {
-      rerender();
-    });
-
-    expect(mockQueryClientInvalidate).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not invalidate when the address is already present at mount", async () => {
-    setBridgeState({
-      ready: true,
-      authenticated: true,
-      user: mockPrivyUser,
-      wallets: [mockWallet],
-      isConnected: true,
-    });
-    const { rerender } = renderHook(() => useAuth(), { wrapper });
-
-    await act(async () => {
-      rerender();
-    });
-
-    expect(mockQueryClientInvalidate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/utilities/fetchData.test.tsx
+++ b/__tests__/unit/utilities/fetchData.test.tsx
@@ -211,4 +211,54 @@ describe("fetchData", () => {
       expect.objectContaining({ signal: controller.signal })
     );
   });
+
+  it("retries once with a fresh token when an authorized indexer request returns 401", async () => {
+    // Simulates the deferred-Privy auth race: the first request fired before the
+    // token was ready and 401'd; a fresh token is now available and the retry
+    // succeeds — instead of dead-ending as an empty result until a page refresh.
+    const unauthorized = { response: { data: { message: "Unauthorized" }, status: 401 } };
+    const okResponse = { data: { result: "recovered" }, status: 200 };
+    (axios.request as vi.Mock)
+      .mockRejectedValueOnce(unauthorized)
+      .mockResolvedValueOnce(okResponse);
+    (TokenManager.getToken as vi.Mock)
+      .mockResolvedValueOnce("stale-token")
+      .mockResolvedValueOnce("fresh-token");
+
+    const [resData, error, , status] = await fetchData("/test-endpoint");
+
+    expect(axios.request).toHaveBeenCalledTimes(2);
+    expect(TokenManager.clearCache).toHaveBeenCalledTimes(1);
+    const retryConfig = (axios.request as vi.Mock).mock.calls[1][0];
+    expect(retryConfig.headers.Authorization).toBe("Bearer fresh-token");
+    expect(resData).toEqual({ result: "recovered" });
+    expect(error).toBeNull();
+    expect(status).toBe(200);
+  });
+
+  it("does not retry a 401 when no fresh token is available", async () => {
+    const unauthorized = { response: { data: { message: "Unauthorized" }, status: 401 } };
+    (axios.request as vi.Mock).mockRejectedValue(unauthorized);
+    (TokenManager.getToken as vi.Mock)
+      .mockResolvedValueOnce("stale-token")
+      .mockResolvedValueOnce(null);
+
+    const [resData, error, , status] = await fetchData("/test-endpoint");
+
+    expect(axios.request).toHaveBeenCalledTimes(1);
+    expect(resData).toBeNull();
+    expect(error).toBe("Unauthorized");
+    expect(status).toBe(401);
+  });
+
+  it("does not retry a 401 for unauthorized (public) requests", async () => {
+    const unauthorized = { response: { data: { message: "Unauthorized" }, status: 401 } };
+    (axios.request as vi.Mock).mockRejectedValue(unauthorized);
+
+    const [, , , status] = await fetchData("/test-endpoint", "GET", {}, {}, {}, false);
+
+    expect(axios.request).toHaveBeenCalledTimes(1);
+    expect(TokenManager.getToken).not.toHaveBeenCalled();
+    expect(status).toBe(401);
+  });
 });

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -142,6 +142,9 @@ export const useAuth = () => {
   const walletsSnapshotRef = useRef<string[]>([]);
   // Grace period after login — suppresses watchAccount false positives from stale wagmi state
   const loginGraceRef = useRef(false);
+  // Tracks the wallet address across renders to detect the undefined→defined
+  // transition once Privy/Wagmi finish hydrating after auth (see refetch barrier).
+  const prevAddressRef = useRef<Hex | undefined>(address);
 
   /**
    * AUTH STATE CHANGE DETECTION
@@ -225,6 +228,25 @@ export const useAuth = () => {
       TokenManager.setPrivyInstance({ getAccessToken });
     }
   }, [ready, getAccessToken]);
+
+  /**
+   * AUTH-READY REFETCH BARRIER
+   *
+   * Privy/Wagmi hydrate the wallet asynchronously: `authenticated` flips true
+   * before `wallets[0].address` is populated (the deferred-SDK race). Any
+   * authenticated query that fired during that window had no token/address and
+   * resolved empty or 401'd. fetchData swallows the 401 into a null tuple, so
+   * React Query treats it as data and never refetches — the stale empty result
+   * sticks until a manual page refresh. When the address first becomes
+   * available, invalidate queries once so they refetch with auth now ready.
+   */
+  useEffect(() => {
+    const prev = prevAddressRef.current;
+    prevAddressRef.current = address;
+    if (authenticated && !prev && address) {
+      queryClient.invalidateQueries();
+    }
+  }, [authenticated, address]);
 
   // Auto-login after logout completes
   useEffect(() => {

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -196,8 +196,14 @@
       "maxBytes": 40000
     },
     "components/Forms/MilestoneUpdate.tsx": {
-      "lines": 761,
+      "lines": 770,
       "bytes": 28479,
+      "maxLines": 600,
+      "maxBytes": 40000
+    },
+    "components/Pages/Admin/ControlCenter/MilestonesSection.tsx": {
+      "lines": 601,
+      "bytes": 26462,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -448,13 +454,13 @@
       "maxBytes": 40000
     },
     "src/features/payout-disbursement/hooks/use-payout-disbursement.ts": {
-      "lines": 779,
+      "lines": 781,
       "bytes": 24563,
       "maxLines": 600,
       "maxBytes": 40000
     },
     "src/features/payout-disbursement/services/payout-disbursement.service.ts": {
-      "lines": 916,
+      "lines": 922,
       "bytes": 23575,
       "maxLines": 600,
       "maxBytes": 40000

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -101,6 +101,18 @@ export function NavbarUserMenu() {
     return null;
   }
 
+  // Authenticated, but identity hasn't resolved yet. During the Privy↔Wagmi
+  // hydration gap `authenticated` is true while `user` and `wallets[0].address`
+  // are still loading, so the trigger would render a blank avatar and the
+  // dropdown would say "No wallet connected" for an actually-connected user.
+  // Show the skeleton instead — a wallet user always resolves an address and a
+  // social user always resolves a farcaster/email identity, so this only covers
+  // the transient loading window.
+  const hasResolvedIdentity = Boolean(user?.farcaster || getUserEmail(user) || address);
+  if (!hasResolvedIdentity) {
+    return <NavbarUserSkeleton />;
+  }
+
   return (
     <Menubar className="border-0 bg-transparent shadow-none p-0 h-auto">
       <MenubarMenu>

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -1,4 +1,4 @@
-import axios, { type Method } from "axios";
+import axios, { type AxiosResponse, type Method } from "axios";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { envVars } from "./enviromentVars";
 import { sanitizeObject } from "./sanitize";
@@ -73,7 +73,26 @@ export default async function fetchData<T = any>(
       }
     }
 
-    const res = await axios.request<T & { pageInfo?: any }>(requestConfig);
+    let res: AxiosResponse<T & { pageInfo?: any }>;
+    try {
+      res = await axios.request<T & { pageInfo?: any }>(requestConfig);
+    } catch (err: any) {
+      // Retry once on 401 for authorized indexer requests. The token may have
+      // been absent or stale because Privy had not finished bootstrapping when
+      // the request fired (the deferred-SDK auth race). Without this, fetchData
+      // swallows the 401 into a "successful" null tuple below, so React Query
+      // treats it as empty data and never refetches — a manual page refresh is
+      // the only recovery. Re-fetching a fresh token and retrying self-heals it.
+      if (isIndexerUrl && isAuthorized && err?.response?.status === 401) {
+        TokenManager.clearCache();
+        const freshToken = await TokenManager.getToken();
+        if (!freshToken) throw err;
+        requestConfig.headers.Authorization = `Bearer ${freshToken}`;
+        res = await axios.request<T & { pageInfo?: any }>(requestConfig);
+      } else {
+        throw err;
+      }
+    }
     const resData = res.data;
     const pageInfo = resData?.pageInfo || null;
     return [resData, null, pageInfo, res.status];

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -76,14 +76,15 @@ export default async function fetchData<T = any>(
     let res: AxiosResponse<T & { pageInfo?: any }>;
     try {
       res = await axios.request<T & { pageInfo?: any }>(requestConfig);
-    } catch (err: any) {
+    } catch (err) {
       // Retry once on 401 for authorized indexer requests. The token may have
       // been absent or stale because Privy had not finished bootstrapping when
       // the request fired (the deferred-SDK auth race). Without this, fetchData
       // swallows the 401 into a "successful" null tuple below, so React Query
       // treats it as empty data and never refetches — a manual page refresh is
       // the only recovery. Re-fetching a fresh token and retrying self-heals it.
-      if (isIndexerUrl && isAuthorized && err?.response?.status === 401) {
+      const status = (err as { response?: { status?: number } } | null)?.response?.status;
+      if (isIndexerUrl && isAuthorized && status === 401) {
         TokenManager.clearCache();
         const freshToken = await TokenManager.getToken();
         if (!freshToken) throw err;


### PR DESCRIPTION
## Problem

Privy and Wagmi initialize independently and asynchronously. On cold and returning page loads, `authenticated` flips `true` **before** `wallets[0].address` hydrates and before the access token is ready. Nothing coordinates a "auth is now ready → re-evaluate" signal, so three user-visible symptoms appear — all of which a manual page refresh "fixes":

1. **"No wallet connected" / blank avatar & name** for an actually-connected user — the navbar reads `address` while it's still `undefined`.
2. **Endpoints fail on first load, work after refresh** — authenticated requests fire before the token is ready and 401. `fetchData` swallows the 401 into a *successful* `[null, …]` tuple, so React Query treats it as data and never refetches.
3. The data that resolved empty during the gap never recovers because there's no refetch trigger when auth becomes ready.

## Fix

Three targeted changes, one per symptom:

**`src/components/navbar/navbar-user-menu.tsx`** — when authenticated but identity hasn't resolved yet (no farcaster/email and no address), render `NavbarUserSkeleton` instead of a blank avatar and "No wallet connected". A wallet user always resolves an address and a social user always resolves a social identity, so this only covers the transient hydration window.

**`utilities/fetchData.ts`** — retry an authorized indexer request **once** on a 401, after clearing the token cache and fetching a fresh token. This self-heals requests that raced the token instead of dead-ending as empty data until a refresh. Non-401s, public (`isAuthorized=false`) requests, and the case where no fresh token is available are unaffected.

**`hooks/useAuth.ts`** — add an auth-ready refetch barrier: when the wallet `address` first transitions `undefined → defined` while authenticated, call `queryClient.invalidateQueries()` once so queries that resolved empty/401 during the gap refetch with auth now ready.

## Tests

- `fetchData`: 401 retry-with-fresh-token success; no retry when no fresh token; no retry for public requests.
- `navbar-user-menu`: shows skeleton (not "No wallet connected") while an authenticated user's wallet is still hydrating.
- `useAuth`: invalidates queries once when the address resolves after auth; does not invalidate when the address is already present at mount.
- All affected suites pass (fetchData, navbar-user-menu, useAuth = 83 tests); `tsc --noEmit` passes.

## Notes / out of scope

- This is independent of the project-owner authorization fix (PR #1537) and branches from `main`.
- Per-account caveat for the original Tower Exchange report still stands separately: whether `isProjectOwner` resolves depends on the owner address `0x0036…86ca` being linked to that Privy account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete user menu UI during the wallet/auth hydration gap.
  * Trigger query refetch when wallet details become available after authentication.
  * Added one-time token-refresh on authorized 401 responses to recover failed requests.

* **Tests**
  * Added unit tests covering wallet hydration behavior, the auth-ready refetch barrier, and 401 retry scenarios for authorized requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->