### PR TITLE
feat(sitemap): make extended sitemap comprehensive (walk all of PAGES)

### DIFF
--- a/__tests__/utilities/appRouteTemplates.test.ts
+++ b/__tests__/utilities/appRouteTemplates.test.ts
@@ -1,24 +1,36 @@
 import { APP_ROUTE_TEMPLATES } from "@/utilities/appRouteTemplates";
 
 describe("APP_ROUTE_TEMPLATES", () => {
-  it("includes the core entity route templates with :param placeholders", () => {
-    expect(APP_ROUTE_TEMPLATES).toContain("/project/:projectSlug");
-    expect(APP_ROUTE_TEMPLATES).toContain("/project/:projectSlug/funding/:grantUID");
-    expect(APP_ROUTE_TEMPLATES).toContain(
-      "/project/:projectSlug/funding/:grantUID/milestones-and-updates"
-    );
-    expect(APP_ROUTE_TEMPLATES).toContain("/community/:communitySlug");
-    expect(APP_ROUTE_TEMPLATES).toContain("/community/:communitySlug/programs/:programId");
-    expect(APP_ROUTE_TEMPLATES).toContain("/community/:communitySlug/applications/:applicationId");
-    expect(APP_ROUTE_TEMPLATES).toContain(
-      "/community/:communitySlug/manage/funding-platform/:programId/milestones/:projectUID"
-    );
+  it("is comprehensive — derived by walking the whole PAGES tree", () => {
+    // A representative spread across the route families that were previously
+    // missing when the list was hand-curated.
     expect(APP_ROUTE_TEMPLATES).toContain("/my-reviews");
+    expect(APP_ROUTE_TEMPLATES).toContain("/my-projects");
+    expect(APP_ROUTE_TEMPLATES).toContain("/project/:project");
+    expect(APP_ROUTE_TEMPLATES).toContain("/project/:project/funding/:grant");
+    expect(APP_ROUTE_TEMPLATES).toContain("/community/:community");
+    expect(APP_ROUTE_TEMPLATES).toContain("/community/:community/applications/:applicationId");
+    expect(APP_ROUTE_TEMPLATES).toContain(
+      "/community/:community/manage/funding-platform/:programId/applications"
+    );
+    expect(APP_ROUTE_TEMPLATES).toContain(
+      "/community/:community/manage/funding-platform/:programId/milestones/:projectId"
+    );
+    // It should be large — the whole PAGES tree, not a hand-picked subset.
+    expect(APP_ROUTE_TEMPLATES.length).toBeGreaterThan(50);
   });
 
-  it("derives every template from PAGES as a root-relative path", () => {
+  it("emits the base path AND the deep-link variant for optional-param routes", () => {
+    // Optional params (e.g. the milestone anchor, the `?programId=` filter)
+    // must not eat the base path.
+    expect(APP_ROUTE_TEMPLATES).toContain("/community/:community");
+    expect(APP_ROUTE_TEMPLATES.some((t) => t.includes("#milestone-:milestoneUid"))).toBe(true);
+  });
+
+  it("contains only valid root-relative paths and no unresolved params", () => {
     for (const template of APP_ROUTE_TEMPLATES) {
       expect(template.startsWith("/")).toBe(true);
+      expect(template).not.toContain("undefined");
     }
   });
 

--- a/utilities/appRouteTemplates.ts
+++ b/utilities/appRouteTemplates.ts
@@ -3,43 +3,67 @@ import { PAGES } from "./pages";
 /**
  * App route TEMPLATES (with `:param` placeholders) for the Karma agent backend.
  *
- * Generated from `PAGES` so they always reflect the real FE routes — this is
- * the single source of truth. Served (crawler-disallowed) via
- * `app/sitemaps/app-routes/sitemap.ts` so the backend can FETCH the routes
- * instead of hardcoding a copy. Only stable, user-facing entity routes the
- * agent links to are included — not every app page.
+ * Derived by walking the ENTIRE `PAGES` object — every string route and every
+ * route builder — so the list is comprehensive and stays in sync with the FE
+ * automatically: add a route to `PAGES` and it shows up here, no manual edit.
+ * Served (crawler-disallowed) via `app/extended-sitemap.xml/route.ts` so the
+ * backend can FETCH the routes instead of hardcoding a copy that drifts.
  *
- * Placeholders use `:paramName` (URL-safe) so the backend can substitute the
- * real slug / id it gets from its tools.
+ * Builders are invoked with `:paramName` sentinels taken from their parameter
+ * names. Optional params are omitted (we pass only the required arity), which
+ * yields the canonical base path for each route.
  */
-const PROJECT_SLUG = ":projectSlug";
-const GRANT_UID = ":grantUID";
-const COMMUNITY_SLUG = ":communitySlug";
-const PROGRAM_ID = ":programId";
-const APPLICATION_ID = ":applicationId";
-const PROJECT_UID = ":projectUID";
 
-export const APP_ROUTE_TEMPLATES: readonly string[] = [
-  // Top-level
-  PAGES.PROJECTS_EXPLORER,
-  PAGES.COMMUNITIES,
-  PAGES.MY_PROJECTS,
-  PAGES.MY_REVIEWS,
-  // Project
-  PAGES.PROJECT.OVERVIEW(PROJECT_SLUG),
-  PAGES.PROJECT.ABOUT(PROJECT_SLUG),
-  PAGES.PROJECT.TEAM(PROJECT_SLUG),
-  PAGES.PROJECT.IMPACT.ROOT(PROJECT_SLUG),
-  // Grant (= project with that grant selected)
-  PAGES.PROJECT.GRANTS(PROJECT_SLUG),
-  PAGES.PROJECT.GRANT(PROJECT_SLUG, GRANT_UID),
-  PAGES.PROJECT.MILESTONES_AND_UPDATES(PROJECT_SLUG, GRANT_UID),
-  // Community / program / application
-  PAGES.COMMUNITY.ALL_GRANTS(COMMUNITY_SLUG),
-  PAGES.COMMUNITY.FUNDING_OPPORTUNITIES(COMMUNITY_SLUG),
-  PAGES.COMMUNITY.PROGRAM_DETAIL(COMMUNITY_SLUG, PROGRAM_ID),
-  PAGES.COMMUNITY.APPLICATION_DETAIL(COMMUNITY_SLUG, APPLICATION_ID),
-  // Reviewer milestone page (deep-link a specific milestone by appending
-  // `#milestone-<milestoneUID>` — the backend adds the anchor)
-  PAGES.MANAGE.FUNDING_PLATFORM.MILESTONES(COMMUNITY_SLUG, PROGRAM_ID, PROJECT_UID),
-];
+/** Extract `:paramName` sentinels (one per parameter) from a builder. */
+function paramSentinels(fn: (...args: string[]) => unknown): string[] {
+  const src = fn.toString();
+  const parens = src.match(/^[^(]*\(([^)]*)\)/);
+  const single = src.match(/^\s*([A-Za-z_$][\w$]*)\s*=>/);
+  const raw = parens ? parens[1] : single ? single[1] : "";
+  return raw
+    .split(",")
+    .map((part) => part.trim().split(/[=:?]/)[0].trim())
+    .filter(Boolean)
+    .map((name) => `:${name}`);
+}
+
+function addRoute(result: unknown, out: Set<string>): void {
+  // A required param left out shows up as the literal "undefined" — skip those;
+  // an OPTIONAL param left out resolves to "" inside the builder's conditional,
+  // giving the clean base path. Restore `:` if encodeURIComponent touched it.
+  if (typeof result === "string" && result.startsWith("/") && !result.includes("undefined")) {
+    out.add(result.replace(/%3A/gi, ":"));
+  }
+}
+
+function collectRoutes(node: unknown, out: Set<string>): void {
+  if (typeof node === "string") {
+    if (node.startsWith("/")) out.add(node);
+    return;
+  }
+  if (typeof node === "function") {
+    const fn = node as (...args: string[]) => unknown;
+    const sentinels = paramSentinels(fn);
+    // Call with full arity down to zero args: full calls yield deep links
+    // (incl. optional query/anchor variants), fewer-arg calls yield the base
+    // path when the omitted params are optional. addRoute() drops any result
+    // where a REQUIRED param was missing (it contains "undefined").
+    for (let count = sentinels.length; count >= 0; count -= 1) {
+      try {
+        addRoute(fn(...sentinels.slice(0, count)), out);
+      } catch {
+        // Skip builders that need non-string args; no linkable route does.
+      }
+    }
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const value of Object.values(node)) collectRoutes(value, out);
+  }
+}
+
+export const APP_ROUTE_TEMPLATES: readonly string[] = (() => {
+  const out = new Set<string>();
+  collectRoutes(PAGES, out);
+  return Array.from(out).sort();
+})();


### PR DESCRIPTION
## Why

The first cut of `/extended-sitemap.xml` (PR #1578) hand-picked ~17 routes and silently dropped many — `/my-reviews`, the `manage/*` reviewer/admin routes, community sub-routes (`donate`, `reports`, `applications`, …), and even the base `/community/:community` path. The agent backend needs the **full** route vocabulary, and a curated list defeats the "derive from `PAGES`" goal.

> Note: this change was briefly pushed directly to `main` by mistake; it has been reverted from `main` and is re-introduced here for proper review.

## What

Replace the hand-picked list in `utilities/appRouteTemplates.ts` with a walk over the **entire `PAGES` tree** — every string route and every route builder. New routes added to `PAGES` now appear automatically with zero manual edits.

How the builders are invoked:
- Each builder is called from **full arity down to zero args**.
- Full-arity calls yield deep links (incl. optional `#milestone-` anchors and `?programId=` filters).
- Fewer-arg calls yield the **base path** when the omitted params are optional (the builder's `x ? … : ""` conditional resolves to `""`).
- Any result where a **required** param was omitted contains the literal `"undefined"` and is dropped.
- A sentinel run through `encodeURIComponent` (e.g. the report `runDate`, the milestone anchor) is restored from `%3A` back to `:`.

This yields ~90 templates including both the base and deep-link forms, e.g.:

```
/community/:community
/community/:community/manage/funding-platform/:programId/milestones/:projectId
/community/:community/manage/funding-platform/:programId/milestones/:projectId#milestone-:milestoneUid
/my-reviews
... (whole PAGES tree)
```

The sitemap publishes **templates** (`:param` placeholders); the agent substitutes real ids at link time.

## Testing

- `__tests__/utilities/appRouteTemplates.test.ts`: comprehensiveness (>50 routes, representative families incl. previously-missing `/my-reviews`, manage routes, base community), base-vs-deep-link emission, no `undefined`, no dupes.
- `pnpm typecheck` + Biome clean. Rendered output verified locally.