### PR TITLE
feat(seo): Sentry tripwire for cross-request canonical mismatch

### DIFF
--- a/__tests__/utilities/sentry/reportCanonicalMismatch.test.ts
+++ b/__tests__/utilities/sentry/reportCanonicalMismatch.test.ts
@@ -1,0 +1,62 @@
+import { captureMessage } from "@sentry/nextjs";
+import { reportCanonicalMismatchIfAny } from "@/utilities/sentry/reportCanonicalMismatch";
+
+const UID = `0x${"a".repeat(64)}`;
+
+describe("reportCanonicalMismatchIfAny", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures a Sentry event when the resolved slug differs from the requested id", () => {
+    reportCanonicalMismatchIfAny({
+      scope: "project",
+      requestedId: "karma---governance",
+      resolvedSlug: "fundacin-salva-terra-1",
+      resolvedUid: UID,
+    });
+
+    expect(captureMessage).toHaveBeenCalledWith("canonical-mismatch:project", {
+      level: "error",
+      tags: { kind: "canonical-mismatch", scope: "project" },
+      extra: {
+        requestedId: "karma---governance",
+        resolvedSlug: "fundacin-salva-terra-1",
+        resolvedUid: UID,
+      },
+    });
+  });
+
+  it("does not fire when the resolved slug matches the requested id (case-insensitive)", () => {
+    reportCanonicalMismatchIfAny({
+      scope: "community",
+      requestedId: "Arbitrum",
+      resolvedSlug: "arbitrum",
+      resolvedUid: UID,
+    });
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the requested id is a uid (no slug to compare)", () => {
+    reportCanonicalMismatchIfAny({
+      scope: "project",
+      requestedId: UID,
+      resolvedSlug: "some-other-slug",
+      resolvedUid: UID,
+    });
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when no slug was resolved", () => {
+    reportCanonicalMismatchIfAny({
+      scope: "project",
+      requestedId: "karma---governance",
+      resolvedSlug: undefined,
+      resolvedUid: undefined,
+    });
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/app/community/[communityId]/layout.tsx
+++ b/app/community/[communityId]/layout.tsx
@@ -6,6 +6,7 @@ import { envVars } from "@/utilities/enviromentVars";
 import { DEFAULT_DESCRIPTION, DEFAULT_TITLE, SITE_URL, twitterMeta } from "@/utilities/meta";
 import { pagesOnRoot } from "@/utilities/pagesOnRoot";
 import { getCommunityDetails } from "@/utilities/queries/v2/getCommunityData";
+import { reportCanonicalMismatchIfAny } from "@/utilities/sentry/reportCanonicalMismatch";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
 // Deduplicate across generateMetadata, generateViewport, and Layout per request
@@ -32,6 +33,16 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { isWhitelabel, config: wlConfig } = await getCachedContext();
 
   const community = await getCommunityDetails(communityId);
+
+  // Tripwire: a resolved community whose slug differs from the requested id
+  // signals the cross-request render bleed (see reportCanonicalMismatchIfAny).
+  reportCanonicalMismatchIfAny({
+    scope: "community",
+    requestedId: communityId,
+    resolvedSlug: community?.details?.slug,
+    resolvedUid: community?.uid,
+  });
+
   const communityName = community?.details?.name || communityId;
 
   const dynamicMetadata = {

--- a/app/project/[projectId]/layout.tsx
+++ b/app/project/[projectId]/layout.tsx
@@ -11,6 +11,7 @@ import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
 import { prefetchProjectProfileData } from "@/utilities/queries/prefetchProjectProfile";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
+import { reportCanonicalMismatchIfAny } from "@/utilities/sentry/reportCanonicalMismatch";
 
 type Params = Promise<{
   projectId: string;
@@ -28,6 +29,16 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
   const { projectId } = awaitedParams;
 
   const projectInfo = await getProjectCachedData(projectId);
+
+  // Tripwire: getProjectCachedData redirects to the canonical slug, so a
+  // resolved slug that differs from the requested id here signals the
+  // cross-request render bleed rather than normal routing.
+  reportCanonicalMismatchIfAny({
+    scope: "project",
+    requestedId: projectId,
+    resolvedSlug: projectInfo?.details?.slug,
+    resolvedUid: projectInfo?.uid,
+  });
 
   return generateProjectOverviewMetadata(projectInfo, projectId);
 }

--- a/utilities/sentry/reportCanonicalMismatch.ts
+++ b/utilities/sentry/reportCanonicalMismatch.ts
@@ -1,0 +1,45 @@
+import * as Sentry from "@sentry/nextjs";
+
+interface CanonicalMismatchReport {
+  scope: "project" | "community";
+  /** The slug or uid from the route params. */
+  requestedId: string;
+  /** The canonical slug of the entity the loader actually resolved. */
+  resolvedSlug: string | undefined;
+  /** The uid of the resolved entity, for cross-referencing in Sentry. */
+  resolvedUid: string | undefined;
+}
+
+// EAS attestation uid (project/community uids look like this in the URL).
+const UID_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Tripwire for the intermittent cross-request SSR render bleed, where one
+ * request's resolved entity has surfaced in another request's metadata under
+ * concurrency.
+ *
+ * In normal flow a route's resolved canonical slug always equals its id param —
+ * the project loader (`getProjectCachedData`) even redirects to the canonical
+ * slug before returning — so reaching `generateMetadata` with a slug that does
+ * not match the requested id is a state that should be impossible. When it
+ * happens we capture the requested-vs-resolved identity so a recurrence leaves
+ * a real, timestamped reproduction in Sentry instead of a one-off anecdote.
+ *
+ * This is a no-op for the common cases (id is a uid, slug missing, or slug
+ * matches), so it adds no Sentry noise during normal operation. It cannot catch
+ * a fully self-consistent params swap (where the whole render is mis-associated)
+ * — only an inconsistency between the resolved entity and the route param.
+ */
+export function reportCanonicalMismatchIfAny(report: CanonicalMismatchReport): void {
+  const { scope, requestedId, resolvedSlug, resolvedUid } = report;
+
+  if (UID_PATTERN.test(requestedId)) return;
+  if (!resolvedSlug) return;
+  if (resolvedSlug.toLowerCase() === requestedId.toLowerCase()) return;
+
+  Sentry.captureMessage(`canonical-mismatch:${scope}`, {
+    level: "error",
+    tags: { kind: "canonical-mismatch", scope },
+    extra: { requestedId, resolvedSlug, resolvedUid },
+  });
+}


### PR DESCRIPTION
## Why

Earlier probing surfaced an **intermittent cross-request render bleed** — under concurrency, one request's resolved entity (title/canonical/og) occasionally surfaced in another request's metadata. It has only ever been observed **once** and is not currently reproducible (0 leaks across 168+ concurrent requests since), so there's no fix to verify against. This adds a **tripwire** so that *if it recurs*, we capture a real, timestamped reproduction instead of a one-off anecdote.

## What

A small helper, `reportCanonicalMismatchIfAny`, called in the **project** and **community** `generateMetadata`. After the cached loader resolves the entity, it compares the resolved canonical slug to the route id param. In normal flow these always match — the project loader (`getProjectCachedData`) even **redirects to the canonical slug before returning** — so a mismatch here is a state normal routing makes impossible. When it happens it fires `Sentry.captureMessage("canonical-mismatch:<scope>")` with `{ requestedId, resolvedSlug, resolvedUid }`.

## Noise / cost
- **No-op in normal operation**: returns early when the id is a uid, the slug is missing, or the slug matches (case-insensitive) — so it adds no Sentry noise day-to-day.
- **Lightweight**: a plain function call, no `headers()`/`cookies()`, so it does **not** opt the route out of ISR/caching.
- **Limitation (documented in code)**: it cannot catch a *fully self-consistent* params swap (where the entire render is mis-associated); it catches an inconsistency between the resolved entity and the route param (the partial/data-swap variant that was actually observed).

## How to use the signal
If `canonical-mismatch:*` events appear in Sentry, a single `requestedId` mapping to **multiple unrelated `resolvedSlug`s** is the bleed's fingerprint — that's the reproduction to act on.

## Testing
`__tests__/utilities/sentry/reportCanonicalMismatch.test.ts` — fires on mismatch; no-ops on match / uid / missing slug. `pnpm typecheck` clean, 4/4 tests pass.