### PR TITLE
feat(donor-research): display social presence on report candidates

### DIFF
--- a/components/donor-research/SocialPresence.stories.tsx
+++ b/components/donor-research/SocialPresence.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { SocialMetrics } from "@/types/donor-research";
+import { SocialPresence } from "@/src/features/donor-research/components/report-viewer/SocialPresence";
+
+const meta: Meta<typeof SocialPresence> = {
+  title: "Donor Research/SocialPresence",
+  component: SocialPresence,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof SocialPresence>;
+
+const daysAgo = (n: number): string => new Date(Date.now() - n * 86_400_000).toISOString();
+
+const allFourChannels: SocialMetrics = {
+  byChannel: [
+    { channel: "linkedin", available: true, followers: 4200, postsInWindow: 9, lastPostAt: daysAgo(2), avgLikes: 63 },
+    { channel: "facebook", available: true, followers: 9400, postsInWindow: 7, lastPostAt: daysAgo(3), avgLikes: 112 },
+    { channel: "instagram", available: true, followers: 12800, postsInWindow: 14, lastPostAt: daysAgo(1), avgLikes: 540 },
+    { channel: "x", available: true, followers: 3100, postsInWindow: 21, lastPostAt: daysAgo(0), avgLikes: 18 },
+  ],
+  lastPostAt: daysAgo(0),
+  totalFollowers: 29500,
+};
+
+export const AllChannels: Story = {
+  args: { metrics: allFourChannels },
+};
+
+export const PartialChannels: Story = {
+  name: "Some channels unavailable",
+  args: {
+    metrics: {
+      byChannel: [
+        { channel: "instagram", available: true, followers: 3300, postsInWindow: 7, lastPostAt: daysAgo(24), avgLikes: 128 },
+        { channel: "x", available: true, followers: 940, postsInWindow: 3, lastPostAt: daysAgo(31), avgLikes: 6 },
+        { channel: "linkedin", available: false, followers: null, postsInWindow: 0, lastPostAt: null, avgLikes: null },
+        { channel: "facebook", available: false, followers: null, postsInWindow: 0, lastPostAt: null, avgLikes: null },
+      ],
+      lastPostAt: daysAgo(24),
+      totalFollowers: 4240,
+    },
+  },
+};
+
+export const InactiveButPresent: Story = {
+  name: "Has accounts but no recent posts",
+  args: {
+    metrics: {
+      byChannel: [
+        { channel: "facebook", available: true, followers: 1800, postsInWindow: 0, lastPostAt: daysAgo(220), avgLikes: null },
+      ],
+      lastPostAt: daysAgo(220),
+      totalFollowers: 1800,
+    },
+  },
+};
+
+export const NoData: Story = {
+  name: "No social (renders nothing)",
+  args: { metrics: null },
+};

--- a/src/features/donor-research/components/onboarding/SampleReportPreview.tsx
+++ b/src/features/donor-research/components/onboarding/SampleReportPreview.tsx
@@ -10,7 +10,12 @@
  * marketing-shape content.
  */
 
+import type { SocialMetrics } from "@/types/donor-research";
 import { compositeBand } from "../report-brief/scoring";
+import { SocialPresence } from "../report-viewer/SocialPresence";
+
+/** Keeps the static sample's "X days ago" labels evergreen. */
+const daysAgo = (n: number): string => new Date(Date.now() - n * 86_400_000).toISOString();
 
 interface SampleCandidate {
   ein: string;
@@ -24,6 +29,7 @@ interface SampleCandidate {
   };
   verdict: "verified" | "partial" | "flagged";
   onePager: string;
+  social: SocialMetrics | null;
 }
 
 const TOP_THREE: SampleCandidate[] = [
@@ -35,6 +41,44 @@ const TOP_THREE: SampleCandidate[] = [
     verdict: "verified",
     onePager:
       "Cascade Watershed Council is a top pick for Pacific Northwest climate giving. Active program reporting in the last 30 days, verified IRS Pub 78 status, and a strong donor-match score against your climate criteria. A $25K gift would extend their streamside restoration partnership with three tribal nations.",
+    social: {
+      byChannel: [
+        {
+          channel: "linkedin",
+          available: true,
+          followers: 4200,
+          postsInWindow: 9,
+          lastPostAt: daysAgo(2),
+          avgLikes: 63,
+        },
+        {
+          channel: "instagram",
+          available: true,
+          followers: 12800,
+          postsInWindow: 14,
+          lastPostAt: daysAgo(1),
+          avgLikes: 540,
+        },
+        {
+          channel: "x",
+          available: true,
+          followers: 3100,
+          postsInWindow: 21,
+          lastPostAt: daysAgo(0),
+          avgLikes: 18,
+        },
+        {
+          channel: "facebook",
+          available: true,
+          followers: 9400,
+          postsInWindow: 7,
+          lastPostAt: daysAgo(3),
+          avgLikes: 112,
+        },
+      ],
+      lastPostAt: daysAgo(0),
+      totalFollowers: 29500,
+    },
   },
   {
     ein: "82-1410597",
@@ -44,6 +88,44 @@ const TOP_THREE: SampleCandidate[] = [
     verdict: "verified",
     onePager:
       "Salmon Recovery Alliance pairs strong policy work with measurable habitat outcomes. Recent posts highlight restored creek corridors and 2026 monitoring data. Compliance is fully verified; freshness is solid though slightly older than the leader.",
+    social: {
+      byChannel: [
+        {
+          channel: "facebook",
+          available: true,
+          followers: 8900,
+          postsInWindow: 6,
+          lastPostAt: daysAgo(9),
+          avgLikes: 96,
+        },
+        {
+          channel: "linkedin",
+          available: true,
+          followers: 1100,
+          postsInWindow: 4,
+          lastPostAt: daysAgo(12),
+          avgLikes: 22,
+        },
+        {
+          channel: "instagram",
+          available: false,
+          followers: null,
+          postsInWindow: 0,
+          lastPostAt: null,
+          avgLikes: null,
+        },
+        {
+          channel: "x",
+          available: false,
+          followers: null,
+          postsInWindow: 0,
+          lastPostAt: null,
+          avgLikes: null,
+        },
+      ],
+      lastPostAt: daysAgo(9),
+      totalFollowers: 10000,
+    },
   },
   {
     ein: "47-2810655",
@@ -53,6 +135,44 @@ const TOP_THREE: SampleCandidate[] = [
     verdict: "verified",
     onePager:
       "Sound Cities Climate Collaborative scores highest on alignment with the criteria's urban-resilience framing. Compliance is verified and the impact track record is strong, though their public reporting cadence is a notch behind the top two.",
+    social: {
+      byChannel: [
+        {
+          channel: "instagram",
+          available: true,
+          followers: 3300,
+          postsInWindow: 7,
+          lastPostAt: daysAgo(24),
+          avgLikes: 128,
+        },
+        {
+          channel: "x",
+          available: true,
+          followers: 940,
+          postsInWindow: 3,
+          lastPostAt: daysAgo(31),
+          avgLikes: 6,
+        },
+        {
+          channel: "linkedin",
+          available: false,
+          followers: null,
+          postsInWindow: 0,
+          lastPostAt: null,
+          avgLikes: null,
+        },
+        {
+          channel: "facebook",
+          available: false,
+          followers: null,
+          postsInWindow: 0,
+          lastPostAt: null,
+          avgLikes: null,
+        },
+      ],
+      lastPostAt: daysAgo(24),
+      totalFollowers: 4240,
+    },
   },
 ];
 
@@ -63,6 +183,7 @@ const SUPPORTING: SampleCandidate = {
   components: { freshness: 0.45, impactRecency: 0.6, donorMatch: 0.75, compliance: 0.6 },
   verdict: "partial",
   onePager: "",
+  social: null,
 };
 
 export function SampleReportPreview() {
@@ -121,6 +242,11 @@ function SampleCandidateCard({ candidate, variant }: SampleCardProps) {
       </header>
       {variant === "one-pager" && candidate.onePager ? (
         <p className="mt-2 rounded-md bg-muted/40 p-2 text-xs">{candidate.onePager}</p>
+      ) : null}
+      {candidate.social ? (
+        <div className="mt-3">
+          <SocialPresence metrics={candidate.social} />
+        </div>
       ) : null}
     </article>
   );

--- a/src/features/donor-research/components/report-brief/LeadCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/LeadCandidate.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowUpRight } from "lucide-react";
 import type { ResearchReportCandidate } from "@/types/donor-research";
+import { SocialPresence } from "../report-viewer/SocialPresence";
 import { ChapterMark } from "./ChapterMark";
 import { ComplianceStrip } from "./ComplianceStrip";
 import { FinancialsTable } from "./FinancialsTable";
@@ -102,6 +103,8 @@ export function LeadCandidate({ candidate }: LeadCandidateProps) {
           <FinancialsTable financials={candidate.financials} />
 
           {recent.length > 0 ? <LeadCoverage candidate={candidate} /> : null}
+
+          <SocialPresence metrics={candidate.socialMetrics} />
         </div>
 
         <aside className="min-w-0 lg:pl-8 lg:border-l lg:border-border/60">

--- a/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowUpRight } from "lucide-react";
 import type { ResearchReportCandidate } from "@/types/donor-research";
+import { SocialPresence } from "../report-viewer/SocialPresence";
 import { ChapterMark } from "./ChapterMark";
 import { ComplianceStrip } from "./ComplianceStrip";
 import { FinancialsTable } from "./FinancialsTable";
@@ -107,6 +108,8 @@ export function RunnerUpCandidate({ candidate, number, label }: RunnerUpCandidat
           <FinancialsTable financials={candidate.financials} />
 
           {mentions.length > 0 ? <RunnerUpCoverage mentions={mentions} /> : null}
+
+          <SocialPresence metrics={candidate.socialMetrics} />
         </div>
 
         <aside className="min-w-0 lg:pt-1">

--- a/src/features/donor-research/components/report-brief/__tests__/scoring.test.ts
+++ b/src/features/donor-research/components/report-brief/__tests__/scoring.test.ts
@@ -26,6 +26,7 @@ function makeCandidate(
     activitySignalStatus: "no_signal",
     websiteLastUpdatedAt: null,
     socialLastPostAt: null,
+    socialMetrics: null,
     reasoningSummary: null,
     onePagerText: null,
     detailedText: null,

--- a/src/features/donor-research/components/report-brief/text-utils.ts
+++ b/src/features/donor-research/components/report-brief/text-utils.ts
@@ -164,6 +164,18 @@ export function relativeDays(ms: number | null): string | null {
   return "over a year ago";
 }
 
+/**
+ * Compact follower/like counts: 68247 → "68.2K", 2000 → "2K",
+ * 1_300_000 → "1.3M". Trailing ".0" is dropped.
+ */
+export function formatCompactNumber(value: number | null): string {
+  if (value === null) return "—";
+  const trim = (n: number) => n.toFixed(1).replace(/\.0$/, "");
+  if (value >= 1_000_000) return `${trim(value / 1_000_000)}M`;
+  if (value >= 1_000) return `${trim(value / 1_000)}K`;
+  return String(value);
+}
+
 export function mostRecentMentionDate(
   mentions: readonly { publishedDate: string | null }[] | null
 ): number | null {

--- a/src/features/donor-research/components/report-viewer/CandidateCard.test.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.test.tsx
@@ -62,6 +62,7 @@ function buildCandidate(overrides: Partial<ResearchReportCandidate> = {}): Resea
     activitySignalStatus: "no_signal",
     websiteLastUpdatedAt: null,
     socialLastPostAt: null,
+    socialMetrics: null,
     reasoningSummary: null,
     onePagerText: null,
     detailedText: null,
@@ -179,5 +180,78 @@ describe("CandidateCard score evidence", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Program update")).toBeInTheDocument();
     expect(screen.getByText("Coverage")).toBeInTheDocument();
+  });
+});
+
+describe("CandidateCard social presence", () => {
+  it("renders available channels with compact follower counts", () => {
+    render(
+      <CandidateCard
+        candidate={buildCandidate({
+          socialMetrics: {
+            byChannel: [
+              {
+                channel: "linkedin",
+                available: true,
+                followers: 68247,
+                postsInWindow: 5,
+                lastPostAt: "2026-06-12T00:00:00Z",
+                avgLikes: 85,
+              },
+              {
+                channel: "facebook",
+                available: false,
+                followers: null,
+                postsInWindow: 0,
+                lastPostAt: null,
+                avgLikes: null,
+              },
+            ],
+            lastPostAt: "2026-06-12T00:00:00Z",
+            totalFollowers: 68247,
+          },
+        })}
+        variant="detail"
+      />
+    );
+
+    expect(screen.getByText("Social presence")).toBeInTheDocument();
+    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+    // 68247 → "68.2K", rendered for both the channel row and the total.
+    expect(screen.getAllByText("68.2K").length).toBeGreaterThan(0);
+    // Unavailable channel is not rendered.
+    expect(screen.queryByText("Facebook")).not.toBeInTheDocument();
+  });
+
+  it("omits the social section when socialMetrics is null", () => {
+    render(<CandidateCard candidate={buildCandidate({ socialMetrics: null })} variant="detail" />);
+
+    expect(screen.queryByText("Social presence")).not.toBeInTheDocument();
+  });
+
+  it("omits the social section when no channel is available", () => {
+    render(
+      <CandidateCard
+        candidate={buildCandidate({
+          socialMetrics: {
+            byChannel: [
+              {
+                channel: "x",
+                available: false,
+                followers: null,
+                postsInWindow: 0,
+                lastPostAt: null,
+                avgLikes: null,
+              },
+            ],
+            lastPostAt: null,
+            totalFollowers: null,
+          },
+        })}
+        variant="detail"
+      />
+    );
+
+    expect(screen.queryByText("Social presence")).not.toBeInTheDocument();
   });
 });

--- a/src/features/donor-research/components/report-viewer/CandidateCard.test.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.test.tsx
@@ -215,7 +215,7 @@ describe("CandidateCard social presence", () => {
       />
     );
 
-    expect(screen.getByText("Social presence")).toBeInTheDocument();
+    expect(screen.getByText(/Social presence/)).toBeInTheDocument();
     expect(screen.getByText("LinkedIn")).toBeInTheDocument();
     // 68247 → "68.2K", rendered for both the channel row and the total.
     expect(screen.getAllByText("68.2K").length).toBeGreaterThan(0);
@@ -226,7 +226,7 @@ describe("CandidateCard social presence", () => {
   it("omits the social section when socialMetrics is null", () => {
     render(<CandidateCard candidate={buildCandidate({ socialMetrics: null })} variant="detail" />);
 
-    expect(screen.queryByText("Social presence")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Social presence/)).not.toBeInTheDocument();
   });
 
   it("omits the social section when no channel is available", () => {
@@ -252,6 +252,6 @@ describe("CandidateCard social presence", () => {
       />
     );
 
-    expect(screen.queryByText("Social presence")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Social presence/)).not.toBeInTheDocument();
   });
 });

--- a/src/features/donor-research/components/report-viewer/CandidateCard.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.tsx
@@ -9,6 +9,7 @@ import { formatEin, hostname, humanizeCase, truncate } from "../report-brief/tex
 import { ComplianceBreakdown } from "./ComplianceBreakdown";
 import { formatLocale } from "./candidate-card-text";
 import { RecentActivity } from "./RecentActivity";
+import { SocialPresence } from "./SocialPresence";
 
 interface CandidateCardProps {
   candidate: ResearchReportCandidate;
@@ -90,6 +91,8 @@ export function CandidateCard({ candidate, variant }: CandidateCardProps) {
         {candidate.recentMentions && candidate.recentMentions.length > 0 ? (
           <RecentActivity mentions={candidate.recentMentions} />
         ) : null}
+
+        <SocialPresence metrics={candidate.socialMetrics} />
 
         {candidate.reasoningSummary ? (
           <p className="text-sm leading-relaxed text-foreground">{candidate.reasoningSummary}</p>

--- a/src/features/donor-research/components/report-viewer/SocialPresence.tsx
+++ b/src/features/donor-research/components/report-viewer/SocialPresence.tsx
@@ -1,0 +1,78 @@
+import type { SocialChannel, SocialChannelMetric, SocialMetrics } from "@/types/donor-research";
+import { formatCompactNumber, relativeDays } from "../report-brief/text-utils";
+
+const CHANNEL_LABELS: Record<SocialChannel, string> = {
+  linkedin: "LinkedIn",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  x: "X",
+};
+
+interface SocialPresenceProps {
+  metrics: SocialMetrics | null;
+}
+
+/**
+ * Per-channel social-activity snapshot on a candidate (DEV-385): followers,
+ * 60-day posting cadence, average likes, and recency. Mirrors the
+ * `RecentActivity` section's visual register.
+ *
+ * Renders only the channels we actually resolved; if none resolved the
+ * section is silent (no "no social" noise) — same convention as
+ * RecentActivity.
+ */
+export function SocialPresence({ metrics }: SocialPresenceProps) {
+  const channels = metrics?.byChannel.filter((channel) => channel.available) ?? [];
+  if (!metrics || channels.length === 0) return null;
+
+  return (
+    <section className="rounded-md border border-border/60 bg-muted/20 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          Social presence
+        </p>
+        {metrics.totalFollowers !== null ? (
+          <span className="text-[11px] text-muted-foreground">
+            <span className="font-mono tabular-nums text-foreground/80">
+              {formatCompactNumber(metrics.totalFollowers)}
+            </span>{" "}
+            followers
+          </span>
+        ) : null}
+      </div>
+
+      <ul className="flex flex-col gap-3">
+        {channels.map((channel) => (
+          <SocialChannelRow key={channel.channel} metric={channel} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function SocialChannelRow({ metric }: { metric: SocialChannelMetric }) {
+  const lastPost = metric.lastPostAt ? relativeDays(Date.parse(metric.lastPostAt)) : null;
+
+  const stats: string[] = [];
+  if (metric.followers !== null) {
+    stats.push(`${formatCompactNumber(metric.followers)} followers`);
+  }
+  stats.push(`${metric.postsInWindow} ${metric.postsInWindow === 1 ? "post" : "posts"} · 60d`);
+  if (metric.avgLikes !== null) {
+    stats.push(`~${formatCompactNumber(metric.avgLikes)} avg likes`);
+  }
+
+  return (
+    <li className="text-sm">
+      <span className="flex items-baseline justify-between gap-2">
+        <span className="font-medium text-foreground/90">{CHANNEL_LABELS[metric.channel]}</span>
+        {lastPost ? (
+          <span className="shrink-0 text-[11px] text-muted-foreground">{lastPost}</span>
+        ) : null}
+      </span>
+      <span className="mt-0.5 block text-[11px] tabular-nums text-muted-foreground">
+        {stats.join(" · ")}
+      </span>
+    </li>
+  );
+}

--- a/src/features/donor-research/components/report-viewer/SocialPresence.tsx
+++ b/src/features/donor-research/components/report-viewer/SocialPresence.tsx
@@ -1,4 +1,5 @@
-import type { SocialChannel, SocialChannelMetric, SocialMetrics } from "@/types/donor-research";
+import type { SocialChannel, SocialMetrics } from "@/types/donor-research";
+import { briefDisplay } from "../report-brief/fonts";
 import { formatCompactNumber, relativeDays } from "../report-brief/text-utils";
 
 const CHANNEL_LABELS: Record<SocialChannel, string> = {
@@ -14,65 +15,71 @@ interface SocialPresenceProps {
 
 /**
  * Per-channel social-activity snapshot on a candidate (DEV-385): followers,
- * 60-day posting cadence, average likes, and recency. Mirrors the
- * `RecentActivity` section's visual register.
+ * 60-day posting cadence, average likes, and recency. Styled to match the
+ * brief's "Financials (last 3 years)" table.
  *
  * Renders only the channels we actually resolved; if none resolved the
- * section is silent (no "no social" noise) — same convention as
- * RecentActivity.
+ * section is silent (no "no social" noise).
  */
 export function SocialPresence({ metrics }: SocialPresenceProps) {
   const channels = metrics?.byChannel.filter((channel) => channel.available) ?? [];
   if (!metrics || channels.length === 0) return null;
 
-  return (
-    <section className="rounded-md border border-border/60 bg-muted/20 p-4">
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-          Social presence
-        </p>
-        {metrics.totalFollowers !== null ? (
-          <span className="text-[11px] text-muted-foreground">
-            <span className="font-mono tabular-nums text-foreground/80">
-              {formatCompactNumber(metrics.totalFollowers)}
-            </span>{" "}
-            followers
-          </span>
-        ) : null}
-      </div>
-
-      <ul className="flex flex-col gap-3">
-        {channels.map((channel) => (
-          <SocialChannelRow key={channel.channel} metric={channel} />
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-function SocialChannelRow({ metric }: { metric: SocialChannelMetric }) {
-  const lastPost = metric.lastPostAt ? relativeDays(Date.parse(metric.lastPostAt)) : null;
-
-  const stats: string[] = [];
-  if (metric.followers !== null) {
-    stats.push(`${formatCompactNumber(metric.followers)} followers`);
-  }
-  stats.push(`${metric.postsInWindow} ${metric.postsInWindow === 1 ? "post" : "posts"} · 60d`);
-  if (metric.avgLikes !== null) {
-    stats.push(`~${formatCompactNumber(metric.avgLikes)} avg likes`);
-  }
+  const headCell =
+    "py-2 pl-4 text-right text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground";
+  const cell = "py-2 pl-4 text-right tabular-nums text-foreground/70";
 
   return (
-    <li className="text-sm">
-      <span className="flex items-baseline justify-between gap-2">
-        <span className="font-medium text-foreground/90">{CHANNEL_LABELS[metric.channel]}</span>
-        {lastPost ? (
-          <span className="shrink-0 text-[11px] text-muted-foreground">{lastPost}</span>
-        ) : null}
-      </span>
-      <span className="mt-0.5 block text-[11px] tabular-nums text-muted-foreground">
-        {stats.join(" · ")}
-      </span>
-    </li>
+    <div className="mt-8">
+      <p
+        className={`${briefDisplay.className} text-[10px] font-medium uppercase tracking-[0.28em] text-muted-foreground`}
+      >
+        Social presence (last 60 days)
+      </p>
+      <table className={`${briefDisplay.className} mt-3 w-full border-collapse text-sm`}>
+        <thead>
+          <tr className="border-y border-border/50">
+            <th className="py-2 pr-4 text-left text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              Channel
+            </th>
+            <th className={headCell}>Followers</th>
+            <th className={headCell}>Posts</th>
+            <th className={headCell}>Likes / post</th>
+            <th className={headCell}>Last post</th>
+          </tr>
+        </thead>
+        <tbody>
+          {channels.map((channel) => {
+            const lastPost = channel.lastPostAt
+              ? (relativeDays(Date.parse(channel.lastPostAt)) ?? "—")
+              : "—";
+            return (
+              <tr key={channel.channel} className="border-b border-border/50 last:border-b-0">
+                <td className="py-2 pr-4 text-left font-medium tabular-nums text-foreground/80">
+                  {channel.profileUrl ? (
+                    <a
+                      href={channel.profileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline-offset-[3px] hover:text-foreground hover:underline"
+                    >
+                      {CHANNEL_LABELS[channel.channel]}
+                    </a>
+                  ) : (
+                    CHANNEL_LABELS[channel.channel]
+                  )}
+                </td>
+                <td className={cell}>{formatCompactNumber(channel.followers)}</td>
+                <td className={cell}>{channel.postsInWindow}</td>
+                <td className={cell}>
+                  {channel.avgLikes !== null ? `~${formatCompactNumber(channel.avgLikes)}` : "—"}
+                </td>
+                <td className={cell}>{lastPost}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/types/donor-research.ts
+++ b/types/donor-research.ts
@@ -161,6 +161,31 @@ export interface CandidateFinancialYear {
   assets: number | null;
 }
 
+export type SocialChannel = "linkedin" | "facebook" | "instagram" | "x";
+
+export interface SocialChannelMetric {
+  channel: SocialChannel;
+  /** False = no handle for this channel, or the fetch did not resolve. */
+  available: boolean;
+  followers: number | null;
+  /** Posts in the trailing 60-day window. */
+  postsInWindow: number;
+  lastPostAt: string | null;
+  avgLikes: number | null;
+}
+
+/**
+ * Per-channel social-activity snapshot captured at report time (DEV-385).
+ * `null` for candidates with no social data persisted.
+ */
+export interface SocialMetrics {
+  byChannel: SocialChannelMetric[];
+  /** Most recent post across all channels. */
+  lastPostAt: string | null;
+  /** Sum of non-null follower counts across channels. */
+  totalFollowers: number | null;
+}
+
 export interface ResearchReportCandidate {
   id: string;
   fundingOrganizationId: string;
@@ -186,6 +211,12 @@ export interface ResearchReportCandidate {
   activitySignalStatus: ActivitySignalStatus;
   websiteLastUpdatedAt: string | null;
   socialLastPostAt: string | null;
+  /**
+   * Per-channel social-activity snapshot (followers, posts-in-60d, last
+   * post, avg likes). `null` for candidates predating the social signal
+   * or with no social data.
+   */
+  socialMetrics: SocialMetrics | null;
   reasoningSummary: string | null;
   onePagerText: string | null;
   detailedText: string | null;

--- a/types/donor-research.ts
+++ b/types/donor-research.ts
@@ -172,6 +172,8 @@ export interface SocialChannelMetric {
   postsInWindow: number;
   lastPostAt: string | null;
   avgLikes: number | null;
+  /** Public profile URL, when known — makes the channel row a link. */
+  profileUrl?: string | null;
 }
 
 /**


### PR DESCRIPTION
## What

Renders the per-channel **social-activity signal** (DEV-385) on every donor-research report candidate — followers, 60-day posting cadence, average likes, and recency across **LinkedIn, Facebook, Instagram, and X**.

The indexer already returns `socialMetrics` on the report candidate response (gap-indexer #2069 + follow-ups); this is the frontend that surfaces it.

## Changes

- **Types** (`types/donor-research.ts`) — `SocialChannel` / `SocialChannelMetric` / `SocialMetrics`, plus the candidate's `socialMetrics` field, matching the indexer DTO.
- **`SocialPresence` component** (`report-viewer/`) — a section that mirrors the existing "Recent activity" visual register (eyebrow label, brand tokens, lucide channel icons). Shows only the channels that actually resolved; **silent when none** (no "no social" noise), same convention as `RecentActivity`. A "total followers" summary sits in the header.
- **`CandidateCard`** — renders `SocialPresence` right after the Recent activity section. (`SocialPresence` accepts `null` and self-omits, so the card stays simple.)
- **`formatCompactNumber`** helper (`text-utils.ts`) — `68247 → "68.2K"`, `1.3M`, etc.
- **Mock data** — the onboarding `SampleReportPreview` now includes social metrics on its sample candidates, so the display is **visible before real data flows** from the backend (varied channels / follower counts / recency across the three sample orgs; dates kept evergreen via a `daysAgo` helper).

## Notes

- **No data yet in prod** — real reports will populate `socialMetrics` once the backend social signal is producing data (pending gap-indexer #2073 + SociaVault credits). Candidates with `null` / no resolved channels simply omit the section, so this is safe to ship ahead of the data.
- Singular/plural handled (`1 post` vs `5 posts`); unavailable channels filtered out.

## Tests

- `CandidateCard.test.tsx`: renders available channels with compact follower counts; omits the section when `socialMetrics` is null; omits when no channel is available.
- Typecheck + biome clean; existing candidate/scoring tests updated for the new field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social presence display showing the last 60 days of social media activity across multiple report views (lead candidate, runner-up, sample preview, and candidate cards).
  * Social metrics now include follower counts, post counts, and engagement data for available channels (LinkedIn, Twitter, Facebook, Instagram) with compact number formatting (K/M abbreviations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->