### PR TITLE
fix(permissions): resolve global-owner and community-admin across all linked wallets

### DIFF
--- a/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
+++ b/__tests__/unit/hooks/useCheckCommunityAdmin.test.tsx
@@ -29,20 +29,23 @@ vi.mock("@/utilities/eas-wagmi-utils", () => ({
   useSigner: vi.fn(() => "mockSigner"),
 }));
 
-// Mock isCommunityAdminOf
+// Mock the community-admin SDK. The hook resolves admin status across every
+// linked wallet via isCommunityAdminOfAny.
 vi.mock("@/utilities/sdk/communities/isCommunityAdmin", () => ({
-  isCommunityAdminOf: vi.fn(),
+  isCommunityAdminOfAny: vi.fn(),
 }));
 
 import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
 import { useSigner } from "@/utilities/eas-wagmi-utils";
-import { isCommunityAdminOf } from "@/utilities/sdk/communities/isCommunityAdmin";
+import { isCommunityAdminOfAny } from "@/utilities/sdk/communities/isCommunityAdmin";
 
 const mockUseAccount = useAccount as vi.MockedFunction<typeof useAccount>;
 const mockUseAuth = useAuth as vi.MockedFunction<typeof useAuth>;
 const mockUseSigner = useSigner as vi.MockedFunction<typeof useSigner>;
-const mockIsCommunityAdminOf = isCommunityAdminOf as vi.MockedFunction<typeof isCommunityAdminOf>;
+const mockIsCommunityAdminOfAny = isCommunityAdminOfAny as vi.MockedFunction<
+  typeof isCommunityAdminOfAny
+>;
 
 // Test data
 const mockCommunity: CommunityDetails = {
@@ -103,7 +106,7 @@ describe("useCheckCommunityAdmin", () => {
 
   describe("Admin Status Verification (Security-Critical)", () => {
     it("should return isAdmin: true when user is admin", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -118,7 +121,7 @@ describe("useCheckCommunityAdmin", () => {
     });
 
     it("should return isAdmin: false when user is not admin", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(false);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -133,7 +136,7 @@ describe("useCheckCommunityAdmin", () => {
     });
 
     it("should return isAdmin: false when isCommunityAdminOf returns undefined", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(undefined as unknown as boolean);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(undefined as unknown as boolean);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -147,22 +150,26 @@ describe("useCheckCommunityAdmin", () => {
       expect(result.current.isAdmin).toBe(false);
     });
 
-    it("should call isCommunityAdminOf with correct parameters", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+    it("should call isCommunityAdminOfAny with the active wallet", async () => {
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
       });
 
       await waitFor(() => {
-        expect(mockIsCommunityAdminOf).toHaveBeenCalled();
+        expect(mockIsCommunityAdminOfAny).toHaveBeenCalled();
       });
 
-      expect(mockIsCommunityAdminOf).toHaveBeenCalledWith(mockCommunity, mockAddress, "mockSigner");
+      expect(mockIsCommunityAdminOfAny).toHaveBeenCalledWith(
+        mockCommunity,
+        [mockAddress],
+        "mockSigner"
+      );
     });
 
     it("should use provided address over connected account address", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
       const customAddress = "0xCustomAddress";
 
       renderHook(() => useCheckCommunityAdmin(mockCommunity, customAddress), {
@@ -170,12 +177,69 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       await waitFor(() => {
-        expect(mockIsCommunityAdminOf).toHaveBeenCalled();
+        expect(mockIsCommunityAdminOfAny).toHaveBeenCalled();
       });
 
-      expect(mockIsCommunityAdminOf).toHaveBeenCalledWith(
+      expect(mockIsCommunityAdminOfAny).toHaveBeenCalledWith(
         mockCommunity,
-        customAddress,
+        [customAddress],
+        "mockSigner"
+      );
+    });
+
+    it("checks every linked wallet of the authenticated user, not just the active one", async () => {
+      mockUseAuth.mockReturnValue({
+        authenticated: true,
+        address: "0xActiveWallet",
+        user: {
+          linkedAccounts: [
+            { type: "wallet", address: "0xActiveWallet" },
+            { type: "wallet", address: "0xAdminWallet" },
+          ],
+        },
+      } as unknown as ReturnType<typeof useAuth>);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
+
+      const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isAdmin).toBe(true);
+      });
+
+      expect(mockIsCommunityAdminOfAny).toHaveBeenCalledWith(
+        mockCommunity,
+        expect.arrayContaining(["0xActiveWallet", "0xAdminWallet"]),
+        "mockSigner"
+      );
+    });
+
+    it("does not expand to linked wallets when an explicit address is provided", async () => {
+      mockUseAuth.mockReturnValue({
+        authenticated: true,
+        address: "0xActiveWallet",
+        user: {
+          linkedAccounts: [
+            { type: "wallet", address: "0xActiveWallet" },
+            { type: "wallet", address: "0xAdminWallet" },
+          ],
+        },
+      } as unknown as ReturnType<typeof useAuth>);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
+      const someoneElse = "0xSomeoneElse";
+
+      renderHook(() => useCheckCommunityAdmin(mockCommunity, someoneElse), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(mockIsCommunityAdminOfAny).toHaveBeenCalled();
+      });
+
+      expect(mockIsCommunityAdminOfAny).toHaveBeenCalledWith(
+        mockCommunity,
+        [someoneElse],
         "mockSigner"
       );
     });
@@ -187,7 +251,7 @@ describe("useCheckCommunityAdmin", () => {
       const pendingPromise = new Promise<boolean>((resolve) => {
         resolvePromise = resolve;
       });
-      mockIsCommunityAdminOf.mockReturnValueOnce(pendingPromise);
+      mockIsCommunityAdminOfAny.mockReturnValueOnce(pendingPromise);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -213,7 +277,7 @@ describe("useCheckCommunityAdmin", () => {
       );
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
   });
 
@@ -224,7 +288,7 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
 
     it("should not fetch when community is null", () => {
@@ -233,7 +297,7 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
 
     it("should not fetch when user is not authenticated", () => {
@@ -246,7 +310,7 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
 
     it("should not fetch when no address is available", () => {
@@ -260,7 +324,7 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
 
     it("should not fetch when enabled option is false", () => {
@@ -272,18 +336,18 @@ describe("useCheckCommunityAdmin", () => {
       );
 
       expect(result.current.isLoading).toBe(false);
-      expect(mockIsCommunityAdminOf).not.toHaveBeenCalled();
+      expect(mockIsCommunityAdminOfAny).not.toHaveBeenCalled();
     });
 
     it("should fetch when all conditions are met", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
       });
 
       await waitFor(() => {
-        expect(mockIsCommunityAdminOf).toHaveBeenCalled();
+        expect(mockIsCommunityAdminOfAny).toHaveBeenCalled();
       });
     });
   });
@@ -292,7 +356,7 @@ describe("useCheckCommunityAdmin", () => {
     it("should return isAdmin: false when isCommunityAdminOf returns false (internal error handling)", async () => {
       // isCommunityAdminOf catches errors internally and returns false
       // So we test that the hook properly handles this case
-      mockIsCommunityAdminOf.mockResolvedValueOnce(false);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -311,7 +375,7 @@ describe("useCheckCommunityAdmin", () => {
       // When isCommunityAdminOf encounters an error, it catches it internally
       // and returns false (with error logged via errorManager)
       // This test verifies the hook handles this gracefully
-      mockIsCommunityAdminOf.mockResolvedValueOnce(false);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -329,7 +393,7 @@ describe("useCheckCommunityAdmin", () => {
 
   describe("Refetch Functionality", () => {
     it("should provide a refetch function", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(false);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -343,7 +407,7 @@ describe("useCheckCommunityAdmin", () => {
     });
 
     it("should re-fetch admin status when refetch is called", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(false);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -354,7 +418,7 @@ describe("useCheckCommunityAdmin", () => {
       });
 
       // Change the mock to return true
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       // Call refetch
       await result.current.refetch();
@@ -367,14 +431,14 @@ describe("useCheckCommunityAdmin", () => {
 
   describe("Query Key Structure", () => {
     it("should use correct query key for caching", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
       });
 
       await waitFor(() => {
-        expect(mockIsCommunityAdminOf).toHaveBeenCalled();
+        expect(mockIsCommunityAdminOfAny).toHaveBeenCalled();
       });
 
       // Verify the query is cached with the correct key components (using centralized QUERY_KEYS)
@@ -383,7 +447,9 @@ describe("useCheckCommunityAdmin", () => {
         "isCommunityAdmin",
         mockCommunity.uid,
         mockCommunity.chainID,
-        mockAddress,
+        // The key carries the order-independent, lowercased signature of the
+        // checked wallet set (here just the single active wallet).
+        mockAddress.toLowerCase(),
         "mockSigner",
       ]);
       expect(cachedData).toBe(true);
@@ -392,7 +458,7 @@ describe("useCheckCommunityAdmin", () => {
 
   describe("Return Value Structure", () => {
     it("should return all expected properties", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(true);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(true);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),
@@ -410,7 +476,7 @@ describe("useCheckCommunityAdmin", () => {
     });
 
     it("should default isAdmin to false when data is falsy", async () => {
-      mockIsCommunityAdminOf.mockResolvedValueOnce(null as unknown as boolean);
+      mockIsCommunityAdminOfAny.mockResolvedValueOnce(null as unknown as boolean);
 
       const { result } = renderHook(() => useCheckCommunityAdmin(mockCommunity), {
         wrapper: createWrapper(queryClient),

--- a/__tests__/unit/hooks/useContractOwner.multi-wallet.test.tsx
+++ b/__tests__/unit/hooks/useContractOwner.multi-wallet.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Regression tests: the global EAS contract-owner check must match the owner
+ * against EVERY wallet linked to the authenticated account, not only the active
+ * one. A single Privy account can hold multiple embedded wallets and the owner
+ * role may sit on a non-active one.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useContractOwner } from "@/hooks/useContractOwner";
+import { getContractOwner } from "@/utilities/sdk/getContractOwner";
+
+vi.mock("ethers", () => ({
+  // Must be constructable (`new JsonRpcProvider(...)`), so use a class, not an
+  // arrow function.
+  JsonRpcProvider: class {},
+}));
+
+vi.mock("@/utilities/network", () => ({
+  gapSupportedNetworks: [{ id: 10, name: "Optimism" }],
+}));
+
+vi.mock("@/utilities/rpcClient", () => ({
+  getRPCUrlByChainId: vi.fn().mockReturnValue("https://rpc.optimism.test"),
+}));
+
+vi.mock("@/utilities/sdk/getContractOwner", () => ({
+  getContractOwner: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/store/owner", () => ({
+  useOwnerStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setIsOwner: vi.fn(), setIsOwnerLoading: vi.fn() })
+  ),
+}));
+
+vi.mock("@/utilities/eas-wagmi-utils", () => ({
+  useSigner: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+vi.mock("@/utilities/cache-config", () => ({
+  CONTRACT_OWNER_CACHE_CONFIG: { staleTime: 0, gcTime: 0 },
+}));
+
+vi.mock("@/utilities/queryKeys", () => ({
+  QUERY_KEYS: {
+    AUTH: {
+      CONTRACT_OWNER: (walletsKey?: string, chainId?: number) => [
+        "contract-owner",
+        walletsKey,
+        chainId,
+      ],
+    },
+  },
+}));
+
+const mockUseAuth = useAuth as unknown as vi.Mock;
+const mockGetContractOwner = getContractOwner as unknown as vi.Mock;
+
+const ACTIVE = "0xActiveWalletaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const OWNER = "0xOwnerWalletbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useContractOwner — multi-wallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is owner when the contract owner matches a non-active linked wallet", async () => {
+    mockUseAuth.mockReturnValue({
+      authenticated: true,
+      address: ACTIVE,
+      user: {
+        linkedAccounts: [
+          { type: "wallet", address: ACTIVE },
+          { type: "wallet", address: OWNER },
+        ],
+      },
+    });
+    // On-chain owner is the NON-active linked wallet.
+    mockGetContractOwner.mockResolvedValue(OWNER);
+
+    const { result } = renderHook(() => useContractOwner(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(true);
+    });
+  });
+
+  it("is not owner when no linked wallet matches the contract owner", async () => {
+    mockUseAuth.mockReturnValue({
+      authenticated: true,
+      address: ACTIVE,
+      user: {
+        linkedAccounts: [
+          { type: "wallet", address: ACTIVE },
+          { type: "wallet", address: OWNER },
+        ],
+      },
+    });
+    mockGetContractOwner.mockResolvedValue("0xUnrelatedccccccccccccccccccccccccccccc1");
+
+    const { result } = renderHook(() => useContractOwner(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.data).toBe(false);
+  });
+});

--- a/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
+++ b/__tests__/utilities/sdk/communities/isCommunityAdmin.test.ts
@@ -1,7 +1,10 @@
 import { GAP } from "@show-karma/karma-gap-sdk";
 import type { Community } from "@/types/v2/community";
 import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
-import { isCommunityAdminOf } from "@/utilities/sdk/communities/isCommunityAdmin";
+import {
+  isCommunityAdminOf,
+  isCommunityAdminOfAny,
+} from "@/utilities/sdk/communities/isCommunityAdmin";
 
 vi.mock("@show-karma/karma-gap-sdk", () => ({
   GAP: {
@@ -65,5 +68,63 @@ describe("isCommunityAdminOf", () => {
     const result = await isCommunityAdminOf(community, address);
 
     expect(result).toBe(false);
+  });
+});
+
+describe("isCommunityAdminOfAny", () => {
+  const adminWallet = "0xAdminWallet000000000000000000000000000001";
+  const otherWallet = "0xOtherWallet00000000000000000000000000002";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when any wallet is an admin and fetches the resolver only once", async () => {
+    const isAdmin = vi.fn(async (_uid: string, addr: string) => addr === adminWallet);
+    mockGetCommunityResolver.mockResolvedValue({ isAdmin });
+
+    const result = await isCommunityAdminOfAny(community, [otherWallet, adminWallet]);
+
+    expect(result).toBe(true);
+    expect(mockGetCommunityResolver).toHaveBeenCalledTimes(1);
+    expect(isAdmin).toHaveBeenCalledWith(community.uid, otherWallet);
+    expect(isAdmin).toHaveBeenCalledWith(community.uid, adminWallet);
+  });
+
+  it("returns false when no wallet is an admin", async () => {
+    const isAdmin = vi.fn().mockResolvedValue(false);
+    mockGetCommunityResolver.mockResolvedValue({ isAdmin });
+
+    const result = await isCommunityAdminOfAny(community, [otherWallet, adminWallet]);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false for an empty address list without calling the resolver", async () => {
+    const result = await isCommunityAdminOfAny(community, []);
+
+    expect(result).toBe(false);
+    expect(mockGetCommunityResolver).not.toHaveBeenCalled();
+  });
+
+  it("dedupes addresses case-insensitively", async () => {
+    const isAdmin = vi.fn().mockResolvedValue(false);
+    mockGetCommunityResolver.mockResolvedValue({ isAdmin });
+
+    await isCommunityAdminOfAny(community, [adminWallet, adminWallet.toLowerCase()]);
+
+    expect(isAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a per-wallet check failure and still resolves the others", async () => {
+    const isAdmin = vi.fn(async (_uid: string, addr: string) => {
+      if (addr === otherWallet) throw new Error("boom");
+      return true;
+    });
+    mockGetCommunityResolver.mockResolvedValue({ isAdmin });
+
+    const result = await isCommunityAdminOfAny(community, [otherWallet, adminWallet]);
+
+    expect(result).toBe(true);
   });
 });

--- a/hooks/communities/useCheckCommunityAdmin.ts
+++ b/hooks/communities/useCheckCommunityAdmin.ts
@@ -1,11 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import type { Hex } from "viem";
 import { useAuth } from "@/hooks/useAuth";
 import type { Community } from "@/types/v2/community";
+import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { ADMIN_CACHE_CONFIG } from "@/utilities/cache-config";
 import { useSigner } from "@/utilities/eas-wagmi-utils";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
-import { isCommunityAdminOf } from "@/utilities/sdk/communities/isCommunityAdmin";
+import { isCommunityAdminOfAny } from "@/utilities/sdk/communities/isCommunityAdmin";
 
 interface UseCheckCommunityAdminOptions {
   enabled?: boolean;
@@ -30,25 +32,49 @@ export const useCheckCommunityAdmin = (
   options?: UseCheckCommunityAdminOptions
 ) => {
   const signer = useSigner();
-  const { authenticated: isAuth, address: accountAddress } = useAuth();
+  const { authenticated: isAuth, address: accountAddress, user } = useAuth();
 
-  const checkAddress = address || accountAddress;
+  // When an explicit address is provided, check exactly that address. Otherwise
+  // authorize the whole authenticated account: the active wallet plus every
+  // wallet linked to the Privy user. A single account may hold several wallets
+  // (e.g. multiple embedded wallets) and admin authority may sit on a non-active
+  // one, so checking only the active address can wrongly deny access.
+  const checkAddresses = useMemo<(string | Hex)[]>(() => {
+    if (address) return [address];
+    const seen = new Set<string>();
+    const result: (string | Hex)[] = [];
+    for (const candidate of [accountAddress, ...(user ? getLinkedWalletAddresses(user) : [])]) {
+      if (!candidate) continue;
+      const key = candidate.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(candidate);
+    }
+    return result;
+  }, [address, accountAddress, user]);
+
+  // Order-independent signature of the checked set for the query key.
+  const walletsKey = useMemo(
+    () =>
+      checkAddresses.length
+        ? checkAddresses
+            .map((candidate) => candidate.toLowerCase())
+            .sort()
+            .join(",")
+        : undefined,
+    [checkAddresses]
+  );
 
   const query = useQuery({
-    queryKey: QUERY_KEYS.COMMUNITY.IS_ADMIN(
-      community?.uid,
-      community?.chainID,
-      checkAddress,
-      signer
-    ),
+    queryKey: QUERY_KEYS.COMMUNITY.IS_ADMIN(community?.uid, community?.chainID, walletsKey, signer),
     queryFn: async () => {
-      if (!community || !checkAddress || !isAuth) {
+      if (!community || checkAddresses.length === 0 || !isAuth) {
         return false;
       }
 
-      return await isCommunityAdminOf(community, checkAddress, signer);
+      return await isCommunityAdminOfAny(community, checkAddresses, signer);
     },
-    enabled: !!community && !!checkAddress && !!isAuth && options?.enabled !== false,
+    enabled: !!community && checkAddresses.length > 0 && !!isAuth && options?.enabled !== false,
     staleTime: ADMIN_CACHE_CONFIG.staleTime,
     gcTime: ADMIN_CACHE_CONFIG.gcTime,
     refetchOnWindowFocus: false,

--- a/hooks/useContractOwner.ts
+++ b/hooks/useContractOwner.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { Chain } from "viem";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAuth } from "@/hooks/useAuth";
 import { useOwnerStore } from "@/store/owner";
+import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 import { CONTRACT_OWNER_CACHE_CONFIG } from "@/utilities/cache-config";
 import { useSigner } from "@/utilities/eas-wagmi-utils";
 import { gapSupportedNetworks } from "@/utilities/network";
@@ -11,8 +12,12 @@ import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { getRPCUrlByChainId } from "@/utilities/rpcClient";
 import { getContractOwner } from "@/utilities/sdk/getContractOwner";
 
-const fetchContractOwner = async (address: string): Promise<boolean> => {
-  if (!address) return false;
+// Resolve whether the EAS contract owner matches ANY of the supplied wallets.
+// A single authenticated account can hold multiple wallets (e.g. several Privy
+// embedded wallets); the owner role may sit on a non-active one, so checking
+// only the active address can wrongly deny global-owner access.
+const fetchIsContractOwner = async (addresses: string[]): Promise<boolean> => {
+  if (addresses.length === 0) return false;
   const chain = gapSupportedNetworks[0];
   const rpcUrl = getRPCUrlByChainId(chain.id);
 
@@ -27,23 +32,50 @@ const fetchContractOwner = async (address: string): Promise<boolean> => {
   });
 
   const owner = await getContractOwner(provider, chain);
-  return owner?.toLowerCase() === address?.toLowerCase();
+  const ownerAddress = owner?.toLowerCase();
+  return !!ownerAddress && addresses.some((address) => address.toLowerCase() === ownerAddress);
 };
 
 export const useContractOwner = (chainOverride?: Chain) => {
-  const { authenticated: isAuth, address } = useAuth();
+  const { authenticated: isAuth, address, user } = useAuth();
   const setIsOwner = useOwnerStore((state) => state.setIsOwner);
   const setIsOwnerLoading = useOwnerStore((state) => state.setIsOwnerLoading);
   const signer = useSigner();
   const chain = chainOverride || gapSupportedNetworks[0];
 
+  // The active wallet plus every wallet linked to the Privy user, deduped.
+  const candidateAddresses = useMemo(() => {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const candidate of [address, ...(user ? getLinkedWalletAddresses(user) : [])]) {
+      if (!candidate) continue;
+      const key = candidate.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(candidate);
+    }
+    return result;
+  }, [address, user]);
+
+  // Order-independent signature of the candidate set for the query key.
+  const walletsKey = useMemo(
+    () =>
+      candidateAddresses.length
+        ? candidateAddresses
+            .map((candidate) => candidate.toLowerCase())
+            .sort()
+            .join(",")
+        : undefined,
+    [candidateAddresses]
+  );
+
   const queryResult = useQuery<boolean, Error>({
-    queryKey: QUERY_KEYS.AUTH.CONTRACT_OWNER(address, chain?.id),
+    queryKey: QUERY_KEYS.AUTH.CONTRACT_OWNER(walletsKey, chain?.id),
     queryFn: () =>
-      fetchContractOwner(address!).catch(() => {
+      fetchIsContractOwner(candidateAddresses).catch(() => {
         return false;
       }),
-    enabled: !!address && isAuth,
+    enabled: candidateAddresses.length > 0 && isAuth,
     staleTime: CONTRACT_OWNER_CACHE_CONFIG.staleTime,
     gcTime: CONTRACT_OWNER_CACHE_CONFIG.gcTime,
     refetchOnMount: false,

--- a/utilities/sdk/communities/isCommunityAdmin.ts
+++ b/utilities/sdk/communities/isCommunityAdmin.ts
@@ -5,7 +5,72 @@ import type { Community } from "@/types/v2/community";
 import { getGapRpcConfig } from "@/utilities/gapRpcConfig";
 
 /**
- * Check if a user is an admin of a community
+ * Check if ANY of the given wallet addresses is an admin of a community.
+ *
+ * A single authenticated account can hold multiple wallets (e.g. several Privy
+ * embedded wallets), and admin authority may sit on a non-active one. Resolve
+ * the on-chain `isAdmin` check across every supplied wallet so the account is
+ * authorized wherever the role lives. The resolver is fetched once and reused.
+ *
+ * @param community - The community to check admin status for
+ * @param addresses - The wallet addresses to check
+ * @param signer - Optional signer for blockchain calls
+ * @returns boolean - true if any address is an admin, false otherwise or on failure
+ */
+export const isCommunityAdminOfAny = async (
+  community: Community,
+  addresses: (string | Hex)[],
+  signer?: SignerOrProvider
+): Promise<boolean> => {
+  const { uid, chainID } = community;
+
+  // Dedupe case-insensitively while preserving the original-cased address.
+  const uniqueAddresses = Array.from(
+    new Map(
+      addresses.filter((address) => !!address).map((address) => [address.toLowerCase(), address])
+    ).values()
+  );
+  if (uniqueAddresses.length === 0) return false;
+
+  try {
+    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig(), chainID);
+    if (!resolver) {
+      errorManager(`Community resolver not available for chain ${chainID}`, null, {
+        uid,
+        chainID,
+        addresses: uniqueAddresses,
+      });
+      return false;
+    }
+
+    const results = await Promise.all(
+      uniqueAddresses.map((address) =>
+        Promise.resolve(resolver.isAdmin(uid as Hex, address))
+          .then((response) => response ?? false)
+          .catch((error: unknown) => {
+            errorManager(`Error checking if user ${address} is community(${uid}) admin`, error, {
+              uid,
+              chainID,
+              address,
+            });
+            return false;
+          })
+      )
+    );
+
+    return results.some(Boolean);
+  } catch (error: unknown) {
+    errorManager(`Error checking community(${uid}) admin for addresses`, error, {
+      uid,
+      chainID,
+      addresses: uniqueAddresses,
+    });
+    return false;
+  }
+};
+
+/**
+ * Check if a user is an admin of a community.
  *
  * @param community - The community to check admin status for
  * @param address - The wallet address to check
@@ -16,27 +81,4 @@ export const isCommunityAdminOf = async (
   community: Community,
   address: string | Hex,
   signer?: SignerOrProvider
-): Promise<boolean> => {
-  const { uid, chainID } = community;
-  try {
-    const resolver = await GAP.getCommunityResolver(signer, getGapRpcConfig(), chainID);
-    if (!resolver) {
-      errorManager(`Community resolver not available for chain ${chainID}`, null, {
-        uid,
-        chainID,
-        address,
-      });
-      return false;
-    }
-
-    const response = await resolver.isAdmin(uid as Hex, address);
-    return response ?? false;
-  } catch (error: unknown) {
-    errorManager(`Error checking if user ${address} is community(${uid}) admin`, error, {
-      uid,
-      chainID,
-      address,
-    });
-    return false;
-  }
-};
+): Promise<boolean> => isCommunityAdminOfAny(community, [address], signer);


### PR DESCRIPTION
## Summary

Follow-up to #1550 (project owner/admin multi-wallet fix). A Privy account can hold **multiple wallets** (e.g. several embedded wallets), only one of which is the active signer at a time. Two more authorization gates still resolved a role against **only the active wallet**, so an account whose authority sits on a *non-active* linked wallet was wrongly denied access:

1. **Global EAS owner** — `hooks/useContractOwner.ts`
   Compared the on-chain contract `owner()` to the single active address. Now matches it against the active wallet **plus every wallet linked to the Privy user**.

2. **Community admin** — `hooks/communities/useCheckCommunityAdmin.ts` / `utilities/sdk/communities/isCommunityAdmin.ts`
   Ran the on-chain `isAdmin()` check against the active address only. Adds **`isCommunityAdminOfAny`**, which fetches the resolver **once** and checks every supplied wallet in parallel; `isCommunityAdminOf` now delegates to it.

## Why owner was already partly covered but these weren't

`useProjectPermissions` (#1550) and `useIsOwner` already use `compareAllWallets`. These two paths predate that pattern and compared a single address.

## Notes / safety

- **Explicit-address isolation:** `useCheckCommunityAdmin` expands to all linked wallets **only when checking the current user**. When an explicit address is passed (e.g. "is *this* address an admin"), it's still checked alone — verified by a dedicated test.
- Both keep their permissions query keyed on an **order-independent signature** of the checked wallet set, mirroring #1550 (recompute when the linked set changes; no refetch on active-wallet toggles).
- Reviewer / staff roles were confirmed already safe (resolved server-side from the session, not the active wallet) and are untouched.

## Tests

- `useContractOwner`: owner on a non-active linked wallet → granted; no match → denied.
- `isCommunityAdminOfAny`: any-wallet match, none-match, empty list (no resolver call), case-insensitive dedup, per-wallet failure tolerance (resolver fetched once).
- `useCheckCommunityAdmin`: checks all linked wallets for the current user; does **not** expand for an explicit address.

All touched test suites pass; `tsc --noEmit` and Biome clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R8VMdvMQi2Fep5vR2UbNP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8VMdvMQi2Fep5vR2UbNP1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated admin-status verification tests for multi-wallet scenarios
  * Added comprehensive test coverage for contract ownership across multiple wallets
  * Added multi-address admin verification tests

* **New Features**
  * Users with multiple connected wallets are now recognized as community admins if any wallet has admin status
  * Contract ownership verification now checks all user wallets instead of just the primary one

<!-- end of auto-generated comment: release notes by coderabbit.ai -->