### PR TITLE
fix(manage): resolve dynamic breadcrumb labels for program and report ids

### DIFF
--- a/__tests__/components/Manage/ManageBreadcrumbs.test.tsx
+++ b/__tests__/components/Manage/ManageBreadcrumbs.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for ManageBreadcrumbs.
+ *
+ * Covers the breadcrumb dynamic-label resolution that fixes:
+ *  - #1545: raw programId shown instead of the program name
+ *  - #1423: raw portfolio-report slug + id shown instead of readable labels
+ *  - #1269: missing labels for `portfolio-reports` / `config` segments
+ *
+ * Plus the agreed acceptance gates: positional `config` (no global collision),
+ * graceful finite fallback for unresolved ids, loading skeleton (no raw-id
+ * flash), whitelabel resolution, and per-page query gating (no cross-fetch).
+ */
+
+import { screen } from "@testing-library/react";
+import { ManageBreadcrumbs } from "@/components/Manage/ManageBreadcrumbs";
+import { formatRunDate } from "@/utilities/portfolio-reports/period";
+import { renderWithProviders } from "../../utils/render";
+
+const usePathnameMock = vi.fn();
+const useParamsMock = vi.fn();
+const useProgramMock = vi.fn();
+const usePortfolioReportMock = vi.fn();
+const useWhitelabelMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathnameMock(),
+  useParams: () => useParamsMock(),
+}));
+
+vi.mock("@/features/programs/hooks/use-program", () => ({
+  useProgram: (programId: string) => useProgramMock(programId),
+}));
+
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports", () => ({
+  usePortfolioReport: (slug: string, reportId: string) => usePortfolioReportMock(slug, reportId),
+}));
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: () => useWhitelabelMock(),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const COMMUNITY = "test-community";
+const MANAGE_ROOT = `/community/${COMMUNITY}/manage`;
+
+function setProgram(value: { program: { name: string } | null; loading: boolean }) {
+  useProgramMock.mockReturnValue({ ...value, error: null, refetch: vi.fn() });
+}
+
+function setReport(value: { data: { runDate: string } | undefined; isLoading: boolean }) {
+  usePortfolioReportMock.mockReturnValue(value);
+}
+
+function render(pathname: string, params: Record<string, string> = {}) {
+  usePathnameMock.mockReturnValue(pathname);
+  useParamsMock.mockReturnValue({ communityId: COMMUNITY, ...params });
+  return renderWithProviders(<ManageBreadcrumbs communitySlug={COMMUNITY} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Sensible defaults: nothing resolving, not whitelabel.
+  setProgram({ program: null, loading: false });
+  setReport({ data: undefined, isLoading: false });
+  useWhitelabelMock.mockReturnValue({ isWhitelabel: false });
+});
+
+describe("ManageBreadcrumbs", () => {
+  describe("structural rendering", () => {
+    it("renders nothing on the manage root itself", () => {
+      const { container } = render(MANAGE_ROOT);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing outside the manage area", () => {
+      const { container } = render(`/community/${COMMUNITY}/projects`);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("static segment labels", () => {
+    it("maps known static segments to human-readable labels", () => {
+      render(`${MANAGE_ROOT}/milestones-report`);
+      expect(screen.getByText("Dashboard")).toBeInTheDocument();
+      expect(screen.getByText("Milestones")).toBeInTheDocument();
+    });
+
+    it("labels the portfolio-reports segment (#1269)", () => {
+      render(`${MANAGE_ROOT}/portfolio-reports`);
+      expect(screen.getByText("Portfolio Reports")).toBeInTheDocument();
+      expect(screen.queryByText("portfolio-reports")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("dynamic programId resolution (#1545)", () => {
+    const PATH = `${MANAGE_ROOT}/funding-platform/101105/applications`;
+
+    it("shows the program name instead of the raw id", () => {
+      setProgram({ program: { name: "Filecoin Karma Batch!" }, loading: false });
+      render(PATH, { programId: "101105" });
+      expect(screen.getByText("Filecoin Karma Batch!")).toBeInTheDocument();
+      expect(screen.queryByText("101105")).not.toBeInTheDocument();
+    });
+
+    it("shows a loading skeleton (never the raw id) while resolving", () => {
+      setProgram({ program: null, loading: true });
+      render(PATH, { programId: "101105" });
+      expect(screen.getByLabelText("Loading")).toBeInTheDocument();
+      expect(screen.queryByText("101105")).not.toBeInTheDocument();
+    });
+
+    it("falls back to a generic finite label when the id resolves to nothing", () => {
+      setProgram({ program: null, loading: false });
+      render(PATH, { programId: "101105" });
+      expect(screen.getByText("Program")).toBeInTheDocument();
+      expect(screen.queryByText("101105")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("dynamic reportId resolution (#1423)", () => {
+    const PATH = `${MANAGE_ROOT}/portfolio-reports/rep-123`;
+
+    it("shows the report's run-date label from the same formatter the page header uses", () => {
+      setReport({ data: { runDate: "2026-04-30" }, isLoading: false });
+      render(PATH, { reportId: "rep-123" });
+      // Derived from the shared formatRunDate — proves crumb and header cannot drift.
+      const expected = formatRunDate("2026-04-30").label;
+      expect(expected).toBe("April 30, 2026");
+      expect(screen.getByText(expected)).toBeInTheDocument();
+      expect(screen.queryByText("rep-123")).not.toBeInTheDocument();
+    });
+
+    it("falls back to a generic label for a deleted / non-existent report id", () => {
+      setReport({ data: undefined, isLoading: false });
+      render(`${MANAGE_ROOT}/portfolio-reports/fake-report-id`, { reportId: "fake-report-id" });
+      expect(screen.getByText("Report")).toBeInTheDocument();
+      expect(screen.queryByText("fake-report-id")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("positional `config` label (#1269)", () => {
+    it("labels config as Configuration under portfolio-reports", () => {
+      render(`${MANAGE_ROOT}/portfolio-reports/config`);
+      expect(screen.getByText("Portfolio Reports")).toBeInTheDocument();
+      expect(screen.getByText("Configuration")).toBeInTheDocument();
+    });
+
+    it("does NOT relabel config when it appears under a different parent", () => {
+      render(`${MANAGE_ROOT}/setup/config`);
+      expect(screen.queryByText("Configuration")).not.toBeInTheDocument();
+      // Unrecognised-here segment is titleized, not turned into the special label.
+      expect(screen.getByText("Config")).toBeInTheDocument();
+    });
+  });
+
+  describe("query gating (no cross-fetch between pages)", () => {
+    it("disables the report query on a funding page", () => {
+      render(`${MANAGE_ROOT}/funding-platform/101105/applications`, { programId: "101105" });
+      // Empty reportId → usePortfolioReport's internal `enabled` is false.
+      expect(usePortfolioReportMock).toHaveBeenCalledWith(COMMUNITY, "");
+    });
+
+    it("disables the program query on a report page", () => {
+      render(`${MANAGE_ROOT}/portfolio-reports/rep-123`, { reportId: "rep-123" });
+      // Empty programId → useProgram's internal `enabled` is false.
+      expect(useProgramMock).toHaveBeenCalledWith("");
+    });
+  });
+
+  describe("whitelabel mode", () => {
+    it("resolves dynamic names on the shortened whitelabel path", () => {
+      useWhitelabelMock.mockReturnValue({ isWhitelabel: true });
+      setProgram({ program: { name: "Filecoin Karma Batch!" }, loading: false });
+      // Whitelabel pathname omits the /community/<slug> prefix.
+      render("/manage/funding-platform/101105/applications", { programId: "101105" });
+      expect(screen.getByText("Filecoin Karma Batch!")).toBeInTheDocument();
+      expect(screen.queryByText("101105")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("render stability", () => {
+    it("produces stable output across re-renders with the same props (no #185 loop)", () => {
+      setProgram({ program: { name: "Filecoin Karma Batch!" }, loading: false });
+      const { rerender } = render(`${MANAGE_ROOT}/funding-platform/101105/applications`, {
+        programId: "101105",
+      });
+      expect(screen.getByText("Filecoin Karma Batch!")).toBeInTheDocument();
+      rerender(<ManageBreadcrumbs communitySlug={COMMUNITY} />);
+      expect(screen.getByText("Filecoin Karma Batch!")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/Manage/ManageBreadcrumbs.tsx
+++ b/components/Manage/ManageBreadcrumbs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Home } from "lucide-react";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import React, { useMemo } from "react";
 import {
   Breadcrumb,
@@ -11,11 +11,23 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useProgram } from "@/features/programs/hooks/use-program";
+import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 import { Link } from "@/src/components/navigation/Link";
 import { PAGES } from "@/utilities/pages";
+import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 
-/** Human-readable labels for URL path segments */
+/**
+ * Human-readable labels for *static* URL path segments.
+ *
+ * Dynamic segments (program ids, report ids, …) are NOT listed here — they are
+ * resolved to their entity name reactively (see the resolver hooks below).
+ * Context-sensitive segments whose label depends on their parent (e.g. `config`)
+ * are handled by {@link CONTEXTUAL_LABELS}, never this flat map, so a label can
+ * never leak onto an unrelated route that happens to reuse the same segment.
+ */
 const SEGMENT_LABELS: Record<string, string> = {
   manage: "Dashboard",
   "funding-platform": "Funding Platform",
@@ -36,17 +48,108 @@ const SEGMENT_LABELS: Record<string, string> = {
   "knowledge-base": "Knowledge Base",
   "access-denied-messages": "Access Denied Page",
   impact: "Impact",
+  "portfolio-reports": "Portfolio Reports",
 };
+
+/**
+ * Labels for segments whose meaning depends on the segment immediately before
+ * them. Matching is positional so the label only ever applies under the
+ * intended parent (e.g. `config` reads "Configuration" only inside
+ * `portfolio-reports`, never on some other `.../config` route).
+ */
+const CONTEXTUAL_LABELS: Record<string, { parent: string; label: string }> = {
+  config: { parent: "portfolio-reports", label: "Configuration" },
+};
+
+/** A segment longer than this with no known label is treated as an opaque id. */
+const ID_TRUNCATE_THRESHOLD = 20;
+
+type CrumbState = "static" | "resolved" | "pending" | "unresolved";
 
 interface Crumb {
   label: string;
   href: string;
   isLast: boolean;
+  state: CrumbState;
+}
+
+/** Title-cases a kebab-case slug: `foo-bar` → `Foo Bar`. */
+function titleizeSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/** Fallback label for an unrecognised segment (truncate opaque ids, titleize slugs). */
+function fallbackLabel(segment: string): string {
+  if (segment.length > ID_TRUNCATE_THRESHOLD) {
+    return `${segment.slice(0, 8)}...`;
+  }
+  return titleizeSlug(segment);
+}
+
+interface ResolvedLabel {
+  label: string;
+  state: CrumbState;
+}
+
+/** Context needed to resolve a dynamic segment to its entity label. */
+interface ResolutionContext {
+  programId: string;
+  programName: string | undefined;
+  programLoading: boolean;
+  reportId: string;
+  reportLabel: string | undefined;
+  reportLoading: boolean;
+}
+
+/**
+ * Maps a dynamic id segment to a label: the resolved entity name, a pending
+ * placeholder while loading, or a generic finite fallback when the id resolves
+ * to nothing — never the raw id, never an endless spinner.
+ */
+function resolveDynamic(
+  name: string | undefined,
+  loading: boolean,
+  genericFallback: string
+): ResolvedLabel {
+  if (name) return { label: name, state: "resolved" };
+  if (loading) return { label: "", state: "pending" };
+  return { label: genericFallback, state: "unresolved" };
+}
+
+/** Resolves a single path segment to its crumb label + state. */
+function resolveSegment(
+  segment: string,
+  index: number,
+  segments: string[],
+  ctx: ResolutionContext
+): ResolvedLabel {
+  if (ctx.programId && segment === ctx.programId) {
+    return resolveDynamic(ctx.programName, ctx.programLoading, "Program");
+  }
+  if (ctx.reportId && segment === ctx.reportId) {
+    return resolveDynamic(ctx.reportLabel, ctx.reportLoading, "Report");
+  }
+
+  const contextual = CONTEXTUAL_LABELS[segment];
+  if (contextual && segments[index - 1] === contextual.parent) {
+    return { label: contextual.label, state: "static" };
+  }
+
+  const staticLabel = SEGMENT_LABELS[segment];
+  if (staticLabel) return { label: staticLabel, state: "static" };
+
+  return { label: fallbackLabel(segment), state: "static" };
 }
 
 export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) {
   const rawPathname = usePathname();
+  const params = useParams();
   const { isWhitelabel } = useWhitelabel();
+
   // In whitelabel mode, usePathname() returns "/manage/..." but the crumb logic
   // needs the full "/community/<slug>/manage/..." form for prefix matching.
   const communityPrefix = `/community/${communitySlug}`;
@@ -55,10 +158,31 @@ export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) 
       ? `${communityPrefix}${rawPathname}`
       : rawPathname;
 
+  // Dynamic route params come from the Next.js route (not the displayed URL), so
+  // they resolve identically in whitelabel mode. Guard to primitive strings to
+  // keep the useMemo deps stable and avoid render loops (React error #185).
+  const programId = typeof params.programId === "string" ? params.programId : "";
+  const reportId = typeof params.reportId === "string" ? params.reportId : "";
+
+  // A fixed, unconditional set of resolver hooks — one per dynamic entity type,
+  // never called inside the segment loop (that would break the rules of hooks).
+  // Each is internally gated by `enabled`, so the report hook never fetches on a
+  // funding page and vice-versa. These re-render when data arrives, which is
+  // what makes the breadcrumb reactive (a passive cache read would get stuck on
+  // the fallback if the breadcrumb mounted before the page's query resolved).
+  const { program, loading: programLoading } = useProgram(programId);
+  const { data: report, isLoading: reportLoading } = usePortfolioReport(communitySlug, reportId);
+
+  // Match the editor page header character-for-character — it renders the same
+  // `formatRunDate(report.runDate).label` (the canonical "header + breadcrumb"
+  // label per the formatter's contract).
+  const programName = program?.name;
+  const reportLabel = report ? formatRunDate(report.runDate).label : undefined;
+
   const crumbs = useMemo((): Crumb[] => {
     const managePrefix = PAGES.ADMIN.ROOT(communitySlug);
 
-    // Only show breadcrumbs for sub-pages, not the manage root itself
+    // Only show breadcrumbs for sub-pages, not the manage root itself.
     if (
       !pathname.startsWith(managePrefix) ||
       pathname === managePrefix ||
@@ -72,26 +196,38 @@ export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) 
 
     if (segments.length === 0) return [];
 
-    const result: Crumb[] = [{ label: "Dashboard", href: managePrefix, isLast: false }];
+    const ctx: ResolutionContext = {
+      programId,
+      programName,
+      programLoading,
+      reportId,
+      reportLabel,
+      reportLoading,
+    };
+
+    const result: Crumb[] = [
+      { label: "Dashboard", href: managePrefix, isLast: false, state: "static" },
+    ];
 
     let builtPath = managePrefix;
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];
       builtPath += `/${segment}`;
-      const isLast = i === segments.length - 1;
-
-      // Use human-readable label or truncate UUIDs/IDs
-      let label = SEGMENT_LABELS[segment] || segment;
-      if (label.length > 20 && !SEGMENT_LABELS[segment]) {
-        // Likely a programId or applicationId — show truncated
-        label = `${label.slice(0, 8)}...`;
-      }
-
-      result.push({ label, href: builtPath, isLast });
+      const { label, state } = resolveSegment(segment, i, segments, ctx);
+      result.push({ label, href: builtPath, isLast: i === segments.length - 1, state });
     }
 
     return result;
-  }, [pathname, communitySlug]);
+  }, [
+    pathname,
+    communitySlug,
+    programId,
+    reportId,
+    programName,
+    programLoading,
+    reportLabel,
+    reportLoading,
+  ]);
 
   if (crumbs.length === 0) return null;
 
@@ -103,12 +239,17 @@ export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) 
             {index > 0 && <BreadcrumbSeparator />}
             <BreadcrumbItem>
               {crumb.isLast ? (
-                <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                <BreadcrumbPage>
+                  <CrumbLabel crumb={crumb} />
+                </BreadcrumbPage>
               ) : (
                 <BreadcrumbLink asChild>
-                  <Link href={crumb.href} className="flex items-center gap-1">
+                  <Link
+                    href={crumb.href}
+                    className="flex items-center gap-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
                     {index === 0 && <Home className="size-3.5" />}
-                    <span>{crumb.label}</span>
+                    <CrumbLabel crumb={crumb} />
                   </Link>
                 </BreadcrumbLink>
               )}
@@ -118,4 +259,20 @@ export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) 
       </BreadcrumbList>
     </Breadcrumb>
   );
+}
+
+/**
+ * Renders a crumb label. While a dynamic name is still loading it shows a
+ * fixed-width skeleton (stable layout, no shift when the name swaps in) and
+ * exposes a loading state to assistive tech instead of announcing a raw id.
+ */
+function CrumbLabel({ crumb }: { crumb: Crumb }) {
+  if (crumb.state === "pending") {
+    return (
+      <output aria-busy="true" aria-label="Loading" className="inline-flex">
+        <Skeleton aria-hidden="true" className="inline-block h-4 w-24 align-middle" />
+      </output>
+    );
+  }
+  return <span title={crumb.label}>{crumb.label}</span>;
 }

--- a/components/Manage/ManageBreadcrumbs.tsx
+++ b/components/Manage/ManageBreadcrumbs.tsx
@@ -266,7 +266,7 @@ export function ManageBreadcrumbs({ communitySlug }: { communitySlug: string }) 
  * fixed-width skeleton (stable layout, no shift when the name swaps in) and
  * exposes a loading state to assistive tech instead of announcing a raw id.
  */
-function CrumbLabel({ crumb }: { crumb: Crumb }) {
+const CrumbLabel = React.memo(function CrumbLabel({ crumb }: { crumb: Crumb }) {
   if (crumb.state === "pending") {
     return (
       <output aria-busy="true" aria-label="Loading" className="inline-flex">
@@ -275,4 +275,4 @@ function CrumbLabel({ crumb }: { crumb: Crumb }) {
     );
   }
   return <span title={crumb.label}>{crumb.label}</span>;
-}
+});


### PR DESCRIPTION
## Overview

The admin **manage** breadcrumb (`ManageBreadcrumbs`) only had a flat `segment → label` map, so it could not label **dynamic** route segments. Program ids, report ids, and the `portfolio-reports` / `config` segments rendered as raw slugs/ids. This is one root cause with three reported symptoms.

Closes #1545
Closes #1423
Closes #1269

## Problem

`SEGMENT_LABELS[segment] || segment` treats every path segment as static. Routes under `/community/[id]/manage/...` contain two kinds of segments:
- **Static** (`applications`, `setup`, `portfolio-reports`) — want a constant label.
- **Dynamic** (`[programId]`, `[reportId]`, …) — carry an opaque id whose label must be **resolved** from data.

So `101105`, `fake-report-id`, `portfolio-reports`, and `config` all fell through to the raw value. Just adding two more static map entries (the originally proposed workaround in #1269) would not resolve the dynamic ids and could mislabel an unrelated `config` route.

## Solution

Replace the single static-map strategy with a **small, fixed set of resolver hooks** feeding a pure segment resolver:

- **#1545** — `programId` → program name, via `useProgram` (subscribed, so it appears as soon as it loads).
- **#1423** — `reportId` → report run-date label via `usePortfolioReport`, using the **same** `formatRunDate` the editor page header uses, so crumb and header cannot drift.
- **#1269** — `portfolio-reports` gets a static label; `config` is matched **positionally** (only under `portfolio-reports`) so it never collides with another `config` route or clobbers a report literally titled "config".

### Why hooks, not a passive cache read
A `getQueryData()` read inside `useMemo` is **not reactive**: if the breadcrumb mounts before the page's query resolves (direct nav / refresh), it would stay stuck on the fallback. The fixed resolver hooks subscribe and re-render when data arrives. Each is internally gated by `enabled`, so the report query is disabled on funding pages and vice-versa (no cross-fetch). No hook is ever called inside the segment loop (rules-of-hooks / no React #185 loop — ids are guarded to primitives in the deps).

### Fallback ladder (UX)
- resolved → entity name
- pending (loading) → fixed-width skeleton (no layout shift, `aria-busy`)
- settled but not found (deleted/fake id) → generic finite label `Program` / `Report` (never a raw id, never an endless spinner)
- static → label; unknown → titleized slug

## Scope

Ships the **program** and **report** resolvers (the two in the issues). The resolver structure supports adding `application` / `project` later as a one-entry change; intentionally not shipping those now.

## Testing steps

`pnpm test -- ManageBreadcrumbs` — 15 tests, all green. Manually:
1. Open a funding applications page → 3rd crumb shows the program name, not the numeric id.
2. Open a portfolio report editor → crumb shows the report run-date label matching the page header; `portfolio-reports` and `config` read as words.
3. Open `/portfolio-reports/<deleted-id>` → crumb reads `Report`, no crash/spinner.
4. Repeat 1–2 in whitelabel mode → names still resolve.

## Checklist
- [x] Loading / unresolved / static states all handled — never raw id, never `return null` for a data state
- [x] No `any` / `as any`
- [x] No hardcoded URLs (uses `PAGES`) or colors (Tailwind theme + `Skeleton`)
- [x] `pluralize` n/a (no dynamic counts)
- [x] Biome lint + format pass
- [x] `tsc --noEmit` passes
- [x] Unit tests added (component had none before)