### PR TITLE
fix(seo): permanent redirects + canonical/noindex corrections (GSC audit)

### DIFF
--- a/__tests__/middleware-dashboard.test.ts
+++ b/__tests__/middleware-dashboard.test.ts
@@ -105,3 +105,38 @@ describe("middleware dashboard redirects", () => {
     expect(response?.headers.get("location")).toBeNull();
   });
 });
+
+describe("middleware project URL-structure redirects", () => {
+  const uid = `0x${"a".repeat(64)}`;
+
+  it("permanently (308) redirects legacy /grants/:uid to /funding/:uid", async () => {
+    const response = await middleware(createRequest(`/project/karma/grants/${uid}`));
+
+    expect(response?.headers.get("location")).toBe(
+      `http://${STANDARD_HOST}/project/karma/funding/${uid}`
+    );
+    expect(response?.status).toBe(308);
+  });
+
+  it("permanently (308) redirects /funding/create-grant to /funding/new", async () => {
+    const response = await middleware(createRequest("/project/karma/funding/create-grant"));
+
+    expect(response?.headers.get("location")).toBe(
+      `http://${STANDARD_HOST}/project/karma/funding/new`
+    );
+    expect(response?.status).toBe(308);
+  });
+
+  it("redirects legacy /roadmap straight to the project overview (no chain) with 308", async () => {
+    const response = await middleware(createRequest("/project/karma/roadmap"));
+
+    expect(response?.headers.get("location")).toBe(`http://${STANDARD_HOST}/project/karma`);
+    expect(response?.status).toBe(308);
+  });
+
+  it("does not redirect a project literally named 'grants'", async () => {
+    const response = await middleware(createRequest("/project/grants"));
+
+    expect(response?.headers.get("location")).toBeNull();
+  });
+});

--- a/__tests__/utilities/metadata/communityCanonical.test.ts
+++ b/__tests__/utilities/metadata/communityCanonical.test.ts
@@ -1,0 +1,28 @@
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
+
+vi.mock("@/utilities/whitelabel-server", () => ({
+  getWhitelabelContext: vi.fn(),
+}));
+
+describe("communitySubpageMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds a full /community/<id>/<subpath> self-canonical on the main site", async () => {
+    vi.mocked(getWhitelabelContext).mockResolvedValue({ isWhitelabel: false } as never);
+
+    const meta = await communitySubpageMetadata("arbitrum", "reports");
+
+    expect(meta.alternates?.canonical).toBe("/community/arbitrum/reports");
+  });
+
+  it("strips the /community/<id> prefix on a whitelabel domain", async () => {
+    vi.mocked(getWhitelabelContext).mockResolvedValue({ isWhitelabel: true } as never);
+
+    const meta = await communitySubpageMetadata("optimism", "reports/2026-05-01");
+
+    expect(meta.alternates?.canonical).toBe("/reports/2026-05-01");
+  });
+});

--- a/__tests__/utilities/metadata/projectMetadata.test.ts
+++ b/__tests__/utilities/metadata/projectMetadata.test.ts
@@ -1,0 +1,33 @@
+import type { Project as ProjectResponse } from "@/types/v2/project";
+import {
+  generateProjectAboutMetadata,
+  generateProjectContactMetadata,
+} from "@/utilities/metadata/projectMetadata";
+
+const project = {
+  uid: "0x1",
+  details: { title: "Acme", slug: "acme", description: "A grant project" },
+} as unknown as ProjectResponse;
+
+describe("generateProjectContactMetadata", () => {
+  it("marks the auth-gated contact-info page as noindex but followable", () => {
+    const meta = generateProjectContactMetadata(project, "acme");
+
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("still self-canonicalizes to the contact-info path", () => {
+    const meta = generateProjectContactMetadata(project, "acme");
+
+    expect(meta.alternates?.canonical).toBe("/project/acme/contact-info");
+  });
+});
+
+describe("generateProjectAboutMetadata", () => {
+  it("does not set noindex on the public about page", () => {
+    const meta = generateProjectAboutMetadata(project, "acme");
+
+    expect(meta.robots).toBeUndefined();
+    expect(meta.alternates?.canonical).toBe("/project/acme/about");
+  });
+});

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/page.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/page.tsx
@@ -10,9 +10,11 @@ interface Props {
 }
 
 // Self-canonical per report run-date. Previously inherited defaultMetadata,
-// whose canonical is the homepage "/".
+// whose canonical is the homepage "/". Mirror the page's run-date validation so
+// an invalid run-date (which the page 404s) never emits a bogus canonical.
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { communityId, runDate } = await params;
+  if (!RUN_DATE_REGEX.test(runDate)) return {};
   return communitySubpageMetadata(communityId, `reports/${runDate}`);
 }
 

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/page.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/page.tsx
@@ -1,13 +1,19 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { PublicReportViewPage } from "@/components/Pages/Community/PortfolioReports/PublicReportViewPage";
-import { defaultMetadata } from "@/utilities/meta";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { RUN_DATE_REGEX } from "@/utilities/portfolio-reports/period";
 import { getCommunityDetails } from "@/utilities/queries/v2/community";
 
-export const metadata = defaultMetadata;
-
 interface Props {
   params: Promise<{ communityId: string; runDate: string }>;
+}
+
+// Self-canonical per report run-date. Previously inherited defaultMetadata,
+// whose canonical is the homepage "/".
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { communityId, runDate } = await params;
+  return communitySubpageMetadata(communityId, `reports/${runDate}`);
 }
 
 export default async function Page(props: Props) {

--- a/app/community/[communityId]/(with-header)/reports/page.tsx
+++ b/app/community/[communityId]/(with-header)/reports/page.tsx
@@ -1,12 +1,19 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
-import { defaultMetadata } from "@/utilities/meta";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
 import { getCommunityDetails } from "@/utilities/queries/v2/community";
-
-export const metadata = defaultMetadata;
 
 interface Props {
   params: Promise<{ communityId: string }>;
+}
+
+// Self-canonical. Previously inherited defaultMetadata, whose canonical is the
+// homepage "/", so every community's reports page pointed its canonical at the
+// site root instead of itself.
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { communityId } = await params;
+  return communitySubpageMetadata(communityId, "reports");
 }
 
 export default async function Page(props: Props) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -195,18 +195,24 @@ export async function middleware(request: NextRequest) {
   }
 
   if (path.startsWith("/project/")) {
-    // Check if the path contains /grants and redirect to /funding
+    // These are permanent URL-structure changes, so emit 308 (not the default
+    // 307). A 307 tells Google the old URL is temporary, so it keeps the
+    // legacy URL in "Page with redirect" instead of consolidating to the new
+    // one; 308 lets it transfer signals to the new URL and drop the old.
     if (path.includes("/grants") && !path.includes("/project/grants")) {
       const newPath = path.replace("/grants", "/funding");
-      return NextResponse.redirect(new URL(newPath, request.url));
+      return NextResponse.redirect(new URL(newPath, request.url), 308);
     }
     if (path.includes("/funding/create-grant")) {
       const newPath = path.replace("/funding/create-grant", "/funding/new");
-      return NextResponse.redirect(new URL(newPath, request.url));
+      return NextResponse.redirect(new URL(newPath, request.url), 308);
     }
+    // Send legacy /roadmap straight to the project overview. It used to
+    // redirect to /updates, which then redirects to the overview — a redirect
+    // chain Google has to follow; collapse it to a single hop.
     if (path.includes("/roadmap") && !path.includes("/project/roadmap")) {
-      const newPath = path.replace("/roadmap", "/updates");
-      return NextResponse.redirect(new URL(newPath, request.url));
+      const newPath = path.replace(/\/roadmap.*$/, "");
+      return NextResponse.redirect(new URL(newPath, request.url), 308);
     }
   }
 

--- a/utilities/metadata/communityCanonical.ts
+++ b/utilities/metadata/communityCanonical.ts
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
+
+/**
+ * Self-referential canonical for a community sub-page.
+ *
+ * Mirrors the community layout's whitelabel handling: on a whitelabel domain
+ * the `/community/<slug>` prefix is stripped from URLs, so the canonical is the
+ * bare sub-path; on the main site it is the full `/community/<slug>/<subpath>`.
+ *
+ * Returning only `alternates` keeps the title/description the page inherits from
+ * the community layout and just corrects the canonical — used to replace pages
+ * that previously set `defaultMetadata` (whose canonical is the homepage "/").
+ */
+export async function communitySubpageMetadata(
+  communityId: string,
+  subpath: string
+): Promise<Metadata> {
+  const { isWhitelabel } = await getWhitelabelContext();
+  const canonical = isWhitelabel ? `/${subpath}` : `/community/${communityId}/${subpath}`;
+  return { alternates: { canonical } };
+}

--- a/utilities/metadata/projectMetadata.ts
+++ b/utilities/metadata/projectMetadata.ts
@@ -146,6 +146,10 @@ export const generateProjectContactMetadata = (
     description:
       getRealDescriptionExcerpt(project) || `Contact information for ${projectTitle} project team.`,
     canonicalPath: `/project/${projectId}/contact-info`,
+    // Contact info is auth-gated (Project Admin/Owner/Staff/Contract Owner) and
+    // renders near-identical chrome across every project to anonymous crawlers,
+    // so it should not be indexed — keep it out of the duplicate/low-value pool.
+    robots: { index: false, follow: true },
   });
 };
 


### PR DESCRIPTION
From the GSC Page Indexing audit (11K indexed / 46.6K not indexed). Two evidence-based fixes plus the audit's deliberate non-changes.

## 1. Legacy redirects: 307 → 308 (permanent) + de-chain
`middleware.ts` redirected the restructured project URLs with the default **307 (Temporary)**, which tells Google to keep the old URL — so legacy `/project/.../grants/{uid}` (the pre-rename form of every grant + milestone) lingered in **"Page with redirect" (10,983)** instead of consolidating.
- `/grants`→`/funding` and `/funding/create-grant`→`/funding/new`: now **308**.
- `/roadmap`: now redirects **straight to the project overview** (was a 2-hop chain via `/updates`).

## 2. Canonical / noindex corrections
- **`/project/[projectId]/contact-info` → `noindex`**: auth-gated (Admin/Owner/Staff/Contract Owner), renders near-identical chrome across all ~7.6K projects to crawlers, and isn't in the sitemap. A clear duplicate/low-value source. (keeps `follow`)
- **Community `/reports` + `/reports/[runDate]` self-canonical**: they inherited `defaultMetadata`, whose canonical is the **homepage `/`** — so every community's report pages canonicalized to the site root. New whitelabel-aware `communitySubpageMetadata` helper fixes it.

## What the audit deliberately did NOT change
- **Project tabs** (`/about`, `/impact`, `/team`, `/funding`, `/funding/{uid}`, milestones) are **already correctly self-canonical** (verified live).
- **Community sub-tabs** (`/projects`, `/updates`, `/impact`, `/financials`, `/funding-opportunities`, `/browse-applications`) canonicalize to the community root. That is Google's normal **"Alternate page with proper canonical"** handling (consolidating tab variants), *not* an error. Whether to make them independently indexable is a content-strategy call — flagged for a follow-up, not changed here.

## Testing
- `middleware-dashboard.test.ts`: +4 cases (308 + de-chain + 'grants'-named project guard) — 10/10 pass.
- `communityCanonical.test.ts`: whitelabel + main-site canonical — 2/2 pass.
- `pnpm typecheck` clean, `pnpm build` clean.