### PR TITLE
feat(find-funders): restore saved conversations from search history

### DIFF
--- a/src/features/non-profits/__tests__/saved-conversation.test.ts
+++ b/src/features/non-profits/__tests__/saved-conversation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for lib/saved-conversation.ts — mapping between persisted
+ * conversation turns and the in-memory ChatTurn shape.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  chatTurnToTurnPayload,
+  savedTurnsToChatTurns,
+  savedTurnToChatTurn,
+} from "../lib/saved-conversation";
+import type { SavedSearchTurn } from "../services/search-history.service";
+import type { ChatTurn } from "../store/philanthropy";
+import type { RankedEntity } from "../types/philanthropy";
+
+function makeEntity(id: string): RankedEntity {
+  return {
+    entityType: "foundation",
+    id,
+    name: `Foundation ${id}`,
+    description: null,
+    ein: null,
+    location: null,
+    totalAssets: null,
+    amount: null,
+    date: null,
+    filingYear: null,
+    foundationId: null,
+    foundationName: null,
+    nonprofitId: null,
+    nonprofitName: null,
+    scores: { semantic: 1, amount: 0, recency: 0, composite: 1 },
+  };
+}
+
+function makeSavedTurn(overrides: Partial<SavedSearchTurn> = {}): SavedSearchTurn {
+  return {
+    id: "turn-1",
+    searchHistoryId: "sh-1",
+    turnIndex: 0,
+    userQuery: "Foundations in Ohio",
+    narrative: "Top funders…",
+    entities: [makeEntity("f-1")],
+    citations: [{ entityId: "f-1", entityType: "foundation", filingYear: 2023, fieldPath: "x" }],
+    traceId: "trace-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeChatTurn(overrides: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    id: "turn-1",
+    userQuery: "Foundations in Ohio",
+    narrative: "Top funders…",
+    entities: [makeEntity("f-1")],
+    citations: [],
+    traceId: "trace-1",
+    pagination: null,
+    status: "done",
+    error: null,
+    progress: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe("savedTurnToChatTurn", () => {
+  it("restores a completed turn with no streaming residue", () => {
+    const turn = savedTurnToChatTurn(makeSavedTurn());
+
+    expect(turn).toEqual({
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [makeEntity("f-1")],
+      citations: [{ entityId: "f-1", entityType: "foundation", filingYear: 2023, fieldPath: "x" }],
+      traceId: "trace-1",
+      pagination: null,
+      status: "done",
+      error: null,
+      progress: null,
+      attachments: [],
+    });
+  });
+
+  it("preserves turn order in savedTurnsToChatTurns", () => {
+    const turns = savedTurnsToChatTurns([
+      makeSavedTurn({ id: "t-1", turnIndex: 0 }),
+      makeSavedTurn({ id: "t-2", turnIndex: 1 }),
+    ]);
+
+    expect(turns.map((t) => t.id)).toEqual(["t-1", "t-2"]);
+  });
+});
+
+describe("chatTurnToTurnPayload", () => {
+  it("snapshots id, query, narrative, entities, citations and traceId", () => {
+    const payload = chatTurnToTurnPayload(makeChatTurn());
+
+    expect(payload).toEqual({
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [makeEntity("f-1")],
+      citations: [],
+      traceId: "trace-1",
+    });
+  });
+
+  it("clamps oversized fields to the server bounds", () => {
+    const entities = Array.from({ length: 600 }, (_, i) => makeEntity(`f-${i}`));
+    const payload = chatTurnToTurnPayload(
+      makeChatTurn({
+        userQuery: "q".repeat(5000),
+        narrative: "n".repeat(50000),
+        entities,
+      })
+    );
+
+    expect(payload.userQuery).toHaveLength(4000);
+    expect(payload.narrative).toHaveLength(40000);
+    expect(payload.entities).toHaveLength(500);
+  });
+});

--- a/src/features/non-profits/__tests__/search-history-service.test.ts
+++ b/src/features/non-profits/__tests__/search-history-service.test.ts
@@ -48,6 +48,20 @@ const HISTORY_ENTRY = {
   createdAt: "2024-01-01T00:00:00Z",
 };
 
+const SAVED_TURN = {
+  id: "turn-1",
+  searchHistoryId: "sh-1",
+  turnIndex: 0,
+  userQuery: "Foundations in Ohio",
+  narrative: "Top funders…",
+  entities: [],
+  citations: [],
+  traceId: "trace-1",
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+const HISTORY_DETAIL = { ...HISTORY_ENTRY, turns: [SAVED_TURN] };
+
 describe("searchHistoryService", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -104,12 +118,24 @@ describe("searchHistoryService", () => {
       if (result.isOk()) {
         expect(result.value.id).toBe("sh-1");
       }
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ query: "Foundations in Ohio" });
+    });
+
+    it("includes the conversation id in the body when supplied", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_ENTRY));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await searchHistoryService.create("Foundations in Ohio", "thread-1");
+
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ query: "Foundations in Ohio", id: "thread-1" });
     });
   });
 
   describe("getById", () => {
-    it("calls the GET endpoint for the given id", async () => {
-      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_ENTRY));
+    it("calls the GET endpoint for the given id and returns saved turns", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_DETAIL));
       vi.stubGlobal("fetch", fetchMock);
 
       const result = await searchHistoryService.getById("sh-1");
@@ -117,6 +143,8 @@ describe("searchHistoryService", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value.id).toBe("sh-1");
+        expect(result.value.turns).toHaveLength(1);
+        expect(result.value.turns[0].userQuery).toBe("Foundations in Ohio");
       }
       const calledUrl = fetchMock.mock.calls[0][0] as string;
       expect(calledUrl).toContain("/v2/search-history/sh-1");
@@ -131,6 +159,45 @@ describe("searchHistoryService", () => {
       if (result.isErr()) {
         expect(result.error.type).toBe("ApiError");
         expect((result.error as { type: string; status: number }).status).toBe(404);
+      }
+    });
+  });
+
+  describe("appendTurn", () => {
+    it("posts the turn snapshot to the turns endpoint", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(SAVED_TURN));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await searchHistoryService.appendTurn("sh-1", {
+        id: "turn-1",
+        userQuery: "Foundations in Ohio",
+        narrative: "Top funders…",
+        entities: [],
+        citations: [],
+        traceId: "trace-1",
+      });
+
+      expect(result.isOk()).toBe(true);
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v2/search-history/sh-1/turns");
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "POST" });
+    });
+
+    it("returns ApiError when unauthenticated", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(401, "Unauthorized")));
+
+      const result = await searchHistoryService.appendTurn("sh-1", {
+        id: "turn-1",
+        userQuery: "q",
+        narrative: "",
+        entities: [],
+        citations: [],
+        traceId: null,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("ApiError");
       }
     });
   });

--- a/src/features/non-profits/__tests__/search-session.test.ts
+++ b/src/features/non-profits/__tests__/search-session.test.ts
@@ -100,4 +100,33 @@ describe("useSearchSessionStore", () => {
     const id2 = useSearchSessionStore.getState().createSession("query beta");
     expect(id1).not.toBe(id2);
   });
+
+  it("createSession marks the session fresh", () => {
+    const id = useSearchSessionStore.getState().createSession("brand new search");
+    expect(useSearchSessionStore.getState().getSession(id)?.fresh).toBe(true);
+  });
+
+  it("consumeFresh returns true exactly once for a fresh session", () => {
+    const id = useSearchSessionStore.getState().createSession("brand new search");
+
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(true);
+    // Second call: the flag was consumed — this is now a revisit.
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(false);
+    expect(useSearchSessionStore.getState().getSession(id)?.query).toBe("brand new search");
+  });
+
+  it("consumeFresh returns false for sessions written via setSession", () => {
+    useSearchSessionStore.getState().setSession("remote-id", "hydrated from server");
+    expect(useSearchSessionStore.getState().consumeFresh("remote-id")).toBe(false);
+  });
+
+  it("consumeFresh returns false for unknown ids", () => {
+    expect(useSearchSessionStore.getState().consumeFresh("nonexistent")).toBe(false);
+  });
+
+  it("setSession clears the fresh flag for an existing session", () => {
+    const id = useSearchSessionStore.getState().createSession("first query");
+    useSearchSessionStore.getState().setSession(id, "first query");
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(false);
+  });
 });

--- a/src/features/non-profits/__tests__/use-search-history.test.ts
+++ b/src/features/non-profits/__tests__/use-search-history.test.ts
@@ -12,13 +12,18 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useAddSearchHistory,
+  useAppendSearchTurn,
   useClearSearchHistory,
   useDeleteSearchHistoryEntry,
   useSearchHistory,
   useSearchHistoryList,
 } from "../hooks/use-search-history";
 import type { AppError } from "../lib/errors";
-import type { SearchHistoryEntry } from "../services/search-history.service";
+import type {
+  SavedSearchTurn,
+  SearchHistoryDetail,
+  SearchHistoryEntry,
+} from "../services/search-history.service";
 import { searchHistoryService } from "../services/search-history.service";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -28,6 +33,7 @@ vi.mock("../services/search-history.service", () => ({
     list: vi.fn(),
     create: vi.fn(),
     getById: vi.fn(),
+    appendTurn: vi.fn(),
     deleteOne: vi.fn(),
     clearAll: vi.fn(),
   },
@@ -78,7 +84,9 @@ describe("useSearchHistory (getById)", () => {
   });
 
   it("fetches entry by id", async () => {
-    vi.mocked(searchHistoryService.getById).mockReturnValue(okAsync(ENTRY_1));
+    vi.mocked(searchHistoryService.getById).mockReturnValue(
+      okAsync({ ...ENTRY_1, turns: [] } satisfies SearchHistoryDetail)
+    );
 
     const { result } = renderHook(() => useSearchHistory("sh-1"), { wrapper });
 
@@ -171,7 +179,7 @@ describe("useAddSearchHistory", () => {
     const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
 
     await act(async () => {
-      result.current.mutate("Foundations in Ohio");
+      result.current.mutate({ query: "Foundations in Ohio" });
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -181,6 +189,101 @@ describe("useAddSearchHistory", () => {
     const queries = cached?.map((e) => e.query.toLowerCase()) ?? [];
     const unique = [...new Set(queries)];
     expect(unique).toHaveLength(queries.length);
+  });
+
+  it("passes the conversation id through to the service", async () => {
+    vi.mocked(searchHistoryService.create).mockReturnValue(okAsync(ENTRY_1));
+
+    const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({ query: "Foundations in Ohio", id: "thread-1" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(searchHistoryService.create).toHaveBeenCalledWith("Foundations in Ohio", "thread-1");
+  });
+
+  it("leaves cached detail entries (non-list values) untouched", async () => {
+    const detail: SearchHistoryDetail = { ...ENTRY_1, turns: [] };
+    queryClient.setQueryData([...SEARCH_HISTORY_KEY, "sh-1"], detail);
+    vi.mocked(searchHistoryService.create).mockReturnValue(okAsync(ENTRY_2));
+
+    const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({ query: "Youth literacy funders" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData([...SEARCH_HISTORY_KEY, "sh-1"])).toEqual(detail);
+  });
+});
+
+describe("useAppendSearchTurn", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("appends the turn via the service", async () => {
+    const savedTurn: SavedSearchTurn = {
+      id: "turn-1",
+      searchHistoryId: "sh-1",
+      turnIndex: 0,
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [],
+      citations: [],
+      traceId: null,
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    vi.mocked(searchHistoryService.appendTurn).mockReturnValue(okAsync(savedTurn));
+
+    const { result } = renderHook(() => useAppendSearchTurn(), { wrapper });
+
+    const payload = {
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [],
+      citations: [],
+      traceId: null,
+    };
+    await act(async () => {
+      result.current.mutate({ searchId: "sh-1", turn: payload });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(searchHistoryService.appendTurn).toHaveBeenCalledWith("sh-1", payload);
+  });
+
+  it("surfaces errors without throwing", async () => {
+    const appError: AppError = { type: "ApiError", status: 401, message: "Unauthorized" };
+    vi.mocked(searchHistoryService.appendTurn).mockReturnValue(errAsync(appError));
+
+    const { result } = renderHook(() => useAppendSearchTurn(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        searchId: "sh-1",
+        turn: {
+          id: "turn-1",
+          userQuery: "q",
+          narrative: "",
+          entities: [],
+          citations: [],
+          traceId: null,
+        },
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(appError);
   });
 });
 

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -12,7 +12,8 @@
  * - Store: useGrantAtlasStore → usePhilanthropyStore
  * - messages selector: useShallow + EMPTY_MESSAGES constant (Zustand v5 safety)
  * - No motion imports; no retry button on stream error (error card only)
- * - New chat: abort stream + reset() store, STAY on current URL
+ * - New chat: abort stream + reset() store, replace URL with a fresh session
+ *   id (conversations are persisted per URL id)
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
@@ -28,6 +29,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -57,6 +59,7 @@ import {
   useRemoveFromResearchTray,
   useResearchTray,
 } from "../hooks/use-research-tray";
+import { savedTurnsToChatTurns } from "../lib/saved-conversation";
 import { FILINGS_STATS } from "../lib/stats";
 import { decideThreadSeed } from "../lib/thread-seed";
 import { searchHistoryService } from "../services/search-history.service";
@@ -348,6 +351,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
+  const router = useRouter();
 
   const [input, setInput] = useState("");
   const [trayOpen, setTrayOpen] = useState(false);
@@ -383,23 +387,36 @@ export function ChatView({ searchId }: { searchId?: string }) {
       reset();
     }
     usePhilanthropyStore.getState().setThreadId(searchId);
-    // Fast path: local session store
-    const session = useSearchSessionStore.getState().getSession(searchId);
+    const sessionStore = useSearchSessionStore.getState();
+    const session = sessionStore.getSession(searchId);
     const localQuery = session?.query?.trim();
-    if (localQuery) {
-      void search(localQuery, 1, { chat: true });
+    // Fast path: a session minted just now (landing page submit / new chat)
+    // runs its query immediately. `consumeFresh` is one-shot, so any later
+    // visit to the same URL takes the hydration path below instead of
+    // re-running the search.
+    if (sessionStore.consumeFresh(searchId)) {
+      if (localQuery) void search(localQuery, 1, { chat: true });
       return;
     }
-    // Fallback: fetch from server (shared link / cold load)
+    // Revisit / shared link: restore the saved conversation if the server
+    // has turns for it; otherwise fall back to re-running the query.
     void searchHistoryService.getById(searchId).match(
       (entry) => {
+        if (entry.turns.length > 0) {
+          useSearchSessionStore.getState().setSession(searchId, entry.query);
+          usePhilanthropyStore.getState().hydrateTurns(savedTurnsToChatTurns(entry.turns));
+          return;
+        }
         const remoteQuery = entry.query?.trim();
         if (!remoteQuery) return;
         useSearchSessionStore.getState().setSession(searchId, remoteQuery);
         void search(remoteQuery, 1, { chat: true });
       },
       () => {
-        /* 404 or error — render empty workbench, degrade gracefully */
+        // 404 (never persisted — e.g. anonymous search) or network error:
+        // re-run the locally cached query if we have one, else render the
+        // empty workbench and degrade gracefully.
+        if (localQuery) void search(localQuery, 1, { chat: true });
       }
     );
   }, [searchId, messages.length, search, abort, reset]);
@@ -422,15 +439,19 @@ export function ChatView({ searchId }: { searchId?: string }) {
     [search, isSearching]
   );
 
-  // New chat: abort active stream + reset chat store, STAY on current URL.
-  // Clear the session's seed query so the initial-query effect (re-armed by
-  // resetting the ref below) doesn't immediately re-run the original query.
+  // New chat: abort active stream + reset chat store, then move to a fresh
+  // session URL. Conversations are persisted under the URL id, so staying on
+  // the old URL would either resurrect the saved thread (the seeding effect
+  // hydrates it) or append unrelated turns to it — a new id gives the next
+  // conversation its own saved thread. `createSession("")` marks the new id
+  // fresh so the seeding effect renders an empty workbench without fetching.
   const onNewChat = useCallback(() => {
     abort();
     reset();
-    if (searchId) useSearchSessionStore.getState().clearSession(searchId);
     seededSearchIdRef.current = null;
-  }, [abort, reset, searchId]);
+    const newId = useSearchSessionStore.getState().createSession("");
+    router.replace(NON_PROFITS_PAGES.SEARCH(newId));
+  }, [abort, reset, router]);
 
   const showEmpty = messages.length === 0 && !isSearching;
   const lastTurn = messages[messages.length - 1];

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -22,6 +22,7 @@ import {
 } from "../lib/agentic-philanthropy";
 import { NON_PROFITS_API } from "../lib/api";
 import type { AppError } from "../lib/errors";
+import { chatTurnToTurnPayload } from "../lib/saved-conversation";
 import { type ChatTurn, usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 import type {
@@ -30,7 +31,7 @@ import type {
   QueryResponse,
   RankedEntity,
 } from "../types/philanthropy";
-import { useAddSearchHistory } from "./use-search-history";
+import { useAddSearchHistory, useAppendSearchTurn } from "./use-search-history";
 
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -394,6 +395,7 @@ function buildConversationMessages(
 export function usePhilanthropySearch() {
   const abortRef = useRef<AbortController | null>(null);
   const addHistory = useAddSearchHistory();
+  const appendTurn = useAppendSearchTurn();
 
   const search = useCallback(
     async (
@@ -594,19 +596,56 @@ export function usePhilanthropySearch() {
               status: "done",
               progress: null,
             });
+
+            // Persist the completed turn so revisiting the URL replays the
+            // conversation instead of re-running the search. The first turn
+            // creates the history entry under the thread/URL id; follow-ups
+            // append to it. Both calls fail silently for anonymous users
+            // (the endpoints require auth) — the local session still works.
+            const state = usePhilanthropyStore.getState();
+            const threadId = state.threadId;
+            const completedTurn = state.messages[state.messages.length - 1];
+            if (threadId && completedTurn?.status === "done") {
+              const turnPayload = chatTurnToTurnPayload(completedTurn);
+              const doneCount = state.messages.filter((t) => t.status === "done").length;
+              if (doneCount === 1) {
+                addHistory.mutate(
+                  { query: normalizedQuery, id: threadId },
+                  {
+                    onSuccess: (entry) => {
+                      useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
+                      options?.onSearchId?.(entry.id);
+                      appendTurn.mutate({ searchId: entry.id, turn: turnPayload });
+                    },
+                    onError: () => {
+                      // Anonymous/offline: keep the local session so the
+                      // page keeps working without server persistence.
+                      useSearchSessionStore.getState().setSession(threadId, normalizedQuery);
+                      options?.onSearchId?.(threadId);
+                    },
+                  }
+                );
+              } else {
+                appendTurn.mutate({ searchId: threadId, turn: turnPayload });
+              }
+            }
+            return;
           }
 
           if (!isPagination) {
-            addHistory.mutate(normalizedQuery, {
-              onSuccess: (entry) => {
-                useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
-                options?.onSearchId?.(entry.id);
-              },
-              onError: () => {
-                const sessionId = useSearchSessionStore.getState().createSession(normalizedQuery);
-                options?.onSearchId?.(sessionId);
-              },
-            });
+            addHistory.mutate(
+              { query: normalizedQuery },
+              {
+                onSuccess: (entry) => {
+                  useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
+                  options?.onSearchId?.(entry.id);
+                },
+                onError: () => {
+                  const sessionId = useSearchSessionStore.getState().createSession(normalizedQuery);
+                  options?.onSearchId?.(sessionId);
+                },
+              }
+            );
           }
         },
         (appErr) => {
@@ -627,7 +666,7 @@ export function usePhilanthropySearch() {
 
       usePhilanthropyStore.getState().setSearching(false);
     },
-    [addHistory]
+    [addHistory, appendTurn]
   );
 
   const abort = useCallback(() => {

--- a/src/features/non-profits/hooks/use-search-history.ts
+++ b/src/features/non-profits/hooks/use-search-history.ts
@@ -11,7 +11,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/useAuth";
 import { resultToPromise } from "../lib/result-to-promise";
-import { type SearchHistoryEntry, searchHistoryService } from "../services/search-history.service";
+import {
+  type SearchHistoryEntry,
+  type SearchTurnPayload,
+  searchHistoryService,
+} from "../services/search-history.service";
 
 const SEARCH_HISTORY_KEY = ["non-profits-search-history"] as const;
 
@@ -39,13 +43,32 @@ export function useAddSearchHistory() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (query: string) => resultToPromise(searchHistoryService.create(query)),
+    // `id` is the conversation id (the /search/[id] URL UUID) so turns
+    // appended later attach to the URL the user is already on.
+    mutationFn: ({ query, id }: { query: string; id?: string }) =>
+      resultToPromise(searchHistoryService.create(query, id)),
     onSuccess: (newEntry) => {
       queryClient.setQueriesData<SearchHistoryEntry[]>({ queryKey: SEARCH_HISTORY_KEY }, (old) => {
-        if (!old) return [newEntry];
+        // The key prefix also matches detail entries ([key, id]) which hold
+        // objects, not lists — leave those untouched.
+        if (!Array.isArray(old)) return old;
         const filtered = old.filter((e) => e.query.toLowerCase() !== newEntry.query.toLowerCase());
         return [newEntry, ...filtered].slice(0, 50);
       });
+      queryClient.invalidateQueries({ queryKey: [...SEARCH_HISTORY_KEY, "list"] });
+    },
+  });
+}
+
+export function useAppendSearchTurn() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ searchId, turn }: { searchId: string; turn: SearchTurnPayload }) =>
+      resultToPromise(searchHistoryService.appendTurn(searchId, turn)),
+    onSuccess: (_turn, { searchId }) => {
+      // Refresh the cached detail so a later revisit hydrates the new turn.
+      queryClient.invalidateQueries({ queryKey: [...SEARCH_HISTORY_KEY, searchId] });
     },
   });
 }

--- a/src/features/non-profits/lib/api.ts
+++ b/src/features/non-profits/lib/api.ts
@@ -12,6 +12,7 @@ export const NON_PROFITS_API = {
     LIST: "/v2/search-history",
     GET: (id: string) => `/v2/search-history/${id}`,
     CREATE: "/v2/search-history",
+    APPEND_TURN: (id: string) => `/v2/search-history/${id}/turns`,
     DELETE: (id: string) => `/v2/search-history/${id}`,
     CLEAR: "/v2/search-history",
   },

--- a/src/features/non-profits/lib/saved-conversation.ts
+++ b/src/features/non-profits/lib/saved-conversation.ts
@@ -1,0 +1,51 @@
+/**
+ * Mapping between persisted conversation turns (indexer `search_history_turn`
+ * rows) and the in-memory `ChatTurn` shape the chat workbench renders.
+ *
+ * Saved turns are always completed exchanges, so hydrated turns come back
+ * with `status: "done"` and no streaming progress. Attachments (CSV exports)
+ * are intentionally not persisted — they can be large base64 blobs and the
+ * agent can regenerate them on request — so hydrated turns have none.
+ */
+import type { SavedSearchTurn, SearchTurnPayload } from "../services/search-history.service";
+import type { ChatTurn } from "../store/philanthropy";
+
+// Server-side zod bounds on the append-turn endpoint. Snapshots are clamped
+// client-side so an oversized turn degrades (truncated snapshot) instead of
+// failing to persist at all.
+const MAX_SAVED_QUERY_CHARS = 4000;
+const MAX_SAVED_NARRATIVE_CHARS = 40000;
+const MAX_SAVED_ENTITIES = 500;
+const MAX_SAVED_CITATIONS = 2000;
+
+export function savedTurnToChatTurn(turn: SavedSearchTurn): ChatTurn {
+  return {
+    id: turn.id,
+    userQuery: turn.userQuery,
+    narrative: turn.narrative,
+    entities: turn.entities,
+    citations: turn.citations,
+    traceId: turn.traceId,
+    pagination: null,
+    status: "done",
+    error: null,
+    progress: null,
+    attachments: [],
+  };
+}
+
+export function savedTurnsToChatTurns(turns: ReadonlyArray<SavedSearchTurn>): ChatTurn[] {
+  return turns.map(savedTurnToChatTurn);
+}
+
+/** Snapshot a completed in-memory turn for persistence, within server bounds. */
+export function chatTurnToTurnPayload(turn: ChatTurn): SearchTurnPayload {
+  return {
+    id: turn.id,
+    userQuery: turn.userQuery.slice(0, MAX_SAVED_QUERY_CHARS),
+    narrative: turn.narrative.slice(0, MAX_SAVED_NARRATIVE_CHARS),
+    entities: turn.entities.slice(0, MAX_SAVED_ENTITIES),
+    citations: turn.citations.slice(0, MAX_SAVED_CITATIONS),
+    traceId: turn.traceId,
+  };
+}

--- a/src/features/non-profits/services/search-history.service.ts
+++ b/src/features/non-profits/services/search-history.service.ts
@@ -5,12 +5,19 @@
  * Uses apiFetch (authenticated via TokenManager) to create and retrieve
  * search history entries. Returns ResultAsync<_, AppError> for neverthrow
  * pipeline compatibility.
+ *
+ * Entries are full saved conversations: the client supplies the conversation
+ * id (the /find-funders/search/[id] URL UUID) at create time and appends a
+ * turn snapshot (query + narrative + entities + citations) after each
+ * completed exchange, so revisiting the URL replays the conversation without
+ * re-running the search.
  */
 import type { ResultAsync } from "neverthrow";
 import { z } from "zod";
 import { NON_PROFITS_API } from "../lib/api";
 import { apiFetch } from "../lib/api-fetch";
 import type { AppError } from "../lib/errors";
+import { CitationSchema, RankedEntitySchema } from "../types/philanthropy";
 
 export const SearchHistoryEntrySchema = z.object({
   id: z.string(),
@@ -19,6 +26,34 @@ export const SearchHistoryEntrySchema = z.object({
   createdAt: z.string(),
 });
 export type SearchHistoryEntry = z.infer<typeof SearchHistoryEntrySchema>;
+
+export const SavedSearchTurnSchema = z.object({
+  id: z.string(),
+  searchHistoryId: z.string(),
+  turnIndex: z.number(),
+  userQuery: z.string(),
+  narrative: z.string(),
+  entities: z.array(RankedEntitySchema),
+  citations: z.array(CitationSchema),
+  traceId: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type SavedSearchTurn = z.infer<typeof SavedSearchTurnSchema>;
+
+export const SearchHistoryDetailSchema = SearchHistoryEntrySchema.extend({
+  turns: z.array(SavedSearchTurnSchema),
+});
+export type SearchHistoryDetail = z.infer<typeof SearchHistoryDetailSchema>;
+
+/** Turn snapshot sent to the indexer after a chat exchange completes. */
+export interface SearchTurnPayload {
+  id: string;
+  userQuery: string;
+  narrative: string;
+  entities: SavedSearchTurn["entities"];
+  citations: SavedSearchTurn["citations"];
+  traceId: string | null;
+}
 
 export const searchHistoryService = {
   list(limit = 20): ResultAsync<SearchHistoryEntry[], AppError> {
@@ -29,14 +64,24 @@ export const searchHistoryService = {
     );
   },
 
-  create(query: string): ResultAsync<SearchHistoryEntry, AppError> {
+  create(query: string, id?: string): ResultAsync<SearchHistoryEntry, AppError> {
     return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.CREATE, SearchHistoryEntrySchema, "POST", {
       query,
+      ...(id ? { id } : {}),
     });
   },
 
-  getById(id: string): ResultAsync<SearchHistoryEntry, AppError> {
-    return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.GET(id), SearchHistoryEntrySchema, "GET");
+  getById(id: string): ResultAsync<SearchHistoryDetail, AppError> {
+    return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.GET(id), SearchHistoryDetailSchema, "GET");
+  },
+
+  appendTurn(searchId: string, turn: SearchTurnPayload): ResultAsync<SavedSearchTurn, AppError> {
+    return apiFetch(
+      NON_PROFITS_API.SEARCH_HISTORY.APPEND_TURN(searchId),
+      SavedSearchTurnSchema,
+      "POST",
+      turn
+    );
   },
 
   deleteOne(id: string): ResultAsync<void, AppError> {

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -115,6 +115,8 @@ interface PhilanthropyStore {
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
   updateLastTurn: (patch: Partial<ChatTurn>) => void;
+  /** Replace the thread with turns restored from a saved conversation. */
+  hydrateTurns: (turns: ReadonlyArray<ChatTurn>) => void;
   setThreadId: (id: string | null) => void;
 
   // ── Legacy actions ──
@@ -142,6 +144,7 @@ const initialState = {
   PhilanthropyStore,
   | "appendTurn"
   | "updateLastTurn"
+  | "hydrateTurns"
   | "setThreadId"
   | "setQuery"
   | "setNarrative"
@@ -171,6 +174,9 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
       const updated = { ...last, ...patch };
       return { messages: [...s.messages.slice(0, -1), updated] };
     }),
+
+  // Restore a saved conversation in one shot (revisit / shared link).
+  hydrateTurns: (turns) => set({ messages: [...turns] }),
 
   setThreadId: (threadId) => set({ threadId }),
   setQuery: (query) => set({ query }),

--- a/src/features/non-profits/store/search-session.ts
+++ b/src/features/non-profits/store/search-session.ts
@@ -13,6 +13,15 @@ import { persist } from "zustand/middleware";
 interface SearchSession {
   id: string;
   query: string;
+  /**
+   * True while the session was created locally (landing page / new chat) but
+   * its first search hasn't been kicked off yet. ChatView consumes the flag
+   * exactly once: a fresh session runs the query immediately; a non-fresh
+   * session is a revisit and is hydrated from the saved conversation instead
+   * of re-running the search. Pre-existing persisted sessions lack the flag
+   * and are treated as revisits.
+   */
+  fresh?: boolean;
 }
 
 interface SearchSessionStore {
@@ -21,6 +30,8 @@ interface SearchSessionStore {
   createSession: (query: string) => string;
   setSession: (id: string, query: string) => void;
   getSession: (id: string) => SearchSession | undefined;
+  /** Returns whether the session was fresh, clearing the flag (one-shot). */
+  consumeFresh: (id: string) => boolean;
   clearSession: (id: string) => void;
   setCurrentId: (id: string | null) => void;
 }
@@ -52,7 +63,7 @@ export const useSearchSessionStore = create<SearchSessionStore>()(
             : sessions;
 
         set({
-          sessions: { ...trimmed, [id]: { id, query } },
+          sessions: { ...trimmed, [id]: { id, query, fresh: true } },
           currentId: id,
         });
         return id;
@@ -73,6 +84,16 @@ export const useSearchSessionStore = create<SearchSessionStore>()(
       },
 
       getSession: (id: string) => get().sessions[id],
+
+      consumeFresh: (id: string) => {
+        const { sessions } = get();
+        const session = sessions[id];
+        if (!session?.fresh) return false;
+        set({
+          sessions: { ...sessions, [id]: { id, query: session.query } },
+        });
+        return true;
+      },
 
       clearSession: (id: string) => {
         const { sessions, currentId } = get();


### PR DESCRIPTION
## Overview

Saved find-funders searches now persist the entire conversation — query, results, and every follow-up turn. Revisiting `/nonprofits/find-funders/search/<id>` replays the full thread instantly and lets the user continue chatting with context intact.

## Problem

The saved-search URL only carried the query: the UUID was a browser-local session id, the backend entry stored just the query text, and the chat page re-ran the agent on every visit. Results and follow-up turns were lost, revisits were slow, and each one consumed another agent run.

## Solution

- The session URL UUID is sent as the search-history `id` on create, so the backend entry **is** the conversation record for the URL the user is already on
- After each turn's stream completes, the turn snapshot (query, narrative, entities, citations, traceId) is appended via `POST /v2/search-history/:id/turns`; the first turn creates the entry, follow-ups append
- The seeding effect in `ChatView` distinguishes brand-new sessions from revisits with a one-shot `fresh` flag on search sessions: fresh sessions run the query immediately (unchanged UX), everything else fetches `GET /v2/search-history/:id` and hydrates the saved turns into the chat store — no agent re-run
- New chat moves to a fresh session URL (`router.replace`) instead of staying put, since staying would either resurrect the saved thread or append unrelated turns to it
- Legacy entries without turns and anonymous users degrade gracefully to the old re-run behavior, and legacy entries self-heal on first revisit

## Why This Approach

Minting the conversation id client-side keeps the URL stable from the first render — no mid-session URL swap, no redirect after the backend assigns an id. The `fresh` flag avoids adding a server round-trip to the brand-new-search path, which streams immediately exactly as before. Attachments (CSV exports) are intentionally not persisted: they can be multi-MB base64 blobs and the agent regenerates them on request.

## Testing Steps

1. `pnpm vitest run --project unit src/features/non-profits` — 21 files / 180+ tests pass, including new coverage for the turn mapper, fresh-flag semantics, append-turn hook/service, and the detail schema
2. Manual (logged in): run a search from the landing page, ask 1-2 follow-ups, copy the URL, hard-reload → the full conversation renders without re-running; ask another follow-up → it continues with context and persists
3. Manual: open the same URL in a second logged-in session of the same user → conversation restores; logged out → empty workbench (private, same as search history today)
4. Click an entry in the search-history panel → conversation hydrates instead of re-running

## Technical Details

- New `lib/saved-conversation.ts` maps persisted turns ↔ `ChatTurn` and clamps snapshots to the server's zod bounds (4k query / 40k narrative / 500 entities / 2000 citations) so an oversized turn truncates instead of failing to persist
- `useAddSearchHistory` now takes `{query, id}`; new `useAppendSearchTurn` mutation invalidates the cached detail; the list-cache updater no longer clobbers detail cache entries
- Follow-ups no longer create separate history entries — the history panel lists one entry per conversation, labeled by its first query
- Requires the companion indexer PR; against an older indexer the `id`/turns calls fail silently and behavior falls back to today's re-run flow

## Breaking Changes

None client-facing. `New chat` now changes the URL to a fresh session id.

## Companion PR

show-karma/gap-indexer#2059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Implemented automatic conversation persistence to allow users to save and restore chat sessions
- Enabled conversation continuation: users can now append new messages to previously saved conversation threads, maintaining full chat history
- Updated navigation flow: creating a new chat now generates a unique session URL, enabling users to manage multiple independent conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->