### PR TITLE
fix: reset pending-verification table on filter change (DEV-365)

### DIFF
--- a/__tests__/components/Pages/Admin/PendingVerificationTable.test.tsx
+++ b/__tests__/components/Pages/Admin/PendingVerificationTable.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import {
   getEmptyStateMessage,
   PendingVerificationTable,
@@ -17,11 +18,11 @@ vi.mock("@/components/Utilities/TablePagination", () => ({
 }));
 
 vi.mock("@/src/components/navigation/Link", () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+  Link: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
 }));
 
 vi.mock("@/components/Utilities/ExternalLink", () => ({
-  ExternalLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+  ExternalLink: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
 }));
 
 function makeMilestone(
@@ -123,9 +124,11 @@ describe("PendingVerificationTable empty state", () => {
         makeMilestone({ milestoneUid: "0xb", grantUid: "0xg2" }),
       ];
 
-      render(<PendingVerificationTable {...baseProps} milestones={milestones} totalItems={2} />);
+      // API total deliberately differs from the rendered row count: the badge
+      // and pagination must reflect totalItems, never milestones.length.
+      render(<PendingVerificationTable {...baseProps} milestones={milestones} totalItems={57} />);
 
-      expect(screen.getByTestId("table-pagination")).toHaveAttribute("data-total", "2");
+      expect(screen.getByTestId("table-pagination")).toHaveAttribute("data-total", "57");
     });
   });
 });

--- a/__tests__/components/Pages/Admin/PendingVerificationTable.test.tsx
+++ b/__tests__/components/Pages/Admin/PendingVerificationTable.test.tsx
@@ -1,8 +1,46 @@
 /**
- * Tests for PendingVerificationTable empty state logic.
+ * Tests for PendingVerificationTable empty state logic and row rendering.
  */
 
-import { getEmptyStateMessage } from "@/components/Pages/Admin/PendingVerificationTable";
+import { render, screen } from "@testing-library/react";
+import {
+  getEmptyStateMessage,
+  PendingVerificationTable,
+} from "@/components/Pages/Admin/PendingVerificationTable";
+import type { PendingVerificationMilestone } from "@/hooks/usePendingVerificationMilestones";
+
+vi.mock("@/components/Utilities/TablePagination", () => ({
+  __esModule: true,
+  default: (props: { totalPosts: number }) => (
+    <div data-testid="table-pagination" data-total={props.totalPosts} />
+  ),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+vi.mock("@/components/Utilities/ExternalLink", () => ({
+  ExternalLink: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+function makeMilestone(
+  overrides: Partial<PendingVerificationMilestone> = {}
+): PendingVerificationMilestone {
+  return {
+    milestoneUid: "0xmilestone",
+    milestoneTitle: "Milestone Title",
+    completedAt: "2026-06-01T00:00:00.000Z",
+    grantUid: "0xgrant",
+    grantTitle: "Grant Title",
+    programId: "992",
+    projectUid: "0xproject",
+    projectTitle: "Project Title",
+    projectSlug: "project-slug",
+    status: "pending_verification",
+    ...overrides,
+  };
+}
 
 describe("PendingVerificationTable empty state", () => {
   const userAddress = "0x1234567890abcdef1234567890abcdef12345678";
@@ -39,6 +77,55 @@ describe("PendingVerificationTable empty state", () => {
 
     it("returns generic message when both are undefined", () => {
       expect(getEmptyStateMessage(undefined, undefined)).toBe("All milestones are verified");
+    });
+  });
+
+  // DEV-365: the rendered rows must match exactly the milestones provided —
+  // never more (a stale/foreign row) and never fewer than the data set.
+  describe("row rendering", () => {
+    const baseProps = {
+      isLoading: false,
+      error: null,
+      communityId: "filecoin",
+      page: 1,
+      onPageChange: vi.fn(),
+      itemsPerPage: 50,
+    };
+
+    it("renders exactly one data row per milestone", () => {
+      const milestones = [
+        makeMilestone({ milestoneUid: "0xa", grantUid: "0xg1", milestoneTitle: "Alpha" }),
+        makeMilestone({ milestoneUid: "0xb", grantUid: "0xg2", milestoneTitle: "Beta" }),
+        makeMilestone({ milestoneUid: "0xc", grantUid: "0xg3", milestoneTitle: "Gamma" }),
+      ];
+
+      const { container } = render(
+        <PendingVerificationTable {...baseProps} milestones={milestones} totalItems={3} />
+      );
+
+      expect(container.querySelectorAll("tbody tr")).toHaveLength(milestones.length);
+    });
+
+    it("does not render rows that are absent from the milestones prop", () => {
+      const milestones = [
+        makeMilestone({ milestoneUid: "0xa", grantUid: "0xg1", milestoneTitle: "Kept" }),
+      ];
+
+      render(<PendingVerificationTable {...baseProps} milestones={milestones} totalItems={1} />);
+
+      expect(screen.getByText("Kept")).toBeInTheDocument();
+      expect(screen.queryByText("Double Cursor Ingest")).not.toBeInTheDocument();
+    });
+
+    it("passes the API total (not the visible row count) to pagination", () => {
+      const milestones = [
+        makeMilestone({ milestoneUid: "0xa", grantUid: "0xg1" }),
+        makeMilestone({ milestoneUid: "0xb", grantUid: "0xg2" }),
+      ];
+
+      render(<PendingVerificationTable {...baseProps} milestones={milestones} totalItems={2} />);
+
+      expect(screen.getByTestId("table-pagination")).toHaveAttribute("data-total", "2");
     });
   });
 });

--- a/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
+++ b/__tests__/hooks/useReportPageData.reviewer-filter.test.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CommunityReviewer } from "@/hooks/useCommunityMilestoneReviewers";
-import { computeDefaultReviewerAddress } from "@/hooks/useReportPageData";
+import { computeDefaultReviewerAddress, getPendingTableResetKey } from "@/hooks/useReportPageData";
 
 describe("useReportPageData reviewer filter logic (address-based)", () => {
   const userAddress = "0x1234567890abcdef1234567890abcdef12345678";
@@ -108,6 +108,38 @@ describe("useReportPageData reviewer filter logic (address-based)", () => {
     it("user not in reviewer list defaults to seeing all milestones", () => {
       const reviewers = [makeReviewer(otherAddress)];
       expect(computeDefaultReviewerAddress(reviewers, userAddress)).toBeUndefined();
+    });
+  });
+
+  // DEV-365: the pending table must fully remount when the filter changes so a
+  // row from a previous reviewer/program/page can't survive list reconciliation.
+  describe("getPendingTableResetKey", () => {
+    it("changes when the reviewer changes", () => {
+      const all = getPendingTableResetKey(undefined, [], 1);
+      const scoped = getPendingTableResetKey(userAddress, [], 1);
+      expect(all).not.toBe(scoped);
+    });
+
+    it("changes when the selected programs change", () => {
+      const noProgram = getPendingTableResetKey(userAddress, [], 1);
+      const withProgram = getPendingTableResetKey(userAddress, ["992"], 1);
+      expect(noProgram).not.toBe(withProgram);
+    });
+
+    it("changes when the page changes", () => {
+      expect(getPendingTableResetKey(userAddress, ["992"], 1)).not.toBe(
+        getPendingTableResetKey(userAddress, ["992"], 2)
+      );
+    });
+
+    it("is stable regardless of program-id ordering", () => {
+      expect(getPendingTableResetKey(userAddress, ["992", "1"], 1)).toBe(
+        getPendingTableResetKey(userAddress, ["1", "992"], 1)
+      );
+    });
+
+    it("treats 'all reviewers' (undefined) distinctly from a specific address", () => {
+      expect(getPendingTableResetKey(undefined, ["992"], 1)).toBe("all-992-1");
     });
   });
 });

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -17,7 +17,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
 import { useCommunityMilestoneReviewers } from "@/hooks/useCommunityMilestoneReviewers";
 import { useReviewerPrograms } from "@/hooks/usePermissions";
-import { itemsPerPage, useReportPageData } from "@/hooks/useReportPageData";
+import {
+  getPendingTableResetKey,
+  itemsPerPage,
+  useReportPageData,
+} from "@/hooks/useReportPageData";
 import {
   useIsReviewerType,
   usePermissionContext,
@@ -241,6 +245,11 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
 
         <TabsContent value="pending-verification">
           <PendingVerificationTable
+            key={getPendingTableResetKey(
+              reportData.selectedReviewerAddress,
+              reportData.effectiveProgramIds,
+              reportData.pendingPage
+            )}
             milestones={reportData.pendingMilestones}
             isLoading={reportData.isPendingLoading}
             error={reportData.pendingError}

--- a/hooks/useReportPageData.ts
+++ b/hooks/useReportPageData.ts
@@ -109,6 +109,20 @@ export function computeDefaultReviewerAddress(
   return match?.publicAddress;
 }
 
+/**
+ * Identity of the current pending-verification result set. Used as a React
+ * `key` on the table so the row subtree is fully rebuilt whenever the
+ * reviewer/program/page filter changes — preventing a row from a previous
+ * filter from surviving list reconciliation (DEV-365).
+ */
+export function getPendingTableResetKey(
+  reviewerAddress: string | undefined,
+  programIds: string[],
+  page: number
+): string {
+  return `${reviewerAddress ?? "all"}-${[...programIds].sort().join(",")}-${page}`;
+}
+
 export function useReportPageData({
   communityId,
   grantPrograms,


### PR DESCRIPTION
## Problem

On `/community/[communityId]/manage/milestones-report`, the **Pending Verification** tab renders one more row than the count reports. As filed (DEV-365): filtered by a reviewer, the badge said **5** but **6** rows showed. Reproduced again live with another reviewer: badge **7**, pagination "Showing 1–7 of 7", but **8** rows — the extra row (`Interplanetary Network Indexers / Filecoin ProPGF Batch 1 / Double Cursor Ingest`, no amount) belonged to a **previously-selected filter** and is absent from the current API response.

## Root cause

The backend is correct and self-consistent. The `pending-verification` endpoint builds both values from one array — `totalItems = merged.length` and `data = merged.slice(...)` — so `pageInfo.totalItems` always equals `data.length` for a page. A direct API call confirms it returns exactly 7 items with `totalItems: 7`.

The badge and table both read from that single response, so the count is right. The extra row is a **stale row surviving React list reconciliation** when the reviewer/program filter changes — the table component is reused across the transition and an old row isn't dropped.

## Why not the other approach

The previously-proposed fix (#1543) did `Math.max(totalItems, visibleRows)` on the count. That's backwards: the API count is the correct number, and flooring it to the rendered row count would raise the correct `7` to the buggy `8`, corrupting the badge **and** pagination. It treats the one number that was right. This PR supersedes #1543 — that PR should be closed.

## Fix

Give the table a stable identity per filter (`reviewer + programs + page`) via `getPendingTableResetKey`, used as the React `key` on `<PendingVerificationTable>`. When the filter changes, React rebuilds the row subtree from scratch instead of reconciling against the previous result, so no stale row can survive. The API `totalItems` stays the authoritative count for the badge and pagination.

## Changes
- `hooks/useReportPageData.ts` — add pure `getPendingTableResetKey(reviewerAddress, programIds, page)` helper (program-order-stable).
- `components/Pages/Admin/ReportMilestonePage.tsx` — apply it as the table's `key`.

## Tests
- `getPendingTableResetKey`: key changes on reviewer/program/page change, is stable across program-id ordering, and maps `undefined` reviewer to `all`.
- `PendingVerificationTable` render tests: renders exactly one row per milestone, never an extra/foreign row, and passes the API `totalItems` (not the visible row count) to pagination.

```
pnpm exec vitest run --project unit \
  __tests__/hooks/useReportPageData.reviewer-filter.test.ts \
  __tests__/components/Pages/Admin/PendingVerificationTable.test.tsx
# 26 passed
```

## Testing steps
1. Open a community milestones report with several reviewers (e.g. `filecoin`).
2. In the Pending Verification tab, switch the Reviewer filter between reviewers a few times.
3. The rendered rows should always match the badge count and "Showing 1–N of N" — no leftover row from the prior selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the pending verification table with improved row rendering and filter validation tests.

* **Bug Fixes**
  * The pending verification table now properly resets and reloads when reviewer selection, program filters, or page number changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->