### PR TITLE
feat(r): FE-owned permalink redirect routes for review links (DEV-363)

### DIFF
--- a/__tests__/app/r/review-redirects.test.ts
+++ b/__tests__/app/r/review-redirects.test.ts
@@ -1,0 +1,148 @@
+import { notFound, redirect } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCommunitySlug } from "@/app/r/_lib/resolve-review-redirect";
+import ApplicationReviewRedirectPage from "@/app/r/application-review/page";
+import MilestoneReviewRedirectPage from "@/app/r/milestone-review/page";
+
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: vi.fn().mockResolvedValue({ isWhitelabel: false, communitySlug: null }),
+  buildWhitelabelRedirectPath: vi.fn((path: string) => path),
+}));
+
+function mockFetchOnce(value: { ok: boolean; body?: unknown }) {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: value.ok,
+    json: async () => value.body,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn();
+  // notFound() throws in production to halt rendering; mirror that so the
+  // page under test stops at the guard instead of falling through.
+  (notFound as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  });
+});
+
+describe("resolveCommunitySlug", () => {
+  it("should_return_the_community_slug_when_the_program_resolves", async () => {
+    mockFetchOnce({ ok: true, body: { communitySlug: "filecoin" } });
+
+    expect(await resolveCommunitySlug("992")).toBe("filecoin");
+  });
+
+  it("should_unwrap_an_enveloped_response", async () => {
+    mockFetchOnce({ ok: true, body: { data: { communitySlug: "optimism" } } });
+
+    expect(await resolveCommunitySlug("992")).toBe("optimism");
+  });
+
+  it("should_normalize_a_composite_program_id_before_lookup", async () => {
+    mockFetchOnce({ ok: true, body: { communitySlug: "filecoin" } });
+
+    await resolveCommunitySlug("992_42161");
+
+    const calledUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/v2/funding-program-configs/992");
+    expect(calledUrl).not.toContain("992_42161");
+  });
+
+  it("should_return_null_when_the_program_is_not_found", async () => {
+    mockFetchOnce({ ok: false });
+
+    expect(await resolveCommunitySlug("992")).toBeNull();
+  });
+
+  it("should_return_null_when_the_request_throws", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network"));
+
+    expect(await resolveCommunitySlug("992")).toBeNull();
+  });
+});
+
+describe("app/r/milestone-review redirect", () => {
+  it("should_redirect_to_the_canonical_milestone_page", async () => {
+    mockFetchOnce({ ok: true, body: { communitySlug: "filecoin" } });
+
+    await MilestoneReviewRedirectPage({
+      searchParams: Promise.resolve({
+        programId: "992_42161",
+        projectUID: "0xproj",
+      }),
+    });
+
+    expect(redirect).toHaveBeenCalledWith(
+      "/community/filecoin/manage/funding-platform/992/milestones/0xproj"
+    );
+  });
+
+  it("should_pass_the_milestone_anchor_through", async () => {
+    mockFetchOnce({ ok: true, body: { communitySlug: "filecoin" } });
+
+    await MilestoneReviewRedirectPage({
+      searchParams: Promise.resolve({
+        programId: "992",
+        projectUID: "0xproj",
+        milestoneUID: "0xms",
+      }),
+    });
+
+    expect(redirect).toHaveBeenCalledWith(
+      "/community/filecoin/manage/funding-platform/992/milestones/0xproj#milestone-0xms"
+    );
+  });
+
+  it("should_notFound_when_required_params_are_missing", async () => {
+    await expect(
+      MilestoneReviewRedirectPage({
+        searchParams: Promise.resolve({ programId: "992" }),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFound).toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("should_notFound_when_the_community_cannot_be_resolved", async () => {
+    mockFetchOnce({ ok: false });
+
+    await expect(
+      MilestoneReviewRedirectPage({
+        searchParams: Promise.resolve({ programId: "992", projectUID: "0xp" }),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFound).toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});
+
+describe("app/r/application-review redirect", () => {
+  it("should_redirect_to_the_canonical_application_page", async () => {
+    mockFetchOnce({ ok: true, body: { communitySlug: "filecoin" } });
+
+    await ApplicationReviewRedirectPage({
+      searchParams: Promise.resolve({
+        programId: "992",
+        referenceNumber: "APP-ABC-123",
+      }),
+    });
+
+    expect(redirect).toHaveBeenCalledWith(
+      "/community/filecoin/manage/funding-platform/992/applications/APP-ABC-123"
+    );
+  });
+
+  it("should_notFound_when_the_reference_number_is_missing", async () => {
+    await expect(
+      ApplicationReviewRedirectPage({
+        searchParams: Promise.resolve({ programId: "992" }),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/app/r/_lib/resolve-review-redirect.ts
+++ b/app/r/_lib/resolve-review-redirect.ts
@@ -1,0 +1,27 @@
+import { envVars } from "@/utilities/enviromentVars";
+import { INDEXER } from "@/utilities/indexer";
+import { normalizeProgramId } from "@/utilities/normalizeProgramId";
+
+/**
+ * Resolve the community slug that owns a funding program, server-side, via the
+ * public program-config endpoint. The backend emits structure-agnostic
+ * permalinks (`/r/<type>?programId=...`) precisely so this repo owns turning a
+ * programId into a route — keeping frontend route knowledge out of the backend.
+ *
+ * Returns null when the program can't be resolved (bad id, 404, network) so the
+ * caller can fall back to a 404 instead of redirecting somewhere wrong.
+ */
+export async function resolveCommunitySlug(programId: string): Promise<string | null> {
+  try {
+    const url = `${
+      envVars.NEXT_PUBLIC_GAP_INDEXER_URL
+    }${INDEXER.V2.FUNDING_PROGRAMS.GET(normalizeProgramId(programId))}`;
+    const res = await fetch(url, { next: { revalidate: 300 } });
+    if (!res.ok) return null;
+    const body = await res.json();
+    const program = body?.data ?? body;
+    return program?.communitySlug ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/app/r/application-review/error.tsx
+++ b/app/r/application-review/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Link } from "@/src/components/navigation/Link";
+
+export default function ApplicationReviewRedirectError() {
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-xl font-semibold text-foreground">Link could not be opened</h1>
+      <p className="text-sm text-muted-foreground">
+        We couldn’t resolve this application review link. It may have expired, or the program may no
+        longer exist.
+      </p>
+      <Link href="/" className="text-sm font-medium text-primary underline underline-offset-4">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/app/r/application-review/loading.tsx
+++ b/app/r/application-review/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center px-4">
+      <p className="text-sm text-muted-foreground">Redirecting…</p>
+    </div>
+  );
+}

--- a/app/r/application-review/page.tsx
+++ b/app/r/application-review/page.tsx
@@ -1,0 +1,38 @@
+import { notFound, redirect } from "next/navigation";
+import { normalizeProgramId } from "@/utilities/normalizeProgramId";
+import { PAGES } from "@/utilities/pages";
+import { buildWhitelabelRedirectPath, getWhitelabelContext } from "@/utilities/whitelabel-server";
+import { resolveCommunitySlug } from "../_lib/resolve-review-redirect";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<{
+  programId?: string;
+  referenceNumber?: string;
+}>;
+
+/**
+ * Permalink resolver for application reviews. The backend links here with stable
+ * identifiers; this route owns the frontend route structure and whitelabel
+ * host, resolves the community, and redirects to the canonical manage page.
+ */
+export default async function ApplicationReviewRedirectPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { programId, referenceNumber } = await searchParams;
+  if (!programId || !referenceNumber) notFound();
+
+  const communitySlug = await resolveCommunitySlug(programId);
+  if (!communitySlug) notFound();
+
+  const target = PAGES.MANAGE.FUNDING_PLATFORM.APPLICATION_DETAIL(
+    communitySlug,
+    normalizeProgramId(programId),
+    referenceNumber
+  );
+
+  const ctx = await getWhitelabelContext();
+  redirect(buildWhitelabelRedirectPath(target, ctx));
+}

--- a/app/r/milestone-review/error.tsx
+++ b/app/r/milestone-review/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Link } from "@/src/components/navigation/Link";
+
+export default function MilestoneReviewRedirectError() {
+  return (
+    <div className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-xl font-semibold text-foreground">Link could not be opened</h1>
+      <p className="text-sm text-muted-foreground">
+        We couldn’t resolve this milestone review link. It may have expired, or the program may no
+        longer exist.
+      </p>
+      <Link href="/" className="text-sm font-medium text-primary underline underline-offset-4">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/app/r/milestone-review/loading.tsx
+++ b/app/r/milestone-review/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center px-4">
+      <p className="text-sm text-muted-foreground">Redirecting…</p>
+    </div>
+  );
+}

--- a/app/r/milestone-review/page.tsx
+++ b/app/r/milestone-review/page.tsx
@@ -1,0 +1,41 @@
+import { notFound, redirect } from "next/navigation";
+import { normalizeProgramId } from "@/utilities/normalizeProgramId";
+import { PAGES } from "@/utilities/pages";
+import { buildWhitelabelRedirectPath, getWhitelabelContext } from "@/utilities/whitelabel-server";
+import { resolveCommunitySlug } from "../_lib/resolve-review-redirect";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<{
+  programId?: string;
+  projectUID?: string;
+  milestoneUID?: string;
+}>;
+
+/**
+ * Permalink resolver for milestone reviews. The backend (emails, the AI agent
+ * via `reviewUrl`) links here with stable identifiers; this route owns the
+ * frontend route structure and whitelabel host, resolves the community, and
+ * redirects to the canonical manage page. Route changes stay in this repo.
+ */
+export default async function MilestoneReviewRedirectPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { programId, projectUID, milestoneUID } = await searchParams;
+  if (!programId || !projectUID) notFound();
+
+  const communitySlug = await resolveCommunitySlug(programId);
+  if (!communitySlug) notFound();
+
+  const target = PAGES.MANAGE.FUNDING_PLATFORM.MILESTONES(
+    communitySlug,
+    normalizeProgramId(programId),
+    projectUID,
+    milestoneUID
+  );
+
+  const ctx = await getWhitelabelContext();
+  redirect(buildWhitelabelRedirectPath(target, ctx));
+}


### PR DESCRIPTION
## What

Adds frontend-owned permalink redirect routes so the backend never has to encode frontend route structure:

- `GET /r/milestone-review?programId=<id>&projectUID=<uid>[&milestoneUID=<uid>]`
- `GET /r/application-review?programId=<id>&referenceNumber=<ref>`

Each route resolves the community from the public program-config endpoint, builds the canonical manage route via `PAGES` constants, applies the whitelabel host (`getWhitelabelContext` / `buildWhitelabelRedirectPath`), and `redirect()`s. Unresolvable links fall back to `notFound()`.

## Why (DEV-363)

The AI chatbot returned milestone-review links that 404'd because the backend hand-assembled community-scoped URLs (`karmahq.xyz/<community>/…`) — wrong path, wrong whitelabel host. The deeper issue: **any backend that emits a frontend URL duplicates this repo's routing knowledge, so an FE route change silently breaks those links.**

This flips the ownership. The backend now emits a stable, structure-agnostic permalink (`/r/<type>?<ids>`) and **this repo owns turning it into a route**. When a funding-platform route moves, only this repo changes — emails, the AI agent, and any other server-side link producer keep working.

Pairs with show-karma/gap-indexer#1963, which changes `DeepLinkBuilderService` to emit these permalinks.

## Testing

`__tests__/app/r/review-redirects.test.ts` — 11 cases: resolver (slug resolution, envelope unwrap, composite-programId normalization, 404 → null, network → null) and both pages (canonical redirect, milestone anchor passthrough, `notFound()` on missing params / unresolvable community). `pnpm biome check` clean, `tsc --noEmit` clean.

## Notes

- Whitelabel: redirects respect the current host (strips `/community/<slug>` on whitelabel domains via the existing helper).
- Composite programIds (`992_42161`) are normalized to the base id for both the lookup and the route, matching the app's own `<Link>`s.

Closes DEV-363 (frontend half).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permalink URLs for accessing application reviews, with automatic redirect to the canonical review page.
  * Added permalink URLs for accessing milestone reviews, with automatic redirect to the canonical review page.
  * Improved user experience with loading indicators during redirects and error messages when redirects fail.

* **Tests**
  * Added comprehensive test suite for review redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->