### PR TITLE
feat(ask-karma): persona-aware start-screen prompts (DEV-371)

### DIFF
--- a/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-page.test.tsx
@@ -44,6 +44,14 @@ vi.mock("@/utilities/whitelabel-context", () => ({
   useWhitelabel: () => mockUseWhitelabel(),
 }));
 
+// Persona resolution hits useAuth + a React Query permission check; stub it
+// so the page test stays focused on view transitions and the exit CTA. The
+// persona → prompt mapping is covered in use-ask-karma-persona.test.tsx and
+// config.test.ts.
+vi.mock("@/src/features/ask-karma/hooks/use-ask-karma-persona", () => ({
+  useAskKarmaPersona: () => "grantee",
+}));
+
 const config: AskKarmaConfig = {
   heading: "Ask Karma",
   subheading: "Sub",

--- a/__tests__/unit/features/ask-karma/config.test.ts
+++ b/__tests__/unit/features/ask-karma/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getAskKarmaConfig } from "@/src/features/ask-karma/config";
+import { getAskKarmaConfig, selectAskKarmaQuestions } from "@/src/features/ask-karma/config";
+import type { AskKarmaConfig } from "@/src/features/ask-karma/types";
 
 describe("getAskKarmaConfig", () => {
   it("returns the default config when no tenant id is provided", () => {
@@ -54,5 +55,87 @@ describe("getAskKarmaConfig", () => {
       const hasCta = Boolean(topic.cta);
       expect(hasLinks || hasCta).toBe(true);
     }
+  });
+
+  it("defines persona-specific prompts for the default and filecoin tenants", () => {
+    for (const key of [undefined, "filecoin"]) {
+      const byPersona = getAskKarmaConfig(key).exampleQuestionsByPersona;
+      expect(byPersona?.visitor?.length).toBeGreaterThan(0);
+      expect(byPersona?.reviewer?.length).toBeGreaterThan(0);
+      expect(byPersona?.grantee?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("surfaces the filecoin-specific reviewer prompts (ProPGF / Batch 3)", () => {
+    const filecoin = getAskKarmaConfig("filecoin").exampleQuestionsByPersona;
+    expect(filecoin?.visitor).toContain("What is ProPGF?");
+    expect(filecoin?.reviewer?.some((q) => q.includes("Batch 3"))).toBe(true);
+    // Filecoin's customer-specific copy must not leak into the generic tenant.
+    const generic = getAskKarmaConfig().exampleQuestionsByPersona;
+    expect(generic?.visitor?.some((q) => q.includes("ProPGF"))).toBe(false);
+    expect(generic?.reviewer?.some((q) => q.includes("Batch 3"))).toBe(false);
+  });
+});
+
+describe("selectAskKarmaQuestions", () => {
+  const withPersonas: AskKarmaConfig = {
+    ...getAskKarmaConfig(),
+    exampleQuestions: ["fallback-a", "fallback-b"],
+    exampleQuestionsByPersona: {
+      visitor: ["v1", "v2"],
+      reviewer: ["r1", "r2", "r3", "r4"],
+      grantee: ["g1", "g2", "g3", "g4", "g5"],
+    },
+  };
+
+  it("returns the flat list when a tenant defines no persona prompts", () => {
+    const flat: AskKarmaConfig = {
+      ...getAskKarmaConfig(),
+      exampleQuestions: ["only-a", "only-b"],
+      exampleQuestionsByPersona: undefined,
+    };
+    expect(selectAskKarmaQuestions(flat, "visitor")).toEqual(["only-a", "only-b"]);
+    expect(selectAskKarmaQuestions(flat, "reviewer")).toEqual(["only-a", "only-b"]);
+    expect(selectAskKarmaQuestions(flat, "grantee")).toEqual(["only-a", "only-b"]);
+  });
+
+  it("returns the visitor and grantee sets verbatim", () => {
+    expect(selectAskKarmaQuestions(withPersonas, "visitor")).toEqual(["v1", "v2"]);
+    expect(selectAskKarmaQuestions(withPersonas, "grantee")).toEqual([
+      "g1",
+      "g2",
+      "g3",
+      "g4",
+      "g5",
+    ]);
+  });
+
+  it("blends reviewer prompts first, then tops up with grantee prompts, capped at 6", () => {
+    const result = selectAskKarmaQuestions(withPersonas, "reviewer");
+    expect(result).toEqual(["r1", "r2", "r3", "r4", "g1", "g2"]);
+    expect(result.length).toBeLessThanOrEqual(6);
+  });
+
+  it("does not duplicate a prompt shared between reviewer and grantee sets", () => {
+    const overlap: AskKarmaConfig = {
+      ...withPersonas,
+      exampleQuestionsByPersona: {
+        reviewer: ["shared", "r2"],
+        grantee: ["shared", "g2"],
+      },
+    };
+    const result = selectAskKarmaQuestions(overlap, "reviewer");
+    expect(result).toEqual(["shared", "r2", "g2"]);
+  });
+
+  it("falls back per-persona when a persona list is missing", () => {
+    const partial: AskKarmaConfig = {
+      ...getAskKarmaConfig(),
+      exampleQuestions: ["fallback"],
+      exampleQuestionsByPersona: { grantee: ["g1"] },
+    };
+    expect(selectAskKarmaQuestions(partial, "visitor")).toEqual(["fallback"]);
+    // No reviewer set → fall back to grantee, then to the flat list.
+    expect(selectAskKarmaQuestions(partial, "reviewer")).toEqual(["g1"]);
   });
 });

--- a/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
@@ -2,15 +2,15 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useAuth } from "@/hooks/useAuth";
-import { usePermissions } from "@/hooks/usePermissions";
+import { useReviewerPrograms } from "@/hooks/usePermissions";
 import { useAskKarmaPersona } from "@/src/features/ask-karma/hooks/use-ask-karma-persona";
 
 vi.mock("@/hooks/useAuth", () => ({ useAuth: vi.fn() }));
-vi.mock("@/hooks/usePermissions", () => ({ usePermissions: vi.fn() }));
+vi.mock("@/hooks/usePermissions", () => ({ useReviewerPrograms: vi.fn() }));
 vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({ useIsCommunityAdmin: vi.fn() }));
 
 const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
-const mockUsePermissions = usePermissions as unknown as ReturnType<typeof vi.fn>;
+const mockUseReviewerPrograms = useReviewerPrograms as unknown as ReturnType<typeof vi.fn>;
 const mockUseIsCommunityAdmin = useIsCommunityAdmin as unknown as ReturnType<typeof vi.fn>;
 
 interface SetupOptions {
@@ -21,7 +21,7 @@ interface SetupOptions {
 
 function setup({ authenticated, reviewerPrograms = [], isCommunityAdmin = false }: SetupOptions) {
   mockUseAuth.mockReturnValue({ authenticated, address: authenticated ? "0xabc" : undefined });
-  mockUsePermissions.mockReturnValue({ programs: reviewerPrograms });
+  mockUseReviewerPrograms.mockReturnValue({ programs: reviewerPrograms });
   mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin });
 }
 

--- a/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
@@ -1,18 +1,39 @@
-import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { useAskKarmaPersona } from "@/src/features/ask-karma/hooks/use-ask-karma-persona";
+import fetchData from "@/utilities/fetchData";
 
 vi.mock("@/hooks/useAuth", () => ({ useAuth: vi.fn() }));
 vi.mock("@/hooks/usePermissions", () => ({ usePermissions: vi.fn() }));
+vi.mock("@/utilities/fetchData", () => ({ default: vi.fn() }));
 
 const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
 const mockUsePermissions = usePermissions as unknown as ReturnType<typeof vi.fn>;
+const mockFetchData = fetchData as unknown as ReturnType<typeof vi.fn>;
 
-function setup({ authenticated, isReviewer }: { authenticated: boolean; isReviewer: boolean }) {
-  mockUseAuth.mockReturnValue({ authenticated });
+function setup({
+  authenticated,
+  isReviewer,
+  isAdmin = false,
+}: {
+  authenticated: boolean;
+  isReviewer: boolean;
+  isAdmin?: boolean;
+}) {
+  mockUseAuth.mockReturnValue({ authenticated, address: authenticated ? "0xabc" : undefined });
   mockUsePermissions.mockReturnValue({ hasRole: isReviewer });
+  mockFetchData.mockResolvedValue([{ communities: isAdmin ? [{ uid: "c1" }] : [] }, null]);
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
 describe("useAskKarmaPersona", () => {
@@ -22,19 +43,26 @@ describe("useAskKarmaPersona", () => {
 
   it("returns 'visitor' when the user is signed out", () => {
     setup({ authenticated: false, isReviewer: false });
-    const { result } = renderHook(() => useAskKarmaPersona());
+    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
     expect(result.current).toBe("visitor");
   });
 
   it("returns 'reviewer' when a signed-in user reviews any program", () => {
     setup({ authenticated: true, isReviewer: true });
-    const { result } = renderHook(() => useAskKarmaPersona());
+    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
     expect(result.current).toBe("reviewer");
   });
 
-  it("returns 'grantee' for a signed-in user who is not a reviewer", () => {
-    setup({ authenticated: true, isReviewer: false });
-    const { result } = renderHook(() => useAskKarmaPersona());
+  it("returns 'reviewer' when a signed-in user administers any community", async () => {
+    setup({ authenticated: true, isReviewer: false, isAdmin: true });
+    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
+    // Admin status resolves via an async query — defaults to grantee until it lands.
+    await waitFor(() => expect(result.current).toBe("reviewer"));
+  });
+
+  it("returns 'grantee' for a signed-in user who is neither reviewer nor admin", () => {
+    setup({ authenticated: true, isReviewer: false, isAdmin: false });
+    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
     expect(result.current).toBe("grantee");
   });
 
@@ -42,7 +70,13 @@ describe("useAskKarmaPersona", () => {
     // The permission query is disabled when signed out; even if it leaked a
     // stale `true`, a signed-out visitor must stay on the visitor prompts.
     setup({ authenticated: false, isReviewer: true });
-    const { result } = renderHook(() => useAskKarmaPersona());
+    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
     expect(result.current).toBe("visitor");
+  });
+
+  it("does not query for admin communities while signed out", () => {
+    setup({ authenticated: false, isReviewer: false });
+    renderHook(() => useAskKarmaPersona(), { wrapper });
+    expect(mockFetchData).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
@@ -13,17 +13,15 @@ const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
 const mockUsePermissions = usePermissions as unknown as ReturnType<typeof vi.fn>;
 const mockUseIsCommunityAdmin = useIsCommunityAdmin as unknown as ReturnType<typeof vi.fn>;
 
-function setup({
-  authenticated,
-  isReviewer,
-  isCommunityAdmin = false,
-}: {
+interface SetupOptions {
   authenticated: boolean;
-  isReviewer: boolean;
+  reviewerPrograms?: Array<{ communitySlug?: string; communityUID?: string }>;
   isCommunityAdmin?: boolean;
-}) {
+}
+
+function setup({ authenticated, reviewerPrograms = [], isCommunityAdmin = false }: SetupOptions) {
   mockUseAuth.mockReturnValue({ authenticated, address: authenticated ? "0xabc" : undefined });
-  mockUsePermissions.mockReturnValue({ hasRole: isReviewer });
+  mockUsePermissions.mockReturnValue({ programs: reviewerPrograms });
   mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin });
 }
 
@@ -33,25 +31,37 @@ describe("useAskKarmaPersona", () => {
   });
 
   it("returns 'visitor' when the user is signed out", () => {
-    setup({ authenticated: false, isReviewer: false });
+    setup({ authenticated: false });
     const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("visitor");
   });
 
-  it("returns 'reviewer' when a signed-in user reviews any program", () => {
-    setup({ authenticated: true, isReviewer: true });
+  it("returns 'reviewer' when the user reviews a program in the page's community", () => {
+    setup({ authenticated: true, reviewerPrograms: [{ communitySlug: "filecoin" }] });
     const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("reviewer");
   });
 
-  it("returns 'reviewer' when a signed-in user administers the page's community", () => {
-    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: true });
+  it("matches the reviewer program by community UID as well as slug", () => {
+    setup({ authenticated: true, reviewerPrograms: [{ communityUID: "0xCommunityUID" }] });
+    const { result } = renderHook(() => useAskKarmaPersona("0xcommunityuid"));
+    expect(result.current).toBe("reviewer");
+  });
+
+  it("ignores reviewer programs from a different community", () => {
+    setup({ authenticated: true, reviewerPrograms: [{ communitySlug: "optimism" }] });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
+    expect(result.current).toBe("grantee");
+  });
+
+  it("returns 'reviewer' when the user administers the page's community", () => {
+    setup({ authenticated: true, isCommunityAdmin: true });
     const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("reviewer");
   });
 
   it("scopes the admin check to the page's community", () => {
-    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: true });
+    setup({ authenticated: true, isCommunityAdmin: true });
     renderHook(() => useAskKarmaPersona("filecoin"));
     expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith(
       "filecoin",
@@ -60,14 +70,20 @@ describe("useAskKarmaPersona", () => {
     );
   });
 
-  it("returns 'grantee' for a signed-in user who is neither reviewer nor admin", () => {
-    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: false });
+  it("returns 'grantee' for a signed-in user with no role in the page's community", () => {
+    setup({ authenticated: true });
     const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("grantee");
   });
 
+  it("falls back to 'reviewer of any program' when no community is in scope", () => {
+    setup({ authenticated: true, reviewerPrograms: [{ communitySlug: "optimism" }] });
+    const { result } = renderHook(() => useAskKarmaPersona(undefined));
+    expect(result.current).toBe("reviewer");
+  });
+
   it("disables the admin check when there is no community in scope", () => {
-    setup({ authenticated: true, isReviewer: false });
+    setup({ authenticated: true });
     renderHook(() => useAskKarmaPersona(undefined));
     expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith(
       undefined,
@@ -77,9 +93,9 @@ describe("useAskKarmaPersona", () => {
   });
 
   it("ignores reviewer status while signed out", () => {
-    // The permission query is disabled when signed out; even if it leaked a
-    // stale `true`, a signed-out visitor must stay on the visitor prompts.
-    setup({ authenticated: false, isReviewer: true });
+    // The permission query is disabled when signed out; even if it leaked
+    // stale programs, a signed-out visitor must stay on the visitor prompts.
+    setup({ authenticated: false, reviewerPrograms: [{ communitySlug: "filecoin" }] });
     const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("visitor");
   });

--- a/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAuth } from "@/hooks/useAuth";
+import { usePermissions } from "@/hooks/usePermissions";
+import { useAskKarmaPersona } from "@/src/features/ask-karma/hooks/use-ask-karma-persona";
+
+vi.mock("@/hooks/useAuth", () => ({ useAuth: vi.fn() }));
+vi.mock("@/hooks/usePermissions", () => ({ usePermissions: vi.fn() }));
+
+const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
+const mockUsePermissions = usePermissions as unknown as ReturnType<typeof vi.fn>;
+
+function setup({ authenticated, isReviewer }: { authenticated: boolean; isReviewer: boolean }) {
+  mockUseAuth.mockReturnValue({ authenticated });
+  mockUsePermissions.mockReturnValue({ hasRole: isReviewer });
+}
+
+describe("useAskKarmaPersona", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'visitor' when the user is signed out", () => {
+    setup({ authenticated: false, isReviewer: false });
+    const { result } = renderHook(() => useAskKarmaPersona());
+    expect(result.current).toBe("visitor");
+  });
+
+  it("returns 'reviewer' when a signed-in user reviews any program", () => {
+    setup({ authenticated: true, isReviewer: true });
+    const { result } = renderHook(() => useAskKarmaPersona());
+    expect(result.current).toBe("reviewer");
+  });
+
+  it("returns 'grantee' for a signed-in user who is not a reviewer", () => {
+    setup({ authenticated: true, isReviewer: false });
+    const { result } = renderHook(() => useAskKarmaPersona());
+    expect(result.current).toBe("grantee");
+  });
+
+  it("ignores reviewer status while signed out", () => {
+    // The permission query is disabled when signed out; even if it leaked a
+    // stale `true`, a signed-out visitor must stay on the visitor prompts.
+    setup({ authenticated: false, isReviewer: true });
+    const { result } = renderHook(() => useAskKarmaPersona());
+    expect(result.current).toBe("visitor");
+  });
+});

--- a/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
+++ b/__tests__/unit/features/ask-karma/use-ask-karma-persona.test.tsx
@@ -1,39 +1,30 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { useAskKarmaPersona } from "@/src/features/ask-karma/hooks/use-ask-karma-persona";
-import fetchData from "@/utilities/fetchData";
 
 vi.mock("@/hooks/useAuth", () => ({ useAuth: vi.fn() }));
 vi.mock("@/hooks/usePermissions", () => ({ usePermissions: vi.fn() }));
-vi.mock("@/utilities/fetchData", () => ({ default: vi.fn() }));
+vi.mock("@/hooks/communities/useIsCommunityAdmin", () => ({ useIsCommunityAdmin: vi.fn() }));
 
 const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
 const mockUsePermissions = usePermissions as unknown as ReturnType<typeof vi.fn>;
-const mockFetchData = fetchData as unknown as ReturnType<typeof vi.fn>;
+const mockUseIsCommunityAdmin = useIsCommunityAdmin as unknown as ReturnType<typeof vi.fn>;
 
 function setup({
   authenticated,
   isReviewer,
-  isAdmin = false,
+  isCommunityAdmin = false,
 }: {
   authenticated: boolean;
   isReviewer: boolean;
-  isAdmin?: boolean;
+  isCommunityAdmin?: boolean;
 }) {
   mockUseAuth.mockReturnValue({ authenticated, address: authenticated ? "0xabc" : undefined });
   mockUsePermissions.mockReturnValue({ hasRole: isReviewer });
-  mockFetchData.mockResolvedValue([{ communities: isAdmin ? [{ uid: "c1" }] : [] }, null]);
-}
-
-function wrapper({ children }: { children: ReactNode }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  mockUseIsCommunityAdmin.mockReturnValue({ isCommunityAdmin });
 }
 
 describe("useAskKarmaPersona", () => {
@@ -43,40 +34,53 @@ describe("useAskKarmaPersona", () => {
 
   it("returns 'visitor' when the user is signed out", () => {
     setup({ authenticated: false, isReviewer: false });
-    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("visitor");
   });
 
   it("returns 'reviewer' when a signed-in user reviews any program", () => {
     setup({ authenticated: true, isReviewer: true });
-    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("reviewer");
   });
 
-  it("returns 'reviewer' when a signed-in user administers any community", async () => {
-    setup({ authenticated: true, isReviewer: false, isAdmin: true });
-    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
-    // Admin status resolves via an async query — defaults to grantee until it lands.
-    await waitFor(() => expect(result.current).toBe("reviewer"));
+  it("returns 'reviewer' when a signed-in user administers the page's community", () => {
+    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: true });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
+    expect(result.current).toBe("reviewer");
+  });
+
+  it("scopes the admin check to the page's community", () => {
+    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: true });
+    renderHook(() => useAskKarmaPersona("filecoin"));
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith(
+      "filecoin",
+      undefined,
+      expect.objectContaining({ enabled: true })
+    );
   });
 
   it("returns 'grantee' for a signed-in user who is neither reviewer nor admin", () => {
-    setup({ authenticated: true, isReviewer: false, isAdmin: false });
-    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
+    setup({ authenticated: true, isReviewer: false, isCommunityAdmin: false });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("grantee");
+  });
+
+  it("disables the admin check when there is no community in scope", () => {
+    setup({ authenticated: true, isReviewer: false });
+    renderHook(() => useAskKarmaPersona(undefined));
+    expect(mockUseIsCommunityAdmin).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      expect.objectContaining({ enabled: false })
+    );
   });
 
   it("ignores reviewer status while signed out", () => {
     // The permission query is disabled when signed out; even if it leaked a
     // stale `true`, a signed-out visitor must stay on the visitor prompts.
     setup({ authenticated: false, isReviewer: true });
-    const { result } = renderHook(() => useAskKarmaPersona(), { wrapper });
+    const { result } = renderHook(() => useAskKarmaPersona("filecoin"));
     expect(result.current).toBe("visitor");
-  });
-
-  it("does not query for admin communities while signed out", () => {
-    setup({ authenticated: false, isReviewer: false });
-    renderHook(() => useAskKarmaPersona(), { wrapper });
-    expect(mockFetchData).not.toHaveBeenCalled();
   });
 });

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -39,7 +39,7 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
   // Tailor the start-screen prompts to the visitor (signed out vs. reviewer
   // vs. grantee) on top of the tenant config resolved on the server. Only the
   // example questions change, so the rest of the config flows through.
-  const persona = useAskKarmaPersona();
+  const persona = useAskKarmaPersona(communityId);
   const startConfig = useMemo<AskKarmaConfig>(
     () => ({ ...config, exampleQuestions: selectAskKarmaQuestions(config, persona) }),
     [config, persona]

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -2,12 +2,14 @@
 
 import { ArrowLeftIcon } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgentStream } from "@/hooks/useAgentStream";
 import { useAgentChatStore } from "@/store/agentChat";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
+import { selectAskKarmaQuestions } from "../config";
+import { useAskKarmaPersona } from "../hooks/use-ask-karma-persona";
 import type { AskKarmaConfig } from "../types";
 import { AskKarmaChat } from "./ask-karma-chat";
 import { AskKarmaStart } from "./ask-karma-start";
@@ -33,6 +35,15 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
 
   const { sendMessage, abort } = useAgentStream();
   const [view, setView] = useState<AskKarmaView>("start");
+
+  // Tailor the start-screen prompts to the visitor (signed out vs. reviewer
+  // vs. grantee) on top of the tenant config resolved on the server. Only the
+  // example questions change, so the rest of the config flows through.
+  const persona = useAskKarmaPersona();
+  const startConfig = useMemo<AskKarmaConfig>(
+    () => ({ ...config, exampleQuestions: selectAskKarmaQuestions(config, persona) }),
+    [config, persona]
+  );
   const transitionTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -126,7 +137,7 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
           )}
           style={isLeaving ? { animationFillMode: "forwards" } : undefined}
         >
-          <AskKarmaStart config={config} onSubmit={handleSubmit} />
+          <AskKarmaStart config={startConfig} onSubmit={handleSubmit} />
         </div>
       )}
       {showChat && (

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -1,5 +1,5 @@
 import { isKnownTenant, type KnownTenantId } from "@/src/infrastructure/types/tenant";
-import type { AskKarmaConfig } from "./types";
+import type { AskKarmaConfig, AskKarmaPersona } from "./types";
 
 const DEFAULT_CONFIG: AskKarmaConfig = {
   heading: "Ask Karma",
@@ -14,6 +14,28 @@ const DEFAULT_CONFIG: AskKarmaConfig = {
     "Are there retrospective reports from previous funding rounds?",
     "How do I apply to an open funding round?",
   ],
+  exampleQuestionsByPersona: {
+    visitor: [
+      "What is Karma GAP?",
+      "What types of projects receive funding?",
+      "How do I apply or get involved?",
+      "When does the next funding round open?",
+      "How does the funding process work?",
+    ],
+    reviewer: [
+      "Why can't I access the project I am reviewing?",
+      "What milestones or proposals are pending my review?",
+      "Which metrics matter most when evaluating project impact?",
+      "What is the review process for grant proposals?",
+    ],
+    grantee: [
+      "Why can't I submit project updates?",
+      "How do I submit a milestone update for my project?",
+      "When will my invoice be processed?",
+      "When are my milestone updates due?",
+      "What should I include in my milestone update?",
+    ],
+  },
   featuredTopicsHeading: "Check out these featured topics",
   featuredTopics: [
     {
@@ -59,6 +81,28 @@ const TENANT_CONFIGS: Partial<Record<KnownTenantId, AskKarmaConfig>> = {
       "What is the typical payment timeline after invoice submission?",
       "Are there retrospective reports from previous funding rounds?",
     ],
+    exampleQuestionsByPersona: {
+      visitor: [
+        "What is ProPGF?",
+        "What is RetroPGF?",
+        "What types of projects receive funding?",
+        "How do I apply or get involved?",
+        "When does the next funding round open?",
+      ],
+      reviewer: [
+        "How come I don't have reviewer access for a project?",
+        "What milestones or proposals are pending my review?",
+        "What is the criteria for Batch 3 General Track proposals?",
+        "What is the review process for Batch 3 Grant proposals?",
+      ],
+      grantee: [
+        "How come I don't have access to submit project updates?",
+        "How do I submit a milestone update for my project?",
+        "When will my invoice be processed?",
+        "When are my milestone updates due?",
+        "What should I include in my milestone update?",
+      ],
+    },
     featuredTopics: [
       {
         icon: "dollar",
@@ -154,4 +198,40 @@ export function getAskKarmaConfig(lookupKey?: string | null): AskKarmaConfig {
     return TENANT_CONFIGS[lookupKey] ?? DEFAULT_CONFIG;
   }
   return DEFAULT_CONFIG;
+}
+
+// A reviewer is usually a grantee too, so their prompts lead with the
+// review-focused set and top up with grantee questions. Capped so the chip
+// row stays scannable rather than turning into a wall of suggestions.
+const REVIEWER_PROMPT_LIMIT = 6;
+
+/**
+ * Pick the start-screen prompts for a persona. Tenants that don't define
+ * `exampleQuestionsByPersona` (or omit a given persona) fall back to the flat
+ * `exampleQuestions` list, so this is safe for every config.
+ *
+ * Reviewers get a blended list — their review prompts first, then grantee
+ * prompts to fill out the row — because a reviewer is typically a grantee as
+ * well and benefits from both.
+ */
+export function selectAskKarmaQuestions(
+  config: AskKarmaConfig,
+  persona: AskKarmaPersona
+): string[] {
+  const byPersona = config.exampleQuestionsByPersona;
+  if (!byPersona) return config.exampleQuestions;
+
+  if (persona === "visitor") return byPersona.visitor ?? config.exampleQuestions;
+  if (persona === "grantee") return byPersona.grantee ?? config.exampleQuestions;
+
+  // Reviewer: lead with review prompts, then fill from grantee prompts.
+  const reviewer = byPersona.reviewer ?? [];
+  if (reviewer.length === 0) return byPersona.grantee ?? config.exampleQuestions;
+
+  const blended = [...reviewer];
+  for (const question of byPersona.grantee ?? []) {
+    if (blended.length >= REVIEWER_PROMPT_LIMIT) break;
+    if (!blended.includes(question)) blended.push(question);
+  }
+  return blended;
 }

--- a/src/features/ask-karma/config.ts
+++ b/src/features/ask-karma/config.ts
@@ -229,9 +229,13 @@ export function selectAskKarmaQuestions(
   if (reviewer.length === 0) return byPersona.grantee ?? config.exampleQuestions;
 
   const blended = [...reviewer];
+  const seen = new Set(reviewer);
   for (const question of byPersona.grantee ?? []) {
     if (blended.length >= REVIEWER_PROMPT_LIMIT) break;
-    if (!blended.includes(question)) blended.push(question);
+    if (!seen.has(question)) {
+      seen.add(question);
+      blended.push(question);
+    }
   }
   return blended;
 }

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -7,22 +7,45 @@ import { usePermissions } from "@/hooks/usePermissions";
 import type { AskKarmaPersona } from "../types";
 
 /**
+ * True when the caller reviews a program belonging to `communityId`. The
+ * reviewer-programs list isn't community-scoped server-side, but each program
+ * carries its community, so we filter client-side. `communityId` is matched
+ * against both the slug and UID since the page receives a slug from the
+ * `/community/[id]` route but a UID is possible too.
+ *
+ * With no community in scope (the generic Karma root, not a tenant) we fall
+ * back to "reviews any program" — there's no tenant to filter against, so any
+ * reviewer relationship is the relevant signal there.
+ */
+function isReviewerForCommunity(
+  programs: Array<{ communitySlug?: string; communityUID?: string }>,
+  communityId?: string
+): boolean {
+  if (!communityId) return programs.length > 0;
+  const target = communityId.toLowerCase();
+  return programs.some(
+    (program) =>
+      program.communitySlug?.toLowerCase() === target ||
+      program.communityUID?.toLowerCase() === target
+  );
+}
+
+/**
  * Resolves the Ask Karma audience from the visitor's sign-in state and role,
  * so the start screen can surface prompts that match where they are:
  *
- * - signed out                              → `visitor`
- * - signed in + reviewer OR admin of tenant → `reviewer`
- * - signed in (everyone else)               → `grantee`
+ * - signed out                                  → `visitor`
+ * - signed in + reviewer OR admin of the tenant → `reviewer`
+ * - signed in (everyone else)                   → `grantee`
  *
  * Reviewers and community admins share the same prompt set: both ask
  * operational, review-side questions (pending reviews, evaluation criteria,
  * access) rather than grantee questions about submitting their own work.
  *
- * Admin status is scoped to the page's own community (`communityId` — the
- * whitelabel tenant or the `/community/[id]` route). Being an admin of some
- * *other* community is irrelevant here, so this only flips to `reviewer` for
- * admins of the community whose Ask Karma page they're on. Reviewer status is
- * program-level (no community scope), which is the only signal available.
+ * Both role checks are scoped to the page's own community (`communityId` — the
+ * whitelabel tenant or the `/community/[id]` route): being a reviewer or admin
+ * of some *other* community is irrelevant to which prompts belong on this
+ * tenant's page.
  *
  * While the role checks are in flight we keep the `grantee` default (the
  * common case), so prompts settle on `reviewer` once a role resolves rather
@@ -30,13 +53,15 @@ import type { AskKarmaPersona } from "../types";
  */
 export function useAskKarmaPersona(communityId?: string): AskKarmaPersona {
   const { authenticated } = useAuth();
-  const { hasRole: isReviewer } = usePermissions({
-    role: "reviewer",
-    enabled: authenticated,
-  });
+  const { programs } = usePermissions({ role: "reviewer", enabled: authenticated });
   const { isCommunityAdmin } = useIsCommunityAdmin(communityId, undefined, {
     enabled: Boolean(authenticated && communityId),
   });
+
+  const isReviewer = useMemo(
+    () => isReviewerForCommunity(programs, communityId),
+    [programs, communityId]
+  );
 
   return useMemo<AskKarmaPersona>(() => {
     if (!authenticated) return "visitor";

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useAuth } from "@/hooks/useAuth";
-import { usePermissions } from "@/hooks/usePermissions";
+import { useReviewerPrograms } from "@/hooks/usePermissions";
 import type { AskKarmaPersona } from "../types";
 
 /**
@@ -53,7 +53,8 @@ function isReviewerForCommunity(
  */
 export function useAskKarmaPersona(communityId?: string): AskKarmaPersona {
   const { authenticated } = useAuth();
-  const { programs } = usePermissions({ role: "reviewer", enabled: authenticated });
+  // useReviewerPrograms gates its own query on auth + a connected address.
+  const { programs } = useReviewerPrograms();
   const { isCommunityAdmin } = useIsCommunityAdmin(communityId, undefined, {
     enabled: Boolean(authenticated && communityId),
   });

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -1,66 +1,42 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
-import fetchData from "@/utilities/fetchData";
-import { INDEXER } from "@/utilities/indexer";
 import type { AskKarmaPersona } from "../types";
-
-interface AdminCommunitiesResponse {
-  communities?: unknown[];
-}
-
-/**
- * Whether the connected wallet administers any community. The Ask Karma page
- * isn't always community-scoped, so we can't lean on the context RBAC
- * (`isCommunityAdmin`) — we read the cross-community admin list directly.
- *
- * Deliberately lightweight: just the list, no per-community metrics fan-out
- * (unlike `useDashboardAdmin`) and no global-store writes (unlike
- * `useAdminCommunities`) — this only needs a boolean to pick prompt chips.
- */
-function useIsCommunityAdminAnywhere(): boolean {
-  const { authenticated, address } = useAuth();
-  const { data } = useQuery({
-    queryKey: ["ask-karma-admin-communities", address],
-    enabled: Boolean(authenticated && address),
-    staleTime: 5 * 60 * 1000,
-    queryFn: async () => {
-      const [response] = await fetchData<AdminCommunitiesResponse>(
-        INDEXER.V2.USER.ADMIN_COMMUNITIES()
-      );
-      return (response?.communities?.length ?? 0) > 0;
-    },
-  });
-  return data ?? false;
-}
 
 /**
  * Resolves the Ask Karma audience from the visitor's sign-in state and role,
  * so the start screen can surface prompts that match where they are:
  *
- * - signed out                           → `visitor`
- * - signed in + reviewer OR community admin → `reviewer`
- * - signed in (everyone else)            → `grantee`
+ * - signed out                              → `visitor`
+ * - signed in + reviewer OR admin of tenant → `reviewer`
+ * - signed in (everyone else)               → `grantee`
  *
  * Reviewers and community admins share the same prompt set: both ask
  * operational, review-side questions (pending reviews, evaluation criteria,
  * access) rather than grantee questions about submitting their own work.
  *
- * Both role checks are top-level (no community context required), which suits
- * this page. While they're in flight we keep the `grantee` default (the common
- * case), so prompts settle on `reviewer` once a role resolves rather than
- * flashing the wrong copy first.
+ * Admin status is scoped to the page's own community (`communityId` — the
+ * whitelabel tenant or the `/community/[id]` route). Being an admin of some
+ * *other* community is irrelevant here, so this only flips to `reviewer` for
+ * admins of the community whose Ask Karma page they're on. Reviewer status is
+ * program-level (no community scope), which is the only signal available.
+ *
+ * While the role checks are in flight we keep the `grantee` default (the
+ * common case), so prompts settle on `reviewer` once a role resolves rather
+ * than flashing the wrong copy first.
  */
-export function useAskKarmaPersona(): AskKarmaPersona {
+export function useAskKarmaPersona(communityId?: string): AskKarmaPersona {
   const { authenticated } = useAuth();
   const { hasRole: isReviewer } = usePermissions({
     role: "reviewer",
     enabled: authenticated,
   });
-  const isCommunityAdmin = useIsCommunityAdminAnywhere();
+  const { isCommunityAdmin } = useIsCommunityAdmin(communityId, undefined, {
+    enabled: Boolean(authenticated && communityId),
+  });
 
   return useMemo<AskKarmaPersona>(() => {
     if (!authenticated) return "visitor";

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -1,24 +1,58 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
 import type { AskKarmaPersona } from "../types";
+
+interface AdminCommunitiesResponse {
+  communities?: unknown[];
+}
+
+/**
+ * Whether the connected wallet administers any community. The Ask Karma page
+ * isn't always community-scoped, so we can't lean on the context RBAC
+ * (`isCommunityAdmin`) — we read the cross-community admin list directly.
+ *
+ * Deliberately lightweight: just the list, no per-community metrics fan-out
+ * (unlike `useDashboardAdmin`) and no global-store writes (unlike
+ * `useAdminCommunities`) — this only needs a boolean to pick prompt chips.
+ */
+function useIsCommunityAdminAnywhere(): boolean {
+  const { authenticated, address } = useAuth();
+  const { data } = useQuery({
+    queryKey: ["ask-karma-admin-communities", address],
+    enabled: Boolean(authenticated && address),
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const [response] = await fetchData<AdminCommunitiesResponse>(
+        INDEXER.V2.USER.ADMIN_COMMUNITIES()
+      );
+      return (response?.communities?.length ?? 0) > 0;
+    },
+  });
+  return data ?? false;
+}
 
 /**
  * Resolves the Ask Karma audience from the visitor's sign-in state and role,
  * so the start screen can surface prompts that match where they are:
  *
- * - signed out                     → `visitor`
- * - signed in + reviewer anywhere  → `reviewer`
- * - signed in (everyone else)      → `grantee`
+ * - signed out                           → `visitor`
+ * - signed in + reviewer OR community admin → `reviewer`
+ * - signed in (everyone else)            → `grantee`
  *
- * Reviewer status comes from `usePermissions({ role: "reviewer" })`, which
- * reports whether the connected wallet reviews any program at all — no
- * community context required, which suits this top-level page. While that
- * check is in flight we keep the `grantee` default (the common case), so the
- * prompts settle on `reviewer` once it resolves rather than flashing the
- * wrong copy first.
+ * Reviewers and community admins share the same prompt set: both ask
+ * operational, review-side questions (pending reviews, evaluation criteria,
+ * access) rather than grantee questions about submitting their own work.
+ *
+ * Both role checks are top-level (no community context required), which suits
+ * this page. While they're in flight we keep the `grantee` default (the common
+ * case), so prompts settle on `reviewer` once a role resolves rather than
+ * flashing the wrong copy first.
  */
 export function useAskKarmaPersona(): AskKarmaPersona {
   const { authenticated } = useAuth();
@@ -26,10 +60,11 @@ export function useAskKarmaPersona(): AskKarmaPersona {
     role: "reviewer",
     enabled: authenticated,
   });
+  const isCommunityAdmin = useIsCommunityAdminAnywhere();
 
   return useMemo<AskKarmaPersona>(() => {
     if (!authenticated) return "visitor";
-    if (isReviewer) return "reviewer";
+    if (isReviewer || isCommunityAdmin) return "reviewer";
     return "grantee";
-  }, [authenticated, isReviewer]);
+  }, [authenticated, isReviewer, isCommunityAdmin]);
 }

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -59,14 +59,9 @@ export function useAskKarmaPersona(communityId?: string): AskKarmaPersona {
     enabled: Boolean(authenticated && communityId),
   });
 
-  const isReviewer = useMemo(
-    () => isReviewerForCommunity(programs, communityId),
-    [programs, communityId]
-  );
-
   return useMemo<AskKarmaPersona>(() => {
     if (!authenticated) return "visitor";
-    if (isReviewer || isCommunityAdmin) return "reviewer";
+    if (isReviewerForCommunity(programs, communityId) || isCommunityAdmin) return "reviewer";
     return "grantee";
-  }, [authenticated, isReviewer, isCommunityAdmin]);
+  }, [authenticated, programs, communityId, isCommunityAdmin]);
 }

--- a/src/features/ask-karma/hooks/use-ask-karma-persona.ts
+++ b/src/features/ask-karma/hooks/use-ask-karma-persona.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { usePermissions } from "@/hooks/usePermissions";
+import type { AskKarmaPersona } from "../types";
+
+/**
+ * Resolves the Ask Karma audience from the visitor's sign-in state and role,
+ * so the start screen can surface prompts that match where they are:
+ *
+ * - signed out                     → `visitor`
+ * - signed in + reviewer anywhere  → `reviewer`
+ * - signed in (everyone else)      → `grantee`
+ *
+ * Reviewer status comes from `usePermissions({ role: "reviewer" })`, which
+ * reports whether the connected wallet reviews any program at all — no
+ * community context required, which suits this top-level page. While that
+ * check is in flight we keep the `grantee` default (the common case), so the
+ * prompts settle on `reviewer` once it resolves rather than flashing the
+ * wrong copy first.
+ */
+export function useAskKarmaPersona(): AskKarmaPersona {
+  const { authenticated } = useAuth();
+  const { hasRole: isReviewer } = usePermissions({
+    role: "reviewer",
+    enabled: authenticated,
+  });
+
+  return useMemo<AskKarmaPersona>(() => {
+    if (!authenticated) return "visitor";
+    if (isReviewer) return "reviewer";
+    return "grantee";
+  }, [authenticated, isReviewer]);
+}

--- a/src/features/ask-karma/types.ts
+++ b/src/features/ask-karma/types.ts
@@ -34,10 +34,10 @@ export interface AskKarmaTopic {
 
 /**
  * Audience the start-screen prompts are tailored to. Resolved at runtime from
- * the visitor's sign-in state and role:
+ * the visitor's sign-in state and role within the page's community:
  * - `visitor`  — signed out; discovery-oriented questions
- * - `reviewer` — signed in and a reviewer of at least one program
- * - `grantee`  — signed in, default for everyone who isn't a reviewer
+ * - `reviewer` — signed in and a reviewer or admin of the page's community
+ * - `grantee`  — signed in, default for everyone without a review-side role
  */
 export type AskKarmaPersona = "visitor" | "reviewer" | "grantee";
 

--- a/src/features/ask-karma/types.ts
+++ b/src/features/ask-karma/types.ts
@@ -32,12 +32,31 @@ export interface AskKarmaTopic {
   cta?: AskKarmaLink & { href: string };
 }
 
+/**
+ * Audience the start-screen prompts are tailored to. Resolved at runtime from
+ * the visitor's sign-in state and role:
+ * - `visitor`  — signed out; discovery-oriented questions
+ * - `reviewer` — signed in and a reviewer of at least one program
+ * - `grantee`  — signed in, default for everyone who isn't a reviewer
+ */
+export type AskKarmaPersona = "visitor" | "reviewer" | "grantee";
+
 export interface AskKarmaConfig {
   heading: string;
   subheading: string;
   inputPlaceholder: string;
   examplesIntro: string;
+  /**
+   * Fallback prompt list, shown when a tenant doesn't define
+   * `exampleQuestionsByPersona` or a persona is missing from it.
+   */
   exampleQuestions: string[];
+  /**
+   * Persona-tailored prompt lists. When present, the start screen picks the
+   * set matching the visitor's sign-in state and role (see `AskKarmaPersona`),
+   * falling back to `exampleQuestions` for any persona left undefined.
+   */
+  exampleQuestionsByPersona?: Partial<Record<AskKarmaPersona, string[]>>;
   featuredTopicsHeading: string;
   featuredTopics: AskKarmaTopic[];
   assistantTitle: string;


### PR DESCRIPTION
## Overview

Ask Karma's start-screen example prompts were **tenant-scoped only** — every visitor saw the same chips regardless of who they were. DEV-371 asks for prompt suggestions that adapt to the visitor's **sign-in details**, with focus on the **Reviewer** questions.

This resolves a *persona* at runtime and surfaces the matching prompt set, layered on top of the existing per-tenant config.

## Persona mapping

| Sign-in state | Persona | Prompts |
|---|---|---|
| Signed out | `visitor` | Discovery-oriented (what is ProPGF/RetroPGF, how to apply, when rounds open) |
| Signed in + reviewer **or** admin of the page's community | `reviewer` | Review prompts first, topped up with grantee prompts (capped at 6) |
| Signed in, otherwise | `grantee` | Milestone/invoice/update prompts |

Both review-side checks are **scoped to the page's own community** (`communityId` — the whitelabel tenant, or the `/community/[id]` route):

- **Reviewer**: `useReviewerPrograms()` returns the caller's reviewer programs (program-level, not community-scoped server-side). Each program carries its `communitySlug`/`communityUID`, so the hook filters that list to the page's community client-side. With no community in scope (the generic Karma root) it falls back to "reviewer of any program."
- **Community admin**: `useIsCommunityAdmin(communityId)` — the same on-chain check the rest of the app uses; disabled when there's no community in scope.

Being a reviewer or admin of some *other* community does not flip the persona on this tenant's page. While the role checks are in flight we keep the `grantee` default so prompts settle on `reviewer` rather than flashing the wrong copy.

## Tenant scope

The doc's prompt copy is Filecoin-specific (ProPGF, RetroPGF, "Batch 3 General Track"). Those exact prompts are gated to the `filecoin` tenant; every other tenant gets generic persona prompts. A test asserts the Filecoin copy does **not** leak into the default tenant.

## Changes

- `types.ts` — `AskKarmaPersona` + optional `exampleQuestionsByPersona` on the config
- `config.ts` — persona prompt sets for default + Filecoin tenants; `selectAskKarmaQuestions(config, persona)` resolver (reviewer-blend, Set-based dedup, per-persona fallback)
- `hooks/use-ask-karma-persona.ts` — resolves persona from `useReviewerPrograms` (community-filtered) + `useIsCommunityAdmin` (community-scoped)
- `components/ask-karma-page.tsx` — applies the persona, overriding only the start-screen `exampleQuestions`

## Testing

- `selectAskKarmaQuestions`: blend / cap / dedup / per-persona fallback / no-persona-config passthrough
- `useAskKarmaPersona`: visitor / reviewer-by-slug / reviewer-by-UID / cross-community ignored / admin-scoped / no-community fallback / signed-out
- Filecoin copy present + isolated from the generic tenant
- Existing ask-karma suite still green (97 passing); page test stubs the persona hook

```bash
npx vitest run __tests__/unit/features/ask-karma
```

## Follow-ups (out of scope here)

- *"Interface answers should be really strong"* — that's agent/backend answer quality (gap-indexer), separate from these suggestion chips.
- The floating `AgentChatBubble` has its own static empty state; persona-aware suggestions could be extended there for parity.