### PR TITLE
fix(e2e): update homepage smoke test for the three-audience landing

### DIFF
--- a/e2e/tests/smoke/health.smoke.spec.ts
+++ b/e2e/tests/smoke/health.smoke.spec.ts
@@ -8,23 +8,20 @@ test.describe("Smoke Tests — Health", () => {
   test("T35-01: homepage loads and shows main content", async ({ page, withApiMocks }) => {
     const jsErrors = collectJsErrors(page);
 
-    await withApiMocks({
-      "**/v2/communities/stats**": mockJson({
-        totalCommunities: 12,
-        totalProjects: 340,
-        totalGrants: 150,
-      }),
-    });
+    await withApiMocks();
     await page.goto("/", GOTO_OPTIONS);
     await waitForPageReady(page);
 
-    // The homepage hero heading should be visible
+    // The hero heading should be visible — its accessible name comes from
+    // the sr-only span (the rotating-word variant is aria-hidden)
     await expect(
-      page.getByRole("heading", { name: /funding software that does the work/i }).first()
+      page.getByRole("heading", { name: /karma helps funders fund and track/i }).first()
     ).toBeVisible();
 
-    // The FAQ section should be present on the homepage
-    await expect(page.getByText(/frequently asked/i)).toBeVisible();
+    // The workflow section should be present on the homepage
+    await expect(
+      page.getByRole("heading", { name: /one platform for two motions/i })
+    ).toBeVisible();
 
     assertNoJsErrors(jsErrors);
   });


### PR DESCRIPTION
## Overview

Fixes the `smoke` check that is currently red on **every open PR** in this repo.

## Problem

`T35-01: homepage loads and shows main content` still asserts the old homepage: the hero heading /funding software that does the work/i and the FAQ section. Since #1598 reworked `/` into the three-audience landing, that hero lives on `/foundations` and the FAQ section is no longer rendered on the homepage — so the test fails on every branch (12/12 most recent smoke runs across different PRs are failures).

## Solution

- Assert the new hero heading via its accessible name: /karma helps funders fund and track/i — the accessible name comes from the sr-only span, since the visible rotating-word variant is `aria-hidden`
- Assert the workflow section heading /one platform for two motions/i instead of the removed FAQ section
- Drop the `**/v2/communities/stats**` mock that fed the removed numbers section (`withApiMocks()` default is what every other smoke test uses)

## Testing Steps

1. The `smoke` check on this PR is the test: T35-01 should pass against the Vercel preview while the other 84 smoke assertions stay green
2. Locally: `pnpm test:e2e -- e2e/tests/smoke/health.smoke.spec.ts`

## Risk

Test-only change; no runtime code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated homepage smoke test assertions to verify interface visibility through accessible role and name checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->