### PR TITLE
fix: serialize gasless UserOperations per sender to prevent AA25 nonce collisions

### DIFF
--- a/__tests__/unit/utilities/gasless/userOpQueue.test.ts
+++ b/__tests__/unit/utilities/gasless/userOpQueue.test.ts
@@ -1,0 +1,130 @@
+import { serializeBySender, withUserOpSerialization } from "@/utilities/gasless/utils/userOpQueue";
+
+const SENDER_A = "0xAAAA000000000000000000000000000000000000";
+const SENDER_B = "0xBBBB000000000000000000000000000000000000";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("serializeBySender", () => {
+  it("runs ops for the same sender one at a time, in order", async () => {
+    const events: string[] = [];
+    const first = deferred<void>();
+
+    const op1 = serializeBySender(SENDER_A, async () => {
+      events.push("1:start");
+      await first.promise;
+      events.push("1:end");
+    });
+
+    const op2 = serializeBySender(SENDER_A, async () => {
+      events.push("2:start");
+      events.push("2:end");
+    });
+
+    // Op2 must not begin until op1 resolves, even though both were queued.
+    await Promise.resolve();
+    expect(events).toEqual(["1:start"]);
+
+    first.resolve();
+    await Promise.all([op1, op2]);
+
+    expect(events).toEqual(["1:start", "1:end", "2:start", "2:end"]);
+  });
+
+  it("does not block a different sender", async () => {
+    const events: string[] = [];
+    const blockA = deferred<void>();
+
+    const opA = serializeBySender(SENDER_A, async () => {
+      events.push("A:start");
+      await blockA.promise;
+      events.push("A:end");
+    });
+
+    const opB = serializeBySender(SENDER_B, async () => {
+      events.push("B:done");
+    });
+
+    await opB;
+    // B finished while A is still pending — senders are independent.
+    expect(events).toEqual(["A:start", "B:done"]);
+
+    blockA.resolve();
+    await opA;
+    expect(events).toEqual(["A:start", "B:done", "A:end"]);
+  });
+
+  it("propagates the task's error to the caller", async () => {
+    const boom = new Error("AA25");
+    await expect(
+      serializeBySender(SENDER_A, async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+  });
+
+  it("keeps draining the queue after one op rejects", async () => {
+    const order: string[] = [];
+
+    const failing = serializeBySender(SENDER_A, async () => {
+      order.push("fail");
+      throw new Error("boom");
+    });
+    const next = serializeBySender(SENDER_A, async () => {
+      order.push("next");
+      return "ok";
+    });
+
+    await expect(failing).rejects.toThrow("boom");
+    await expect(next).resolves.toBe("ok");
+    expect(order).toEqual(["fail", "next"]);
+  });
+});
+
+describe("withUserOpSerialization", () => {
+  it("serializes eth_sendTransaction calls and passes other methods through", async () => {
+    const active = { count: 0, max: 0 };
+    const gate = deferred<void>();
+    let firstSend = true;
+
+    const provider = {
+      request: async ({ method }: { method: string; params?: unknown }) => {
+        if (method === "eth_sendTransaction") {
+          active.count += 1;
+          active.max = Math.max(active.max, active.count);
+          // Hold the first send open so a second concurrent send would overlap
+          // if serialization were not in effect.
+          if (firstSend) {
+            firstSend = false;
+            await gate.promise;
+          }
+          active.count -= 1;
+          return "0xhash";
+        }
+        return "0xchainid";
+      },
+    };
+
+    const wrapped = withUserOpSerialization(provider, SENDER_A);
+
+    const send1 = wrapped.request({ method: "eth_sendTransaction" });
+    const send2 = wrapped.request({ method: "eth_sendTransaction" });
+
+    // A non-send call resolves immediately, not blocked by the in-flight send.
+    await expect(wrapped.request({ method: "eth_chainId" })).resolves.toBe("0xchainid");
+
+    gate.resolve();
+    await Promise.all([send1, send2]);
+
+    // Never more than one send running at once.
+    expect(active.max).toBe(1);
+  });
+});

--- a/__tests__/unit/utilities/gasless/userOpQueue.test.ts
+++ b/__tests__/unit/utilities/gasless/userOpQueue.test.ts
@@ -87,6 +87,29 @@ describe("serializeBySender", () => {
     await expect(next).resolves.toBe("ok");
     expect(order).toEqual(["fail", "next"]);
   });
+
+  it("serializes ops with an undefined sender under the shared fallback key", async () => {
+    // When the smart-account address can't be read it's almost always the same
+    // wallet in-session, so undefined senders must still serialize together to
+    // keep the nonce safe.
+    const order: string[] = [];
+    const gate = deferred<void>();
+
+    const op1 = serializeBySender(undefined, async () => {
+      order.push("1");
+      await gate.promise;
+    });
+    const op2 = serializeBySender(undefined, async () => {
+      order.push("2");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["1"]);
+
+    gate.resolve();
+    await Promise.all([op1, op2]);
+    expect(order).toEqual(["1", "2"]);
+  });
 });
 
 describe("withUserOpSerialization", () => {

--- a/utilities/gasless/providers/alchemy.provider.ts
+++ b/utilities/gasless/providers/alchemy.provider.ts
@@ -11,6 +11,7 @@ import type {
   SmartAccountClient,
 } from "../types";
 import { GaslessProviderError } from "../types";
+import { serializeBySender } from "../utils/userOpQueue";
 
 /**
  * Maps viem chain IDs to Alchemy Account Kit chain definitions.
@@ -121,23 +122,28 @@ export class AlchemyProvider implements IGaslessProvider {
         if (method === "eth_sendTransaction") {
           const tx = (params as Array<{ to: string; data: string; value?: string }>)[0];
 
-          try {
-            // Alchemy uses sendUserOperation for smart account transactions
-            const result = await client.sendUserOperation({
-              uo: {
-                target: tx.to as `0x${string}`,
-                data: (tx.data || "0x") as `0x${string}`,
-                value: tx.value ? BigInt(tx.value) : 0n,
-              },
-            });
+          // Serialize UserOps per sender: an ERC-4337 nonce only advances once
+          // an op is included, so two concurrent ops would share a nonce and
+          // the bundler rejects the second with AA25.
+          return serializeBySender(client.account?.address, async () => {
+            try {
+              // Alchemy uses sendUserOperation for smart account transactions
+              const result = await client.sendUserOperation({
+                uo: {
+                  target: tx.to as `0x${string}`,
+                  data: (tx.data || "0x") as `0x${string}`,
+                  value: tx.value ? BigInt(tx.value) : 0n,
+                },
+              });
 
-            // Wait for the user operation to be included
-            const txHash = await client.waitForUserOperationTransaction(result);
-            return txHash;
-          } catch (txError) {
-            console.error("[Alchemy] Transaction failed:", txError);
-            throw txError;
-          }
+              // Wait for the user operation to be included
+              const txHash = await client.waitForUserOperationTransaction(result);
+              return txHash;
+            } catch (txError) {
+              console.error("[Alchemy] Transaction failed:", txError);
+              throw txError;
+            }
+          });
         }
 
         if (method === "eth_accounts" || method === "eth_requestAccounts") {

--- a/utilities/gasless/providers/zerodev.provider.ts
+++ b/utilities/gasless/providers/zerodev.provider.ts
@@ -15,6 +15,7 @@ import type {
   SmartAccountClient,
 } from "../types";
 import { GaslessProviderError } from "../types";
+import { withUserOpSerialization } from "../utils/userOpQueue";
 
 /**
  * EntryPoint v0.7 for ERC-4337.
@@ -199,8 +200,13 @@ export class ZeroDevProvider implements IGaslessProvider {
     chainId: number,
     config: ChainGaslessConfig
   ): Promise<Signer> {
-    // Create EIP-1193 provider from kernel client
-    const kernelProvider = new KernelEIP1193Provider(client);
+    // Create EIP-1193 provider from kernel client. Serialize UserOps per sender
+    // so concurrent attestations (e.g. deleting several milestones in a row)
+    // can't submit two ops on the same nonce and trip the bundler's AA25 guard.
+    const kernelProvider = withUserOpSerialization(
+      new KernelEIP1193Provider(client),
+      client.account?.address
+    );
 
     // Wrap in ethers BrowserProvider, pinning the network to the kernel
     // client's chain. Without an explicit network, ethers v6 lazily probes

--- a/utilities/gasless/utils/userOpQueue.ts
+++ b/utilities/gasless/utils/userOpQueue.ts
@@ -1,0 +1,76 @@
+/**
+ * Serializes UserOperation submissions per smart-account sender.
+ *
+ * ERC-4337 accounts advance their nonce only once a UserOperation is included.
+ * Firing two operations for the same sender before the first is mined makes
+ * both read the same nonce, and the bundler rejects the second with
+ * `AA25 invalid account nonce: Another UserOperation with same sender and nonce
+ * is already being processed`.
+ *
+ * The app builds a fresh smart-account client per transaction, so a per-client
+ * lock can't span concurrent operations. This queue lives at module scope,
+ * keyed by sender address, so it serializes ops across those independent
+ * clients (and across unrelated UI components that each fire their own tx).
+ */
+
+const tails = new Map<string, Promise<unknown>>();
+
+const keyFor = (sender: string | undefined): string => (sender ?? "unknown").toLowerCase();
+
+/**
+ * Runs `task` only after every previously queued op for `sender` has settled.
+ * The stored tail never rejects, so a failed op delays — but does not poison —
+ * the next one. The caller still receives the task's real result or error.
+ */
+export function serializeBySender<T>(
+  sender: string | undefined,
+  task: () => Promise<T>
+): Promise<T> {
+  const key = keyFor(sender);
+  const prev = tails.get(key) ?? Promise.resolve();
+
+  const run = prev.then(() => task());
+
+  const tail = run.catch(() => undefined);
+  tails.set(key, tail);
+  tail.finally(() => {
+    // Drop the slot when this op is the last one queued, so the map doesn't
+    // grow unbounded over a long session.
+    if (tails.get(key) === tail) {
+      tails.delete(key);
+    }
+  });
+
+  return run;
+}
+
+type Eip1193Like = {
+  request: (args: { method: string; params?: unknown }) => Promise<unknown>;
+};
+
+/**
+ * Wraps an EIP-1193 provider so `eth_sendTransaction` calls are serialized per
+ * sender via {@link serializeBySender}. All other methods pass through
+ * untouched (including any event emitter surface), so vendor providers like
+ * ZeroDev's `KernelEIP1193Provider` keep working as-is.
+ */
+export function withUserOpSerialization<P extends Eip1193Like>(
+  provider: P,
+  sender: string | undefined
+): P {
+  const originalRequest = provider.request.bind(provider);
+
+  return new Proxy(provider, {
+    get(target, prop, receiver) {
+      if (prop === "request") {
+        return (args: { method: string; params?: unknown }) => {
+          if (args?.method === "eth_sendTransaction") {
+            return serializeBySender(sender, () => originalRequest(args));
+          }
+          return originalRequest(args);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}


### PR DESCRIPTION
## Problem

Sentry [GAP-FRONTEND-22W](https://karma-crypto-inc.sentry.io/issues/7536781530/): deleting a milestone failed with

```
AA25 invalid account nonce: Another UserOperation with same sender and nonce is already being processed
```

ERC-4337 smart accounts advance their nonce only once a UserOperation is *included*. Firing two operations for the same sender before the first is mined makes both read the same nonce, so the bundler rejects the second with `AA25`.

### How the race happens
- The only in-flight guard is `isDeleting` in `useMilestone()`, surfaced as the delete dialog's `disabled` button.
- But `useMilestone()` is instantiated **per milestone row**, so each row has its own `isDeleting`. The grant in the event had 28 milestones — deleting two rows in quick succession fires two UserOps from the one wallet.
- A fresh smart-account client is built **per transaction** (`getAttestationSigner` → `createGaslessClient`), so no per-client lock can span operations.
- `multiGrantUndoCompletion` / `completeMilestone` / `multiGrantEditCompletion` have no in-flight guard at all, so a delete racing any other on-chain action collides the same way.

A per-component guard can't fix this — the nonce is **global to the wallet**, the guard is **local to a row**. The fix has to live where UserOps are submitted.

## Solution

A module-level queue keyed by smart-account sender address that serializes `eth_sendTransaction` calls. Because it lives at module scope, it spans the per-transaction clients and any unrelated component that fires its own tx. This covers **every** gasless flow (delete, complete, edit, create), not just delete.

- **`utilities/gasless/utils/userOpQueue.ts`** *(new)* — `serializeBySender(sender, task)` (promise-chain queue; a failed op delays but doesn't poison the next) and `withUserOpSerialization(provider, sender)` (a Proxy that funnels only `eth_sendTransaction` through the queue, passing all other methods through untouched).
- **`providers/zerodev.provider.ts`** — wrap the vendor `KernelEIP1193Provider` with `withUserOpSerialization`. This is the Base/production path that threw.
- **`providers/alchemy.provider.ts`** — wrap the `sendUserOperation` + `waitForUserOperationTransaction` block in `serializeBySender`.

## Testing

- `__tests__/unit/utilities/gasless/userOpQueue.test.ts` *(new, 6 cases)*: same-sender ordering, cross-sender independence, error propagation, queue-survives-rejection, and the wrapper serializing only sends.
- New tests pass; all 135 existing gasless unit tests pass; Biome clean.

### Manual
1. Log in with an email/Google (embedded-wallet) account on a gasless chain (Base).
2. On a grant with several on-chain milestones, click delete on two rows in quick succession.
3. Before the fix: the second submission could fail with `AA25`. After: the second op waits for the first to be included, then proceeds.

## Notes
- Scope is per-tab. A user with two tabs could still theoretically collide; an `AA25`-catch-and-retry could be layered into the same queue later if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gasless transaction reliability by serializing user operations per account, preventing nonce collisions and bundler rejections during concurrent transactions.
* **New Features**
  * Providers now serialize outgoing transaction requests per sender to ensure sequential submission.
* **Tests**
  * Added unit tests covering per-sender serialization behavior, error handling, and non-transaction passthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->