### PR TITLE
feat(sitemap): consolidated per-kind sitemaps, edge SWR caching, cron warmer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ NEXT_PUBLIC_RPC_SCROLL=
 NEXT_PUBLIC_E2E_AUTH_BYPASS=false
 
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+
+# Shared secret for Vercel Cron requests (vercel.json crons). When set, Vercel
+# sends it as 'Authorization: Bearer …' and /api/cron/* routes require it.
+CRON_SECRET=

--- a/__tests__/app/sitemap-routes.test.ts
+++ b/__tests__/app/sitemap-routes.test.ts
@@ -291,4 +291,19 @@ describe("warm-sitemaps cron route", () => {
     expect(res.status).toBe(502);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("reports failure when the index returns 200 but parses to zero children", async () => {
+    // A 200 whose body yields no <loc> entries means the warmer read the wrong
+    // payload — it must not report ok=true after warming nothing.
+    const fetchMock = vi.fn(async () => xmlResponse("<sitemapindex></sitemapindex>"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await warmGet(new Request(`${SITE}/api/cron/warm-sitemaps`));
+    const payload = (await res.json()) as { ok: boolean };
+
+    expect(res.status).toBe(502);
+    expect(payload.ok).toBe(false);
+    // Only the index was fetched; no child warming was attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/app/sitemap-routes.test.ts
+++ b/__tests__/app/sitemap-routes.test.ts
@@ -206,6 +206,22 @@ describe("consolidated per-kind sitemap route", () => {
     expect(res.status).toBe(404);
   });
 
+  it("404s instead of serving a possibly-truncated list at the per-file cap", async () => {
+    // Counts under-report (stale) but every page comes back full: the fetcher
+    // stops at the cap, which means the list may be incomplete — refuse it.
+    const fullPage = Array.from(
+      { length: INDEXER_FETCH_PAGE_SIZE },
+      (_, i) => `https://staging.karmahq.xyz/p/${i}`
+    );
+    stubKindFetch(fullPage);
+
+    const res = await kindGet(new Request(`${SITE}/sitemaps/projects/sitemap.xml`), {
+      params: Promise.resolve({ kind: "projects" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
   it("fetches pages at the indexer page size, not the legacy chunk size", async () => {
     const fetchMock = stubKindFetch(["https://staging.karmahq.xyz/project/a"]);
 

--- a/__tests__/app/sitemap-routes.test.ts
+++ b/__tests__/app/sitemap-routes.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET as warmGet } from "@/app/api/cron/warm-sitemaps/route";
 import { GET as freshIndexGet } from "@/app/sitemap_index.xml/route";
 import { GET as indexGet } from "@/app/sitemap-index.xml/route";
 import { GET as childGet } from "@/app/sitemaps/[kind]/sitemap/[chunk]/route";
+import { GET as kindGet } from "@/app/sitemaps/[kind]/sitemap.xml/route";
+import { INDEXER_FETCH_PAGE_SIZE } from "@/utilities/sitemap";
 
 const SITE = "https://www.karmahq.xyz";
 
@@ -74,7 +77,7 @@ describe("child sitemap route", () => {
 });
 
 describe("sitemap index route", () => {
-  it("serves a sitemap index sized from the live counts", async () => {
+  it("serves a sitemap index with one consolidated child per kind", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -94,8 +97,30 @@ describe("sitemap index route", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toContain("application/xml");
     expect(body).toContain("<sitemapindex");
-    expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/2.xml</loc>`);
+    expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
     expect(body).toContain(`<loc>${SITE}/sitemaps/static/sitemap.xml</loc>`);
+  });
+
+  it("falls back to chunked children when a kind exceeds the per-file limit", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          projects: 46_000,
+          impacts: 0,
+          grants: 0,
+          milestones: 0,
+          fundingPrograms: 0,
+        })
+      )
+    );
+
+    const res = await indexGet();
+    const body = await res.text();
+
+    expect(body).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
+    expect(body).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
   });
 
   it("serves the identical index at the fresh /sitemap_index.xml URL", async () => {
@@ -122,5 +147,132 @@ describe("sitemap index route", () => {
     expect(freshRes.status).toBe(200);
     expect(freshRes.headers.get("Content-Type")).toContain("application/xml");
     expect(freshBody).toBe(legacyBody);
+  });
+});
+
+describe("consolidated per-kind sitemap route", () => {
+  const counts = {
+    projects: 1500,
+    impacts: 0,
+    grants: 0,
+    milestones: 0,
+    fundingPrograms: 0,
+  };
+
+  function stubKindFetch(pageUrls: string[]): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn(async (url: string) =>
+      url.includes("/counts") ? jsonResponse(counts) : jsonResponse({ urls: pageUrls })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("serves the kind's complete urlset", async () => {
+    stubKindFetch(["https://staging.karmahq.xyz/project/a"]);
+
+    const res = await kindGet(new Request(`${SITE}/sitemaps/projects/sitemap.xml`), {
+      params: Promise.resolve({ kind: "projects" }),
+    });
+    const body = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/xml");
+    expect(body).toContain(`<loc>${SITE}/project/a</loc>`);
+    expect(body).not.toContain("staging.karmahq.xyz");
+  });
+
+  it("404s an unknown kind without calling the indexer", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await kindGet(new Request(`${SITE}/sitemaps/bogus/sitemap.xml`), {
+      params: Promise.resolve({ kind: "bogus" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404s a kind past the per-file limit (index lists chunks instead)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ ...counts, projects: 46_000 }))
+    );
+
+    const res = await kindGet(new Request(`${SITE}/sitemaps/projects/sitemap.xml`), {
+      params: Promise.resolve({ kind: "projects" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("fetches pages at the indexer page size, not the legacy chunk size", async () => {
+    const fetchMock = stubKindFetch(["https://staging.karmahq.xyz/project/a"]);
+
+    await kindGet(new Request(`${SITE}/sitemaps/projects/sitemap.xml`), {
+      params: Promise.resolve({ kind: "projects" }),
+    });
+
+    const urlsCall = fetchMock.mock.calls.find(([url]) => !String(url).includes("/counts"));
+    expect(String(urlsCall?.[0])).toContain(`pageSize=${INDEXER_FETCH_PAGE_SIZE}`);
+  });
+});
+
+describe("warm-sitemaps cron route", () => {
+  function xmlResponse(body: string, status = 200): Response {
+    return {
+      ok: status === 200,
+      status,
+      text: async () => body,
+    } as unknown as Response;
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects requests without the cron secret when one is configured", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await warmGet(new Request(`${SITE}/api/cron/warm-sitemaps`));
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("warms the index and every child it lists", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    const index = `<?xml version="1.0"?><sitemapindex><sitemap><loc>${SITE}/sitemaps/static/sitemap.xml</loc></sitemap><sitemap><loc>${SITE}/sitemaps/projects/sitemap.xml</loc></sitemap></sitemapindex>`;
+    const fetchMock = vi.fn(async (url: string) =>
+      url.endsWith("/sitemap_index.xml") ? xmlResponse(index) : xmlResponse("<urlset/>")
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await warmGet(
+      new Request(`${SITE}/api/cron/warm-sitemaps`, {
+        headers: { authorization: "Bearer s3cret" },
+      })
+    );
+    const payload = (await res.json()) as { ok: boolean; warmed: Record<string, number> };
+
+    expect(res.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(Object.keys(payload.warmed)).toEqual([
+      `${SITE}/sitemap_index.xml`,
+      `${SITE}/sitemaps/static/sitemap.xml`,
+      `${SITE}/sitemaps/projects/sitemap.xml`,
+    ]);
+  });
+
+  it("reports failure when the index itself cannot be fetched", async () => {
+    const fetchMock = vi.fn(async () => xmlResponse("oops", 503));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await warmGet(new Request(`${SITE}/api/cron/warm-sitemaps`));
+
+    expect(res.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -213,6 +213,31 @@ describe("buildSitemapIndexBody", () => {
     expect((xml.match(/<sitemap>/g) ?? []).length).toBe(52);
   });
 
+  it("falls back to chunked children for a kind exactly at the per-file URL limit", async () => {
+    // At exactly MAX_URLS_PER_SITEMAP the consolidated route 404s (it can't
+    // prove the list isn't truncated), so the index must list chunks here —
+    // never a consolidated child that would 404. 45_000 / 1_000 = 45 chunks.
+    const counts: SitemapCounts = {
+      projects: 45_000,
+      impacts: 10,
+      grants: 10,
+      milestones: 10,
+      fundingPrograms: 10,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(counts))
+    );
+
+    const xml = await buildSitemapIndexBody();
+
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/1.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/45.xml</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+  });
+
   it("throws when counts is unreachable so SWR keeps the last good index", async () => {
     vi.stubGlobal(
       "fetch",

--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -6,8 +6,10 @@ import {
   canonicalizeSitemapUrl,
   chunkCountFromTotal,
   countForKind,
+  fetchAllSitemapKindUrls,
   fetchSitemapKindPage,
   formatSitemapLastmod,
+  INDEXER_FETCH_PAGE_SIZE,
   type SitemapCounts,
 } from "@/utilities/sitemap";
 
@@ -161,13 +163,13 @@ describe("fetchSitemapKindPage", () => {
 });
 
 describe("buildSitemapIndexBody", () => {
-  it("sizes per-kind chunks from the live counts and includes the local children", async () => {
+  it("lists one consolidated child per kind plus the local children", async () => {
     const counts: SitemapCounts = {
-      projects: 7678, // 8 chunks
-      impacts: 0, // 1 chunk (empty)
-      grants: 1000, // 1 chunk
-      milestones: 2001, // 3 chunks
-      fundingPrograms: 77, // 1 chunk
+      projects: 7678,
+      impacts: 0,
+      grants: 1000,
+      milestones: 2001,
+      fundingPrograms: 77,
     };
     vi.stubGlobal(
       "fetch",
@@ -178,13 +180,37 @@ describe("buildSitemapIndexBody", () => {
 
     expect(xml).toContain(`<loc>${SITE}/sitemaps/static/sitemap.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/communities/sitemap.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/8.xml</loc>`);
-    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap/9.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/milestones/sitemap/3.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/impacts/sitemap/1.xml</loc>`);
-    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/impacts/sitemap/2.xml</loc>`);
-    // static + communities + projects 8 + impacts 1 + grants 1 + milestones 3 + funding-programs 1 = 16
-    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(16);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/impacts/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/milestones/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
+    expect(xml).not.toContain("/sitemap/1.xml");
+    // static + communities + one per kind = 7
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(7);
+  });
+
+  it("falls back to chunked children for a kind past the per-file URL limit", async () => {
+    const counts: SitemapCounts = {
+      projects: 46_000, // > MAX_URLS_PER_SITEMAP -> 46 chunks
+      impacts: 10,
+      grants: 10,
+      milestones: 10,
+      fundingPrograms: 10,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(counts))
+    );
+
+    const xml = await buildSitemapIndexBody();
+
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/1.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    // static + communities + projects 46 chunks + 4 consolidated kinds = 52
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(52);
   });
 
   it("throws when counts is unreachable so SWR keeps the last good index", async () => {
@@ -195,9 +221,9 @@ describe("buildSitemapIndexBody", () => {
     await expect(buildSitemapIndexBody()).rejects.toThrow("HTTP 500");
   });
 
-  it("falls back to one chunk for a kind missing from a partial counts payload", async () => {
-    // A malformed/partial counts response must not drop a kind or crash — each
-    // missing kind still lists exactly one chunk.
+  it("still lists the consolidated child for a kind missing from a partial counts payload", async () => {
+    // A malformed/partial counts response must not drop a kind or crash — the
+    // consolidated child derives completeness from page data, not this count.
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ projects: 1500 }))
@@ -205,8 +231,53 @@ describe("buildSitemapIndexBody", () => {
 
     const xml = await buildSitemapIndexBody();
 
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/2.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap/1.xml</loc>`);
-    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/grants/sitemap/2.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(7);
+  });
+});
+
+describe("fetchAllSitemapKindUrls", () => {
+  const pageOf = (count: number, prefix: string): string[] =>
+    Array.from({ length: count }, (_, i) => `https://staging.karmahq.xyz/${prefix}/${i}`);
+
+  it("pages until a short page and merges the results in order", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const page = new URL(url).searchParams.get("page");
+      return page === "1"
+        ? jsonResponse({ urls: pageOf(INDEXER_FETCH_PAGE_SIZE, "a") })
+        : jsonResponse({ urls: pageOf(2, "b") });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const urls = await fetchAllSitemapKindUrls("projects");
+
+    expect(urls).toHaveLength(INDEXER_FETCH_PAGE_SIZE + 2);
+    expect(urls[0]).toBe(`${SITE}/a/0`);
+    expect(urls[urls.length - 1]).toBe(`${SITE}/b/1`);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain(`pageSize=${INDEXER_FETCH_PAGE_SIZE}`);
+  });
+
+  it("stops after one fetch when the first page is already short", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ urls: pageOf(3, "p") }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const urls = await fetchAllSitemapKindUrls("funding-programs");
+
+    expect(urls).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when any page fails so a partial list is never served as complete", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const page = new URL(url).searchParams.get("page");
+      return page === "1"
+        ? jsonResponse({ urls: pageOf(INDEXER_FETCH_PAGE_SIZE, "a") })
+        : jsonResponse({}, false, 503);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAllSitemapKindUrls("projects")).rejects.toThrow("HTTP 503");
   });
 });

--- a/app/api/cron/warm-sitemaps/route.ts
+++ b/app/api/cron/warm-sitemaps/route.ts
@@ -1,8 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import { SITE_URL } from "@/utilities/meta";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
+
+// Per-fetch cap so one hung upstream fails fast and is reported instead of
+// silently eating the whole maxDuration budget.
+const FETCH_TIMEOUT_MS = 15_000;
 
 // Vercel cron (see vercel.json) that keeps every sitemap warm: it GETs the
 // index, extracts the child URLs, and GETs each one. The public routes then
@@ -13,28 +18,44 @@ export const maxDuration = 60;
 export async function GET(request: Request): Promise<NextResponse> {
   const secret = process.env.CRON_SECRET;
   if (secret && request.headers.get("authorization") !== `Bearer ${secret}`) {
-    return new NextResponse("Unauthorized", { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const warmed: Record<string, number> = {};
 
   const indexUrl = `${SITE_URL}/sitemap_index.xml`;
-  const indexRes = await fetch(indexUrl, { cache: "no-store" });
-  warmed[indexUrl] = indexRes.status;
-  if (!indexRes.ok) {
+  let children: string[];
+  try {
+    const indexRes = await fetch(indexUrl, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    warmed[indexUrl] = indexRes.status;
+    if (!indexRes.ok) {
+      return NextResponse.json({ ok: false, warmed }, { status: 502 });
+    }
+    const body = await indexRes.text();
+    children = Array.from(body.matchAll(/<loc>([^<]+)<\/loc>/g), (m) => m[1]);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { route: "/api/cron/warm-sitemaps" } });
+    warmed[indexUrl] = 0;
     return NextResponse.json({ ok: false, warmed }, { status: 502 });
   }
-
-  const body = await indexRes.text();
-  const children = Array.from(body.matchAll(/<loc>([^<]+)<\/loc>/g), (m) => m[1]);
 
   // Sequential on purpose: a burst would contend with the indexer's public
   // rate limit for no benefit — the cron has a minute and ~7 children.
   for (const child of children) {
     try {
-      const res = await fetch(child, { cache: "no-store" });
+      const res = await fetch(child, {
+        cache: "no-store",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
       warmed[child] = res.status;
-    } catch {
+    } catch (err) {
+      Sentry.captureException(err, {
+        tags: { route: "/api/cron/warm-sitemaps" },
+        extra: { child },
+      });
       warmed[child] = 0;
     }
   }

--- a/app/api/cron/warm-sitemaps/route.ts
+++ b/app/api/cron/warm-sitemaps/route.ts
@@ -36,6 +36,17 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
     const body = await indexRes.text();
     children = Array.from(body.matchAll(/<loc>([^<]+)<\/loc>/g), (m) => m[1]);
+    // A valid index from this app always lists children (static, communities,
+    // and one per kind), so a 200 that parses to zero <loc> entries means the
+    // warmer read the wrong payload — treat it as a failure and report it
+    // rather than returning ok=true after warming nothing.
+    if (children.length === 0) {
+      Sentry.captureException(
+        new Error("warm-sitemaps index parsed to zero child <loc> entries"),
+        { tags: { route: "/api/cron/warm-sitemaps" }, extra: { indexUrl } }
+      );
+      return NextResponse.json({ ok: false, warmed }, { status: 502 });
+    }
   } catch (err) {
     Sentry.captureException(err, { tags: { route: "/api/cron/warm-sitemaps" } });
     warmed[indexUrl] = 0;

--- a/app/api/cron/warm-sitemaps/route.ts
+++ b/app/api/cron/warm-sitemaps/route.ts
@@ -41,10 +41,10 @@ export async function GET(request: Request): Promise<NextResponse> {
     // warmer read the wrong payload — treat it as a failure and report it
     // rather than returning ok=true after warming nothing.
     if (children.length === 0) {
-      Sentry.captureException(
-        new Error("warm-sitemaps index parsed to zero child <loc> entries"),
-        { tags: { route: "/api/cron/warm-sitemaps" }, extra: { indexUrl } }
-      );
+      Sentry.captureException(new Error("warm-sitemaps index parsed to zero child <loc> entries"), {
+        tags: { route: "/api/cron/warm-sitemaps" },
+        extra: { indexUrl },
+      });
       return NextResponse.json({ ok: false, warmed }, { status: 502 });
     }
   } catch (err) {

--- a/app/api/cron/warm-sitemaps/route.ts
+++ b/app/api/cron/warm-sitemaps/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { SITE_URL } from "@/utilities/meta";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Vercel cron (see vercel.json) that keeps every sitemap warm: it GETs the
+// index, extracts the child URLs, and GETs each one. The public routes then
+// refresh their own Data Cache entries (stale-while-revalidate), so crawler
+// traffic is never what triggers a refresh and Googlebot only ever sees warm,
+// fast responses — including right after a deploy, when the CDN cache is cold
+// but the Data Cache (which persists across deployments) is not.
+export async function GET(request: Request): Promise<NextResponse> {
+  const secret = process.env.CRON_SECRET;
+  if (secret && request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const warmed: Record<string, number> = {};
+
+  const indexUrl = `${SITE_URL}/sitemap_index.xml`;
+  const indexRes = await fetch(indexUrl, { cache: "no-store" });
+  warmed[indexUrl] = indexRes.status;
+  if (!indexRes.ok) {
+    return NextResponse.json({ ok: false, warmed }, { status: 502 });
+  }
+
+  const body = await indexRes.text();
+  const children = Array.from(body.matchAll(/<loc>([^<]+)<\/loc>/g), (m) => m[1]);
+
+  // Sequential on purpose: a burst would contend with the indexer's public
+  // rate limit for no benefit — the cron has a minute and ~7 children.
+  for (const child of children) {
+    try {
+      const res = await fetch(child, { cache: "no-store" });
+      warmed[child] = res.status;
+    } catch {
+      warmed[child] = 0;
+    }
+  }
+
+  const failures = Object.values(warmed).filter((status) => status !== 200).length;
+  return NextResponse.json({ ok: failures === 0, warmed }, { status: failures === 0 ? 200 : 502 });
+}

--- a/app/sitemaps/[kind]/sitemap.xml/route.ts
+++ b/app/sitemaps/[kind]/sitemap.xml/route.ts
@@ -42,6 +42,14 @@ export async function GET(
 
   const urls = await fetchAllSitemapKindUrls(meta.kind);
 
+  // The fetcher stops at the per-file URL limit, so hitting it exactly means
+  // the list may be truncated (stale counts under-reporting a kind that has
+  // outgrown one file). Don't serve a silently incomplete sitemap — once the
+  // counts refresh, the index lists the chunked URLs for this kind instead.
+  if (urls.length >= MAX_URLS_PER_SITEMAP) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
   return new NextResponse(buildUrlsetXml(urls, meta.priority, meta.changeFrequency), {
     status: 200,
     headers: {

--- a/app/sitemaps/[kind]/sitemap.xml/route.ts
+++ b/app/sitemaps/[kind]/sitemap.xml/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import {
+  buildUrlsetXml,
+  countForKind,
+  fetchAllSitemapKindUrls,
+  fetchSitemapCounts,
+  MAX_URLS_PER_SITEMAP,
+  SITEMAP_CACHE_CONTROL,
+  SITEMAP_KINDS,
+  type SitemapKind,
+} from "@/utilities/sitemap";
+
+// Consolidated per-kind child sitemap (/sitemaps/projects/sitemap.xml, …): the
+// kind's complete URL list in one file. One file per kind gives Google 7 child
+// fetches instead of 29 — every extra file is another fetch it can delay or
+// fail — and these URLs replaced the chunked ones in the index, so they carry
+// no crawl history. The static and communities siblings are their own routes
+// and take precedence over this dynamic segment.
+const KIND_META = new Map(SITEMAP_KINDS.map((meta) => [meta.kind, meta]));
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ kind: string }> }
+): Promise<NextResponse> {
+  const { kind } = await params;
+
+  const meta = KIND_META.get(kind as SitemapKind);
+  if (!meta) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  // Past the per-file URL limit the index lists the legacy chunked URLs
+  // instead (see buildSitemapIndexBody) — serving 50k+ URLs here would
+  // violate the sitemaps.org cap, so this URL stops existing rather than lie.
+  // The count is only used for this guard; completeness of the list below
+  // comes from the page data itself.
+  const counts = await fetchSitemapCounts();
+  const total = countForKind(counts, meta.kind);
+  if (Number.isFinite(total) && total > MAX_URLS_PER_SITEMAP) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  const urls = await fetchAllSitemapKindUrls(meta.kind);
+
+  return new NextResponse(buildUrlsetXml(urls, meta.priority, meta.changeFrequency), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": SITEMAP_CACHE_CONTROL,
+    },
+  });
+}

--- a/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
+++ b/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
@@ -8,12 +8,12 @@ import {
   type SitemapKind,
 } from "@/utilities/sitemap";
 
-// Per-kind child sitemap chunk. Fetches the chunk's URLs from the indexer,
-// cached in Next's Data Cache with stale-while-revalidate (see
-// fetchSitemapKindPage), so a slow or unreachable indexer keeps serving the
-// last good chunk instead of an empty one. The index only lists chunks that
-// exist (sized from /counts), so a listed chunk normally has URLs; a chunk
-// fetched past the current end returns an empty-but-valid 200 urlset.
+// LEGACY per-kind child sitemap chunk (1,000 URLs per file). The index now
+// lists one consolidated file per kind (/sitemaps/<kind>/sitemap.xml) and only
+// falls back to these chunked URLs for a kind past the per-file URL limit.
+// Kept serving because the chunk URLs were submitted individually in GSC and
+// Google still re-crawls them; same Data Cache + SWR semantics as the
+// consolidated route.
 const KIND_META = new Map(SITEMAP_KINDS.map((meta) => [meta.kind, meta]));
 
 // Positive chunk filenames only — 1.xml, 2.xml, … never 0.xml or zero-padded.

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -469,14 +469,14 @@
   "reactDoctor": {
     "score": 0,
     "errors": 63,
-    "warnings": 3254,
+    "warnings": 3256,
     "byCategory": {
       "Accessibility": 279,
       "Architecture": 1179,
       "Correctness": 397,
       "Next.js": 148,
       "Server": 6,
-      "Performance": 602,
+      "Performance": 604,
       "State & Effects": 663,
       "TanStack Query": 30,
       "Bundle Size": 10,

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -210,8 +210,12 @@ export async function buildSitemapIndexBody(): Promise<string> {
     const total = countForKind(counts, kind);
     // A missing count (partial payload) lists the consolidated child rather
     // than dropping the kind — the child route derives completeness from the
-    // page data itself, not from this count.
-    if (!Number.isFinite(total) || total <= MAX_URLS_PER_SITEMAP) {
+    // page data itself, not from this count. The threshold is strict (`<`) to
+    // match the consolidated route's truncation guard, which 404s at exactly
+    // MAX_URLS_PER_SITEMAP (it can't prove that list isn't truncated): a kind
+    // sitting on the boundary must be listed as chunks, never as a child the
+    // route would 404.
+    if (!Number.isFinite(total) || total < MAX_URLS_PER_SITEMAP) {
       locs.push(`${SITE_URL}/sitemaps/${kind}/sitemap.xml`);
     } else {
       const chunks = chunkCountFromTotal(total);

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -8,9 +8,22 @@ export function formatSitemapLastmod(date: Date = new Date()): string {
   return date.toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
-// Must match SITEMAP_PAGE_SIZE in the indexer. GSC fails on >~1MB / 5000 URLs,
-// so each child sitemap holds at most this many URLs.
+// Page size of the LEGACY chunked child routes (/sitemaps/<kind>/sitemap/<n>.xml).
+// Those URLs were submitted to GSC individually and must keep serving the same
+// chunk boundaries; new crawling goes through the consolidated per-kind files.
 export const SITEMAP_PAGE_SIZE = 1000;
+
+// Page size used when fetching URL lists from the indexer — its hard cap
+// (limitQuerySchema max in gap-indexer's GetSitemapUrlsQuerySchema). Bigger
+// pages mean fewer indexer round-trips: a full cold rebuild of every kind is
+// ~9 requests, comfortably under the indexer's 30 req/min public rate limit
+// (which a 1000-per-page rebuild of 29 chunks sat exactly at).
+export const INDEXER_FETCH_PAGE_SIZE = 5000;
+
+// One consolidated sitemap per kind, capped with margin under the sitemaps.org
+// limit of 50,000 URLs per file. A kind that outgrows this falls back to the
+// legacy chunked URLs in the index; everything still serves.
+export const MAX_URLS_PER_SITEMAP = 45_000;
 
 // Upper bound on a chunk number parsed from a request path — ~100M URLs per
 // kind at SITEMAP_PAGE_SIZE. Guards the child route against absurd or crafted
@@ -24,8 +37,14 @@ export const MAX_SITEMAP_CHUNK = 100_000;
 // instead of an empty one.
 export const SITEMAP_REVALIDATE_SECONDS = 60 * 60 * 24; // 24h
 
-// CDN/browser cache window for the rendered XML response.
-export const SITEMAP_CACHE_CONTROL = "public, max-age=3600";
+// Crawlers get an instant edge hit for a day, then Vercel's CDN serves the
+// stale copy for up to a week while it revalidates in the background — a slow
+// function or indexer never makes Googlebot wait or time out. max-age=0 keeps
+// browsers honest (the CDN, not the client, owns staleness). The CDN layer is
+// opportunistic only (purged on deploy, evicts rarely-hit assets); the
+// deploy-persistent Data Cache underneath is what guarantees fast renders.
+export const SITEMAP_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
 
 export type SitemapKind = "projects" | "impacts" | "grants" | "milestones" | "funding-programs";
 
@@ -140,9 +159,13 @@ export async function fetchSitemapCounts(): Promise<SitemapCounts> {
 
 // Server-only. Fetches one chunk's worth of URLs for a kind, cached the same way
 // as the counts. Returns the canonicalized URLs.
-export async function fetchSitemapKindPage(kind: SitemapKind, page: number): Promise<string[]> {
+export async function fetchSitemapKindPage(
+  kind: SitemapKind,
+  page: number,
+  pageSize: number = SITEMAP_PAGE_SIZE
+): Promise<string[]> {
   const res = await fetch(
-    `${INDEXER_BASE_URL}/v2/sitemap?kind=${kind}&page=${page}&pageSize=${SITEMAP_PAGE_SIZE}`,
+    `${INDEXER_BASE_URL}/v2/sitemap?kind=${kind}&page=${page}&pageSize=${pageSize}`,
     { next: { revalidate: SITEMAP_REVALIDATE_SECONDS } }
   );
   if (!res.ok) {
@@ -152,10 +175,29 @@ export async function fetchSitemapKindPage(kind: SitemapKind, page: number): Pro
   return (data.urls ?? []).map(canonicalizeSitemapUrl);
 }
 
+// Server-only. Fetches a kind's complete URL list for the consolidated per-kind
+// sitemap. Pages sequentially (indexer-rate-limit friendly; each page is its
+// own Data Cache entry, safely under Vercel's 2MB per-entry cap) until a short
+// page marks the end — complete by construction, with no dependence on a
+// counts snapshot that could disagree with the page data. Any failed page
+// throws, so a partial list is never served as if complete — SWR keeps the
+// last good response instead. Page count is capped at the per-file URL limit;
+// kinds bigger than that are served by the chunked routes, not this path.
+export async function fetchAllSitemapKindUrls(kind: SitemapKind): Promise<string[]> {
+  const maxPages = Math.ceil(MAX_URLS_PER_SITEMAP / INDEXER_FETCH_PAGE_SIZE);
+  const urls: string[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const pageUrls = await fetchSitemapKindPage(kind, page, INDEXER_FETCH_PAGE_SIZE);
+    urls.push(...pageUrls);
+    if (pageUrls.length < INDEXER_FETCH_PAGE_SIZE) break;
+  }
+  return urls;
+}
+
 // Server-only. Builds the sitemap index body: the two local-data children
-// (static, communities) plus the per-kind chunks sized from the live counts.
-// The chunk count is derived fresh on every (cached) refresh, so the index
-// grows automatically as the corpus grows — no committed floor to maintain.
+// (static, communities) plus one consolidated child per kind, sized from the
+// live counts. A kind that outgrows MAX_URLS_PER_SITEMAP falls back to the
+// legacy chunked URLs, so growth never breaks the index — it just adds files.
 export async function buildSitemapIndexBody(): Promise<string> {
   const counts = await fetchSitemapCounts();
 
@@ -165,9 +207,17 @@ export async function buildSitemapIndexBody(): Promise<string> {
   ];
 
   for (const { kind } of SITEMAP_KINDS) {
-    const chunks = chunkCountFromTotal(countForKind(counts, kind));
-    for (let page = 1; page <= chunks; page++) {
-      locs.push(`${SITE_URL}/sitemaps/${kind}/sitemap/${page}.xml`);
+    const total = countForKind(counts, kind);
+    // A missing count (partial payload) lists the consolidated child rather
+    // than dropping the kind — the child route derives completeness from the
+    // page data itself, not from this count.
+    if (!Number.isFinite(total) || total <= MAX_URLS_PER_SITEMAP) {
+      locs.push(`${SITE_URL}/sitemaps/${kind}/sitemap.xml`);
+    } else {
+      const chunks = chunkCountFromTotal(total);
+      for (let page = 1; page <= chunks; page++) {
+        locs.push(`${SITE_URL}/sitemaps/${kind}/sitemap/${page}.xml`);
+      }
     }
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,11 @@
     }
   },
   "ignoreCommand": "bash vercel-ignore.sh",
-  "buildCommand": "timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )"
+  "buildCommand": "timeout -k 30s 900s pnpm build || ( rm -rf .next && timeout -k 30s 900s pnpm build )",
+  "crons": [
+    {
+      "path": "/api/cron/warm-sitemaps",
+      "schedule": "0 */6 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Overview

Structural fix for the sitemap discovery pipeline so Google reliably fetches everything from the index alone — no individual child submissions, no manual GSC interventions, resilient to deploys, cold caches, and corpus growth.

## Problem

Even after the fresh-URL index reset (#1603, working — Google read and processed it the same day), the architecture had structural fragility:

1. **29 chunked children of 1,000 URLs each.** Every file is one more fetch Google can delay or fail — today''s bulk test showed exactly that failure shape (first ~9 fetched instantly, rest queued as "Couldn''t fetch"). The 1,000-URL page size dated from a false "GSC fails on >1MB / 5000 URLs" assumption; the real limits are **50,000 URLs / 50MB per file**, and Mueller has stated file count/size has no crawling impact — split only for monitoring.
2. **Cold-cache windows.** A full cold rebuild needed 30 indexer calls — sitting exactly at the indexer''s 30 req/min public rate limit — and whoever hit a cold Data Cache entry (post-deploy, LRU eviction, new chunk) blocked on a live indexer call. If that requester was Googlebot and the indexer was cold: timeout → "Couldn''t fetch" → potentially a re-poisoned sitemap state like the one that pinned discovery at 3,197 for weeks.
3. **Crawler-driven freshness.** Refreshes only happened when a crawler asked, so Googlebot was always the first to pay for staleness.

## Solution

**One consolidated child per kind** (`/sitemaps/<kind>/sitemap.xml`): 7 children instead of 29. Built by paging the indexer at its real cap (pageSize 5000) until a short page marks the end — **complete by construction**, no dependence on a counts snapshot that could disagree with page data. Any failed page throws, so a partial list is never served as complete (SWR keeps the last good response). A kind past 45,000 URLs automatically falls back to the legacy chunked URLs in the index. The chunk routes keep serving for the GSC-submitted legacy URLs. Full cold rebuild: ~9 indexer calls.

**Edge SWR serving**: responses now send `s-maxage=86400, stale-while-revalidate=604800` — Vercel''s CDN serves crawlers instantly and revalidates in the background. The deploy-persistent Data Cache underneath keeps even post-deploy cold-CDN hits fast.

**Cron warmer** (`/api/cron/warm-sitemaps`, every 6h via `vercel.json` crons): GETs the index, extracts children, GETs each — every cache entry permanently warm, refreshes on our schedule, Googlebot never first in line for a cold path. `CRON_SECRET`-guarded when configured. Cost: ~36 function invocations/day — negligible.

Also removes the false >1MB myth comment.

## Testing

- 41 vitest tests across `__tests__/utilities/sitemap.test.ts` + `__tests__/app/sitemap-routes.test.ts` (consolidated index sizing, overflow fallback, partial-counts resilience, page-until-short completeness, failure propagation, per-kind route 404s, warmer auth + flow).
- `pnpm typecheck` clean; full `pnpm build` clean — route manifest verified: index/per-kind/chunk/cron all dynamic, static/communities prerendered as before.

## Ops note (post-merge)

Set `CRON_SECRET` in the Vercel project env (optional but recommended). Nothing to do in Search Console: the already-submitted `sitemap_index.xml` will list the new children on its next read; "Couldn''t fetch" rows on the legacy chunks are GSC''s mislabeled "Pending" and clear on their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled sitemap warming every 6 hours with optional secret-auth protection.
  * Consolidated per-kind sitemap endpoints with automatic fallback to chunked child sitemaps for very large kinds.

* **Performance**
  * Longer CDN/shared-cache window for sitemap responses for faster delivery.

* **Tests / Reliability**
  * Expanded sitemap and cron-route tests; improved handling of partial/stale counts and fetch-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->