### PR TITLE
Check admin/owner permissions across all linked wallets

### DIFF
--- a/__tests__/hooks/useProjectPermissions.test.ts
+++ b/__tests__/hooks/useProjectPermissions.test.ts
@@ -6,7 +6,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useProjectInstance } from "@/hooks/useProjectInstance";
 import { useProjectPermissions } from "@/hooks/useProjectPermissions";
 import { useProjectStore } from "@/store";
-import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
+import { compareAllWallets, getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { getRPCUrlByChainId } from "@/utilities/rpcClient";
 
 vi.mock("@/hooks/useAuth", () => ({
@@ -31,6 +31,7 @@ vi.mock("@/components/Utilities/errorManager", () => ({
 
 vi.mock("@/utilities/auth/compare-all-wallets", () => ({
   compareAllWallets: vi.fn(),
+  getLinkedWalletAddresses: vi.fn(),
 }));
 
 // Override defaultQueryOptions to disable retries in tests (prevents flaky
@@ -66,6 +67,7 @@ const mockUseProjectStore = useProjectStore as unknown as vi.Mock;
 const mockUseProjectInstance = useProjectInstance as unknown as vi.Mock;
 const mockGetRPCUrlByChainId = getRPCUrlByChainId as unknown as vi.Mock;
 const mockCompareAllWallets = compareAllWallets as unknown as vi.Mock;
+const mockGetLinkedWalletAddresses = getLinkedWalletAddresses as unknown as vi.Mock;
 
 // Fresh QueryClient per render — no afterEach cleanup required
 function createWrapper() {
@@ -91,6 +93,7 @@ function setupMocks(
     projectInstance?: any;
     rpcUrl?: string | null;
     compareAllWalletsResult?: boolean;
+    linkedWalletAddresses?: string[];
   } = {}
 ) {
   const {
@@ -102,6 +105,7 @@ function setupMocks(
     projectInstance = null,
     rpcUrl = null,
     compareAllWalletsResult = false,
+    linkedWalletAddresses = [],
   } = overrides;
 
   mockUseAuth.mockReturnValue({
@@ -129,6 +133,7 @@ function setupMocks(
   mockUseProjectInstance.mockReturnValue({ project: projectInstance });
   mockGetRPCUrlByChainId.mockReturnValue(rpcUrl);
   mockCompareAllWallets.mockReturnValue(compareAllWalletsResult);
+  mockGetLinkedWalletAddresses.mockReturnValue(linkedWalletAddresses);
 }
 
 describe("useProjectPermissions", () => {
@@ -364,6 +369,92 @@ describe("useProjectPermissions", () => {
       });
 
       expect(result.current.isProjectAdmin).toBe(false);
+    });
+  });
+
+  describe("multi-wallet admin", () => {
+    const ADMIN_WALLET = "0x741e2cdff080bd42cd30cfd6cc4a8a0f46a80a84";
+    const ACTIVE_WALLET = "0xbec2de31b27f04ea906c139b1c665bcdfd81a1aa";
+
+    const mockProject = {
+      uid: "test-project-uid",
+      details: { slug: "test-slug" },
+      chainID: 10,
+      // Project owner is someone else entirely — this account is only an admin.
+      owner: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    };
+
+    // One Privy account, two embedded wallets. The admin authority sits on
+    // ADMIN_WALLET, but Privy currently surfaces ACTIVE_WALLET as the active one.
+    const mockUser = {
+      linkedAccounts: [
+        { type: "wallet", address: ACTIVE_WALLET, walletClientType: "privy" },
+        { type: "wallet", address: ADMIN_WALLET, walletClientType: "privy" },
+      ],
+    };
+
+    it("recognizes admin when the role sits on a non-active linked wallet", async () => {
+      const mockProjectInstance = {
+        chainID: 10,
+        isOwner: vi.fn().mockResolvedValue(false),
+        // Only the admin wallet returns true on-chain; the active wallet does not.
+        isAdmin: vi.fn((_provider: unknown, addr: string) =>
+          Promise.resolve(addr.toLowerCase() === ADMIN_WALLET.toLowerCase())
+        ),
+      };
+
+      setupMocks({
+        authenticated: true,
+        isConnected: true,
+        address: ACTIVE_WALLET, // the wrong wallet is active
+        user: mockUser,
+        project: mockProject,
+        projectInstance: mockProjectInstance,
+        rpcUrl: "https://mainnet.optimism.io",
+        linkedWalletAddresses: [ACTIVE_WALLET, ADMIN_WALLET],
+      });
+
+      const { result } = renderHook(() => useProjectPermissions(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isProjectAdmin).toBe(true);
+      });
+
+      // isAdmin must have been checked against the non-active admin wallet.
+      expect(mockProjectInstance.isAdmin).toHaveBeenCalledWith(expect.anything(), ADMIN_WALLET);
+      expect(result.current.isProjectOwner).toBe(false);
+    });
+
+    it("denies admin when no linked wallet holds the role on-chain", async () => {
+      const mockProjectInstance = {
+        chainID: 10,
+        isOwner: vi.fn().mockResolvedValue(false),
+        isAdmin: vi.fn().mockResolvedValue(false),
+      };
+
+      setupMocks({
+        authenticated: true,
+        isConnected: true,
+        address: ACTIVE_WALLET,
+        user: mockUser,
+        project: mockProject,
+        projectInstance: mockProjectInstance,
+        rpcUrl: "https://mainnet.optimism.io",
+        linkedWalletAddresses: [ACTIVE_WALLET, ADMIN_WALLET],
+      });
+
+      const { result } = renderHook(() => useProjectPermissions(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isProjectAdmin).toBe(false);
+      expect(result.current.isProjectOwner).toBe(false);
     });
   });
 });

--- a/hooks/useProjectPermissions.ts
+++ b/hooks/useProjectPermissions.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from "react";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAuth } from "@/hooks/useAuth";
 import { useProjectStore } from "@/store";
-import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
+import { compareAllWallets, getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { getRPCUrlByChainId } from "@/utilities/rpcClient";
@@ -24,15 +24,49 @@ export const useProjectPermissions = () => {
   const setIsProjectAdmin = useProjectStore((state) => state.setIsProjectAdmin);
   const setIsProjectOwner = useProjectStore((state) => state.setIsProjectOwner);
 
+  // Every address the authenticated account can act as: the active signer plus
+  // ALL wallets linked to the Privy user. A single Privy account can carry more
+  // than one wallet (e.g. two embedded wallets), and only one is "active" at a
+  // time. On-chain owner/admin authority may sit on a *non-active* wallet, so we
+  // must test every linked wallet — not just the active address — or the account
+  // silently loses access whenever Privy surfaces a different wallet as active.
+  const candidateAddresses = useMemo(() => {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const candidate of [address, ...(user ? getLinkedWalletAddresses(user) : [])]) {
+      if (!candidate) continue;
+      const key = candidate.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(candidate);
+    }
+    return result;
+  }, [address, user]);
+
+  // Order-independent signature of the candidate set for the query key, so
+  // permissions recompute when the linked-wallet set changes but don't refetch
+  // when only the active wallet toggles within the same set.
+  const walletsKey = useMemo(
+    () =>
+      candidateAddresses.length
+        ? candidateAddresses
+            .map((candidate) => candidate.toLowerCase())
+            .sort()
+            .join(",")
+        : null,
+    [candidateAddresses]
+  );
+
   const checkPermissions = async (): Promise<ProjectPermissionsResult> => {
     // Early returns for invalid states
-    if (!isAuth || !isConnected || !address) {
+    if (!isAuth || !isConnected || candidateAddresses.length === 0) {
       return { isProjectOwner: false, isProjectAdmin: false };
     }
 
-    // Check if any of the user's linked wallets matches the project owner
-    // from the API response. This handles multi-wallet users (e.g., user
-    // created the project with MetaMask but primary wallet is now embedded).
+    // Off-chain owner fallback: the indexer exposes a single `project.owner`, so
+    // we can match it against every linked wallet without an on-chain call.
+    // There is no equivalent indexer field for admins — admin authority is
+    // resolved on-chain across the candidate wallets below.
     const isOwnerByApiAddress =
       !!project?.owner && !!user && compareAllWallets(user, project.owner);
 
@@ -54,26 +88,36 @@ export const useProjectPermissions = () => {
       const { ethers } = await import("ethers");
       const rpcProvider = new ethers.JsonRpcProvider(rpcUrl);
 
-      const [isOwnerResult, isAdminResult] = await Promise.all([
-        projectInstance?.isOwner(rpcProvider, address).catch((error) => {
-          errorManager(
-            `Error checking owner permissions for user ${address} on project ${projectId}`,
-            error
-          );
-          return false;
-        }),
-        projectInstance?.isAdmin(rpcProvider, address).catch((error) => {
-          errorManager(
-            `Error checking admin permissions for user ${address} on project ${projectId}`,
-            error
-          );
-          return false;
-        }),
-      ]);
+      // Resolve owner/admin across EVERY candidate wallet, in parallel. A role
+      // held by a non-active linked wallet still grants access.
+      const perWalletResults = await Promise.all(
+        candidateAddresses.map(async (candidate) => {
+          const [isOwnerResult, isAdminResult] = await Promise.all([
+            projectInstance.isOwner(rpcProvider, candidate).catch((error) => {
+              errorManager(
+                `Error checking owner permissions for user ${candidate} on project ${projectId}`,
+                error
+              );
+              return false;
+            }),
+            projectInstance.isAdmin(rpcProvider, candidate).catch((error) => {
+              errorManager(
+                `Error checking admin permissions for user ${candidate} on project ${projectId}`,
+                error
+              );
+              return false;
+            }),
+          ]);
+          return { isOwnerResult, isAdminResult };
+        })
+      );
+
+      const isOwnerOnChain = perWalletResults.some((result) => result.isOwnerResult);
+      const isAdminOnChain = perWalletResults.some((result) => result.isAdminResult);
 
       return {
-        isProjectOwner: isOwnerResult || isOwnerByApiAddress,
-        isProjectAdmin: isAdminResult,
+        isProjectOwner: isOwnerOnChain || isOwnerByApiAddress,
+        isProjectAdmin: isAdminOnChain,
       };
     } catch (error: unknown) {
       errorManager(`Error checking permissions for user ${address} on project ${projectId}`, error);
@@ -91,18 +135,18 @@ export const useProjectPermissions = () => {
   const queryKey = useMemo(
     () =>
       QUERY_KEYS.PROJECT.PERMISSIONS({
-        address: address ?? null,
+        walletsKey,
         projectId: projectId ?? null,
         chainID,
         isAuth,
       }),
-    [address, projectId, chainID, isAuth]
+    [walletsKey, projectId, chainID, isAuth]
   );
 
   const query = useQuery({
     queryKey,
     queryFn: checkPermissions,
-    enabled: !!projectInstance && chainID !== null && !!isAuth && !!address,
+    enabled: !!projectInstance && chainID !== null && !!isAuth && !!walletsKey,
     ...defaultQueryOptions,
     gcTime: 1 * 60 * 1000, // 1 minutes
   });

--- a/utilities/auth/compare-all-wallets.ts
+++ b/utilities/auth/compare-all-wallets.ts
@@ -4,11 +4,18 @@ import { isAddress } from "viem";
 type WalletLike = { address: string };
 
 /**
- * Check if a given address matches any wallet linked to the Privy user,
- * including standard wallets, smart wallets, and cross-app embedded wallets.
+ * Collect EVERY wallet address linked to the Privy user — standard wallets,
+ * smart wallets, the Farcaster owner address, and cross-app embedded + smart
+ * wallets.
+ *
+ * A single Privy account can carry MORE THAN ONE wallet (e.g. two embedded
+ * wallets), only one of which is the "active" signer at a time. Callers that
+ * authorize the *account* rather than the active signer must consider all of
+ * them, or the account silently loses access whenever Privy surfaces a
+ * different wallet as the active one.
  */
-export const compareAllWallets = (user: User, address: string): boolean => {
-  if (!user.linkedAccounts) return false;
+export const getLinkedWalletAddresses = (user: User): string[] => {
+  if (!user.linkedAccounts) return [];
   const wallets: string[] = [];
 
   user.linkedAccounts.forEach((account: LinkedAccountWithMetadata) => {
@@ -39,5 +46,12 @@ export const compareAllWallets = (user: User, address: string): boolean => {
     }
   });
 
-  return wallets.some((wallet) => wallet.toLowerCase() === address.toLowerCase());
+  return wallets;
 };
+
+/**
+ * Check if a given address matches any wallet linked to the Privy user,
+ * including standard wallets, smart wallets, and cross-app embedded wallets.
+ */
+export const compareAllWallets = (user: User, address: string): boolean =>
+  getLinkedWalletAddresses(user).some((wallet) => wallet.toLowerCase() === address.toLowerCase());

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -208,14 +208,14 @@ export const QUERY_KEYS = {
      * to prevent query key instability when project data loads asynchronously.
      */
     PERMISSIONS: (params: {
-      address: string | null;
+      walletsKey: string | null;
       projectId: string | null;
       chainID: number | null;
       isAuth: boolean;
     }) =>
       [
         "project-permissions",
-        params.address,
+        params.walletsKey,
         params.projectId,
         params.chainID,
         params.isAuth,


### PR DESCRIPTION
## Summary
Fixes a critical permission bug where users with multiple linked wallets (e.g., two embedded wallets via Privy) would lose admin/owner access whenever a non-active wallet became the active signer. The hook now checks on-chain permissions against **every** linked wallet, not just the currently active one.

## Key Changes
- **`useProjectPermissions.ts`**: 
  - Added `candidateAddresses` memo that collects the active address plus all linked wallet addresses from the Privy user
  - Refactored on-chain permission checks to test every candidate wallet in parallel, using `Promise.all()` with `some()` to grant access if *any* wallet holds the role
  - Updated query key to use `walletsKey` (sorted, deduplicated wallet set) instead of a single `address`, so permissions recompute when the linked-wallet set changes but don't refetch when only the active wallet toggles within the same set
  - Improved comments explaining the multi-wallet scenario and off-chain owner fallback logic

- **`utilities/auth/compare-all-wallets.ts`**:
  - Extracted wallet collection logic into new `getLinkedWalletAddresses()` function that returns all linked wallet addresses
  - Refactored `compareAllWallets()` to use the new function, reducing duplication

- **`utilities/queryKeys.ts`**:
  - Changed `PERMISSIONS` query key parameter from `address: string | null` to `walletsKey: string | null` to reflect the multi-wallet approach

- **`__tests__/hooks/useProjectPermissions.test.ts`**:
  - Added mocks for `getLinkedWalletAddresses`
  - Added new test suite `"multi-wallet admin"` with two test cases:
    - Verifies admin access is granted when the role sits on a non-active linked wallet
    - Verifies admin access is denied when no linked wallet holds the role on-chain

## Implementation Details
- Deduplication uses a `Set<string>` keyed by lowercase addresses to handle case-insensitive comparison
- The `walletsKey` is a sorted, comma-separated string of lowercase addresses — order-independent so permission queries remain stable across wallet toggles
- Off-chain owner check (via API `project.owner`) still uses `compareAllWallets()` since there's no equivalent indexer field for admins
- Error handling preserves the original address in error messages for debugging (though the check now spans multiple addresses)

https://claude.ai/code/session_01R8VMdvMQi2Fep5vR2UbNP1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project permissions are now correctly evaluated across all linked wallets, including non-active ones. Admin roles are properly recognized regardless of which linked wallet holds the admin role.

* **Tests**
  * Added test coverage for multi-wallet permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->