### PR TITLE
ci: add structural simplification section to PR review rules

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -376,6 +376,17 @@ jobs:
             - Bug fixes without regression tests
             - Tests that test implementation details instead of behavior
 
+            ### 🟡 11. Structural Simplification (MEDIUM — advisory)
+            Look for "code judo" moves: restructurings that preserve behavior while making the change simpler. Only report a finding here if you can show the concrete simpler version in the Fix field — "this could be simpler" without showing how is not a finding. Diff-only applies doubly: never demand refactors of untouched code.
+            - A simpler reframing that would eliminate whole branches, modes, props, or helpers introduced by this diff
+            - Boolean/one-off flags bolted into code paths unrelated to their feature: model the variation as a variant or dedicated abstraction instead
+            - Feature-specific logic added into shared components, hooks, or utilities — keep shared code generic
+            - Thin wrapper components/hooks that only delegate, adding a layer without adding behavior or a meaningful boundary
+            - Generic "magic" abstractions built for a single call site: inline until a second consumer exists
+            - Refactor churn: moving code between files without reducing conceptual load
+            - 🟠 HIGH escalation (only these two): a file crossing 1000 lines as a result of this diff (extract subcomponents/hooks/modules), or a copy-pasted block of 10+ lines instead of extracting
+            - Cap: at most 5 structural findings per review, highest impact only. These are suggestions — never CRITICAL, and they must never drive REQUEST CHANGES on their own.
+
             ---
 
             ## Event-Specific Behavior


### PR DESCRIPTION
## Overview

Adds section **🟡 11. Structural Simplification (MEDIUM — advisory)** to the CI PR review rules in `.github/workflows/claude.yml`.

## Problem

The review's 10 existing rule sections are checklist-driven: they catch waterfalls, bundle issues, component-architecture and TypeScript violations, but never ask whether the change itself could be structurally simpler. Nothing flags files sprawling past healthy size boundaries, one-off boolean props/flags bolted into unrelated code paths, feature logic leaking into shared components/hooks, or thin wrappers that add a layer without adding behavior.

## Solution

A new section 11 in `custom_instructions` covering:

- Simpler reframings that would eliminate whole branches, modes, props, or helpers introduced by the diff
- One-off flags bolted into unrelated code paths (model as a variant or dedicated abstraction)
- Feature-specific logic added into shared components, hooks, or utilities
- Thin wrapper components/hooks that only delegate
- Single-call-site "magic" abstractions (inline until a second consumer exists)
- Refactor churn (moving code without reducing conceptual load)

No `direct_prompt` change was needed — it already reviews against all `custom_instructions` rules.

## Why This Approach

The lens is adapted from Cursor's [thermo-nuclear-code-quality-review](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md) skill, but its original calibration ("disapprove unless there are no missing simplification opportunities") is built for on-demand deep audits, not per-PR CI — run unmodified it would request changes on nearly every PR. So the section is deliberately **advisory**:

- 🟡 MEDIUM by default; 🟠 HIGH only for a file crossing 1000 lines via this diff or a 10+ line copy-pasted block; never CRITICAL — so it can move a verdict from APPROVE to APPROVE WITH SUGGESTIONS but cannot drive REQUEST CHANGES
- A finding is only valid with the concrete simpler version shown in the Fix field
- Capped at 5 findings per review, highest impact only
- Diff-only applies doubly: no refactor demands on untouched code

With the existing -3/MEDIUM scoring, the cap bounds this section at ~15 points of a PR score.

A companion change adds the same lens to gap-indexer as a 4th parallel review agent: show-karma/gap-indexer#2060

## Testing Steps

1. YAML validated with `yaml.safe_load` on the modified workflow
2. After merge: open any non-draft PR and confirm structural findings appear as 🟡 MEDIUM advisory items grouped under the standard issue format, without affecting REQUEST CHANGES behavior

## Checklist

- [x] Workflow YAML parses
- [x] Verdict logic unchanged — REQUEST CHANGES still requires a CRITICAL finding
- [x] Section follows the existing rule-section format (severity emoji, bullet triggers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development review processes and guidelines to better categorize and prioritize feedback types.

---

**Note:** This release contains no end-user facing changes. Updates are limited to internal development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->