### PR TITLE
fix(sentry): filter unactionable wallet-SDK IndexedDB UnknownError noise

### DIFF
--- a/__tests__/unit/utilities/sentry/walletStorageErrors.test.ts
+++ b/__tests__/unit/utilities/sentry/walletStorageErrors.test.ts
@@ -1,0 +1,48 @@
+import { isIndexedDbInternalError } from "../../../../utilities/sentry/walletStorageErrors";
+
+describe("isIndexedDbInternalError", () => {
+  it("suppresses the wallet-SDK IndexedDB 'UnknownError: Internal error.' signature (GAP-FRONTEND-WS)", () => {
+    // WalletConnect's keyvaluestorage (and other idb-keyval consumers) leak an
+    // un-awaited IndexedDB read rejection during startup when the browser's IDB
+    // store is corrupted/unavailable. Chrome surfaces it as a DOMException with
+    // name "UnknownError" and message "Internal error." — environmental noise.
+    const domException = { name: "UnknownError", message: "Internal error.", code: 0 };
+    expect(isIndexedDbInternalError(domException)).toBe(true);
+  });
+
+  it("matches a real DOMException instance when available", () => {
+    // jsdom provides DOMException; guard so the test is a no-op where it isn't.
+    if (typeof DOMException === "undefined") return;
+    const err = new DOMException("Internal error.", "UnknownError");
+    expect(isIndexedDbInternalError(err)).toBe(true);
+  });
+
+  it("matches regardless of message casing or trailing punctuation", () => {
+    expect(isIndexedDbInternalError({ name: "UnknownError", message: "internal error" })).toBe(
+      true
+    );
+    expect(isIndexedDbInternalError({ name: "UnknownError", message: "INTERNAL ERROR." })).toBe(
+      true
+    );
+  });
+
+  it("does NOT match an UnknownError with an unrelated message", () => {
+    // Stay scoped to the observed IndexedDB signature — a generic UnknownError
+    // from elsewhere is still actionable and must reach Sentry.
+    expect(isIndexedDbInternalError({ name: "UnknownError", message: "something else" })).toBe(
+      false
+    );
+  });
+
+  it("does NOT match an 'Internal error.' message from a different error name", () => {
+    expect(isIndexedDbInternalError({ name: "TypeError", message: "Internal error." })).toBe(false);
+    expect(isIndexedDbInternalError(new Error("Internal error."))).toBe(false);
+  });
+
+  it("does not over-match unrelated or empty values", () => {
+    expect(isIndexedDbInternalError(new Error("Something else broke"))).toBe(false);
+    expect(isIndexedDbInternalError(null)).toBe(false);
+    expect(isIndexedDbInternalError(undefined)).toBe(false);
+    expect(isIndexedDbInternalError("Internal error.")).toBe(false);
+  });
+});

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,6 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
 import { isTransientHttpError, isTransientNetworkError } from "./utilities/sentry/transientErrors";
+import { isIndexedDbInternalError } from "./utilities/sentry/walletStorageErrors";
 
 Sentry.init({
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
@@ -18,7 +19,15 @@ Sentry.init({
   // DEV-271 / GAP-FRONTEND-1R1.
   beforeSend(event, hint) {
     const original = hint?.originalException;
-    if (isTransientNetworkError(original) || isTransientHttpError(original)) {
+    if (
+      isTransientNetworkError(original) ||
+      isTransientHttpError(original) ||
+      // Wallet SDKs (WalletConnect/Coinbase/base-account) leak an un-awaited
+      // IndexedDB read rejection on startup when the browser's IDB store is
+      // corrupted/unavailable. Environmental and not actionable from our code.
+      // See GAP-FRONTEND-WS and ./utilities/sentry/walletStorageErrors.ts
+      isIndexedDbInternalError(original)
+    ) {
       return null;
     }
     return event;

--- a/utilities/sentry/walletStorageErrors.ts
+++ b/utilities/sentry/walletStorageErrors.ts
@@ -1,0 +1,58 @@
+/**
+ * Helper for detecting the IndexedDB "UnknownError: Internal error." that wallet
+ * SDKs leak as an unhandled promise rejection during startup — unactionable
+ * third-party noise that should not reach Sentry.
+ *
+ * Context: Sentry issue GAP-FRONTEND-WS ran at 65 events / 4 users with the
+ * signature `UnknownError: Internal error.` (DOMException.code 0, mechanism
+ * `onunhandledrejection`, handled:no, no stacktrace). It fires on page load,
+ * before any user interaction, across tenants and routes.
+ *
+ * Root cause: our wallet stack persists connection state to IndexedDB via
+ * `idb-keyval` (WalletConnect's `keyvaluestorage`, `@coinbase/wallet-sdk`,
+ * `@base-org/account`). The clearest culprit is
+ * `@walletconnect/keyvaluestorage`, whose `KeyValueStorage` constructor fires
+ * an async localStorage→IndexedDB migration that is neither awaited nor
+ * `.catch()`-ed (the surrounding try/catch only guards synchronous throws).
+ * When the browser's IndexedDB store is corrupted or unavailable (unclean
+ * shutdown, disk I/O error, storage eviction, multi-tab/extension contention)
+ * the read rejects with a `DOMException` whose name is `UnknownError` and whose
+ * message is "Internal error.", and that rejection escapes to
+ * `window.onunhandledrejection`.
+ *
+ * This is environmental — the user's IndexedDB is degraded — and not actionable
+ * from our code (we have no first-party IndexedDB usage; wagmi uses
+ * localStorage and React Query has no IDB persister). Filtering it keeps the
+ * Sentry feed actionable.
+ * See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-WS
+ */
+
+function getErrorName(error: unknown): string {
+  if (error && typeof error === "object" && "name" in error) {
+    const name = (error as { name?: unknown }).name;
+    if (typeof name === "string") return name;
+  }
+  return "";
+}
+
+function getErrorMessage(error: unknown): string {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === "string") return msg;
+  }
+  return "";
+}
+
+/**
+ * True when the error is the environmental IndexedDB failure that wallet SDKs
+ * leak during startup. Scoped tightly to the observed signature — a
+ * `UnknownError` DOMException whose message is "Internal error." — so it never
+ * swallows actionable application errors.
+ */
+export function isIndexedDbInternalError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (getErrorName(error) !== "UnknownError") return false;
+  return getErrorMessage(error).toLowerCase().includes("internal error");
+}


### PR DESCRIPTION
## Overview

Stops the `UnknownError: Internal error.` events (Sentry **GAP-FRONTEND-WS**) from reaching the Sentry feed. They are unactionable third-party noise, not a bug in our code.

## Problem

GAP-FRONTEND-WS ran at **65 events / 4 users** with the signature `UnknownError: Internal error.` — `DOMException.code 0`, mechanism `onunhandledrejection`, `handled: no`, **no stacktrace**. It fires on page load, before any user interaction, across tenants (`karmahq.xyz`, `app.opgrants.io`, celo) and routes.

### Root cause

Our wallet stack persists connection state to **IndexedDB** via `idb-keyval` (WalletConnect's `keyvaluestorage`, `@coinbase/wallet-sdk`, `@base-org/account`). The clearest culprit is `@walletconnect/keyvaluestorage`, whose `KeyValueStorage` constructor fires an `async` localStorage→IndexedDB migration that is **neither awaited nor `.catch()`-ed** — its `try/catch` only guards synchronous throws:

```js
constructor() {
  const t = new K;            // localStorage backend
  this.storage = t;
  try {
    const e = new _;          // IndexedDB backend (idb-keyval)
    O(t, e, this.setInitialized);  // async migration: NOT awaited, NOT caught
  } catch { this.initialized = true }  // only catches SYNC throws
}
```

When the browser's IndexedDB store is corrupted or unavailable (unclean shutdown, disk I/O error, storage eviction, multi-tab/extension contention) the migration's read rejects with the `UnknownError` DOMException, which escapes to `window.onunhandledrejection` and is recorded by Sentry.

This is **environmental** — the user's IndexedDB is degraded — and not actionable from our code. We have no first-party IndexedDB usage: wagmi uses `localStorage` (`wagmi.store`) and React Query has no IDB persister.

## Solution

Add `isIndexedDbInternalError()` and drop matching events in `beforeSend`, mirroring the existing `transientErrors` filtering. The predicate is scoped tightly to the observed signature — a `UnknownError` DOMException whose message contains "internal error" — so it never swallows actionable application errors.

## Changes

- `utilities/sentry/walletStorageErrors.ts` — new `isIndexedDbInternalError()` predicate (documented with the root cause).
- `instrumentation-client.ts` — wire the predicate into `beforeSend`.
- `__tests__/unit/utilities/sentry/walletStorageErrors.test.ts` — unit tests covering the matched signature and the over-match guards.

## Testing

- `pnpm vitest run __tests__/unit/utilities/sentry/walletStorageErrors.test.ts` — 6 passing.
- `pnpm vitest run __tests__/infrastructure/instrumentation-client.test.ts` — 6 passing (unchanged config assertions hold).
- Biome + `tsc --noEmit` pass (pre-commit / pre-push hooks green).

## Notes / follow-ups (out of scope)

- This is **noise reduction**, the right call given the small, environmental, non-user-facing footprint.
- A durable "self-heal" (startup probe of `indexedDB.databases()` + `deleteDatabase()` of a corrupted wallet store, plus a scoped global rejection guard) was considered but deemed not worth its blast radius for a 4-user tail. Revisit only if volume escalates into real user complaints.
- Long-term: bump WalletConnect/Privy when an upstream version that awaits/catches its init IDB access is reachable. Note: gap-app-v2 pins transitive deps via pnpm `resolutions`, not npm `overrides`.