### PR TITLE
fix(inbox): restore Comments tab on milestone detail

### DIFF
--- a/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
+++ b/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
@@ -9,6 +9,7 @@ const mockUseIsReviewerType = vi.fn();
 const mockVerifyMilestone = vi.fn();
 const mockUseMilestoneEvaluation = vi.fn();
 const mockUseMilestoneAllocationsByGrants = vi.fn();
+const mockUseFundingApplicationByProjectUID = vi.fn();
 const mockRefetch = vi.fn();
 const mockInvalidateQueries = vi.fn();
 
@@ -57,6 +58,29 @@ vi.mock("@/hooks/useMilestoneEvaluation", () => ({
 vi.mock("@/hooks/useCommunityMilestoneAllocations", () => ({
   useMilestoneAllocationsByGrants: (...args: unknown[]) =>
     mockUseMilestoneAllocationsByGrants(...args),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ address: "0xreviewer" }),
+}));
+
+vi.mock("@/hooks/useFundingApplicationByProjectUID", () => ({
+  useFundingApplicationByProjectUID: (...args: unknown[]) =>
+    mockUseFundingApplicationByProjectUID(...args),
+}));
+
+// Comments threads are exercised in their own suites; stub them to probes that
+// surface the identifier the inbox wired through.
+vi.mock("@/components/Pages/Admin/MilestonesReview/CommentsAndActivity", () => ({
+  CommentsAndActivity: (props: { referenceNumber: string }) => (
+    <div data-testid="comments-and-activity">{props.referenceNumber}</div>
+  ),
+}));
+
+vi.mock("@/components/Pages/Admin/MilestonesReview/GrantCommentsAndActivity", () => ({
+  GrantCommentsAndActivity: (props: { projectUID: string }) => (
+    <div data-testid="grant-comments-and-activity">{props.projectUID}</div>
+  ),
 }));
 
 // MilestoneCard pulls in heavy SDK + clipboard utilities; stub it to a probe
@@ -126,6 +150,12 @@ beforeEach(() => {
     refetch: vi.fn(),
   });
   mockUseMilestoneAllocationsByGrants.mockReturnValue({ allocationMap: new Map() });
+  mockUseFundingApplicationByProjectUID.mockReturnValue({
+    application: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
 });
 
 describe("InboxMilestoneDetail", () => {
@@ -267,6 +297,85 @@ describe("InboxMilestoneDetail", () => {
 
     expect(mockRefetch).toHaveBeenCalled();
     expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ["reviewer-inbox"] });
+  });
+
+  it("renders Details and Comments tabs for a selected milestone", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    expect(screen.getByRole("button", { name: /Details/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Comments/ })).toBeInTheDocument();
+  });
+
+  it("does not fetch the funding application until the Comments tab is opened", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    expect(mockUseFundingApplicationByProjectUID).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    expect(mockUseFundingApplicationByProjectUID).toHaveBeenCalled();
+  });
+
+  it("shows the application comments thread on the Comments tab when a reference number exists", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    mockUseFundingApplicationByProjectUID.mockReturnValue({
+      application: { referenceNumber: "REF-1", statusHistory: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    expect(screen.getByTestId("comments-and-activity")).toHaveTextContent("REF-1");
+  });
+
+  it("falls back to the grant comments thread when no application reference exists", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    expect(screen.getByTestId("grant-comments-and-activity")).toHaveTextContent("proj-1");
+  });
+
+  it("shows a loading skeleton on the Comments tab while the application loads", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    mockUseFundingApplicationByProjectUID.mockReturnValue({
+      application: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    expect(screen.getByLabelText("Loading comments")).toBeInTheDocument();
   });
 
   it("refreshes the reviewer-inbox feed as soon as milestone caches invalidate, before on-chain indexing confirms", () => {

--- a/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
+++ b/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
@@ -308,8 +308,14 @@ describe("InboxMilestoneDetail", () => {
     });
 
     render(<InboxMilestoneDetail {...baseProps} />);
-    expect(screen.getByRole("button", { name: /Details/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Comments/ })).toBeInTheDocument();
+    const detailsTab = screen.getByRole("tab", { name: /Details/ });
+    const commentsTab = screen.getByRole("tab", { name: /Comments/ });
+    expect(detailsTab).toHaveAttribute("aria-selected", "true");
+    expect(commentsTab).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(commentsTab);
+    expect(commentsTab).toHaveAttribute("aria-selected", "true");
+    expect(detailsTab).toHaveAttribute("aria-selected", "false");
   });
 
   it("does not fetch the funding application until the Comments tab is opened", () => {
@@ -323,7 +329,7 @@ describe("InboxMilestoneDetail", () => {
     render(<InboxMilestoneDetail {...baseProps} />);
     expect(mockUseFundingApplicationByProjectUID).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Comments/ }));
     expect(mockUseFundingApplicationByProjectUID).toHaveBeenCalled();
   });
 
@@ -342,7 +348,7 @@ describe("InboxMilestoneDetail", () => {
     });
 
     render(<InboxMilestoneDetail {...baseProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Comments/ }));
     expect(screen.getByTestId("comments-and-activity")).toHaveTextContent("REF-1");
   });
 
@@ -355,7 +361,7 @@ describe("InboxMilestoneDetail", () => {
     });
 
     render(<InboxMilestoneDetail {...baseProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Comments/ }));
     expect(screen.getByTestId("grant-comments-and-activity")).toHaveTextContent("proj-1");
   });
 
@@ -374,7 +380,7 @@ describe("InboxMilestoneDetail", () => {
     });
 
     render(<InboxMilestoneDetail {...baseProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /Comments/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Comments/ }));
     expect(screen.getByLabelText("Loading comments")).toBeInTheDocument();
   });
 

--- a/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
+++ b/__tests__/components/Inbox/InboxMilestoneDetail.test.tsx
@@ -384,6 +384,29 @@ describe("InboxMilestoneDetail", () => {
     expect(screen.getByLabelText("Loading comments")).toBeInTheDocument();
   });
 
+  it("shows an error state with a working retry on the Comments tab when the application fetch fails", () => {
+    mockUseProjectGrantMilestones.mockReturnValue({
+      data: makeData([makeMilestone()]),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const mockAppRefetch = vi.fn();
+    mockUseFundingApplicationByProjectUID.mockReturnValue({
+      application: undefined,
+      isLoading: false,
+      error: new Error("Network error"),
+      refetch: mockAppRefetch,
+    });
+
+    render(<InboxMilestoneDetail {...baseProps} />);
+    fireEvent.click(screen.getByRole("tab", { name: /Comments/ }));
+    expect(screen.getByText("Failed to load comments.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mockAppRefetch).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes the reviewer-inbox feed as soon as milestone caches invalidate, before on-chain indexing confirms", () => {
     mockUseIsReviewerType.mockReturnValue(true);
     mockUseProjectGrantMilestones.mockReturnValue({

--- a/components/Inbox/InboxMilestoneDetail.tsx
+++ b/components/Inbox/InboxMilestoneDetail.tsx
@@ -29,6 +29,12 @@ const MarkdownPreview = dynamic(
   { ssr: false }
 );
 
+/** Detail-pane tabs, mirroring the milestone-review page. */
+const PANEL_TABS = [
+  { key: "details" as const, label: "Details", icon: DocumentTextIcon },
+  { key: "comments" as const, label: "Comments", icon: ChatBubbleLeftRightIcon },
+];
+
 /** Strip the optional chainId suffix from program IDs (e.g. "959_42161" -> "959"). */
 function parseProgramId(programId: string): string {
   if (programId.includes("_")) {
@@ -365,10 +371,7 @@ export function InboxMilestoneDetail({
   return (
     <div className="space-y-4">
       <div className="inline-flex w-max rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-zinc-700 dark:bg-zinc-800">
-        {[
-          { key: "details" as const, label: "Details", icon: DocumentTextIcon },
-          { key: "comments" as const, label: "Comments", icon: ChatBubbleLeftRightIcon },
-        ].map((tab) => {
+        {PANEL_TABS.map((tab) => {
           const Icon = tab.icon;
           const isActive = activePanelTab === tab.key;
           return (

--- a/components/Inbox/InboxMilestoneDetail.tsx
+++ b/components/Inbox/InboxMilestoneDetail.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { SparklesIcon } from "@heroicons/react/20/solid";
+import { ChatBubbleLeftRightIcon, DocumentTextIcon, SparklesIcon } from "@heroicons/react/20/solid";
 import { useQueryClient } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { memo, useCallback, useMemo, useState } from "react";
+import { CommentsAndActivity } from "@/components/Pages/Admin/MilestonesReview/CommentsAndActivity";
+import { GrantCommentsAndActivity } from "@/components/Pages/Admin/MilestonesReview/GrantCommentsAndActivity";
 import { MilestoneCard } from "@/components/Pages/Admin/MilestonesReview/MilestoneCard";
 import { Button } from "@/components/Utilities/Button";
+import { useAuth } from "@/hooks/useAuth";
 import { useMilestoneAllocationsByGrants } from "@/hooks/useCommunityMilestoneAllocations";
+import { useFundingApplicationByProjectUID } from "@/hooks/useFundingApplicationByProjectUID";
 import { useMilestoneCompletionVerification } from "@/hooks/useMilestoneCompletionVerification";
 import { useMilestoneEvaluation } from "@/hooks/useMilestoneEvaluation";
 import { useProjectGrantMilestones } from "@/hooks/useProjectGrantMilestones";
@@ -132,6 +136,95 @@ function InlineAIEvaluation({ milestone }: { milestone: GrantMilestoneWithComple
   );
 }
 
+/**
+ * Comments & activity tab for the inbox milestone detail. Mirrors the
+ * milestone-review page: the thread is keyed on the grantee's funding
+ * application (resolved by project UID), falling back to the grant-level
+ * thread when no application reference exists. The funding application is
+ * fetched lazily — only when this tab is mounted.
+ */
+function MilestoneCommentsTab({
+  projectUID,
+  programId,
+  communityId,
+}: {
+  projectUID: string;
+  programId: string;
+  communityId: string;
+}) {
+  const { address } = useAuth();
+  const {
+    application: fundingApplication,
+    isLoading,
+    error,
+    refetch,
+  } = useFundingApplicationByProjectUID(projectUID || "");
+  const referenceNumber = fundingApplication?.referenceNumber;
+
+  if (isLoading && !referenceNumber) {
+    return (
+      <output
+        aria-label="Loading comments"
+        className="block animate-pulse space-y-3 rounded-lg border border-gray-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        <span className="block h-5 w-40 rounded bg-gray-200 dark:bg-zinc-700" />
+        <span className="block h-4 w-full rounded bg-gray-100 dark:bg-zinc-800" />
+        <span className="block h-4 w-3/4 rounded bg-gray-100 dark:bg-zinc-800" />
+      </output>
+    );
+  }
+
+  if (error && !referenceNumber) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/10">
+        <p className="mb-3 text-sm text-red-700 dark:text-red-300">Failed to load comments.</p>
+        <Button variant="secondary" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (referenceNumber) {
+    return (
+      <CommentsAndActivity
+        referenceNumber={referenceNumber}
+        statusHistory={(fundingApplication?.statusHistory || []).map((item) => ({
+          status: item.status,
+          timestamp:
+            typeof item.timestamp === "string" ? item.timestamp : item.timestamp.toISOString(),
+          reason: item.reason,
+        }))}
+        communityId={communityId}
+        currentUserAddress={address}
+        programId={programId}
+        embedded
+      />
+    );
+  }
+
+  if (projectUID) {
+    return (
+      <GrantCommentsAndActivity
+        projectUID={projectUID}
+        programId={programId}
+        communityId={communityId}
+        currentUserAddress={address}
+        referenceNumber={referenceNumber}
+        embedded
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-dashed border-gray-200 p-8 text-center dark:border-zinc-700">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Comments are not available until the project data finishes loading.
+      </p>
+    </div>
+  );
+}
+
 interface InboxMilestoneDetailProps {
   /** Project UID (or slug) used to fetch the grant's milestones. */
   projectUid: string;
@@ -145,7 +238,7 @@ interface InboxMilestoneDetailProps {
   projectTitle?: string;
   /** The milestone to render. Must match one in the fetched grant. */
   milestoneUid: string;
-  /** Community id (reserved for parity with the report wiring). */
+  /** Community id — scopes the comments/activity thread. */
   communityId: string;
 }
 
@@ -156,9 +249,11 @@ export function InboxMilestoneDetail({
   projectSlug,
   projectTitle,
   milestoneUid,
+  communityId,
 }: InboxMilestoneDetailProps) {
   const parsedProgramId = useMemo(() => parseProgramId(programId), [programId]);
   const queryClient = useQueryClient();
+  const [activePanelTab, setActivePanelTab] = useState<"details" | "comments">("details");
 
   const { data, isLoading, error, refetch } = useProjectGrantMilestones(projectUid, programId);
 
@@ -269,35 +364,71 @@ export function InboxMilestoneDetail({
 
   return (
     <div className="space-y-4">
-      <MilestoneCard
-        key={selectedMilestone.uid}
-        milestone={selectedMilestone}
-        index={index < 0 ? 0 : index}
-        verifyingMilestoneId={verifyingMilestoneId}
-        verificationComment={verificationComment}
-        isVerifying={isVerifying}
-        canVerifyMilestones={canVerifyMilestones}
-        canDeleteMilestones={false}
-        canEditMilestones={false}
-        grantUID={grant?.uid ?? grantUid}
-        grantChainID={grant?.chainID}
-        projectUid={project?.uid ?? projectUid}
-        projectSlug={project?.details?.slug ?? projectSlug}
-        projectTitle={project?.details?.title ?? projectTitle}
-        programId={parsedProgramId}
-        onVerifyClick={handleVerifyClick}
-        onCancelVerification={handleCancelVerification}
-        onVerificationCommentChange={setVerificationComment}
-        onSubmitVerification={handleSubmitVerification}
-        onDeleteMilestone={handleDeleteMilestone}
-        allocationAmount={
-          allocationMap.get(selectedMilestone.uid) ??
-          allocationMap.get(selectedMilestone.uid.toLowerCase())
-        }
-        showAIEvaluationButton={false}
-        quietSurface
-      />
-      <InlineAIEvaluation milestone={selectedMilestone} />
+      <div className="inline-flex w-max rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-zinc-700 dark:bg-zinc-800">
+        {[
+          { key: "details" as const, label: "Details", icon: DocumentTextIcon },
+          { key: "comments" as const, label: "Comments", icon: ChatBubbleLeftRightIcon },
+        ].map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activePanelTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActivePanelTab(tab.key)}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue",
+                isActive
+                  ? "bg-white text-gray-950 shadow-sm dark:bg-zinc-950 dark:text-white"
+                  : "text-gray-600 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white"
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {activePanelTab === "details" ? (
+        <div className="space-y-4">
+          <MilestoneCard
+            key={selectedMilestone.uid}
+            milestone={selectedMilestone}
+            index={index < 0 ? 0 : index}
+            verifyingMilestoneId={verifyingMilestoneId}
+            verificationComment={verificationComment}
+            isVerifying={isVerifying}
+            canVerifyMilestones={canVerifyMilestones}
+            canDeleteMilestones={false}
+            canEditMilestones={false}
+            grantUID={grant?.uid ?? grantUid}
+            grantChainID={grant?.chainID}
+            projectUid={project?.uid ?? projectUid}
+            projectSlug={project?.details?.slug ?? projectSlug}
+            projectTitle={project?.details?.title ?? projectTitle}
+            programId={parsedProgramId}
+            onVerifyClick={handleVerifyClick}
+            onCancelVerification={handleCancelVerification}
+            onVerificationCommentChange={setVerificationComment}
+            onSubmitVerification={handleSubmitVerification}
+            onDeleteMilestone={handleDeleteMilestone}
+            allocationAmount={
+              allocationMap.get(selectedMilestone.uid) ??
+              allocationMap.get(selectedMilestone.uid.toLowerCase())
+            }
+            showAIEvaluationButton={false}
+            quietSurface
+          />
+          <InlineAIEvaluation milestone={selectedMilestone} />
+        </div>
+      ) : (
+        <MilestoneCommentsTab
+          projectUID={project?.uid ?? projectUid}
+          programId={parsedProgramId}
+          communityId={communityId}
+        />
+      )}
     </div>
   );
 }

--- a/components/Inbox/InboxMilestoneDetail.tsx
+++ b/components/Inbox/InboxMilestoneDetail.tsx
@@ -370,7 +370,11 @@ export function InboxMilestoneDetail({
 
   return (
     <div className="space-y-4">
-      <div className="inline-flex w-max rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-zinc-700 dark:bg-zinc-800">
+      <div
+        role="tablist"
+        aria-label="Milestone detail sections"
+        className="inline-flex w-max rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-zinc-700 dark:bg-zinc-800"
+      >
         {PANEL_TABS.map((tab) => {
           const Icon = tab.icon;
           const isActive = activePanelTab === tab.key;
@@ -378,6 +382,10 @@ export function InboxMilestoneDetail({
             <button
               key={tab.key}
               type="button"
+              role="tab"
+              id={`inbox-ms-tab-${tab.key}`}
+              aria-selected={isActive}
+              aria-controls={`inbox-ms-panel-${tab.key}`}
               onClick={() => setActivePanelTab(tab.key)}
               className={cn(
                 "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue",
@@ -393,45 +401,51 @@ export function InboxMilestoneDetail({
         })}
       </div>
 
-      {activePanelTab === "details" ? (
-        <div className="space-y-4">
-          <MilestoneCard
-            key={selectedMilestone.uid}
-            milestone={selectedMilestone}
-            index={index < 0 ? 0 : index}
-            verifyingMilestoneId={verifyingMilestoneId}
-            verificationComment={verificationComment}
-            isVerifying={isVerifying}
-            canVerifyMilestones={canVerifyMilestones}
-            canDeleteMilestones={false}
-            canEditMilestones={false}
-            grantUID={grant?.uid ?? grantUid}
-            grantChainID={grant?.chainID}
-            projectUid={project?.uid ?? projectUid}
-            projectSlug={project?.details?.slug ?? projectSlug}
-            projectTitle={project?.details?.title ?? projectTitle}
+      <div
+        role="tabpanel"
+        id={`inbox-ms-panel-${activePanelTab}`}
+        aria-labelledby={`inbox-ms-tab-${activePanelTab}`}
+      >
+        {activePanelTab === "details" ? (
+          <div className="space-y-4">
+            <MilestoneCard
+              key={selectedMilestone.uid}
+              milestone={selectedMilestone}
+              index={index < 0 ? 0 : index}
+              verifyingMilestoneId={verifyingMilestoneId}
+              verificationComment={verificationComment}
+              isVerifying={isVerifying}
+              canVerifyMilestones={canVerifyMilestones}
+              canDeleteMilestones={false}
+              canEditMilestones={false}
+              grantUID={grant?.uid ?? grantUid}
+              grantChainID={grant?.chainID}
+              projectUid={project?.uid ?? projectUid}
+              projectSlug={project?.details?.slug ?? projectSlug}
+              projectTitle={project?.details?.title ?? projectTitle}
+              programId={parsedProgramId}
+              onVerifyClick={handleVerifyClick}
+              onCancelVerification={handleCancelVerification}
+              onVerificationCommentChange={setVerificationComment}
+              onSubmitVerification={handleSubmitVerification}
+              onDeleteMilestone={handleDeleteMilestone}
+              allocationAmount={
+                allocationMap.get(selectedMilestone.uid) ??
+                allocationMap.get(selectedMilestone.uid.toLowerCase())
+              }
+              showAIEvaluationButton={false}
+              quietSurface
+            />
+            <InlineAIEvaluation milestone={selectedMilestone} />
+          </div>
+        ) : (
+          <MilestoneCommentsTab
+            projectUID={project?.uid ?? projectUid}
             programId={parsedProgramId}
-            onVerifyClick={handleVerifyClick}
-            onCancelVerification={handleCancelVerification}
-            onVerificationCommentChange={setVerificationComment}
-            onSubmitVerification={handleSubmitVerification}
-            onDeleteMilestone={handleDeleteMilestone}
-            allocationAmount={
-              allocationMap.get(selectedMilestone.uid) ??
-              allocationMap.get(selectedMilestone.uid.toLowerCase())
-            }
-            showAIEvaluationButton={false}
-            quietSurface
+            communityId={communityId}
           />
-          <InlineAIEvaluation milestone={selectedMilestone} />
-        </div>
-      ) : (
-        <MilestoneCommentsTab
-          projectUID={project?.uid ?? projectUid}
-          programId={parsedProgramId}
-          communityId={communityId}
-        />
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Overview

Restores the **Comments** tab on the milestone detail view inside the Reviewer Inbox.

## Problem

The milestone-review page (`components/Pages/Admin/MilestonesReview`) renders a selected milestone in a two-tab pane — **Details** and **Comments** — where the Comments tab shows the application comment thread (`CommentsAndActivity`, falling back to `GrantCommentsAndActivity`).

When that detail view was ported into the Reviewer Inbox (`InboxMilestoneDetail`), only the **Details** content (`MilestoneCard` + AI evaluation) was carried over. The Comments tab was dropped, so a reviewer clicking a milestone in the inbox could not see or leave comments.

## Solution

- Restore the `Details | Comments` tab bar in `InboxMilestoneDetail`, matching the review page.
- Add a `MilestoneCommentsTab` sub-component that resolves the grantee's funding application by project UID (`useFundingApplicationByProjectUID`) and renders the same `CommentsAndActivity` thread, with a `GrantCommentsAndActivity` fallback when there is no application reference, plus loading / error / empty states.
- Wire through the previously-unused `communityId` prop.
- The funding application is fetched **lazily** — only when the Comments tab is opened (a small improvement over the review page, which fetches eagerly).

No backend changes. The comment thread is sourced from the funding-application comments API (`useApplicationComments`), unchanged by this PR.

## Testing steps

1. Open `/community/[communityId]/manage/inbox` as a milestone reviewer or community admin.
2. Select a milestone in the list → detail pane shows **Details** and **Comments** tabs.
3. **Details** tab: milestone card + AI evaluation render as before.
4. **Comments** tab: the application comment thread loads (or the grant-level thread when the milestone's project has no application reference); you can read and add comments.
5. Switching back to **Details** preserves the milestone review/verify affordances.

## Risk

Low — additive, scoped to one inbox component. Reuses existing, already-tested comment components. Unit tests cover the tab bar, lazy fetch, application thread, grant fallback, and loading state (16 passing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Comments tab in Inbox Milestone Detail to view comments and activity history.
  * Users can toggle between Details and Comments; Details shows milestone summary and inline evaluation.
  * Comments panel supports lazy loading (fetch only when opened), displays loading state, shows a fallback to grant-level comments if needed, and provides an error state with retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->