### PR TITLE
Restrict project creation networks to Base, Optimism, Celo

### DIFF
--- a/__tests__/components/Dialogs/ProjectDialog.test.tsx
+++ b/__tests__/components/Dialogs/ProjectDialog.test.tsx
@@ -352,6 +352,11 @@ vi.mock("@/utilities/network", () => ({
     { id: 10, name: "Optimism" },
     { id: 42161, name: "Arbitrum" },
   ],
+  projectCreationNetworks: [
+    { id: 10, name: "Optimism" },
+    { id: 8453, name: "Base" },
+    { id: 42220, name: "Celo" },
+  ],
 }));
 
 vi.mock("@/utilities/pages", () => ({

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -57,7 +57,7 @@ import fetchData from "@/utilities/fetchData";
 import { validateGithubInput } from "@/utilities/github";
 import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
-import { gapSupportedNetworks } from "@/utilities/network";
+import { projectCreationNetworks } from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
 import { sanitizeObject } from "@/utilities/sanitize";
 import { getProjectById } from "@/utilities/sdk";
@@ -1543,7 +1543,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                 }}
                 onNetworkChange={handleNetworkChange}
                 isChangingNetwork={isChangingNetwork}
-                networks={gapSupportedNetworks}
+                networks={projectCreationNetworks}
                 previousValue={watch("chainID")}
               />
               <p className="text-red-500">{errors.chainID?.message}</p>

--- a/utilities/network.ts
+++ b/utilities/network.ts
@@ -60,6 +60,22 @@ export const gapSupportedNetworks = appNetwork.filter(
 ) as [Chain, ...Chain[]];
 
 /**
+ * Networks shown in the project creation network selector.
+ *
+ * This is intentionally a curated subset of `gapSupportedNetworks`: every chain
+ * in `gapSupportedNetworks` still works everywhere else (existing projects,
+ * attestations, etc.), but new projects can only be created on these networks.
+ *
+ * NOTE: This is a UI/availability restriction only — do NOT remove the other
+ * chains from `appNetwork`/`gapSupportedNetworks`, they remain fully supported.
+ */
+const projectCreationChainIds: number[] = [optimism.id, base.id, celo.id];
+
+export const projectCreationNetworks = gapSupportedNetworks.filter((chain) =>
+  projectCreationChainIds.includes(chain.id)
+) as [Chain, ...Chain[]];
+
+/**
  * Networks where projects can configure payout addresses for donations.
  * Includes all app networks (including mainnet) since donations don't require
  * GAP SDK/attestation support - only the batch donations contract deployment.


### PR DESCRIPTION
## What

Limits the network selector shown when **creating a new project** to only **Base**, **Optimism**, and **Celo**.

## Why

In production the project-creation dropdown lists many networks. We want new projects to be created only on Base, Optimism, and Celo — without dropping support for the other networks anywhere else.

## How

- Added a curated `projectCreationNetworks` constant in `utilities/network.ts`, derived by filtering `gapSupportedNetworks` down to `[optimism, base, celo]`.
- `components/Dialogs/ProjectDialog/index.tsx` now passes `projectCreationNetworks` to the `NetworkDropdown` instead of `gapSupportedNetworks`.

## Important — no config removed

This is a **UI/availability restriction only**. `appNetwork` and `gapSupportedNetworks` are untouched, so all other networks continue to work everywhere else (existing projects, attestations, donations, etc.). They are simply not offered as options when creating a *new* project.

https://claude.ai/code/session_018XmjQXJqDTmJ3xZF9kCijJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018XmjQXJqDTmJ3xZF9kCijJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creation now supports a curated set of blockchain networks: Optimism, Base, and Celo. The network selection interface has been updated to reflect this specific network availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->