### PR TITLE
fix(auth): prevent duplicate Privy embedded wallet on first login

### DIFF
--- a/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
+++ b/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
@@ -8,8 +8,8 @@
  */
 
 import type { User } from "@privy-io/react-auth";
-import { renderHook } from "@testing-library/react";
-import { useEnsureEmbeddedWallet } from "@/hooks/useEnsureEmbeddedWallet";
+import { renderHook, waitFor } from "@testing-library/react";
+import { RETRY_BASE_DELAY_MS, useEnsureEmbeddedWallet } from "@/hooks/useEnsureEmbeddedWallet";
 
 const mockCreateWallet = vi.fn<() => Promise<unknown>>();
 
@@ -96,38 +96,52 @@ describe("useEnsureEmbeddedWallet", () => {
     expect(mockCreateWallet).toHaveBeenCalledTimes(1);
   });
 
-  it("retries after a transient failure but not after an already-exists error", async () => {
-    mockCreateWallet.mockRejectedValueOnce(new Error("network down"));
+  it("retries a transient failure with backoff and succeeds without reporting", async () => {
+    vi.useFakeTimers();
+    try {
+      mockCreateWallet.mockRejectedValueOnce(new Error("network down")).mockResolvedValue({});
 
-    const transient = renderHook(() =>
-      useEnsureEmbeddedWallet(true, true, makeUser("u-transient"), 0)
-    );
-    await Promise.resolve();
-    transient.unmount();
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-transient"), 0));
 
-    // Slot was released — a later mount retries.
-    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-transient"), 0));
-    expect(mockCreateWallet).toHaveBeenCalledTimes(2);
+      // First attempt rejects, then backoff elapses and the retry succeeds.
+      await vi.advanceTimersByTimeAsync(RETRY_BASE_DELAY_MS);
 
-    mockCreateWallet.mockRejectedValueOnce(new Error("embedded_wallet_already_exists"));
-    const exists = renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exists"), 0));
-    await Promise.resolve();
-    exists.unmount();
-
-    // Slot stays claimed — no retry for an already-existing wallet.
-    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exists"), 0));
-    expect(mockCreateWallet).toHaveBeenCalledTimes(3);
+      expect(mockCreateWallet).toHaveBeenCalledTimes(2);
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("reports a genuine failure to Sentry but stays silent on already-exists", async () => {
-    mockCreateWallet.mockRejectedValueOnce(new Error("network down"));
-    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-report"), 0));
-    await Promise.resolve();
-    expect(mockErrorManager).toHaveBeenCalledTimes(1);
+  it("reports and releases the slot after exhausting retries", async () => {
+    vi.useFakeTimers();
+    try {
+      mockCreateWallet.mockRejectedValue(new Error("network down"));
 
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exhaust"), 0));
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(3);
+      expect(mockErrorManager).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // Slot was released — a later mount retries.
+    mockCreateWallet.mockReset().mockResolvedValue({});
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exhaust"), 0));
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops immediately and stays silent when the wallet already exists", async () => {
     mockCreateWallet.mockRejectedValueOnce(new Error("embedded_wallet_already_exists"));
-    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-report-exists"), 0));
-    await Promise.resolve();
-    expect(mockErrorManager).toHaveBeenCalledTimes(1);
+
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-already"), 0));
+    await waitFor(() => expect(mockCreateWallet).toHaveBeenCalledTimes(1));
+
+    expect(mockErrorManager).not.toHaveBeenCalled();
+    // Slot stays claimed — a later mount of the same user does not retry.
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-already"), 0));
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
+++ b/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @file Tests for useEnsureEmbeddedWallet
+ * @description Guards against the duplicate-embedded-wallet bug: a new user must
+ * get exactly one embedded wallet even when the Privy provider re-initializes
+ * (React Strict Mode, remount, concurrent render). The create decision is based
+ * only on LINKED wallets, so a stale connected-but-unlinked wallet (e.g. a
+ * lingering MetaMask) does not suppress creation.
+ */
+
+import type { User } from "@privy-io/react-auth";
+import { renderHook } from "@testing-library/react";
+import { useEnsureEmbeddedWallet } from "@/hooks/useEnsureEmbeddedWallet";
+
+const mockCreateWallet = vi.fn<() => Promise<unknown>>();
+
+vi.mock("@privy-io/react-auth", () => ({
+  useCreateWallet: () => ({ createWallet: mockCreateWallet }),
+}));
+
+const mockGetLinkedWalletAddresses = vi.fn<() => string[]>();
+
+vi.mock("@/utilities/auth/compare-all-wallets", () => ({
+  getLinkedWalletAddresses: () => mockGetLinkedWalletAddresses(),
+}));
+
+const makeUser = (id: string): User => ({ id }) as User;
+
+describe("useEnsureEmbeddedWallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateWallet.mockResolvedValue({});
+    mockGetLinkedWalletAddresses.mockReturnValue([]);
+  });
+
+  it("creates one wallet for a newly authenticated user without wallets", () => {
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-new"), 0));
+
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates only one wallet across re-renders of the same user", () => {
+    const { rerender } = renderHook(() =>
+      useEnsureEmbeddedWallet(true, true, makeUser("u-rerender"), 0)
+    );
+    rerender();
+    rerender();
+
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates only one wallet across independent mounts (Strict Mode / remount)", () => {
+    const user = makeUser("u-remount");
+    // Two separate hook instances sharing the module-level guard, mimicking
+    // Strict Mode's double mount and lazy-provider remounts.
+    renderHook(() => useEnsureEmbeddedWallet(true, true, user, 0));
+    renderHook(() => useEnsureEmbeddedWallet(true, true, user, 0));
+
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create a wallet when the user already has a linked wallet", () => {
+    mockGetLinkedWalletAddresses.mockReturnValue(["0xabc"]);
+
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-linked"), 1));
+
+    expect(mockCreateWallet).not.toHaveBeenCalled();
+  });
+
+  it("still creates a wallet when a stale, unlinked wallet is connected", () => {
+    // walletCount > 0 (a lingering MetaMask) but nothing linked to the account.
+    mockGetLinkedWalletAddresses.mockReturnValue([]);
+
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-stale-mm"), 1));
+
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing until Privy is ready and authenticated", () => {
+    const { rerender } = renderHook(
+      ({ ready, auth }: { ready: boolean; auth: boolean }) =>
+        useEnsureEmbeddedWallet(ready, auth, makeUser("u-gated"), 0),
+      { initialProps: { ready: false, auth: false } }
+    );
+    expect(mockCreateWallet).not.toHaveBeenCalled();
+
+    rerender({ ready: true, auth: false });
+    expect(mockCreateWallet).not.toHaveBeenCalled();
+
+    rerender({ ready: true, auth: true });
+    expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after a transient failure but not after an already-exists error", async () => {
+    mockCreateWallet.mockRejectedValueOnce(new Error("network down"));
+
+    const transient = renderHook(() =>
+      useEnsureEmbeddedWallet(true, true, makeUser("u-transient"), 0)
+    );
+    await Promise.resolve();
+    transient.unmount();
+
+    // Slot was released — a later mount retries.
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-transient"), 0));
+    expect(mockCreateWallet).toHaveBeenCalledTimes(2);
+
+    mockCreateWallet.mockRejectedValueOnce(new Error("embedded_wallet_already_exists"));
+    const exists = renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exists"), 0));
+    await Promise.resolve();
+    exists.unmount();
+
+    // Slot stays claimed — no retry for an already-existing wallet.
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exists"), 0));
+    expect(mockCreateWallet).toHaveBeenCalledTimes(3);
+  });
+});

--- a/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
+++ b/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
@@ -23,6 +23,12 @@ vi.mock("@/utilities/auth/compare-all-wallets", () => ({
   getLinkedWalletAddresses: () => mockGetLinkedWalletAddresses(),
 }));
 
+const mockErrorManager = vi.fn();
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: (...args: unknown[]) => mockErrorManager(...args),
+}));
+
 const makeUser = (id: string): User => ({ id }) as User;
 
 describe("useEnsureEmbeddedWallet", () => {
@@ -111,5 +117,17 @@ describe("useEnsureEmbeddedWallet", () => {
     // Slot stays claimed — no retry for an already-existing wallet.
     renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-exists"), 0));
     expect(mockCreateWallet).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports a genuine failure to Sentry but stays silent on already-exists", async () => {
+    mockCreateWallet.mockRejectedValueOnce(new Error("network down"));
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-report"), 0));
+    await Promise.resolve();
+    expect(mockErrorManager).toHaveBeenCalledTimes(1);
+
+    mockCreateWallet.mockRejectedValueOnce(new Error("embedded_wallet_already_exists"));
+    renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-report-exists"), 0));
+    await Promise.resolve();
+    expect(mockErrorManager).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/Utilities/PrivyWagmiProviders.tsx
+++ b/components/Utilities/PrivyWagmiProviders.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useAccount } from "wagmi";
 import { PROJECT_NAME } from "@/constants/brand";
 import { usePrivyBridgeSetter } from "@/contexts/privy-bridge-context";
+import { useEnsureEmbeddedWallet } from "@/hooks/useEnsureEmbeddedWallet";
 import type { TenantConfig } from "@/src/infrastructure/types/tenant";
 import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { envVars } from "@/utilities/enviromentVars";
@@ -50,6 +51,10 @@ function PrivyBridgeUpdater() {
 
   const userId = privy.user?.id;
   const walletCount = wallets.length;
+
+  // Create the single embedded wallet for new users. Replaces the SDK's
+  // createOnLogin auto-creation, which double-fired and minted two wallets.
+  useEnsureEmbeddedWallet(privy.ready, privy.authenticated, privy.user, walletCount);
 
   useEffect(() => {
     const p = privyRef.current;
@@ -217,7 +222,11 @@ export default function PrivyWagmiProviders({ tenantConfig }: PrivyWagmiProvider
         },
         embeddedWallets: {
           ethereum: {
-            createOnLogin: "users-without-wallets",
+            // Auto-creation is handled by useEnsureEmbeddedWallet, not the SDK.
+            // The SDK's "users-without-wallets" re-evaluates on every provider
+            // initialization and mints a duplicate embedded wallet before the
+            // first one persists (Strict Mode / remount / concurrent render).
+            createOnLogin: "off",
           },
           // Explicitly disable Solana embedded wallets. The Privy SDK (v3.8)
           // bundles Solana support (~197KB) internally and tree-shaking cannot

--- a/hooks/useEnsureEmbeddedWallet.ts
+++ b/hooks/useEnsureEmbeddedWallet.ts
@@ -17,6 +17,46 @@ const EMBEDDED_WALLET_ALREADY_EXISTS = "embedded_wallet_already_exists";
  */
 const creationAttemptedUserIds = new Set<string>();
 
+const MAX_CREATE_ATTEMPTS = 3;
+export const RETRY_BASE_DELAY_MS = 1000;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Create the embedded wallet, retrying transient failures with exponential
+ * backoff. The slot stays claimed across retries so no parallel creation can
+ * start. Only after all attempts are exhausted is the slot released (so a later
+ * remount or auth-state change can try again) and the failure surfaced.
+ */
+const createEmbeddedWalletWithRetry = async (
+  createWallet: () => Promise<unknown>,
+  userId: string
+): Promise<void> => {
+  for (let attempt = 1; attempt <= MAX_CREATE_ATTEMPTS; attempt += 1) {
+    try {
+      await createWallet();
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Another path already created the wallet — treat as success.
+      if (message.includes(EMBEDDED_WALLET_ALREADY_EXISTS)) return;
+
+      if (attempt === MAX_CREATE_ATTEMPTS) {
+        creationAttemptedUserIds.delete(userId);
+        errorManager("Failed to create embedded wallet on login", error, {
+          userId,
+          attempts: attempt,
+        });
+        return;
+      }
+      await wait(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+    }
+  }
+};
+
 // Match Privy's "users-without-wallets": the decision is based ONLY on wallets
 // LINKED to the account, never on physically-connected ones. A stale MetaMask
 // left connected from a previous session is in useWallets() but not linked — it
@@ -58,14 +98,6 @@ export const useEnsureEmbeddedWallet = (
     // remount, rapid re-render) cannot launch a parallel createWallet().
     creationAttemptedUserIds.add(userId);
 
-    createWallet().catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      // Another path already created the wallet — keep the slot claimed.
-      if (message.includes(EMBEDDED_WALLET_ALREADY_EXISTS)) return;
-      // Genuine failure leaves the user without a wallet — surface it and
-      // release the slot so a later state change retries.
-      creationAttemptedUserIds.delete(userId);
-      errorManager("Failed to create embedded wallet on login", error, { userId });
-    });
+    void createEmbeddedWalletWithRetry(createWallet, userId);
   }, [ready, authenticated, user, walletCount, createWallet]);
 };

--- a/hooks/useEnsureEmbeddedWallet.ts
+++ b/hooks/useEnsureEmbeddedWallet.ts
@@ -1,0 +1,68 @@
+import { type User, useCreateWallet } from "@privy-io/react-auth";
+import { useEffect } from "react";
+import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
+
+// Value of Privy's PrivyErrorCode.EMBEDDED_WALLET_ALREADY_EXISTS. Inlined because
+// the enum is type-only in the runtime ESM build — importing it as a value crashes SSR.
+const EMBEDDED_WALLET_ALREADY_EXISTS = "embedded_wallet_already_exists";
+
+/**
+ * Module-level guard, keyed by Privy user id. Survives component remounts and
+ * React Strict Mode's double-invoked effects within a page session, so the
+ * embedded-wallet creation is attempted at most once per user — never twice
+ * concurrently. This is what prevents the duplicate-wallet bug: Privy's own
+ * `createOnLogin` auto-creation re-evaluates "user without wallet" on every
+ * provider initialization and mints a second wallet before the first persists.
+ */
+const creationAttemptedUserIds = new Set<string>();
+
+// Match Privy's "users-without-wallets": the decision is based ONLY on wallets
+// LINKED to the account, never on physically-connected ones. A stale MetaMask
+// left connected from a previous session is in useWallets() but not linked — it
+// must not suppress embedded-wallet creation, or the email user is left with the
+// stale wallet as their active signer/identity.
+const userHasLinkedWallet = (user: User): boolean => getLinkedWalletAddresses(user).length > 0;
+
+/**
+ * Creates exactly one Privy embedded wallet for a freshly authenticated user
+ * who has no linked wallet, replacing the SDK's `createOnLogin: "users-without-wallets"`
+ * (which double-fires and creates two wallets — see fix/privy-duplicate-embedded-wallet).
+ *
+ * Lives in the always-mounted PrivyBridgeUpdater so it runs no matter where or
+ * how the user logs in (navbar, deep link, modal, returning session). `walletCount`
+ * re-triggers the check once the new embedded wallet appears so the guard settles.
+ */
+export const useEnsureEmbeddedWallet = (
+  ready: boolean,
+  authenticated: boolean,
+  user: User | null,
+  walletCount: number
+) => {
+  const { createWallet } = useCreateWallet();
+
+  useEffect(() => {
+    if (!ready || !authenticated || !user) return;
+
+    const userId = user.id;
+    if (creationAttemptedUserIds.has(userId)) return;
+
+    // A wallet-login user already has a linked wallet and must not get an extra
+    // embedded wallet. Stale connected-but-unlinked wallets are ignored.
+    if (userHasLinkedWallet(user)) {
+      creationAttemptedUserIds.add(userId);
+      return;
+    }
+
+    // Claim the slot BEFORE awaiting so a second effect run (Strict Mode,
+    // remount, rapid re-render) cannot launch a parallel createWallet().
+    creationAttemptedUserIds.add(userId);
+
+    createWallet().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      // Another path already created the wallet — keep the slot claimed.
+      if (message.includes(EMBEDDED_WALLET_ALREADY_EXISTS)) return;
+      // Transient failure — release the slot so a later state change retries.
+      creationAttemptedUserIds.delete(userId);
+    });
+  }, [ready, authenticated, user, walletCount, createWallet]);
+};

--- a/hooks/useEnsureEmbeddedWallet.ts
+++ b/hooks/useEnsureEmbeddedWallet.ts
@@ -1,5 +1,6 @@
 import { type User, useCreateWallet } from "@privy-io/react-auth";
 import { useEffect } from "react";
+import { errorManager } from "@/components/Utilities/errorManager";
 import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
 
 // Value of Privy's PrivyErrorCode.EMBEDDED_WALLET_ALREADY_EXISTS. Inlined because
@@ -61,8 +62,10 @@ export const useEnsureEmbeddedWallet = (
       const message = error instanceof Error ? error.message : String(error);
       // Another path already created the wallet — keep the slot claimed.
       if (message.includes(EMBEDDED_WALLET_ALREADY_EXISTS)) return;
-      // Transient failure — release the slot so a later state change retries.
+      // Genuine failure leaves the user without a wallet — surface it and
+      // release the slot so a later state change retries.
       creationAttemptedUserIds.delete(userId);
+      errorManager("Failed to create embedded wallet on login", error, { userId });
     });
   }, [ready, authenticated, user, walletCount, createWallet]);
 };


### PR DESCRIPTION
## Problem

When a user creates a new account via Privy (first email/social login), **two embedded Ethereum wallets** are created for the same account instead of one.

Root cause: the config `embeddedWallets.ethereum.createOnLogin: "users-without-wallets"` makes the Privy SDK re-evaluate "user without wallet" on every provider initialization. Under React Strict Mode, lazy-provider remounts, or concurrent renders, that evaluation runs twice **before the first wallet persists**, so two embedded wallets get minted. These duplicates then leak into downstream auth gates (see #1553, which had to match permissions against "one of several Privy embedded wallets").

## Solution

- **Disable SDK auto-creation** (`createOnLogin: "off"`).
- **Create the wallet ourselves** via a new `useEnsureEmbeddedWallet` hook, called from `PrivyBridgeUpdater` — the single component always mounted inside `PrivyProvider`. It reacts to global auth state, so it works no matter where/how the user logs in (navbar, deep link, modal, returning session).
- **Idempotent guard**: a module-level `Set` keyed by Privy user id, claimed *before* the async `createWallet()` call, so a second effect run (Strict Mode), remount, or concurrent render can never launch a parallel creation. `createWallet()` also throws `EMBEDDED_WALLET_ALREADY_EXISTS` as a belt-and-suspenders backstop.
- **Linked-only decision**: creation is gated on *linked* accounts (`getLinkedWalletAddresses`), matching Privy's real `users-without-wallets` semantics — not on physically-connected wallets. This fixes a related bug where a stale, unlinked MetaMask left connected from a previous session suppressed embedded-wallet creation, leaving an email user with the stale wallet as their active signer/identity.

## Testing

- New unit suite `__tests__/hooks/useEnsureEmbeddedWallet.test.ts` (7 tests): single creation for a new user; one creation across re-renders; one creation across independent mounts (Strict Mode / remount); no creation when a linked wallet exists; **still** creates when only a stale unlinked wallet is connected; gated on ready+authenticated; retry-on-transient but not-on-already-exists.
- `tsc --noEmit` clean for changed files; Biome clean.

### Manual QA
1. With MetaMask **connected**, log in with a fresh email.
2. Confirm exactly **one** embedded wallet appears in the Privy dashboard.
3. Confirm the authed address settles on the new embedded wallet (not the stale MetaMask) without a manual refresh or disconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where duplicate embedded wallets could be created for newly authenticated users. The system now ensures exactly one embedded wallet is created per user, preventing duplicates across component rerenders and remounts.

* **Tests**
  * Added comprehensive test coverage for embedded wallet creation behavior, validating single-wallet creation for new users and retry logic on transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->