### PR TITLE
fix(markdown): restore heading demotion in card previews and close MarkdownPreview prop contract

### DIFF
--- a/__tests__/components/Utilities/MarkdownPreview.test.tsx
+++ b/__tests__/components/Utilities/MarkdownPreview.test.tsx
@@ -210,6 +210,32 @@ describe("MarkdownPreview", () => {
     });
   });
 
+  describe("style forwarding (#1278)", () => {
+    // Regression: before the prop contract was closed, MarkdownPreview carried a
+    // `[key: string]: unknown` index signature and never read `style`, so call
+    // sites (chat bubbles, project cards) passing inline `style` had it silently
+    // dropped. `style` is now a declared, forwarded prop.
+    it("forwards style to the plain-text fallback wrapper", () => {
+      const { container } = render(
+        <MarkdownPreview source="hello" style={{ color: "rgb(255, 255, 255)" }} />
+      );
+      const wrapper = container.querySelector(".preview") as HTMLElement;
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper.style.color).toBe("rgb(255, 255, 255)");
+    });
+
+    it("forwards style to the rendered wrapper after streamdown loads", async () => {
+      const { container } = render(
+        <MarkdownPreview source="hello" style={{ backgroundColor: "transparent" }} />
+      );
+      await waitFor(() => {
+        const wrapper = container.querySelector('[data-color-mode="light"]') as HTMLElement;
+        expect(wrapper).toBeInTheDocument();
+        expect(wrapper.style.backgroundColor).toBe("transparent");
+      });
+    });
+  });
+
   describe("custom components", () => {
     it("applies default paragraph component with mb-2 class", async () => {
       render(<MarkdownPreview source="A paragraph" />);

--- a/components/Utilities/MarkdownPreview.tsx
+++ b/components/Utilities/MarkdownPreview.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import type { ComponentType } from "react";
+import type { ComponentType, CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { Components } from "streamdown";
 import styles from "@/styles/markdown.module.css";
 import { cn } from "@/utilities/tailwind";
 
 // Inline props type — avoids pulling @uiw/react-markdown-preview into the bundle
-// while keeping call-site compatibility for the props we actually use.
+// while keeping call-site compatibility for the props we actually use. The
+// interface is closed (no `[key: string]: unknown` index signature): every prop
+// a call site passes must be declared and consumed below, so a prop the
+// component does not read is a compile error instead of a silent no-op (#1278).
 interface MarkdownPreviewProps {
   source?: string;
   className?: string;
+  /** Inline style forwarded to the preview's outer wrapper. */
+  style?: CSSProperties;
   /**
    * "inline" strips Streamdown's table chrome (toolbar + card) for help text + submitted answers.
    * "excerpt" renders a static, non-interactive prose preview for clamped cards/links:
@@ -26,9 +31,6 @@ interface MarkdownPreviewProps {
   allowElement?: (element: any, index: number, parent: any) => boolean;
   // biome-ignore lint/suspicious/noExplicitAny: ComponentType<any> makes destructured params explicit-any, avoiding noImplicitAny errors at call sites
   components?: Record<string, ComponentType<any>>;
-  // biome-ignore lint/suspicious/noExplicitAny: no-op kept for call-site compatibility; explicit any avoids noImplicitAny on node param
-  rehypeRewrite?: (node: any, index?: number, parent?: any) => void;
-  [key: string]: unknown; // absorb remaining unused @uiw props without breaking call sites
 }
 
 type StreamdownType = typeof import("streamdown").Streamdown;
@@ -189,6 +191,7 @@ function completeMissingTableSeparators(source: string): string {
 export const MarkdownPreview = ({
   source,
   className,
+  style,
   variant,
   allowElement,
   components,
@@ -249,7 +252,7 @@ export const MarkdownPreview = ({
     const fallbackText =
       variant === "excerpt" ? truncateAtWordBoundary(source, EXCERPT_MAX_CHARS) : source;
     return (
-      <div className={cn("preview w-full max-w-full whitespace-pre-wrap", className)}>
+      <div className={cn("preview w-full max-w-full whitespace-pre-wrap", className)} style={style}>
         {fallbackText}
       </div>
     );
@@ -258,6 +261,7 @@ export const MarkdownPreview = ({
   return (
     <div
       className="preview w-full max-w-full text-foreground"
+      style={style}
       data-color-mode={resolvedTheme === "dark" ? "dark" : "light"}
     >
       <StreamdownComponent


### PR DESCRIPTION
## Summary

`MarkdownPreviewProps` carried a `[key: string]: unknown` index signature and a no-op `rehypeRewrite` prop. The index signature meant **any prop a call site passed but the component never read was silently dropped** rather than flagged by the type checker — the exact failure mode behind #1278 (`rehypeRewrite` dropped after the streamdown migration). Three live call sites (the chat bubbles in `CommunityProjectEvaluatorPage`, `NewGrant/Milestone`, and the cards in `MyProjects`) pass inline `style` that, on `main`, never reaches the DOM for the same reason.

This closes the prop contract so a dropped prop becomes a compile error, and adds a real forwarded `style` prop.

## Context: heading demotion is already fixed on `main`

The original version of this PR restored heading demotion via a `demoteHeadingsTo` prop + a custom rehype plugin. Since then, `main` introduced `MarkdownPreview`'s `variant="excerpt"`, which renders card/link previews as inert prose — **markdown headings render as `<p>`** (not just demoted, fully de-ranked), nested anchors become spans, interactive controls are stripped, and the source is truncated to a word boundary. All three card call sites (`GrantCard`, `ProjectCard`, `seeds-project-card`) already use `variant="excerpt"`.

That fully resolves the user-visible bugs:
- **#1308** (card `# Title` rendering as page-level `<h1>`, polluting the heading outline): excerpt renders headings as `<p>`, so card previews emit zero heading elements. Covered by the existing test *"renders markdown headings as paragraphs, not heading elements"*.
- **#1278** (`rehypeRewrite` silently dropped): the heading-demotion behavior the call sites wanted is now delivered by excerpt. What remained was the **root cause** — the loose interface that let the prop be dropped in the first place.

So this PR is reduced to the durable fix that `main` had not yet addressed, rather than re-introducing a now-redundant (and conflicting) demotion mechanism.

## What changed

- **`components/Utilities/MarkdownPreview.tsx`**
  - Removed the `[key: string]: unknown` index signature → unknown/unread props are now compile errors.
  - Removed the dead no-op `rehypeRewrite` prop (used by zero call sites).
  - Added `style?: CSSProperties`, forwarded to the preview's outer wrapper in both the plain-text fallback and the streamdown render — fixing 3 call sites whose inline `style` was being silently dropped.
- **`__tests__/components/Utilities/MarkdownPreview.test.tsx`**: added a `style forwarding` block asserting `style` reaches the fallback wrapper (synchronous) and the streamdown wrapper (after dynamic import).

## Testing

- `tsc --noEmit` clean **project-wide** — confirms closing the index signature breaks none of the ~63 `MarkdownPreview` call sites, and that the 3 `style` call sites now type-check against the declared prop.
- `vitest run --project unit` on `MarkdownPreview`, `GrantCard`, `ProjectCard`: 72/72 passing.
- `biome check` clean on changed files.

## Manual QA

On `/community/optimism`: exactly one page-level `<h1>` (community name); grant/project card previews with `# Heading` descriptions render as compact `<p>` text, no stray `<h1>`. Chat/preview surfaces passing `style` now reflect their colors.

Closes #1278, #1308
