### PR TITLE
fix(seo): serve sitemap index at a fresh URL to reset Google sitemap state

### DIFF
--- a/__tests__/app/robots.test.ts
+++ b/__tests__/app/robots.test.ts
@@ -100,16 +100,13 @@ describe("robots", () => {
   });
 
   describe("sitemaps", () => {
-    it("should reference the main sitemap index", () => {
-      expect(result.sitemap).toContain(`${SITE_URL}/sitemap.xml`);
+    it("should reference only the fresh sitemap index URL", () => {
+      expect(result.sitemap).toEqual([`${SITE_URL}/sitemap_index.xml`]);
     });
 
-    it("should reference the sitemap-index alias served at a fresh URL", () => {
-      expect(result.sitemap).toContain(`${SITE_URL}/sitemap-index.xml`);
-    });
-
-    it("should list exactly 2 sitemap entries (main + alias)", () => {
-      expect(result.sitemap).toHaveLength(2);
+    it("should not advertise the stuck legacy index URLs", () => {
+      expect(result.sitemap).not.toContain(`${SITE_URL}/sitemap.xml`);
+      expect(result.sitemap).not.toContain(`${SITE_URL}/sitemap-index.xml`);
     });
   });
 

--- a/__tests__/app/sitemap-routes.test.ts
+++ b/__tests__/app/sitemap-routes.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET as freshIndexGet } from "@/app/sitemap_index.xml/route";
 import { GET as indexGet } from "@/app/sitemap-index.xml/route";
 import { GET as childGet } from "@/app/sitemaps/[kind]/sitemap/[chunk]/route";
 
@@ -95,5 +96,31 @@ describe("sitemap index route", () => {
     expect(body).toContain("<sitemapindex");
     expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/2.xml</loc>`);
     expect(body).toContain(`<loc>${SITE}/sitemaps/static/sitemap.xml</loc>`);
+  });
+
+  it("serves the identical index at the fresh /sitemap_index.xml URL", async () => {
+    const counts = {
+      projects: 1500,
+      impacts: 0,
+      grants: 0,
+      milestones: 0,
+      fundingPrograms: 0,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(counts))
+    );
+    const legacyBody = await (await indexGet()).text();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(counts))
+    );
+    const freshRes = await freshIndexGet();
+    const freshBody = await freshRes.text();
+
+    expect(freshRes.status).toBe(200);
+    expect(freshRes.headers.get("Content-Type")).toContain("application/xml");
+    expect(freshBody).toBe(legacyBody);
   });
 });

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -44,7 +44,11 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/"],
       },
     ],
-    sitemap: [`${SITE_URL}/sitemap.xml`, `${SITE_URL}/sitemap-index.xml`],
+    // Only the fresh index URL is advertised: Google's stored sitemap state is
+    // keyed per URL, and the old /sitemap.xml + /sitemap-index.xml entries are
+    // stuck on a degraded May 2026 parse (see app/sitemap_index.xml/route.ts).
+    // Both old URLs keep serving; they're just no longer advertised.
+    sitemap: [`${SITE_URL}/sitemap_index.xml`],
     host: SITE_URL,
   };
 }

--- a/app/sitemap-index.xml/route.ts
+++ b/app/sitemap-index.xml/route.ts
@@ -1,22 +1,14 @@
-import { NextResponse } from "next/server";
-import { buildSitemapIndexBody, SITEMAP_CACHE_CONTROL } from "@/utilities/sitemap";
+import type { NextResponse } from "next/server";
+import { sitemapIndexResponse } from "@/utilities/sitemap";
 
 // Never prerender at build time — render on demand only. The indexer fetch is
-// still cached via the Data Cache (see fetchSitemapCounts), so this stays cheap.
+// still cached via the Data Cache (see fetchSitemapCounts).
 export const dynamic = "force-dynamic";
 
-// Dynamic sitemap index. The expensive per-kind URL derivation stays in the
-// indexer; this route just sizes the index from the indexer's /counts endpoint,
-// which is cached in Next's Data Cache with stale-while-revalidate (see
-// fetchSitemapCounts). A slow or unreachable indexer therefore serves the last
-// good index instead of a degraded one — no build-time generation, no cron.
+// Legacy index URL. Google's stored state for it is stuck on a degraded May
+// 2026 parse, so robots.txt now advertises /sitemap_index.xml instead (see
+// that route for the full story). Kept serving so existing submissions and
+// external references never break.
 export async function GET(): Promise<NextResponse> {
-  const body = await buildSitemapIndexBody();
-  return new NextResponse(body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": SITEMAP_CACHE_CONTROL,
-    },
-  });
+  return sitemapIndexResponse();
 }

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
-import { buildSitemapIndexBody, SITEMAP_CACHE_CONTROL } from "@/utilities/sitemap";
+import type { NextResponse } from "next/server";
+import { sitemapIndexResponse } from "@/utilities/sitemap";
 
 // `/sitemap.xml` is a reserved Next metadata path, so without this it gets
 // statically prerendered at build time — which calls the indexer during the
@@ -8,16 +8,9 @@ import { buildSitemapIndexBody, SITEMAP_CACHE_CONTROL } from "@/utilities/sitema
 // the indexer fetch is still cached via the Data Cache (see fetchSitemapCounts).
 export const dynamic = "force-dynamic";
 
-// Alias of /sitemap-index.xml. Both are advertised in robots.txt; GSC treats
-// the two URLs as independent submissions, so we keep serving both with
-// identical content.
+// Legacy alias of the index. robots.txt now advertises /sitemap_index.xml
+// instead (see that route for why); this URL keeps serving identical content
+// because crawlers probe /sitemap.xml by convention.
 export async function GET(): Promise<NextResponse> {
-  const body = await buildSitemapIndexBody();
-  return new NextResponse(body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": SITEMAP_CACHE_CONTROL,
-    },
-  });
+  return sitemapIndexResponse();
 }

--- a/app/sitemap_index.xml/route.ts
+++ b/app/sitemap_index.xml/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { buildSitemapIndexBody, SITEMAP_CACHE_CONTROL } from "@/utilities/sitemap";
+
+// Never prerender at build time — render on demand only. The indexer fetch is
+// still cached via the Data Cache (see fetchSitemapCounts).
+export const dynamic = "force-dynamic";
+
+// Fresh-URL copy of /sitemap-index.xml. Google pinned its parsed model of the
+// old URL to a degraded 5-child snapshot (May 2026) and successful re-reads
+// never refreshed it — its per-URL sitemap state survives content changes.
+// Serving the identical index at a URL Google has never seen resets that
+// state (John Mueller's documented remedy for stuck sitemap processing).
+// The old URLs keep serving so existing references never break; this one is
+// what robots.txt advertises and what is submitted in Search Console.
+export async function GET(): Promise<NextResponse> {
+  const body = await buildSitemapIndexBody();
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": SITEMAP_CACHE_CONTROL,
+    },
+  });
+}

--- a/app/sitemap_index.xml/route.ts
+++ b/app/sitemap_index.xml/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
-import { buildSitemapIndexBody, SITEMAP_CACHE_CONTROL } from "@/utilities/sitemap";
+import type { NextResponse } from "next/server";
+import { sitemapIndexResponse } from "@/utilities/sitemap";
 
 // Never prerender at build time — render on demand only. The indexer fetch is
 // still cached via the Data Cache (see fetchSitemapCounts).
@@ -13,12 +13,5 @@ export const dynamic = "force-dynamic";
 // The old URLs keep serving so existing references never break; this one is
 // what robots.txt advertises and what is submitted in Search Console.
 export async function GET(): Promise<NextResponse> {
-  const body = await buildSitemapIndexBody();
-  return new NextResponse(body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": SITEMAP_CACHE_CONTROL,
-    },
-  });
+  return sitemapIndexResponse();
 }

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { envVars } from "@/utilities/enviromentVars";
 import { SITE_URL } from "@/utilities/meta";
 
@@ -171,4 +172,19 @@ export async function buildSitemapIndexBody(): Promise<string> {
   }
 
   return buildSitemapIndexXml(locs);
+}
+
+// Shared GET body for the three index routes (/sitemap.xml, /sitemap-index.xml,
+// /sitemap_index.xml) so the response headers can't drift between them. Each
+// route file still declares its own `dynamic = "force-dynamic"` — Next reads
+// that from the route module itself, so it can't live here.
+export async function sitemapIndexResponse(): Promise<NextResponse> {
+  const body = await buildSitemapIndexBody();
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": SITEMAP_CACHE_CONTROL,
+    },
+  });
 }


### PR DESCRIPTION
## Overview

GSC has been stuck reporting **3,197 discovered pages** for `sitemap-index.xml` for weeks, despite the index serving 29 healthy children (~25K URLs) since May 29 and every fix we shipped (#1534, #1566, #1591, #1594, indexer #2031).

## Problem — root cause finally isolated

The GSC sitemap-index drilldown shows **"1–5 of 5"** child sitemaps: communities (120), funding-programs/1 (77), grants/1–3 (1,000 each) — summing to **exactly 3,197**. Google actively re-reads those 5 children (last reads Jun 5–10) but has **never fetched the other 24** (static, projects ×8, impacts ×4, grants 4–7, milestones ×7), even though it re-read the index "successfully" on Jun 4, 8 and 9.

Verified NOT the cause:
- Production serves 29 children consistently, rendered in `iad1` (the region Googlebot crawls), `HTTP 200`, all children full.
- robots.txt is clean; missing children all serve 200 with 1,000 URLs.
- Conditional-request masking ruled out: the route emits **no ETag / Last-Modified**, and requests with stale `If-Modified-Since` / `If-None-Match` get a full 200 with 29 children — Googlebot cannot be receiving 304s.

Remaining explanation, consistent with all evidence: **Google''s per-URL stored model of `/sitemap-index.xml` is pinned to the degraded 5-child snapshot from May** and successful re-fetches do not refresh it. This is a known failure mode: Google keeps per-URL sitemap state, and John Mueller''s documented remedy is to move the sitemap to a URL Google has never seen ("reset Google''s opinion" — seroundtable.com/google-fetch-process-sitemap-file-31042.html). Gary Illyes (June 2023 office hours): Google "will not reprocess a sitemap that hasn''t changed since it was last crawled".

## Solution

- New route `app/sitemap_index.xml/route.ts` — serves the **identical** index (same `buildSitemapIndexBody`, same caching) at a fresh URL with zero Google history.
- `robots.txt` now advertises only `/sitemap_index.xml`. The legacy `/sitemap.xml` and `/sitemap-index.xml` routes keep serving unchanged, so existing references never break.

## Post-merge operational steps (Search Console)

1. Submit `https://www.karmahq.xyz/sitemap_index.xml` in GSC.
2. Submit the 24 never-fetched child sitemaps individually (GSC fetches individual submissions immediately, bypassing index parsing entirely).
3. Expect Discovered pages to move from 3,197 toward ~25K within ~2–7 days of the new index being read. (Indexed count is a separate, slower quality track.)

## Testing

- `pnpm vitest run __tests__/app/robots.test.ts __tests__/app/sitemap-routes.test.ts` — 28 passed, including a new test asserting `/sitemap_index.xml` returns byte-identical output to the legacy route.
- `pnpm typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fresh sitemap index endpoint that generates on-demand XML content.
  * Updated robots.txt to advertise the new sitemap index URL to search engines.
  * Legacy sitemap URLs continue to function for backwards compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->