### PR TITLE
fix(a11y): prevent nested button in tooltip triggers

### DIFF
--- a/components/Utilities/InfoTooltip.tsx
+++ b/components/Utilities/InfoTooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as Tooltip from "@radix-ui/react-tooltip";
 import type { ReactNode } from "react";
 import { cn } from "@/utilities/tailwind";
@@ -53,12 +55,16 @@ export const InfoTooltip = ({
     </button>
   );
 
+  // The default trigger is itself a <button>, so it must be slotted via
+  // asChild to avoid Radix rendering a second wrapping <button> (nested
+  // interactive elements — invalid HTML + duplicate a11y nodes, issue #1458).
+  // Caller-provided children keep honoring the explicit triggerAsChild prop.
+  const useAsChild = children ? triggerAsChild : true;
+
   return (
     <Tooltip.Provider>
       <Tooltip.Root delayDuration={delayDuration}>
-        <Tooltip.Trigger asChild={triggerAsChild} type="button">
-          {children || defaultTrigger}
-        </Tooltip.Trigger>
+        <Tooltip.Trigger asChild={useAsChild}>{children || defaultTrigger}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
             className={cn(

--- a/components/Utilities/QuestionTooltip.tsx
+++ b/components/Utilities/QuestionTooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as Tooltip from "@radix-ui/react-tooltip";
 import type { ReactNode } from "react";
 import { cn } from "@/utilities/tailwind";
@@ -51,12 +53,16 @@ export const QuestionTooltip = ({
     </button>
   );
 
+  // The default trigger is itself a <button>, so it must be slotted via
+  // asChild to avoid Radix rendering a second wrapping <button> (nested
+  // interactive elements — invalid HTML + duplicate a11y nodes, issue #1458).
+  // Caller-provided children keep honoring the explicit triggerAsChild prop.
+  const useAsChild = children ? triggerAsChild : true;
+
   return (
     <Tooltip.Provider>
       <Tooltip.Root delayDuration={delayDuration}>
-        <Tooltip.Trigger asChild={triggerAsChild} type="button">
-          {children || defaultTrigger}
-        </Tooltip.Trigger>
+        <Tooltip.Trigger asChild={useAsChild}>{children || defaultTrigger}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
             className={cn(

--- a/components/Utilities/__tests__/InfoTooltip.test.tsx
+++ b/components/Utilities/__tests__/InfoTooltip.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { InfoTooltip } from "../InfoTooltip";
+
+describe("InfoTooltip", () => {
+  describe("default trigger (no children)", () => {
+    it("renders exactly one button", () => {
+      const { container } = render(<InfoTooltip content="x" />);
+
+      expect(container.querySelectorAll("button")).toHaveLength(1);
+    });
+
+    it("exposes the accessible name 'More information'", () => {
+      render(<InfoTooltip content="x" />);
+
+      expect(screen.getByRole("button", { name: "More information" })).toBeInTheDocument();
+    });
+
+    it("does not nest a button inside another button", () => {
+      const { container } = render(<InfoTooltip content="x" />);
+
+      expect(container.querySelector("button button")).toBeNull();
+    });
+
+    it("renders a button that is enabled and focusable", () => {
+      render(<InfoTooltip content="x" />);
+
+      const trigger = screen.getByRole("button", { name: "More information" });
+      expect(trigger).toBeEnabled();
+
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+    });
+
+    it("shows the tooltip content on hover", async () => {
+      const user = userEvent.setup();
+      render(<InfoTooltip content="Helpful info" delayDuration={0} />);
+
+      const trigger = screen.getByRole("button", { name: "More information" });
+      await user.hover(trigger);
+
+      const matches = await screen.findAllByText("Helpful info");
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("custom children with triggerAsChild", () => {
+    it("renders the custom trigger without nesting buttons", () => {
+      const { container } = render(
+        <InfoTooltip content="x" triggerAsChild>
+          <button type="button" aria-label="Custom trigger">
+            icon
+          </button>
+        </InfoTooltip>
+      );
+
+      expect(container.querySelectorAll("button")).toHaveLength(1);
+      expect(container.querySelector("button button")).toBeNull();
+      expect(screen.getByRole("button", { name: "Custom trigger" })).toBeInTheDocument();
+    });
+  });
+});

--- a/components/Utilities/__tests__/QuestionTooltip.test.tsx
+++ b/components/Utilities/__tests__/QuestionTooltip.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { QuestionTooltip } from "../QuestionTooltip";
+
+describe("QuestionTooltip", () => {
+  describe("default trigger (no children)", () => {
+    it("renders exactly one button", () => {
+      const { container } = render(<QuestionTooltip content="x" />);
+
+      expect(container.querySelectorAll("button")).toHaveLength(1);
+    });
+
+    it("exposes the accessible name 'More information'", () => {
+      render(<QuestionTooltip content="x" />);
+
+      expect(screen.getByRole("button", { name: "More information" })).toBeInTheDocument();
+    });
+
+    it("does not nest a button inside another button", () => {
+      const { container } = render(<QuestionTooltip content="x" />);
+
+      expect(container.querySelector("button button")).toBeNull();
+    });
+
+    it("renders a button that is enabled and focusable", () => {
+      render(<QuestionTooltip content="x" />);
+
+      const trigger = screen.getByRole("button", { name: "More information" });
+      expect(trigger).toBeEnabled();
+
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+    });
+
+    it("shows the tooltip content on hover", async () => {
+      const user = userEvent.setup();
+      render(<QuestionTooltip content="Helpful info" delayDuration={0} />);
+
+      const trigger = screen.getByRole("button", { name: "More information" });
+      await user.hover(trigger);
+
+      const matches = await screen.findAllByText("Helpful info");
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Overview
Fixes **#1458** — `InfoTooltip` (and its twin `QuestionTooltip`) rendered nested `<button>` elements, an invalid-HTML / accessibility-tree defect that affected the majority of the ~17 `InfoTooltip` call sites and the `QuestionTooltip` call site.

## Problem (root cause)
Both components define a default trigger that is itself a real `<button aria-label="More information">`, then pass it through:

```tsx
<Tooltip.Trigger asChild={triggerAsChild} type="button">
  {children || defaultTrigger}
</Tooltip.Trigger>
```

`triggerAsChild` defaults to `false`. With `asChild={false}`, Radix renders **its own** `<button>` and nests our button inside it:

```html
<button>            <!-- Radix-rendered -->
  <button aria-label="More information"><svg/></button>   <!-- ours -->
</button>
```

That is non-conforming HTML (interactive content nested in interactive content) and produces two focusable nodes both named "More information" in the accessibility tree — breaking screen-reader and keyboard semantics (WCAG 4.1.2) and failing axe/Lighthouse `nested-interactive`. Every call site that doesn't pass `children` (the majority) hit this.

## Solution
Slot the default button via `asChild` so Radix renders exactly **one** trigger, while caller-provided `children` keep honoring the explicit `triggerAsChild` prop:

```tsx
// Default trigger is itself a <button>, so it must be slotted via asChild to
// avoid a second wrapping <button>. Children keep honoring triggerAsChild.
const useAsChild = children ? triggerAsChild : true;
...
<Tooltip.Trigger asChild={useAsChild}>{children || defaultTrigger}</Tooltip.Trigger>
```

The redundant `type="button"` on `Tooltip.Trigger` is dropped (the inner button already declares it). This is a **surgical fix**: it changes only the broken default-trigger path; every `children` + `triggerAsChild` call site (e.g. `StatItem`, `NotificationSettingsPage`, `VerificationBadge`) is byte-identical in behavior. Both shared tooltip components share one root cause, so both are fixed together.

### Why this approach
- **Scalable / root cause:** one shared-component change corrects all ~17 default-trigger usages at once — no per-call-site edits.
- **Idiomatic Radix:** `asChild` with a single button child is exactly how the existing `children` call sites already work.
- **No suppression:** the nested `<button>` is removed from the DOM, not masked with `aria-hidden`/CSS.
- `"use client"` added to both files to satisfy the repo's Radix-import rule.

## Scope
Intentionally limited to `InfoTooltip` + `QuestionTooltip` (same defect, same fix). Unrelated a11y issues (#1238, #1433) are deliberately **not** bundled. Follow-ups worth tracking: DRY-unify the two near-duplicate tooltips, and hoist `Tooltip.Provider` to app root.

## Testing
New co-located Vitest + RTL specs (`components/Utilities/__tests__/{InfoTooltip,QuestionTooltip}.test.tsx`) deterministically assert:
- default trigger renders **exactly one** `<button>` with accessible name "More information"
- **no** `button button` nesting (the #1458 regression guard)
- trigger is enabled/focusable and the tooltip content still appears on hover
- `children` + `triggerAsChild` path renders the caller's button with no nesting

```
InfoTooltip (6 tests) — pass
QuestionTooltip (5 tests) — pass
Test Files  2 passed (2)  ·  Tests  11 passed (11)
```
Local Biome lint, `tsc --noEmit` typecheck (pre-push hook), and the new tests all pass.

Closes #1458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for tooltip components, verifying trigger rendering, accessibility features, and tooltip visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
