### PR TITLE
fix(non-profits): send JWT on find-funders stream requests

### DIFF
--- a/src/features/non-profits/__tests__/use-philanthropy-stream.test.ts
+++ b/src/features/non-profits/__tests__/use-philanthropy-stream.test.ts
@@ -15,6 +15,11 @@ vi.mock("@/utilities/enviromentVars", () => ({
   },
 }));
 
+const mockGetToken = vi.hoisted(() => vi.fn<() => Promise<string | null>>());
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: mockGetToken },
+}));
+
 // ── SSE stream builder helpers ────────────────────────────────────────────────
 
 function encodeSSEFrame(event: string, data: unknown): Uint8Array {
@@ -72,6 +77,82 @@ const NO_OP_CALLBACKS = {
 describe("streamPhilanthropyQuery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetToken.mockResolvedValue(null);
+  });
+
+  it("attaches Authorization header when a session token exists", async () => {
+    // Without the JWT, logged-in users hit the indexer as anonymous and
+    // burn the IP-keyed search-metering quota until a 401 login_required.
+    mockGetToken.mockResolvedValue("privy-jwt-123");
+    const stream = makeSSEStream([encodeSSEFrame("final_answer", FINAL_ANSWER_PAYLOAD)]);
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(stream));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new AbortController();
+    await streamPhilanthropyQuery(
+      "test query",
+      undefined,
+      1,
+      controller.signal,
+      true,
+      undefined,
+      undefined,
+      NO_OP_CALLBACKS
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer privy-jwt-123",
+        }),
+      })
+    );
+  });
+
+  it("omits Authorization header when no session token exists", async () => {
+    mockGetToken.mockResolvedValue(null);
+    const stream = makeSSEStream([encodeSSEFrame("final_answer", FINAL_ANSWER_PAYLOAD)]);
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(stream));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new AbortController();
+    await streamPhilanthropyQuery(
+      "test query",
+      undefined,
+      1,
+      controller.signal,
+      true,
+      undefined,
+      undefined,
+      NO_OP_CALLBACKS
+    );
+
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("still issues the request when token retrieval fails", async () => {
+    mockGetToken.mockRejectedValue(new Error("privy unavailable"));
+    const stream = makeSSEStream([encodeSSEFrame("final_answer", FINAL_ANSWER_PAYLOAD)]);
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(stream));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new AbortController();
+    const result = await streamPhilanthropyQuery(
+      "test query",
+      undefined,
+      1,
+      controller.signal,
+      true,
+      undefined,
+      undefined,
+      NO_OP_CALLBACKS
+    );
+
+    expect(result.isOk()).toBe(true);
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
   });
 
   it("resolves with header and narrative on a valid final_answer event", async () => {

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -12,6 +12,7 @@
 import { ResultAsync } from "neverthrow";
 import { useCallback, useRef } from "react";
 import { z } from "zod";
+import { TokenManager } from "@/utilities/auth/token-manager";
 import { envVars } from "@/utilities/enviromentVars";
 import {
   type AgentAttachment,
@@ -187,9 +188,19 @@ export function streamPhilanthropyQuery(
         body.messages = messages;
       }
 
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      // Authenticated users bypass the indexer's anonymous search metering
+      // (IP-keyed free quota → 401 login_required), so always send the JWT
+      // when one exists. A token failure must not block the search — the
+      // request just proceeds anonymously.
+      const token = await TokenManager.getToken().catch(() => null);
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
       const response = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(body),
         signal,
       });


### PR DESCRIPTION
## Summary

The find-funders SSE stream (`streamPhilanthropyQuery`) sent only `Content-Type` — never an `Authorization` header. Every search hit the indexer as **anonymous**, even for signed-in users.

## Why it matters

The indexer's `searchMeteringPreHandler` lets authenticated users pass freely but meters anonymous searches with an **IP-keyed** Redis free quota. Without the JWT:

- Signed-in users burn the anonymous quota anyway.
- Everyone behind a shared network (office, VPN) shares **one** quota and eventually gets `401 login_required` while logged in.
- All searches are attributed to anonymous traffic in metering/telemetry.

## Fix

Attach the Privy JWT via `TokenManager.getToken()` when one exists — the same pattern `api-fetch.ts` already uses for every other non-profits API call; the stream fetch was the only hand-rolled `fetch` in the feature missing it. Token retrieval failures fall back to an anonymous request rather than blocking the search.

## Testing

- New unit tests: header attached when a token exists, omitted when not, and request still proceeds when token retrieval throws.
- `pnpm vitest run` on the feature ✓ (12/12), `pnpm lint:fix` ✓, `pnpm tsc --noEmit` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming queries now support optional JWT authentication via Authorization headers when tokens are available.
  * Requests proceed without authentication if token retrieval is unavailable or fails.

* **Tests**
  * Added comprehensive test coverage for token retrieval and Authorization header behavior in streaming queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->