### PR TITLE
fix(donor-research): simplify signed-out screen and reword pipeline stage

### DIFF
--- a/src/features/donor-research/components/common/DonorResearchError.tsx
+++ b/src/features/donor-research/components/common/DonorResearchError.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, LogIn, RefreshCw } from "lucide-react";
 import { useEffect } from "react";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { useAuth } from "@/hooks/useAuth";
 import { Link } from "@/src/components/navigation/Link";
 import { PAGES } from "@/utilities/pages";
 
@@ -25,6 +26,8 @@ export function DonorResearchError({ error, reset }: DonorResearchErrorProps) {
     error.message ?? ""
   );
 
+  const { authenticated, login } = useAuth();
+
   useEffect(() => {
     // Forward unexpected failures to Sentry/observability (errorManager
     // already drops transient network errors). Skip the signed-out case —
@@ -34,10 +37,43 @@ export function DonorResearchError({ error, reset }: DonorResearchErrorProps) {
     }
   }, [error, isAuthError]);
 
-  const heading = isAuthError ? "Please sign in" : "Something went wrong";
-  const message = isAuthError
-    ? "Your session has expired or you're signed out. Sign in to view donor research, then try again."
-    : "We couldn't load this part of donor research. Please try again.";
+  useEffect(() => {
+    // The signed-out screen's only action is to sign in. Once Privy
+    // reports the user as authenticated, re-render the segment so the
+    // page recovers on its own — no manual "try again" needed.
+    if (isAuthError && authenticated) {
+      reset();
+    }
+  }, [isAuthError, authenticated, reset]);
+
+  // Two distinct failures with two distinct remedies:
+  //  - Auth: the user isn't signed in. Whether the session expired or they
+  //    signed out is the same problem with the same fix, so we don't try to
+  //    tell them apart — the only useful action is to sign in.
+  //  - Everything else: a transient/load failure that a retry can clear.
+  if (isAuthError) {
+    return (
+      <div className="mx-auto max-w-xl px-4 py-12">
+        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <LogIn className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+          </div>
+          <h1 className="text-xl font-semibold text-foreground">Please sign in</h1>
+          <p className="text-sm text-muted-foreground">
+            You need to be signed in to view donor research.
+          </p>
+          <button
+            type="button"
+            onClick={() => login()}
+            className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <LogIn className="h-4 w-4" />
+            Sign in
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-xl px-4 py-12">
@@ -45,8 +81,10 @@ export function DonorResearchError({ error, reset }: DonorResearchErrorProps) {
         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
           <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
         </div>
-        <h1 className="text-xl font-semibold text-foreground">{heading}</h1>
-        <p className="text-sm text-muted-foreground">{message}</p>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We couldn&apos;t load this part of donor research. Please try again.
+        </p>
         {error.digest ? (
           <p className="text-xs text-muted-foreground">Reference: {error.digest}</p>
         ) : null}

--- a/src/features/donor-research/components/report-viewer/ProgressTimeline.tsx
+++ b/src/features/donor-research/components/report-viewer/ProgressTimeline.tsx
@@ -23,7 +23,7 @@ const STAGE_ORDER: Array<{
   {
     name: "pool_loaded",
     label: "Candidate pool",
-    caption: "Querying the 200k-org embedding index for matches.",
+    caption: "Finding organizations matching your criteria.",
   },
   {
     name: "compliance_complete",


### PR DESCRIPTION
## What

Two small donor-research UX fixes from review feedback.

### 1. Signed-out error screen (`DonorResearchError`)
The auth screen previously:
- guessed between *"your session has expired"* and *"you're signed out"* — no real difference to the user, same fix either way;
- offered a **Try again** button that did nothing (`reset()` just re-ran the same fetch while still unauthenticated);
- showed a **Back to donor research** link while the user was already on `/donor-research`.

Now the signed-out state shows a single **Sign in** action that calls Privy `login()`, and the segment auto-recovers (re-renders) once Privy reports the user as authenticated — no second click needed. The generic, non-auth load-failure path is unchanged (keeps **Try again** + **Back**).

### 2. Pipeline caption (`ProgressTimeline`)
Reworded the candidate-pool stage caption from the internal-sounding *"Querying the 200k-org embedding index for matches."* to the user-facing **"Finding organizations matching your criteria."**

## Why
Review feedback: the sign-in screen's actions were confusing/dead, the expired-vs-signed-out distinction was noise, and the pipeline copy leaked implementation detail.

## Testing
- `biome check` clean on both files (also enforced by lint-staged pre-commit).
- No tests referenced the changed copy strings.
- Verified locally against the running dev server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out error handling with a dedicated authentication prompt that automatically resets upon successful login.
  * Clarified progress messaging during the organization matching workflow for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->