### PR TITLE
fix(forms): make milestone description optional and derive required indicators from Zod schemas (single source of truth)

### DIFF
--- a/__tests__/components/Dialogs/ContributorProfileDialog.test.tsx
+++ b/__tests__/components/Dialogs/ContributorProfileDialog.test.tsx
@@ -238,8 +238,9 @@ describe("ContributorProfileDialog", () => {
       expect(form).not.toBeNull();
       fireEvent.submit(form as HTMLFormElement);
 
+      // An empty required field reports "is required", not the min-length message.
       await waitFor(() => {
-        expect(screen.getByText("This name is too short")).toBeInTheDocument();
+        expect(screen.getByText("Name is required")).toBeInTheDocument();
       });
     });
 
@@ -264,7 +265,7 @@ describe("ContributorProfileDialog", () => {
       fireEvent.submit(form as HTMLFormElement);
 
       await waitFor(() => {
-        expect(screen.getByText("This name is too short")).toBeInTheDocument();
+        expect(screen.getByText("Name is required")).toBeInTheDocument();
       });
 
       // The real symptom of the regression: the submit handler never runs, so
@@ -272,6 +273,35 @@ describe("ContributorProfileDialog", () => {
       expect(mockContributorProfileCtor).not.toHaveBeenCalled();
       expect(mockAttest).not.toHaveBeenCalled();
       expect(mockSetupChainAndWallet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #1508: a QA dogfood run reported the "Update profile" button staying
+  // enabled after the Name field was emptied. That was a harness artifact —
+  // Playwright's `fill('')` does not dispatch the React onChange that
+  // `mode: "onChange"` validation depends on. With real synthetic events
+  // (userEvent.clear) the button correctly disables. This test guards the
+  // `mode: "onChange"` + `!isValid` contract against regression.
+  // ---------------------------------------------------------------------------
+  describe("submit button disabled contract (issue #1508)", () => {
+    it("disables the submit button when the name is cleared with real events", async () => {
+      const user = userEvent.setup();
+      render(<ContributorProfileDialog />);
+
+      const submitButton = screen.getByRole("button", { name: /update profile/i });
+
+      // Fill a valid name -> button enables.
+      await user.type(getNameInput(), "Jane Doe");
+      await waitFor(() => {
+        expect(submitButton).not.toBeDisabled();
+      });
+
+      // Clear it with real synthetic events -> validation re-runs and disables.
+      await user.clear(getNameInput());
+      await waitFor(() => {
+        expect(submitButton).toBeDisabled();
+      });
     });
   });
 

--- a/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
+++ b/__tests__/components/FundingPlatform/CreateProgramModal.test.tsx
@@ -417,10 +417,9 @@ describe("CreateProgramModal", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        // AriaLiveError renders a duplicate in sr-only, so use getAllByText
-        expect(
-          screen.getAllByText(/program name must be at least 3 characters/i).length
-        ).toBeGreaterThan(0);
+        // Empty required field reports "is required", not the min-length message (issue #1506).
+        // AriaLiveError renders a duplicate in sr-only, so use getAllByText.
+        expect(screen.getAllByText(/program name is required/i).length).toBeGreaterThan(0);
       });
     });
 

--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -416,8 +416,9 @@ describe("ProgramDetailsTab", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        // Find the visible error message (not the sr-only one)
-        const errorMessages = screen.getAllByText(/program name must be at least 3 characters/i);
+        // Empty required field reports "is required", not the min-length message (issue #1506).
+        // Find the visible error message (not the sr-only one).
+        const errorMessages = screen.getAllByText(/program name is required/i);
         const visibleError = errorMessages.find(
           (el) => !el.closest('[class*="sr-only"]') && el.getAttribute("role") === "alert"
         );

--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -416,8 +416,7 @@ describe("ProgramDetailsTab", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        // Empty required field reports "is required", not the min-length message (issue #1506).
-        // Find the visible error message (not the sr-only one).
+        // Empty required field reports "is required", not min-length (#1506); pick the visible (non-sr-only) one.
         const errorMessages = screen.getAllByText(/program name is required/i);
         const visibleError = errorMessages.find(
           (el) => !el.closest('[class*="sr-only"]') && el.getAttribute("role") === "alert"

--- a/__tests__/pages/onboarding.test.tsx
+++ b/__tests__/pages/onboarding.test.tsx
@@ -102,6 +102,67 @@ describe("OnboardingPage", () => {
     });
   });
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // Issue #1426: the old page gated submit on a truthy-only `canSubmit`, so an
+  // invalid Runtime URL ("not-a-valid-url") still enabled the button, and a
+  // click silently did nothing (native browser bubbles only). The form now uses
+  // zodResolver and renders inline, ARIA-associated errors; clicking submit on
+  // an invalid form surfaces the error and never calls the mutation.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("inline validation (issue #1426)", () => {
+    it("shows an inline error for an invalid Runtime URL and does not provision", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(screen.getByLabelText(/organization handle/i), "acme-nonprofit");
+      await user.type(screen.getByLabelText(/runtime url/i), "not-a-valid-url");
+      await user.type(screen.getByLabelText(/runtime session token/i), "tok_aaaaaaaaaaaaaaaa");
+
+      await user.click(screen.getByRole("button", { name: /set up team/i }));
+
+      const urlInput = screen.getByLabelText(/runtime url/i);
+      await waitFor(() => {
+        expect(screen.getByText(/please enter a valid url/i)).toBeInTheDocument();
+      });
+
+      // Error is associated with the field for assistive tech.
+      expect(urlInput).toHaveAttribute("aria-invalid", "true");
+      const describedBy = urlInput.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      expect(document.getElementById(describedBy as string)).toHaveTextContent(
+        /please enter a valid url/i
+      );
+
+      // The mutation must NOT fire for an invalid form.
+      expect(mockClient.provision).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("shows an inline error when the session token is shorter than 16 characters", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(screen.getByLabelText(/organization handle/i), "acme-nonprofit");
+      await user.type(screen.getByLabelText(/runtime url/i), "https://team-acme.karma.xyz");
+      await user.type(screen.getByLabelText(/runtime session token/i), "short");
+
+      await user.click(screen.getByRole("button", { name: /set up team/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/at least 16 characters/i)).toBeInTheDocument();
+      });
+      expect(mockClient.provision).not.toHaveBeenCalled();
+    });
+
+    it("keeps the submit button enabled on an invalid form so errors can surface", () => {
+      renderPage();
+      // Unlike the old truthy-only gate, the button is only disabled while the
+      // mutation is pending — an invalid form still allows a click that reveals
+      // the inline errors.
+      expect(screen.getByRole("button", { name: /set up team/i })).not.toBeDisabled();
+    });
+  });
+
   it("renders the error message when provisioning fails", async () => {
     const user = userEvent.setup();
     mockClient.provision.mockRejectedValue(new Error("Container unreachable"));

--- a/__tests__/schemas/programFormSchema.test.ts
+++ b/__tests__/schemas/programFormSchema.test.ts
@@ -46,6 +46,21 @@ describe("createProgramSchema", () => {
       }
     });
 
+    it("should report 'required' (not the min-length message) for an empty name (issue #1506)", () => {
+      const result = createProgramSchema.safeParse({
+        name: "",
+        description: "Test description",
+        shortDescription: "Short desc",
+        ...validEmails,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const nameIssue = result.error.issues.find((issue) => issue.path[0] === "name");
+        expect(nameIssue?.message).toBe("Program name is required");
+      }
+    });
+
     it("should reject name longer than 50 characters", () => {
       const result = createProgramSchema.safeParse({
         name: "a".repeat(51),
@@ -98,7 +113,7 @@ describe("createProgramSchema", () => {
       expect(result.success).toBe(true);
     });
 
-    it("should reject description shorter than 3 characters", () => {
+    it("should reject description shorter than 3 characters with the min-length message (issue #1506)", () => {
       const result = createProgramSchema.safeParse({
         name: "Test Program",
         description: "ab",
@@ -108,7 +123,23 @@ describe("createProgramSchema", () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error.issues[0].message).toBe("Description is required");
+        const descIssue = result.error.issues.find((issue) => issue.path[0] === "description");
+        expect(descIssue?.message).toBe("Description must be at least 3 characters");
+      }
+    });
+
+    it("should report 'required' for an empty description (issue #1506)", () => {
+      const result = createProgramSchema.safeParse({
+        name: "Test Program",
+        description: "",
+        shortDescription: "Short desc",
+        ...validEmails,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const descIssue = result.error.issues.find((issue) => issue.path[0] === "description");
+        expect(descIssue?.message).toBe("Description is required");
       }
     });
 

--- a/app/ai-teams/onboarding/onboarding-schema.ts
+++ b/app/ai-teams/onboarding/onboarding-schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { optionalString, requiredString, requiredUrl } from "@/utilities/validation/zod-primitives";
+
+/** Strips anything that isn't a lowercase letter, number, or hyphen. */
+export function normalizeSlug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9-]/g, "");
+}
+
+/**
+ * Validation for the AI-team onboarding wizard. Mirrors the four fields
+ * gap-indexer's `POST /v2/hermes/orgs/:slug/provision` accepts. Built from the
+ * shared primitives so required/length/URL messages stay consistent with the
+ * rest of the app and empty fields report "is required" rather than a length or
+ * format error.
+ */
+export const onboardingSchema = z.object({
+  slug: requiredString("Organization handle", {
+    messages: { required: "Organization handle is required" },
+  }).regex(/^[a-z0-9-]+$/, "Use only lowercase letters, numbers, and hyphens"),
+  containerUrl: requiredUrl("Runtime URL"),
+  sessionToken: requiredString("Runtime session token", {
+    min: 16,
+    messages: {
+      required: "Runtime session token is required",
+      min: "Runtime session token must be at least 16 characters",
+    },
+  }),
+  communityId: optionalString(),
+});
+
+export type OnboardingFormValues = z.infer<typeof onboardingSchema>;

--- a/app/ai-teams/onboarding/page.tsx
+++ b/app/ai-teams/onboarding/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle, ArrowLeft, Globe, Hash, KeyRound, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { type FieldError, useForm } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import { useProvisionOrg } from "@/hooks/useTeam";
 import { humanizeApiError } from "@/lib/ai-agent-error";
 import { PAGES } from "@/utilities/pages";
+import { normalizeSlug, type OnboardingFormValues, onboardingSchema } from "./onboarding-schema";
 
 // Phase 1 wizard: collects the four fields gap-indexer's
 // POST /v2/hermes/orgs/:slug/provision needs to register a pre-existing
@@ -16,12 +19,38 @@ import { PAGES } from "@/utilities/pages";
 export default function OnboardingPage() {
   const router = useRouter();
   const provision = useProvisionOrg();
-  const [slug, setSlug] = useState("");
-  const [containerUrl, setContainerUrl] = useState("");
-  const [sessionToken, setSessionToken] = useState("");
-  const [communityId, setCommunityId] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<OnboardingFormValues>({
+    resolver: zodResolver(onboardingSchema),
+    mode: "onChange",
+    defaultValues: {
+      slug: "",
+      containerUrl: "",
+      sessionToken: "",
+      communityId: "",
+    },
+  });
 
-  const canSubmit = slug && containerUrl && sessionToken && !provision.isPending;
+  const onSubmit = handleSubmit((values) => {
+    provision.mutate(
+      {
+        slug: values.slug.trim(),
+        containerUrl: values.containerUrl.trim(),
+        sessionToken: values.sessionToken.trim(),
+        communityId: values.communityId?.trim() || null,
+      },
+      {
+        onSuccess: (org) => {
+          router.push(PAGES.TEAM.DIRECTORY(org.slug));
+        },
+      }
+    );
+  });
+
+  const slugField = register("slug");
 
   return (
     <main className="mx-auto max-w-2xl px-6 py-12">
@@ -44,23 +73,8 @@ export default function OnboardingPage() {
 
       <form
         className="mt-10 space-y-5 rounded-2xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-6 shadow-sm"
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!canSubmit) return;
-          provision.mutate(
-            {
-              slug: slug.trim(),
-              containerUrl: containerUrl.trim(),
-              sessionToken: sessionToken.trim(),
-              communityId: communityId.trim() || null,
-            },
-            {
-              onSuccess: (org) => {
-                router.push(PAGES.TEAM.DIRECTORY(org.slug));
-              },
-            }
-          );
-        }}
+        onSubmit={onSubmit}
+        noValidate
       >
         <Field
           id="slug"
@@ -68,14 +82,21 @@ export default function OnboardingPage() {
           hint="Lowercase letters, numbers, hyphens. This is internal — won't be shown publicly."
           icon={<Hash className="h-4 w-4" aria-hidden />}
           required
+          error={errors.slug}
         >
           <Input
             id="slug"
-            value={slug}
-            onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))}
+            {...slugField}
+            onChange={(e) => {
+              // Normalize as the user types so the handle always stays valid,
+              // then delegate to RHF's own change handler (keeps dirty/validation).
+              e.target.value = normalizeSlug(e.target.value);
+              slugField.onChange(e);
+            }}
+            aria-invalid={errors.slug ? true : undefined}
+            aria-describedby={errors.slug ? "slug-error" : undefined}
             placeholder="acme-nonprofit"
             className="h-auto rounded-none border-0 bg-transparent py-2 pl-0 pr-3 text-sm text-gray-900 dark:text-zinc-100 shadow-none placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus-visible:ring-0"
-            required
           />
         </Field>
 
@@ -85,15 +106,16 @@ export default function OnboardingPage() {
           hint="Where your team lives — usually provided by ops when the container spins up."
           icon={<Globe className="h-4 w-4" aria-hidden />}
           required
+          error={errors.containerUrl}
         >
           <Input
             id="containerUrl"
             type="url"
-            value={containerUrl}
-            onChange={(e) => setContainerUrl(e.target.value)}
+            {...register("containerUrl")}
+            aria-invalid={errors.containerUrl ? true : undefined}
+            aria-describedby={errors.containerUrl ? "containerUrl-error" : undefined}
             placeholder="https://team-acme.karma.xyz"
             className="h-auto rounded-none border-0 bg-transparent py-2 pl-0 pr-3 text-sm text-gray-900 dark:text-zinc-100 shadow-none placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus-visible:ring-0"
-            required
           />
         </Field>
 
@@ -103,17 +125,17 @@ export default function OnboardingPage() {
           hint="From the runtime's welcome banner. Stored encrypted in our backend and never exposed in logs."
           icon={<KeyRound className="h-4 w-4" aria-hidden />}
           required
+          error={errors.sessionToken}
         >
           <Input
             id="sessionToken"
             type="password"
-            value={sessionToken}
-            onChange={(e) => setSessionToken(e.target.value)}
+            {...register("sessionToken")}
+            aria-invalid={errors.sessionToken ? true : undefined}
+            aria-describedby={errors.sessionToken ? "sessionToken-error" : undefined}
             placeholder="Runtime session token"
             autoComplete="new-password"
             className="h-auto rounded-none border-0 bg-transparent py-2 pl-0 pr-3 font-mono text-sm text-gray-900 dark:text-zinc-100 shadow-none placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus-visible:ring-0"
-            required
-            minLength={16}
           />
         </Field>
 
@@ -122,11 +144,11 @@ export default function OnboardingPage() {
           label="Karma community"
           hint="Optional — link this team to an existing community for shared admin."
           icon={<Hash className="h-4 w-4" aria-hidden />}
+          error={errors.communityId}
         >
           <Input
             id="communityId"
-            value={communityId}
-            onChange={(e) => setCommunityId(e.target.value)}
+            {...register("communityId")}
             placeholder="Leave blank to skip"
             className="h-auto rounded-none border-0 bg-transparent py-2 pl-0 pr-3 text-sm text-gray-900 dark:text-zinc-100 shadow-none placeholder:text-gray-400 dark:placeholder:text-zinc-600 focus-visible:ring-0"
           />
@@ -146,7 +168,7 @@ export default function OnboardingPage() {
 
         <button
           type="submit"
-          disabled={!canSubmit}
+          disabled={provision.isPending}
           className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-gray-900 dark:bg-zinc-100 py-2.5 text-sm font-medium text-white dark:text-zinc-900 shadow-sm transition hover:bg-gray-800 dark:hover:bg-zinc-200 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-zinc-700 disabled:shadow-none"
         >
           {provision.isPending ? (
@@ -173,10 +195,11 @@ interface FieldProps {
   hint?: string;
   icon?: ReactNode;
   required?: boolean;
+  error?: FieldError;
   children: ReactNode;
 }
 
-function Field({ id, label, hint, icon, required, children }: FieldProps) {
+function Field({ id, label, hint, icon, required, error, children }: FieldProps) {
   return (
     <div>
       <label htmlFor={id} className="block text-sm font-medium text-gray-900 dark:text-zinc-100">
@@ -195,7 +218,17 @@ function Field({ id, label, hint, icon, required, children }: FieldProps) {
         ) : null}
         {children}
       </div>
-      {hint ? <p className="mt-1.5 text-xs text-gray-500 dark:text-zinc-400">{hint}</p> : null}
+      {error ? (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="mt-1.5 text-xs text-red-600 dark:text-red-400"
+        >
+          {error.message}
+        </p>
+      ) : hint ? (
+        <p className="mt-1.5 text-xs text-gray-500 dark:text-zinc-400">{hint}</p>
+      ) : null}
     </div>
   );
 }

--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -26,9 +26,10 @@ import { INDEXER } from "@/utilities/indexer";
 import { gapSupportedNetworks, getChainIdByName } from "@/utilities/network";
 import { urlRegex } from "@/utilities/regexs/urlRegex";
 import { cn } from "@/utilities/tailwind";
+import { requiredString } from "@/utilities/validation/zod-primitives";
 
 const profileSchema = z.object({
-  name: z.string().min(3, { message: "This name is too short" }),
+  name: requiredString("Name", { min: 3, messages: { min: "This name is too short" } }),
   aboutMe: z.string().optional(),
   github: z
     .string()

--- a/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
@@ -8,6 +8,10 @@ import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { z } from "zod";
 import { buildRepeatableObjectSchema } from "@/components/FundingPlatform/ApplicationView/lib/repeatable-field-schema";
+import {
+  metricItemSchema,
+  milestoneItemSchema,
+} from "@/components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas";
 import { KarmaProfileLinkInput } from "@/components/FundingPlatform/FormFields/KarmaProfileLinkInput";
 import { MetricInput } from "@/components/FundingPlatform/FormFields/MetricInput";
 import { MilestoneInput } from "@/components/FundingPlatform/FormFields/MilestoneInput";
@@ -282,42 +286,25 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
           fieldSchema = z.string();
           break;
         case "milestone": {
-          fieldSchema = buildRepeatableObjectSchema(
-            z.object({
-              title: z.string().min(1, "Milestone title is required"),
-              description: z.string().min(1, "Milestone description is required"),
-              dueDate: z.string().min(1, "Due date is required"),
-              fundingRequested: z.string().min(1, "Milestone funding requested is required"),
-              completionCriteria: z.string().min(1, "Completion criteria is required"),
-            }),
-            {
-              required: field.required,
-              label: field.label,
-              min: field.validation?.minMilestones,
-              max: field.validation?.maxMilestones,
-              minMessage: (n) => `Please add at least ${n} milestone(s)`,
-              maxMessage: (n) => `Maximum ${n} milestone(s) allowed`,
-            }
-          );
+          fieldSchema = buildRepeatableObjectSchema(milestoneItemSchema, {
+            required: field.required,
+            label: field.label,
+            min: field.validation?.minMilestones,
+            max: field.validation?.maxMilestones,
+            minMessage: (n) => `Please add at least ${n} milestone(s)`,
+            maxMessage: (n) => `Maximum ${n} milestone(s) allowed`,
+          });
           break;
         }
         case "metric": {
-          fieldSchema = buildRepeatableObjectSchema(
-            z.object({
-              metric: z.string().trim().min(1, "Metric is required"),
-              dataSource: z.string().trim().min(1, "Data source is required"),
-              howItsMeasured: z.string().trim().min(1, "How it's measured is required"),
-              target: z.string().trim().min(1, "Target is required"),
-            }),
-            {
-              required: field.required,
-              label: field.label,
-              min: field.validation?.minMetrics,
-              max: field.validation?.maxMetrics,
-              minMessage: (n) => `Please add at least ${n} ${pluralize("metric", n)}`,
-              maxMessage: (n) => `Maximum ${n} ${pluralize("metric", n)} allowed`,
-            }
-          );
+          fieldSchema = buildRepeatableObjectSchema(metricItemSchema, {
+            required: field.required,
+            label: field.label,
+            min: field.validation?.minMetrics,
+            max: field.validation?.maxMetrics,
+            minMessage: (n) => `Please add at least ${n} ${pluralize("metric", n)}`,
+            maxMessage: (n) => `Maximum ${n} ${pluralize("metric", n)} allowed`,
+          });
           break;
         }
         case "karma_profile_link": {

--- a/components/FundingPlatform/ApplicationView/lib/__tests__/repeatable-item-schemas.test.ts
+++ b/components/FundingPlatform/ApplicationView/lib/__tests__/repeatable-item-schemas.test.ts
@@ -1,0 +1,105 @@
+import {
+  deriveRequiredMap,
+  METRIC_FIELD_REQUIRED,
+  MILESTONE_FIELD_REQUIRED,
+  metricItemSchema,
+  milestoneItemSchema,
+} from "../repeatable-item-schemas";
+
+const validMilestone = {
+  title: "Ship v1",
+  description: "",
+  dueDate: "2024-12-31",
+  fundingRequested: "5000",
+  completionCriteria: "All tests pass",
+};
+
+function firstError(result: {
+  success: boolean;
+  error?: { issues: { message: string }[] };
+}): string {
+  if (result.success) throw new Error("expected validation to fail");
+  return result.error!.issues[0].message;
+}
+
+describe("milestoneItemSchema", () => {
+  it("accepts a milestone with an empty description (issue #1179 fix)", () => {
+    expect(milestoneItemSchema.safeParse(validMilestone).success).toBe(true);
+  });
+
+  it("accepts a milestone with a filled description", () => {
+    expect(
+      milestoneItemSchema.safeParse({ ...validMilestone, description: "Build the thing" }).success
+    ).toBe(true);
+  });
+
+  it("rejects an empty title with the required message", () => {
+    expect(firstError(milestoneItemSchema.safeParse({ ...validMilestone, title: "" }))).toBe(
+      "Milestone title is required"
+    );
+  });
+
+  it("rejects an empty due date with the required message", () => {
+    expect(firstError(milestoneItemSchema.safeParse({ ...validMilestone, dueDate: "" }))).toBe(
+      "Due date is required"
+    );
+  });
+
+  it("rejects empty funding requested with the required message", () => {
+    expect(
+      firstError(milestoneItemSchema.safeParse({ ...validMilestone, fundingRequested: "" }))
+    ).toBe("Milestone funding requested is required");
+  });
+
+  it("rejects empty completion criteria with the required message", () => {
+    expect(
+      firstError(milestoneItemSchema.safeParse({ ...validMilestone, completionCriteria: "" }))
+    ).toBe("Completion criteria is required");
+  });
+});
+
+describe("metricItemSchema", () => {
+  const validMetric = {
+    metric: "MAU",
+    dataSource: "Dune",
+    howItsMeasured: "Unique wallets",
+    target: "10000",
+  };
+
+  it("accepts a fully filled metric", () => {
+    expect(metricItemSchema.safeParse(validMetric).success).toBe(true);
+  });
+
+  it("rejects an empty metric with the required message", () => {
+    expect(firstError(metricItemSchema.safeParse({ ...validMetric, metric: "" }))).toBe(
+      "Metric is required"
+    );
+  });
+});
+
+describe("deriveRequiredMap", () => {
+  it("marks only the milestone description as optional", () => {
+    expect(MILESTONE_FIELD_REQUIRED).toEqual({
+      title: true,
+      description: false,
+      dueDate: true,
+      fundingRequested: true,
+      completionCriteria: true,
+    });
+  });
+
+  it("marks all metric fields as required", () => {
+    expect(METRIC_FIELD_REQUIRED).toEqual({
+      metric: true,
+      dataSource: true,
+      howItsMeasured: true,
+      target: true,
+    });
+  });
+
+  it("reflects schema changes (single source of truth)", () => {
+    const map = deriveRequiredMap(milestoneItemSchema);
+    expect(map.description).toBe(false);
+    expect(map.title).toBe(true);
+  });
+});

--- a/components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas.ts
+++ b/components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { optionalString, requiredString } from "@/utilities/validation/zod-primitives";
+
+/**
+ * Single source of truth for the sub-fields of repeatable milestone and metric
+ * inputs. These were previously declared inline inside
+ * `ApplicationSubmission.generateValidationSchema`, which is wired with a
+ * zodResolver — so the schema is the SOLE validation authority and any
+ * per-Controller `rules` are dead code.
+ *
+ * Issue #1179: the milestone `description` was required here while the UI
+ * advertised it as optional (PR #1174). It is now `optionalString()` — the one
+ * declaration of its required-ness — and the UI derives its indicator from this
+ * schema via `MILESTONE_FIELD_REQUIRED` so the two can never disagree again.
+ */
+export const milestoneItemSchema = z.object({
+  title: requiredString("Milestone title", {
+    messages: { required: "Milestone title is required" },
+  }),
+  description: optionalString(),
+  dueDate: requiredString("Due date", { messages: { required: "Due date is required" } }),
+  fundingRequested: requiredString("Milestone funding requested", {
+    messages: { required: "Milestone funding requested is required" },
+  }),
+  completionCriteria: requiredString("Completion criteria", {
+    messages: { required: "Completion criteria is required" },
+  }),
+});
+
+export const metricItemSchema = z.object({
+  metric: requiredString("Metric", { messages: { required: "Metric is required" } }),
+  dataSource: requiredString("Data source", { messages: { required: "Data source is required" } }),
+  howItsMeasured: requiredString("How it's measured", {
+    messages: { required: "How it's measured is required" },
+  }),
+  target: requiredString("Target", { messages: { required: "Target is required" } }),
+});
+
+/**
+ * Derive a `{ field: isRequired }` map from a Zod object schema by reading each
+ * shape entry's `.isOptional()`. UI components use this to render asterisks and
+ * `isRequired` props, guaranteeing they are a projection of the schema rather
+ * than a hand-maintained duplicate.
+ */
+export function deriveRequiredMap<Shape extends z.ZodRawShape>(
+  schema: z.ZodObject<Shape>
+): Record<keyof Shape, boolean> {
+  const entries = Object.entries(schema.shape).map(([key, fieldSchema]) => [
+    key,
+    !(fieldSchema as z.ZodType).isOptional(),
+  ]);
+  return Object.fromEntries(entries) as Record<keyof Shape, boolean>;
+}
+
+export const MILESTONE_FIELD_REQUIRED = deriveRequiredMap(milestoneItemSchema);
+export const METRIC_FIELD_REQUIRED = deriveRequiredMap(metricItemSchema);

--- a/components/FundingPlatform/FormFields/MetricInput.tsx
+++ b/components/FundingPlatform/FormFields/MetricInput.tsx
@@ -5,9 +5,13 @@ import pluralize from "pluralize";
 import type { FC } from "react";
 import type { Control } from "react-hook-form";
 import { Controller, useFieldArray } from "react-hook-form";
+import { METRIC_FIELD_REQUIRED } from "@/components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas";
 import { Button } from "@/components/Utilities/Button";
 import type { IFormField, IMetricData } from "@/types/funding-platform";
 import { cn } from "@/utilities/tailwind";
+
+/** Asterisk shown next to required sub-field labels, driven by the schema. */
+const RequiredMark: FC = () => <span className="text-red-500 ml-1">{" *"}</span>;
 
 interface MetricInputProps {
   field: IFormField;
@@ -100,7 +104,8 @@ export const MetricInput: FC<MetricInputProps> = ({
                 render={({ field: metricField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-metric`} className={labelStyle}>
-                      Metric *
+                      Metric
+                      {METRIC_FIELD_REQUIRED.metric && <RequiredMark />}
                     </label>
                     <input
                       {...metricField}
@@ -127,7 +132,8 @@ export const MetricInput: FC<MetricInputProps> = ({
                 render={({ field: sourceField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-dataSource`} className={labelStyle}>
-                      Data Source *
+                      Data Source
+                      {METRIC_FIELD_REQUIRED.dataSource && <RequiredMark />}
                     </label>
                     <input
                       {...sourceField}
@@ -154,7 +160,8 @@ export const MetricInput: FC<MetricInputProps> = ({
                 render={({ field: measuredField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-howItsMeasured`} className={labelStyle}>
-                      How It's Measured *
+                      How It's Measured
+                      {METRIC_FIELD_REQUIRED.howItsMeasured && <RequiredMark />}
                     </label>
                     <textarea
                       {...measuredField}
@@ -182,7 +189,8 @@ export const MetricInput: FC<MetricInputProps> = ({
                 render={({ field: targetField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-target`} className={labelStyle}>
-                      Target *
+                      Target
+                      {METRIC_FIELD_REQUIRED.target && <RequiredMark />}
                     </label>
                     <input
                       {...targetField}

--- a/components/FundingPlatform/FormFields/MilestoneInput.tsx
+++ b/components/FundingPlatform/FormFields/MilestoneInput.tsx
@@ -4,11 +4,15 @@ import { TrashIcon } from "@heroicons/react/24/solid";
 import type { FC } from "react";
 import type { Control, FieldError } from "react-hook-form";
 import { Controller, useFieldArray } from "react-hook-form";
+import { MILESTONE_FIELD_REQUIRED } from "@/components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas";
 import { Button } from "@/components/Utilities/Button";
 import { DatePicker } from "@/components/Utilities/DatePicker";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import type { IFormField, IMilestoneData } from "@/types/funding-platform";
 import { cn } from "@/utilities/tailwind";
+
+/** Asterisk shown next to required sub-field labels, driven by the schema. */
+const RequiredMark: FC = () => <span className="text-red-500 ml-1">{" *"}</span>;
 
 interface MilestoneInputProps {
   field: IFormField;
@@ -97,11 +101,11 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
               <Controller
                 name={`${fieldKey}.${index}.title`}
                 control={control}
-                rules={{ required: "Title is required" }}
                 render={({ field: titleField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-title`} className={labelStyle}>
-                      Title *
+                      Title
+                      {MILESTONE_FIELD_REQUIRED.title && <RequiredMark />}
                     </label>
                     <input
                       {...titleField}
@@ -127,13 +131,17 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
                 control={control}
                 render={({ field: descField, fieldState }) => (
                   <MarkdownEditor
-                    label="Description"
+                    label={
+                      MILESTONE_FIELD_REQUIRED.description
+                        ? "Description"
+                        : "Description (Optional)"
+                    }
                     placeholder="Describe what will be accomplished in this milestone"
                     value={descField.value || ""}
                     onChange={descField.onChange}
                     onBlur={descField.onBlur}
                     error={fieldState.error?.message}
-                    isRequired={false}
+                    isRequired={MILESTONE_FIELD_REQUIRED.description}
                     isDisabled={isLoading}
                     id={`${fieldKey}-${index}-description`}
                     height={200}
@@ -146,7 +154,6 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
               <Controller
                 name={`${fieldKey}.${index}.dueDate`}
                 control={control}
-                rules={{ required: "Due date is required" }}
                 render={({ field: dateField, fieldState }) => {
                   const dateValue = dateField.value
                     ? (() => {
@@ -160,7 +167,10 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
 
                   return (
                     <div>
-                      <span className={labelStyle}>Due Date *</span>
+                      <span className={labelStyle}>
+                        Due Date
+                        {MILESTONE_FIELD_REQUIRED.dueDate && <RequiredMark />}
+                      </span>
                       <DatePicker
                         selected={dateValue}
                         onSelect={(date) => {
@@ -187,11 +197,11 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
               <Controller
                 name={`${fieldKey}.${index}.fundingRequested`}
                 control={control}
-                rules={{ required: "Milestone funding requested is required" }}
                 render={({ field: fundingField, fieldState }) => (
                   <div>
                     <label htmlFor={`${fieldKey}-${index}-fundingRequested`} className={labelStyle}>
-                      Milestone funding requested *
+                      Milestone funding requested
+                      {MILESTONE_FIELD_REQUIRED.fundingRequested && <RequiredMark />}
                     </label>
                     <input
                       {...fundingField}
@@ -215,7 +225,6 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
               <Controller
                 name={`${fieldKey}.${index}.completionCriteria`}
                 control={control}
-                rules={{ required: "Completion criteria is required" }}
                 render={({ field: criteriaField, fieldState }) => (
                   <MarkdownEditor
                     label="Completion Criteria"
@@ -224,7 +233,7 @@ export const MilestoneInput: FC<MilestoneInputProps> = ({
                     onChange={criteriaField.onChange}
                     onBlur={criteriaField.onBlur}
                     error={fieldState.error?.message}
-                    isRequired
+                    isRequired={MILESTONE_FIELD_REQUIRED.completionCriteria}
                     isDisabled={isLoading}
                     id={`${fieldKey}-${index}-completionCriteria`}
                     height={150}

--- a/components/FundingPlatform/FormFields/__tests__/MilestoneInput.test.tsx
+++ b/components/FundingPlatform/FormFields/__tests__/MilestoneInput.test.tsx
@@ -108,10 +108,10 @@ describe("MilestoneInput Component", () => {
       fireEvent.click(addButton);
 
       expect(screen.getByLabelText(/title \*/i)).toBeInTheDocument();
-      // Description is a MarkdownEditor with isRequired=false, check for label text
-      expect(screen.getByText(/^description$/i)).toBeInTheDocument();
+      // Description is optional (issue #1179) — label is suffixed with "(Optional)"
+      expect(screen.getByText(/description \(optional\)/i)).toBeInTheDocument();
       // Due Date uses DatePicker with aria-label, check for label text instead
-      expect(screen.getByText(/due date \*/i)).toBeInTheDocument();
+      expect(screen.getByText(/due date/i)).toBeInTheDocument();
     });
 
     it("should render new optional fields", () => {
@@ -295,6 +295,22 @@ describe("MilestoneInput Component", () => {
 
       // MarkdownEditor doesn't have proper label association, just verify label exists
       expect(screen.getByText(/^completion criteria$/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Schema-derived required indicators (issue #1179)", () => {
+    it("renders no required marker for Description and markers for the four required sub-fields", () => {
+      render(<TestWrapper field={mockField} />);
+      fireEvent.click(screen.getByRole("button", { name: /add milestone/i }));
+
+      // Description is advertised as optional and carries no asterisk
+      expect(screen.getByText(/description \(optional\)/i)).toBeInTheDocument();
+      expect(screen.queryByText(/^description$/i)).not.toBeInTheDocument();
+
+      // The four schema-required sub-fields all carry a "*" marker in their label
+      expect(screen.getByLabelText(/title \*/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/funding requested \*/i)).toBeInTheDocument();
+      expect(screen.getByText(/due date/i).querySelector("span")).toHaveTextContent("*");
     });
   });
 

--- a/src/features/applications/components/MilestoneItem.tsx
+++ b/src/features/applications/components/MilestoneItem.tsx
@@ -8,8 +8,13 @@ import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MILESTONE_ITEM_FIELD_REQUIRED } from "@/features/applications/lib/schema-builders/milestone-schema";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import type { MilestoneData } from "@/types/whitelabel-entities";
+
+/** Renders a trailing required-indicator asterisk for required sub-fields only. */
+const RequiredMark = ({ required }: { required: boolean }) =>
+  required ? <span className="text-destructive"> *</span> : null;
 
 interface MilestoneItemProps {
   index: number;
@@ -87,7 +92,10 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`milestone-title-${index}`}>Title *</Label>
+        <Label htmlFor={`milestone-title-${index}`}>
+          Title
+          <RequiredMark required={MILESTONE_ITEM_FIELD_REQUIRED.title} />
+        </Label>
         <Input
           id={`milestone-title-${index}`}
           placeholder="Enter milestone title"
@@ -108,12 +116,15 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
         value={milestone.description}
         onChange={(value) => handleFieldChange("description", value)}
         isDisabled={disabled}
-        isRequired
+        isRequired={MILESTONE_ITEM_FIELD_REQUIRED.description}
         error={errors?.description?.message}
       />
 
       <div className="space-y-2">
-        <span className="text-sm font-medium">Due Date *</span>
+        <span className="text-sm font-medium">
+          Due Date
+          <RequiredMark required={MILESTONE_ITEM_FIELD_REQUIRED.dueDate} />
+        </span>
         <DatePicker
           selected={dueDateAsDate}
           onSelect={handleDueDateSelect}
@@ -129,7 +140,10 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`milestone-funding-${index}`}>Funding Requested *</Label>
+        <Label htmlFor={`milestone-funding-${index}`}>
+          Funding Requested
+          <RequiredMark required={MILESTONE_ITEM_FIELD_REQUIRED.fundingRequested} />
+        </Label>
         <Input
           id={`milestone-funding-${index}`}
           placeholder="e.g., $5,000 USD or 5000"
@@ -150,7 +164,7 @@ export const MilestoneItem: React.FC<MilestoneItemProps> = ({
         value={milestone.completionCriteria || ""}
         onChange={(value) => handleFieldChange("completionCriteria", value)}
         isDisabled={disabled}
-        isRequired
+        isRequired={MILESTONE_ITEM_FIELD_REQUIRED.completionCriteria}
         error={errors?.completionCriteria?.message}
       />
 

--- a/src/features/applications/components/__tests__/MilestoneItem.test.tsx
+++ b/src/features/applications/components/__tests__/MilestoneItem.test.tsx
@@ -33,6 +33,27 @@ describe("MilestoneItem", () => {
     expect(screen.getByTestId("milestone-title-input-0")).toHaveValue("Test Milestone");
   });
 
+  it("derives required indicators from the schema: description has no asterisk, others do (#1179)", () => {
+    render(
+      <MilestoneItem
+        index={0}
+        milestone={mockMilestone}
+        onUpdate={mockOnUpdate}
+        onRemove={mockOnRemove}
+        canRemove={true}
+      />
+    );
+
+    // Required sub-fields keep their asterisk.
+    expect(screen.getByText("Title").parentElement?.textContent).toContain("*");
+    expect(screen.getByText("Due Date").parentElement?.textContent).toContain("*");
+    expect(screen.getByText("Funding Requested").parentElement?.textContent).toContain("*");
+    expect(screen.getByText("Completion Criteria").textContent).toContain("*");
+
+    // Description is optional now, so its label must NOT advertise an asterisk.
+    expect(screen.getByText("Description").textContent).not.toContain("*");
+  });
+
   it("should display milestoneUID when present", () => {
     const milestoneWithUID: MilestoneData = {
       ...mockMilestone,

--- a/src/features/applications/lib/schema-builders/__tests__/milestone-schema.test.ts
+++ b/src/features/applications/lib/schema-builders/__tests__/milestone-schema.test.ts
@@ -70,6 +70,23 @@ describe("buildMilestoneSchema — required sub-fields", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts a milestone with an empty description (#1179)", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+
+    const result = schema.safeParse([{ ...validMilestone, description: "" }]);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a milestone missing description entirely (#1179)", () => {
+    const schema = buildMilestoneSchema(baseQuestion);
+    const { description: _drop, ...withoutDescription } = validMilestone;
+
+    const result = schema.safeParse([withoutDescription]);
+
+    expect(result.success).toBe(true);
+  });
+
   it("applies required sub-field validation even on optional milestone arrays", () => {
     // When the milestone field is itself optional but a user adds a
     // milestone, the new row's sub-fields must still meet the schema.

--- a/src/features/applications/lib/schema-builders/milestone-schema.ts
+++ b/src/features/applications/lib/schema-builders/milestone-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ApplicationQuestion } from "@/types/whitelabel-entities";
+import { optionalString, requiredString } from "@/utilities/validation/zod-primitives";
 
 const MAX_YEAR = new Date().getFullYear() + 10;
 
@@ -36,13 +37,48 @@ const futureDateSchema = dateStringSchema.refine(
   { message: "Due date must be today or in the future" }
 );
 
+/**
+ * Sub-field shape for a single milestone row in the public applicant flow.
+ *
+ * Required-ness is declared ONCE here using the shared `requiredString` /
+ * `optionalString` primitives, and the UI (`MilestoneItem`) derives its
+ * asterisks/`isRequired` indicators from `MILESTONE_ITEM_FIELD_REQUIRED` below
+ * so the schema and the visual indicator can never disagree.
+ *
+ * Issue #1179: `description` is `optionalString()` — an applicant can submit a
+ * milestone without a description. This matches PR #1174's product intent and
+ * the FundingPlatform admin/edit path (see
+ * `components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas.ts`).
+ *
+ * Note: `dueDate` keeps its bespoke future-date union here (the FundingPlatform
+ * path validates dates differently), so this object is composed locally rather
+ * than imported wholesale from the FundingPlatform schema.
+ */
 const milestoneSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().min(1, "Description is required"),
+  title: requiredString("Title", { messages: { required: "Title is required" } }),
+  description: optionalString(),
   dueDate: z.union([futureDateSchema, z.date()]),
-  fundingRequested: z.string().min(1, "Milestone funding requested is required"),
-  completionCriteria: z.string().min(1, "Completion criteria is required"),
+  fundingRequested: requiredString("Milestone funding requested", {
+    messages: { required: "Milestone funding requested is required" },
+  }),
+  completionCriteria: requiredString("Completion criteria", {
+    messages: { required: "Completion criteria is required" },
+  }),
 });
+
+/**
+ * Single source of truth for which milestone sub-fields are required in the
+ * public applicant flow. Derived from `milestoneSchema` so the UI indicator and
+ * the validation rule are guaranteed to stay in sync.
+ */
+export const MILESTONE_ITEM_FIELD_REQUIRED: Record<keyof z.infer<typeof milestoneSchema>, boolean> =
+  {
+    title: !milestoneSchema.shape.title.isOptional(),
+    description: !milestoneSchema.shape.description.isOptional(),
+    dueDate: !milestoneSchema.shape.dueDate.isOptional(),
+    fundingRequested: !milestoneSchema.shape.fundingRequested.isOptional(),
+    completionCriteria: !milestoneSchema.shape.completionCriteria.isOptional(),
+  };
 
 export function buildMilestoneSchema(q: ApplicationQuestion) {
   const minMilestones = q.validation?.minMilestones || (q.required ? 1 : 0);

--- a/src/features/program-registry/schemas/base.ts
+++ b/src/features/program-registry/schemas/base.ts
@@ -1,15 +1,24 @@
 import { z } from "zod";
+import { requiredString } from "@/utilities/validation/zod-primitives";
 
 /**
  * Base schema fields shared between create and update program forms.
  * Used by both admin (CreateProgramModal, ProgramDetailsTab) and public (AddProgram) schemas.
  */
 export const baseProgramFields = {
-  name: z
-    .string()
-    .min(3, { message: "Program name must be at least 3 characters" })
-    .max(50, { message: "Program name must be at most 50 characters" }),
-  description: z.string().min(3, { message: "Description is required" }),
+  name: requiredString("Program name", {
+    min: 3,
+    max: 50,
+    messages: {
+      required: "Program name is required",
+      min: "Program name must be at least 3 characters",
+      max: "Program name must be at most 50 characters",
+    },
+  }),
+  description: requiredString("Description", {
+    min: 3,
+    messages: { min: "Description must be at least 3 characters" },
+  }),
   shortDescription: z
     .string()
     .max(100, { message: "Short description must be at most 100 characters" })

--- a/src/features/program-registry/schemas/public-form.ts
+++ b/src/features/program-registry/schemas/public-form.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { MESSAGES } from "@/utilities/messages";
 import { urlRegex } from "@/utilities/regexs/urlRegex";
+import { requiredString } from "@/utilities/validation/zod-primitives";
 
 /**
  * Preprocessor for optional numeric fields.
@@ -101,10 +102,15 @@ export const createProgramSchema = z
     acceleratorMeta: acceleratorMetadataSchema,
     vcFundMeta: vcFundMetadataSchema,
     rfpMeta: rfpMetadataSchema,
-    name: z
-      .string()
-      .min(3, { message: MESSAGES.REGISTRY.FORM.NAME.MIN })
-      .max(50, { message: MESSAGES.REGISTRY.FORM.NAME.MAX }),
+    name: requiredString("Name", {
+      min: 3,
+      max: 50,
+      messages: {
+        required: MESSAGES.REGISTRY.FORM.NAME.REQUIRED,
+        min: MESSAGES.REGISTRY.FORM.NAME.MIN,
+        max: MESSAGES.REGISTRY.FORM.NAME.MAX,
+      },
+    }),
     dates: z
       .object({
         endsAt: z.date().optional(),
@@ -205,8 +211,12 @@ export const createProgramSchema = z
       .optional()
       .or(z.literal("")),
     amountDistributed: optionalNumber,
-    description: z.string().min(3, {
-      message: MESSAGES.REGISTRY.FORM.DESCRIPTION,
+    description: requiredString("Description", {
+      min: 3,
+      messages: {
+        required: MESSAGES.REGISTRY.FORM.DESCRIPTION_REQUIRED,
+        min: MESSAGES.REGISTRY.FORM.DESCRIPTION,
+      },
     }),
     networkToCreate: optionalNumber,
     budget: optionalNumber,

--- a/utilities/messages.ts
+++ b/utilities/messages.ts
@@ -383,9 +383,11 @@ export const MESSAGES = {
   REGISTRY: {
     FORM: {
       NAME: {
+        REQUIRED: "Name is required",
         MIN: "Name must be at least 3 characters",
         MAX: "Name must be less than 50 characters",
       },
+      DESCRIPTION_REQUIRED: "Description is required",
       DESCRIPTION: "Description must be at least 3 characters",
       BUDGET: "You need to specify a budget",
       AMOUNT_DISTRIBUTED: "You need to specify an amount distributed to date",

--- a/utilities/validation/__tests__/zod-primitives.test.ts
+++ b/utilities/validation/__tests__/zod-primitives.test.ts
@@ -1,0 +1,122 @@
+import {
+  optionalEmail,
+  optionalString,
+  optionalUrl,
+  requiredString,
+  requiredUrl,
+} from "../zod-primitives";
+
+function firstError(result: {
+  success: boolean;
+  error?: { issues: { message: string }[] };
+}): string {
+  if (result.success) throw new Error("expected validation to fail");
+  return result.error!.issues[0].message;
+}
+
+describe("zod-primitives", () => {
+  describe("requiredString", () => {
+    it("reports the required message for an empty value (not the length message)", () => {
+      const schema = requiredString("Name", { min: 3 });
+      expect(firstError(schema.safeParse(""))).toBe("Name is required");
+    });
+
+    it("reports the required message for whitespace-only input", () => {
+      const schema = requiredString("Name", { min: 3 });
+      expect(firstError(schema.safeParse("   "))).toBe("Name is required");
+    });
+
+    it("reports the min-length message for a too-short non-empty value", () => {
+      const schema = requiredString("Name", { min: 3 });
+      expect(firstError(schema.safeParse("ab"))).toBe("Name must be at least 3 characters");
+    });
+
+    it("accepts a valid value and trims it", () => {
+      const schema = requiredString("Name", { min: 3 });
+      const result = schema.safeParse("  Alice  ");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toBe("Alice");
+    });
+
+    it("honours a custom required message override", () => {
+      const schema = requiredString("Name", {
+        min: 3,
+        messages: { required: "Please tell us your name" },
+      });
+      expect(firstError(schema.safeParse(""))).toBe("Please tell us your name");
+    });
+
+    it("honours custom min/max message overrides while keeping required precedence", () => {
+      const schema = requiredString("Title", {
+        min: 3,
+        max: 5,
+        messages: { min: "Too short", max: "Too long" },
+      });
+      expect(firstError(schema.safeParse(""))).toBe("Title is required");
+      expect(firstError(schema.safeParse("ab"))).toBe("Too short");
+      expect(firstError(schema.safeParse("abcdef"))).toBe("Too long");
+    });
+  });
+
+  describe("optionalString", () => {
+    it("accepts the empty string", () => {
+      expect(optionalString().safeParse("").success).toBe(true);
+    });
+
+    it("accepts undefined", () => {
+      expect(optionalString().safeParse(undefined).success).toBe(true);
+    });
+
+    it("accepts a normal value", () => {
+      expect(optionalString().safeParse("hello").success).toBe(true);
+    });
+  });
+
+  describe("requiredUrl", () => {
+    it("reports the required message for an empty value", () => {
+      expect(firstError(requiredUrl("Runtime URL").safeParse(""))).toBe("Runtime URL is required");
+    });
+
+    it("reports the invalid message for a malformed URL", () => {
+      expect(firstError(requiredUrl("Runtime URL").safeParse("not-a-valid-url"))).toBe(
+        "Please enter a valid URL"
+      );
+    });
+
+    it("accepts a valid URL", () => {
+      expect(requiredUrl("Runtime URL").safeParse("https://team-acme.karma.xyz").success).toBe(
+        true
+      );
+    });
+  });
+
+  describe("optionalUrl", () => {
+    it("accepts empty/undefined", () => {
+      expect(optionalUrl().safeParse("").success).toBe(true);
+      expect(optionalUrl().safeParse(undefined).success).toBe(true);
+    });
+
+    it("rejects a malformed URL", () => {
+      expect(optionalUrl().safeParse("not a url").success).toBe(false);
+    });
+
+    it("accepts a valid URL", () => {
+      expect(optionalUrl().safeParse("https://example.com").success).toBe(true);
+    });
+  });
+
+  describe("optionalEmail", () => {
+    it("accepts empty/undefined", () => {
+      expect(optionalEmail().safeParse("").success).toBe(true);
+      expect(optionalEmail().safeParse(undefined).success).toBe(true);
+    });
+
+    it("accepts a valid email", () => {
+      expect(optionalEmail().safeParse("user@example.com").success).toBe(true);
+    });
+
+    it("rejects an invalid email", () => {
+      expect(optionalEmail().safeParse("nope").success).toBe(false);
+    });
+  });
+});

--- a/utilities/validation/__tests__/zod-primitives.test.ts
+++ b/utilities/validation/__tests__/zod-primitives.test.ts
@@ -70,6 +70,24 @@ describe("zod-primitives", () => {
     it("accepts a normal value", () => {
       expect(optionalString().safeParse("hello").success).toBe(true);
     });
+
+    it("still accepts the empty string when min/max are supplied", () => {
+      const schema = optionalString({ min: 3, max: 5 });
+      expect(schema.safeParse("").success).toBe(true);
+      expect(schema.safeParse(undefined).success).toBe(true);
+    });
+
+    it("enforces min/max on non-empty values", () => {
+      const schema = optionalString({
+        min: 3,
+        max: 5,
+        minMessage: "Too short",
+        maxMessage: "Too long",
+      });
+      expect(firstError(schema.safeParse("ab"))).toBe("Too short");
+      expect(firstError(schema.safeParse("abcdef"))).toBe("Too long");
+      expect(schema.safeParse("abcd").success).toBe(true);
+    });
   });
 
   describe("requiredUrl", () => {

--- a/utilities/validation/zod-primitives.ts
+++ b/utilities/validation/zod-primitives.ts
@@ -16,7 +16,7 @@ import { urlRegex } from "@/utilities/regexs/urlRegex";
  * and so `z.infer` resolves to `string` for form typing.
  */
 
-export interface RequiredStringMessages {
+interface RequiredStringMessages {
   /** Message when the trimmed value is empty. Defaults to "{label} is required". */
   required?: string;
   /** Message when the value is shorter than `min`. */
@@ -25,7 +25,7 @@ export interface RequiredStringMessages {
   max?: string;
 }
 
-export interface RequiredStringOptions {
+interface RequiredStringOptions {
   min?: number;
   max?: number;
   messages?: RequiredStringMessages;
@@ -57,7 +57,7 @@ export function requiredString(label: string, options: RequiredStringOptions = {
   return schema;
 }
 
-export interface OptionalStringOptions {
+interface OptionalStringOptions {
   min?: number;
   max?: number;
   /** Message when a non-empty value is shorter than `min`. */

--- a/utilities/validation/zod-primitives.ts
+++ b/utilities/validation/zod-primitives.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { urlRegex } from "@/utilities/regexs/urlRegex";
+
+/**
+ * Shared Zod validation primitives — the single source of truth for the
+ * required/optional/length/url/email idioms that were previously re-invented
+ * (and frequently mis-ordered) in every form across the app.
+ *
+ * Key invariant: a `required` field whose value is empty ALWAYS reports a
+ * "{label} is required" message, never a length message. This is enforced by
+ * chaining `.trim().min(1, required)` BEFORE any length `.min(...)`, so the
+ * required check fails first for empty/whitespace input.
+ *
+ * The builders intentionally return the concrete Zod types (`ZodString`, etc.)
+ * rather than a widened `ZodType` so callers can keep chaining (e.g. `.regex`)
+ * and so `z.infer` resolves to `string` for form typing.
+ */
+
+export interface RequiredStringMessages {
+  /** Message when the trimmed value is empty. Defaults to "{label} is required". */
+  required?: string;
+  /** Message when the value is shorter than `min`. */
+  min?: string;
+  /** Message when the value is longer than `max`. */
+  max?: string;
+}
+
+export interface RequiredStringOptions {
+  min?: number;
+  max?: number;
+  messages?: RequiredStringMessages;
+}
+
+/**
+ * A required, trimmed string.
+ *
+ * - Empty / whitespace-only input -> `"{label} is required"` (or `messages.required`).
+ * - Shorter than `min` -> `messages.min` (or a sensible default).
+ * - Longer than `max` -> `messages.max` (or a sensible default).
+ */
+export function requiredString(label: string, options: RequiredStringOptions = {}): z.ZodString {
+  const { min, max, messages } = options;
+  const requiredMessage = messages?.required ?? `${label} is required`;
+
+  let schema = z.string().trim().min(1, requiredMessage);
+
+  if (min !== undefined && min > 1) {
+    const minMessage = messages?.min ?? `${label} must be at least ${min} characters`;
+    schema = schema.min(min, minMessage);
+  }
+
+  if (max !== undefined) {
+    const maxMessage = messages?.max ?? `${label} must be at most ${max} characters`;
+    schema = schema.max(max, maxMessage);
+  }
+
+  return schema;
+}
+
+export interface OptionalStringOptions {
+  min?: number;
+  max?: number;
+  /** Message when a non-empty value is shorter than `min`. */
+  minMessage?: string;
+  /** Message when a value is longer than `max`. */
+  maxMessage?: string;
+}
+
+/**
+ * An optional string that also accepts the empty string. Encapsulates the
+ * `.optional().or(z.literal(""))` idiom duplicated across ~11 schemas.
+ *
+ * When `min`/`max` are supplied the constraints apply only to non-empty values
+ * (the empty string short-circuits via the `z.literal("")` branch).
+ */
+export function optionalString(options: OptionalStringOptions = {}) {
+  const { min, max, minMessage, maxMessage } = options;
+
+  let base = z.string();
+  if (min !== undefined) {
+    base = base.min(min, minMessage ?? `Must be at least ${min} characters`);
+  }
+  if (max !== undefined) {
+    base = base.max(max, maxMessage ?? `Must be at most ${max} characters`);
+  }
+
+  return base.optional().or(z.literal(""));
+}
+
+/**
+ * A required URL validated against the shared `urlRegex`. Empty input reports
+ * the required message; a malformed value reports the URL message.
+ */
+export function requiredUrl(
+  label: string,
+  messages?: { required?: string; invalid?: string }
+): z.ZodString {
+  const requiredMessage = messages?.required ?? `${label} is required`;
+  const invalidMessage = messages?.invalid ?? "Please enter a valid URL";
+
+  return z.string().trim().min(1, requiredMessage).regex(urlRegex, invalidMessage);
+}
+
+/**
+ * An optional URL: accepts empty/undefined, otherwise must match `urlRegex`.
+ */
+export function optionalUrl(invalidMessage = "Please enter a valid URL") {
+  return z.string().trim().regex(urlRegex, invalidMessage).optional().or(z.literal(""));
+}
+
+/**
+ * An optional email: accepts empty/undefined, otherwise must be a valid email.
+ */
+export function optionalEmail(invalidMessage = "Please enter a valid email") {
+  return z.union([z.literal(""), z.email(invalidMessage)]).optional();
+}


### PR DESCRIPTION
## Summary

Form validation across the funding/application forms had required-ness declared ad-hoc in multiple unconnected places, so the Zod schema (which the resolver enforces) and the visible required indicator (asterisks / `isRequired`) could disagree. The headline symptom (#1179) was milestone submission being blocked by a "Milestone description is required" error even though the UI advertised the description as optional.

This change introduces a single source of truth for required/optional/length/url/email string validation and makes every required indicator a projection of the schema, so the rule and the indicator can never drift apart again.

## Root cause

Required-ness was hand-maintained in two layers that were not connected:

- The Zod schemas enforced by `zodResolver` declared `.min(1, "... is required")` per field.
- The UI components separately hardcoded asterisks and `isRequired` props.

On top of that, the **same milestone form existed twice** — once in the FundingPlatform admin/edit path and once in the public whitelabel applicant flow — and the two copies disagreed on whether `description` was required. The public apply flow (the place an end user actually hits) still required the description, so #1179 remained reproducible there.

## What changed

- **Shared Zod primitives** (`utilities/validation/zod-primitives.ts`): `requiredString`, `optionalString`, `requiredUrl`, `optionalUrl`, `optionalEmail`. `requiredString` chains `.trim().min(1, "{label} is required")` BEFORE any length `.min`, so empty input always reports "is required" and never a length message (#1506).
- **Repeatable milestone/metric schemas extracted** to `components/FundingPlatform/ApplicationView/lib/repeatable-item-schemas.ts`. `description` is now `optionalString()`. `MILESTONE_FIELD_REQUIRED` / `METRIC_FIELD_REQUIRED` are derived from the schema; `MilestoneInput`/`MetricInput` render asterisks and `isRequired` from those maps, and the dead per-`Controller` `rules={{ required }}` props (ignored under `zodResolver`) were removed.
- **Public applicant milestone flow migrated** (`src/features/applications/lib/schema-builders/milestone-schema.ts`, `src/features/applications/components/MilestoneItem.tsx`): milestone sub-field validators now use the shared `requiredString`/`optionalString` primitives, `description` is optional, and `MilestoneItem` derives its asterisks from the new `MILESTONE_ITEM_FIELD_REQUIRED` map. This closes the second, live copy of the #1179 bug so both milestone paths now agree.
- **Onboarding page migrated** (`app/ai-teams/onboarding/page.tsx` + `onboarding-schema.ts`) from raw `useState` + truthy `canSubmit` to `useForm` + `zodResolver` with inline `aria-invalid`/`aria-describedby` errors; the existing `useProvisionOrg` React Query mutation and error panel are preserved and the submit button gates only on `isPending` (#1426).
- **Program registry + contributor dialog** schemas (`src/features/program-registry/schemas/public-form.ts`, `base.ts`, `components/Dialogs/ContributorProfileDialog.tsx`) use `requiredString`, with new `MESSAGES.REGISTRY.FORM.NAME.REQUIRED` / `DESCRIPTION_REQUIRED` so empty fields read "is required" while length messages are preserved (#1506, #1508).

## Testing

- Targeted Vitest across the touched schemas/components/pages (zod-primitives, repeatable-item-schemas, milestone-schema, MilestoneItem, MilestoneInput, MetricInput, onboarding, ContributorProfileDialog, programFormSchema, ApplicationSubmission, CreateProgramModal, ProgramDetailsTab) — all green, including new cases proving the public apply flow accepts an empty/missing milestone description and that the description label no longer renders an asterisk while required fields still do.
- `tsc --noEmit` on the whole project: 0 errors.
- Biome on all changed files: clean.

Closes #1179, #1426, #1506, #1508
