### PR TITLE
feat(milestones-review): complete milestones on behalf of grantees (admins only)

### DIFF
--- a/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
+++ b/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
@@ -175,3 +175,100 @@ describe("MilestoneCard (admin review) — overflow → delete dialog flow", () 
     expect(screen.queryByRole("button", { name: /more actions/i })).not.toBeInTheDocument();
   });
 });
+
+const COMPLETION_PROPS = {
+  ...DEFAULT_PROPS,
+  canCompleteMilestones: true,
+  completingMilestoneId: null,
+  completionComment: "",
+  isCompleting: false,
+  onCompleteClick: vi.fn(),
+  onCancelCompletion: vi.fn(),
+  onCompletionCommentChange: vi.fn(),
+  onSubmitCompletion: vi.fn(),
+};
+
+describe("MilestoneCard (admin review) — complete on behalf of grantee", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_render_complete_button_for_pending_milestone_when_canCompleteMilestones", () => {
+    render(<MilestoneCard {...COMPLETION_PROPS} milestone={createMilestone()} />);
+
+    expect(
+      screen.getByRole("button", { name: /complete on behalf of grantee/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should_not_render_complete_button_when_canCompleteMilestones_is_false", () => {
+    render(
+      <MilestoneCard
+        {...COMPLETION_PROPS}
+        canCompleteMilestones={false}
+        milestone={createMilestone()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /complete on behalf of grantee/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_not_render_complete_button_when_milestone_already_has_a_completion", () => {
+    render(
+      <MilestoneCard
+        {...COMPLETION_PROPS}
+        milestone={createMilestone({
+          completionDetails: {
+            description: "submitted",
+            completedAt: "2026-01-01T00:00:00Z",
+            deliverables: [],
+          } as unknown as GrantMilestoneWithCompletion["completionDetails"],
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /complete on behalf of grantee/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should_call_onCompleteClick_with_milestone_uid_when_complete_button_clicked", () => {
+    const onCompleteClick = vi.fn();
+    const milestone = createMilestone();
+
+    render(
+      <MilestoneCard
+        {...COMPLETION_PROPS}
+        milestone={milestone}
+        onCompleteClick={onCompleteClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /complete on behalf of grantee/i }));
+
+    expect(onCompleteClick).toHaveBeenCalledWith(milestone.uid);
+  });
+
+  it("should_show_inline_completion_form_and_submit_when_milestone_is_being_completed", () => {
+    const onSubmitCompletion = vi.fn();
+    const milestone = createMilestone();
+
+    render(
+      <MilestoneCard
+        {...COMPLETION_PROPS}
+        milestone={milestone}
+        completingMilestoneId={milestone.uid}
+        onSubmitCompletion={onSubmitCompletion}
+      />
+    );
+
+    // The on-chain attribution is surfaced to the admin before they submit.
+    expect(screen.getByText(/attributed to your wallet/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^complete$/i }));
+
+    expect(onSubmitCompletion).toHaveBeenCalledWith(milestone);
+  });
+});

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -144,6 +144,15 @@ interface MilestoneCardProps {
   verificationComment: string;
   isVerifying: boolean;
   canVerifyMilestones: boolean;
+  /**
+   * Completion-on-behalf is opt-in per surface. The Milestones Review page wires
+   * these up for community admins; other surfaces (e.g. the reviewer Inbox) omit
+   * them so the action never renders.
+   */
+  canCompleteMilestones?: boolean;
+  completingMilestoneId?: string | null;
+  completionComment?: string;
+  isCompleting?: boolean;
   canDeleteMilestones: boolean;
   canEditMilestones?: boolean;
   grantUID?: string;
@@ -156,6 +165,10 @@ interface MilestoneCardProps {
   onCancelVerification: () => void;
   onVerificationCommentChange: (comment: string) => void;
   onSubmitVerification: (milestone: GrantMilestoneWithCompletion) => void;
+  onCompleteClick?: (uid: string) => void;
+  onCancelCompletion?: () => void;
+  onCompletionCommentChange?: (comment: string) => void;
+  onSubmitCompletion?: (milestone: GrantMilestoneWithCompletion) => void;
   onRequestChanges?: () => void;
   onDeleteMilestone: (milestone: GrantMilestoneWithCompletion) => Promise<void>;
   isDeleting?: boolean;
@@ -172,6 +185,10 @@ export function MilestoneCard({
   verificationComment,
   isVerifying,
   canVerifyMilestones,
+  canCompleteMilestones = false,
+  completingMilestoneId = null,
+  completionComment = "",
+  isCompleting = false,
   canDeleteMilestones,
   canEditMilestones = false,
   grantUID,
@@ -184,6 +201,10 @@ export function MilestoneCard({
   onCancelVerification,
   onVerificationCommentChange,
   onSubmitVerification,
+  onCompleteClick,
+  onCancelCompletion,
+  onCompletionCommentChange,
+  onSubmitCompletion,
   onRequestChanges,
   onDeleteMilestone,
   isDeleting = false,
@@ -754,6 +775,56 @@ export function MilestoneCard({
             )
           )}
         </>
+      )}
+
+      {/* Complete on behalf of grantee — community admins only, for milestones
+          with no completion yet. The attestation is signed by and attributed to
+          the admin's wallet. */}
+      {!hasCompletion && canCompleteMilestones && (
+        <div className="mb-3">
+          {completingMilestoneId === milestone.uid ? (
+            <div className="p-3 bg-blue-50 dark:bg-blue-900/10 border border-blue-200 dark:border-blue-800 rounded-md space-y-2">
+              <p className="text-sm font-semibold text-blue-900 dark:text-blue-200">
+                Complete milestone on behalf of grantee
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                This completion is recorded on-chain and attributed to your wallet.
+              </p>
+              <textarea
+                value={completionComment}
+                onChange={(e) => onCompletionCommentChange?.(e.target.value)}
+                placeholder="Describe what was completed (optional)..."
+                rows={3}
+                className="w-full px-3 py-2 text-sm border border-blue-300 dark:border-blue-700 rounded-md bg-white dark:bg-zinc-800 text-black dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+              />
+              <div className="flex gap-2">
+                <Button
+                  onClick={() => onSubmitCompletion?.(milestone)}
+                  className="px-3 py-1 text-xs bg-brand-blue hover:bg-brand-blue/90"
+                  disabled={isCompleting}
+                  isLoading={isCompleting}
+                >
+                  Complete
+                </Button>
+                <Button
+                  onClick={() => onCancelCompletion?.()}
+                  className="px-3 py-1 text-xs bg-gray-500 hover:bg-gray-600"
+                  disabled={isCompleting}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button
+              onClick={() => onCompleteClick?.(milestone.uid)}
+              className="flex items-center gap-2 px-4 py-2 text-sm bg-brand-blue hover:bg-brand-blue/90"
+            >
+              <CheckCircleIcon className="w-4 h-4" />
+              Complete on behalf of grantee
+            </Button>
+          )}
+        </div>
       )}
 
       {hasCompletion && isEvaluationModalOpen && (

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -794,6 +794,7 @@ export function MilestoneCard({
                 value={completionComment}
                 onChange={(e) => onCompletionCommentChange?.(e.target.value)}
                 placeholder="Describe what was completed (optional)..."
+                aria-label={`Completion description for ${milestone.title}`}
                 rows={3}
                 className="w-full px-3 py-2 text-sm border border-blue-300 dark:border-blue-700 rounded-md bg-white dark:bg-zinc-800 text-black dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-blue"
               />

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -467,6 +467,8 @@ function MilestonesReviewPageContent({
   const { data, isLoading, error, refetch } = useProjectGrantMilestones(projectId, programId);
   const [verifyingMilestoneId, setVerifyingMilestoneId] = useState<string | null>(null);
   const [verificationComment, setVerificationComment] = useState("");
+  const [completingMilestoneId, setCompletingMilestoneId] = useState<string | null>(null);
+  const [completionComment, setCompletionComment] = useState("");
   const [deletingMilestoneId, setDeletingMilestoneId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<MilestoneFilterKey | null>(null);
   const [selectedMilestoneUid, setSelectedMilestoneUid] = useState<string | null>(null);
@@ -496,6 +498,11 @@ function MilestonesReviewPageContent({
   // backend service-level auth in milestone-on-chain-{edit,delete}.write.service.
   // Milestone reviewers verify completions but cannot mutate milestone definitions.
   const canEditOrDeleteMilestones = isStaff || hasAdminAccess;
+
+  // Completing a milestone on the grantee's behalf is an admin/staff action only.
+  // Milestone reviewers are explicitly excluded — they review completions, they
+  // do not author them.
+  const canCompleteMilestones = isStaff || hasAdminAccess;
 
   // Delete milestone hook with proper React Query mutation/query relationship
   const { deleteMilestoneAsync, isDeleting } = useDeleteMilestone({
@@ -595,15 +602,18 @@ function MilestonesReviewPageContent({
     parsedProgramId,
   ]);
 
-  const { verifyMilestone, isVerifying } = useMilestoneCompletionVerification({
-    projectId,
-    programId,
-    onSuccess: async () => {
-      await refetch();
-      setVerifyingMilestoneId(null);
-      setVerificationComment("");
-    },
-  });
+  const { verifyMilestone, isVerifying, completeMilestone, isCompleting } =
+    useMilestoneCompletionVerification({
+      projectId,
+      programId,
+      onSuccess: async () => {
+        await refetch();
+        setVerifyingMilestoneId(null);
+        setVerificationComment("");
+        setCompletingMilestoneId(null);
+        setCompletionComment("");
+      },
+    });
 
   const handleVerifyClick = useCallback((completionId: string) => {
     setVerifyingMilestoneId(completionId);
@@ -622,6 +632,24 @@ function MilestonesReviewPageContent({
       await verifyMilestone(milestone, isMilestoneReviewer || false, data, verificationComment);
     },
     [data, verifyMilestone, isMilestoneReviewer, verificationComment]
+  );
+
+  const handleCompleteClick = useCallback((milestoneUid: string) => {
+    setCompletingMilestoneId(milestoneUid);
+    setCompletionComment("");
+  }, []);
+
+  const handleCancelCompletion = useCallback(() => {
+    setCompletingMilestoneId(null);
+    setCompletionComment("");
+  }, []);
+
+  const handleSubmitCompletion = useCallback(
+    async (milestone: GrantMilestoneWithCompletion) => {
+      if (!data) return;
+      await completeMilestone(milestone, data, completionComment);
+    },
+    [data, completeMilestone, completionComment]
   );
 
   const handleDeleteMilestone = useCallback(
@@ -955,6 +983,10 @@ function MilestonesReviewPageContent({
                       verificationComment={verificationComment}
                       isVerifying={isVerifying}
                       canVerifyMilestones={canVerifyMilestones}
+                      canCompleteMilestones={canCompleteMilestones}
+                      completingMilestoneId={completingMilestoneId}
+                      completionComment={completionComment}
+                      isCompleting={isCompleting}
                       canDeleteMilestones={canEditOrDeleteMilestones}
                       canEditMilestones={canEditOrDeleteMilestones}
                       grantUID={grant?.uid}
@@ -967,6 +999,10 @@ function MilestonesReviewPageContent({
                       onCancelVerification={handleCancelVerification}
                       onVerificationCommentChange={setVerificationComment}
                       onSubmitVerification={handleSubmitVerification}
+                      onCompleteClick={handleCompleteClick}
+                      onCancelCompletion={handleCancelCompletion}
+                      onCompletionCommentChange={setCompletionComment}
+                      onSubmitCompletion={handleSubmitCompletion}
                       onRequestChanges={handleRequestChanges}
                       onDeleteMilestone={handleDeleteMilestone}
                       isDeleting={isDeleting && deletingMilestoneId === selectedMilestone.uid}

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -64,6 +64,7 @@ export const useMilestoneCompletionVerification = ({
   onCachesInvalidated,
 }: UseMilestoneCompletionVerificationParams) => {
   const [isVerifying, setIsVerifying] = useState(false);
+  const [isCompleting, setIsCompleting] = useState(false);
   const { address, chain } = useAccount();
   const { switchChainAsync } = useWallet();
   const { startAttestation, showLoading, showSuccess, showError, changeStepperStep, dismiss } =
@@ -262,6 +263,42 @@ export const useMilestoneCompletionVerification = ({
 
         // Otherwise just check verification
         return !!isVerified;
+      },
+      undefined,
+      undefined,
+      undefined,
+      signal
+    );
+  };
+
+  const pollForCompletionStatus = async (
+    gapClient: GAP,
+    data: ProjectGrantMilestonesResponse,
+    milestone: GrantMilestoneWithCompletion,
+    inputProgramId: string,
+    signal?: AbortSignal
+  ) => {
+    const normalizedInputId = normalizeProgramId(inputProgramId);
+
+    await retryUntilConditionMet(
+      async () => {
+        const updatedProject = await gapClient.fetch.projectById(data.project.uid);
+
+        if (!updatedProject) return false;
+
+        const updatedGrant = updatedProject.grants.find((g) => {
+          const storedId = g.details?.programId;
+          if (!storedId) return false;
+          return normalizeProgramId(storedId) === normalizedInputId;
+        });
+
+        if (!updatedGrant) return false;
+
+        const updatedMilestone = updatedGrant.milestones?.find((m) => m.uid === milestone.uid);
+
+        if (!updatedMilestone) return false;
+
+        return !!updatedMilestone.completed;
       },
       undefined,
       undefined,
@@ -509,8 +546,111 @@ export const useMilestoneCompletionVerification = ({
     }
   };
 
+  /**
+   * Completes a milestone on the grantee's behalf as a community admin.
+   * The completion attestation is signed by — and attributed to — the
+   * admin's connected wallet. Reviewers are not granted this action; that
+   * gating lives in the calling UI.
+   */
+  const completeMilestone = async (
+    milestone: GrantMilestoneWithCompletion,
+    data: ProjectGrantMilestonesResponse,
+    completionComment: string
+  ) => {
+    if (!address || !data) {
+      showError("Please connect your wallet");
+      return;
+    }
+
+    if (!milestone.uid) {
+      showError("Cannot complete milestone without UID");
+      return;
+    }
+
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const { signal } = controller;
+
+    setIsCompleting(true);
+    startAttestation("Completing milestone...");
+
+    try {
+      changeStepperStep("preparing");
+
+      const chainSetup = await setupChainAndWalletForMilestone(milestone, data);
+      if (!chainSetup) return;
+
+      const { gapClient, walletSigner } = chainSetup;
+
+      const { milestoneInstance, communityUID } = await fetchMilestoneInstance(
+        gapClient,
+        data,
+        milestone
+      );
+
+      const milestoneCompletedSchema = gapClient.findSchema("MilestoneCompleted");
+      const completionAttestation = new MilestoneCompleted({
+        data: sanitizeObject({
+          reason: completionComment || "",
+          proofOfWork: "",
+          type: "completed",
+        }),
+        refUID: milestone.uid as Hex,
+        schema: milestoneCompletedSchema,
+        recipient: milestoneInstance.recipient,
+      });
+      const payloads = [await completionAttestation.payloadFor(0)];
+
+      changeStepperStep("pending");
+
+      const result = await GapContract.multiAttest(walletSigner, payloads, changeStepperStep);
+
+      changeStepperStep("indexing");
+
+      const txHash = result?.tx[0]?.hash || undefined;
+      await notifyIndexerAndInvalidateCache(
+        txHash,
+        milestoneInstance.chainID,
+        payloads.length,
+        communityUID
+      );
+
+      await pollForCompletionStatus(gapClient, data, milestone, programId, signal);
+
+      if (signal.aborted) return;
+
+      changeStepperStep("indexed");
+      showSuccess("Milestone completed successfully!");
+
+      onSuccess?.();
+    } catch (error: any) {
+      if (isAbortError(error)) {
+        return;
+      }
+      console.error("Error completing milestone:", error);
+
+      if (error?.message?.includes("User rejected") || error?.code === 4001) {
+        showError("Completion cancelled");
+      } else {
+        showError("Failed to complete milestone");
+        errorManager("Error completing milestone", error, {
+          milestoneUID: milestone.uid,
+          address,
+        });
+      }
+    } finally {
+      if (!signal.aborted) {
+        setIsCompleting(false);
+      }
+      dismiss();
+    }
+  };
+
   return {
     verifyMilestone,
     isVerifying,
+    completeMilestone,
+    isCompleting,
   };
 };

--- a/hooks/useMilestoneCompletionVerification.ts
+++ b/hooks/useMilestoneCompletionVerification.ts
@@ -221,6 +221,31 @@ export const useMilestoneCompletionVerification = ({
     onCachesInvalidated?.();
   };
 
+  // Re-fetch the milestone from the SDK and locate it within its grant, used by
+  // the post-attestation polls to observe on-chain → indexer state transitions.
+  // Returns null until the project, grant, and milestone are all present.
+  const findIndexedMilestone = async (
+    gapClient: GAP,
+    data: ProjectGrantMilestonesResponse,
+    milestone: GrantMilestoneWithCompletion,
+    inputProgramId: string
+  ) => {
+    const normalizedInputId = normalizeProgramId(inputProgramId);
+    const updatedProject = await gapClient.fetch.projectById(data.project.uid);
+
+    if (!updatedProject) return null;
+
+    const updatedGrant = updatedProject.grants.find((g) => {
+      const storedId = g.details?.programId;
+      if (!storedId) return false;
+      return normalizeProgramId(storedId) === normalizedInputId;
+    });
+
+    if (!updatedGrant) return null;
+
+    return updatedGrant.milestones?.find((m) => m.uid === milestone.uid) ?? null;
+  };
+
   const pollForMilestoneStatus = async (
     gapClient: GAP,
     data: ProjectGrantMilestonesResponse,
@@ -230,24 +255,14 @@ export const useMilestoneCompletionVerification = ({
     inputProgramId: string,
     signal?: AbortSignal
   ) => {
-    // Normalize for comparison (supports both programId formats)
-    const normalizedInputId = normalizeProgramId(inputProgramId);
-
     await retryUntilConditionMet(
       async () => {
-        const updatedProject = await gapClient.fetch.projectById(data.project.uid);
-
-        if (!updatedProject) return false;
-
-        const updatedGrant = updatedProject.grants.find((g) => {
-          const storedId = g.details?.programId;
-          if (!storedId) return false;
-          return normalizeProgramId(storedId) === normalizedInputId;
-        });
-
-        if (!updatedGrant) return false;
-
-        const updatedMilestone = updatedGrant.milestones?.find((m) => m.uid === milestone.uid);
+        const updatedMilestone = await findIndexedMilestone(
+          gapClient,
+          data,
+          milestone,
+          inputProgramId
+        );
 
         if (!updatedMilestone) return false;
 
@@ -278,27 +293,16 @@ export const useMilestoneCompletionVerification = ({
     inputProgramId: string,
     signal?: AbortSignal
   ) => {
-    const normalizedInputId = normalizeProgramId(inputProgramId);
-
     await retryUntilConditionMet(
       async () => {
-        const updatedProject = await gapClient.fetch.projectById(data.project.uid);
+        const updatedMilestone = await findIndexedMilestone(
+          gapClient,
+          data,
+          milestone,
+          inputProgramId
+        );
 
-        if (!updatedProject) return false;
-
-        const updatedGrant = updatedProject.grants.find((g) => {
-          const storedId = g.details?.programId;
-          if (!storedId) return false;
-          return normalizeProgramId(storedId) === normalizedInputId;
-        });
-
-        if (!updatedGrant) return false;
-
-        const updatedMilestone = updatedGrant.milestones?.find((m) => m.uid === milestone.uid);
-
-        if (!updatedMilestone) return false;
-
-        return !!updatedMilestone.completed;
+        return !!updatedMilestone?.completed;
       },
       undefined,
       undefined,
@@ -624,13 +628,14 @@ export const useMilestoneCompletionVerification = ({
       showSuccess("Milestone completed successfully!");
 
       onSuccess?.();
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (isAbortError(error)) {
         return;
       }
       console.error("Error completing milestone:", error);
 
-      if (error?.message?.includes("User rejected") || error?.code === 4001) {
+      const walletError = error as { message?: string; code?: number };
+      if (walletError?.message?.includes("User rejected") || walletError?.code === 4001) {
         showError("Completion cancelled");
       } else {
         showError("Failed to complete milestone");


### PR DESCRIPTION
## Overview

Adds a **"Complete on behalf of grantee"** action to the Milestones Review workspace (`components/Pages/Admin/MilestonesReview/`) for community admins. Previously, pending/past-due milestones with no completion had no action at all — the only action (Verify) required an existing completion.

This was scoped per product decision: surface it **only in the Milestone Report**, attribute the completion to the admin (transparent on-chain), and **exclude milestone reviewers**.

## Problem

A grantee sometimes never submits a milestone completion (inactive, past due, etc.), leaving admins with no way to record it from the review surface. The review workspace only rendered a Verify button, and only when a completion already existed.

## Solution

- **`useMilestoneCompletionVerification`** — new `completeMilestone(milestone, data, comment)` method (+ `isCompleting`). Reuses the hook's existing chain/wallet setup, milestone-instance fetch, indexer notification and cache invalidation. Creates a single `type: "completed"` `MilestoneCompleted` attestation via `GapContract.multiAttest`, signed by and attributed to the admin's connected wallet.
- **`MilestoneCard`** — renders the action only when the milestone has **no** completion yet. Inline form with an optional description and an honest notice: *"This completion is recorded on-chain and attributed to your wallet."* New props are optional with safe defaults, so other surfaces (reviewer Inbox) never render the action.
- **`index.tsx`** — gated behind `canCompleteMilestones = isStaff || hasAdminAccess` (admin tier; **excludes** milestone reviewers). Wires state + handlers.

## State reset & fresh-data guarantee

After the on-chain attestation:
1. `notifyIndexerAndInvalidateCache` invalidates the exact query key the page reads — `["project-grant-milestones", projectId, programId]` — plus `["reportMilestones", communityUID]`.
2. `pollForCompletionStatus` blocks until the SDK confirms the completion is indexed.
3. `onSuccess` runs `await refetch()` and resets `completingMilestoneId` / `completionComment`.
4. `selectedMilestone` re-derives via `useMemo` → the card re-renders with `hasCompletion=true`: the Complete button disappears, the status badge flips to **Pending Verification**, and the Verify section appears. No stale pending data.

This mirrors the proven `verifyMilestone` flow.

## Testing steps

1. As a **community admin**, open a project's Milestones Review for a program with a pending or past-due milestone.
2. Select a milestone with no completion → confirm the **"Complete on behalf of grantee"** button appears.
3. Click it, optionally add a description, submit → approve the wallet signature.
4. After indexing, confirm the card updates in place: badge → "Pending Verification", Complete button gone, Verify section now available.
5. As a **milestone reviewer (non-admin)**, confirm the Complete action does **not** appear.
6. Confirm the action does not appear once a completion already exists.

## Tests

- 5 new `MilestoneCard` tests (renders for admins, hidden for non-admins, hidden when completion exists, fires `onCompleteClick`, inline form submits + shows attribution notice).
- Full milestone suite green (38 tests), incl. reviewer Inbox regression.
- `tsc --noEmit` clean.

## Notes

- Attribution to the admin is intentional and approved — transparency is the mitigation for the "completer also verifies" case; no conflict-of-interest block added.
- Scope intentionally limited to the Milestones Review page; the reviewer Inbox and application admin milestones tab are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins and staff can now complete milestones on behalf of grantees via a dedicated "Complete on behalf of grantee" action.
  * A completion form appears with an optional comment field and submit/cancel actions.
  * Completion status is tracked and reflected in the UI.

* **Tests**
  * Added comprehensive test coverage for the milestone completion feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->