### PR TITLE
chore: refresh quality-gate baseline for accumulated drift

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./scripts/quality-baseline.schema.json",
-  "generatedAt": "2026-06-04T03:56:41.033Z",
-  "generatedFromCommit": "48e1469",
+  "generatedAt": "2026-06-07T17:34:34.000Z",
+  "generatedFromCommit": "9b9698e",
   "coverage": {
     "lines": 0,
     "statements": 0,
@@ -244,14 +244,14 @@
       "maxBytes": 40000
     },
     "components/Pages/Admin/MilestonesReview/MilestoneCard.tsx": {
-      "lines": 780,
-      "bytes": 31590,
+      "lines": 852,
+      "bytes": 34809,
       "maxLines": 600,
       "maxBytes": 40000
     },
     "components/Pages/Admin/MilestonesReview/index.tsx": {
-      "lines": 1053,
-      "bytes": 41394,
+      "lines": 1089,
+      "bytes": 42980,
       "maxLines": 600,
       "maxBytes": 40000
     },
@@ -458,19 +458,25 @@
       "bytes": 28913,
       "maxLines": 600,
       "maxBytes": 40000
+    },
+    "hooks/useMilestoneCompletionVerification.ts": {
+      "lines": 661,
+      "bytes": 20047,
+      "maxLines": 600,
+      "maxBytes": 40000
     }
   },
   "reactDoctor": {
     "score": 0,
     "errors": 61,
-    "warnings": 3232,
+    "warnings": 3236,
     "byCategory": {
-      "Accessibility": 273,
+      "Accessibility": 275,
       "Architecture": 1170,
       "Correctness": 399,
       "Next.js": 145,
       "Server": 6,
-      "Performance": 598,
+      "Performance": 600,
       "State & Effects": 659,
       "TanStack Query": 30,
       "Bundle Size": 10,


### PR DESCRIPTION
## Problem

The committed `quality-baseline.json` (captured at `48e1469`, 2026-06-04) went stale as `main` evolved. As a result `quality-gate` fails on **every** PR for drift unrelated to that PR — e.g. it blocked #1588 over files that PR never touched. This is the documented repo-wide flake.

## What changed

A **targeted** baseline refresh absorbing the current accumulated drift (no production code changes):

| Metric | Baseline | Now |
|--------|----------|-----|
| `MilestonesReview/MilestoneCard.tsx` | 780 lines | 852 |
| `MilestonesReview/index.tsx` | 1053 lines | 1089 |
| `hooks/useMilestoneCompletionVerification.ts` | (untracked) | 661 lines |
| React Doctor warnings | 3232 | 3236 (Accessibility +2, Performance +2) |

## Why a targeted edit, not a full `quality:baseline` regen

A full `pnpm run quality:baseline` on a Windows/CRLF checkout pollutes the Biome count: local `biome check` reports **3084 spurious `format` diagnostics** for CRLF line endings (4328 total locally vs 1245 on CI's LF). Removing those format diagnostics gives 1244 ≈ the CI baseline, confirming the only real drift is the line-count and React-Doctor metrics above — both line-ending-insensitive. So this PR edits only those, leaving the Biome/coverage/knip/duplication figures (which already match the gate) untouched. Byte/line figures are computed LF-accurate (verified: `useMilestoneCompletionVerification.ts` → 661 lines / 20047 bytes matches CI's reported value exactly).

## Risk

None to runtime — only `quality-baseline.json` changes. After this merges, `quality-gate` returns to a true pass/fail signal for subsequent PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal quality baseline metrics and generation metadata to reflect current codebase state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->