### PR TITLE
fix(funding-platform): make URL the source of truth for program filters so Applications links navigate

### DIFF
--- a/.claude/hooks/post-edit-antipatterns.sh
+++ b/.claude/hooks/post-edit-antipatterns.sh
@@ -57,10 +57,21 @@ case "$FILE_PATH" in
       ISSUES="${ISSUES}\n- HARDCODED_ROUTES: Use PAGES constants from utilities/pages.ts."
     fi
 
-    # 5. useRouter/useParams in useEffect deps
-    ROUTER_IN_DEPS=$(grep -nE "useEffect\(.*\[.*router|useEffect\(.*\[.*params" "$FILE_PATH" 2>/dev/null || true)
+    # 5. useRouter/useParams in useEffect deps (single-line and multi-line arrays)
+    # Matches both inline deps (useEffect(..., [..., router])) and the closing
+    # line of a multi-line dependency array such as `}, [searchTerm, router]);`.
+    ROUTER_IN_DEPS=$(grep -nE "useEffect\(.*\[.*\b(router|params|searchParams|pathname)\b|^\s*\},\s*\[[^]]*\b(router|params|searchParams|pathname)\b" "$FILE_PATH" 2>/dev/null || true)
     if [ -n "$ROUTER_IN_DEPS" ]; then
-      ISSUES="${ISSUES}\n- ROUTER_IN_DEPS: Destructure router/params to primitives before useEffect deps."
+      ISSUES="${ISSUES}\n- ROUTER_IN_DEPS: Destructure router/params to primitives before useEffect deps, or use nuqs useQueryState for URL-synced state."
+    fi
+
+    # 5b. URL-synced state mirrored via router.push/replace inside an effect.
+    # Flags files that build a URLSearchParams AND call router.push/replace —
+    # the issue #1547 anti-pattern. Use nuqs useQueryState instead (see
+    # hooks/useProjectFilters.ts) so the URL is the source of truth.
+    if grep -qE "new URLSearchParams" "$FILE_PATH" 2>/dev/null &&
+      grep -qE "router\.(push|replace)\(" "$FILE_PATH" 2>/dev/null; then
+      ISSUES="${ISSUES}\n- URL_SYNC_EFFECT: Mirroring state to the URL with router.push/replace races and cancels Link navigations. Use nuqs useQueryState (hooks/useProjectFilters.ts)."
     fi
 
     # 6. Hardcoded colors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ pnpm lint:fix           # Biome lint + format
 - **Zustand resets**: When adding state properties, update `initialState` too — `reset()` spreads it and will miss new fields.
 - **Pluralization**: Any dynamic count rendered next to a noun MUST use the `pluralize` library (`pluralize("team", count)`). No manual ternaries, no hardcoded plural-only nouns. Strings like `"1 teams"`, `"0 apply"`, `"1 days left"` are bugs.
 - **Empty-state conditional rendering**: UI blocks tied to a count or array (e.g. "Closing this week — N apply before deadline") must be hidden entirely when the count is 0. Don't render "0 …" copy.
+- **URL-synced filter state**: Must use nuqs `useQueryState` (see `hooks/useProjectFilters.ts` / `hooks/useFundingProgramFilters.ts`). NEVER mirror component state into the URL with `router.push`/`router.replace` inside a `useEffect` — it dispatches App Router navigations that race and cancel in-flight `<Link>` clicks (issue #1547) and spams the history stack.
 - **Authorization is tri-state, not boolean**: Gate auth-sensitive UI through a tri-state hook that returns `{ isAuthorized, isLoading }` (e.g. `useProjectAuthorization`). Render a skeleton while `isLoading`, never the authorized controls or a denial. Specifically:
   - Never read `useOwnerStore.isOwner` without `isOwnerLoading`.
   - For authorization-resolved decisions, never use a query's `isLoading` when that query can be disabled — a disabled React Query v5 query reports `isLoading=false` while still undecided. Use `isPending`-aware composition (`isResolving`).

--- a/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
+++ b/__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx
@@ -3,19 +3,55 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { BrowseApplicationsClient } from "@/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient";
-import fetchData from "@/utilities/fetchData";
-
-const mockFetchData = vi.mocked(fetchData);
 
 // --- Mocks ---
 
-const mockRouterReplace = vi.fn();
-const mockRouterPush = vi.fn();
+// The component now uses nuqs `useQueryState` (via useBrowseApplicationFilters)
+// as the single source of truth for the programId/status/search filters — it no
+// longer calls router.replace. nuqs writes through history.replaceState in the
+// real app; here we stub it with a reactive store so we can assert the resulting
+// query string the same way the old router-based tests did.
+const { urlStore } = vi.hoisted(() => ({ urlStore: new Map<string, string>() }));
+
+/** Serialize the current nuqs-backed query state to a URL-style string. */
+function currentUrl(): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of urlStore) params.set(key, value);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+vi.mock("nuqs", async () => {
+  const { useState } = await import("react");
+  return {
+    useQueryState: (
+      key: string,
+      options?: { defaultValue?: unknown; clearOnDefault?: boolean }
+    ) => {
+      const [value, setValue] = useState<unknown>(
+        () => urlStore.get(key) ?? options?.defaultValue ?? null
+      );
+      const set = (next: unknown) => {
+        const resolved =
+          typeof next === "function" ? (next as (p: unknown) => unknown)(value) : next;
+        const isDefault = options?.clearOnDefault && resolved === options?.defaultValue;
+        if (resolved == null || resolved === "" || isDefault) {
+          urlStore.delete(key);
+        } else {
+          urlStore.set(key, String(resolved));
+        }
+        setValue(resolved);
+        return Promise.resolve(new URLSearchParams());
+      };
+      return [value, set] as const;
+    },
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: mockRouterPush,
-    replace: mockRouterReplace,
+    push: vi.fn(),
+    replace: vi.fn(),
     prefetch: vi.fn(),
     back: vi.fn(),
     pathname: "/community/test-community/browse-applications",
@@ -134,16 +170,12 @@ async function clickStatusChip(user: ReturnType<typeof userEvent.setup>, label: 
   await user.click(chip);
 }
 
-function lastReplaceUrl(): string {
-  const calls = mockRouterReplace.mock.calls;
-  return calls[calls.length - 1][0] as string;
-}
-
 // --- Tests ---
 
 describe("BrowseApplicationsClient - URL sync on filter change", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    urlStore.clear();
   });
 
   it("updates the URL with programId when a program is selected", async () => {
@@ -154,11 +186,7 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
 
     await selectProgram(user, "Test Grant Program");
 
-    // The component should call router.replace with the programId in the URL
-    expect(mockRouterReplace).toHaveBeenCalledWith(
-      expect.stringContaining("programId=program-abc"),
-      expect.anything()
-    );
+    await waitFor(() => expect(currentUrl()).toContain("programId=program-abc"));
   });
 
   it("updates the URL with status when status filter changes", async () => {
@@ -169,15 +197,9 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
 
     // First select a program so the status filter is rendered
     await selectProgram(user, "Test Grant Program");
-
-    mockRouterReplace.mockClear();
-
     await clickStatusChip(user, "Approved");
 
-    expect(mockRouterReplace).toHaveBeenCalledWith(
-      expect.stringContaining("status=approved"),
-      expect.anything()
-    );
+    await waitFor(() => expect(currentUrl()).toContain("status=approved"));
   });
 
   it("updates the URL with search term when the user types in the search box", async () => {
@@ -189,18 +211,11 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
     // First select a program so the search input is rendered
     await selectProgram(user, "Test Grant Program");
 
-    mockRouterReplace.mockClear();
-
     const searchInput = screen.getByLabelText("Search applications");
     await user.type(searchInput, "my project");
 
-    // The search term is debounced before being pushed to the URL.
-    await waitFor(() => {
-      expect(mockRouterReplace).toHaveBeenCalledWith(
-        expect.stringContaining("search="),
-        expect.anything()
-      );
-    });
+    await waitFor(() => expect(currentUrl()).toContain("search="));
+    expect(urlStore.get("search")).toBe("my project");
   });
 
   it("reflects combined filter state in the URL", async () => {
@@ -212,11 +227,11 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
     await selectProgram(user, "Test Grant Program");
     await clickStatusChip(user, "Pending");
 
-    // The last call to replace should include both programId and status
-    expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = lastReplaceUrl();
-    expect(lastCall).toContain("programId=program-abc");
-    expect(lastCall).toContain("status=pending");
+    await waitFor(() => {
+      const url = currentUrl();
+      expect(url).toContain("programId=program-abc");
+      expect(url).toContain("status=pending");
+    });
   });
 
   it("removes status param from URL when reset to 'all'", async () => {
@@ -228,11 +243,10 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
     await selectProgram(user, "Test Grant Program");
 
     await clickStatusChip(user, "Approved");
-    await clickStatusChip(user, "All");
+    await waitFor(() => expect(currentUrl()).toContain("status=approved"));
 
-    expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = lastReplaceUrl();
-    expect(lastCall).not.toContain("status=");
+    await clickStatusChip(user, "All");
+    await waitFor(() => expect(currentUrl()).not.toContain("status="));
   });
 
   it("keeps programId in the URL after a status filter is toggled off", async () => {
@@ -247,9 +261,10 @@ describe("BrowseApplicationsClient - URL sync on filter change", () => {
     await clickStatusChip(user, "Approved");
     await clickStatusChip(user, "All");
 
-    expect(mockRouterReplace).toHaveBeenCalled();
-    const lastCall = lastReplaceUrl();
-    expect(lastCall).toContain("programId=program-abc");
-    expect(lastCall).not.toContain("status=");
+    await waitFor(() => {
+      const url = currentUrl();
+      expect(url).toContain("programId=program-abc");
+      expect(url).not.toContain("status=");
+    });
   });
 });

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -318,47 +318,25 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
   // The query string is the single source of truth for these filters. nuqs
   // writes through history.replaceState (no App Router navigation), so updating
   // a filter never races or cancels a Link click (issue #1547).
-  const [selectedProgramId, setSelectedProgramIdQuery] = useQueryState("programId", {
+  const [selectedProgramId, setSelectedProgramId] = useQueryState("programId", {
     defaultValue: "",
     clearOnDefault: true,
   });
-  const [statusFilterRaw, setStatusFilterQuery] = useQueryState<ApplicationStatus | "all">(
-    "status",
-    {
-      defaultValue: "all",
-      clearOnDefault: true,
-      serialize: (value) => (isFilterableStatus(value) ? value : ""),
-      parse: (value) => (isFilterableStatus(value) ? value : "all"),
-    }
-  );
+  const [statusFilterRaw, setStatusFilter] = useQueryState<ApplicationStatus | "all">("status", {
+    defaultValue: "all",
+    clearOnDefault: true,
+    serialize: (value) => (isFilterableStatus(value) ? value : ""),
+    parse: (value) => (isFilterableStatus(value) ? value : "all"),
+  });
   const statusFilter: ApplicationStatus | "all" = isFilterableStatus(statusFilterRaw)
     ? statusFilterRaw
     : "all";
-  const [searchInput, setSearchInputQuery] = useQueryState("search", {
+  const [searchInput, setSearchInput] = useQueryState("search", {
     defaultValue: "",
     clearOnDefault: true,
     throttleMs: 300,
   });
   const [debouncedSearch, setDebouncedSearch] = useState(searchInput);
-
-  const setSelectedProgramId = useCallback(
-    (value: string) => {
-      setSelectedProgramIdQuery(value);
-    },
-    [setSelectedProgramIdQuery]
-  );
-  const setStatusFilter = useCallback(
-    (value: ApplicationStatus | "all") => {
-      setStatusFilterQuery(value);
-    },
-    [setStatusFilterQuery]
-  );
-  const setSearchInput = useCallback(
-    (value: string) => {
-      setSearchInputQuery(value);
-    },
-    [setSearchInputQuery]
-  );
 
   // Debounce only the value that drives the API query; the URL write is already
   // throttled by nuqs and the input stays responsive via the optimistic value.

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -2,7 +2,7 @@
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { ChevronDown, Lock, RefreshCw, Search, X } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getProjectTitle } from "@/components/FundingPlatform/helper/getProjectTitle";
 import { useProgramsWithConfig } from "@/features/programs/hooks/use-programs-with-config";
@@ -15,6 +15,17 @@ import { cn } from "@/utilities/tailwind";
 interface BrowseApplicationsClientProps {
   communityId: string;
 }
+
+const FILTERABLE_STATUSES: ApplicationStatus[] = [
+  "pending",
+  "under_review",
+  "revision_requested",
+  "approved",
+  "rejected",
+];
+
+const isFilterableStatus = (value: string | null): value is ApplicationStatus =>
+  value != null && (FILTERABLE_STATUSES as string[]).includes(value);
 
 const statusOptions: Array<{
   value: ApplicationStatus | "all";
@@ -300,42 +311,61 @@ function ProgramPillSelector({
 }
 
 export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClientProps) {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const { programs } = useProgramsWithConfig(communityId);
 
-  const [selectedProgramId, setSelectedProgramId] = useState<string>(
-    () => searchParams.get("programId") || ""
-  );
-  const [statusFilter, setStatusFilter] = useState<ApplicationStatus | "all">(() => {
-    const s = searchParams.get("status");
-    if (
-      s &&
-      ["pending", "under_review", "revision_requested", "approved", "rejected"].includes(s)
-    ) {
-      return s as ApplicationStatus;
-    }
-    return "all";
+  // The query string is the single source of truth for these filters. nuqs
+  // writes through history.replaceState (no App Router navigation), so updating
+  // a filter never races or cancels a Link click (issue #1547).
+  const [selectedProgramId, setSelectedProgramIdQuery] = useQueryState("programId", {
+    defaultValue: "",
+    clearOnDefault: true,
   });
-  const [searchInput, setSearchInput] = useState(() => searchParams.get("search") || "");
+  const [statusFilterRaw, setStatusFilterQuery] = useQueryState<ApplicationStatus | "all">(
+    "status",
+    {
+      defaultValue: "all",
+      clearOnDefault: true,
+      serialize: (value) => (isFilterableStatus(value) ? value : ""),
+      parse: (value) => (isFilterableStatus(value) ? value : "all"),
+    }
+  );
+  const statusFilter: ApplicationStatus | "all" = isFilterableStatus(statusFilterRaw)
+    ? statusFilterRaw
+    : "all";
+  const [searchInput, setSearchInputQuery] = useQueryState("search", {
+    defaultValue: "",
+    clearOnDefault: true,
+    throttleMs: 300,
+  });
   const [debouncedSearch, setDebouncedSearch] = useState(searchInput);
 
+  const setSelectedProgramId = useCallback(
+    (value: string) => {
+      setSelectedProgramIdQuery(value);
+    },
+    [setSelectedProgramIdQuery]
+  );
+  const setStatusFilter = useCallback(
+    (value: ApplicationStatus | "all") => {
+      setStatusFilterQuery(value);
+    },
+    [setStatusFilterQuery]
+  );
+  const setSearchInput = useCallback(
+    (value: string) => {
+      setSearchInputQuery(value);
+    },
+    [setSearchInputQuery]
+  );
+
+  // Debounce only the value that drives the API query; the URL write is already
+  // throttled by nuqs and the input stays responsive via the optimistic value.
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchInput), 500);
     return () => clearTimeout(timer);
   }, [searchInput]);
-
-  useEffect(() => {
-    const params = new URLSearchParams();
-    if (selectedProgramId) params.set("programId", selectedProgramId);
-    if (statusFilter !== "all") params.set("status", statusFilter);
-    if (debouncedSearch) params.set("search", debouncedSearch);
-    const query = params.toString();
-    router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
-  }, [selectedProgramId, statusFilter, debouncedSearch, pathname, router]);
 
   const selectedProgram = programs.find((p) => p.programId === selectedProgramId);
   const hasPrivateApplicationsSetting =

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -2,10 +2,10 @@
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { ChevronDown, Lock, RefreshCw, Search, X } from "lucide-react";
-import { useQueryState } from "nuqs";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getProjectTitle } from "@/components/FundingPlatform/helper/getProjectTitle";
 import { useProgramsWithConfig } from "@/features/programs/hooks/use-programs-with-config";
+import { useBrowseApplicationFilters } from "@/hooks/useBrowseApplicationFilters";
 import { Link } from "@/src/components/navigation/Link";
 import type { Application, ApplicationStatus } from "@/types/whitelabel-entities";
 import fetchData from "@/utilities/fetchData";
@@ -15,17 +15,6 @@ import { cn } from "@/utilities/tailwind";
 interface BrowseApplicationsClientProps {
   communityId: string;
 }
-
-const FILTERABLE_STATUSES: ApplicationStatus[] = [
-  "pending",
-  "under_review",
-  "revision_requested",
-  "approved",
-  "rejected",
-];
-
-const isFilterableStatus = (value: string | null): value is ApplicationStatus =>
-  value != null && (FILTERABLE_STATUSES as string[]).includes(value);
 
 const statusOptions: Array<{
   value: ApplicationStatus | "all";
@@ -315,27 +304,17 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
 
   const { programs } = useProgramsWithConfig(communityId);
 
-  // The query string is the single source of truth for these filters. nuqs
-  // writes through history.replaceState (no App Router navigation), so updating
-  // a filter never races or cancels a Link click (issue #1547).
-  const [selectedProgramId, setSelectedProgramId] = useQueryState("programId", {
-    defaultValue: "",
-    clearOnDefault: true,
-  });
-  const [statusFilterRaw, setStatusFilter] = useQueryState<ApplicationStatus | "all">("status", {
-    defaultValue: "all",
-    clearOnDefault: true,
-    serialize: (value) => (isFilterableStatus(value) ? value : ""),
-    parse: (value) => (isFilterableStatus(value) ? value : "all"),
-  });
-  const statusFilter: ApplicationStatus | "all" = isFilterableStatus(statusFilterRaw)
-    ? statusFilterRaw
-    : "all";
-  const [searchInput, setSearchInput] = useQueryState("search", {
-    defaultValue: "",
-    clearOnDefault: true,
-    throttleMs: 300,
-  });
+  // The query string is the single source of truth for these filters (see
+  // useBrowseApplicationFilters): nuqs writes through history.replaceState, so
+  // updating a filter never races or cancels a Link click (issue #1547).
+  const {
+    programId: selectedProgramId,
+    setProgramId: setSelectedProgramId,
+    status: statusFilter,
+    setStatus: setStatusFilter,
+    search: searchInput,
+    setSearch: setSearchInput,
+  } = useBrowseApplicationFilters();
   const [debouncedSearch, setDebouncedSearch] = useState(searchInput);
 
   // Debounce only the value that drives the API query; the URL write is already

--- a/app/community/[communityId]/manage/funding-platform/__tests__/page.regression.test.tsx
+++ b/app/community/[communityId]/manage/funding-platform/__tests__/page.regression.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FundingProgram } from "@/services/fundingPlatformService";
+import { PAGES } from "@/utilities/pages";
+
+const COMMUNITY_ID = "test-community";
+
+// Shared router spy so we can assert the old state->URL sync effect is gone:
+// mounting the programs list must dispatch zero App Router navigations.
+const pushSpy = vi.fn();
+const replaceSpy = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ communityId: COMMUNITY_ID }),
+  useRouter: () => ({
+    push: pushSpy,
+    replace: replaceSpy,
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => `/community/${COMMUNITY_ID}/manage/funding-platform`,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// nuqs writes through history.replaceState, not the router. A simple stateful
+// stub keeps the component rendering without touching `pushSpy`/`replaceSpy`.
+vi.mock("nuqs", () => ({
+  useQueryState: (_key: string, options?: { defaultValue?: unknown }) => {
+    let value: unknown = options?.defaultValue ?? null;
+    const setValue = (next: unknown) => {
+      value = next;
+    };
+    return [value, setValue] as const;
+  },
+}));
+
+const createMockProgram = (overrides: Partial<FundingProgram> = {}): FundingProgram =>
+  ({
+    programId: "program-1",
+    chainID: 1,
+    name: "Test Program",
+    metadata: {
+      title: "Test Program",
+      description: "A funding program",
+      shortDescription: "A funding program",
+    },
+    applicationConfig: { isEnabled: true },
+    metrics: {
+      totalApplications: 5,
+      pendingApplications: 2,
+      approvedApplications: 1,
+      rejectedApplications: 1,
+      revisionRequestedApplications: 0,
+      underReviewApplications: 1,
+    },
+    ...overrides,
+  }) as FundingProgram;
+
+const mockPrograms: FundingProgram[] = [createMockProgram()];
+
+vi.mock("@/hooks/useFundingPlatform", () => ({
+  useFundingPrograms: () => ({
+    programs: mockPrograms,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/usePermissions", () => ({
+  useReviewerPrograms: () => ({ programs: [], isLoading: false }),
+}));
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: () => ({ isWhitelabel: false }),
+}));
+
+vi.mock("@/src/core/rbac", () => ({
+  FundingPlatformGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  AdminOnly: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useIsFundingPlatformAdmin: () => true,
+}));
+
+// Render Link as a plain anchor so we can read the resolved href directly.
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source?: string }) => <div>{source}</div>,
+}));
+
+vi.mock("@/components/FundingPlatform/CreateProgramModal", () => ({
+  CreateProgramModal: () => null,
+}));
+
+import FundingPlatformPage from "../page";
+
+describe("FundingPlatformPage — URL navigation regression (#1547)", () => {
+  beforeEach(() => {
+    pushSpy.mockClear();
+    replaceSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches zero router.push navigations on mount", () => {
+    render(<FundingPlatformPage />);
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders the Applications link with the exact PAGES href", () => {
+    render(<FundingPlatformPage />);
+
+    const expectedHref = PAGES.MANAGE.FUNDING_PLATFORM.APPLICATIONS(COMMUNITY_ID, "program-1");
+    const applicationsLink = screen.getByRole("link", { name: /Applications/i });
+
+    expect(applicationsLink).toHaveAttribute("href", expectedHref);
+  });
+});

--- a/app/community/[communityId]/manage/funding-platform/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/page.tsx
@@ -18,8 +18,9 @@ import {
   ClipboardDocumentListIcon,
   PlusIcon,
 } from "@heroicons/react/24/solid";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { useQueryState } from "nuqs";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { CreateProgramModal } from "@/components/FundingPlatform/CreateProgramModal";
 import { FundingPlatformStatsCard } from "@/components/FundingPlatform/Dashboard/card";
@@ -33,6 +34,7 @@ import { LoadingOverlay } from "@/components/Utilities/LoadingOverlay";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
+import { useFundingProgramFilters } from "@/hooks/useFundingProgramFilters";
 import { useReviewerPrograms } from "@/hooks/usePermissions";
 import { type FundingProgram, fundingPlatformService } from "@/services/fundingPlatformService";
 import { Link } from "@/src/components/navigation/Link";
@@ -46,8 +48,6 @@ import { useWhitelabel } from "@/utilities/whitelabel-context";
 
 function FundingPlatformContent() {
   const { communityId } = useParams() as { communityId: string };
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const { isWhitelabel } = useWhitelabel();
 
   const isAdmin = useIsFundingPlatformAdmin();
@@ -86,21 +86,22 @@ function FundingPlatformContent() {
     return allPrograms.filter((program) => reviewerProgramIds.has(program.programId));
   }, [allPrograms, isAdmin, reviewerPrograms, communityId]);
 
-  const [showCreateModal, setShowCreateModal] = useState(false);
   const [togglingPrograms, setTogglingPrograms] = useState<Set<string>>(new Set());
 
-  // Auto-open create modal when navigated with ?create=true
-  const createParam = searchParams.get("create");
-  useEffect(() => {
-    if (createParam === "true" && isAdmin) {
-      setShowCreateModal(true);
-    }
-  }, [createParam, isAdmin]);
+  // ?create=true auto-opens the create modal. The URL is the source of truth so
+  // closing the modal simply clears the param (nuqs replaceState — no router
+  // navigation that could race a Link click).
+  const [createParam, setCreateParam] = useQueryState("create");
+  const showCreateModal = createParam === "true" && isAdmin;
+  const openCreateModal = () => setCreateParam("true");
+  const closeCreateModal = () => setCreateParam(null);
 
-  const [searchTerm, setSearchTerm] = useState(searchParams.get("search") || "");
-  const [enabledFilter, setEnabledFilter] = useState<"all" | "enabled" | "disabled">(
-    (searchParams.get("status") as "all" | "enabled" | "disabled") || "all"
-  );
+  const {
+    search: searchTerm,
+    setSearch,
+    status: enabledFilter,
+    setStatus,
+  } = useFundingProgramFilters();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const handleToggleProgram = async (programId: string, currentEnabled: boolean) => {
@@ -182,25 +183,6 @@ function FundingPlatformContent() {
       return matchesSearch && matchesEnabled;
     });
   }, [programs, searchTerm, enabledFilter]);
-
-  useEffect(() => {
-    const params = new URLSearchParams();
-
-    if (searchTerm) {
-      params.set("search", searchTerm);
-    }
-
-    if (enabledFilter !== "all") {
-      params.set("status", enabledFilter);
-    }
-
-    const queryString = params.toString();
-    const newUrl = queryString
-      ? `${PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId)}?${queryString}`
-      : PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId);
-
-    router.push(newUrl, { scroll: false });
-  }, [searchTerm, enabledFilter, communityId, router]);
 
   // For non-admins, also wait for reviewer programs to load
   const isLoading = isLoadingPrograms || (!isAdmin && isLoadingReviewerPrograms);
@@ -372,7 +354,7 @@ function FundingPlatformContent() {
       {/* Create Program Button - Admin Only */}
       <AdminOnly>
         <div className="flex justify-end">
-          <Button onClick={() => setShowCreateModal(true)} className="inline-flex items-center">
+          <Button onClick={openCreateModal} className="inline-flex items-center">
             <PlusIcon className="w-4 h-4 mr-2" />
             Create New Program
           </Button>
@@ -390,7 +372,7 @@ function FundingPlatformContent() {
                 type="text"
                 placeholder="Search programs by name or description..."
                 value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
+                onChange={(e) => setSearch(e.target.value)}
                 className="w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
@@ -416,12 +398,12 @@ function FundingPlatformContent() {
               )}
             >
               <div className="py-1" role="menu">
-                {["all", "enabled", "disabled"].map((status) => (
+                {(["all", "enabled", "disabled"] as const).map((status) => (
                   <button
                     key={status}
                     type="button"
                     onClick={() => {
-                      setEnabledFilter(status as typeof enabledFilter);
+                      setStatus(status);
                       setIsDropdownOpen(false);
                     }}
                     className={cn(
@@ -699,7 +681,7 @@ function FundingPlatformContent() {
           className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-8"
           action={
             <AdminOnly>
-              <Button onClick={() => setShowCreateModal(true)} className="inline-flex items-center">
+              <Button onClick={openCreateModal} className="inline-flex items-center">
                 <PlusIcon className="w-4 h-4 mr-2" />
                 Create your first program
               </Button>
@@ -712,19 +694,7 @@ function FundingPlatformContent() {
       <AdminOnly>
         <CreateProgramModal
           isOpen={showCreateModal}
-          onClose={() => {
-            setShowCreateModal(false);
-            if (searchParams.get("create")) {
-              const params = new URLSearchParams(searchParams.toString());
-              params.delete("create");
-              const queryString = params.toString();
-              router.replace(
-                queryString
-                  ? `${PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId)}?${queryString}`
-                  : PAGES.MANAGE.FUNDING_PLATFORM.ROOT(communityId)
-              );
-            }
-          }}
+          onClose={closeCreateModal}
           communityId={communityId}
           onSuccess={async () => {
             await refetch();

--- a/e2e/tests/regression/funding-platform-url-filters.regression.spec.ts
+++ b/e2e/tests/regression/funding-platform-url-filters.regression.spec.ts
@@ -1,0 +1,273 @@
+import type { Page } from "@playwright/test";
+import { expect, mockJson, test } from "../../fixtures";
+import { assertNoJsErrors, collectJsErrors } from "../../helpers/assertions";
+import { GOTO_OPTIONS, waitForPageReady } from "../../helpers/navigation";
+
+/**
+ * Regression coverage for PR #1620 / issue #1547 — "URL is the single source of
+ * truth for funding-platform filters".
+ *
+ * The bug: the programs list and browse-applications view mirrored their
+ * search/status filter state into the URL via a router.push/replace inside a
+ * useEffect. That self-navigation (a) raced and cancelled Applications <Link>
+ * clicks (the click looked like a no-op) and (b) pushed a history entry per
+ * keystroke (Back stepped through stale filter states instead of leaving).
+ *
+ * The fix moves filter state to nuqs useQueryState (history.replaceState, no
+ * App Router navigation). These tests drive the real browser to assert the
+ * URL-as-source-of-truth behaviour and, crucially, the original failure modes —
+ * not just the happy path.
+ */
+
+const COMMUNITY = "optimism";
+const PROGRAM_ID = "program-url-001";
+const FUNDING_BASE = `/community/${COMMUNITY}/manage/funding-platform`;
+const BROWSE_BASE = `/community/${COMMUNITY}/browse-applications`;
+
+// Next.js dev compiles each route on first hit, which can exceed the default
+// 5s expect timeout. Wait generously for the first content element, then run
+// the (fast) assertions.
+const COMPILE_TIMEOUT = 60_000;
+
+const PROGRAM = {
+  programId: PROGRAM_ID,
+  chainID: 10,
+  name: "URL Filter Test Program",
+  metadata: { title: "URL Filter Test Program", description: "Program for URL filter tests" },
+  applicationConfig: {
+    isEnabled: true,
+    formSchema: { fields: [], settings: { privateApplications: false } },
+  },
+  metrics: {
+    totalApplications: 4,
+    approvedApplications: 1,
+    rejectedApplications: 1,
+    pendingApplications: 2,
+    revisionRequestedApplications: 0,
+    underReviewApplications: 0,
+  },
+};
+
+function programMocks() {
+  return {
+    // Both the programs list (BY_COMMUNITY) and browse-applications
+    // (BY_COMMUNITY_ACTIVE) hit this path with different query strings.
+    "**/v2/funding-program-configs/community/optimism**": mockJson([PROGRAM]),
+    "**/v2/funding-program-configs/program-url-001": mockJson(PROGRAM),
+    "**/v2/funding-applications/program/program-url-001**": mockJson({
+      applications: [],
+      pagination: { page: 1, limit: 100, total: 0, totalPages: 1 },
+    }),
+    "**/v2/user/communities/admin**": mockJson([
+      { uid: "community-uid-optimism", slug: "optimism" },
+    ]),
+  };
+}
+
+/** Read a query-string param from the live browser URL. */
+function param(page: Page, key: string): string | null {
+  return new URL(page.url()).searchParams.get(key);
+}
+
+const fundingSearch = (page: Page) =>
+  page.getByPlaceholder("Search programs by name or description...");
+const browseSearch = (page: Page) => page.getByPlaceholder("Search project or reference…");
+
+test.describe.configure({ timeout: 90_000 });
+
+test.describe("Regression #1547 — funding-platform URL filters", () => {
+  // ---- Programs list page (the page that holds the Applications links) ----
+
+  test("T-URL-01: deep link pre-applies combined search + status filters", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    const jsErrors = collectJsErrors(page);
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(`${FUNDING_BASE}?search=Filter&status=enabled`, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    const search = fundingSearch(page);
+    await search.waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+    await expect(search).toHaveValue("Filter");
+    // URL stays the source of truth and the dropdown trigger reflects the param.
+    expect(param(page, "status")).toBe("enabled");
+    await expect(page.getByRole("button", { name: "enabled", exact: true }).first()).toBeVisible();
+
+    assertNoJsErrors(jsErrors);
+  });
+
+  test("T-URL-02: typing search updates the URL without polluting history", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(FUNDING_BASE, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    const search = fundingSearch(page);
+    await search.waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+
+    const historyBefore = await page.evaluate(() => window.history.length);
+
+    await search.fill("alpha");
+    // nuqs throttles the URL write — poll until it lands.
+    await expect.poll(() => param(page, "search")).toBe("alpha");
+
+    await search.fill("alpha beta");
+    await expect.poll(() => param(page, "search")).toBe("alpha beta");
+
+    const historyAfter = await page.evaluate(() => window.history.length);
+    // replaceState (not pushState) ⇒ no new history entries per keystroke.
+    expect(historyAfter).toBe(historyBefore);
+  });
+
+  test("T-URL-03: Applications link navigates even right after a filter change (the bug)", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(FUNDING_BASE, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    // Target the program card's Applications link by href (unambiguous — the
+    // manage sidebar also has an "Applications" link).
+    const appsLink = page.locator(`a[href$="/${PROGRAM_ID}/applications"]`).first();
+    await appsLink.waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+
+    // Reproduce the original race: mutate the filter (previously dispatched a
+    // self-navigation) and immediately click the Applications link. Use a term
+    // that still matches the program so the card — and its link — stay mounted.
+    // With the fix there is no navigation to cancel, so the click must land.
+    await fundingSearch(page).fill("URL");
+    await expect(appsLink).toBeVisible();
+    await appsLink.click();
+
+    await page.waitForURL(/\/funding-platform\/program-url-001\/applications/, {
+      timeout: COMPILE_TIMEOUT,
+    });
+    expect(page.url()).toContain(`/${PROGRAM_ID}/applications`);
+  });
+
+  test("T-URL-04: invalid status param falls back to 'all' without crashing", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    const jsErrors = collectJsErrors(page);
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(`${FUNDING_BASE}?status=not-a-real-status`, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    await fundingSearch(page).waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+    // Garbage status is ignored ⇒ dropdown shows the default and the program
+    // card still renders (the bad value did not filter everything out).
+    await expect(page.getByText("All Programs", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("URL Filter Test Program").first()).toBeVisible();
+
+    assertNoJsErrors(jsErrors);
+  });
+
+  test("T-URL-05: selecting 'All Programs' clears the status param (clearOnDefault)", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(`${FUNDING_BASE}?status=enabled`, GOTO_OPTIONS);
+    await waitForPageReady(page);
+    await fundingSearch(page).waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+    expect(param(page, "status")).toBe("enabled");
+
+    // Open the status dropdown and pick "All Programs".
+    await page.getByRole("button", { name: "enabled", exact: true }).first().click();
+    await page.getByRole("menuitem").filter({ hasText: "All Programs" }).click();
+
+    await expect.poll(() => param(page, "status")).toBeNull();
+  });
+
+  test("T-URL-06: ?create=true opens the create modal; closing strips the param", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(`${FUNDING_BASE}?create=true`, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    // Scope to the create-program dialog specifically (the app also mounts an
+    // unrelated assistant dialog).
+    const createDialog = page.getByRole("dialog").filter({ hasText: "Create New Program" });
+    await expect(createDialog).toBeVisible({ timeout: COMPILE_TIMEOUT });
+
+    await page.keyboard.press("Escape");
+    await expect.poll(() => param(page, "create")).toBeNull();
+  });
+
+  // ---- Browse-applications view (the file refactored in this PR) ----
+
+  test("T-URL-07: browse-applications deep link pre-applies programId + status + search", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    const jsErrors = collectJsErrors(page);
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(
+      `${BROWSE_BASE}?programId=${PROGRAM_ID}&status=approved&search=hello`,
+      GOTO_OPTIONS
+    );
+    await waitForPageReady(page);
+
+    // Search input (only rendered once a program is selected) reflects the URL.
+    const search = browseSearch(page);
+    await search.waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+    await expect(search).toHaveValue("hello");
+    // The "Approved" status pill is active.
+    await expect(page.getByRole("button", { name: /approved/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    assertNoJsErrors(jsErrors);
+  });
+
+  test("T-URL-08: browse-applications clear-search button strips the search param", async ({
+    page,
+    withApiMocks,
+    loginAs,
+  }) => {
+    await withApiMocks(programMocks());
+    await loginAs("communityAdmin", { communityId: COMMUNITY });
+
+    await page.goto(`${BROWSE_BASE}?programId=${PROGRAM_ID}&search=hello`, GOTO_OPTIONS);
+    await waitForPageReady(page);
+
+    const search = browseSearch(page);
+    await search.waitFor({ state: "visible", timeout: COMPILE_TIMEOUT });
+    await expect(search).toHaveValue("hello");
+
+    const clearButton = page.getByRole("button", { name: "Clear search" });
+    await expect(clearButton).toBeVisible();
+    await clearButton.click();
+    await expect.poll(() => param(page, "search")).toBeNull();
+    await expect(search).toHaveValue("");
+  });
+});

--- a/hooks/__tests__/useFundingProgramFilters.test.ts
+++ b/hooks/__tests__/useFundingProgramFilters.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Simulated query string seeding the hook. Each test mutates this before
+// rendering to emulate a deep link such as `?search=foo&status=enabled`.
+const initialParams: Record<string, string | null> = {};
+
+// Stateful nuqs mock backed by useState, but seeded from `initialParams` and
+// passed through the hook's own `parse` so the typed-narrowing logic (invalid
+// status -> "all") is genuinely exercised, mirroring real nuqs read behavior.
+vi.mock("nuqs", () => ({
+  useQueryState: (
+    key: string,
+    options: {
+      defaultValue?: unknown;
+      parse?: (value: string) => unknown;
+    }
+  ) => {
+    const raw = initialParams[key];
+    const seeded =
+      raw != null ? (options?.parse ? options.parse(raw) : raw) : (options?.defaultValue ?? null);
+    const [value, setValue] = useState<unknown>(seeded);
+    return [value, (next: unknown) => setValue(next)] as const;
+  },
+}));
+
+import { useFundingProgramFilters } from "@/hooks/useFundingProgramFilters";
+
+describe("useFundingProgramFilters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(initialParams)) {
+      delete initialParams[key];
+    }
+  });
+
+  describe("defaults", () => {
+    it("returns empty search and 'all' status with an empty URL", () => {
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      expect(result.current.search).toBe("");
+      expect(result.current.status).toBe("all");
+    });
+  });
+
+  describe("deep-link seeding", () => {
+    it("seeds search and status from ?search=foo&status=enabled", () => {
+      initialParams.search = "foo";
+      initialParams.status = "enabled";
+
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      expect(result.current.search).toBe("foo");
+      expect(result.current.status).toBe("enabled");
+    });
+
+    it("seeds the disabled status", () => {
+      initialParams.status = "disabled";
+
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      expect(result.current.status).toBe("disabled");
+    });
+
+    it("narrows an invalid status value to 'all'", () => {
+      initialParams.status = "bogus";
+
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      expect(result.current.status).toBe("all");
+    });
+  });
+
+  describe("setters", () => {
+    it("round-trips the search value", () => {
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      act(() => result.current.setSearch("grants"));
+
+      expect(result.current.search).toBe("grants");
+    });
+
+    it("round-trips the status value", () => {
+      const { result } = renderHook(() => useFundingProgramFilters());
+
+      act(() => result.current.setStatus("enabled"));
+      expect(result.current.status).toBe("enabled");
+
+      act(() => result.current.setStatus("disabled"));
+      expect(result.current.status).toBe("disabled");
+
+      act(() => result.current.setStatus("all"));
+      expect(result.current.status).toBe("all");
+    });
+  });
+});

--- a/hooks/useBrowseApplicationFilters.ts
+++ b/hooks/useBrowseApplicationFilters.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useQueryState } from "nuqs";
+import type { ApplicationStatus } from "@/types/whitelabel-entities";
+
+export type BrowseApplicationStatusFilter = ApplicationStatus | "all";
+
+const FILTERABLE_STATUSES: ApplicationStatus[] = [
+  "pending",
+  "under_review",
+  "revision_requested",
+  "approved",
+  "rejected",
+];
+
+const isFilterableStatus = (value: string | null): value is ApplicationStatus =>
+  value != null && (FILTERABLE_STATUSES as string[]).includes(value);
+
+interface BrowseApplicationFiltersState {
+  programId: string;
+  setProgramId: (value: string) => void;
+  status: BrowseApplicationStatusFilter;
+  setStatus: (value: BrowseApplicationStatusFilter) => void;
+  search: string;
+  setSearch: (value: string) => void;
+}
+
+/**
+ * URL-backed filter state for the community browse-applications view.
+ *
+ * The query string is the single source of truth for the `programId`, `status`
+ * and `search` filters, so deep links pre-apply and the back button steps
+ * cleanly. nuqs writes through `history.replaceState`, which never dispatches an
+ * App Router navigation — so updating a filter cannot race or cancel a Link
+ * click (issue #1547). Mirrors `useFundingProgramFilters`.
+ */
+export function useBrowseApplicationFilters(): BrowseApplicationFiltersState {
+  const [programId, setProgramId] = useQueryState("programId", {
+    defaultValue: "",
+    clearOnDefault: true,
+  });
+
+  const [statusRaw, setStatus] = useQueryState<BrowseApplicationStatusFilter>("status", {
+    defaultValue: "all",
+    clearOnDefault: true,
+    serialize: (value) => (isFilterableStatus(value) ? value : ""),
+    parse: (value) => (isFilterableStatus(value) ? value : "all"),
+  });
+
+  const status = isFilterableStatus(statusRaw) ? statusRaw : "all";
+
+  const [search, setSearch] = useQueryState("search", {
+    defaultValue: "",
+    clearOnDefault: true,
+    throttleMs: 300,
+  });
+
+  return {
+    programId,
+    setProgramId,
+    status,
+    setStatus,
+    search,
+    setSearch,
+  };
+}

--- a/hooks/useFundingProgramFilters.ts
+++ b/hooks/useFundingProgramFilters.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useQueryState } from "nuqs";
+import { useCallback } from "react";
+
+export type FundingProgramStatusFilter = "all" | "enabled" | "disabled";
+
+const isValidStatus = (value: string | null): value is FundingProgramStatusFilter =>
+  value === "enabled" || value === "disabled";
+
+interface FundingProgramFiltersState {
+  search: string;
+  setSearch: (value: string) => void;
+  status: FundingProgramStatusFilter;
+  setStatus: (value: FundingProgramStatusFilter) => void;
+}
+
+/**
+ * URL-backed filter state for the funding platform programs list.
+ *
+ * The query string is the single source of truth for the `search` and `status`
+ * filters, so deep links such as `?search=foo&status=enabled` pre-apply the
+ * filters and the back button steps cleanly. nuqs writes through
+ * `history.replaceState`, which never dispatches an App Router navigation — so
+ * typing in the search box cannot race or cancel a Link click (issue #1547).
+ *
+ * Filtering itself is a client-side `useMemo`, so the optimistic value returned
+ * by nuqs keeps the input responsive while the URL write is throttled.
+ */
+export function useFundingProgramFilters(): FundingProgramFiltersState {
+  const [search, setSearchQuery] = useQueryState("search", {
+    defaultValue: "",
+    throttleMs: 300,
+  });
+
+  const [statusRaw, setStatusQuery] = useQueryState<FundingProgramStatusFilter>("status", {
+    defaultValue: "all",
+    clearOnDefault: true,
+    serialize: (value) => (isValidStatus(value) ? value : ""),
+    parse: (value) => (isValidStatus(value) ? value : "all"),
+  });
+
+  const status = isValidStatus(statusRaw) ? statusRaw : "all";
+
+  const setSearch = useCallback(
+    (value: string) => {
+      setSearchQuery(value);
+    },
+    [setSearchQuery]
+  );
+
+  const setStatus = useCallback(
+    (value: FundingProgramStatusFilter) => {
+      setStatusQuery(value);
+    },
+    [setStatusQuery]
+  );
+
+  return {
+    search,
+    setSearch,
+    status,
+    setStatus,
+  };
+}

--- a/hooks/useFundingProgramFilters.ts
+++ b/hooks/useFundingProgramFilters.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQueryState } from "nuqs";
-import { useCallback } from "react";
 
 export type FundingProgramStatusFilter = "all" | "enabled" | "disabled";
 
@@ -28,12 +27,13 @@ interface FundingProgramFiltersState {
  * by nuqs keeps the input responsive while the URL write is throttled.
  */
 export function useFundingProgramFilters(): FundingProgramFiltersState {
-  const [search, setSearchQuery] = useQueryState("search", {
+  const [search, setSearch] = useQueryState("search", {
     defaultValue: "",
+    clearOnDefault: true,
     throttleMs: 300,
   });
 
-  const [statusRaw, setStatusQuery] = useQueryState<FundingProgramStatusFilter>("status", {
+  const [statusRaw, setStatus] = useQueryState<FundingProgramStatusFilter>("status", {
     defaultValue: "all",
     clearOnDefault: true,
     serialize: (value) => (isValidStatus(value) ? value : ""),
@@ -41,20 +41,6 @@ export function useFundingProgramFilters(): FundingProgramFiltersState {
   });
 
   const status = isValidStatus(statusRaw) ? statusRaw : "all";
-
-  const setSearch = useCallback(
-    (value: string) => {
-      setSearchQuery(value);
-    },
-    [setSearchQuery]
-  );
-
-  const setStatus = useCallback(
-    (value: FundingProgramStatusFilter) => {
-      setStatusQuery(value);
-    },
-    [setStatusQuery]
-  );
 
   return {
     search,


### PR DESCRIPTION
## Summary

The funding-platform programs list and the browse-applications view were mirroring their search/status filter state into the URL via a `router.push`/`router.replace` inside a `useEffect`. This made Applications links feel broken (clicks appeared to do nothing) and broke the browser back button. This PR inverts the data flow so the URL query string is the single source of truth for those filters.

## Root cause

In `funding-platform/page.tsx` a state-to-URL sync effect ran on mount and on every keystroke, dispatching App Router navigations that resolved back to the programs-list URL. Under Next 15's serialized action queue the last navigation wins, so an Applications `Link` click made while one of those self-navigations was in flight got discarded — the click looked like a no-op. The same effect also pushed a duplicate history entry per keystroke, so a single Back press stepped through stale filter states instead of leaving the page. `BrowseApplicationsClient.tsx` had the same class of `router.replace` sync effect.

## What changed

- Added `hooks/useFundingProgramFilters.ts` — URL-backed `search` (throttled) and typed `"all" | "enabled" | "disabled"` status using nuqs `useQueryState` with parse/serialize narrowing (no `any` casts). This follows the existing codebase pattern (`hooks/useProjectFilters.ts`).
- `funding-platform/page.tsx` — removed the `useState` seeding and the entire state-to-URL sync effect; wired the search input and status dropdown to the nuqs setters; replaced the `?create=true` plumbing with `useQueryState("create")`. `useRouter`/`useSearchParams` are gone. nuqs writes through `history.replaceState` and never dispatches an App Router navigation, so there is no navigation for a `Link` click to race — the failure mode is now structurally impossible.
- `BrowseApplicationsClient.tsx` — migrated the same-class `router.replace` sync effect to nuqs for `programId`/`status`/`search`, keeping a derived debounced value to drive the API query.
- Strengthened `.claude/hooks/post-edit-antipatterns.sh` (multi-line router-in-deps match, plus a URL-sync-effect check) and documented the URL-as-source-of-truth rule in `CLAUDE.md`.

Loading, empty, and error states of the page are untouched.

## Testing

- `vitest run --project unit` on the two new test files (`useFundingProgramFilters.test.ts`, `page.regression.test.tsx`) — 2 files / 8 tests pass. The regression test asserts zero `router.push` on mount and a correct Applications href.
- Scoped `tsc --noEmit` — no type errors in the changed files; no `any`/`as any` casts.
- `biome check` on the changed source files — only pre-existing `noExcessiveCognitiveComplexity` warnings on untouched code remain.

Manual QA to perform: click an Applications link immediately after first paint (navigation works); type in search (URL gains `?search=` with no extra history entries); reload a `?search=foo&status=enabled` deep link (filters pre-apply); press Back from the applications page (single step returns); `?create=true` auto-opens the create modal and closing strips the param.

Closes #1547
