### PR TITLE
fix: show milestone update buttons to community admins on project pages

### DIFF
--- a/__tests__/components/Pages/GrantMilestonesAndUpdates/screens/MilestoneDetails.test.tsx
+++ b/__tests__/components/Pages/GrantMilestonesAndUpdates/screens/MilestoneDetails.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MilestoneDetails } from "@/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+
+vi.mock("@/components/Shared/ActivityCard", () => ({
+  ActivityCard: ({ isAuthorized }: { isAuthorized?: boolean }) => (
+    <div data-testid="activity-card" data-is-authorized={String(Boolean(isAuthorized))} />
+  ),
+}));
+
+const mockIsOwner = vi.fn(() => false);
+const mockIsProjectOwner = vi.fn(() => false);
+const mockIsProjectAdmin = vi.fn(() => false);
+
+vi.mock("@/store", () => ({
+  useOwnerStore: vi.fn(() => mockIsOwner()),
+  useProjectStore: vi.fn((selector: any) => {
+    const source = selector.toString();
+    if (source.includes("isProjectOwner")) return mockIsProjectOwner();
+    if (source.includes("isProjectAdmin")) return mockIsProjectAdmin();
+    return undefined;
+  }),
+}));
+
+vi.mock("@/store/grant", () => ({
+  useGrantStore: vi.fn((selector: any) => selector({ grant: { communityUID: "0xcommunity" } })),
+}));
+
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: vi.fn(() => ({ isCommunityAdmin: false })),
+}));
+
+const mockUseIsCommunityAdmin = vi.mocked(useIsCommunityAdmin);
+
+const baseMilestone = {
+  uid: "milestone-1",
+  refUID: "grant-1",
+  title: "Milestone 1",
+  description: "desc",
+  chainID: 42161,
+} as any;
+
+const renderComponent = () => render(<MilestoneDetails milestone={baseMilestone} />);
+
+describe("MilestoneDetails gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsOwner.mockReturnValue(false);
+    mockIsProjectOwner.mockReturnValue(false);
+    mockIsProjectAdmin.mockReturnValue(false);
+    mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin: false } as any);
+  });
+
+  it("should_query_community_admin_with_the_grant_communityUID", () => {
+    renderComponent();
+
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith("0xcommunity");
+  });
+
+  it("should_authorize_when_user_is_community_admin", () => {
+    mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin: true } as any);
+
+    renderComponent();
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "true");
+  });
+
+  it("should_not_authorize_when_user_has_no_role", () => {
+    renderComponent();
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "false");
+  });
+
+  it("should_authorize_when_user_is_project_owner", () => {
+    mockIsProjectOwner.mockReturnValue(true);
+
+    renderComponent();
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "true");
+  });
+});

--- a/__tests__/components/Pages/Project/v2/MainContent/ActivityFeed.test.tsx
+++ b/__tests__/components/Pages/Project/v2/MainContent/ActivityFeed.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ActivityFeed } from "@/components/Pages/Project/v2/MainContent/ActivityFeed";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "project-1" }),
+}));
+
+vi.mock("@/components/Shared/ActivityCard", () => ({
+  ActivityCard: ({ isAuthorized }: { isAuthorized?: boolean }) => (
+    <div data-testid="activity-card" data-is-authorized={String(Boolean(isAuthorized))} />
+  ),
+}));
+
+vi.mock("@/hooks/useCommunityMilestoneAllocations", () => ({
+  useMilestoneAllocationsByGrants: () => ({ allocationMap: new Map() }),
+}));
+
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: vi.fn(() => ({ isCommunityAdmin: false })),
+}));
+
+const mockUseIsCommunityAdmin = vi.mocked(useIsCommunityAdmin);
+
+const grantMilestoneItem = {
+  uid: "milestone-1",
+  type: "milestone",
+  title: "Milestone 1",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  completed: false,
+  source: {
+    type: "grant",
+    grantMilestone: {
+      milestone: { uid: "milestone-1" },
+      grant: {
+        uid: "grant-1",
+        chainID: 42161,
+        community: { uid: "", chainID: 42161, details: { slug: "filecoin" } },
+      },
+    },
+  },
+} as any;
+
+describe("ActivityFeed per-item community admin gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin: false } as any);
+  });
+
+  it("should_query_community_admin_with_the_grant_community_slug", () => {
+    render(<ActivityFeed milestones={[grantMilestoneItem]} isAuthorized={false} />);
+
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith("filecoin");
+  });
+
+  it("should_authorize_item_when_user_is_community_admin_even_if_not_project_authorized", () => {
+    mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin: true } as any);
+
+    render(<ActivityFeed milestones={[grantMilestoneItem]} isAuthorized={false} />);
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "true");
+  });
+
+  it("should_not_authorize_item_when_neither_project_nor_community_admin", () => {
+    render(<ActivityFeed milestones={[grantMilestoneItem]} isAuthorized={false} />);
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "false");
+  });
+
+  it("should_authorize_item_when_project_authorized", () => {
+    render(<ActivityFeed milestones={[grantMilestoneItem]} isAuthorized={true} />);
+
+    expect(screen.getByTestId("activity-card")).toHaveAttribute("data-is-authorized", "true");
+  });
+});

--- a/components/Forms/MilestoneUpdate.tsx
+++ b/components/Forms/MilestoneUpdate.tsx
@@ -24,10 +24,9 @@ import {
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import { useProjectGrants } from "@/hooks/v2/useProjectGrants";
-import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
 import { useGrantInvoiceRequired } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import { submitGranteeInvoice } from "@/src/features/payout-disbursement/services/payout-disbursement.service";
-import { useOwnerStore, useProjectStore } from "@/store";
+import { useProjectStore } from "@/store";
 import { useShareDialogStore } from "@/store/modals/shareDialog";
 import type { GrantMilestone } from "@/types/v2/grant";
 import fetchData from "@/utilities/fetchData";
@@ -115,11 +114,6 @@ export const MilestoneUpdateForm: FC<MilestoneUpdateFormProps> = ({
   const { chain, address } = useAccount();
   const { switchChainAsync } = useWallet();
   const { setupChainAndWallet } = useSetupChainAndWallet();
-  const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
-  const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const isCommunityAdmin = useIsCommunityAdmin();
-  const _isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
   const { openShareDialog, closeShareDialog } = useShareDialogStore();
   const router = useRouter();
   const pathname = usePathname();

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/GrantUpdate.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/GrantUpdate.tsx
@@ -4,13 +4,13 @@ import { useAccount } from "wagmi";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useOffChainRevoke } from "@/hooks/useOffChainRevoke";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
 import { useWallet } from "@/hooks/useWallet";
 import { useProjectGrants } from "@/hooks/v2/useProjectGrants";
 import { getProjectGrants } from "@/services/project-grants.service";
-import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useGrantStore } from "@/store/grant";
 import type { GrantUpdate as GrantUpdateType } from "@/types/v2/grant";
@@ -78,6 +78,7 @@ export const GrantUpdate: FC<GrantUpdateProps> = ({ title, description, index, d
 
   // Fetch grants using dedicated hook
   const { grants, refetch: refetchProjectGrants } = useProjectGrants(projectIdOrSlug);
+  const grant = grants.find((g) => g.uid?.toLowerCase() === update.refUID?.toLowerCase());
   // Get refreshGrant from store to update the UI after deletion
   const refreshGrant = useGrantStore((state) => state.refreshGrant);
 
@@ -202,7 +203,7 @@ export const GrantUpdate: FC<GrantUpdateProps> = ({ title, description, index, d
   };
 
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
-  const isCommunityAdmin = useIsCommunityAdmin();
+  const { isCommunityAdmin } = useIsCommunityAdmin(grant?.communityUID);
 
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
 
@@ -217,8 +218,6 @@ export const GrantUpdate: FC<GrantUpdateProps> = ({ title, description, index, d
   };
 
   const isAfterProofLaunch = checkProofLaunch();
-
-  const grant = grants.find((g) => g.uid?.toLowerCase() === update.refUID?.toLowerCase());
 
   return (
     <div className="flex w-full flex-1 max-w-full flex-col gap-4 rounded-lg border border-zinc-200 dark:bg-zinc-800 dark:border-zinc-700 bg-white p-4 transition-all duration-200 ease-in-out  max-sm:px-2">

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
@@ -2,7 +2,7 @@
 
 import { type FC, useMemo } from "react";
 import { ActivityCard } from "@/components/Shared/ActivityCard";
-import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useGrantStore } from "@/store/grant";
 import type { GrantMilestone } from "@/types/v2/grant";
@@ -116,13 +116,12 @@ export const MilestoneDetails: FC<MilestoneDetailsProps> = ({
   allocationAmount,
   grantMilestoneOrder,
 }) => {
+  const grant = useGrantStore((state) => state.grant);
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const isCommunityAdmin = useIsCommunityAdmin();
+  const { isCommunityAdmin } = useIsCommunityAdmin(grant?.communityUID);
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
-
-  const grant = useGrantStore((state) => state.grant);
 
   const unifiedMilestone = useMemo(() => {
     const base = toUnifiedMilestone(milestone, grant);

--- a/components/Pages/Grants/MilestonesAndUpdates/index.tsx
+++ b/components/Pages/Grants/MilestonesAndUpdates/index.tsx
@@ -4,10 +4,10 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useParams } from "next/navigation";
 import { ExternalLink } from "@/components/Utilities/ExternalLink";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useTracksForProgram } from "@/hooks/useTracks";
 import { useGrantLinkedActivities } from "@/hooks/v2/useGrantLinkedActivities";
 import type { Track } from "@/services/tracks";
-import { useIsCommunityAdmin } from "@/src/core/rbac/context/permission-context";
 import { useOwnerStore, useProjectStore } from "@/store";
 import { useGrantStore } from "@/store/grant";
 import { useProgressModalStore } from "@/store/modals/progress";
@@ -22,7 +22,7 @@ const EmptyMilestone = ({ grant }: { grant?: Grant; project?: ProjectResponse })
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const isCommunityAdmin = useIsCommunityAdmin();
+  const { isCommunityAdmin } = useIsCommunityAdmin(grant?.communityUID);
   const { openProgressModalWithScreen } = useProgressModalStore();
 
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
@@ -231,7 +231,7 @@ export default function MilestonesAndUpdates() {
   const isProjectOwner = useProjectStore((state) => state.isProjectOwner);
   const isProjectAdmin = useProjectStore((state) => state.isProjectAdmin);
   const isContractOwner = useOwnerStore((state) => state.isOwner);
-  const isCommunityAdmin = useIsCommunityAdmin();
+  const { isCommunityAdmin } = useIsCommunityAdmin(grant?.communityUID);
   const isAuthorized = isProjectOwner || isProjectAdmin || isContractOwner || isCommunityAdmin;
 
   const handleAddMilestone = () => {

--- a/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeed.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import React, { useMemo } from "react";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { ActivityCard } from "@/components/Shared/ActivityCard";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { cn } from "@/utilities/tailwind";
@@ -59,6 +60,11 @@ const TimelineItem = React.memo(function TimelineItem({
   formatDisplayDate,
   allocationAmount,
 }: TimelineItemProps) {
+  const grantCommunity = milestone.source?.grantMilestone?.grant?.community;
+  const { isCommunityAdmin } = useIsCommunityAdmin(
+    grantCommunity?.uid || grantCommunity?.details?.slug
+  );
+  const itemAuthorized = isAuthorized || isCommunityAdmin;
   return (
     <div className="relative pl-8 max-lg:pl-7" data-testid="activity-item">
       {/* Timeline icon - positioned relative to item, not content row */}
@@ -169,7 +175,7 @@ const TimelineItem = React.memo(function TimelineItem({
                   allocationAmount,
                 }
         }
-        isAuthorized={isAuthorized}
+        isAuthorized={itemAuthorized}
       />
     </div>
   );


### PR DESCRIPTION
## Overview

Community admins could not see milestone-update / add-milestone / grant-update actions on a project's **funding tab** or **project-root Updates tab**. This fixes the permission gates so those actions appear for community admins, consistent with what the indexer will actually accept on-chain.

## Problem

gap-app-v2 has **two** `useIsCommunityAdmin` hooks:

- `@/src/core/rbac/context/permission-context` — reads `PermissionContext`, only populated by a `PermissionProvider`, which is mounted **only** on dashboard / `app/community/[communityId]/*` / manage layouts. There is **no `PermissionProvider` on `app/project/*`**, so on a project page it always returns `false`.
- `@/hooks/communities/useIsCommunityAdmin` — data-driven, takes a `communityUID`/slug, resolves via on-chain `CommunityResolver.isAdmin`.

The project-page gates used the wrong signal:
- **Funding tab** action gates used the RBAC-context hook with no args (always false on project pages).
- **Updates tab** used `useProjectAuthorization()`, which only checks `isOwner || isProjectAdmin || isProjectOwner` — no community-admin signal at all.

This matches the repo's RBAC guidance in `gap-app-v2/CLAUDE.md`: context-specific flags only work inside community-scoped layouts; project pages must detect roles from data.

## Solution

Switch the gates to the data-driven `useIsCommunityAdmin(communityUID|slug)`, resolving the community from the relevant grant.

**Funding tab** (`/project/[id]/funding/[grantUid]/milestones-and-updates`):
- `MilestoneDetails.tsx` — milestone update/complete button (feeds `isAuthorized` → `ActivityCard` → `MilestoneCard`).
- `Pages/Grants/MilestonesAndUpdates/index.tsx` — the two "Add a new milestone" gates.
- `GrantUpdate.tsx` — grant-update actions.
- `MilestoneUpdate.tsx` — removed the dead, misleading RBAC gate.

**Project-root Updates tab** (activity feed mixes activities across grants/communities, so the check must be **per item**):
- `ActivityFeed.tsx` `TimelineItem` — resolves each item's grant community (uid or slug) and ORs `useIsCommunityAdmin` into that item's authorization before passing it to `ActivityCard`.

`hooks/useCanVerifyMilestone.ts` already followed this pattern (data hook + community), so this aligns the action gates with the existing verification gate.

## Why This Approach

The indexer's milestone-completion acceptance gate (`gap-indexer` `validate-attestation.ts` → `validateCanAttestToMilestoneStatus`) calls the **same on-chain `CommunityResolver.isAdmin`** that `useIsCommunityAdmin` resolves through. Gating the UI with the data-driven hook means the action is shown **exactly when** the resulting on-chain attestation will be accepted and indexed — frontend and indexer cannot drift.

For an on-chain community admin this is the complete fix (admin signs with their own wallet; the indexer already accepts it). It does not introduce "on-behalf-of" attribution — the completion is attributed to the admin's address, which is expected.

## Testing Steps

1. Log in as an **on-chain community admin** of a community that owns a grant.
2. **Funding tab:** open `/project/[id]/funding/[grantUid]/milestones-and-updates` for a grant with an uncompleted milestone → the update/submit button and "Add a new milestone" appear.
3. **Updates tab:** open the project root Updates tab → grant milestone/update items show the edit/post actions; project-level updates (not tied to a grant) do not.
4. Post the update; confirm the on-chain attestation is created and the milestone shows completed after indexing.
5. Negative check: as a wallet with no role on that community/project, confirm no actions appear.

Automated tests:
- `__tests__/.../MilestoneDetails.test.tsx` — funding-tab gate.
- `__tests__/.../MainContent/ActivityFeed.test.tsx` — Updates-tab per-item gate (hook called with the grant's community slug; authorizes the item for community admins; not authorized otherwise).

## Validation

- `vitest run` on the touched areas — all pass (incl. 2 new test files).
- `tsc --noEmit` — clean (exit 0).
- `biome check` — clean on touched files.

## Notes / Follow-ups (not in this PR)

- The same RBAC-context-hook bug also exists in `GrantCompleteButton/index.tsx` (complete grant) and `Forms/Milestone.tsx` (milestone creation) on other routes. Same swap applies; left out to keep this PR focused.
- True "on behalf of the grantee" attribution (completion reads as the grantee, not the admin) would require a separate backend-signed attestation path + a `completedBy` field; out of scope here.
