### PR TITLE
chore(milestones): remove dead off-chain milestone-completion references

### DIFF
--- a/services/milestones.ts
+++ b/services/milestones.ts
@@ -203,17 +203,6 @@ export async function fetchProjectGrantMilestones(
   };
 }
 
-export async function updateMilestoneCompletion(
-  completionId: string,
-  completionText: string
-): Promise<MilestoneCompletionData> {
-  const response = await apiClient.put<{ completion: MilestoneCompletionData }>(
-    `/v2/milestone-completions/${completionId}`,
-    { completionText }
-  );
-  return response.data.completion;
-}
-
 /**
  * Attest milestone completion as a program reviewer (backend creates on-chain attestation)
  */

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -167,8 +167,6 @@ export const INDEXER = {
       ACCESS: (referenceNumber: string) => `/v2/funding-applications/${referenceNumber}/access`,
       MY_APPLICATIONS: (communitySlug: string) =>
         `/v2/funding-applications/user/my-applications?communitySlug=${communitySlug}`,
-      MILESTONE_COMPLETIONS: (referenceNumber: string) =>
-        `/v2/funding-applications/${referenceNumber}/milestone-completions`,
       INVOICE_CONFIG: (referenceNumber: string) =>
         `/v2/funding-applications/${referenceNumber}/invoice-config`,
       MILESTONE_EVALUATION: (referenceNumber: string, milestoneTitle: string) =>


### PR DESCRIPTION
## Summary

Removes two pieces of dead frontend code that referenced the off-chain `milestone-completions` endpoints retired in **DEV-234** (gap-indexer Phase 4).

## What & why

- `services/milestones.ts` — deleted `updateMilestoneCompletion()`. It was never imported anywhere and called `PUT /v2/milestone-completions/:completionId`, an endpoint that no longer exists.
- `utilities/indexer.ts` — deleted the `MILESTONE_COMPLETIONS` URL builder (`/v2/funding-applications/:ref/milestone-completions`). It was never referenced.

The **live** milestone completion flow (`components/Forms/MilestoneUpdate.tsx`) is already fully on-chain and does not touch these endpoints, so there is no functional change. `MilestoneCompletionData` is retained — it's still used by the on-chain `GrantMilestoneWithCompletion` type.

## Testing

- `biome check` on changed files — clean (only pre-existing `any` warnings, untouched)
- `tsc --noEmit` — no type errors in the changed files
- No remaining references to the removed symbols (`grep` clean)

DEV-234


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Milestone completion update functionality is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->