### PR TITLE
feat(find-funders): show feedback card at end of search results

### DIFF
--- a/src/features/non-profits/__tests__/search-feedback.test.tsx
+++ b/src/features/non-profits/__tests__/search-feedback.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchFeedback } from "../components/search-feedback";
+
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
+
+vi.mock("../hooks/use-feedback", () => ({
+  useSubmitFeedback: () => ({ mutate, isPending: false }),
+}));
+
+describe("SearchFeedback", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+  });
+
+  it("renders the rating prompt and both controls", () => {
+    render(<SearchFeedback traceId="t1" />);
+
+    expect(screen.getByText("How were these results?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Helpful results" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Not helpful results" })).toBeInTheDocument();
+  });
+
+  it("submits positive feedback with value 1 on Helpful", () => {
+    render(<SearchFeedback traceId="trace-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Helpful results" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { traceId: "trace-1", value: 1 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it("does not re-submit positive feedback once selected", () => {
+    render(<SearchFeedback traceId="trace-2" />);
+
+    const button = screen.getByRole("button", { name: "Helpful results" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a comment box on Not helpful and submits value -1 with the comment", () => {
+    render(<SearchFeedback traceId="trace-3" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Not helpful results" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "missing midwest funders" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit feedback" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { traceId: "trace-3", value: -1, comment: "missing midwest funders" },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it("caps the comment at 2000 characters", () => {
+    render(<SearchFeedback traceId="trace-4" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Not helpful results" }));
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "x".repeat(2500) } });
+
+    expect(textarea.value).toHaveLength(2000);
+  });
+
+  it("clears the comment and resets selection on Cancel", () => {
+    render(<SearchFeedback traceId="trace-5" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Not helpful results" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Not helpful results" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("shows a confirmation and hides the controls after a successful submission", () => {
+    mutate.mockImplementation((_vars, opts) => opts?.onSuccess?.());
+    render(<SearchFeedback traceId="trace-6" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Helpful results" }));
+
+    expect(screen.getByText(/Thanks for the feedback/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Helpful results" })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -319,7 +319,9 @@ const AssistantTurn = memo(function AssistantTurn({
           <EntityList entities={[...turn.entities]} searchId={searchId} />
         )}
         {turn.attachments.length > 0 && <AttachmentsPanel attachments={[...turn.attachments]} />}
-        {turn.status === "done" && turn.traceId && <SearchFeedback traceId={turn.traceId} />}
+        {turn.status === "done" && turn.traceId && (
+          <SearchFeedback key={turn.traceId} traceId={turn.traceId} />
+        )}
       </MessageContent>
     </Message>
   );

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -70,6 +70,7 @@ import { BookmarksDrawer } from "./bookmarks-drawer";
 import { ConnectorNudge } from "./connector-nudge";
 import { NarrativeBlock } from "./narrative-block";
 import { ProgressView } from "./progress-view";
+import { SearchFeedback } from "./search-feedback";
 import { SearchHistoryPanel } from "./search-history-panel";
 
 // ── Entity presentation constants ──────────────────────────────────────────
@@ -312,17 +313,13 @@ const AssistantTurn = memo(function AssistantTurn({
         )}
         {isStreaming && turn.progress && <ProgressView progress={turn.progress} />}
         {hasNarrative && (
-          <NarrativeBlock
-            narrative={turn.narrative}
-            entities={[...turn.entities]}
-            traceId={turn.traceId}
-            status={turn.status}
-          />
+          <NarrativeBlock narrative={turn.narrative} entities={[...turn.entities]} />
         )}
         {turn.entities.length > 0 && (
           <EntityList entities={[...turn.entities]} searchId={searchId} />
         )}
         {turn.attachments.length > 0 && <AttachmentsPanel attachments={[...turn.attachments]} />}
+        {turn.status === "done" && turn.traceId && <SearchFeedback traceId={turn.traceId} />}
       </MessageContent>
     </Message>
   );

--- a/src/features/non-profits/components/narrative-block.tsx
+++ b/src/features/non-profits/components/narrative-block.tsx
@@ -1,168 +1,23 @@
 "use client";
 
-import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useMemo } from "react";
 import { MessageResponse } from "@/src/components/ai-elements/message-response";
-import { useSubmitFeedback } from "../hooks/use-feedback";
 import { linkifyNarrative } from "../lib/linkify-narrative";
-import type { ChatTurn } from "../store/philanthropy";
 import type { RankedEntity } from "../types/philanthropy";
 
 interface NarrativeBlockProps {
   narrative: string;
   entities: RankedEntity[];
-  traceId: string | null;
-  status: ChatTurn["status"];
 }
 
 export const NarrativeBlock = memo(function NarrativeBlock({
   narrative,
   entities,
-  traceId,
-  status,
 }: NarrativeBlockProps) {
-  const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
-  const [commentOpen, setCommentOpen] = useState(false);
-  const [comment, setComment] = useState("");
-  const [submitted, setSubmitted] = useState(false);
-  const { mutate: submitFeedback, isPending: isSending } = useSubmitFeedback();
-
-  // Reset feedback UI whenever the traceId changes (new search).
-  useEffect(() => {
-    setFeedback(null);
-    setCommentOpen(false);
-    setComment("");
-    setSubmitted(false);
-  }, [traceId]);
-
   const linked = useMemo(
     () => (entities.length > 0 ? linkifyNarrative(narrative, entities) : narrative),
     [narrative, entities]
   );
 
-  const showFeedback = Boolean(traceId) && status === "done";
-
-  const handleThumbsUp = useCallback(() => {
-    if (!traceId || isSending || feedback === "up") return;
-    setFeedback("up");
-    setCommentOpen(false);
-    submitFeedback(
-      { traceId, value: 1 },
-      {
-        onSuccess: () => setSubmitted(true),
-      }
-    );
-  }, [traceId, isSending, feedback, submitFeedback]);
-
-  const handleThumbsDown = useCallback(() => {
-    if (!traceId || isSending) return;
-    if (feedback === "down") {
-      setCommentOpen((v) => !v);
-      return;
-    }
-    setFeedback("down");
-    setCommentOpen(true);
-    setSubmitted(false);
-  }, [traceId, isSending, feedback]);
-
-  const handleSubmitComment = useCallback(() => {
-    if (!traceId || isSending) return;
-    submitFeedback(
-      { traceId, value: -1, comment },
-      {
-        onSuccess: () => {
-          setSubmitted(true);
-          setCommentOpen(false);
-          setComment("");
-        },
-      }
-    );
-  }, [traceId, isSending, submitFeedback, comment]);
-
-  const handleCancelComment = useCallback(() => {
-    setCommentOpen(false);
-    setComment("");
-    if (!submitted) setFeedback(null);
-  }, [submitted]);
-
-  return (
-    <div>
-      <MessageResponse>{linked}</MessageResponse>
-      {showFeedback && (
-        <div className="mt-2">
-          {submitted && (
-            <output className="mb-2 block text-xs text-brand dark:text-brand-subtle">
-              Thanks for your feedback!
-            </output>
-          )}
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={handleThumbsUp}
-              aria-label="Helpful"
-              aria-pressed={feedback === "up"}
-              disabled={isSending}
-              className={`rounded-lg p-1.5 transition-colors ${
-                feedback === "up"
-                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
-                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-              }`}
-            >
-              <ThumbsUp className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={handleThumbsDown}
-              aria-label="Not helpful"
-              aria-pressed={feedback === "down"}
-              disabled={isSending}
-              className={`rounded-lg p-1.5 transition-colors ${
-                feedback === "down"
-                  ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
-                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-              }`}
-            >
-              <ThumbsDown className="size-3.5" />
-            </button>
-          </div>
-          {commentOpen && traceId && (
-            <div className="mt-2 rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
-              <label
-                htmlFor={`feedback-comment-${traceId}`}
-                className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
-              >
-                What went wrong? (optional)
-              </label>
-              <textarea
-                id={`feedback-comment-${traceId}`}
-                value={comment}
-                onChange={(e) => setComment(e.target.value.slice(0, 2000))}
-                rows={2}
-                maxLength={2000}
-                placeholder="Tell us what was missing or inaccurate..."
-                className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
-              />
-              <div className="mt-2 flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={handleCancelComment}
-                  className="rounded-md px-2.5 py-1 text-xs text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={handleSubmitComment}
-                  disabled={isSending}
-                  className="rounded-md bg-brand px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
-                >
-                  {isSending ? "Sending..." : "Submit"}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
+  return <MessageResponse>{linked}</MessageResponse>;
 });

--- a/src/features/non-profits/components/search-feedback.tsx
+++ b/src/features/non-profits/components/search-feedback.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { useSubmitFeedback } from "../hooks/use-feedback";
 
 interface SearchFeedbackProps {
@@ -14,13 +14,6 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
   const [comment, setComment] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const { mutate: submitFeedback, isPending: isSending } = useSubmitFeedback();
-
-  useEffect(() => {
-    setFeedback(null);
-    setCommentOpen(false);
-    setComment("");
-    setSubmitted(false);
-  }, [traceId]);
 
   const handleThumbsUp = useCallback(() => {
     if (isSending || feedback === "up") return;
@@ -129,6 +122,7 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
           </label>
           <textarea
             id={`search-feedback-comment-${traceId}`}
+            aria-label="What was missing or inaccurate?"
             value={comment}
             onChange={(e) => setComment(e.target.value.slice(0, 2000))}
             rows={3}

--- a/src/features/non-profits/components/search-feedback.tsx
+++ b/src/features/non-profits/components/search-feedback.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { memo, useCallback, useEffect, useState } from "react";
+import { useSubmitFeedback } from "../hooks/use-feedback";
+
+interface SearchFeedbackProps {
+  traceId: string;
+}
+
+export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFeedbackProps) {
+  const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
+  const [commentOpen, setCommentOpen] = useState(false);
+  const [comment, setComment] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const { mutate: submitFeedback, isPending: isSending } = useSubmitFeedback();
+
+  useEffect(() => {
+    setFeedback(null);
+    setCommentOpen(false);
+    setComment("");
+    setSubmitted(false);
+  }, [traceId]);
+
+  const handleThumbsUp = useCallback(() => {
+    if (isSending || feedback === "up") return;
+    setFeedback("up");
+    setCommentOpen(false);
+    submitFeedback(
+      { traceId, value: 1 },
+      {
+        onSuccess: () => setSubmitted(true),
+      }
+    );
+  }, [traceId, isSending, feedback, submitFeedback]);
+
+  const handleThumbsDown = useCallback(() => {
+    if (isSending) return;
+    if (feedback === "down") {
+      setCommentOpen((v) => !v);
+      return;
+    }
+    setFeedback("down");
+    setCommentOpen(true);
+    setSubmitted(false);
+  }, [isSending, feedback]);
+
+  const handleSubmitComment = useCallback(() => {
+    if (isSending) return;
+    submitFeedback(
+      { traceId, value: -1, comment },
+      {
+        onSuccess: () => {
+          setSubmitted(true);
+          setCommentOpen(false);
+          setComment("");
+        },
+      }
+    );
+  }, [traceId, isSending, submitFeedback, comment]);
+
+  const handleCancelComment = useCallback(() => {
+    setCommentOpen(false);
+    setComment("");
+    if (!submitted) setFeedback(null);
+  }, [submitted]);
+
+  return (
+    <section
+      aria-label="Rate these results"
+      className="mt-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/40"
+    >
+      {submitted ? (
+        <output className="flex items-center gap-2 text-sm font-medium text-brand dark:text-brand-subtle">
+          <ThumbsUp className="size-4" aria-hidden="true" />
+          Thanks for the feedback, it helps us improve search quality.
+        </output>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              How were these results?
+            </p>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Your rating tunes the prospecting agent.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleThumbsUp}
+              aria-label="Helpful results"
+              aria-pressed={feedback === "up"}
+              disabled={isSending}
+              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 ${
+                feedback === "up"
+                  ? "border-emerald-300 bg-emerald-100 text-emerald-800 dark:border-emerald-700/60 dark:bg-emerald-900/40 dark:text-emerald-200"
+                  : "border-zinc-200 bg-white text-zinc-600 hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-emerald-700/60 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-200"
+              }`}
+            >
+              <ThumbsUp className="size-4" aria-hidden="true" />
+              Helpful
+            </button>
+            <button
+              type="button"
+              onClick={handleThumbsDown}
+              aria-label="Not helpful results"
+              aria-pressed={feedback === "down"}
+              disabled={isSending}
+              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 ${
+                feedback === "down"
+                  ? "border-red-300 bg-red-100 text-red-800 dark:border-red-700/60 dark:bg-red-900/40 dark:text-red-200"
+                  : "border-zinc-200 bg-white text-zinc-600 hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-red-700/60 dark:hover:bg-red-900/30 dark:hover:text-red-200"
+              }`}
+            >
+              <ThumbsDown className="size-4" aria-hidden="true" />
+              Not helpful
+            </button>
+          </div>
+        </div>
+      )}
+      {commentOpen && !submitted && (
+        <div className="mt-3 rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
+          <label
+            htmlFor={`search-feedback-comment-${traceId}`}
+            className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
+          >
+            What was missing or inaccurate? (optional)
+          </label>
+          <textarea
+            id={`search-feedback-comment-${traceId}`}
+            value={comment}
+            onChange={(e) => setComment(e.target.value.slice(0, 2000))}
+            rows={3}
+            maxLength={2000}
+            placeholder="Tell us what would have made this better..."
+            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleCancelComment}
+              className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmitComment}
+              disabled={isSending}
+              className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
+            >
+              {isSending ? "Sending..." : "Submit feedback"}
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+});

--- a/src/features/non-profits/components/search-feedback.tsx
+++ b/src/features/non-profits/components/search-feedback.tsx
@@ -8,6 +8,12 @@ interface SearchFeedbackProps {
   traceId: string;
 }
 
+// Buttons live inside the find-funders `.landing` scope, whose global
+// `.landing button` reset strips background/color/border. The `!` utilities
+// below restore the platform tokens (brand / destructive) over that reset.
+const BTN_BASE =
+  "inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-40";
+
 export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFeedbackProps) {
   const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
   const [commentOpen, setCommentOpen] = useState(false);
@@ -61,14 +67,16 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
   return (
     <section
       aria-label="Rate these results"
-      className="mt-4 overflow-hidden rounded-xl border border-brand/20 bg-gradient-to-br from-brand-faint via-white to-white dark:border-brand-emphasis/25 dark:from-brand-emphasis/10 dark:via-zinc-900 dark:to-zinc-900"
+      className="mt-4 overflow-hidden rounded-xl border border-border bg-card !py-0"
     >
-      <div className="flex items-start gap-3.5 p-4">
+      <div
+        className={`flex gap-3.5 px-4 py-3 ${
+          commentOpen && !submitted ? "items-start" : "items-center"
+        }`}
+      >
         <div
-          className={`flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors ${
-            submitted
-              ? "bg-brand text-white"
-              : "bg-brand/10 text-brand-emphasis dark:bg-brand/15 dark:text-brand-subtle"
+          className={`flex size-9 shrink-0 items-center justify-center rounded-lg ${
+            submitted ? "bg-brand text-white" : "bg-brand/10 text-brand-emphasis"
           }`}
         >
           {submitted ? (
@@ -80,17 +88,15 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
 
         <div className="min-w-0 flex-1">
           {submitted ? (
-            <output className="block pt-1.5 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            <output className="block text-sm font-medium text-foreground">
               Thanks for the feedback — it helps us improve search quality.
             </output>
           ) : (
             <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2.5">
               <div className="min-w-0">
-                <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  How were these results?
-                </p>
-                <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
-                  Your rating tunes the prospecting agent.
+                <p className="text-sm font-semibold text-foreground">How were these results?</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Your feedback helps us improve the tool.
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -100,10 +106,10 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
                   aria-label="Helpful results"
                   aria-pressed={feedback === "up"}
                   disabled={isSending}
-                  className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 ${
+                  className={`${BTN_BASE} ${
                     feedback === "up"
-                      ? "border-brand bg-brand/10 text-brand-emphasis dark:border-brand/60 dark:bg-brand/15 dark:text-brand-subtle"
-                      : "border-zinc-200 bg-white text-zinc-600 hover:border-brand/50 hover:text-brand-emphasis dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-brand/50 dark:hover:text-brand-subtle"
+                      ? "!border-brand !bg-brand/10 !text-brand-emphasis"
+                      : "!border-border !bg-card !text-muted-foreground hover:!border-brand hover:!text-brand-emphasis"
                   }`}
                 >
                   <ThumbsUp className="size-3.5" aria-hidden="true" />
@@ -115,10 +121,10 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
                   aria-label="Not helpful results"
                   aria-pressed={feedback === "down"}
                   disabled={isSending}
-                  className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 ${
+                  className={`${BTN_BASE} ${
                     feedback === "down"
-                      ? "border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-700/60 dark:bg-rose-900/30 dark:text-rose-200"
-                      : "border-zinc-200 bg-white text-zinc-600 hover:border-rose-300 hover:text-rose-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-rose-700/60 dark:hover:text-rose-200"
+                      ? "!border-destructive !bg-destructive/10 !text-destructive"
+                      : "!border-border !bg-card !text-muted-foreground hover:!border-destructive hover:!text-destructive"
                   }`}
                 >
                   <ThumbsDown className="size-3.5" aria-hidden="true" />
@@ -129,10 +135,10 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
           )}
 
           {commentOpen && !submitted && (
-            <div className="mt-3 border-t border-brand/15 pt-3 dark:border-brand-emphasis/20">
+            <div className="mt-3 border-t border-border pt-3">
               <label
                 htmlFor={`search-feedback-comment-${traceId}`}
-                className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
+                className="mb-1.5 block text-xs font-medium text-muted-foreground"
               >
                 What was missing or inaccurate? (optional)
               </label>
@@ -144,13 +150,13 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
                 rows={3}
                 maxLength={2000}
                 placeholder="Tell us what would have made this better..."
-                className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand/30 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
+                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-sm !text-foreground placeholder:text-muted-foreground focus:!border-brand focus:outline-none"
               />
               <div className="mt-2 flex justify-end gap-2">
                 <button
                   type="button"
                   onClick={handleCancelComment}
-                  className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                  className="rounded-md px-3 py-1.5 text-xs font-medium !text-muted-foreground transition-colors hover:!bg-muted"
                 >
                   Cancel
                 </button>
@@ -158,7 +164,7 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
                   type="button"
                   onClick={handleSubmitComment}
                   disabled={isSending}
-                  className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
+                  className="rounded-md !bg-brand px-3 py-1.5 text-xs font-medium !text-white transition-colors hover:!bg-brand-emphasis disabled:opacity-40"
                 >
                   {isSending ? "Sending..." : "Submit feedback"}
                 </button>

--- a/src/features/non-profits/components/search-feedback.tsx
+++ b/src/features/non-profits/components/search-feedback.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { Check, MessageSquare, ThumbsDown, ThumbsUp } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import { useSubmitFeedback } from "../hooks/use-feedback";
 
@@ -61,94 +61,112 @@ export const SearchFeedback = memo(function SearchFeedback({ traceId }: SearchFe
   return (
     <section
       aria-label="Rate these results"
-      className="mt-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/40"
+      className="mt-4 overflow-hidden rounded-xl border border-brand/20 bg-gradient-to-br from-brand-faint via-white to-white dark:border-brand-emphasis/25 dark:from-brand-emphasis/10 dark:via-zinc-900 dark:to-zinc-900"
     >
-      {submitted ? (
-        <output className="flex items-center gap-2 text-sm font-medium text-brand dark:text-brand-subtle">
-          <ThumbsUp className="size-4" aria-hidden="true" />
-          Thanks for the feedback, it helps us improve search quality.
-        </output>
-      ) : (
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-              How were these results?
-            </p>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">
-              Your rating tunes the prospecting agent.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleThumbsUp}
-              aria-label="Helpful results"
-              aria-pressed={feedback === "up"}
-              disabled={isSending}
-              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 ${
-                feedback === "up"
-                  ? "border-emerald-300 bg-emerald-100 text-emerald-800 dark:border-emerald-700/60 dark:bg-emerald-900/40 dark:text-emerald-200"
-                  : "border-zinc-200 bg-white text-zinc-600 hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-emerald-700/60 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-200"
-              }`}
-            >
-              <ThumbsUp className="size-4" aria-hidden="true" />
-              Helpful
-            </button>
-            <button
-              type="button"
-              onClick={handleThumbsDown}
-              aria-label="Not helpful results"
-              aria-pressed={feedback === "down"}
-              disabled={isSending}
-              className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 ${
-                feedback === "down"
-                  ? "border-red-300 bg-red-100 text-red-800 dark:border-red-700/60 dark:bg-red-900/40 dark:text-red-200"
-                  : "border-zinc-200 bg-white text-zinc-600 hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-red-700/60 dark:hover:bg-red-900/30 dark:hover:text-red-200"
-              }`}
-            >
-              <ThumbsDown className="size-4" aria-hidden="true" />
-              Not helpful
-            </button>
-          </div>
+      <div className="flex items-start gap-3.5 p-4">
+        <div
+          className={`flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors ${
+            submitted
+              ? "bg-brand text-white"
+              : "bg-brand/10 text-brand-emphasis dark:bg-brand/15 dark:text-brand-subtle"
+          }`}
+        >
+          {submitted ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <MessageSquare className="size-4" aria-hidden="true" />
+          )}
         </div>
-      )}
-      {commentOpen && !submitted && (
-        <div className="mt-3 rounded-lg border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900">
-          <label
-            htmlFor={`search-feedback-comment-${traceId}`}
-            className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
-          >
-            What was missing or inaccurate? (optional)
-          </label>
-          <textarea
-            id={`search-feedback-comment-${traceId}`}
-            aria-label="What was missing or inaccurate?"
-            value={comment}
-            onChange={(e) => setComment(e.target.value.slice(0, 2000))}
-            rows={3}
-            maxLength={2000}
-            placeholder="Tell us what would have made this better..."
-            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
-          />
-          <div className="mt-2 flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={handleCancelComment}
-              className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmitComment}
-              disabled={isSending}
-              className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
-            >
-              {isSending ? "Sending..." : "Submit feedback"}
-            </button>
-          </div>
+
+        <div className="min-w-0 flex-1">
+          {submitted ? (
+            <output className="block pt-1.5 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              Thanks for the feedback — it helps us improve search quality.
+            </output>
+          ) : (
+            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2.5">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  How were these results?
+                </p>
+                <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+                  Your rating tunes the prospecting agent.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleThumbsUp}
+                  aria-label="Helpful results"
+                  aria-pressed={feedback === "up"}
+                  disabled={isSending}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 ${
+                    feedback === "up"
+                      ? "border-brand bg-brand/10 text-brand-emphasis dark:border-brand/60 dark:bg-brand/15 dark:text-brand-subtle"
+                      : "border-zinc-200 bg-white text-zinc-600 hover:border-brand/50 hover:text-brand-emphasis dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-brand/50 dark:hover:text-brand-subtle"
+                  }`}
+                >
+                  <ThumbsUp className="size-3.5" aria-hidden="true" />
+                  Helpful
+                </button>
+                <button
+                  type="button"
+                  onClick={handleThumbsDown}
+                  aria-label="Not helpful results"
+                  aria-pressed={feedback === "down"}
+                  disabled={isSending}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 ${
+                    feedback === "down"
+                      ? "border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-700/60 dark:bg-rose-900/30 dark:text-rose-200"
+                      : "border-zinc-200 bg-white text-zinc-600 hover:border-rose-300 hover:text-rose-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-rose-700/60 dark:hover:text-rose-200"
+                  }`}
+                >
+                  <ThumbsDown className="size-3.5" aria-hidden="true" />
+                  Not helpful
+                </button>
+              </div>
+            </div>
+          )}
+
+          {commentOpen && !submitted && (
+            <div className="mt-3 border-t border-brand/15 pt-3 dark:border-brand-emphasis/20">
+              <label
+                htmlFor={`search-feedback-comment-${traceId}`}
+                className="mb-1.5 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
+              >
+                What was missing or inaccurate? (optional)
+              </label>
+              <textarea
+                id={`search-feedback-comment-${traceId}`}
+                aria-label="What was missing or inaccurate?"
+                value={comment}
+                onChange={(e) => setComment(e.target.value.slice(0, 2000))}
+                rows={3}
+                maxLength={2000}
+                placeholder="Tell us what would have made this better..."
+                className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 placeholder-zinc-400 focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand/30 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500"
+              />
+              <div className="mt-2 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleCancelComment}
+                  className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSubmitComment}
+                  disabled={isSending}
+                  className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-emphasis disabled:opacity-40"
+                >
+                  {isSending ? "Sending..." : "Submit feedback"}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </section>
   );
 });


### PR DESCRIPTION
## Summary

- Move the thumbs up/down feedback out of `NarrativeBlock` into a new `SearchFeedback` component rendered at the **bottom** of each completed assistant turn (after the entity list and attachments).
- The previous placement attached the controls to the narrative paragraph, which sat above long lists of nonprofit/foundation/grant cards. The buttons were scrolled off-screen by the time a user finished reviewing results, so almost no ratings were captured.
- The new card has a labeled prompt ("How were these results?"), full-width "Helpful" / "Not helpful" buttons, and the existing thumbs-down comment textarea. State resets when `traceId` changes (new search).

## Backend wiring

No backend changes. The component still calls `useSubmitFeedback` → `POST /v2/agent/rating`, which Langfuse records as a `user_rating` score on the `philanthropy-agent-query` trace.

## Test plan

- [ ] Run a /nonprofits/find-funders search and scroll to the end of the results — feedback card is visible right below the entity list.
- [ ] Click "Helpful" — card flips to "Thanks for the feedback…" and a `user_rating = 1` score appears in Langfuse on the trace.
- [ ] Click "Not helpful" — comment textarea appears. Submit with or without a comment — `user_rating = -1` recorded; comment is encoded into the Langfuse score comment alongside `[user:<wallet>]`.
- [ ] Issue a new search in the same session — feedback state resets (no stale "Thanks…" message).
- [ ] Card does not render while a search is streaming or on an error turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now provide feedback on search results through thumbs up/down ratings with optional comments.

* **Refactor**
  * Internal feedback component reorganization for improved separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->