### PR TITLE
fix(find-funders): loading states on first load + logo links to main site

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -15,8 +15,8 @@
   "violations": {
     "biome": 1245,
     "knipUnusedFiles": 212,
-    "knipUnusedExports": 420,
-    "knipUnusedTypes": 353,
+    "knipUnusedExports": 419,
+    "knipUnusedTypes": 354,
     "knipUnusedDeps": 20,
     "knipDuplicates": 34
   },
@@ -412,8 +412,8 @@
       "maxBytes": 40000
     },
     "src/features/non-profits/hooks/use-philanthropy-stream.ts": {
-      "lines": 627,
-      "bytes": 21111,
+      "lines": 638,
+      "bytes": 21642,
       "maxLines": 600,
       "maxBytes": 40000
     },

--- a/src/features/non-profits/components/chat-view-dynamic.tsx
+++ b/src/features/non-profits/components/chat-view-dynamic.tsx
@@ -9,6 +9,10 @@
  *
  * The chat workbench relies on browser APIs (SSE fetch, sessionStorage,
  * Zustand persist) that must not run on the server.
+ *
+ * The `loading` fallback mirrors search/[id]/loading.tsx: with `ssr: false`
+ * the client chunk loads after hydration with no fallback, so without this the
+ * workbench is blank between navigation and the first streamed result.
  */
 import dynamic from "next/dynamic";
 
@@ -17,5 +21,26 @@ export const ChatViewDynamic = dynamic(
     import("./chat-view-client").then((m) => ({
       default: m.ChatView,
     })),
-  { ssr: false }
+  {
+    ssr: false,
+    // Inlined (not a named local component) so this file keeps a single
+    // component export — react-refresh's only-export-components rule flags a
+    // local component declaration alongside the exported one. A <div> (not
+    // <main>) avoids nested landmarks: the search page already wraps this in
+    // its own <main>.
+    loading: () => (
+      <div className="flex w-full min-h-[60vh] flex-col gap-6 px-4 py-16 max-w-4xl mx-auto">
+        <div className="h-8 w-2/3 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-1/3 animate-pulse rounded-md bg-muted" />
+        <div className="mt-4 flex flex-col gap-4">
+          {["s1", "s2", "s3", "s4", "s5"].map((id) => (
+            <div
+              key={id}
+              className="h-24 w-full animate-pulse rounded-xl border border-border bg-card"
+            />
+          ))}
+        </div>
+      </div>
+    ),
+  }
 );

--- a/src/features/non-profits/components/landing-page-dynamic.tsx
+++ b/src/features/non-profits/components/landing-page-dynamic.tsx
@@ -6,6 +6,11 @@
  * `ssr: false` is not allowed in Server Components (Next.js / Turbopack
  * enforces this). This thin client wrapper re-exports a lazily loaded version
  * so the page.tsx Server Component can import it safely.
+ *
+ * The `loading` fallback matters here: with `ssr: false`, nothing renders on
+ * the server and the route's `loading.tsx` only covers the initial segment
+ * suspense — once hydrated, the client chunk loads with no fallback, leaving a
+ * blank flash on first load. The spinner below mirrors that `loading.tsx`.
  */
 import dynamic from "next/dynamic";
 
@@ -14,5 +19,19 @@ export const LandingPageDynamic = dynamic(
     import("./landing-page-client").then((m) => ({
       default: m.LandingPageClient,
     })),
-  { ssr: false }
+  {
+    ssr: false,
+    // Inlined (not a named local component) so this file keeps a single
+    // component export — react-refresh's only-export-components rule flags a
+    // local component declaration alongside the exported one. `<output>` has
+    // an implicit role="status" for screen readers.
+    loading: () => (
+      <main className="flex w-full min-h-screen items-center justify-center bg-background">
+        <output
+          className="block h-10 w-10 animate-spin rounded-full border-2 border-border border-t-primary"
+          aria-label="Loading"
+        />
+      </main>
+    ),
+  }
 );

--- a/src/features/non-profits/components/non-profits-navbar.tsx
+++ b/src/features/non-profits/components/non-profits-navbar.tsx
@@ -29,7 +29,7 @@ import {
   useNavbarPermissions,
 } from "@/src/components/navbar/navbar-permissions-context";
 import { NavbarUserSkeleton } from "@/src/components/navbar/navbar-user-skeleton";
-import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { NON_PROFITS_PAGES, PAGES } from "@/utilities/pages";
 import { useResearchTray } from "../hooks/use-research-tray";
 import { FILINGS_STATS } from "../lib/stats";
 import { BookmarksDrawer } from "./bookmarks-drawer";
@@ -122,7 +122,7 @@ export function NonProfitsNavbar() {
     <>
       <nav className="lp-nav">
         <div className="lp-container lp-nav-inner">
-          <Link href={NON_PROFITS_PAGES.HOME} aria-label="Karma Find Funders home">
+          <Link href={PAGES.HOME} aria-label="Karma home">
             <BrandMark />
           </Link>
 


### PR DESCRIPTION
## Summary

Fixes two issues on the **/non-profits/find-funders** flow:

1. **No loading state on first load.** The landing page and the search workbench render through `dynamic(..., { ssr: false })` with **no `loading` fallback**. The route's `loading.tsx` only covers the initial server/segment suspense — once the page hydrates, the client-only chunk loads with nothing on screen, producing a blank flash. Added `loading` fallbacks to both dynamic wrappers (mirroring the existing `loading.tsx` markup).

2. **Logo link.** The navbar brand logo pointed at `NON_PROFITS_PAGES.HOME` (`/non-profits/find-funders`); it now points at the main site (`PAGES.HOME` = `/`). `isHomepage` detection is unchanged.

## Changes

- `components/landing-page-dynamic.tsx` — spinner `loading` fallback (inlined, semantic `<output>`)
- `components/chat-view-dynamic.tsx` — skeleton `loading` fallback (inlined `<div>` to avoid nesting inside the search page's `<main>`)
- `components/non-profits-navbar.tsx` — logo → `PAGES.HOME`

## Note on scope

This branch originally also fixed the **stale search result when switching examples**. That bug is now handled on `main` by the `decideThreadSeed` / `threadId` work from #1606, so those changes were dropped and the branch was rebased onto the latest `main` to keep things conflict-free and non-duplicative.

## Test plan

- [ ] First load of `/non-profits/find-funders` shows a loading state, no blank flash
- [ ] Clicking an example shows a skeleton while the workbench chunk loads
- [ ] Clicking the logo navigates to `/`

> Built from a clean worktree off `origin/main`. Local `biome`/`tsc` can't run (WSL + Windows-native `node_modules`); relying on CI.
