### PR TITLE
fix(auth): resolve identity from the linked wallet, not the first connected one

### DIFF
--- a/__tests__/unit/features/claim-funds/use-claim-transaction-real.test.ts
+++ b/__tests__/unit/features/claim-funds/use-claim-transaction-real.test.ts
@@ -18,6 +18,7 @@ const {
   mockWriteContract,
   mockWalletClient,
   mockWallets,
+  mockUserRef,
   mockSanitizeErrorMessage,
   mockSwitchOrAddChain,
   mockWaitForTransactionReceipt,
@@ -31,8 +32,11 @@ const {
   const mockWalletClient = { writeContract: mockWriteContract };
   const mockWallets: Array<{
     address: string;
+    walletClientType?: string;
     getEthereumProvider: () => Promise<unknown>;
   }> = [];
+  // Privy user (with linkedAccounts) used by selectPrimaryWallet; null = anonymous.
+  const mockUserRef: { current: unknown } = { current: null };
   const mockSanitizeErrorMessage = vi.fn((err: unknown, defaultTitle: string) => ({
     title: defaultTitle,
     message: err instanceof Error ? err.message : "Unknown error",
@@ -45,6 +49,7 @@ const {
     mockWriteContract,
     mockWalletClient,
     mockWallets,
+    mockUserRef,
     mockSanitizeErrorMessage,
     mockSwitchOrAddChain,
     mockWaitForTransactionReceipt,
@@ -63,6 +68,7 @@ vi.mock("viem", () => ({
 vi.mock("@/contexts/privy-bridge-context", () => ({
   usePrivyBridge: vi.fn(() => ({
     wallets: mockWallets,
+    user: mockUserRef.current,
   })),
 }));
 
@@ -146,6 +152,7 @@ describe("useClaimTransaction (real hook)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWallets.length = 0;
+    mockUserRef.current = null;
     mockWriteContract.mockReset();
     mockWaitForTransactionReceipt.mockReset();
     mockSwitchOrAddChain.mockReset();
@@ -225,6 +232,66 @@ describe("useClaimTransaction (real hook)", () => {
       await act(async () => {
         resolveWrite!(MOCK_TX_HASH);
       });
+    });
+  });
+
+  describe("stale wallet — linked-wallet selection (regression)", () => {
+    const STALE_METAMASK = "0x9999999999999999999999999999999999999999";
+    const EMAIL_EMBEDDED = "0x3333333333333333333333333333333333333333";
+
+    // Two connected wallets: a stale MetaMask listed FIRST (as Privy often does after
+    // logging out of a wallet session and back in with email), plus the email user's
+    // embedded wallet. Only the embedded wallet is linked to the authenticated user.
+    function setupStaleAndEmbedded() {
+      const staleGetProvider = vi.fn().mockResolvedValue({ request: vi.fn() });
+      const embeddedGetProvider = vi.fn().mockResolvedValue({ request: vi.fn() });
+      mockWallets.length = 0;
+      mockWallets.push(
+        {
+          address: STALE_METAMASK,
+          walletClientType: "metamask",
+          getEthereumProvider: staleGetProvider,
+        },
+        {
+          address: EMAIL_EMBEDDED,
+          walletClientType: "privy",
+          getEthereumProvider: embeddedGetProvider,
+        }
+      );
+      mockUserRef.current = {
+        linkedAccounts: [
+          { type: "email", address: "user@example.com" },
+          { type: "wallet", address: EMAIL_EMBEDDED, walletClientType: "privy" },
+        ],
+      };
+      return { staleGetProvider, embeddedGetProvider };
+    }
+
+    it("signs with the linked (embedded) wallet, not the stale wallets[0] MetaMask", async () => {
+      const { staleGetProvider, embeddedGetProvider } = setupStaleAndEmbedded();
+      mockWriteContract.mockResolvedValue(MOCK_TX_HASH);
+      mockWaitForTransactionReceipt.mockResolvedValue({ status: "success" });
+
+      const { wrapper, queryClient } = createWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderHook(() => useClaimTransaction("tenant-1", undefined), { wrapper });
+
+      act(() => {
+        result.current.claim(MOCK_CAMPAIGN_ID, createMockEligibility(), MOCK_CONTRACT);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      // The embedded (linked) wallet signed — the stale MetaMask was never touched.
+      expect(embeddedGetProvider).toHaveBeenCalled();
+      expect(staleGetProvider).not.toHaveBeenCalled();
+
+      // Eligibility cache is keyed/invalidated on the embedded address, not the stale one.
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: expect.arrayContaining([EMAIL_EMBEDDED]) })
+      );
     });
   });
 

--- a/__tests__/unit/hooks/useAuth.primary-wallet.test.tsx
+++ b/__tests__/unit/hooks/useAuth.primary-wallet.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @file Tests for useAuth primary-wallet resolution
+ * @description Verifies useAuth derives identity from the wallet linked to the
+ * authenticated user (via selectPrimaryWallet), not from a stale, still-connected
+ * wallet such as a lingering MetaMask. Kept separate from useAuth.test.tsx to avoid
+ * growing that (already oversized) file.
+ */
+
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
+
+// Undo the global mock of useAuth from __tests__/navbar/setup.ts
+// so we can test the real hook implementation
+vi.unmock("@/hooks/useAuth");
+
+// Mock next/navigation so useRouter() and usePathname() don't throw
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// Mock useWhitelabel which is called inside useAuth
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: vi.fn(() => ({
+    isWhitelabel: false,
+    whitelabelConfig: null,
+  })),
+}));
+
+// Mock store used in login redirect logic
+vi.mock("@/store/modals/projectCreate", () => ({
+  useProjectCreateModalStore: {
+    getState: vi.fn(() => ({ isProjectCreateModalOpen: false })),
+  },
+}));
+
+// Mock compareAllWallets — overridden per-test to model which wallets are linked
+vi.mock("@/utilities/auth/compare-all-wallets", () => ({
+  compareAllWallets: vi.fn(() => true),
+}));
+
+// Mock PAGES constants
+vi.mock("@/utilities/pages", () => ({
+  PAGES: {
+    DASHBOARD: "/dashboard",
+  },
+}));
+
+const mockLogin = vi.fn();
+const mockLogout = vi.fn();
+const mockGetAccessToken = vi.fn();
+const mockGetToken = vi.fn();
+
+// Mock the bridge context that useAuth reads from
+const mockBridgeState = {
+  ready: true,
+  authenticated: false,
+  user: null as any,
+  login: mockLogin,
+  logout: mockLogout,
+  getAccessToken: mockGetAccessToken,
+  connectWallet: vi.fn(),
+  wallets: [] as any[],
+  isConnected: false,
+};
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => mockBridgeState,
+  PrivyBridgeContext: {
+    Provider: ({ children }: { children: any }) => children,
+  },
+  PRIVY_BRIDGE_DEFAULTS: {
+    ready: false,
+    authenticated: false,
+    user: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    getAccessToken: async () => null,
+    connectWallet: vi.fn(),
+    wallets: [],
+    isConnected: false,
+  },
+}));
+
+// Mock @wagmi/core for the dynamic import in the watchAccount effect
+vi.mock("@wagmi/core", () => ({
+  watchAccount: vi.fn(() => vi.fn()),
+}));
+
+// Mock privy-config for the dynamic import in the watchAccount effect
+vi.mock("@/utilities/wagmi/privy-config", () => ({
+  privyConfig: {},
+  getPrivyWagmiConfig: vi.fn(() => ({})),
+}));
+
+const mockQueryClientClear = vi.fn();
+const mockClearCache = vi.fn();
+
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: {
+    clear: (...args: unknown[]) => mockQueryClientClear(...args),
+    invalidateQueries: vi.fn(),
+  },
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: (...args: unknown[]) => mockGetToken(...args),
+    setPrivyInstance: vi.fn(),
+    clearTokens: vi.fn(),
+    clearCache: (...args: unknown[]) => mockClearCache(...args),
+  },
+}));
+
+/** Helper to update mockBridgeState in place */
+function setBridgeState(overrides: Partial<typeof mockBridgeState>) {
+  Object.assign(mockBridgeState, overrides);
+}
+
+/** Reset bridge state to defaults */
+function resetBridgeState() {
+  Object.assign(mockBridgeState, {
+    ready: true,
+    authenticated: false,
+    user: null,
+    login: mockLogin,
+    logout: mockLogout,
+    getAccessToken: mockGetAccessToken,
+    connectWallet: vi.fn(),
+    wallets: [],
+    isConnected: false,
+  });
+}
+
+describe("useAuth - stale connected wallet after switching login method", () => {
+  /**
+   * Regression: login with MetaMask, log out, then log in with email.
+   *
+   * MetaMask cannot be disconnected programmatically (Privy's wallet.disconnect()
+   * is a no-op for it), so it stays connected and remains in useWallets() — often
+   * as wallets[0] — even though it is NOT linked to the new email user. The address
+   * exposed by useAuth() (used for the avatar and on-chain lookups) must resolve to
+   * the email user's own (embedded) wallet, never the leftover MetaMask wallet.
+   */
+  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  const mockCompareAllWallets = vi.mocked(compareAllWallets);
+
+  const STALE_METAMASK_ADDRESS = "0xMETAMASK00000000000000000000000000000001";
+  const EMAIL_EMBEDDED_ADDRESS = "0xEMBEDDED00000000000000000000000000000002";
+
+  const emailUser = {
+    id: "email-user-1",
+    email: { address: "user@example.com" },
+    wallet: { address: EMAIL_EMBEDDED_ADDRESS },
+    linkedAccounts: [
+      { type: "email", address: "user@example.com" },
+      { type: "wallet", address: EMAIL_EMBEDDED_ADDRESS, walletClientType: "privy" },
+    ],
+  };
+
+  // Stale MetaMask wallet is listed first by Privy (connected earlier), embedded second.
+  const staleMetaMaskWallet = {
+    address: STALE_METAMASK_ADDRESS,
+    chainId: "eip155:10",
+    walletClientType: "metamask",
+  };
+  const embeddedWallet = {
+    address: EMAIL_EMBEDDED_ADDRESS,
+    chainId: "eip155:10",
+    walletClientType: "privy",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Realistic behavior: only the embedded wallet is linked to the email user.
+    mockCompareAllWallets.mockImplementation(
+      (_user, address) => address.toLowerCase() === EMAIL_EMBEDDED_ADDRESS.toLowerCase()
+    );
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: emailUser,
+      wallets: [staleMetaMaskWallet, embeddedWallet],
+      isConnected: true,
+    });
+  });
+
+  afterEach(() => {
+    resetBridgeState();
+    // Restore the default global mock implementation for other suites.
+    mockCompareAllWallets.mockImplementation(() => true);
+  });
+
+  it("resolves the address to the linked embedded wallet, not the stale MetaMask wallet", () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(EMAIL_EMBEDDED_ADDRESS);
+    expect(result.current.address).not.toBe(STALE_METAMASK_ADDRESS);
+    expect(result.current.primaryWallet?.address).toBe(EMAIL_EMBEDDED_ADDRESS);
+  });
+
+  it("falls back to the first connected wallet when none are linked to the user (hydration gap)", () => {
+    // No wallet is linked yet (e.g. linkedAccounts not populated during hydration).
+    mockCompareAllWallets.mockImplementation(() => false);
+    setBridgeState({ wallets: [staleMetaMaskWallet] });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(STALE_METAMASK_ADDRESS);
+  });
+
+  it("keeps the active wallet (wallets[0]) when an account has multiple linked wallets", () => {
+    const secondLinkedAddress = "0xLINKED0000000000000000000000000000000003";
+    // Both connected wallets belong to the user — selection must not reorder them.
+    mockCompareAllWallets.mockImplementation((_user, address) =>
+      [EMAIL_EMBEDDED_ADDRESS, secondLinkedAddress].some(
+        (a) => a.toLowerCase() === address.toLowerCase()
+      )
+    );
+    setBridgeState({
+      wallets: [
+        { address: secondLinkedAddress, chainId: "eip155:10", walletClientType: "rainbow" },
+        embeddedWallet,
+      ],
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(secondLinkedAddress);
+  });
+});

--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -7,6 +7,7 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { useAuth } from "@/hooks/useAuth";
+import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 // Undo the global mock of useAuth from __tests__/navbar/setup.ts
@@ -527,6 +528,105 @@ describe("useAuth - Re-login with different wallet", () => {
     // Should NOT trigger user-switch logout — the user explicitly
     // logged out then logged in again, this is not a cross-tab switch.
     expect(mockLogout).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAuth - stale connected wallet after switching login method", () => {
+  /**
+   * Regression: login with MetaMask, log out, then log in with email.
+   *
+   * MetaMask cannot be disconnected programmatically (Privy's wallet.disconnect()
+   * is a no-op for it), so it stays connected and remains in useWallets() — often
+   * as wallets[0] — even though it is NOT linked to the new email user. The address
+   * exposed by useAuth() (used for the avatar and on-chain lookups) must resolve to
+   * the email user's own (embedded) wallet, never the leftover MetaMask wallet.
+   */
+  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  const mockCompareAllWallets = vi.mocked(compareAllWallets);
+
+  const STALE_METAMASK_ADDRESS = "0xMETAMASK00000000000000000000000000000001";
+  const EMAIL_EMBEDDED_ADDRESS = "0xEMBEDDED00000000000000000000000000000002";
+
+  const emailUser = {
+    id: "email-user-1",
+    email: { address: "user@example.com" },
+    wallet: { address: EMAIL_EMBEDDED_ADDRESS },
+    linkedAccounts: [
+      { type: "email", address: "user@example.com" },
+      { type: "wallet", address: EMAIL_EMBEDDED_ADDRESS, walletClientType: "privy" },
+    ],
+  };
+
+  // Stale MetaMask wallet is listed first by Privy (connected earlier), embedded second.
+  const staleMetaMaskWallet = {
+    address: STALE_METAMASK_ADDRESS,
+    chainId: "eip155:10",
+    walletClientType: "metamask",
+  };
+  const embeddedWallet = {
+    address: EMAIL_EMBEDDED_ADDRESS,
+    chainId: "eip155:10",
+    walletClientType: "privy",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Realistic behavior: only the embedded wallet is linked to the email user.
+    mockCompareAllWallets.mockImplementation(
+      (_user, address) => address.toLowerCase() === EMAIL_EMBEDDED_ADDRESS.toLowerCase()
+    );
+    setBridgeState({
+      ready: true,
+      authenticated: true,
+      user: emailUser,
+      wallets: [staleMetaMaskWallet, embeddedWallet],
+      isConnected: true,
+    });
+  });
+
+  afterEach(() => {
+    resetBridgeState();
+    // Restore the default global mock implementation for other suites.
+    mockCompareAllWallets.mockImplementation(() => true);
+  });
+
+  it("resolves the address to the linked embedded wallet, not the stale MetaMask wallet", () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(EMAIL_EMBEDDED_ADDRESS);
+    expect(result.current.address).not.toBe(STALE_METAMASK_ADDRESS);
+    expect(result.current.primaryWallet?.address).toBe(EMAIL_EMBEDDED_ADDRESS);
+  });
+
+  it("falls back to the first connected wallet when none are linked to the user (hydration gap)", () => {
+    // No wallet is linked yet (e.g. linkedAccounts not populated during hydration).
+    mockCompareAllWallets.mockImplementation(() => false);
+    setBridgeState({ wallets: [staleMetaMaskWallet] });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(STALE_METAMASK_ADDRESS);
+  });
+
+  it("keeps the active wallet (wallets[0]) when an account has multiple linked wallets", () => {
+    const secondLinkedAddress = "0xLINKED0000000000000000000000000000000003";
+    // Both connected wallets belong to the user — selection must not reorder them.
+    mockCompareAllWallets.mockImplementation((_user, address) =>
+      [EMAIL_EMBEDDED_ADDRESS, secondLinkedAddress].some(
+        (a) => a.toLowerCase() === address.toLowerCase()
+      )
+    );
+    setBridgeState({
+      wallets: [
+        { address: secondLinkedAddress, chainId: "eip155:10", walletClientType: "rainbow" },
+        embeddedWallet,
+      ],
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.address).toBe(secondLinkedAddress);
   });
 });
 

--- a/__tests__/unit/hooks/useAuth.test.tsx
+++ b/__tests__/unit/hooks/useAuth.test.tsx
@@ -7,7 +7,6 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { useAuth } from "@/hooks/useAuth";
-import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 
 // Undo the global mock of useAuth from __tests__/navbar/setup.ts
@@ -528,105 +527,6 @@ describe("useAuth - Re-login with different wallet", () => {
     // Should NOT trigger user-switch logout — the user explicitly
     // logged out then logged in again, this is not a cross-tab switch.
     expect(mockLogout).not.toHaveBeenCalled();
-  });
-});
-
-describe("useAuth - stale connected wallet after switching login method", () => {
-  /**
-   * Regression: login with MetaMask, log out, then log in with email.
-   *
-   * MetaMask cannot be disconnected programmatically (Privy's wallet.disconnect()
-   * is a no-op for it), so it stays connected and remains in useWallets() — often
-   * as wallets[0] — even though it is NOT linked to the new email user. The address
-   * exposed by useAuth() (used for the avatar and on-chain lookups) must resolve to
-   * the email user's own (embedded) wallet, never the leftover MetaMask wallet.
-   */
-  const wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
-
-  const mockCompareAllWallets = vi.mocked(compareAllWallets);
-
-  const STALE_METAMASK_ADDRESS = "0xMETAMASK00000000000000000000000000000001";
-  const EMAIL_EMBEDDED_ADDRESS = "0xEMBEDDED00000000000000000000000000000002";
-
-  const emailUser = {
-    id: "email-user-1",
-    email: { address: "user@example.com" },
-    wallet: { address: EMAIL_EMBEDDED_ADDRESS },
-    linkedAccounts: [
-      { type: "email", address: "user@example.com" },
-      { type: "wallet", address: EMAIL_EMBEDDED_ADDRESS, walletClientType: "privy" },
-    ],
-  };
-
-  // Stale MetaMask wallet is listed first by Privy (connected earlier), embedded second.
-  const staleMetaMaskWallet = {
-    address: STALE_METAMASK_ADDRESS,
-    chainId: "eip155:10",
-    walletClientType: "metamask",
-  };
-  const embeddedWallet = {
-    address: EMAIL_EMBEDDED_ADDRESS,
-    chainId: "eip155:10",
-    walletClientType: "privy",
-  };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    // Realistic behavior: only the embedded wallet is linked to the email user.
-    mockCompareAllWallets.mockImplementation(
-      (_user, address) => address.toLowerCase() === EMAIL_EMBEDDED_ADDRESS.toLowerCase()
-    );
-    setBridgeState({
-      ready: true,
-      authenticated: true,
-      user: emailUser,
-      wallets: [staleMetaMaskWallet, embeddedWallet],
-      isConnected: true,
-    });
-  });
-
-  afterEach(() => {
-    resetBridgeState();
-    // Restore the default global mock implementation for other suites.
-    mockCompareAllWallets.mockImplementation(() => true);
-  });
-
-  it("resolves the address to the linked embedded wallet, not the stale MetaMask wallet", () => {
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    expect(result.current.address).toBe(EMAIL_EMBEDDED_ADDRESS);
-    expect(result.current.address).not.toBe(STALE_METAMASK_ADDRESS);
-    expect(result.current.primaryWallet?.address).toBe(EMAIL_EMBEDDED_ADDRESS);
-  });
-
-  it("falls back to the first connected wallet when none are linked to the user (hydration gap)", () => {
-    // No wallet is linked yet (e.g. linkedAccounts not populated during hydration).
-    mockCompareAllWallets.mockImplementation(() => false);
-    setBridgeState({ wallets: [staleMetaMaskWallet] });
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    expect(result.current.address).toBe(STALE_METAMASK_ADDRESS);
-  });
-
-  it("keeps the active wallet (wallets[0]) when an account has multiple linked wallets", () => {
-    const secondLinkedAddress = "0xLINKED0000000000000000000000000000000003";
-    // Both connected wallets belong to the user — selection must not reorder them.
-    mockCompareAllWallets.mockImplementation((_user, address) =>
-      [EMAIL_EMBEDDED_ADDRESS, secondLinkedAddress].some(
-        (a) => a.toLowerCase() === address.toLowerCase()
-      )
-    );
-    setBridgeState({
-      wallets: [
-        { address: secondLinkedAddress, chainId: "eip155:10", walletClientType: "rainbow" },
-        embeddedWallet,
-      ],
-    });
-
-    const { result } = renderHook(() => useAuth(), { wrapper });
-
-    expect(result.current.address).toBe(secondLinkedAddress);
   });
 });
 

--- a/__tests__/utilities/auth/select-primary-wallet.test.ts
+++ b/__tests__/utilities/auth/select-primary-wallet.test.ts
@@ -1,0 +1,73 @@
+import type { User } from "@privy-io/react-auth";
+import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
+
+const ADDR = {
+  metamask: "0x1111111111111111111111111111111111111111",
+  rainbow: "0x2222222222222222222222222222222222222222",
+  embedded: "0x3333333333333333333333333333333333333333",
+  stale: "0x9999999999999999999999999999999999999999",
+};
+
+const makeUser = (linkedAccounts: unknown[]): User => ({ linkedAccounts }) as unknown as User;
+const wallet = (address: string) => ({ address, walletClientType: "x" });
+
+describe("selectPrimaryWallet", () => {
+  it("returns undefined when there are no wallets", () => {
+    const user = makeUser([{ type: "wallet", address: ADDR.embedded }]);
+    expect(selectPrimaryWallet(user, [])).toBeUndefined();
+  });
+
+  it("falls back to wallets[0] before the user is resolved (pre-auth / hydration)", () => {
+    const wallets = [wallet(ADDR.metamask)];
+    expect(selectPrimaryWallet(null, wallets)).toBe(wallets[0]);
+    expect(selectPrimaryWallet(undefined, wallets)).toBe(wallets[0]);
+  });
+
+  it("returns the linked wallet and skips a stale unlinked wallet listed first", () => {
+    // login-with-email scenario: a stale MetaMask lingers as wallets[0] but is NOT
+    // linked to the email user; the linked embedded wallet must win.
+    const user = makeUser([
+      { type: "email", address: "user@example.com" },
+      { type: "wallet", address: ADDR.embedded, walletClientType: "privy" },
+    ]);
+    const wallets = [wallet(ADDR.stale), wallet(ADDR.embedded)];
+
+    expect(selectPrimaryWallet(user, wallets)?.address).toBe(ADDR.embedded);
+  });
+
+  describe("multiple wallets linked to one account", () => {
+    const multiWalletUser = makeUser([
+      { type: "email", address: "user@example.com" },
+      { type: "wallet", address: ADDR.metamask, walletClientType: "metamask" },
+      { type: "wallet", address: ADDR.rainbow, walletClientType: "rainbow" },
+      { type: "wallet", address: ADDR.embedded, walletClientType: "privy" },
+    ]);
+
+    it("keeps wallets[0] (Privy's active wallet) when it is linked", () => {
+      // All connected wallets belong to the user — selection must match the active
+      // wallet (wallets[0]) and not reorder it.
+      const wallets = [wallet(ADDR.rainbow), wallet(ADDR.metamask), wallet(ADDR.embedded)];
+      expect(selectPrimaryWallet(multiWalletUser, wallets)?.address).toBe(ADDR.rainbow);
+    });
+
+    it("follows the active wallet when wallets[0] changes between renders", () => {
+      const first = [wallet(ADDR.metamask), wallet(ADDR.rainbow)];
+      const afterSwitch = [wallet(ADDR.rainbow), wallet(ADDR.metamask)];
+      expect(selectPrimaryWallet(multiWalletUser, first)?.address).toBe(ADDR.metamask);
+      expect(selectPrimaryWallet(multiWalletUser, afterSwitch)?.address).toBe(ADDR.rainbow);
+    });
+
+    it("picks the first linked wallet when wallets[0] is an unlinked stale wallet", () => {
+      const wallets = [wallet(ADDR.stale), wallet(ADDR.metamask), wallet(ADDR.rainbow)];
+      expect(selectPrimaryWallet(multiWalletUser, wallets)?.address).toBe(ADDR.metamask);
+    });
+  });
+
+  it("falls back to wallets[0] when no connected wallet is linked yet", () => {
+    // linkedAccounts not populated during hydration — keep something rather than
+    // flipping to undefined.
+    const user = makeUser([]);
+    const wallets = [wallet(ADDR.stale)];
+    expect(selectPrimaryWallet(user, wallets)?.address).toBe(ADDR.stale);
+  });
+});

--- a/components/Utilities/PrivyWagmiProviders.tsx
+++ b/components/Utilities/PrivyWagmiProviders.tsx
@@ -9,6 +9,7 @@ import { useAccount } from "wagmi";
 import { PROJECT_NAME } from "@/constants/brand";
 import { type PrivyBridgeValue, usePrivyBridgeSetter } from "@/contexts/privy-bridge-context";
 import type { TenantConfig } from "@/src/infrastructure/types/tenant";
+import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { envVars } from "@/utilities/enviromentVars";
 import { appNetwork } from "@/utilities/network";
 import { privyConfig } from "@/utilities/wagmi/privy-config";
@@ -79,20 +80,41 @@ function PrivyBridgeUpdater() {
   // The app has two WagmiProviders: the outer one wraps all components (useAccount()
   // reads from it) and this inner one syncs with Privy. Without this bridge,
   // the outer useAccount().address is undefined during the Privy↔wagmi sync gap.
-  const outerSyncedRef = useRef(false);
-  const primaryWallet = wallets[0];
+  // Tracks which address the outer config is currently synced to (undefined = none),
+  // so we re-sync when the selected wallet changes — e.g. when the user's embedded
+  // wallet finishes connecting after an email login, replacing a stale MetaMask that
+  // was briefly wallets[0]. A plain boolean would sync only once and leave
+  // useAccount() pinned to the first (possibly stale) wallet.
+  const syncedAddressRef = useRef<string | undefined>(undefined);
+  // Sync the SAME wallet useAuth treats as the user's identity (linked wallet
+  // preferred over a stale, unlinked one like a lingering MetaMask) so the outer
+  // wagmi config — and therefore useAccount() used by signing/attestation flows —
+  // never diverges from useAuth().address.
+  const primaryWallet = selectPrimaryWallet(privy.user, wallets);
   const primaryWalletAddress = primaryWallet?.address;
 
   useEffect(() => {
-    if (!primaryWallet || outerSyncedRef.current) return;
+    if (!primaryWallet) return;
+    // Already synced to this exact wallet — nothing to do.
+    if (syncedAddressRef.current === primaryWalletAddress) return;
 
     const syncOuterConfig = async () => {
       try {
         const { minimalWagmiConfig } = await import("@/utilities/wagmi/privy-config");
         const { privyBridgeConnector } = await import("@/utilities/wagmi/privy-bridge-connector");
+        // Disconnect the previously-synced wallet before connecting the new one so
+        // useAccount() reflects the currently selected wallet rather than stacking
+        // connectors.
+        if (syncedAddressRef.current) {
+          try {
+            await wagmiCoreDisconnect(minimalWagmiConfig);
+          } catch {
+            // Ignore disconnect errors
+          }
+        }
         const connector = privyBridgeConnector(primaryWallet, chainId || appNetwork[0].id);
         await wagmiCoreConnect(minimalWagmiConfig, { connector });
-        outerSyncedRef.current = true;
+        syncedAddressRef.current = primaryWalletAddress;
       } catch {
         // Non-fatal: outer useAccount() will lack address, but useAuth().address still works
       }
@@ -103,7 +125,7 @@ function PrivyBridgeUpdater() {
 
   // Disconnect outer config when user logs out
   useEffect(() => {
-    if (!privy.authenticated && outerSyncedRef.current) {
+    if (!privy.authenticated && syncedAddressRef.current) {
       const disconnectOuter = async () => {
         try {
           const { minimalWagmiConfig } = await import("@/utilities/wagmi/privy-config");
@@ -111,7 +133,7 @@ function PrivyBridgeUpdater() {
         } catch {
           // Ignore disconnect errors
         }
-        outerSyncedRef.current = false;
+        syncedAddressRef.current = undefined;
       };
       disconnectOuter();
     }

--- a/components/Utilities/PrivyWagmiProviders.tsx
+++ b/components/Utilities/PrivyWagmiProviders.tsx
@@ -4,10 +4,10 @@ import { PrivyProvider, usePrivy, useWallets } from "@privy-io/react-auth";
 import { useSmartWallets } from "@privy-io/react-auth/smart-wallets";
 import { WagmiProvider } from "@privy-io/wagmi";
 import { connect as wagmiCoreConnect, disconnect as wagmiCoreDisconnect } from "@wagmi/core";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAccount } from "wagmi";
 import { PROJECT_NAME } from "@/constants/brand";
-import { type PrivyBridgeValue, usePrivyBridgeSetter } from "@/contexts/privy-bridge-context";
+import { usePrivyBridgeSetter } from "@/contexts/privy-bridge-context";
 import type { TenantConfig } from "@/src/infrastructure/types/tenant";
 import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { envVars } from "@/utilities/enviromentVars";
@@ -37,7 +37,7 @@ function PrivyBridgeUpdater() {
   const privy = usePrivy();
   const { wallets } = useWallets();
   const { client: smartWalletClient } = useSmartWallets();
-  const { isConnected, address, chainId } = useAccount();
+  const { isConnected, chainId } = useAccount();
 
   // Store latest values in refs so the effect always has fresh data.
   // Depend on primitives only (stable across renders when unchanged).
@@ -90,7 +90,10 @@ function PrivyBridgeUpdater() {
   // preferred over a stale, unlinked one like a lingering MetaMask) so the outer
   // wagmi config — and therefore useAccount() used by signing/attestation flows —
   // never diverges from useAuth().address.
-  const primaryWallet = selectPrimaryWallet(privy.user, wallets);
+  const primaryWallet = useMemo(
+    () => selectPrimaryWallet(privy.user, wallets),
+    [privy.user, wallets]
+  );
   const primaryWalletAddress = primaryWallet?.address;
 
   useEffect(() => {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -9,7 +9,6 @@ import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { getE2EMockAuthState } from "@/utilities/auth/e2e-auth";
 import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { TokenManager } from "@/utilities/auth/token-manager";
-import { PAGES } from "@/utilities/pages";
 import { queryClient } from "@/utilities/query-client";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -7,6 +7,7 @@ import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { useProjectCreateModalStore } from "@/store/modals/projectCreate";
 import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { getE2EMockAuthState } from "@/utilities/auth/e2e-auth";
+import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { PAGES } from "@/utilities/pages";
 import { queryClient } from "@/utilities/query-client";
@@ -123,7 +124,11 @@ export const useAuth = () => {
   const pathname = usePathname();
   const { isWhitelabel } = useWhitelabel();
 
-  const primaryWallet = wallets[0];
+  // Resolve the wallet representing the authenticated user's identity. See
+  // selectPrimaryWallet for why wallets[0] is not safe (stale, unlinked wallets such
+  // as MetaMask can linger in useWallets() across login methods). Shared with
+  // PrivyWagmiProviders so useAuth().address and useAccount() agree.
+  const primaryWallet = useMemo(() => selectPrimaryWallet(user, wallets), [user, wallets]);
   // Track client-side hydration so getE2EMockAuthState() re-evaluates after SSR.
   // During SSR, window is undefined so the check returns null. Without isClient,
   // useMemo caches the SSR result when Privy's ready/authenticated haven't changed yet.

--- a/src/features/claim-funds/hooks/use-claim-transaction.ts
+++ b/src/features/claim-funds/hooks/use-claim-transaction.ts
@@ -1,11 +1,12 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { createWalletClient, custom } from "viem";
 import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import type { ClaimGrantsConfig } from "@/src/infrastructure/types/tenant";
+import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { sanitizeErrorMessage } from "../lib/error-messages";
 import { CLAIM_CAMPAIGNS_ABI, uuidToBytes16 } from "../lib/hedgey-contract";
 import { getChainByName, getPublicClient, switchOrAddChain } from "../lib/viem-clients";
@@ -39,7 +40,12 @@ export function useClaimTransaction(
 ): UseClaimTransactionReturn {
   const provider = useClaimProvider(claimGrants);
   const queryClient = useQueryClient();
-  const { wallets } = usePrivyBridge();
+  const { wallets, user } = usePrivyBridge();
+  // Sign the claim with the wallet linked to the authenticated user, not whatever
+  // Privy lists first. A stale external wallet (e.g. a still-connected MetaMask from
+  // a previous session) can otherwise be wallets[0], which would check eligibility
+  // for — and sign the claim with — the wrong address. Mirrors useAuth().primaryWallet.
+  const primaryWallet = useMemo(() => selectPrimaryWallet(user, wallets), [user, wallets]);
 
   const [isConfirming, setIsConfirming] = useState(false);
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>(undefined);
@@ -65,7 +71,7 @@ export function useClaimTransaction(
 
   const mutation = useMutation({
     mutationFn: async ({ campaignId, eligibility, contractAddress }: ClaimVariables) => {
-      const wallet = wallets[0];
+      const wallet = primaryWallet;
       const capturedAddress = wallet?.address;
 
       if (!wallet || !capturedAddress) {
@@ -75,7 +81,9 @@ export function useClaimTransaction(
       const ethereumProvider = await wallet.getEthereumProvider();
       await switchOrAddChain(ethereumProvider, chain);
 
-      if (wallets[0]?.address !== capturedAddress) {
+      // Re-derive from the live wallet list to catch a wallet switch/disconnect
+      // during the awaited provider + chain setup above.
+      if (selectPrimaryWallet(user, wallets)?.address !== capturedAddress) {
         throw new Error("Wallet disconnected during operation");
       }
 
@@ -111,7 +119,7 @@ export function useClaimTransaction(
     onSuccess: () => {
       toast.success("Your tokens have been claimed!", { id: "claim-tx" });
       queryClient.invalidateQueries({
-        queryKey: ["claim-eligibility", providerId, tenantId, wallets[0]?.address ?? ""],
+        queryKey: ["claim-eligibility", providerId, tenantId, primaryWallet?.address ?? ""],
       });
       queryClient.invalidateQueries({
         queryKey: ["claimed-statuses"],
@@ -130,14 +138,14 @@ export function useClaimTransaction(
   const claim = useCallback(
     (campaignId: string, eligibility: ClaimEligibility, contractAddress: `0x${string}`) => {
       if (isClaimingRef.current || mutation.isPending) return;
-      if (!wallets[0]?.address) {
+      if (!primaryWallet?.address) {
         toast.error("Please connect your wallet to claim");
         return;
       }
       isClaimingRef.current = true;
       mutation.mutate({ campaignId, eligibility, contractAddress });
     },
-    [mutation, wallets]
+    [mutation, primaryWallet]
   );
 
   const reset = useCallback(() => {

--- a/utilities/auth/select-primary-wallet.ts
+++ b/utilities/auth/select-primary-wallet.ts
@@ -1,0 +1,38 @@
+import type { User } from "@privy-io/react-auth";
+import { compareAllWallets } from "./compare-all-wallets";
+
+/**
+ * Choose the wallet that represents the authenticated user's identity and active
+ * signer, from the full list of wallets Privy reports as connected in the browser.
+ *
+ * Privy's useWallets() lists EVERY physically-connected wallet, which can include
+ * one left over from a previous session that is NOT linked to the current user —
+ * notably MetaMask, which Privy cannot disconnect programmatically (its
+ * wallet.disconnect() is a documented no-op). After logging out of a wallet session
+ * and back in with email/social, that stale wallet is often wallets[0], so naively
+ * using wallets[0] leaks the previous wallet's address/avatar and reads its on-chain
+ * data.
+ *
+ * Rules:
+ * - Prefer a connected wallet that is actually linked to the authenticated user.
+ *   `compareAllWallets` covers every linked wallet (standard, smart, embedded,
+ *   farcaster owner, cross-app), so an account with MULTIPLE linked wallets resolves
+ *   to whichever linked wallet Privy lists first — which is wallets[0] (the active
+ *   wallet) in the normal case, so the selection matches Privy's active wallet.
+ * - Fall back to wallets[0] only when no linked wallet is connected: pre-auth /
+ *   hydration (before linkedAccounts populate) or login methods that expose no
+ *   browser wallet.
+ *
+ * Used by both useAuth (identity address) and PrivyWagmiProviders (the wallet synced
+ * into the outer wagmi config that useAccount() reads) so the two never disagree.
+ */
+export const selectPrimaryWallet = <T extends { address: string }>(
+  user: User | null | undefined,
+  wallets: T[]
+): T | undefined => {
+  if (user) {
+    const linkedWallet = wallets.find((w) => compareAllWallets(user, w.address));
+    if (linkedWallet) return linkedWallet;
+  }
+  return wallets[0];
+};


### PR DESCRIPTION
## Overview

After logging in with MetaMask, logging out via the user dropdown, then logging in with email, the app kept showing the MetaMask avatar and pulled on-chain data from the MetaMask wallet — and the transaction signer could disagree with the displayed account. It only corrected itself after manually disconnecting in MetaMask.

## Problem

Privy's `useWallets()` returns **every** wallet physically connected in the browser. MetaMask in particular **cannot be disconnected programmatically** (Privy's `wallet.disconnect()` is a documented no-op for it), so a wallet from a previous session lingers in the list — often as `wallets[0]`.

The app derived identity from `wallets[0]`:
- `useAuth().address` → drove the navbar avatar, profile name, and on-chain/profile lookups.
- `PrivyWagmiProviders` synced `wallets[0]` into the outer wagmi config that `useAccount()` reads, so signing/attestation flows could use the stale wallet.
- `useClaimTransaction` signed the claim and keyed `claim-eligibility` on `wallets[0]` (a money path).

So an email/social user with a leftover MetaMask connection inherited the previous wallet's identity and on-chain data.

## Solution

New helper `selectPrimaryWallet(user, wallets)` (`utilities/auth/select-primary-wallet.ts`): prefer the connected wallet that is actually **linked to the authenticated user** (via the existing `compareAllWallets`, which covers standard/smart/embedded/farcaster/cross-app wallets and therefore **multiple linked wallets**), falling back to `wallets[0]` only before the user resolves or for login methods without a browser wallet.

Applied in three places so identity and signer never diverge:
- **`hooks/useAuth.ts`** — `primaryWallet`/`address` now come from the helper.
- **`components/Utilities/PrivyWagmiProviders.tsx`** — syncs the same selected wallet into the outer wagmi config; the sync is now **address-keyed** so it re-syncs when the selected wallet changes (e.g. the embedded wallet connecting after a stale MetaMask), instead of pinning to the first wallet for the session.
- **`src/features/claim-funds/hooks/use-claim-transaction.ts`** — signs and keys eligibility on the linked wallet; the mid-operation guard re-derives from live state.

Multiple linked wallets are handled: when all connected wallets belong to the user, selection keeps Privy's active wallet (`wallets[0]`) and does not reorder.

## Testing

- `__tests__/utilities/auth/select-primary-wallet.test.ts` — helper: stale-skip, multiple linked wallets, active-wallet follow, hydration fallback.
- `__tests__/unit/hooks/useAuth.test.tsx` — stale MetaMask → email, multi-wallet, hydration fallback.
- `__tests__/unit/features/claim-funds/use-claim-transaction-real.test.ts` — claim signs with the embedded (linked) wallet, never the stale MetaMask; eligibility keyed on the embedded address.

Manual QA (local, against staging API): MetaMask login → logout via dropdown → email login now shows the email account's avatar and data, not the lingering MetaMask.

### How to reproduce / verify manually
1. Log in with MetaMask.
2. Log out via the user dropdown (do **not** disconnect in MetaMask).
3. Log in with email.
4. The navbar should show your email account's avatar, and on-chain/profile data should be the email account's — not the MetaMask wallet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed wallet selection to prevent claims and transactions from using stale or unlinked wallets
  * Improved primary wallet resolution to correctly identify your authenticated linked wallet when multiple wallets are connected

* **Tests**
  * Added comprehensive test coverage for wallet selection behavior and authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->