### PR TITLE
fix: keep pending milestone count in sync

### DIFF
--- a/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
+++ b/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
@@ -10,7 +10,10 @@
  */
 
 import type { CommunityReviewer } from "@/hooks/useCommunityMilestoneReviewers";
-import { computeDefaultReviewerAddress } from "@/hooks/useReportPageData";
+import {
+  computeDefaultReviewerAddress,
+  getPendingVerificationTotalItems,
+} from "@/hooks/useReportPageData";
 
 describe("useReportPageData reviewer filter logic (address-based)", () => {
   const userAddress = "0x1234567890abcdef1234567890abcdef12345678";
@@ -108,6 +111,22 @@ describe("useReportPageData reviewer filter logic (address-based)", () => {
     it("user not in reviewer list defaults to seeing all milestones", () => {
       const reviewers = [makeReviewer(otherAddress)];
       expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBeUndefined();
+    });
+  });
+
+  describe("getPendingVerificationTotalItems", () => {
+    it("never reports fewer items than are visible in the current table data", () => {
+      expect(getPendingVerificationTotalItems(5, 6)).toBe(6);
+    });
+
+    it("keeps the API total when it already matches or exceeds the visible rows", () => {
+      expect(getPendingVerificationTotalItems(6, 5)).toBe(6);
+      expect(getPendingVerificationTotalItems(6, 6)).toBe(6);
+    });
+
+    it("falls back to the visible row count when the API total is missing", () => {
+      expect(getPendingVerificationTotalItems(undefined, 4)).toBe(4);
+      expect(getPendingVerificationTotalItems(null, 3)).toBe(3);
     });
   });
 });

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -109,6 +109,13 @@ export function computeDefaultReviewerAddress(
   return match?.publicAddress;
 }
 
+export function getPendingVerificationTotalItems(
+  totalItems: number | null | undefined,
+  visibleMilestonesCount: number
+): number {
+  return Math.max(totalItems ?? 0, visibleMilestonesCount);
+}
+
 export function useReportPageData({
   communityId,
   grantPrograms,
@@ -266,7 +273,10 @@ export function useReportPageData({
 
   const reports = data?.data;
   const totalItems = data?.pageInfo?.totalItems ?? 0;
-  const pendingTotalItems = pendingPageInfo?.totalItems ?? 0;
+  const pendingTotalItems = getPendingVerificationTotalItems(
+    pendingPageInfo?.totalItems,
+    pendingMilestones.length
+  );
 
   const handleSort = useCallback(
     (newSort: string) => {


### PR DESCRIPTION
## Summary
- keep the pending verification count from dropping below the number of milestones already rendered
- add regression coverage for the pending-count fallback used by the milestones report

## Testing
- `pnpm exec vitest run --project unit __tests__/hooks/useReportPageData.reviewer-filter.test.ts`
- `pnpm run test` *(fails on this branch and on refreshed `origin/main` due existing baseline issues, including `storage.setItem is not a function` failures in zustand-backed tests and unrelated expectation drift in community financials / grant completion tests)*

## Risks
- small UI-only change; if the API under-reports the total, the badge/pagination now floor at the number of visible rows instead of showing a smaller count


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pending verification pagination calculation to ensure the displayed total item count accurately reflects at least the visible rows in the table.
  * Improved fallback behavior when server data is unavailable by using the visible row count instead.

* **Tests**
  * Added unit tests validating pagination calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->