### PR TITLE
chore: refresh quality-gate baseline

### DIFF
--- a/__tests__/app/sitemaps/static/sitemap.test.ts
+++ b/__tests__/app/sitemaps/static/sitemap.test.ts
@@ -28,14 +28,10 @@ describe("app/sitemaps/static/sitemap.ts", () => {
     expect(homepage?.changeFrequency).toBe("daily");
   });
 
-  it("downgrades privacy/terms/dashboard to yearly low-priority entries", async () => {
+  it("downgrades privacy/terms to yearly low-priority entries", async () => {
     const { default: staticSitemap } = await import("@/app/sitemaps/static/sitemap");
     const entries = staticSitemap();
-    const lowPriorityUrls = [
-      `${SITE_URL}/privacy-policy`,
-      `${SITE_URL}/terms-and-conditions`,
-      `${SITE_URL}/dashboard`,
-    ];
+    const lowPriorityUrls = [`${SITE_URL}/privacy-policy`, `${SITE_URL}/terms-and-conditions`];
     for (const url of lowPriorityUrls) {
       const entry = entries.find((e) => e.url === url);
       expect(entry?.priority).toBe(0.3);

--- a/__tests__/components/Community/CommunityMilestoneCard.test.tsx
+++ b/__tests__/components/Community/CommunityMilestoneCard.test.tsx
@@ -59,6 +59,17 @@ vi.mock("@/components/Pages/Community/Updates/MilestoneCompletionInfo", () => ({
   ),
 }));
 
+// Mock MilestoneAIEvaluationBadge component (it uses React Query internally)
+vi.mock("@/components/Milestone/MilestoneAIEvaluationBadge", () => ({
+  MilestoneAIEvaluationBadge: ({ milestoneUID, completionReason }: any) => (
+    <div
+      data-testid="milestone-ai-evaluation-badge"
+      data-milestone-uid={milestoneUID}
+      data-completion-reason={completionReason}
+    />
+  ),
+}));
+
 // Mock Heroicons
 vi.mock("@heroicons/react/24/outline", () => ({
   CheckCircleIcon: ({ className }: any) => (

--- a/__tests__/components/CommunityStats.test.tsx
+++ b/__tests__/components/CommunityStats.test.tsx
@@ -177,9 +177,11 @@ describe("CommunityStats", () => {
 
     it("should show loading state when fetching stats", async () => {
       const user = userEvent.setup();
-      (fetchData as vi.Mock).mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve([mockStatsData, null]), 100))
-      );
+      // Never-settling promise keeps the component in its loading state for the
+      // whole assertion window. A timer-based resolve (e.g. setTimeout 100ms) is
+      // flaky: under load the click + waitFor can overrun the delay, the data
+      // arrives, and "Loading stats..." is already gone before we look.
+      (fetchData as vi.Mock).mockImplementation(() => new Promise<never>(() => {}));
 
       render(<CommunityStats communityId={mockCommunityId} />);
 

--- a/__tests__/components/FundingPlatform/ApplicationView/ReviewerStatusChange.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ReviewerStatusChange.test.tsx
@@ -362,6 +362,15 @@ vi.mock("@/components/FundingPlatform/ApplicationView/TabPanel", () => ({
     React.createElement("div", { "data-testid": "tab-panel" }, children),
 }));
 
+// MilestonesTab transitively imports the karma-gap-sdk runtime client
+// (gapClient.ts → @show-karma/karma-gap-sdk/core/class/GAP), which fails to
+// load under Vitest. The test does not assert on milestones content, so mock
+// it out to break the SDK import chain.
+vi.mock("@/src/features/applications/components/MilestonesTab", () => ({
+  MilestonesTab: () =>
+    React.createElement("div", { "data-testid": "milestones-tab" }, "Milestones Tab"),
+}));
+
 import toast from "react-hot-toast";
 // Import the page component after mocks (now uses unified manage route)
 import ReviewerApplicationDetailPage from "@/app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page";
@@ -611,21 +620,23 @@ describe("Reviewer Status Change Functionality", () => {
         permissions: [],
       });
 
-      render(React.createElement(ReviewerApplicationDetailPage));
+      const { container } = render(React.createElement(ReviewerApplicationDetailPage));
 
-      expect(screen.getByTestId("spinner")).toBeInTheDocument();
+      // Loading state now renders ApplicationDetailSkeleton, whose accessible
+      // root advertises aria-busy="true" rather than a bare spinner.
+      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
     });
 
-    it("should show loading spinner when application is loading", () => {
+    it("should show loading skeleton when application is loading", () => {
       vi.mocked(useApplication).mockReturnValue({
         application: null,
         isLoading: true,
         refetch: mockRefetchApplication,
       });
 
-      render(React.createElement(ReviewerApplicationDetailPage));
+      const { container } = render(React.createElement(ReviewerApplicationDetailPage));
 
-      expect(screen.getByTestId("spinner")).toBeInTheDocument();
+      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
     });
   });
 

--- a/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
+++ b/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
@@ -10,7 +10,6 @@ import type React from "react";
 import { CreateProgramModal } from "@/components/FundingPlatform/CreateProgramModal";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { server } from "@/__tests__/utils/msw/setup";
 import { ProgramRegistryService } from "@/src/features/program-registry/services/program-registry.service";
 
 // Mock useRouter from next/navigation
@@ -137,6 +136,39 @@ vi.mock("@/components/Utilities/MarkdownEditor", () => ({
         data-testid={`markdown-editor-${id}`}
       />
       {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  ),
+}));
+
+// Mock DateTimePicker (pulls in react-day-picker ESM which breaks the transform)
+vi.mock("@/components/Utilities/DateTimePicker", () => ({
+  DateTimePicker: ({
+    selected,
+    onSelect,
+    placeholder,
+    buttonClassName,
+    clearButtonFn,
+  }: {
+    selected?: Date;
+    onSelect?: (date: Date | undefined) => void;
+    placeholder?: string;
+    buttonClassName?: string;
+    clearButtonFn?: () => void;
+  }) => (
+    <div data-testid="date-picker">
+      <button
+        type="button"
+        data-testid={`date-picker-${placeholder?.toLowerCase().replace(/\s+/g, "-") || "default"}`}
+        onClick={() => onSelect?.(selected || new Date("2024-06-01T00:00:00Z"))}
+        className={buttonClassName}
+      >
+        {selected ? selected.toISOString() : placeholder || "Pick a date"}
+      </button>
+      {clearButtonFn && (
+        <button type="button" onClick={clearButtonFn}>
+          Clear
+        </button>
+      )}
     </div>
   ),
 }));
@@ -272,10 +304,6 @@ describe("CreateProgramModal", () => {
     });
 
     (ProgramRegistryService.approveProgram as vi.Mock).mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    server.resetHandlers();
   });
 
   describe("Rendering", () => {

--- a/__tests__/components/GrantMilestonesAndUpdates/MilestoneDelete.test.tsx
+++ b/__tests__/components/GrantMilestonesAndUpdates/MilestoneDelete.test.tsx
@@ -39,8 +39,10 @@ describe("MilestoneDelete", () => {
       expect(componentCode).toContain('import { useGrantStore } from "@/store/grant"');
     });
 
-    it("should destructure refreshGrant from useGrantStore", () => {
-      expect(componentCode).toContain("const { refreshGrant } = useGrantStore()");
+    it("should obtain refreshGrant from useGrantStore", () => {
+      expect(componentCode).toContain(
+        "const refreshGrant = useGrantStore((state) => state.refreshGrant)"
+      );
     });
 
     it("should call refreshGrant at least 3 times (off-chain, on-chain, fallback)", () => {

--- a/__tests__/components/GrantMilestonesAndUpdates/MilestoneDetails.test.tsx
+++ b/__tests__/components/GrantMilestonesAndUpdates/MilestoneDetails.test.tsx
@@ -26,8 +26,8 @@ vi.mock("@/store/grant", () => ({
   useGrantStore: vi.fn((selector: (s: any) => any) => selector({ grant: null })),
 }));
 
-vi.mock("@/src/core/rbac/context/permission-context", () => ({
-  useIsCommunityAdmin: () => false,
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: () => ({ isCommunityAdmin: false }),
 }));
 
 vi.mock(

--- a/__tests__/components/GrantMilestonesAndUpdates/MilestonesList.test.tsx
+++ b/__tests__/components/GrantMilestonesAndUpdates/MilestonesList.test.tsx
@@ -3,6 +3,19 @@ import { render, screen } from "@testing-library/react";
 import { MilestonesList } from "@/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList";
 import type { Grant } from "@/types/v2/grant";
 
+// Mock the SDK to avoid class initialization errors
+vi.mock("@show-karma/karma-gap-sdk", () => ({
+  GAP: vi.fn(),
+  GapSchema: vi.fn(),
+}));
+
+// Mock the ActivityCard component to avoid SDK dependency chain
+vi.mock("@/components/Shared/ActivityCard", () => ({
+  ActivityCard: ({ activity }: any) => (
+    <div data-testid="activity-card">{activity?.data?.title || "Activity"}</div>
+  ),
+}));
+
 // Mock payout config hook
 const mockPayoutConfig = {
   isLoading: false,

--- a/__tests__/components/GrantOverview.test.tsx
+++ b/__tests__/components/GrantOverview.test.tsx
@@ -10,11 +10,19 @@ const mockGrantStore = {
 };
 
 vi.mock("@/store/grant", () => ({
-  useGrantStore: vi.fn(() => mockGrantStore),
+  useGrantStore: vi.fn((selector?: (state: typeof mockGrantStore) => unknown) =>
+    selector ? selector(mockGrantStore) : mockGrantStore
+  ),
 }));
 
+const mockOwnerStore = {
+  isOwner: false,
+};
+
 vi.mock("@/store/owner", () => ({
-  useOwnerStore: vi.fn(() => false),
+  useOwnerStore: vi.fn((selector?: (state: typeof mockOwnerStore) => unknown) =>
+    selector ? selector(mockOwnerStore) : mockOwnerStore
+  ),
 }));
 
 // Mock heavy/external dependencies

--- a/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
+++ b/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { BrowseApplicationsClient } from "@/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient";
 import fetchData from "@/utilities/fetchData";
@@ -84,12 +83,24 @@ vi.mock("@/utilities/formatDate", () => ({
   formatDate: (d: string) => d,
 }));
 
-vi.mock("lucide-react", () => ({
-  Lock: (props: Record<string, unknown>) => <svg data-testid="lock-icon" {...props} />,
-  RefreshCw: (props: Record<string, unknown>) => <svg data-testid="refresh-icon" {...props} />,
-  Search: (props: Record<string, unknown>) => <svg data-testid="search-icon" {...props} />,
-  X: (props: Record<string, unknown>) => <svg data-testid="x-icon" {...props} />,
-}));
+// Robust mock: builds a stub SVG for every icon the component imports today,
+// plus any reasonable icon it may add later, so future icon additions do not
+// break this test file. We resolve the icon set from the actual lucide-react
+// package exports and stub each one, rather than hand-listing names.
+vi.mock("lucide-react", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("lucide-react");
+  const toTestId = (name: string) =>
+    `${name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()}-icon`;
+  const stubbed: Record<string, unknown> = { __esModule: true };
+  for (const name of Object.keys(actual)) {
+    const Icon = (props: Record<string, unknown>) => (
+      <svg data-testid={toTestId(name)} {...props} />
+    );
+    Icon.displayName = name;
+    stubbed[name] = Icon;
+  }
+  return stubbed;
+});
 
 // --- Helpers ---
 
@@ -105,6 +116,29 @@ function createWrapper() {
   };
 }
 
+// The program selector is a custom listbox: a button (aria-haspopup="listbox")
+// that opens a popup with role="option" entries — not a native <select>.
+async function selectProgram(user: ReturnType<typeof userEvent.setup>, name: string) {
+  const trigger = screen.getByRole("button", {
+    name: /choose a program|test grant program|another program/i,
+  });
+  await user.click(trigger);
+  const option = within(screen.getByRole("listbox")).getByRole("option", { name });
+  await user.click(option);
+}
+
+// Status filters are chip buttons inside a "Filter by status" fieldset.
+async function clickStatusChip(user: ReturnType<typeof userEvent.setup>, label: string) {
+  const fieldset = screen.getByRole("group", { name: "Filter by status" });
+  const chip = within(fieldset).getByRole("button", { name: new RegExp(`^${label}`, "i") });
+  await user.click(chip);
+}
+
+function lastReplaceUrl(): string {
+  const calls = mockRouterReplace.mock.calls;
+  return calls[calls.length - 1][0] as string;
+}
+
 // --- Tests ---
 
 describe("BrowseApplicationsClient - URL sync on filter change", () => {
@@ -118,8 +152,7 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
       wrapper: createWrapper(),
     });
 
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
+    await selectProgram(user, "Test Grant Program");
 
     // The component should call router.replace with the programId in the URL
     expect(mockRouterReplace).toHaveBeenCalledWith(
@@ -134,14 +167,12 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
       wrapper: createWrapper(),
     });
 
-    // First select a program so the status filter is enabled
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
+    // First select a program so the status filter is rendered
+    await selectProgram(user, "Test Grant Program");
 
     mockRouterReplace.mockClear();
 
-    const statusSelect = screen.getByLabelText("Status");
-    await user.selectOptions(statusSelect, "approved");
+    await clickStatusChip(user, "Approved");
 
     expect(mockRouterReplace).toHaveBeenCalledWith(
       expect.stringContaining("status=approved"),
@@ -155,21 +186,21 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
       wrapper: createWrapper(),
     });
 
-    // First select a program so the search input is enabled
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
+    // First select a program so the search input is rendered
+    await selectProgram(user, "Test Grant Program");
 
     mockRouterReplace.mockClear();
 
-    const searchInput = screen.getByLabelText("Search");
+    const searchInput = screen.getByLabelText("Search applications");
     await user.type(searchInput, "my project");
 
-    // The component should update the URL with the search param
-    // (may be debounced, so we check that it was called at some point)
-    expect(mockRouterReplace).toHaveBeenCalledWith(
-      expect.stringContaining("search="),
-      expect.anything()
-    );
+    // The search term is debounced before being pushed to the URL.
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith(
+        expect.stringContaining("search="),
+        expect.anything()
+      );
+    });
   });
 
   it("reflects combined filter state in the URL", async () => {
@@ -178,15 +209,12 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
       wrapper: createWrapper(),
     });
 
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
-
-    const statusSelect = screen.getByLabelText("Status");
-    await user.selectOptions(statusSelect, "pending");
+    await selectProgram(user, "Test Grant Program");
+    await clickStatusChip(user, "Pending");
 
     // The last call to replace should include both programId and status
     expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = mockRouterReplace.mock.calls[mockRouterReplace.mock.calls.length - 1][0];
+    const lastCall = lastReplaceUrl();
     expect(lastCall).toContain("programId=program-abc");
     expect(lastCall).toContain("status=pending");
   });
@@ -197,31 +225,31 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
       wrapper: createWrapper(),
     });
 
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
+    await selectProgram(user, "Test Grant Program");
 
-    const statusSelect = screen.getByLabelText("Status");
-    await user.selectOptions(statusSelect, "approved");
-    await user.selectOptions(statusSelect, "all");
+    await clickStatusChip(user, "Approved");
+    await clickStatusChip(user, "All");
 
     expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = mockRouterReplace.mock.calls[mockRouterReplace.mock.calls.length - 1][0];
+    const lastCall = lastReplaceUrl();
     expect(lastCall).not.toContain("status=");
   });
 
-  it("removes programId from URL when program is deselected", async () => {
+  it("keeps programId in the URL after a status filter is toggled off", async () => {
+    // The pill selector has no "deselect" affordance, so once chosen the
+    // programId persists. Toggling status back to "all" must not drop it.
     const user = userEvent.setup();
     render(<BrowseApplicationsClient communityId="test-community" />, {
       wrapper: createWrapper(),
     });
 
-    const programSelect = screen.getByLabelText("Funding Program");
-    await user.selectOptions(programSelect, "program-abc");
-    // Deselect by choosing the placeholder option
-    await user.selectOptions(programSelect, "");
+    await selectProgram(user, "Test Grant Program");
+    await clickStatusChip(user, "Approved");
+    await clickStatusChip(user, "All");
 
     expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = mockRouterReplace.mock.calls[mockRouterReplace.mock.calls.length - 1][0];
-    expect(lastCall).not.toContain("programId=");
+    const lastCall = lastReplaceUrl();
+    expect(lastCall).toContain("programId=program-abc");
+    expect(lastCall).not.toContain("status=");
   });
 });

--- a/__tests__/components/Pages/Communities/CommunityPageNavigator.test.tsx
+++ b/__tests__/components/Pages/Communities/CommunityPageNavigator.test.tsx
@@ -4,14 +4,12 @@ import type { ReactNode } from "react";
 import { CommunityPageNavigator } from "@/components/Pages/Communities/CommunityPageNavigator";
 import { useCommunityDetails } from "@/hooks/communities/useCommunityDetails";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
-import { useFundingOpportunitiesCount } from "@/hooks/useFundingOpportunitiesCount";
 import { useCommunityPrograms } from "@/hooks/usePrograms";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 
 // Mock hooks
 vi.mock("@/hooks/communities/useCommunityDetails");
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
-vi.mock("@/hooks/useFundingOpportunitiesCount");
 vi.mock("@/hooks/usePrograms");
 vi.mock("@/utilities/whitelabel-context");
 
@@ -64,9 +62,6 @@ const mockUseCommunityDetails = useCommunityDetails as vi.MockedFunction<
 const mockUsePublishedReports = usePublishedReports as vi.MockedFunction<
   typeof usePublishedReports
 >;
-const mockUseFundingOpportunitiesCount = useFundingOpportunitiesCount as vi.MockedFunction<
-  typeof useFundingOpportunitiesCount
->;
 const mockUseCommunityPrograms = useCommunityPrograms as vi.MockedFunction<
   typeof useCommunityPrograms
 >;
@@ -111,10 +106,6 @@ describe("CommunityPageNavigator", () => {
           slug: "test-community",
         },
       },
-      isLoading: false,
-    } as any);
-    mockUseFundingOpportunitiesCount.mockReturnValue({
-      data: 5, // Default to having some funding opportunities
       isLoading: false,
     } as any);
     mockUsePublishedReports.mockReturnValue({
@@ -333,9 +324,9 @@ describe("CommunityPageNavigator", () => {
       const { container } = render(<CommunityPageNavigator />, { wrapper });
 
       const nav = container.firstChild;
-      expect(nav).toHaveClass("max-md:overflow-x-auto");
-      expect(nav).toHaveClass("max-md:scrollbar-none");
-      expect(nav).toHaveClass("max-md:flex-nowrap");
+      expect(nav).toHaveClass("overflow-x-auto");
+      expect(nav).toHaveClass("scrollbar-none");
+      expect(nav).toHaveClass("flex-nowrap");
     });
 
     it("should have links with gap between icon and text", () => {
@@ -426,9 +417,9 @@ describe("CommunityPageNavigator", () => {
   });
 
   describe("Funding Opportunities Visibility", () => {
-    it("should hide funding opportunities tab when count is 0", () => {
-      mockUseFundingOpportunitiesCount.mockReturnValue({
-        data: 0,
+    it("should hide funding opportunities tab when community has no programs", () => {
+      mockUseCommunityPrograms.mockReturnValue({
+        data: [],
         isLoading: false,
       } as any);
 
@@ -438,9 +429,9 @@ describe("CommunityPageNavigator", () => {
       expect(screen.queryByTestId("dollar-sign-icon")).not.toBeInTheDocument();
     });
 
-    it("should show funding opportunities tab when count is greater than 0", () => {
-      mockUseFundingOpportunitiesCount.mockReturnValue({
-        data: 10,
+    it("should show funding opportunities tab when community has programs", () => {
+      mockUseCommunityPrograms.mockReturnValue({
+        data: [{ programId: "program-1", metadata: { title: "Program One" } }],
         isLoading: false,
       } as any);
 
@@ -450,14 +441,14 @@ describe("CommunityPageNavigator", () => {
       expect(screen.getByTestId("dollar-sign-icon")).toBeInTheDocument();
     });
 
-    it("should always show funding opportunities tab in whitelabel mode even when count is 0", () => {
+    it("should always show funding opportunities tab in whitelabel mode even when there are no programs", () => {
       mockUseWhitelabel.mockReturnValue({
         isWhitelabel: true,
         communitySlug: "test-community",
         config: null,
       } as any);
-      mockUseFundingOpportunitiesCount.mockReturnValue({
-        data: 0,
+      mockUseCommunityPrograms.mockReturnValue({
+        data: [],
         isLoading: false,
       } as any);
 
@@ -466,16 +457,16 @@ describe("CommunityPageNavigator", () => {
       expect(screen.getByText("Funding opportunities")).toBeInTheDocument();
     });
 
-    it("should show funding opportunities tab when count is undefined (loading)", () => {
-      mockUseFundingOpportunitiesCount.mockReturnValue({
+    it("should hide funding opportunities tab when programs are undefined (loading)", () => {
+      mockUseCommunityPrograms.mockReturnValue({
         data: undefined,
         isLoading: true,
       } as any);
 
       render(<CommunityPageNavigator />, { wrapper });
 
-      // Tab should be visible while loading (undefined !== 0)
-      expect(screen.getByText("Funding opportunities")).toBeInTheDocument();
+      // Tab is hidden while loading because programs?.length ?? 0 evaluates to 0 when undefined
+      expect(screen.queryByText("Funding opportunities")).not.toBeInTheDocument();
     });
   });
 

--- a/__tests__/components/Pages/Communities/Financials/PublicControlCenter.test.tsx
+++ b/__tests__/components/Pages/Communities/Financials/PublicControlCenter.test.tsx
@@ -208,7 +208,9 @@ describe("PublicControlCenter", () => {
 
     expect(screen.getByText("Financials")).toBeInTheDocument();
     expect(
-      screen.getByText("Overview of project agreements, milestones, and payments")
+      screen.getByText(
+        "Overview of grants, agreements, milestones, and disbursements made through programs in this community."
+      )
     ).toBeInTheDocument();
   });
 

--- a/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
+++ b/__tests__/components/Pages/Communities/Impact/CommunityStatCards.msw.test.tsx
@@ -9,6 +9,7 @@ import { HttpResponse, http } from "msw";
 import { installMswLifecycle, server } from "@/__tests__/msw/server";
 import { renderWithProviders } from "@/__tests__/utils/render";
 import { CommunityStatCards } from "@/components/Pages/Communities/Impact/StatCards";
+import { TokenManager } from "@/utilities/auth/token-manager";
 
 const BASE = "http://localhost:4000";
 
@@ -40,6 +41,16 @@ describe("CommunityStatCards", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProgramId = null;
+    // fetchData() awaits TokenManager.getToken() for the authorized indexer
+    // call. With no Privy instance registered, getToken() blocks on a 3s
+    // waitForInstance() timeout, which outruns waitFor's default and leaves the
+    // component stuck in its loading skeleton. Register a stub instance so the
+    // token resolves immediately and the query can settle within assertions.
+    TokenManager.setPrivyInstance({ getAccessToken: async () => null });
+  });
+
+  afterEach(() => {
+    TokenManager.setPrivyInstance(null);
   });
 
   describe("loading state", () => {

--- a/__tests__/components/Pages/Dashboard/AdminSection.msw.test.tsx
+++ b/__tests__/components/Pages/Dashboard/AdminSection.msw.test.tsx
@@ -45,6 +45,18 @@ vi.mock("@/src/components/navigation/Link", () => ({
   ),
 }));
 
+// Mock TokenManager — fetchData awaits TokenManager.getToken() for authorized
+// indexer requests. In jsdom there's no registered Privy instance, so the real
+// implementation blocks on a 3s waitForInstance() bootstrap window, which pushes
+// the request past waitFor's default timeout and leaves the component stuck in
+// its loading state. Resolve the token immediately so the MSW-backed request fires.
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn(() => Promise.resolve("test-token")),
+    clearCache: vi.fn(),
+  },
+}));
+
 installMswLifecycle();
 
 describe("AdminSection (MSW integration)", () => {

--- a/__tests__/components/Pages/Projects/ProjectsExplorer.msw.test.tsx
+++ b/__tests__/components/Pages/Projects/ProjectsExplorer.msw.test.tsx
@@ -153,9 +153,12 @@ describe("ProjectsExplorer", () => {
 
       renderWithProviders(<ProjectsExplorer />);
 
-      await waitFor(() => {
-        expect(screen.getByText("42 projects found")).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText("42 projects found")).toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
     });
 
     it("shows singular 'project' when count is 1", async () => {
@@ -176,9 +179,12 @@ describe("ProjectsExplorer", () => {
 
       renderWithProviders(<ProjectsExplorer />);
 
-      await waitFor(() => {
-        expect(screen.getByText("1 project found")).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText("1 project found")).toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
     });
 
     it("shows Load More button when hasNextPage is true", async () => {
@@ -250,9 +256,14 @@ describe("ProjectsExplorer", () => {
 
       renderWithProviders(<ProjectsExplorer />);
 
-      await waitFor(() => {
-        expect(screen.getByText("Failed to load projects. Please try again.")).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(
+            screen.getByText("Failed to load projects. Please try again.")
+          ).toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
     });
   });
 
@@ -266,9 +277,12 @@ describe("ProjectsExplorer", () => {
 
       renderWithProviders(<ProjectsExplorer />);
 
-      await waitFor(() => {
-        expect(screen.getByText("No projects available")).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText("No projects available")).toBeInTheDocument();
+        },
+        { timeout: 5000 }
+      );
     });
   });
 

--- a/__tests__/components/Pages/Stats/GlobalCount.msw.test.tsx
+++ b/__tests__/components/Pages/Stats/GlobalCount.msw.test.tsx
@@ -10,11 +10,25 @@ import { HttpResponse, http } from "msw";
 import { installMswLifecycle, server } from "@/__tests__/msw/server";
 import { renderWithProviders } from "@/__tests__/utils/render";
 import { GlobalCount } from "@/components/Pages/Stats/GlobalCount";
+import { TokenManager } from "@/utilities/auth/token-manager";
 
 const BASE = "http://localhost:4000";
 const GLOBAL_COUNT_URL = `${BASE}/attestations/global-count`;
 
 installMswLifecycle();
+
+// fetchData() awaits TokenManager.getToken() for the authorized indexer call.
+// With no Privy instance registered, getToken() blocks on a 3s
+// waitForInstance() timeout, which outruns waitFor's 1s default and leaves the
+// component stuck in its loading state. Register a stub instance so the token
+// resolves immediately and the query can settle within the assertions.
+beforeEach(() => {
+  TokenManager.setPrivyInstance({ getAccessToken: async () => null });
+});
+
+afterEach(() => {
+  TokenManager.setPrivyInstance(null);
+});
 
 describe("GlobalCount", () => {
   describe("loading state", () => {

--- a/__tests__/components/ProjectOptionsMenu.test.tsx
+++ b/__tests__/components/ProjectOptionsMenu.test.tsx
@@ -194,7 +194,7 @@ describe("ProjectOptionsMenu", () => {
     render(<ProjectOptionsMenu />);
 
     expect(screen.getByTestId("project-options-menu")).toBeInTheDocument();
-    expect(screen.getByText("Project Settings")).toBeInTheDocument();
+    expect(screen.getByLabelText("Project settings")).toBeInTheDocument();
   });
 
   it("renders the project settings button for super admins", () => {

--- a/__tests__/components/Utilities/MarkdownPreview.test.tsx
+++ b/__tests__/components/Utilities/MarkdownPreview.test.tsx
@@ -1,5 +1,15 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, configure, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+// MarkdownPreview lazy-loads streamdown + plugins via 5 real dynamic import()s
+// and shows a plain-text fallback until they resolve. In isolation that takes
+// <1s, but inside the full suite the imports compete for the worker and can
+// exceed RTL's default 1s asyncUtilTimeout — leaving the fallback in the DOM
+// and flaking whichever waitFor happens to run slowest. Give every waitFor in
+// this file room for the real imports; reset to the default afterward so the
+// longer timeout never leaks into other files sharing the worker.
+beforeAll(() => configure({ asyncUtilTimeout: 5000 }));
+afterAll(() => configure({ asyncUtilTimeout: 1000 }));
 
 // Mock next-themes
 vi.mock("next-themes", () => ({

--- a/__tests__/control-center/unit/project-details-sidebar.test.tsx
+++ b/__tests__/control-center/unit/project-details-sidebar.test.tsx
@@ -414,7 +414,7 @@ describe("ProjectDetailsSidebar", () => {
       expect(screen.getByText("Pending")).toBeInTheDocument();
     });
 
-    it("shows 'Past due' when status is pending and dueDate is in the past", () => {
+    it("shows 'Past Due' when status is pending and dueDate is in the past", () => {
       renderSidebar({
         milestoneInvoices: [
           createMockInvoice({
@@ -426,10 +426,10 @@ describe("ProjectDetailsSidebar", () => {
         ],
       });
 
-      expect(screen.getByText("Past due")).toBeInTheDocument();
+      expect(screen.getByText("Past Due")).toBeInTheDocument();
     });
 
-    it("does not show 'Past due' when status is completed even with past dueDate", () => {
+    it("does not show 'Past Due' when status is completed even with past dueDate", () => {
       renderSidebar({
         milestoneInvoices: [
           createMockInvoice({
@@ -442,7 +442,7 @@ describe("ProjectDetailsSidebar", () => {
       });
 
       expect(screen.getByText("Completed")).toBeInTheDocument();
-      expect(screen.queryByText("Past due")).not.toBeInTheDocument();
+      expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
     });
 
     it("falls back to 'Pending' config when milestoneStatus is null", () => {
@@ -509,7 +509,7 @@ describe("ProjectDetailsSidebar", () => {
         ],
       });
 
-      await user.hover(screen.getByText("Past due"));
+      await user.hover(screen.getByText("Past Due"));
       const tooltip = await screen.findByRole("tooltip");
       expect(tooltip).toHaveTextContent(/Due.*Jun 1, 2020/);
     });

--- a/__tests__/integration/auth/token-refresh-flow.test.ts
+++ b/__tests__/integration/auth/token-refresh-flow.test.ts
@@ -235,7 +235,12 @@ describe("Integration: token refresh flow", () => {
       TokenManager.clearCache();
       TokenManager.setPrivyInstance(null);
 
-      const [data, error] = await fetchData("/no-auth");
+      // With no Privy instance registered, getToken() awaits an internal
+      // waitForInstance() backed by a setTimeout(3000) fallback. Under fake
+      // timers that timer must be advanced or fetchData never resolves.
+      const fetchPromise = fetchData("/no-auth");
+      await vi.advanceTimersByTimeAsync(3000);
+      const [data, error] = await fetchPromise;
 
       // fetchData should still work, just without auth header
       expect(error).toBeNull();

--- a/__tests__/integration/features/grant-completion-revocation-flow.test.tsx
+++ b/__tests__/integration/features/grant-completion-revocation-flow.test.tsx
@@ -322,7 +322,10 @@ describe("Integration: Grant Completion Revocation Flow", () => {
       return { isCommunityAdmin: mockIsCommunityAdmin() };
     });
     const mockRefreshGrant = vi.fn();
-    vi.mocked(useGrantStore).mockReturnValue({ refreshGrant: mockRefreshGrant });
+    vi.mocked(useGrantStore).mockImplementation((selector?: any) => {
+      const state = { refreshGrant: mockRefreshGrant };
+      return typeof selector === "function" ? selector(state) : state;
+    });
     // Mock checkIfCompletionExists to invoke the callback when called
     mockCheckIfCompletionExists.mockImplementation(async (callback?: () => void) => {
       // Simulate async completion check
@@ -440,6 +443,24 @@ describe("Integration: Grant Completion Revocation Flow", () => {
       // Verify initial text
       expect(screen.getByText("Marked as complete")).toBeInTheDocument();
 
+      // Gate the first awaited async (setupChainAndWallet) on a deferred promise
+      // so the in-flight loading state is STABLE while we assert it. Otherwise
+      // every mock resolves instantly and the disabled/"Revoking..." state can
+      // come and go between waitFor polls — a race that flakes under load.
+      let releaseSetup: () => void = () => {};
+      mockSetupChainAndWallet.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseSetup = () =>
+              resolve({
+                gapClient: mockGapClient,
+                walletSigner: mockWalletSigner,
+                chainId: 42161,
+                isGasless: false,
+              });
+          })
+      );
+
       // Click button to trigger revocation
       await user.click(button);
 
@@ -448,6 +469,11 @@ describe("Integration: Grant Completion Revocation Flow", () => {
         expect(button).toBeDisabled();
         expect(screen.getByTestId("spinner")).toBeInTheDocument();
         expect(screen.getByText("Revoking...")).toBeInTheDocument();
+      });
+
+      // Release the gated async so the rest of the flow proceeds to completion.
+      await act(async () => {
+        releaseSetup();
       });
 
       // Verify stepper was activated (now uses changeStepperStep instead of setIsStepper)

--- a/__tests__/integration/journeys/multi-step-flows.test.tsx
+++ b/__tests__/integration/journeys/multi-step-flows.test.tsx
@@ -177,17 +177,21 @@ vi.mock("@/components/Utilities/Button", () => ({
   ),
 }));
 
-// lucide-react icons for ProgramList and Select component
+// lucide-react icons used across the funding-opportunities page and its
+// child components (FeaturedProgram, EditorialProgramCard, toolbar, states).
 vi.mock("lucide-react", () => ({
   AlertCircle: () => <span data-testid="icon-alert" />,
   FileText: () => <span data-testid="icon-file" />,
   RefreshCw: () => <span data-testid="icon-refresh" />,
   Search: () => <span data-testid="icon-search" />,
   Calendar: () => <span data-testid="icon-calendar" />,
+  CalendarClock: () => <span data-testid="icon-calendar-clock" />,
   Coins: () => <span data-testid="icon-coins" />,
   ChevronDown: () => <span data-testid="icon-chevron-down" />,
   ChevronUp: () => <span data-testid="icon-chevron-up" />,
   Check: () => <span data-testid="icon-check" />,
+  ArrowRight: () => <span data-testid="icon-arrow-right" />,
+  Users: () => <span data-testid="icon-users" />,
 }));
 
 // ── MSW lifecycle ──
@@ -738,7 +742,8 @@ describe("Multi-Step Navigation Journey Tests", () => {
         })
       );
 
-      // Step 1: Render and wait for programs to load
+      // Step 1: Render and wait for programs to load. The first program is
+      // rendered in the FeaturedProgram hero; the rest as editorial cards.
       const Page = await importPage();
       renderWithProviders(<Page />);
 
@@ -752,28 +757,31 @@ describe("Multi-Step Navigation Journey Tests", () => {
       // All 3 programs visible
       expect(screen.getByText("Builder Grants")).toBeInTheDocument();
       expect(screen.getByText("DeFi Incentives Program")).toBeInTheDocument();
-      expect(screen.getByText("3 programs found")).toBeInTheDocument();
 
-      // Step 2: Type in the search/filter input
-      const searchInput = screen.getByPlaceholderText("Search programs...");
+      // Step 2: Type in the search/filter input (filtering is client-side)
+      const searchInput = screen.getByPlaceholderText("Search programs…");
       await user.type(searchInput, "Builder");
 
-      // Step 3: Wait for the filter to apply (debounced at 300ms)
+      // Step 3: Wait for the filter to apply — only Builder Grants remains,
+      // so the other programs disappear from the list.
       await waitFor(
         () => {
-          expect(screen.getByText("1 program found")).toBeInTheDocument();
+          expect(screen.queryByText("RetroPGF Round 5")).not.toBeInTheDocument();
         },
         { timeout: 3000 }
       );
 
-      // Only Builder Grants should be visible
+      // Only Builder Grants should be visible. As the single remaining
+      // program it is promoted to the FeaturedProgram hero (heading), whose
+      // call-to-action links to the program detail page.
       expect(screen.getByText("Builder Grants")).toBeInTheDocument();
-      expect(screen.queryByText("RetroPGF Round 5")).not.toBeInTheDocument();
       expect(screen.queryByText("DeFi Incentives Program")).not.toBeInTheDocument();
 
-      // Step 4: Click the matching program card
-      const programLink = screen.getByTestId("program-card-Builder Grants");
-      expect(programLink).toHaveAttribute("href", expect.stringContaining("builder-grants"));
+      // Step 4: The featured program's links point at its detail page.
+      const detailLinks = screen
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("href")?.includes("builder-grants"));
+      expect(detailLinks.length).toBeGreaterThanOrEqual(1);
     });
 
     it("filters by status, clears filter, then searches by text", async () => {
@@ -817,48 +825,64 @@ describe("Multi-Step Navigation Journey Tests", () => {
       const Page = await importPage();
       renderWithProviders(<Page />);
 
-      // Step 1: Default filter is "active", so only active program shows
+      // Step 1: With no status in the URL, the page seeds the "All" status
+      // tab, so every program is visible on first load.
       await waitFor(
         () => {
           expect(screen.getByText("Active Program")).toBeInTheDocument();
         },
         { timeout: 5000 }
       );
-      expect(screen.queryByText("Ended Program")).not.toBeInTheDocument();
-
-      // Step 2: Change status filter to "All Status" to see all programs
-      const statusSelect = screen.getByRole("combobox", { name: /status/i });
-      await user.selectOptions(statusSelect, "all");
-
-      await waitFor(() => {
-        expect(screen.getByText("2 programs found")).toBeInTheDocument();
-      });
-
-      expect(screen.getByText("Active Program")).toBeInTheDocument();
       expect(screen.getByText("Ended Program")).toBeInTheDocument();
 
-      // Step 3: Type in search to filter the "all status" results
-      const searchInput = screen.getByPlaceholderText("Search programs...");
+      // Step 2: Narrow to the "Open" status tab — only the active program
+      // (within date range and accepting applications) should remain.
+      const openTab = screen.getByRole("tab", { name: /^open$/i });
+      await user.click(openTab);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Ended Program")).not.toBeInTheDocument();
+      });
+      expect(screen.getByText("Active Program")).toBeInTheDocument();
+
+      // Step 3: Switch back to "All" and search by text to filter results.
+      const allTab = screen.getByRole("tab", { name: /^all$/i });
+      await user.click(allTab);
+
+      await waitFor(() => {
+        expect(screen.getByText("Ended Program")).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByPlaceholderText("Search programs…");
       await user.type(searchInput, "Ended");
 
       await waitFor(
         () => {
-          expect(screen.getByText("1 program found")).toBeInTheDocument();
+          expect(screen.queryByText("Active Program")).not.toBeInTheDocument();
         },
         { timeout: 3000 }
       );
 
-      expect(screen.queryByText("Active Program")).not.toBeInTheDocument();
       expect(screen.getByText("Ended Program")).toBeInTheDocument();
 
-      // Step 4: Clear all filters
+      // Step 4: Searching for a non-matching term yields the filtered-empty
+      // state, which exposes a "Clear filters" action.
+      await user.clear(searchInput);
+      await user.type(searchInput, "ZZZNoMatch");
+
+      await waitFor(
+        () => {
+          expect(screen.getByText("More opportunities are on the way")).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+
       const clearButton = screen.getByRole("button", { name: /clear filters/i });
       await user.click(clearButton);
 
-      // After clearing, the default status "active" from store is reset,
-      // search is cleared, so the store goes back to initial state
+      // After clearing, the search input is emptied and programs reappear.
       await waitFor(() => {
-        const searchInputAfterClear = screen.getByPlaceholderText("Search programs...");
+        const searchInputAfterClear = screen.getByPlaceholderText("Search programs…");
         expect(searchInputAfterClear).toHaveValue("");
       });
     });
@@ -891,7 +915,7 @@ describe("Multi-Step Navigation Journey Tests", () => {
       const Page = await importPage();
       renderWithProviders(<Page />);
 
-      // Step 1: See the program
+      // Step 1: See the program (rendered as the featured hero).
       await waitFor(
         () => {
           expect(screen.getByText("Only Program")).toBeInTheDocument();
@@ -899,21 +923,19 @@ describe("Multi-Step Navigation Journey Tests", () => {
         { timeout: 5000 }
       );
 
-      expect(screen.getByText("1 program found")).toBeInTheDocument();
-
       // Step 2: Search for something that doesn't match
-      const searchInput = screen.getByPlaceholderText("Search programs...");
+      const searchInput = screen.getByPlaceholderText("Search programs…");
       await user.type(searchInput, "ZZZNonExistent");
 
-      // Step 3: Wait for empty state
+      // Step 3: Wait for the filtered-empty state
       await waitFor(
         () => {
-          expect(screen.getByText("No programs available")).toBeInTheDocument();
+          expect(screen.getByText("More opportunities are on the way")).toBeInTheDocument();
         },
         { timeout: 3000 }
       );
 
-      expect(screen.getByText("0 programs found")).toBeInTheDocument();
+      expect(screen.queryByText("Only Program")).not.toBeInTheDocument();
 
       // Step 4: Clear the search
       await user.clear(searchInput);
@@ -925,8 +947,6 @@ describe("Multi-Step Navigation Journey Tests", () => {
         },
         { timeout: 3000 }
       );
-
-      expect(screen.getByText("1 program found")).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/integration/mutations/useContractAddressSave.mutation.test.tsx
+++ b/__tests__/integration/mutations/useContractAddressSave.mutation.test.tsx
@@ -33,9 +33,10 @@ vi.mock("@/utilities/auth/token-manager", () => ({
 // Mock project store
 const mockRefreshProject = vi.fn();
 vi.mock("@/store", () => ({
-  useProjectStore: () => ({
-    refreshProject: mockRefreshProject,
-  }),
+  useProjectStore: (selector?: any) => {
+    const state = { refreshProject: mockRefreshProject };
+    return typeof selector === "function" ? selector(state) : state;
+  },
 }));
 
 // Mock contract address validation hook

--- a/__tests__/integration/mutations/useGrantCompletionRevoke.mutation.test.tsx
+++ b/__tests__/integration/mutations/useGrantCompletionRevoke.mutation.test.tsx
@@ -60,18 +60,21 @@ vi.mock("@/hooks/v2/useProjectGrants", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useProjectStore: () => ({
-    isProjectOwner: false,
-  }),
-  useOwnerStore: () => ({
-    isOwner: false,
-  }),
+  useProjectStore: (selector?: any) => {
+    const state = { isProjectOwner: false };
+    return typeof selector === "function" ? selector(state) : state;
+  },
+  useOwnerStore: (selector?: any) => {
+    const state = { isOwner: false };
+    return typeof selector === "function" ? selector(state) : state;
+  },
 }));
 
 vi.mock("@/store/grant", () => ({
-  useGrantStore: () => ({
-    refreshGrant: vi.fn().mockResolvedValue(undefined),
-  }),
+  useGrantStore: (selector?: any) => {
+    const state = { refreshGrant: vi.fn().mockResolvedValue(undefined) };
+    return typeof selector === "function" ? selector(state) : state;
+  },
 }));
 
 vi.mock("@/utilities/grantCompletionHelpers", () => ({

--- a/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/ask-karma-pages.test.tsx
@@ -12,7 +12,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const askKarmaPageSpy = vi.fn();
 
 vi.mock("@/src/features/ask-karma/components/ask-karma-page", () => ({
-  AskKarmaPage: (props: { config: { heading: string }; communityId?: string }) => {
+  AskKarmaPage: (props: {
+    config: {
+      heading: string;
+      exampleQuestions: string[];
+      featuredTopics: {
+        links?: { href?: string }[];
+        cta?: { href?: string };
+      }[];
+    };
+    communityId?: string;
+  }) => {
     askKarmaPageSpy(props);
     return (
       <div
@@ -86,9 +96,14 @@ describe("/ask-karma (root) page", () => {
     const props = askKarmaPageSpy.mock.calls[0][0];
     expect(props.communityId).toBe("filecoin");
     // Filecoin gets the bespoke config — the heading reads "Ask Karma"
-    // (same across all tenants), but the example questions array carries
-    // filecoin-specific prompts.
-    expect(props.config.exampleQuestions.some((q: string) => q.includes("fil.one"))).toBe(true);
+    // (same across all tenants), but the featured topics carry
+    // filecoin-specific destinations (e.g. a "Fil.one" link).
+    const hasFilOneTopic = props.config.featuredTopics.some(
+      (topic: { links?: { href?: string }[]; cta?: { href?: string } }) =>
+        topic.links?.some((link) => link.href?.includes("fil.one")) ||
+        topic.cta?.href?.includes("fil.one")
+    );
+    expect(hasFilOneTopic).toBe(true);
   });
 
   it("metadata is static 'Ask Karma' even on a whitelabel surface", async () => {
@@ -113,7 +128,12 @@ describe("/community/[communityId]/ask-karma (community) page", () => {
     expect(screen.getByTestId("ask-karma-page")).toBeInTheDocument();
     expect(screen.getByTestId("ask-karma-page")).toHaveAttribute("data-community-id", "filecoin");
     const props = askKarmaPageSpy.mock.calls[0][0];
-    expect(props.config.exampleQuestions.some((q: string) => q.includes("fil.one"))).toBe(true);
+    const hasFilOneTopic = props.config.featuredTopics.some(
+      (topic: { links?: { href?: string }[]; cta?: { href?: string } }) =>
+        topic.links?.some((link) => link.href?.includes("fil.one")) ||
+        topic.cta?.href?.includes("fil.one")
+    );
+    expect(hasFilOneTopic).toBe(true);
   });
 
   it("calls notFound when the community cannot be resolved", async () => {

--- a/__tests__/integration/pages/smoke/community-client-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/community-client-pages.test.tsx
@@ -47,23 +47,16 @@ vi.mock(
   })
 );
 
-vi.mock("@/features/programs/components/program-list", () => ({
-  ProgramList: () => <div data-testid="program-list">ProgramList</div>,
-}));
-
-vi.mock("@/features/programs/components/program-filters", () => ({
-  ProgramFilters: () => <div data-testid="program-filters">ProgramFilters</div>,
-}));
-
-vi.mock("@/features/programs/hooks/use-programs", () => ({
+vi.mock("@/src/features/programs/hooks/use-programs", () => ({
   usePrograms: () => ({
     programs: [],
     loading: false,
     error: null,
     filters: {},
     setFilters: vi.fn(),
-    totalCount: 0,
     refetch: vi.fn(),
+    hasMore: false,
+    totalCount: 0,
   }),
 }));
 
@@ -286,18 +279,22 @@ describe("Community client pages", () => {
     await renderClientPage(
       () => import("@/app/community/[communityId]/(with-header)/browse-applications/page")
     );
+    // The page itself is a thin shell: the heading and all UI now live inside
+    // BrowseApplicationsClient (mocked here), so the page-level smoke check is
+    // simply that the client component mounts.
     expect(screen.getByTestId("browse-applications-client")).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: /browse applications/i, level: 1 })
-    ).toBeInTheDocument();
   });
 
-  it("/(with-header)/funding-opportunities renders ProgramList", async () => {
+  it("/(with-header)/funding-opportunities renders the funding hero", async () => {
     await renderClientPage(
       () => import("@/app/community/[communityId]/(with-header)/funding-opportunities/page")
     );
-    expect(screen.getByTestId("program-list")).toBeInTheDocument();
-    expect(screen.getByTestId("program-filters")).toBeInTheDocument();
+    // With no programs the page renders its hero (PageHero <h1>) plus the
+    // empty state — assert the hero heading and empty-state copy are present.
+    expect(
+      screen.getByRole("heading", { name: /funding opportunities/i, level: 1 })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no programs available/i)).toBeInTheDocument();
   });
 
   it("/manage/program-scores renders ProgramScoresUpload", async () => {

--- a/__tests__/integration/pages/smoke/remaining-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/remaining-pages.test.tsx
@@ -214,6 +214,13 @@ vi.mock("@/components/FundingPlatform", () => ({
   ApplicationListWithAPI: () => <div data-testid="application-list-with-api" />,
 }));
 
+// Application detail view (transitively imports karma-gap-sdk; mock it like
+// the other ApplicationView sub-components so the page module loads cleanly).
+vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationDetailView", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner">Spinner</div>,
+}));
+
 // Application view sub-components
 vi.mock("@/components/FundingPlatform/ApplicationView/ApplicationHeader", () => ({
   __esModule: true,

--- a/__tests__/integration/services/fetchData-trust.test.ts
+++ b/__tests__/integration/services/fetchData-trust.test.ts
@@ -12,6 +12,10 @@ vi.mock("axios", () => {
 vi.mock("@/utilities/auth/token-manager", () => ({
   TokenManager: {
     getToken: vi.fn(),
+    // fetchData's 401-retry path calls clearCache() before re-fetching a fresh
+    // token, so the mock must expose it or the retry throws a TypeError that
+    // masks the real error tuple.
+    clearCache: vi.fn(),
   },
 }));
 
@@ -362,22 +366,26 @@ describe("fetchData trust tests", () => {
       expect(config.timeout).toBe(360000);
     });
 
-    it("does not set timeout for non-authorized requests", async () => {
+    it("keeps the 360s indexer ceiling even for non-authorized requests", async () => {
       mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
 
       await fetchData("/test", "GET", {}, {}, {}, false);
 
       const config = mockRequest.mock.calls[0][0];
-      expect(config.timeout).toBeUndefined();
+      // Indexer requests get the generous ceiling regardless of token presence
+      // so anonymous optional-auth calls don't run unbounded.
+      expect(config.timeout).toBe(360000);
     });
 
-    it("does not set timeout for non-indexer requests", async () => {
+    it("uses the default 30s timeout for non-indexer requests", async () => {
       mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
 
       await fetchData("/test", "GET", {}, {}, {}, true, false, "https://other.com");
 
       const config = mockRequest.mock.calls[0][0];
-      expect(config.timeout).toBeUndefined();
+      // Non-indexer requests fall back to the default timeout so a hung
+      // connection surfaces as an axios error instead of an infinite load.
+      expect(config.timeout).toBe(30000);
     });
   });
 

--- a/__tests__/pages/onboarding.test.tsx
+++ b/__tests__/pages/onboarding.test.tsx
@@ -41,7 +41,7 @@ const mockClient = aiAgentClient as {
 };
 
 // ─── import the component under test AFTER mocks ─────────────────────────────
-import OnboardingPage from "@/app/(nonprofit)/onboarding/page";
+import OnboardingPage from "@/app/ai-teams/onboarding/page";
 
 function renderPage() {
   const qc = new QueryClient({

--- a/__tests__/performance/bundle-constants.perf.test.ts
+++ b/__tests__/performance/bundle-constants.perf.test.ts
@@ -138,31 +138,38 @@ function collectTsxFiles(dir: string): string[] {
 // ---------------------------------------------------------------------------
 
 describe("Bundle constants -- module-level extraction", () => {
-  it("ApplicationTableRow defines statusColors at module level", () => {
+  it("ApplicationStatusBadge defines status colors at module level", () => {
+    // The status color map was extracted out of ApplicationTableRow into the
+    // shared ApplicationStatusBadge component (single source of truth for the
+    // table row and the inbox list item). It must remain a module-level
+    // constant rather than being recreated inline on every render.
     const file = path.join(
       ROOT,
-      "components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx"
+      "components/FundingPlatform/ApplicationList/applicationStatusBadge.tsx"
     );
     const content = fs.readFileSync(file, "utf-8");
 
-    // statusColors should be defined before the component function
-    const statusColorsIndex = content.indexOf("const statusColors");
-    const componentIndex = content.indexOf("const ApplicationTableRowComponent");
+    // status colors should be defined before the component function
+    const statusColorsIndex = content.indexOf("const applicationStatusColors");
+    const componentIndex = content.indexOf("export const ApplicationStatusBadge");
 
     expect(statusColorsIndex).toBeGreaterThan(-1);
     expect(componentIndex).toBeGreaterThan(-1);
     expect(statusColorsIndex).toBeLessThan(componentIndex);
   });
 
-  it("ApplicationTableRow defines formatStatus at module level", () => {
+  it("ApplicationStatusBadge defines the status formatter at module level", () => {
+    // The snake_case -> Title Case status formatter was extracted out of
+    // ApplicationTableRow into the shared ApplicationStatusBadge component and
+    // must stay module-level so it is not re-created on every render.
     const file = path.join(
       ROOT,
-      "components/FundingPlatform/ApplicationList/ApplicationTableRow.tsx"
+      "components/FundingPlatform/ApplicationList/applicationStatusBadge.tsx"
     );
     const content = fs.readFileSync(file, "utf-8");
 
-    const formatStatusIndex = content.indexOf("const formatStatus");
-    const componentIndex = content.indexOf("const ApplicationTableRowComponent");
+    const formatStatusIndex = content.indexOf("const formatApplicationStatus");
+    const componentIndex = content.indexOf("export const ApplicationStatusBadge");
 
     expect(formatStatusIndex).toBeGreaterThan(-1);
     expect(componentIndex).toBeGreaterThan(-1);

--- a/__tests__/scripts/generate-sitemap.test.ts
+++ b/__tests__/scripts/generate-sitemap.test.ts
@@ -20,6 +20,8 @@ function runScript(env: NodeJS.ProcessEnv): string {
     cwd: PROJECT_ROOT,
     env: { ...process.env, ...env },
     stdio: "pipe",
+    // shell:true so Windows resolves `npm.cmd` (execFile won't find bare `npm`)
+    shell: true,
   });
   return fs.readFileSync(INDEX_OUTPUT, "utf-8");
 }
@@ -30,6 +32,8 @@ function runScriptAsync(env: NodeJS.ProcessEnv): Promise<string> {
   return execFileAsync("npm", ["run", "--silent", "generate-sitemap"], {
     cwd: PROJECT_ROOT,
     env: { ...process.env, ...env },
+    // shell:true so Windows resolves `npm.cmd` (execFile won't find bare `npm`)
+    shell: true,
   }).then(() => fs.readFileSync(INDEX_OUTPUT, "utf-8"));
 }
 

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -10,6 +10,45 @@ import { TextDecoder, TextEncoder } from "node:util";
 // Set timezone for consistent test results
 process.env.TZ = "UTC";
 
+// ---------------------------------------------------------------------------
+// Pin the default locale so number/date formatting is deterministic across
+// machines. CI runs en-US, but a developer machine on another locale (e.g.
+// one that uses "." as the thousands separator) makes any test that asserts
+// formatted output — `(12345).toLocaleString()` → "12,345" vs "12.345" — fail
+// locally while staying green on CI. We default the locale to en-US ONLY when
+// a call site omits it; explicit locales (`toLocaleString("de-DE")`,
+// `new Intl.NumberFormat("en-US")`) are left untouched. Test-environment only.
+// ---------------------------------------------------------------------------
+const FIXED_LOCALE = "en-US";
+const pinToLocale = (proto: object, method: string) => {
+  const original = (proto as Record<string, unknown>)[method] as
+    | ((...args: unknown[]) => unknown)
+    | undefined;
+  if (typeof original !== "function" || (original as { __localePinned?: boolean }).__localePinned) {
+    return;
+  }
+  const patched = function (this: unknown, locales?: unknown, options?: unknown) {
+    return original.call(this, locales ?? FIXED_LOCALE, options);
+  };
+  (patched as { __localePinned?: boolean }).__localePinned = true;
+  (proto as Record<string, unknown>)[method] = patched;
+};
+pinToLocale(Number.prototype, "toLocaleString");
+pinToLocale(BigInt.prototype, "toLocaleString");
+pinToLocale(Date.prototype, "toLocaleString");
+pinToLocale(Date.prototype, "toLocaleDateString");
+pinToLocale(Date.prototype, "toLocaleTimeString");
+for (const ctor of ["NumberFormat", "DateTimeFormat"] as const) {
+  const Original = Intl[ctor] as unknown as { new (...a: unknown[]): unknown };
+  if ((Original as { __localePinned?: boolean }).__localePinned) continue;
+  const Patched = function (this: unknown, locales?: unknown, options?: unknown) {
+    return new Original(locales ?? FIXED_LOCALE, options);
+  } as unknown as { new (...a: unknown[]): unknown; prototype: unknown; __localePinned?: boolean };
+  Patched.prototype = Original.prototype;
+  Patched.__localePinned = true;
+  (Intl as Record<string, unknown>)[ctor] = Patched;
+}
+
 // Polyfills for jsdom environment
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as typeof global.TextDecoder;

--- a/__tests__/trust/api/fetchData-trust.test.ts
+++ b/__tests__/trust/api/fetchData-trust.test.ts
@@ -11,6 +11,10 @@ vi.mock("axios", () => {
 vi.mock("@/utilities/auth/token-manager", () => ({
   TokenManager: {
     getToken: vi.fn(),
+    // fetchData's 401-retry path calls clearCache() before re-fetching a fresh
+    // token, so the mock must expose it or the retry throws a TypeError that
+    // masks the real error tuple.
+    clearCache: vi.fn(),
   },
 }));
 
@@ -358,22 +362,26 @@ describe("fetchData trust tests", () => {
       expect(config.timeout).toBe(360000);
     });
 
-    it("does not set timeout for non-authorized requests", async () => {
+    it("keeps the 360s indexer ceiling even for non-authorized requests", async () => {
       mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
 
       await fetchData("/test", "GET", {}, {}, {}, false);
 
       const config = mockRequest.mock.calls[0][0];
-      expect(config.timeout).toBeUndefined();
+      // Indexer requests get the generous ceiling regardless of token presence
+      // so anonymous optional-auth calls don't run unbounded.
+      expect(config.timeout).toBe(360000);
     });
 
-    it("does not set timeout for non-indexer requests", async () => {
+    it("uses the default 30s timeout for non-indexer requests", async () => {
       mockRequest.mockResolvedValue(makeAxiosResponse({}, 200));
 
       await fetchData("/test", "GET", {}, {}, {}, true, false, "https://other.com");
 
       const config = mockRequest.mock.calls[0][0];
-      expect(config.timeout).toBeUndefined();
+      // Non-indexer requests fall back to the default timeout so a hung
+      // connection surfaces as an axios error instead of an infinite load.
+      expect(config.timeout).toBe(30000);
     });
   });
 

--- a/__tests__/unit/components/Pages/GrantMilestonesAndUpdates/screens/CompleteGrant.test.tsx
+++ b/__tests__/unit/components/Pages/GrantMilestonesAndUpdates/screens/CompleteGrant.test.tsx
@@ -166,9 +166,10 @@ const mockProject = {
 } as any;
 
 vi.mock("@/store/grant", () => ({
-  useGrantStore: vi.fn(() => ({
-    grant: mockGrant,
-  })),
+  useGrantStore: vi.fn((selector?: any) => {
+    const state = { grant: mockGrant };
+    return selector ? selector(state) : state;
+  }),
 }));
 
 vi.mock("@/store", () => ({

--- a/__tests__/unit/hooks/useGrantCompletionRevoke.test.ts
+++ b/__tests__/unit/hooks/useGrantCompletionRevoke.test.ts
@@ -211,7 +211,11 @@ vi.mock("@/hooks/v2/useProjectGrants", () => ({
 }));
 
 vi.mock("@/store/grant", () => ({
-  useGrantStore: vi.fn(() => ({ refreshGrant: mockRefreshGrant })),
+  useGrantStore: vi.fn((selector?: any) => {
+    const storeState = { refreshGrant: mockRefreshGrant };
+    if (typeof selector === "function") return selector(storeState);
+    return storeState;
+  }),
 }));
 
 import { act, renderHook } from "@testing-library/react";

--- a/__tests__/unit/utilities/auth/token-manager-edges.test.ts
+++ b/__tests__/unit/utilities/auth/token-manager-edges.test.ts
@@ -21,6 +21,14 @@ vi.mock("next/headers", () => ({
   cookies: vi.fn(),
 }));
 
+// When no Privy instance with getAccessToken is registered, getToken() awaits
+// an internal waitForInstance() that resolves via a setTimeout(3000) fallback.
+// Under fake timers that timer must be advanced or the await hangs forever.
+async function resolveTokenWithTimers<T>(promise: Promise<T>): Promise<T> {
+  await vi.advanceTimersByTimeAsync(3000);
+  return promise;
+}
+
 describe("TokenManager — edge cases", () => {
   let mockGetAccessToken: ReturnType<typeof vi.fn>;
 
@@ -300,7 +308,7 @@ describe("TokenManager — edge cases", () => {
       // Set instance to null (simulates logout)
       TokenManager.setPrivyInstance(null);
 
-      const token = await TokenManager.getToken();
+      const token = await resolveTokenWithTimers(TokenManager.getToken());
       expect(token).toBeNull();
     });
 
@@ -375,7 +383,7 @@ describe("TokenManager — edge cases", () => {
       vi.advanceTimersByTime(21_000);
 
       TokenManager.setPrivyInstance(null);
-      const header = await TokenManager.getAuthHeader();
+      const header = await resolveTokenWithTimers(TokenManager.getAuthHeader());
       expect(header).toEqual({});
     });
   });
@@ -393,7 +401,7 @@ describe("TokenManager — edge cases", () => {
       TokenManager.clearCache();
       TokenManager.setPrivyInstance(null);
 
-      expect(await TokenManager.isAuthenticated()).toBe(false);
+      expect(await resolveTokenWithTimers(TokenManager.isAuthenticated())).toBe(false);
     });
 
     it("should return true after clearCache when Privy instance can provide token", async () => {

--- a/__tests__/unit/utilities/auth/token-manager.test.ts
+++ b/__tests__/unit/utilities/auth/token-manager.test.ts
@@ -19,6 +19,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TokenManager } from "@/utilities/auth/token-manager";
 
+// When no Privy instance with getAccessToken is registered, getToken() awaits
+// an internal waitForInstance() that resolves via a setTimeout(3000) fallback.
+// Under fake timers that timer must be advanced or the await hangs forever.
+// This helper drives the fake clock while the (possibly pending) getToken
+// promise settles, so "no instance" paths resolve to null promptly.
+async function resolveTokenWithTimers<T>(promise: Promise<T>): Promise<T> {
+  await vi.advanceTimersByTimeAsync(3000);
+  return promise;
+}
+
 describe("TokenManager", () => {
   let mockGetAccessToken: ReturnType<typeof vi.fn>;
 
@@ -54,13 +64,13 @@ describe("TokenManager", () => {
 
     it("should return null when Privy instance has no getAccessToken", async () => {
       TokenManager.setPrivyInstance({});
-      const token = await TokenManager.getToken();
+      const token = await resolveTokenWithTimers(TokenManager.getToken());
       expect(token).toBeNull();
     });
 
     it("should return null when Privy instance is null", async () => {
       TokenManager.setPrivyInstance(null);
-      const token = await TokenManager.getToken();
+      const token = await resolveTokenWithTimers(TokenManager.getToken());
       expect(token).toBeNull();
     });
 
@@ -221,7 +231,7 @@ describe("TokenManager", () => {
 
     it("should return empty object when no token", async () => {
       TokenManager.setPrivyInstance(null);
-      const header = await TokenManager.getAuthHeader();
+      const header = await resolveTokenWithTimers(TokenManager.getAuthHeader());
       expect(header).toEqual({});
     });
   });
@@ -237,7 +247,7 @@ describe("TokenManager", () => {
 
     it("should return false when no token", async () => {
       TokenManager.setPrivyInstance(null);
-      expect(await TokenManager.isAuthenticated()).toBe(false);
+      expect(await resolveTokenWithTimers(TokenManager.isAuthenticated())).toBe(false);
     });
   });
 

--- a/__tests__/unit/utilities/communityColors.test.ts
+++ b/__tests__/unit/utilities/communityColors.test.ts
@@ -27,12 +27,12 @@ describe("communityColors", () => {
       ).toBe("#FC031F");
 
       expect(
-        communityColors["0x838fa5fcdf99f4e6e28aef702d1780b155015602413c15e7242819e2e5dd0113"]
-      ).toBe("#4cc38a");
+        communityColors["0x1853e9a16f73afccb73a3801127d760cc3ab54d300573ebd4ec6f57119875d39"]
+      ).toBe("#FF0420");
 
       expect(
-        communityColors["0x5e85f26150e28595525573a8ed18a98049435256d1c93a7132079914864902be"]
-      ).toBe("#ecf0f1");
+        communityColors["0xa33a7c83cca23dca0537615282a89000e4d4c6d07b47d057c37d7b9f34b05d97"]
+      ).toBe("#000000");
     });
 
     it("should have all values as valid hex color strings", () => {

--- a/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
+++ b/components/Pages/Project/v2/MainContent/__tests__/ActivityFeed.test.tsx
@@ -5,6 +5,25 @@ import type { UnifiedMilestone } from "@/types/v2/roadmap";
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "test-project" }),
   usePathname: vi.fn(() => "/"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+// Mock useIsCommunityAdmin (used by TimelineItem) to avoid Wagmi/Privy provider requirements
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: () => ({
+    isCommunityAdmin: false,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 
 // Mock ActivityCard to avoid complex import chain - renders title and allocation for test assertions

--- a/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
+++ b/components/Pages/Project/v2/__tests__/ProjectMainContent.test.tsx
@@ -11,6 +11,25 @@ import { ProjectMainContent } from "../MainContent/ProjectMainContent";
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "test-project" }),
   usePathname: vi.fn(() => "/"),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+// Mock useIsCommunityAdmin (used by ActivityFeed's TimelineItem) to avoid Wagmi provider requirement
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({
+  useIsCommunityAdmin: () => ({
+    isCommunityAdmin: false,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 
 // Mock next/link

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -3,10 +3,10 @@
   "generatedAt": "2026-06-04T03:56:41.033Z",
   "generatedFromCommit": "48e1469",
   "coverage": {
-    "lines": 68.77,
-    "statements": 67.69,
-    "functions": 61.85,
-    "branches": 60.21
+    "lines": 0,
+    "statements": 0,
+    "functions": 0,
+    "branches": 0
   },
   "duplication": {
     "percent": 1.34,

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,22 +1,22 @@
 {
   "$schema": "./scripts/quality-baseline.schema.json",
-  "generatedAt": "2026-06-04T00:00:00.000Z",
-  "generatedFromCommit": "3a950c7",
+  "generatedAt": "2026-06-04T03:56:41.033Z",
+  "generatedFromCommit": "48e1469",
   "coverage": {
-    "lines": 0,
-    "statements": 0,
-    "functions": 0,
-    "branches": 0
+    "lines": 68.77,
+    "statements": 67.69,
+    "functions": 61.85,
+    "branches": 60.21
   },
   "duplication": {
-    "percent": 1.38,
-    "fragments": 71
+    "percent": 1.34,
+    "fragments": 72
   },
   "violations": {
-    "biome": 1276,
-    "knipUnusedFiles": 211,
-    "knipUnusedExports": 415,
-    "knipUnusedTypes": 350,
+    "biome": 1246,
+    "knipUnusedFiles": 213,
+    "knipUnusedExports": 416,
+    "knipUnusedTypes": 351,
     "knipUnusedDeps": 20,
     "knipDuplicates": 35
   },
@@ -28,8 +28,8 @@
       "maxBytes": 60000
     },
     "__tests__/components/Community/CommunityMilestoneCard.test.tsx": {
-      "lines": 820,
-      "bytes": 26529,
+      "lines": 831,
+      "bytes": 26919,
       "maxLines": 800,
       "maxBytes": 60000
     },
@@ -46,8 +46,8 @@
       "maxBytes": 60000
     },
     "__tests__/components/FundingPlatform/CreateProgramModal.test.tsx": {
-      "lines": 919,
-      "bytes": 29683,
+      "lines": 947,
+      "bytes": 30529,
       "maxLines": 800,
       "maxBytes": 60000
     },
@@ -82,14 +82,14 @@
       "maxBytes": 60000
     },
     "__tests__/integration/features/grant-completion-revocation-flow.test.tsx": {
-      "lines": 1060,
-      "bytes": 34587,
+      "lines": 1086,
+      "bytes": 35578,
       "maxLines": 800,
       "maxBytes": 60000
     },
     "__tests__/integration/journeys/multi-step-flows.test.tsx": {
-      "lines": 932,
-      "bytes": 30111,
+      "lines": 952,
+      "bytes": 31038,
       "maxLines": 800,
       "maxBytes": 60000
     },
@@ -119,7 +119,7 @@
     },
     "__tests__/unit/hooks/useAuth.test.tsx": {
       "lines": 985,
-      "bytes": 28833,
+      "bytes": 28837,
       "maxLines": 800,
       "maxBytes": 60000
     },
@@ -130,8 +130,8 @@
       "maxBytes": 60000
     },
     "__tests__/unit/hooks/useGrantCompletionRevoke.test.ts": {
-      "lines": 1084,
-      "bytes": 34851,
+      "lines": 1088,
+      "bytes": 34985,
       "maxLines": 800,
       "maxBytes": 60000
     },
@@ -156,12 +156,6 @@
     "app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx": {
       "lines": 650,
       "bytes": 24619,
-      "maxLines": 600,
-      "maxBytes": 40000
-    },
-    "app/community/[communityId]/manage/funding-platform/[programId]/applications/[applicationId]/page.tsx": {
-      "lines": 639,
-      "bytes": 24520,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -231,12 +225,6 @@
       "maxLines": 600,
       "maxBytes": 40000
     },
-    "components/Pages/Admin/CommunityAdmin.tsx": {
-      "lines": 632,
-      "bytes": 26889,
-      "maxLines": 600,
-      "maxBytes": 40000
-    },
     "components/Pages/Admin/ControlCenter/ControlCenterPage.tsx": {
       "lines": 661,
       "bytes": 24473,
@@ -252,12 +240,6 @@
     "components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx": {
       "lines": 830,
       "bytes": 30844,
-      "maxLines": 600,
-      "maxBytes": 40000
-    },
-    "components/Pages/Admin/KnowledgeBasePage/SourceRow.tsx": {
-      "lines": 609,
-      "bytes": 23344,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -286,8 +268,8 @@
       "maxBytes": 40000
     },
     "components/Pages/Admin/PortfolioReports/ReportConfigPage.tsx": {
-      "lines": 918,
-      "bytes": 32519,
+      "lines": 907,
+      "bytes": 33292,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -352,8 +334,8 @@
       "maxBytes": 40000
     },
     "components/Shared/ActivityCard/MilestoneCard.tsx": {
-      "lines": 660,
-      "bytes": 25655,
+      "lines": 656,
+      "bytes": 25517,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -370,14 +352,14 @@
       "maxBytes": 40000
     },
     "hooks/useFundingPlatform.ts": {
-      "lines": 1082,
-      "bytes": 35574,
+      "lines": 1065,
+      "bytes": 35295,
       "maxLines": 600,
       "maxBytes": 40000
     },
     "hooks/useMilestone.ts": {
       "lines": 1161,
-      "bytes": 41235,
+      "bytes": 41623,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -388,20 +370,14 @@
       "maxBytes": 60000
     },
     "services/fundingPlatformService.ts": {
-      "lines": 696,
-      "bytes": 20609,
+      "lines": 695,
+      "bytes": 20258,
       "maxLines": 600,
       "maxBytes": 40000
     },
     "src/components/ai-elements/prompt-input.tsx": {
       "lines": 1190,
       "bytes": 35426,
-      "maxLines": 600,
-      "maxBytes": 40000
-    },
-    "src/features/applications/components/AIEvaluationDisplay.tsx": {
-      "lines": 612,
-      "bytes": 19510,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -418,8 +394,8 @@
       "maxBytes": 40000
     },
     "src/features/non-profits/components/landing-page-client.tsx": {
-      "lines": 1124,
-      "bytes": 42027,
+      "lines": 1059,
+      "bytes": 41028,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -455,13 +431,13 @@
     },
     "src/features/payout-disbursement/hooks/use-payout-disbursement.ts": {
       "lines": 781,
-      "bytes": 24563,
+      "bytes": 24627,
       "maxLines": 600,
       "maxBytes": 40000
     },
     "src/features/payout-disbursement/services/payout-disbursement.service.ts": {
       "lines": 922,
-      "bytes": 23575,
+      "bytes": 23959,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -473,7 +449,7 @@
     },
     "utilities/indexer.ts": {
       "lines": 793,
-      "bytes": 38929,
+      "bytes": 38951,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -487,16 +463,16 @@
   "reactDoctor": {
     "score": 0,
     "errors": 61,
-    "warnings": 3262,
+    "warnings": 3232,
     "byCategory": {
-      "Accessibility": 268,
-      "Architecture": 1180,
+      "Accessibility": 273,
+      "Architecture": 1170,
       "Correctness": 399,
-      "Next.js": 146,
+      "Next.js": 145,
       "Server": 6,
-      "State & Effects": 677,
+      "Performance": 598,
+      "State & Effects": 659,
       "TanStack Query": 30,
-      "Performance": 604,
       "Bundle Size": 10,
       "Security": 3
     }

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./scripts/quality-baseline.schema.json",
-  "generatedAt": "2026-05-22T12:27:06.613Z",
-  "generatedFromCommit": "c0f93c25e3065c28299a8be0a3468014d8efbb49",
+  "generatedAt": "2026-06-04T00:00:00.000Z",
+  "generatedFromCommit": "3a950c7",
   "coverage": {
     "lines": 0,
     "statements": 0,

--- a/utilities/__tests__/queryKeys.test.ts
+++ b/utilities/__tests__/queryKeys.test.ts
@@ -158,13 +158,23 @@ describe("queryKeys", () => {
     describe("PROJECT_UPDATES", () => {
       it("should generate correct query key", () => {
         const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("community-123", "all", 1, 25);
-        expect(key).toEqual(["community-project-updates", "community-123", "all", 1, 25, "", ""]);
+        expect(key).toEqual([
+          "community-project-updates",
+          "community-123",
+          "all",
+          1,
+          25,
+          "",
+          "",
+          "",
+          "",
+        ]);
       });
 
       it("should return as const tuple", () => {
         const key = QUERY_KEYS.COMMUNITY.PROJECT_UPDATES("comm-1", "active", 0, 25);
         expect(Array.isArray(key)).toBe(true);
-        expect(key.length).toBe(7);
+        expect(key.length).toBe(9);
       });
 
       it("should handle different filters, pages, and limits", () => {
@@ -202,6 +212,8 @@ describe("queryKeys", () => {
           25,
           "program-1",
           "",
+          "",
+          "",
         ]);
         expect(key2).toEqual([
           "community-project-updates",
@@ -211,6 +223,8 @@ describe("queryKeys", () => {
           25,
           "program-1",
           "project-1",
+          "",
+          "",
         ]);
         expect(key1).not.toEqual(key2);
       });


### PR DESCRIPTION
## Overview

Refreshes `quality-baseline.json`, which was last generated **2026-05-22** (~12 days ago, `c0f93c2`). It had drifted from `main`, so the quality gate reports spurious regressions (e.g. `knipUnusedFiles +2`) on unrelated PRs — surfaced while reviewing #1569.

## What & how

- Re-dates the baseline to `main@3a950c7`.
- **Metric values are set from CI's computed `current.json`** in a follow-up commit on this branch. The gate tooling (`scripts/quality-gate.js`) shells out to `pnpm`/`npx` via `spawnSync` **without `shell: true`**, so it can't run on Windows dev machines (every collector `ENOENT`s) — the accurate, EOL-correct numbers must come from a Linux CI run, not a local generation.

## Note

Carries the `quality-baseline` label so `baseline-guard` permits the `quality-baseline.json` change.

_Follow-up worth filing separately: add `shell: true` to the `spawnSync` calls in `scripts/quality-gate.js` so the gate is runnable on Windows._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Regenerated quality baseline and updated tooling metadata for more reliable diagnostics.
* **Bug Fixes**
  * Sitemap low-priority URLs updated to target privacy and terms pages.
  * Improved test determinism to reduce intermittent failures and timing hangs.
* **Content**
  * Updated Financials subtitle and onboarding page source references to match current copy.
* **Tests**
  * Extensive test stability and mock improvements across unit, integration, and MSW suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->