### PR TITLE
Add progress bar to community milestone position display

### DIFF
--- a/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
@@ -129,41 +129,34 @@ const CommunityMilestonesTableRowComponent: FC<CommunityMilestonesTableRowProps>
 
       {/* Milestone X of Y */}
       <td className={cellClasses}>
-        {hasMilestonePosition ? (
-          (() => {
-            const index = milestone.grantMilestoneIndex as number;
-            const total = milestone.grantMilestoneTotal as number;
-            const progressPct =
-              total > 0 ? Math.min(100, Math.max(0, (index / total) * 100)) : 0;
-            return (
-              <div
-                className="flex flex-col gap-1 min-w-[88px]"
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={total}
-                aria-valuenow={index}
-                aria-label={`Milestone ${index} of ${total}`}
-              >
-                <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap tabular-nums">
-                  {index} of {total}
-                </span>
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-700">
+        {hasMilestonePosition
+          ? (() => {
+              const index = milestone.grantMilestoneIndex as number;
+              const total = milestone.grantMilestoneTotal as number;
+              const progressPct = total > 0 ? Math.min(100, Math.max(0, (index / total) * 100)) : 0;
+              return (
+                <div className="flex flex-col gap-1 min-w-[88px]">
+                  <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap tabular-nums">
+                    {index} of {total}
+                  </span>
                   <div
-                    className={cn(
-                      "h-full origin-left rounded-full transition-[width] duration-300 ease-out",
-                      progressPct >= 100
-                        ? "bg-green-500 dark:bg-green-400"
-                        : "bg-brand-blue dark:bg-blue-400"
-                    )}
-                    style={{ width: `${progressPct}%` }}
-                  />
+                    aria-hidden="true"
+                    className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-700"
+                  >
+                    <div
+                      className={cn(
+                        "h-full origin-left rounded-full transition-[width] duration-300 ease-out",
+                        progressPct >= 100
+                          ? "bg-green-500 dark:bg-green-400"
+                          : "bg-brand-blue dark:bg-blue-400"
+                      )}
+                      style={{ width: `${progressPct}%` }}
+                    />
+                  </div>
                 </div>
-              </div>
-            );
-          })()
-        ) : (
-          placeholder
-        )}
+              );
+            })()
+          : placeholder}
       </td>
 
       {/* Completion date */}

--- a/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
@@ -130,9 +130,37 @@ const CommunityMilestonesTableRowComponent: FC<CommunityMilestonesTableRowProps>
       {/* Milestone X of Y */}
       <td className={cellClasses}>
         {hasMilestonePosition ? (
-          <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap tabular-nums">
-            {milestone.grantMilestoneIndex} of {milestone.grantMilestoneTotal}
-          </span>
+          (() => {
+            const index = milestone.grantMilestoneIndex as number;
+            const total = milestone.grantMilestoneTotal as number;
+            const progressPct =
+              total > 0 ? Math.min(100, Math.max(0, (index / total) * 100)) : 0;
+            return (
+              <div
+                className="flex flex-col gap-1 min-w-[88px]"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={total}
+                aria-valuenow={index}
+                aria-label={`Milestone ${index} of ${total}`}
+              >
+                <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap tabular-nums">
+                  {index} of {total}
+                </span>
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-zinc-700">
+                  <div
+                    className={cn(
+                      "h-full origin-left rounded-full transition-[width] duration-300 ease-out",
+                      progressPct >= 100
+                        ? "bg-green-500 dark:bg-green-400"
+                        : "bg-brand-blue dark:bg-blue-400"
+                    )}
+                    style={{ width: `${progressPct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })()
         ) : (
           placeholder
         )}


### PR DESCRIPTION
## Summary
Enhanced the milestone position display in the Community Milestones table to include a visual progress bar alongside the "X of Y" text, improving visibility of milestone completion status.

## Key Changes
- Replaced simple text display with a flex container showing both milestone count and progress bar
- Added progress calculation based on milestone index and total (`(index / total) * 100`)
- Implemented animated progress bar with conditional styling:
  - Green when milestone is complete (100%)
  - Brand blue when in progress
- Added proper accessibility attributes (`role="progressbar"`, `aria-valuemin/max/now`, `aria-label`)
- Progress bar includes smooth CSS transition animation (`duration-300 ease-out`)
- Clamped progress value between 0-100% to handle edge cases

## Implementation Details
- Used IIFE pattern to encapsulate progress calculation logic
- Progress bar container has `min-w-[88px]` to maintain consistent layout
- Dark mode support with appropriate color variants (`dark:bg-zinc-700`, `dark:bg-green-400`, `dark:bg-blue-400`)
- Maintains existing text styling and whitespace behavior

https://claude.ai/code/session_017TgRejNAromqTzQuQimx8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Milestone progress cells now display a visual progress indicator alongside the text counter.
  * Progress bar styling changes upon completion status.
  * Enhanced accessibility with proper ARIA attributes for progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->