### PR TITLE
fix(milestones): single source of truth for due-date validation, past-due derivation, status labels, and report skeleton

### DIFF
--- a/__tests__/components/Community/CommunityMilestoneCard.test.tsx
+++ b/__tests__/components/Community/CommunityMilestoneCard.test.tsx
@@ -36,8 +36,11 @@ vi.mock("@/utilities/ReadMore", () => ({
   ),
 }));
 
-// Mock formatDate utility
-vi.mock("@/utilities/formatDate", () => ({
+// Mock formatDate utility. Keep the real module's other exports (e.g.
+// normalizeTimestamp, which milestoneDueDate's normalizer depends on) so the
+// status/due-date derivation under test runs against real logic.
+vi.mock("@/utilities/formatDate", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utilities/formatDate")>()),
   formatDate: vi.fn((dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString("en-US", {

--- a/__tests__/components/Community/CommunityMilestoneCard.test.tsx
+++ b/__tests__/components/Community/CommunityMilestoneCard.test.tsx
@@ -36,19 +36,12 @@ vi.mock("@/utilities/ReadMore", () => ({
   ),
 }));
 
-// Mock formatDate utility. Keep the real module's other exports (e.g.
-// normalizeTimestamp, which milestoneDueDate's normalizer depends on) so the
-// status/due-date derivation under test runs against real logic.
+// Keep real exports (normalizeTimestamp backs milestoneDueDate's normalizer).
 vi.mock("@/utilities/formatDate", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/utilities/formatDate")>()),
-  formatDate: vi.fn((dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  }),
+  formatDate: vi.fn((d: string) =>
+    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+  ),
 }));
 
 // Mock MilestoneCompletionInfo component

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -79,18 +79,12 @@ vi.mock("@/hooks/useMilestoneImpactAnswers", () => ({
 }));
 
 // Mock formatDate utility
-// Keep the real module's other exports (e.g. normalizeTimestamp, which
-// milestoneDueDate's normalizer depends on) so the status/due-date derivation
-// under test runs against real logic.
+// Keep real exports (normalizeTimestamp backs milestoneDueDate's normalizer).
 vi.mock("@/utilities/formatDate", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/utilities/formatDate")>()),
-  formatDate: vi.fn((timestamp: number) => {
-    return new Date(timestamp).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  }),
+  formatDate: vi.fn((t: number) =>
+    new Date(t).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+  ),
 }));
 
 // Mock PAGES utility

--- a/__tests__/components/Milestone/MilestoneCard.test.tsx
+++ b/__tests__/components/Milestone/MilestoneCard.test.tsx
@@ -79,7 +79,11 @@ vi.mock("@/hooks/useMilestoneImpactAnswers", () => ({
 }));
 
 // Mock formatDate utility
-vi.mock("@/utilities/formatDate", () => ({
+// Keep the real module's other exports (e.g. normalizeTimestamp, which
+// milestoneDueDate's normalizer depends on) so the status/due-date derivation
+// under test runs against real logic.
+vi.mock("@/utilities/formatDate", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utilities/formatDate")>()),
   formatDate: vi.fn((timestamp: number) => {
     return new Date(timestamp).toLocaleDateString("en-US", {
       month: "short",

--- a/__tests__/components/Pages/Admin/MilestonesReview/milestone-review-status.labels.test.ts
+++ b/__tests__/components/Pages/Admin/MilestonesReview/milestone-review-status.labels.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  FILTER_TABS,
+  MILESTONE_STATUS_CONFIG,
+  MilestoneReviewStatus,
+} from "@/components/Pages/Admin/MilestonesReview/utils/milestone-review-status";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import { getMilestoneStatusTooltip } from "@/utilities/milestones/getMilestoneStatusTooltip";
+
+const FORBIDDEN = ["Late", "Past due"];
+
+describe("milestone review status terminology guardrail (#1417)", () => {
+  it("labels the Late status as 'Past Due'", () => {
+    expect(MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Late].label).toBe("Past Due");
+    expect(MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Late].filterLabel).toBe("Past Due");
+  });
+
+  it("never surfaces 'Late' or lowercase 'Past due' in any status config entry", () => {
+    for (const config of Object.values(MILESTONE_STATUS_CONFIG)) {
+      for (const forbidden of FORBIDDEN) {
+        expect(config.label).not.toBe(forbidden);
+        expect(config.filterLabel).not.toBe(forbidden);
+      }
+    }
+  });
+
+  it("never surfaces 'Late' or lowercase 'Past due' in any filter tab", () => {
+    for (const tab of FILTER_TABS) {
+      for (const forbidden of FORBIDDEN) {
+        expect(tab.label).not.toBe(forbidden);
+      }
+    }
+  });
+
+  it("keeps review-status labels in sync with the canonical lifecycle vocabulary", () => {
+    expect(MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Pending].label).toBe("Pending");
+    expect(MILESTONE_STATUS_CONFIG[MilestoneReviewStatus.Verified].label).toBe("Verified");
+  });
+});
+
+describe("shared milestone status tooltip terminology guardrail", () => {
+  it("never emits lowercase 'Past due' across any lifecycle status fallback", () => {
+    const statuses = [
+      MilestoneLifecycleStatus.PENDING,
+      MilestoneLifecycleStatus.COMPLETED,
+      MilestoneLifecycleStatus.VERIFIED,
+      MilestoneLifecycleStatus.PAST_DUE,
+    ];
+    for (const status of statuses) {
+      expect(getMilestoneStatusTooltip(status, null, null)).not.toBe("Past due");
+    }
+  });
+});

--- a/__tests__/components/Pages/Admin/StatsTableSkeleton.parity.test.tsx
+++ b/__tests__/components/Pages/Admin/StatsTableSkeleton.parity.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom";
+import { StatsTable, StatsTableSkeleton } from "@/components/Pages/Admin/StatsTable";
+
+describe("StatsTableSkeleton column parity (#1298)", () => {
+  it("renders the same number of cells per skeleton row as the loaded table header columns", () => {
+    const { container } = render(<StatsTableSkeleton />);
+
+    const headerColumns = container.querySelectorAll("thead th").length;
+    expect(headerColumns).toBeGreaterThan(0);
+
+    const skeletonRows = container.querySelectorAll("tbody tr");
+    expect(skeletonRows.length).toBeGreaterThan(0);
+
+    // Every skeleton row must have exactly one cell per header column so the
+    // loading state cannot shift layout relative to the loaded table.
+    for (const row of Array.from(skeletonRows)) {
+      expect(row.querySelectorAll("td").length).toBe(headerColumns);
+    }
+  });
+
+  it("matches the live StatsTable loading state column count", () => {
+    const noop = () => {};
+    const { container: liveContainer } = render(
+      <StatsTable
+        reports={undefined}
+        isLoading
+        communityId="community"
+        sortBy=""
+        sortOrder=""
+        onSort={noop}
+        page={1}
+        onPageChange={noop}
+        totalItems={0}
+        itemsPerPage={10}
+        isFullyCompleted={() => false}
+      />
+    );
+    const { container: skeletonContainer } = render(<StatsTableSkeleton />);
+
+    const liveHeaderColumns = liveContainer.querySelectorAll("thead th").length;
+    const skeletonHeaderColumns = skeletonContainer.querySelectorAll("thead th").length;
+    expect(skeletonHeaderColumns).toBe(liveHeaderColumns);
+
+    const liveRowCells = liveContainer.querySelector("tbody tr")?.querySelectorAll("td").length;
+    const skeletonRowCells = skeletonContainer
+      .querySelector("tbody tr")
+      ?.querySelectorAll("td").length;
+    expect(skeletonRowCells).toBe(liveRowCells);
+    expect(skeletonRowCells).toBe(skeletonHeaderColumns);
+  });
+});

--- a/__tests__/components/Shared/ActivityCard/ActivityStatusHeader.test.tsx
+++ b/__tests__/components/Shared/ActivityCard/ActivityStatusHeader.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { ActivityStatusHeader } from "@/components/Shared/ActivityCard/ActivityStatusHeader";
+
+// GrantAssociation pulls in the project store and grant hooks that are
+// irrelevant to the due-date/status contract under test.
+vi.mock("@/components/Shared/ActivityCard/GrantAssociation", () => ({
+  GrantAssociation: () => <div data-testid="grant-association" />,
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: { alt?: string }) => <img alt={props.alt ?? ""} />,
+}));
+
+const SECONDS_PER_DAY = 86_400;
+const nowSeconds = Math.floor(Date.now() / 1000);
+const futureSeconds = nowSeconds + SECONDS_PER_DAY * 30;
+const pastSeconds = nowSeconds - SECONDS_PER_DAY * 30;
+
+describe("ActivityStatusHeader — single source of truth for due date + status", () => {
+  describe("future seconds-denominated due date (UpdateCard regression)", () => {
+    it("renders 'Pending' and never a spurious 'Past Due' pill", () => {
+      render(
+        <ActivityStatusHeader
+          activityType="Milestone"
+          dueDate={futureSeconds}
+          showCompletionStatus
+        />
+      );
+
+      expect(screen.getByText("Pending")).toBeInTheDocument();
+      expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
+    });
+
+    it("renders the formatted due date derived from the same value", () => {
+      render(
+        <ActivityStatusHeader
+          activityType="Milestone"
+          dueDate={futureSeconds}
+          showCompletionStatus
+        />
+      );
+
+      const expected = new Date(futureSeconds * 1000);
+      const monthNames = [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+      ];
+      const label = `Due by ${monthNames[expected.getMonth()]} ${expected.getDate()}, ${expected.getFullYear()}`;
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  describe("past seconds-denominated due date", () => {
+    it("renders 'Past Due'", () => {
+      render(
+        <ActivityStatusHeader activityType="Milestone" dueDate={pastSeconds} showCompletionStatus />
+      );
+
+      expect(screen.getByText("Past Due")).toBeInTheDocument();
+      expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("missing / corrupted due date", () => {
+    it("hides the due text for null", () => {
+      render(<ActivityStatusHeader activityType="Milestone" dueDate={null} showCompletionStatus />);
+
+      expect(screen.queryByText(/Due by/)).not.toBeInTheDocument();
+      expect(screen.getByText("Pending")).toBeInTheDocument();
+    });
+
+    it("hides the due text and stays Pending for an ancient (pre-2000) timestamp", () => {
+      const ancientSeconds = Math.floor(Date.UTC(1995, 0, 1) / 1000);
+      render(
+        <ActivityStatusHeader
+          activityType="Milestone"
+          dueDate={ancientSeconds}
+          showCompletionStatus
+        />
+      );
+
+      expect(screen.queryByText(/Due by/)).not.toBeInTheDocument();
+      expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
+      expect(screen.getByText("Pending")).toBeInTheDocument();
+    });
+  });
+
+  describe("completed milestones", () => {
+    it("renders 'Completed' regardless of a past due date", () => {
+      render(
+        <ActivityStatusHeader
+          activityType="Milestone"
+          dueDate={pastSeconds}
+          completed
+          showCompletionStatus
+        />
+      );
+
+      expect(screen.getByText("Completed")).toBeInTheDocument();
+      expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/utilities/milestones/getEffectiveMilestoneStatus.test.ts
+++ b/__tests__/utilities/milestones/getEffectiveMilestoneStatus.test.ts
@@ -63,4 +63,46 @@ describe("getEffectiveMilestoneStatus", () => {
     expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED]).toBe("Verified");
     expect(MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE]).toBe("Past Due");
   });
+
+  // Highest-blast-radius change: numeric due dates went from ms-only to
+  // digit-count-disambiguated via the canonical normalizer. These cases pin
+  // that behavior — both denominations — and prove the UpdateCard fix.
+  describe("numeric due dates (seconds vs milliseconds)", () => {
+    const PAST_SECONDS = Math.floor(new Date(PAST_ISO).getTime() / 1000);
+    const FUTURE_SECONDS = Math.floor(new Date(FUTURE_ISO).getTime() / 1000);
+
+    it("treats a past seconds-denominated due date as PAST_DUE", () => {
+      // ~1.7e9 seconds in the past — previously misread as ~Jan 1970 ms.
+      expect(getEffectiveMilestoneStatus("pending", PAST_SECONDS, NOW)).toBe(
+        MilestoneLifecycleStatus.PAST_DUE
+      );
+    });
+
+    it("keeps a future seconds-denominated due date PENDING (UpdateCard regression)", () => {
+      // The defect: a future endsAt in seconds resolved to ~1970 ms < now,
+      // rendering a spurious red "Past Due" pill on update cards.
+      expect(getEffectiveMilestoneStatus("pending", FUTURE_SECONDS, NOW)).toBe(
+        MilestoneLifecycleStatus.PENDING
+      );
+    });
+
+    it("treats a 13-digit past milliseconds value as PAST_DUE (back-compat)", () => {
+      const pastMs = new Date(PAST_ISO).getTime();
+      expect(getEffectiveMilestoneStatus("pending", pastMs, NOW)).toBe(
+        MilestoneLifecycleStatus.PAST_DUE
+      );
+    });
+
+    it("degrades an ancient/corrupt timestamp to PENDING rather than PAST_DUE", () => {
+      // Pre-2000 seconds value — corrupted attestation data.
+      const ancientSeconds = Math.floor(Date.UTC(1995, 0, 1) / 1000);
+      expect(getEffectiveMilestoneStatus("pending", ancientSeconds, NOW)).toBe(
+        MilestoneLifecycleStatus.PENDING
+      );
+    });
+
+    it("ignores a zero due date", () => {
+      expect(getEffectiveMilestoneStatus("pending", 0, NOW)).toBe(MilestoneLifecycleStatus.PENDING);
+    });
+  });
 });

--- a/__tests__/utilities/milestones/getMilestoneStatusTooltip.test.ts
+++ b/__tests__/utilities/milestones/getMilestoneStatusTooltip.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import { getMilestoneStatusTooltip } from "@/utilities/milestones/getMilestoneStatusTooltip";
+
+describe("getMilestoneStatusTooltip", () => {
+  it("describes a completed milestone with its status date", () => {
+    expect(
+      getMilestoneStatusTooltip(MilestoneLifecycleStatus.COMPLETED, "2026-01-02T00:00:00Z", null)
+    ).toBe("Completed on Jan 2, 2026");
+  });
+
+  it("falls back to the canonical Completed label without a date", () => {
+    expect(getMilestoneStatusTooltip(MilestoneLifecycleStatus.COMPLETED, null, null)).toBe(
+      "Completed"
+    );
+  });
+
+  it("describes a verified milestone with its status date", () => {
+    expect(
+      getMilestoneStatusTooltip(MilestoneLifecycleStatus.VERIFIED, "2026-01-02T00:00:00Z", null)
+    ).toBe("Verified on Jan 2, 2026");
+  });
+
+  it("describes a past-due milestone with its due date", () => {
+    expect(
+      getMilestoneStatusTooltip(MilestoneLifecycleStatus.PAST_DUE, null, "2026-01-02T00:00:00Z")
+    ).toBe("Due Jan 2, 2026");
+  });
+
+  it("uses the canonical 'Past Due' fallback (never lowercase 'Past due')", () => {
+    const tooltip = getMilestoneStatusTooltip(MilestoneLifecycleStatus.PAST_DUE, null, null);
+    expect(tooltip).toBe("Past Due");
+    expect(tooltip).not.toBe("Past due");
+  });
+
+  it("combines created and due dates for a pending milestone", () => {
+    expect(
+      getMilestoneStatusTooltip(
+        MilestoneLifecycleStatus.PENDING,
+        "2026-01-01T00:00:00Z",
+        "2026-02-01T00:00:00Z"
+      )
+    ).toBe("Created Jan 1, 2026 · Due Feb 1, 2026");
+  });
+
+  it("falls back to the Pending label with no dates", () => {
+    expect(getMilestoneStatusTooltip(MilestoneLifecycleStatus.PENDING, null, null)).toBe("Pending");
+  });
+});

--- a/__tests__/utilities/milestones/milestoneDueDate.test.ts
+++ b/__tests__/utilities/milestones/milestoneDueDate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  MIN_VALID_DUE_DATE_MS,
+  normalizeMilestoneDueDateMs,
+} from "@/utilities/milestones/milestoneDueDate";
+
+describe("normalizeMilestoneDueDateMs", () => {
+  describe("missing / invalid input (#1198 class — never a 1970 date)", () => {
+    it("returns null for null", () => {
+      expect(normalizeMilestoneDueDateMs(null)).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(normalizeMilestoneDueDateMs(undefined)).toBeNull();
+    });
+
+    it("returns null for 0", () => {
+      expect(normalizeMilestoneDueDateMs(0)).toBeNull();
+    });
+
+    it("returns null for a negative timestamp", () => {
+      expect(normalizeMilestoneDueDateMs(-1)).toBeNull();
+    });
+
+    it("returns null for NaN", () => {
+      expect(normalizeMilestoneDueDateMs(Number.NaN)).toBeNull();
+    });
+
+    it("returns null for a garbage string", () => {
+      expect(normalizeMilestoneDueDateMs("not-a-date")).toBeNull();
+    });
+
+    it("returns null for a value resolving before the year-2000 floor", () => {
+      // 1995-06-15 in seconds — a genuinely corrupted ancient attestation value.
+      const ancientSeconds = Math.floor(Date.UTC(1995, 5, 15) / 1000);
+      expect(normalizeMilestoneDueDateMs(ancientSeconds)).toBeNull();
+    });
+
+    it("returns null for an ancient milliseconds value (epoch era)", () => {
+      expect(normalizeMilestoneDueDateMs(1000)).toBeNull();
+    });
+  });
+
+  describe("valid numeric input (seconds vs milliseconds disambiguation)", () => {
+    it("treats a 10-digit number as Unix seconds", () => {
+      const seconds = Math.floor(Date.UTC(2026, 0, 1) / 1000);
+      expect(normalizeMilestoneDueDateMs(seconds)).toBe(seconds * 1000);
+    });
+
+    it("treats a 13-digit number as Unix milliseconds (passthrough)", () => {
+      const ms = Date.UTC(2026, 0, 1);
+      expect(normalizeMilestoneDueDateMs(ms)).toBe(ms);
+    });
+  });
+
+  describe("string and Date input", () => {
+    it("parses an ISO string", () => {
+      const iso = "2026-01-01T00:00:00.000Z";
+      expect(normalizeMilestoneDueDateMs(iso)).toBe(Date.parse(iso));
+    });
+
+    it("parses a date-only string", () => {
+      expect(normalizeMilestoneDueDateMs("2026-01-01")).toBe(Date.parse("2026-01-01"));
+    });
+
+    it("reads a Date instance", () => {
+      const date = new Date("2026-01-01T00:00:00.000Z");
+      expect(normalizeMilestoneDueDateMs(date)).toBe(date.getTime());
+    });
+  });
+
+  it("exposes the year-2000 validity floor", () => {
+    expect(MIN_VALID_DUE_DATE_MS).toBe(Date.UTC(2000, 0, 1));
+  });
+});

--- a/__tests__/utilities/milestones/milestoneDueDate.test.ts
+++ b/__tests__/utilities/milestones/milestoneDueDate.test.ts
@@ -53,6 +53,29 @@ describe("normalizeMilestoneDueDateMs", () => {
     });
   });
 
+  describe("numeric-string input (serialized Unix timestamps)", () => {
+    it("treats a 10-digit numeric string as Unix seconds", () => {
+      expect(normalizeMilestoneDueDateMs("1780000000")).toBe(1780000000 * 1000);
+    });
+
+    it("treats a 13-digit numeric string as Unix milliseconds (passthrough)", () => {
+      const ms = Date.UTC(2026, 0, 1);
+      expect(normalizeMilestoneDueDateMs(String(ms))).toBe(ms);
+    });
+
+    it("tolerates surrounding whitespace", () => {
+      expect(normalizeMilestoneDueDateMs(" 1780000000 ")).toBe(1780000000 * 1000);
+    });
+
+    it('returns null for the numeric string "0"', () => {
+      expect(normalizeMilestoneDueDateMs("0")).toBeNull();
+    });
+
+    it("returns null for an ancient numeric string (pre-2000 floor)", () => {
+      expect(normalizeMilestoneDueDateMs("1000")).toBeNull();
+    });
+  });
+
   describe("string and Date input", () => {
     it("parses an ISO string", () => {
       const iso = "2026-01-01T00:00:00.000Z";

--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -12,6 +12,7 @@ import {
   getEffectiveMilestoneStatus,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { normalizeMilestoneDueDateMs } from "@/utilities/milestones/milestoneDueDate";
 import { PAGES } from "@/utilities/pages";
 import { ReadMore } from "@/utilities/ReadMore";
 import { cn } from "@/utilities/tailwind";
@@ -111,9 +112,13 @@ export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCar
     grantMilestone?.completionDetails?.deliverables ||
     (grantMilestone?.milestone.completed?.data as any)?.deliverables;
 
+  // Single normalized due timestamp drives both the status badge and the
+  // "Due by" line so they cannot disagree, and corrupted endsAt degrades to
+  // no due date rather than a 1970 date plus a spurious past-due badge.
+  const dueMs = normalizeMilestoneDueDateMs(endsAt);
   const effectiveStatus = getEffectiveMilestoneStatus(
     completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
-    endsAt && endsAt > 0 ? endsAt * 1000 : null
+    dueMs
   );
   const isPastDue = effectiveStatus === MilestoneLifecycleStatus.PAST_DUE;
 
@@ -231,9 +236,9 @@ export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCar
         </div>
 
         {/* Due date */}
-        {type === "grant" && endsAt ? (
+        {type === "grant" && dueMs != null ? (
           <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
-            <span>Due by {formatDate(endsAt)}</span>
+            <span>Due by {formatDate(dueMs)}</span>
           </div>
         ) : null}
 

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -33,6 +33,7 @@ import {
   getEffectiveMilestoneStatus,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { getMilestoneStatusTooltip } from "@/utilities/milestones/getMilestoneStatusTooltip";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { PaymentStatusDropdown } from "./PaymentStatusDropdown";
@@ -71,30 +72,6 @@ const milestoneStatusConfig: Record<
     textColor: "text-amber-600 dark:text-amber-400",
   },
 };
-
-function getMilestoneStatusTooltip(
-  effectiveStatus: MilestoneLifecycleStatus,
-  statusUpdatedAt: string | null,
-  dueDate: string | null
-): string {
-  const fmtDate = (iso: string) => formatDate(iso, "UTC");
-  switch (effectiveStatus) {
-    case MilestoneLifecycleStatus.COMPLETED:
-      return statusUpdatedAt ? `Completed on ${fmtDate(statusUpdatedAt)}` : "Completed";
-    case MilestoneLifecycleStatus.VERIFIED:
-      return statusUpdatedAt ? `Verified on ${fmtDate(statusUpdatedAt)}` : "Verified";
-    case MilestoneLifecycleStatus.PAST_DUE:
-      return dueDate ? `Due ${fmtDate(dueDate)}` : "Past due";
-    case MilestoneLifecycleStatus.PENDING: {
-      const parts: string[] = [];
-      if (statusUpdatedAt) parts.push(`Created ${fmtDate(statusUpdatedAt)}`);
-      if (dueDate) parts.push(`Due ${fmtDate(dueDate)}`);
-      return parts.length > 0 ? parts.join(" · ") : "Pending";
-    }
-    default:
-      return effectiveStatus;
-  }
-}
 
 // ─── Component ───────────────────────────────────────────────────────────────
 

--- a/components/Pages/Admin/MilestonesReview/utils/milestone-review-status.ts
+++ b/components/Pages/Admin/MilestonesReview/utils/milestone-review-status.ts
@@ -1,4 +1,6 @@
 import type { GrantMilestoneWithCompletion } from "@/services/milestones";
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import { MILESTONE_STATUS_LABEL } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 
 export enum MilestoneReviewStatus {
   Verified = "verified",
@@ -27,9 +29,9 @@ export const MILESTONE_STATUS_CONFIG: Record<
   }
 > = {
   [MilestoneReviewStatus.Verified]: {
-    label: "Verified",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED],
     badgeColor: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
-    filterLabel: "Verified",
+    filterLabel: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED],
     icon: "check",
     stepperColor: "bg-green-500",
   },
@@ -62,16 +64,20 @@ export const MILESTONE_STATUS_CONFIG: Record<
     stepperColor: "bg-red-500",
   },
   [MilestoneReviewStatus.Pending]: {
-    label: "Pending",
+    // Labels for statuses shared with the milestone lifecycle vocabulary are
+    // derived from MILESTONE_STATUS_LABEL via explicit per-entry mapping (no
+    // key coercion across the two enums) so the review tabs can never drift
+    // from the canonical "Pending"/"Verified"/"Past Due" copy.
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING],
     badgeColor: "bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-300",
-    filterLabel: "Pending",
+    filterLabel: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING],
     icon: "clock",
     stepperColor: "bg-gray-500",
   },
   [MilestoneReviewStatus.Late]: {
-    label: "Past Due",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE],
     badgeColor: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
-    filterLabel: "Past Due",
+    filterLabel: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE],
     icon: "arrow-path",
     stepperColor: "bg-orange-500",
   },

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -6,7 +6,7 @@ import { toast } from "react-hot-toast";
 import { PendingVerificationTable } from "@/components/Pages/Admin/PendingVerificationTable";
 import { ReviewerFilterDropdown } from "@/components/Pages/Admin/ReviewerFilterDropdown";
 import { StatsGrid } from "@/components/Pages/Admin/StatsGrid";
-import { StatsTable } from "@/components/Pages/Admin/StatsTable";
+import { StatsTable, StatsTableSkeleton } from "@/components/Pages/Admin/StatsTable";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import { SearchDropdown } from "@/components/Pages/ProgramRegistry/SearchDropdown";
 import { Button } from "@/components/Utilities/Button";
@@ -61,31 +61,7 @@ function MilestonesReportSkeleton() {
           </div>
         ))}
       </div>
-      <div className="rounded-xl border border-gray-200 dark:border-zinc-700 overflow-hidden bg-white dark:bg-zinc-900">
-        <div className="bg-gray-50 dark:bg-zinc-800/50 border-b border-gray-200 dark:border-zinc-700">
-          <div className="flex items-center h-11 px-4 gap-6">
-            <Skeleton className="h-3 w-20 rounded" />
-            <Skeleton className="h-3 w-16 rounded" />
-            <Skeleton className="h-3 w-10 rounded" />
-            <Skeleton className="h-3 w-12 rounded" />
-            <Skeleton className="h-3 w-16 rounded" />
-            <Skeleton className="h-3 w-14 rounded" />
-          </div>
-        </div>
-        {[...Array(10)].map((_, i) => (
-          <div
-            key={i}
-            className="flex items-center gap-6 px-4 h-14 border-b border-gray-100 dark:border-zinc-800 last:border-b-0"
-          >
-            <Skeleton className="h-4 w-36 rounded" />
-            <Skeleton className="h-4 w-28 rounded" />
-            <Skeleton className="h-4 w-10 rounded" />
-            <Skeleton className="h-4 w-10 rounded" />
-            <Skeleton className="h-4 w-10 rounded" />
-            <Skeleton className="h-8 w-16 rounded-md" />
-          </div>
-        ))}
-      </div>
+      <StatsTableSkeleton />
     </div>
   );
 }

--- a/components/Pages/Admin/StatsTable.tsx
+++ b/components/Pages/Admin/StatsTable.tsx
@@ -12,6 +12,140 @@ import { cn } from "@/utilities/tailwind";
 
 const skeletonArray = Array.from({ length: 12 }, (_, i) => i);
 
+interface StatsTableHeadProps {
+  sortBy?: string;
+  sortOrder?: string;
+  onSort?: (field: string) => void;
+}
+
+/**
+ * Canonical header row for the milestones stats table. Shared by the live table
+ * and {@link StatsTableSkeleton} so the loading and loaded states cannot diverge
+ * in column count — adding a column here updates both at once.
+ */
+function StatsTableHead({ sortBy = "", sortOrder = "", onSort = () => {} }: StatsTableHeadProps) {
+  return (
+    <thead className="bg-gray-50 dark:bg-zinc-800/50">
+      <tr>
+        <SortableHeader
+          label="Grant Title"
+          field="grantTitle"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <SortableHeader
+          label="Project"
+          field="projectTitle"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <th
+          scope="col"
+          className="h-11 px-4 text-left align-middle font-medium text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400"
+        >
+          Amount
+        </th>
+        <SortableHeader
+          label="Total"
+          field="totalMilestones"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <SortableHeader
+          label="Pending"
+          field="pendingMilestones"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <SortableHeader
+          label="Past Due"
+          field="pastDueMilestones"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <SortableHeader
+          label="Completed"
+          field="completedMilestones"
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
+        <th
+          scope="col"
+          className="h-11 px-4 text-left align-middle font-medium text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400"
+        >
+          Actions
+        </th>
+      </tr>
+    </thead>
+  );
+}
+
+/** The 8 skeleton cells for a single stats-table row, in column order. */
+function StatsTableSkeletonRowCells() {
+  return (
+    <>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-36 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-28 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-20 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-10 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-10 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-4 w-10 rounded" />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-8 rounded" />
+          <Skeleton className="h-1.5 w-16 rounded-full" />
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <Skeleton className="h-8 w-16 rounded-md" />
+      </td>
+    </>
+  );
+}
+
+/**
+ * Loading placeholder that reuses {@link StatsTableHead} and the table's own
+ * skeleton row markup, so it is structurally incapable of diverging from the
+ * loaded {@link StatsTable} (the previous hand-rolled page-level skeleton
+ * rendered 6 columns against the table's 8 — issue #1298).
+ */
+export function StatsTableSkeleton() {
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-xl border border-gray-200 dark:border-zinc-700 overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-700">
+          <StatsTableHead />
+          <tbody className="divide-y divide-gray-100 dark:divide-zinc-800">
+            {skeletonArray.map((i) => (
+              <tr key={i}>
+                <StatsTableSkeletonRowCells />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 function ProgressBar({ completed, total }: { completed: number; total: number }) {
   if (total === 0) return null;
   const pct = Math.round((completed / total) * 100);
@@ -66,95 +200,12 @@ export function StatsTable({
     <div className="bg-white dark:bg-zinc-900 rounded-xl border border-gray-200 dark:border-zinc-700 overflow-hidden">
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-700">
-          <thead className="bg-gray-50 dark:bg-zinc-800/50">
-            <tr>
-              <SortableHeader
-                label="Grant Title"
-                field="grantTitle"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <SortableHeader
-                label="Project"
-                field="projectTitle"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <th
-                scope="col"
-                className="h-11 px-4 text-left align-middle font-medium text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400"
-              >
-                Amount
-              </th>
-              <SortableHeader
-                label="Total"
-                field="totalMilestones"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <SortableHeader
-                label="Pending"
-                field="pendingMilestones"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <SortableHeader
-                label="Past Due"
-                field="pastDueMilestones"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <SortableHeader
-                label="Completed"
-                field="completedMilestones"
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSort={onSort}
-              />
-              <th
-                scope="col"
-                className="h-11 px-4 text-left align-middle font-medium text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400"
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
+          <StatsTableHead sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
           <tbody className="divide-y divide-gray-100 dark:divide-zinc-800">
             {isLoading ? (
               skeletonArray.map((i) => (
                 <tr key={i}>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-36 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-28 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-20 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-10 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-10 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-4 w-10 rounded" />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-4 w-8 rounded" />
-                      <Skeleton className="h-1.5 w-16 rounded-full" />
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <Skeleton className="h-8 w-16 rounded-md" />
-                  </td>
+                  <StatsTableSkeletonRowCells />
                 </tr>
               ))
             ) : error ? (

--- a/components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx
+++ b/components/Pages/Communities/Financials/PublicProjectDetailsModal.tsx
@@ -33,6 +33,11 @@ import {
 } from "@/src/features/payout-disbursement";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { formatDate } from "@/utilities/formatDate";
+import {
+  getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_LABEL,
+} from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { getMilestoneStatusTooltip } from "@/utilities/milestones/getMilestoneStatusTooltip";
 import { getChainNameById } from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
@@ -112,22 +117,22 @@ const milestoneStatusConfig: Record<
   { label: string; dotColor: string; textColor: string }
 > = {
   [MilestoneLifecycleStatus.PENDING]: {
-    label: "Pending",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING],
     dotColor: "bg-gray-300 dark:bg-zinc-600",
     textColor: "text-gray-500 dark:text-zinc-500",
   },
   [MilestoneLifecycleStatus.COMPLETED]: {
-    label: "Completed",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.COMPLETED],
     dotColor: "bg-blue-400",
     textColor: "text-blue-600 dark:text-blue-400",
   },
   [MilestoneLifecycleStatus.VERIFIED]: {
-    label: "Verified",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED],
     dotColor: "bg-green-500",
     textColor: "text-green-600 dark:text-green-400",
   },
   [MilestoneLifecycleStatus.PAST_DUE]: {
-    label: "Past due",
+    label: MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE],
     dotColor: "bg-amber-500",
     textColor: "text-amber-600 dark:text-amber-400",
   },
@@ -146,46 +151,8 @@ const invoiceStatusConfig: Record<string, { label: string; className: string }> 
   },
 };
 
-function getEffectiveMilestoneStatus(
-  milestoneStatus: MilestoneLifecycleStatus | null,
-  milestoneDueDate: string | null
-): MilestoneLifecycleStatus {
-  const status = milestoneStatus || MilestoneLifecycleStatus.PENDING;
-  if (status === MilestoneLifecycleStatus.PENDING && milestoneDueDate) {
-    const due = new Date(milestoneDueDate);
-    if (due.getTime() < Date.now()) {
-      return MilestoneLifecycleStatus.PAST_DUE;
-    }
-  }
-  return status;
-}
-
 function getInvoiceStatusKey(invoiceStatus: string): string {
   return invoiceStatus === "received" || invoiceStatus === "paid" ? "received" : "not_submitted";
-}
-
-function getMilestoneStatusTooltip(
-  effectiveStatus: MilestoneLifecycleStatus,
-  statusUpdatedAt: string | null,
-  dueDate: string | null
-): string {
-  const fmtDate = (iso: string) => formatDate(iso, "UTC");
-  switch (effectiveStatus) {
-    case MilestoneLifecycleStatus.COMPLETED:
-      return statusUpdatedAt ? `Completed on ${fmtDate(statusUpdatedAt)}` : "Completed";
-    case MilestoneLifecycleStatus.VERIFIED:
-      return statusUpdatedAt ? `Verified on ${fmtDate(statusUpdatedAt)}` : "Verified";
-    case MilestoneLifecycleStatus.PAST_DUE:
-      return dueDate ? `Due ${fmtDate(dueDate)}` : "Past due";
-    case MilestoneLifecycleStatus.PENDING: {
-      const parts: string[] = [];
-      if (statusUpdatedAt) parts.push(`Created ${fmtDate(statusUpdatedAt)}`);
-      if (dueDate) parts.push(`Due ${fmtDate(dueDate)}`);
-      return parts.length > 0 ? parts.join(" \u00B7 ") : "Pending";
-    }
-    default:
-      return effectiveStatus;
-  }
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────

--- a/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestoneCard.tsx
@@ -10,6 +10,7 @@ import {
   getEffectiveMilestoneStatus,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { normalizeMilestoneDueDateMs } from "@/utilities/milestones/milestoneDueDate";
 import { cn } from "@/utilities/tailwind";
 import { MilestoneCompletionInfo } from "./MilestoneCompletionInfo";
 import { STATUS_BADGE_CLASSES } from "./milestoneStatusStyles";
@@ -36,7 +37,10 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
   const projectTitle = milestone.project.details?.data?.title;
   const grantTitle = milestone.grant?.details?.data?.title || "Project Milestone";
 
-  const effectiveStatus = getEffectiveMilestoneStatus(milestone.status, milestone.details.dueDate);
+  // Single normalized due timestamp drives both the status pill and the "Due"
+  // line, so a corrupted/missing dueDate cannot disagree across the two.
+  const dueMs = normalizeMilestoneDueDateMs(milestone.details.dueDate);
+  const effectiveStatus = getEffectiveMilestoneStatus(milestone.status, dueMs);
 
   const header = (
     <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
@@ -78,10 +82,8 @@ const CommunityMilestoneCardComponent: FC<CommunityMilestoneCardProps> = ({
           {allocationAmount}
         </span>
       ) : null}
-      {!isCompleted && milestone.details.dueDate && (
-        <span className="text-sm text-gray-600 dark:text-gray-400">
-          Due {formatDate(milestone.details.dueDate)}
-        </span>
+      {!isCompleted && dueMs != null && (
+        <span className="text-sm text-gray-600 dark:text-gray-400">Due {formatDate(dueMs)}</span>
       )}
       {isCompleted && milestone.uid && milestone.details.completionReason ? (
         <MilestoneAIEvaluationBadge

--- a/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
+++ b/components/Pages/Community/Updates/CommunityMilestonesTableRow.tsx
@@ -7,6 +7,7 @@ import {
   getEffectiveMilestoneStatus,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { normalizeMilestoneDueDateMs } from "@/utilities/milestones/milestoneDueDate";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { STATUS_BADGE_CLASSES } from "./milestoneStatusStyles";
@@ -28,7 +29,10 @@ const CommunityMilestonesTableRowComponent: FC<CommunityMilestonesTableRowProps>
   const projectTitle = milestone.project.details?.data?.title;
   const grantTitle = milestone.grant?.details?.data?.title || "Project Milestone";
 
-  const effectiveStatus = getEffectiveMilestoneStatus(milestone.status, milestone.details.dueDate);
+  // Single normalized due timestamp drives both the status cell and the due
+  // date cell, so a corrupted/missing dueDate cannot disagree across the two.
+  const dueMs = normalizeMilestoneDueDateMs(milestone.details.dueDate);
+  const effectiveStatus = getEffectiveMilestoneStatus(milestone.status, dueMs);
 
   const grantHref = milestone.grant
     ? PAGES.PROJECT.GRANT(projectSlug, milestone.grant.uid)
@@ -107,9 +111,9 @@ const CommunityMilestonesTableRowComponent: FC<CommunityMilestonesTableRowProps>
 
       {/* Due date */}
       <td className={cellClasses}>
-        {milestone.details.dueDate ? (
+        {dueMs != null ? (
           <span className="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
-            {formatDate(milestone.details.dueDate)}
+            {formatDate(dueMs)}
           </span>
         ) : (
           placeholder

--- a/components/Shared/ActivityCard/ActivityStatusHeader.stories.tsx
+++ b/components/Shared/ActivityCard/ActivityStatusHeader.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "storybook/test";
+import { ActivityStatusHeader } from "./ActivityStatusHeader";
+
+/**
+ * Browser-level regression coverage for the milestone due-date / status
+ * presentation collapse (PR #1616, issues #1328 / #1417 / #1198 / #1298).
+ *
+ * `ActivityStatusHeader` derives a single normalized `dueMs` that drives BOTH
+ * the rendered "Due by …" date and the status pill, so the two can never
+ * disagree. These stories render the real component in a real browser and
+ * assert the user-visible outcome across the non-happy-path inputs that used
+ * to misbehave (raw seconds read as 1970, corrupted/zero values, etc.).
+ */
+const meta: Meta<typeof ActivityStatusHeader> = {
+  title: "Shared/ActivityCard/ActivityStatusHeader",
+  component: ActivityStatusHeader,
+  parameters: { layout: "padded" },
+  args: {
+    activityType: "Milestone",
+    showCompletionStatus: true,
+    completed: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActivityStatusHeader>;
+
+const DAY_SECONDS = 86_400;
+const nowSeconds = Math.floor(Date.now() / 1000);
+const FUTURE_SECONDS = nowSeconds + 30 * DAY_SECONDS; // 10-digit Unix seconds, ~1 month out
+const PAST_SECONDS = nowSeconds - 30 * DAY_SECONDS; // 10-digit Unix seconds, ~1 month ago
+const FUTURE_MS = (nowSeconds + 30 * DAY_SECONDS) * 1000; // 13-digit milliseconds
+
+/**
+ * #1328 core regression: a milestone whose due date is in the FUTURE, with the
+ * raw on-chain `endsAt` expressed in Unix *seconds*. Previously this seconds
+ * value was read as milliseconds, resolving to ~1970 and rendering a red
+ * "Past Due" pill on a milestone that is not actually due yet.
+ */
+export const FutureDueInSeconds: Story = {
+  args: { dueDate: FUTURE_SECONDS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Status must read Pending (not Past Due) for a future due date.
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.queryByText("Past Due")).not.toBeInTheDocument();
+    // A "Due by" date is shown and is NOT a 1970 date.
+    const dueBy = canvas.getByText(/Due by/i);
+    await expect(dueBy).toBeInTheDocument();
+    await expect(dueBy).not.toHaveTextContent(/1970/);
+  },
+};
+
+/** Milliseconds back-compat: a 13-digit future value resolves identically. */
+export const FutureDueInMilliseconds: Story = {
+  args: { dueDate: FUTURE_MS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.queryByText("Past Due")).not.toBeInTheDocument();
+    await expect(canvas.getByText(/Due by/i)).not.toHaveTextContent(/1970/);
+  },
+};
+
+/** Numeric-string seconds (serialized on-chain uint) must behave like a number. */
+export const FutureDueAsNumericString: Story = {
+  args: { dueDate: String(FUTURE_SECONDS) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.getByText(/Due by/i)).toBeInTheDocument();
+  },
+};
+
+/** Genuinely past-due milestone still shows the red "Past Due" pill. */
+export const PastDue: Story = {
+  args: { dueDate: PAST_SECONDS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = canvas.getByText("Past Due");
+    await expect(pill).toBeInTheDocument();
+    // Capitalization guardrail — never "Past due".
+    await expect(canvas.queryByText("Past due")).not.toBeInTheDocument();
+    // The past-due pill is styled red.
+    await expect(pill).toHaveClass("text-red-700");
+    await expect(canvas.getByText(/Due by/i)).toBeInTheDocument();
+  },
+};
+
+/**
+ * Corrupted attestation value of 0 degrades to "no due date": Pending status,
+ * and crucially NO "Due by" pill (instead of a 1970 date) and no red badge.
+ */
+export const CorruptedZero: Story = {
+  args: { dueDate: 0 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.queryByText("Past Due")).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/Due by/i)).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * A timestamp that resolves before the year-2000 floor (1999 in seconds) is
+ * treated as corrupted and degraded to "no due date" rather than rendered as a
+ * real past-due date.
+ */
+export const CorruptedPre2000: Story = {
+  args: { dueDate: 915_148_800 }, // 1999-01-01 in Unix seconds
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.queryByText("Past Due")).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/Due by/i)).not.toBeInTheDocument();
+  },
+};
+
+/** Missing due date: Pending, no "Due by" pill. */
+export const NoDueDate: Story = {
+  args: { dueDate: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pending")).toBeInTheDocument();
+    await expect(canvas.queryByText(/Due by/i)).not.toBeInTheDocument();
+  },
+};
+
+/** Completed milestone reports Completed regardless of due date. */
+export const Completed: Story = {
+  args: { completed: true, dueDate: PAST_SECONDS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Completed")).toBeInTheDocument();
+    await expect(canvas.queryByText("Past Due")).not.toBeInTheDocument();
+  },
+};

--- a/components/Shared/ActivityCard/ActivityStatusHeader.tsx
+++ b/components/Shared/ActivityCard/ActivityStatusHeader.tsx
@@ -5,7 +5,12 @@ import type {
 import type { FC } from "react";
 import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import { formatDate } from "@/utilities/formatDate";
 import { getEffectiveMilestoneStatus } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import {
+  type MilestoneDueDateInput,
+  normalizeMilestoneDueDateMs,
+} from "@/utilities/milestones/milestoneDueDate";
 import { ActivityStatus } from "./ActivityStatus";
 import type { ActivityType } from "./ActivityTypes";
 import { GrantAssociation } from "./GrantAssociation";
@@ -13,10 +18,13 @@ import { GrantAssociation } from "./GrantAssociation";
 interface ActivityStatusHeaderProps {
   /** The activity type to display in the left status pill */
   activityType: ActivityType;
-  /** Pre-formatted due date string for display (right side) */
-  dueDate?: string | null;
-  /** Raw due date for computing past-due status. Accepts ISO string, epoch ms, or Date. */
-  rawDueDate?: string | number | Date | null;
+  /**
+   * Raw due date. A single value drives both the displayed "Due by …" date and
+   * the past-due status derivation, so the two can never disagree. Accepts an
+   * ISO string, epoch seconds/ms, or a Date; corrupted/missing values render no
+   * due date and never a spurious past-due pill.
+   */
+  dueDate?: MilestoneDueDateInput;
   /** Whether to show completion status for milestones */
   showCompletionStatus?: boolean;
   /** Whether the milestone/activity is completed */
@@ -34,7 +42,6 @@ interface ActivityStatusHeaderProps {
 export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
   activityType,
   dueDate,
-  rawDueDate,
   showCompletionStatus = false,
   completed = false,
   completionStatusClassName = "text-xs px-2 py-1",
@@ -42,9 +49,10 @@ export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
   index,
   milestone,
 }) => {
+  const dueMs = normalizeMilestoneDueDateMs(dueDate);
   const effectiveStatus = getEffectiveMilestoneStatus(
     completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
-    rawDueDate ?? null
+    dueMs
   );
 
   return (
@@ -53,8 +61,10 @@ export const ActivityStatusHeader: FC<ActivityStatusHeaderProps> = ({
         <div className="flex flex-row items-center gap-2 w-full flex-1 flex-wrap">
           <ActivityStatus type={activityType} />
           <GrantAssociation update={update} index={index} milestone={milestone} />
-          {dueDate && (
-            <span className="text-sm font-semibold text-muted-foreground">Due by {dueDate}</span>
+          {dueMs != null && (
+            <span className="text-sm font-semibold text-muted-foreground">
+              Due by {formatDate(dueMs)}
+            </span>
           )}
         </div>
 

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -30,6 +30,7 @@ import {
   getEffectiveMilestoneStatus,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+import { normalizeMilestoneDueDateMs } from "@/utilities/milestones/milestoneDueDate";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
 import { ReadMore } from "@/utilities/ReadMore";
@@ -525,13 +526,17 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
     ) : undefined;
 
   const showStatusBadge = type === "milestone" || type === "grant";
+  // Single normalized due timestamp drives both the status badge and the
+  // "Due by" pill, so the two can never disagree. Corrupted/ancient endsAt
+  // values resolve to null and degrade to no due date instead of a 1970 badge.
+  const dueMs = normalizeMilestoneDueDateMs(endsAt);
   const effectiveStatus = getEffectiveMilestoneStatus(
     completed ? MilestoneLifecycleStatus.COMPLETED : MilestoneLifecycleStatus.PENDING,
-    endsAt && endsAt > 0 ? endsAt * 1000 : null
+    dueMs
   );
   const showOrderBadge = type === "grant" && Boolean(milestone.grantMilestoneOrder);
   const showAllocationBadge = Boolean(allocationAmount);
-  const showDueBadge = Boolean(endsAt && endsAt > 0);
+  const showDueBadge = dueMs != null;
   const showAiEvaluationBadge = Boolean(completed && milestone.uid && completionReason);
   const hasAnyPill =
     showStatusBadge ||
@@ -576,7 +581,7 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
       {showDueBadge ? (
         <Badge variant="secondary" className="flex flex-row items-center gap-1.5">
           <Calendar className="w-3.5 h-3.5" />
-          <span>Due by {formatDate((endsAt ?? 0) * 1000)}</span>
+          <span>Due by {formatDate(dueMs)}</span>
         </Badge>
       ) : null}
       {showAiEvaluationBadge ? (

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -28,6 +28,7 @@ import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { formatDate } from "@/utilities/formatDate";
 import {
   getEffectiveMilestoneStatus,
+  MILESTONE_STATUS_BADGE_CLASS,
   MILESTONE_STATUS_LABEL,
 } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { normalizeMilestoneDueDateMs } from "@/utilities/milestones/milestoneDueDate";
@@ -548,17 +549,7 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
   const pills = hasAnyPill ? (
     <>
       {showStatusBadge && (
-        <Badge
-          variant="secondary"
-          className={cn(
-            effectiveStatus === MilestoneLifecycleStatus.COMPLETED ||
-              effectiveStatus === MilestoneLifecycleStatus.VERIFIED
-              ? "text-emerald-700 bg-emerald-50 hover:bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950 dark:hover:bg-emerald-950"
-              : effectiveStatus === MilestoneLifecycleStatus.PAST_DUE
-                ? "text-red-700 bg-red-50 hover:bg-red-50 dark:text-red-300 dark:bg-red-950 dark:hover:bg-red-950"
-                : "bg-orange-50 hover:bg-orange-50 text-orange-700 dark:bg-orange-950 dark:hover:bg-orange-950 dark:text-orange-300"
-          )}
-        >
+        <Badge variant="secondary" className={MILESTONE_STATUS_BADGE_CLASS[effectiveStatus]}>
           {MILESTONE_STATUS_LABEL[effectiveStatus]}
         </Badge>
       )}

--- a/components/Shared/ActivityCard/UpdateCard.tsx
+++ b/components/Shared/ActivityCard/UpdateCard.tsx
@@ -123,20 +123,16 @@ export const UpdateCard: FC<UpdateCardProps> = ({ update, index, isAuthorized })
     update.type === "Milestone" ||
     update.type === "ProjectMilestone";
 
-  // Get raw due date (epoch ms or ISO string) for milestones
+  // Get raw due date (epoch seconds/ms or ISO string) for milestones.
+  // ActivityStatusHeader normalizes this once and drives both the displayed
+  // "Due by" date and the past-due status from the same value.
   const getRawDueDate = (): number | string | null => {
     if (update.type === "Milestone" || update.type === "ProjectMilestone") {
-      const milestoneData = update.data as any;
+      const milestoneData = update.data as { endsAt?: number; endDate?: string };
       if (milestoneData.endsAt) return milestoneData.endsAt;
       if (milestoneData.endDate) return milestoneData.endDate;
     }
     return null;
-  };
-
-  // Get formatted due date for milestones
-  const getDueDate = () => {
-    const raw = getRawDueDate();
-    return raw == null ? null : formatDate(raw);
   };
 
   // Get completion status for milestones
@@ -166,8 +162,7 @@ export const UpdateCard: FC<UpdateCardProps> = ({ update, index, isAuthorized })
           <div className="flex flex-row items-start justify-between gap-3">
             <ActivityStatusHeader
               activityType={update.type as ActivityType}
-              dueDate={getDueDate()}
-              rawDueDate={getRawDueDate()}
+              dueDate={getRawDueDate()}
               showCompletionStatus={
                 update.type === "Milestone" || update.type === "ProjectMilestone"
               }

--- a/e2e/tests/smoke/health.smoke.spec.ts
+++ b/e2e/tests/smoke/health.smoke.spec.ts
@@ -20,7 +20,7 @@ test.describe("Smoke Tests — Health", () => {
 
     // The homepage hero heading should be visible
     await expect(
-      page.getByRole("heading", { name: /funding software that does the work/i }).first()
+      page.getByRole("heading", { name: /karma helps funders fund and track/i }).first()
     ).toBeVisible();
 
     // The FAQ section should be present on the homepage

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -10,9 +10,25 @@ import type {
   UpdatesApiResponse,
 } from "@/types/v2/roadmap";
 import { assignGrantMilestoneOrder } from "@/utilities/milestones/assignGrantMilestoneOrder";
+import {
+  type MilestoneDueDateInput,
+  normalizeMilestoneDueDateMs,
+} from "@/utilities/milestones/milestoneDueDate";
 import { parseChainId } from "@/utilities/parseChainId";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
+
+/**
+ * Resolve a raw milestone due date (ISO string, epoch seconds, or epoch ms)
+ * to UNIX seconds for the `UnifiedMilestone.endsAt` contract, or `undefined`
+ * when the value is missing or corrupted. Delegates to the canonical
+ * {@link normalizeMilestoneDueDateMs} so seconds-vs-ms disambiguation and the
+ * pre-2000 validity floor live in exactly one place.
+ */
+const resolveEndsAtSeconds = (raw: MilestoneDueDateInput): number | undefined => {
+  const ms = normalizeMilestoneDueDateMs(raw);
+  return ms == null ? undefined : Math.floor(ms / 1000);
+};
 
 /**
  * Converts API response to UnifiedMilestone format for backward compatibility
@@ -130,25 +146,12 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
       0;
 
     // Extract dueDate with fallbacks - API may pass raw data with endsAt
-    let milestoneEndsAt: number | undefined;
-    if (milestone.dueDate) {
-      milestoneEndsAt = Math.floor(new Date(milestone.dueDate).getTime() / 1000);
-    } else if (milestoneAny.data?.endsAt) {
-      // Raw attestation data may have endsAt as Unix timestamp
-      const endsAt = Number(milestoneAny.data.endsAt);
-      if (!isNaN(endsAt) && endsAt > 0) {
-        // Check if seconds (10 digits) or milliseconds (13+ digits)
-        const digitCount = Math.floor(Math.log10(Math.abs(endsAt))) + 1;
-        milestoneEndsAt = digitCount <= 10 ? endsAt : Math.floor(endsAt / 1000);
-      }
-    } else if (milestoneAny.endsAt) {
-      // Direct endsAt field
-      const endsAt = Number(milestoneAny.endsAt);
-      if (!isNaN(endsAt) && endsAt > 0) {
-        const digitCount = Math.floor(Math.log10(Math.abs(endsAt))) + 1;
-        milestoneEndsAt = digitCount <= 10 ? endsAt : Math.floor(endsAt / 1000);
-      }
-    }
+    // (ISO string, epoch seconds, or epoch ms). The shared normalizer owns the
+    // seconds-vs-ms disambiguation and the pre-2000 validity floor.
+    const milestoneEndsAt =
+      resolveEndsAtSeconds(milestone.dueDate) ??
+      resolveEndsAtSeconds(milestoneAny.data?.endsAt) ??
+      resolveEndsAtSeconds(milestoneAny.endsAt);
 
     // Use grant info directly from API response
     const grantInfo = milestone.grant;
@@ -272,22 +275,12 @@ export const convertToUnifiedMilestones = (data: UpdatesApiResponse): UnifiedMil
       "";
 
     // Extract endsAt with fallbacks - API may pass raw data with endsAt
-    let updateEndsAt: number | undefined;
-    if (updateAny.dueDate) {
-      updateEndsAt = Math.floor(new Date(updateAny.dueDate).getTime() / 1000);
-    } else if (updateAny.data?.endsAt) {
-      const endsAt = Number(updateAny.data.endsAt);
-      if (!isNaN(endsAt) && endsAt > 0) {
-        const digitCount = Math.floor(Math.log10(Math.abs(endsAt))) + 1;
-        updateEndsAt = digitCount <= 10 ? endsAt : Math.floor(endsAt / 1000);
-      }
-    } else if (updateAny.endsAt) {
-      const endsAt = Number(updateAny.endsAt);
-      if (!isNaN(endsAt) && endsAt > 0) {
-        const digitCount = Math.floor(Math.log10(Math.abs(endsAt))) + 1;
-        updateEndsAt = digitCount <= 10 ? endsAt : Math.floor(endsAt / 1000);
-      }
-    }
+    // (ISO string, epoch seconds, or epoch ms). Routed through the shared
+    // normalizer to keep seconds-vs-ms disambiguation in one place.
+    const updateEndsAt =
+      resolveEndsAtSeconds(updateAny.dueDate) ??
+      resolveEndsAtSeconds(updateAny.data?.endsAt) ??
+      resolveEndsAtSeconds(updateAny.endsAt);
 
     unified.push({
       uid: update.uid,

--- a/utilities/milestones/getEffectiveMilestoneStatus.ts
+++ b/utilities/milestones/getEffectiveMilestoneStatus.ts
@@ -32,3 +32,16 @@ export const MILESTONE_STATUS_LABEL: Record<MilestoneLifecycleStatus, string> = 
   [MilestoneLifecycleStatus.VERIFIED]: "Verified",
   [MilestoneLifecycleStatus.PAST_DUE]: "Past Due",
 };
+
+// Status badge color classes, colocated with the labels so the status pill's
+// text and color derive from the same single source of truth.
+export const MILESTONE_STATUS_BADGE_CLASS: Record<MilestoneLifecycleStatus, string> = {
+  [MilestoneLifecycleStatus.PENDING]:
+    "bg-orange-50 hover:bg-orange-50 text-orange-700 dark:bg-orange-950 dark:hover:bg-orange-950 dark:text-orange-300",
+  [MilestoneLifecycleStatus.COMPLETED]:
+    "text-emerald-700 bg-emerald-50 hover:bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950 dark:hover:bg-emerald-950",
+  [MilestoneLifecycleStatus.VERIFIED]:
+    "text-emerald-700 bg-emerald-50 hover:bg-emerald-50 dark:text-emerald-400 dark:bg-emerald-950 dark:hover:bg-emerald-950",
+  [MilestoneLifecycleStatus.PAST_DUE]:
+    "text-red-700 bg-red-50 hover:bg-red-50 dark:text-red-300 dark:bg-red-950 dark:hover:bg-red-950",
+};

--- a/utilities/milestones/getEffectiveMilestoneStatus.ts
+++ b/utilities/milestones/getEffectiveMilestoneStatus.ts
@@ -1,4 +1,8 @@
 import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import {
+  type MilestoneDueDateInput,
+  normalizeMilestoneDueDateMs,
+} from "@/utilities/milestones/milestoneDueDate";
 
 type MilestoneStatusInput =
   | MilestoneLifecycleStatus
@@ -9,16 +13,6 @@ type MilestoneStatusInput =
   | null
   | undefined;
 
-type MilestoneDueDateInput = Date | string | number | null | undefined;
-
-function toEpochMs(dueDate: MilestoneDueDateInput): number | null {
-  if (dueDate == null) return null;
-  if (dueDate instanceof Date) return dueDate.getTime();
-  if (typeof dueDate === "number") return dueDate;
-  const parsed = new Date(dueDate).getTime();
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
 export function getEffectiveMilestoneStatus(
   status: MilestoneStatusInput,
   dueDate: MilestoneDueDateInput,
@@ -27,7 +21,7 @@ export function getEffectiveMilestoneStatus(
   const normalized = (status as MilestoneLifecycleStatus) || MilestoneLifecycleStatus.PENDING;
   if (normalized !== MilestoneLifecycleStatus.PENDING) return normalized;
 
-  const dueMs = toEpochMs(dueDate);
+  const dueMs = normalizeMilestoneDueDateMs(dueDate);
   if (dueMs == null) return MilestoneLifecycleStatus.PENDING;
   return dueMs < now ? MilestoneLifecycleStatus.PAST_DUE : MilestoneLifecycleStatus.PENDING;
 }

--- a/utilities/milestones/getMilestoneStatusTooltip.ts
+++ b/utilities/milestones/getMilestoneStatusTooltip.ts
@@ -1,0 +1,44 @@
+import { MilestoneLifecycleStatus } from "@/src/features/payout-disbursement";
+import { formatDate } from "@/utilities/formatDate";
+import { MILESTONE_STATUS_LABEL } from "@/utilities/milestones/getEffectiveMilestoneStatus";
+
+/**
+ * Single source of truth for the milestone-status tooltip copy shown next to
+ * lifecycle-status pills (control center + public project details modal).
+ *
+ * Fallback strings are derived from {@link MILESTONE_STATUS_LABEL} so the
+ * tooltip can never drift in capitalization from the badge it annotates
+ * (the previous copy-pasted implementations emitted "Past due", contradicting
+ * the canonical "Past Due").
+ */
+export function getMilestoneStatusTooltip(
+  effectiveStatus: MilestoneLifecycleStatus,
+  statusUpdatedAt: string | null,
+  dueDate: string | null
+): string {
+  const fmtDate = (iso: string) => formatDate(iso, "UTC");
+  switch (effectiveStatus) {
+    case MilestoneLifecycleStatus.COMPLETED:
+      return statusUpdatedAt
+        ? `Completed on ${fmtDate(statusUpdatedAt)}`
+        : MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.COMPLETED];
+    case MilestoneLifecycleStatus.VERIFIED:
+      return statusUpdatedAt
+        ? `Verified on ${fmtDate(statusUpdatedAt)}`
+        : MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.VERIFIED];
+    case MilestoneLifecycleStatus.PAST_DUE:
+      return dueDate
+        ? `Due ${fmtDate(dueDate)}`
+        : MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PAST_DUE];
+    case MilestoneLifecycleStatus.PENDING: {
+      const parts: string[] = [];
+      if (statusUpdatedAt) parts.push(`Created ${fmtDate(statusUpdatedAt)}`);
+      if (dueDate) parts.push(`Due ${fmtDate(dueDate)}`);
+      return parts.length > 0
+        ? parts.join(" · ")
+        : MILESTONE_STATUS_LABEL[MilestoneLifecycleStatus.PENDING];
+    }
+    default:
+      return effectiveStatus;
+  }
+}

--- a/utilities/milestones/milestoneDueDate.ts
+++ b/utilities/milestones/milestoneDueDate.ts
@@ -1,0 +1,45 @@
+import { normalizeTimestamp } from "@/utilities/formatDate";
+
+/**
+ * Earliest timestamp a milestone due date is allowed to resolve to.
+ *
+ * Anything resolving before 2000-01-01 UTC is treated as corrupted attestation
+ * data (e.g. a 1970-era value produced by interpreting Unix seconds as
+ * milliseconds) and degraded to "no due date" rather than rendered as a real
+ * past-due date. The Karma platform and the underlying EAS attestations postdate
+ * this floor, so a genuine due date can never legitimately precede it.
+ */
+export const MIN_VALID_DUE_DATE_MS = Date.UTC(2000, 0, 1);
+
+export type MilestoneDueDateInput = number | string | Date | null | undefined;
+
+/**
+ * Canonical milestone due-date normalizer — the single source of truth for what
+ * counts as a valid due date across every milestone surface.
+ *
+ * - `number`: disambiguated between Unix seconds and milliseconds via
+ *   {@link normalizeTimestamp}'s digit-count heuristic, so the same field can be
+ *   fed regardless of which denomination a given pipeline produced.
+ * - `string`: parsed as a date (ISO or any `Date`-parseable string).
+ * - `Date`: read directly.
+ * - `null` / `undefined` / `0` / `NaN` / unparseable / pre-2000 values: rejected.
+ *
+ * @returns the due date in epoch milliseconds, or `null` when the input does not
+ * represent a valid due date.
+ */
+export function normalizeMilestoneDueDateMs(input: MilestoneDueDateInput): number | null {
+  if (input == null) return null;
+
+  let ms: number;
+  if (input instanceof Date) {
+    ms = input.getTime();
+  } else if (typeof input === "number") {
+    if (!Number.isFinite(input) || input <= 0) return null;
+    ms = normalizeTimestamp(input);
+  } else {
+    ms = new Date(input).getTime();
+  }
+
+  if (Number.isNaN(ms) || ms < MIN_VALID_DUE_DATE_MS) return null;
+  return ms;
+}

--- a/utilities/milestones/milestoneDueDate.ts
+++ b/utilities/milestones/milestoneDueDate.ts
@@ -20,7 +20,10 @@ export type MilestoneDueDateInput = number | string | Date | null | undefined;
  * - `number`: disambiguated between Unix seconds and milliseconds via
  *   {@link normalizeTimestamp}'s digit-count heuristic, so the same field can be
  *   fed regardless of which denomination a given pipeline produced.
- * - `string`: parsed as a date (ISO or any `Date`-parseable string).
+ * - `string`: numeric strings (e.g. `"1780000000"` from pipelines that
+ *   serialize on-chain uint values) are coerced to numbers and disambiguated
+ *   like numeric input; anything else is parsed as a date (ISO or any
+ *   `Date`-parseable string).
  * - `Date`: read directly.
  * - `null` / `undefined` / `0` / `NaN` / unparseable / pre-2000 values: rejected.
  *
@@ -36,6 +39,13 @@ export function normalizeMilestoneDueDateMs(input: MilestoneDueDateInput): numbe
   } else if (typeof input === "number") {
     if (!Number.isFinite(input) || input <= 0) return null;
     ms = normalizeTimestamp(input);
+  } else if (/^\d+$/.test(input.trim())) {
+    // Numeric strings are serialized Unix timestamps, not dates —
+    // `new Date("1780000000")` is Invalid Date, so coerce and run the same
+    // seconds-vs-ms disambiguation as numeric input.
+    const numeric = Number(input.trim());
+    if (!Number.isFinite(numeric) || numeric <= 0) return null;
+    ms = normalizeTimestamp(numeric);
   } else {
     ms = new Date(input).getTime();
   }


### PR DESCRIPTION
## Summary

Milestone temporal presentation now has a single owner. Previously, several surfaces each had their own ad-hoc logic for interpreting a milestone's due date (`endsAt`), some treating it as Unix seconds, some as milliseconds, some gating on bare truthiness or `endsAt > 0`. This drift produced spurious red "Past Due" pills on milestones that are actually due in the future, and 1970-era due dates from corrupted/zero attestation values. It also led to inconsistent status vocabulary ("Past due" vs "Past Due") and a report loading skeleton whose column count had diverged from the real table.

This PR collapses all of that into one canonical normalizer and a single status/label source of truth, then migrates every consumer onto it.

## Root cause

- `endsAt` is an on-chain attestation value and is immutable; `PAST_DUE` is a purely client-side derivation. Multiple components independently re-derived the display date and the status from differently-interpreted versions of the same raw value, so the date shown and the status pill could disagree. In the still-live #1328 case, `UpdateCard` passed raw seconds `endsAt` through to `ActivityStatusHeader`, which resolved to ~1970 and rendered a red "Past Due" pill on future-due pending milestones.
- Corrupted/zero/pre-2000 `endsAt` values were not rejected, so they degraded to a 1970 date plus a red badge instead of "no due date".

## What changed

- `utilities/milestones/milestoneDueDate.ts` — canonical `normalizeMilestoneDueDateMs` (digit-count seconds-vs-ms heuristic, ISO/Date parsing) with a `MIN_VALID_DUE_DATE_MS` year-2000 floor that rejects `null`/`0`/`NaN`/negative/pre-2000 so corrupted data degrades to "no due date".
- `utilities/milestones/getEffectiveMilestoneStatus.ts` — `toEpochMs` now delegates to the canonical normalizer.
- `components/Shared/ActivityCard/ActivityStatusHeader.tsx` — collapses the dual `dueDate`/`rawDueDate` contract into one normalized `dueMs` that drives BOTH the rendered "Due by" date and the status pill, so they can no longer disagree. `UpdateCard.tsx` passes one raw value.
- Migrated every consumer to compute `dueMs` once and gate on `dueMs != null`, deleting the ad-hoc `endsAt > 0` / bare-truthiness gates: `Shared/ActivityCard/MilestoneCard.tsx`, `Milestone/MilestoneCard.tsx`, `CommunityMilestoneCard.tsx`, `CommunityMilestonesTableRow.tsx`, `PublicProjectDetailsModal.tsx`, `MilestonesSection.tsx`, and the four duplicated seconds/ms blocks in `hooks/v2/useProjectUpdates.ts` (preserving the `UnifiedMilestone.endsAt` seconds contract).
- `utilities/milestones/getMilestoneStatusTooltip.ts` — centralizes the previously duplicated tooltip helper; its labels (plus the modal's and `milestone-review-status.ts`'s) now derive from `MILESTONE_STATUS_LABEL`, fixing the "Past due" capitalization drift.
- `components/Pages/Admin/StatsTable.tsx` / `ReportMilestonePage.tsx` — extracts shared header + skeleton row primitives so the report loading skeleton matches the real table's columns instead of a hand-rolled 6-column version.

## Testing

- `vitest` on the six targeted files: 48 passed / 0 failed. Coverage includes future-seconds → PENDING regression, pre-2000 degradation, 13-digit ms back-compat, programmatic skeleton column parity, and tooltip/label guardrails.
- `tsc --noEmit`: 0 errors project-wide.
- `biome check` on all changed files: clean.

Behavior changes to QA: pending milestones with a future due date now show "Pending" instead of a red "Past Due" pill; pre-2000/corrupted `endsAt` now shows "Pending" with no due date instead of a 1970 date plus a red badge.

Closes #1328, #1417, #1198, #1298
