### PR TITLE
fix(sitemap): omit always-now lastmod from generated sitemaps

### DIFF
--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -82,14 +82,18 @@ describe("canonicalizeSitemapUrl", () => {
 });
 
 describe("buildUrlsetXml", () => {
-  it("emits a urlset entry per URL with second-precision lastmod", () => {
+  it("emits a urlset entry per URL and canonicalizes the host", () => {
     const xml = buildUrlsetXml(["https://staging.karmahq.xyz/a"], 0.8, "daily");
     expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
     expect(xml).toContain(`<loc>${SITE}/a</loc>`);
     expect(xml).toContain("<changefreq>daily</changefreq>");
     expect(xml).toContain("<priority>0.8</priority>");
-    expect(xml).toMatch(/<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z<\/lastmod>/);
     expect(xml).not.toContain("staging.karmahq.xyz");
+  });
+
+  it("omits lastmod (no accurate per-URL modified date to emit)", () => {
+    const xml = buildUrlsetXml(["https://www.karmahq.xyz/a"], 0.8, "daily");
+    expect(xml).not.toContain("<lastmod>");
   });
 
   it("escapes XML-significant characters in URLs", () => {
@@ -109,6 +113,11 @@ describe("buildSitemapIndexXml", () => {
     const xml = buildSitemapIndexXml([`${SITE}/sitemaps/grants/sitemap/1.xml`]);
     expect(xml).toContain('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
     expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap/1.xml</loc>`);
+  });
+
+  it("omits lastmod on child entries", () => {
+    const xml = buildSitemapIndexXml([`${SITE}/sitemaps/grants/sitemap/1.xml`]);
+    expect(xml).not.toContain("<lastmod>");
   });
 });
 

--- a/app/sitemaps/communities/sitemap.ts
+++ b/app/sitemaps/communities/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
 import { chosenCommunities } from "@/utilities/chosenCommunities";
-import { formatSitemapLastmod } from "@/utilities/sitemap";
 
 const communitySubPages = [
   "funding-opportunities",
@@ -12,22 +11,21 @@ const communitySubPages = [
   "reports",
 ] as const;
 
+// `lastModified` is intentionally omitted — we have no accurate per-page
+// modified date, and a fabricated "now" makes Google distrust the signal
+// (see utilities/sitemap.ts buildUrlsetXml).
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = formatSitemapLastmod();
-
   return chosenCommunities().flatMap((community) => {
     const identifier = community.slug || community.uid;
 
     const rootEntry: MetadataRoute.Sitemap[number] = {
       url: `https://www.karmahq.xyz/community/${identifier}`,
-      lastModified: now,
       changeFrequency: "daily",
       priority: 0.9,
     };
 
     const subPageEntries: MetadataRoute.Sitemap = communitySubPages.map((subPage) => ({
       url: `https://www.karmahq.xyz/community/${identifier}/${subPage}`,
-      lastModified: now,
       changeFrequency: "daily" as const,
       priority: 0.7,
     }));

--- a/app/sitemaps/static/sitemap.ts
+++ b/app/sitemaps/static/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/utilities/meta";
-import { formatSitemapLastmod } from "@/utilities/sitemap";
 
 const staticPages = [
   "",
@@ -50,11 +49,12 @@ const staticPages = [
 
 const lowPriorityPages = ["/privacy-policy", "/terms-and-conditions"];
 
+// `lastModified` is intentionally omitted — we have no accurate per-page
+// modified date, and a fabricated "now" makes Google distrust the signal
+// (see utilities/sitemap.ts buildUrlsetXml).
 export default function sitemap(): MetadataRoute.Sitemap {
-  const lastModified = formatSitemapLastmod();
   return staticPages.map((path) => ({
     url: `${SITE_URL}${path}`,
-    lastModified,
     changeFrequency: path === "" ? "daily" : lowPriorityPages.includes(path) ? "yearly" : "weekly",
     priority:
       path === ""

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -95,24 +95,28 @@ export function canonicalizeSitemapUrl(url: string): string {
   }
 }
 
+// `lastmod` is intentionally omitted. The indexer returns only URL strings (no
+// per-entity modified date), so the only value we could emit is "now" on every
+// request — which Google treats as an inaccurate freshness signal and, per
+// Gary Illyes, makes it distrust/ignore lastmod for the whole site (the signal
+// is binary: trustworthy or ignored). Omitting it is strictly better than a
+// fabricated date. To reinstate an accurate lastmod, have the indexer return a
+// per-URL updatedAt and thread it through `urls` here.
 export function buildUrlsetXml(urls: string[], priority: number, changeFrequency: string): string {
-  const now = formatSitemapLastmod();
   const items = urls
     .map(
       (url) =>
-        `  <url>\n    <loc>${escapeXml(canonicalizeSitemapUrl(url))}</loc>\n    <lastmod>${now}</lastmod>\n    <changefreq>${changeFrequency}</changefreq>\n    <priority>${priority}</priority>\n  </url>`
+        `  <url>\n    <loc>${escapeXml(canonicalizeSitemapUrl(url))}</loc>\n    <changefreq>${changeFrequency}</changefreq>\n    <priority>${priority}</priority>\n  </url>`
     )
     .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</urlset>\n`;
 }
 
+// See buildUrlsetXml: `lastmod` is omitted here for the same reason (we have no
+// accurate per-child-sitemap modified date, only "now").
 export function buildSitemapIndexXml(locs: string[]): string {
-  const now = formatSitemapLastmod();
   const items = locs
-    .map(
-      (loc) =>
-        `  <sitemap>\n    <loc>${escapeXml(loc)}</loc>\n    <lastmod>${now}</lastmod>\n  </sitemap>`
-    )
+    .map((loc) => `  <sitemap>\n    <loc>${escapeXml(loc)}</loc>\n  </sitemap>`)
     .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</sitemapindex>\n`;
 }


### PR DESCRIPTION
## Problem

Every generated sitemap entry stamped `<lastmod>` with the **current request time**, so all ~25k project/community/grant URLs claimed they were modified "just now" on every fetch.

Google treats an always-current `lastmod` as an inaccurate freshness signal and stops trusting it. Per Google's Gary Illyes the signal is **binary** — a site with inaccurate `lastmod` history has the tag **ignored entirely**; John Mueller calls stamping today's date "a lazy setup" that "makes it harder for search engines to spot truly updated pages." This degrades how efficiently Googlebot prioritizes crawling the corpus, which matters at 25k URLs.

## Change

We only have URL strings from the indexer (no per-entity modified date), so the only value we could emit is `now`. Omitting `lastmod` is strictly better than a fabricated one. Removed it from:

- the sitemap **index** (`buildSitemapIndexXml`)
- the per-kind **child urlsets** (`buildUrlsetXml`)
- the **static** and **communities** sitemap routes

`changefreq`/`priority` are kept (ignored by Google but harmless). `formatSitemapLastmod` remains for the `Disallow`ed `/extended-sitemap.xml` route.

## Follow-up

To reinstate an **accurate** `lastmod`, have the indexer return a per-URL `updatedAt` and thread it through `buildUrlsetXml`.

## Testing

- `pnpm typecheck` — clean
- `pnpm vitest run __tests__/utilities/sitemap.test.ts` — 23 passed (added assertions that index + urlset omit `lastmod`)

## Context

Part of the Google Search Console indexing investigation (`karmahq.xyz` discovered-URL count stuck well below the ~25k the sitemap serves). This addresses the freshness-signal trust issue; sitemap discovery is otherwise healthy and serving the full corpus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed inaccurate last modification dates from sitemap XML output.

* **Tests**
  * Updated tests to verify last modification dates are omitted from generated sitemaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->