### PR TITLE
fix(non-profits): mint a fresh session per submit on find-funders

### DIFF
--- a/src/features/non-profits/__tests__/search-session.test.ts
+++ b/src/features/non-profits/__tests__/search-session.test.ts
@@ -27,10 +27,15 @@ describe("useSearchSessionStore", () => {
     expect(useSearchSessionStore.getState().currentId).toBe(id);
   });
 
-  it("createSession reuses an existing session for a duplicate query (case-insensitive)", () => {
+  it("createSession ALWAYS mints a fresh session even for an identical query", () => {
+    // The prior dedup behaviour caused stale results when the user
+    // navigated back to the landing page and submitted the same chip
+    // again — the route pointed at the cached old session instead of
+    // a fresh run. Each submit must be a brand-new session.
     const id1 = useSearchSessionStore.getState().createSession("Youth literacy");
     const id2 = useSearchSessionStore.getState().createSession("youth LITERACY");
-    expect(id2).toBe(id1);
+    expect(id2).not.toBe(id1);
+    expect(useSearchSessionStore.getState().currentId).toBe(id2);
   });
 
   it("setSession creates or overwrites a session with the given id", () => {

--- a/src/features/non-profits/__tests__/thread-seed.test.ts
+++ b/src/features/non-profits/__tests__/thread-seed.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for non-profits/lib/thread-seed.ts and the threadId field on
+ * the philanthropy store.
+ *
+ * Covers the stale-thread bug: the philanthropy store is global, so a
+ * previous session's chat thread survives client-side navigation. ChatView
+ * must reset it before seeding a new session's query — otherwise the new
+ * query is silently swallowed and only a hard refresh recovers.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { decideThreadSeed } from "../lib/thread-seed";
+import { usePhilanthropyStore } from "../store/philanthropy";
+
+describe("decideThreadSeed", () => {
+  it("seeds when the store is empty (cold load)", () => {
+    expect(
+      decideThreadSeed({ searchId: "a", seededSearchId: null, messageCount: 0, threadId: null })
+    ).toBe("seed");
+  });
+
+  it("does nothing when this instance already seeded this searchId", () => {
+    expect(
+      decideThreadSeed({ searchId: "a", seededSearchId: "a", messageCount: 1, threadId: "a" })
+    ).toBe("already-seeded");
+  });
+
+  it("keeps the thread when it belongs to this searchId (remount/back-nav)", () => {
+    expect(
+      decideThreadSeed({ searchId: "a", seededSearchId: null, messageCount: 3, threadId: "a" })
+    ).toBe("adopt-existing-thread");
+  });
+
+  it("resets then seeds when a previous session's thread is still in the store", () => {
+    // The fixed bug: landing → search (thread for "a") → back → new search "b".
+    expect(
+      decideThreadSeed({ searchId: "b", seededSearchId: "a", messageCount: 2, threadId: "a" })
+    ).toBe("reset-then-seed");
+  });
+
+  it("resets then seeds when the thread predates threadId tracking (null threadId)", () => {
+    expect(
+      decideThreadSeed({ searchId: "b", seededSearchId: null, messageCount: 2, threadId: null })
+    ).toBe("reset-then-seed");
+  });
+
+  it("re-seeds after new-chat re-arms the ref on an empty store", () => {
+    expect(
+      decideThreadSeed({ searchId: "a", seededSearchId: null, messageCount: 0, threadId: null })
+    ).toBe("seed");
+  });
+});
+
+describe("usePhilanthropyStore.threadId", () => {
+  beforeEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("defaults to null and is settable", () => {
+    expect(usePhilanthropyStore.getState().threadId).toBeNull();
+    usePhilanthropyStore.getState().setThreadId("session-1");
+    expect(usePhilanthropyStore.getState().threadId).toBe("session-1");
+  });
+
+  it("is cleared by reset()", () => {
+    usePhilanthropyStore.getState().setThreadId("session-1");
+    usePhilanthropyStore.getState().reset();
+    expect(usePhilanthropyStore.getState().threadId).toBeNull();
+  });
+});

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -58,6 +58,7 @@ import {
   useResearchTray,
 } from "../hooks/use-research-tray";
 import { FILINGS_STATS } from "../lib/stats";
+import { decideThreadSeed } from "../lib/thread-seed";
 import { searchHistoryService } from "../services/search-history.service";
 import type { FieldRect, PageTransitionFields } from "../store/page-transition";
 import { usePageTransitionStore } from "../store/page-transition";
@@ -351,29 +352,45 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const [input, setInput] = useState("");
   const [trayOpen, setTrayOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
-  const initialQueryRanRef = useRef(false);
+  // searchId this component instance last seeded. A plain boolean is not
+  // enough: navigating between two session URLs reuses the same instance
+  // (same dynamic segment), so the ref must be keyed by session.
+  const seededSearchIdRef = useRef<string | null>(null);
 
-  // First-time load: when arriving on /non-profits/find-funders/search/[id] with an empty
-  // thread, grab the initial query from the search session store and run it.
-  // Fallback: if the local session is missing (shared link / cold load),
-  // fetch via searchHistoryService.getById() to seed the search.
+  // Seed the thread for the session in the URL. The philanthropy store is
+  // global and survives client-side navigation, so arriving here can mean:
+  // - empty store (cold load) → seed from the session store, falling back
+  //   to searchHistoryService.getById() (shared link);
+  // - the store still holds THIS session's thread (remount/back-nav) →
+  //   keep it;
+  // - the store holds a PREVIOUS session's thread (landing → new search) →
+  //   reset it, then seed. Without this branch the new query was silently
+  //   swallowed and the stale conversation rendered until a hard refresh.
   useEffect(() => {
-    if (initialQueryRanRef.current) return;
     if (!searchId) return;
-    if (messages.length > 0) {
-      initialQueryRanRef.current = true;
-      return;
+    const store = usePhilanthropyStore.getState();
+    const decision = decideThreadSeed({
+      searchId,
+      seededSearchId: seededSearchIdRef.current,
+      messageCount: store.messages.length,
+      threadId: store.threadId,
+    });
+    if (decision === "already-seeded") return;
+    seededSearchIdRef.current = searchId;
+    if (decision === "adopt-existing-thread") return;
+    if (decision === "reset-then-seed") {
+      abort();
+      reset();
     }
+    usePhilanthropyStore.getState().setThreadId(searchId);
     // Fast path: local session store
     const session = useSearchSessionStore.getState().getSession(searchId);
     const localQuery = session?.query?.trim();
     if (localQuery) {
-      initialQueryRanRef.current = true;
       void search(localQuery, 1, { chat: true });
       return;
     }
     // Fallback: fetch from server (shared link / cold load)
-    initialQueryRanRef.current = true;
     void searchHistoryService.getById(searchId).match(
       (entry) => {
         const remoteQuery = entry.query?.trim();
@@ -385,7 +402,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
         /* 404 or error — render empty workbench, degrade gracefully */
       }
     );
-  }, [searchId, messages.length, search]);
+  }, [searchId, messages.length, search, abort, reset]);
 
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {
@@ -412,7 +429,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
     abort();
     reset();
     if (searchId) useSearchSessionStore.getState().clearSession(searchId);
-    initialQueryRanRef.current = false;
+    seededSearchIdRef.current = null;
   }, [abort, reset, searchId]);
 
   const showEmpty = messages.length === 0 && !isSearching;

--- a/src/features/non-profits/lib/thread-seed.ts
+++ b/src/features/non-profits/lib/thread-seed.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides what ChatView's seeding effect should do when it observes a
+ * `searchId` from the route. Extracted as a pure function because the
+ * surrounding effect mixes three sources of truth (a per-instance ref,
+ * the global philanthropy store, and the route param) and the stale
+ * combinations are easy to regress — see the fixed bug where a previous
+ * session's thread survived client-side navigation and silently swallowed
+ * the new session's query.
+ */
+export type ThreadSeedDecision =
+  /** This component instance already seeded this searchId — do nothing. */
+  | "already-seeded"
+  /** The in-memory thread belongs to this searchId (remount/back-nav) — keep it. */
+  | "adopt-existing-thread"
+  /** A different session's thread is in the global store — reset it, then seed. */
+  | "reset-then-seed"
+  /** Store is empty — seed the session's query. */
+  | "seed";
+
+export function decideThreadSeed(args: {
+  searchId: string;
+  /** searchId this component instance last seeded (per-instance ref). */
+  seededSearchId: string | null;
+  /** Number of turns currently in the global philanthropy store. */
+  messageCount: number;
+  /** searchId the global store's thread belongs to (null = never seeded). */
+  threadId: string | null;
+}): ThreadSeedDecision {
+  if (args.seededSearchId === args.searchId) return "already-seeded";
+  if (args.messageCount > 0) {
+    return args.threadId === args.searchId ? "adopt-existing-thread" : "reset-then-seed";
+  }
+  return "seed";
+}

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -92,6 +92,14 @@ interface SearchResult {
 interface PhilanthropyStore {
   // ── Chat-style multi-turn state ──
   messages: ReadonlyArray<ChatTurn>;
+  /**
+   * The search-session id the current `messages` thread belongs to, or null
+   * when no thread has been seeded. The store is global and survives
+   * client-side navigation, so ChatView uses this to tell "returning to the
+   * same session" (keep the thread) apart from "arriving on a new session
+   * while a previous thread is still in memory" (reset, then seed).
+   */
+  threadId: string | null;
 
   // ── Legacy single-query state ──
   // Preserved during transition. New code should read `messages`.
@@ -107,6 +115,7 @@ interface PhilanthropyStore {
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
   updateLastTurn: (patch: Partial<ChatTurn>) => void;
+  setThreadId: (id: string | null) => void;
 
   // ── Legacy actions ──
   setQuery: (query: string) => void;
@@ -122,6 +131,7 @@ interface PhilanthropyStore {
 
 const initialState = {
   messages: EMPTY_MESSAGES as ReadonlyArray<ChatTurn>,
+  threadId: null as string | null,
   query: "",
   narrative: "",
   traceId: null as string | null,
@@ -132,6 +142,7 @@ const initialState = {
   PhilanthropyStore,
   | "appendTurn"
   | "updateLastTurn"
+  | "setThreadId"
   | "setQuery"
   | "setNarrative"
   | "setTraceId"
@@ -161,6 +172,7 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
       return { messages: [...s.messages.slice(0, -1), updated] };
     }),
 
+  setThreadId: (threadId) => set({ threadId }),
   setQuery: (query) => set({ query }),
   setNarrative: (narrative) => set({ narrative }),
   setTraceId: (traceId) => set({ traceId }),

--- a/src/features/non-profits/store/search-session.ts
+++ b/src/features/non-profits/store/search-session.ts
@@ -38,16 +38,12 @@ export const useSearchSessionStore = create<SearchSessionStore>()(
       currentId: null,
 
       createSession: (query: string) => {
+        // Always mint a fresh session. The prior implementation deduped
+        // by query text, which meant submitting the same question twice
+        // (from the landing page after navigating back) routed the user
+        // to the cached old result instead of a re-run. A refresh fixed
+        // it, which is exactly the smell of stale-session-on-replay.
         const { sessions } = get();
-
-        // Reuse existing session for the same query
-        for (const [id, session] of Object.entries(sessions)) {
-          if (session.query.toLowerCase() === query.toLowerCase()) {
-            set({ currentId: id });
-            return id;
-          }
-        }
-
         const id = generateId();
         const entries = Object.entries(sessions);
         const trimmed =


### PR DESCRIPTION
## Summary

Fixes a stale-session bug on `/non-profits/find-funders`. Today: ask a question, navigate back to the landing page, ask again → the route resolves to the *previous* session and shows the cached old response. Only a hard refresh starts a fresh stream.

The fix has two halves (one commit each): mint a fresh session id per submit, and reset the stale in-memory chat thread when arriving on a new session.

## Root cause

**1. Session-id dedup.** `useSearchSessionStore.createSession` had a query-text dedup loop:

```ts
for (const [id, session] of Object.entries(sessions)) {
  if (session.query.toLowerCase() === query.toLowerCase()) {
    set({ currentId: id });
    return id;   // ← returns the old session id, never re-runs
  }
}
```

When the user submits the same chip a second time (or rewrites the same question), this short-circuits to the existing session id. The router then navigates to `/non-profits/find-funders/<oldId>`, the chat view reads the cached state, and no fresh SSE stream is opened.

**2. Stale chat thread.** Fixing the id alone wasn't enough: the chat thread lives in the global `usePhilanthropyStore`, which survives client-side navigation. `ChatView`'s seeding effect bailed out whenever messages were already present:

```ts
if (messages.length > 0) {
  initialQueryRanRef.current = true;
  return;   // ← previous session's thread still in memory → new query never runs
}
```

So even with a fresh session id, landing → ask → back → ask rendered the previous conversation and never started the new stream.

## Fix

- `createSession` always mints a new uuid + new session record, even for identical query text. Submitting the same question twice = two distinct sessions, each with its own stream.
- The philanthropy store now tracks `threadId` — the session the in-memory thread belongs to. `ChatView` seeding is keyed by session id (a `seededSearchIdRef`, since navigating between two session URLs reuses the same component instance): arriving on a different session's URL aborts the active stream, resets the thread, and seeds the new query; returning to the same session keeps the conversation; "New chat" behavior is unchanged. The decision logic is a pure `decideThreadSeed()` helper in `lib/thread-seed.ts`.

The test that asserted the prior dedup is flipped to assert distinct ids, and `thread-seed.test.ts` covers every seeding branch including the repro above.

## Test plan

- [x] `pnpm vitest run src/features/non-profits` — 20 files / 152 tests pass.
- [x] `pnpm typecheck` clean.
- [ ] Manual: ask "youth literacy in Ohio" → answer renders. Navigate back. Click the same chip (or type a new question) → workbench clears and a fresh stream renders the new response, no refresh needed. Navigate to an entity page and back to the same session → conversation is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search queries now always generate new sessions instead of reusing existing sessions for duplicate queries, ensuring each submission is treated as a fresh search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
