### PR TITLE
fix(project-dialog): retry gasless client creation and surface retryable errors

### DIFF
--- a/__tests__/unit/hooks/useZeroDevSigner-gasless-retry.test.ts
+++ b/__tests__/unit/hooks/useZeroDevSigner-gasless-retry.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @file Gasless client-creation retry tests for useZeroDevSigner.
+ *
+ * GAP-FRONTEND-23C: a transient ZeroDev bundler-RPC failure dropped an email
+ * user off the gasless path and onto a (then-broken) fallback. These tests
+ * assert the client-creation step is retried with backoff before giving up,
+ * that a deliberate GaslessProviderError is never retried, and that exhausting
+ * the retries still recovers via the embedded-direct path.
+ *
+ * Mock wiring mirrors useZeroDevSigner-chain.test.ts (module mocks are
+ * file-scoped, so it can't be shared).
+ */
+import { act, renderHook } from "@testing-library/react";
+
+const {
+  mockUseChainId,
+  mockPrivyState,
+  mockSafeGetWalletClient,
+  mockWalletClientToSigner,
+  mockGetSigner,
+} = vi.hoisted(() => ({
+  mockUseChainId: vi.fn().mockReturnValue(10),
+  mockPrivyState: {
+    ready: true as boolean,
+    user: null as MockUser | null,
+    wallets: [] as MockWallet[],
+  },
+  mockSafeGetWalletClient: vi.fn(),
+  mockWalletClientToSigner: vi.fn(),
+  mockGetSigner: vi.fn(),
+}));
+
+vi.mock("wagmi", () => ({
+  useChainId: () => mockUseChainId(),
+}));
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: vi.fn(() => ({
+    ready: mockPrivyState.ready,
+    user: mockPrivyState.user,
+    wallets: mockPrivyState.wallets,
+  })),
+}));
+
+vi.mock("@/utilities/wallet-helpers", () => ({
+  safeGetWalletClient: (...args: unknown[]) => mockSafeGetWalletClient(...args),
+}));
+
+vi.mock("@/utilities/eas-wagmi-utils", () => ({
+  walletClientToSigner: (...args: unknown[]) => mockWalletClientToSigner(...args),
+}));
+
+vi.mock("@/utilities/network", () => ({
+  appNetwork: [
+    { id: 10, name: "Optimism" },
+    { id: 42161, name: "Arbitrum" },
+  ],
+}));
+
+const mockViemCreateWalletClient = vi.fn();
+vi.mock("viem", () => ({
+  createWalletClient: (...args: unknown[]) => mockViemCreateWalletClient(...args),
+  custom: vi.fn((provider: unknown) => provider),
+}));
+
+// Chain-aware ethers BrowserProvider mock (reflects the underlying provider's chain).
+vi.mock("ethers", () => ({
+  BrowserProvider: class MockBrowserProvider {
+    _underlying: { __chainId?: number } | undefined;
+    _pinnedChainId: number | undefined;
+
+    constructor(underlying?: { __chainId?: number }, network?: { chainId?: number }) {
+      this._underlying = underlying;
+      this._pinnedChainId = network?.chainId;
+    }
+
+    getNetwork = async () => {
+      const chainId = this._pinnedChainId ?? this._underlying?.__chainId ?? 1;
+      return { chainId: BigInt(chainId) };
+    };
+
+    getSigner = async () => mockGetSigner(this);
+  },
+}));
+
+import {
+  createGaslessClient,
+  createPrivySignerForGasless,
+  GaslessProviderError,
+  getGaslessSigner,
+  isChainSupportedForGasless,
+} from "@/utilities/gasless";
+
+// Import the REAL hook via relative path to bypass the @/ alias mock.
+import { useZeroDevSigner } from "../../../hooks/useZeroDevSigner";
+
+import {
+  chainIdOf,
+  createEmbeddedWallet,
+  EMBEDDED_WALLET_ADDRESS,
+  type MockUser,
+  type MockWallet,
+  signerOnChain,
+} from "./zerodev-signer-test-utils";
+
+function setupEmailUser(initialChainId = 1) {
+  mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+  mockPrivyState.wallets = [createEmbeddedWallet(EMBEDDED_WALLET_ADDRESS, { initialChainId })];
+}
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+describe("useZeroDevSigner — gasless retry (GAP-FRONTEND-23C)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrivyState.ready = true;
+    mockPrivyState.user = null;
+    mockPrivyState.wallets = [];
+    mockUseChainId.mockReturnValue(10);
+
+    // Gasless is supported for these tests; individual tests drive createGaslessClient.
+    asMock(isChainSupportedForGasless).mockReturnValue(true);
+    asMock(createPrivySignerForGasless).mockResolvedValue("signer");
+    asMock(getGaslessSigner).mockImplementation(async (_client: unknown, chainId: number) =>
+      signerOnChain(chainId)
+    );
+
+    mockGetSigner.mockReset();
+    mockGetSigner.mockImplementation(async (browserProvider?: unknown) => ({
+      getAddress: vi.fn().mockResolvedValue(EMBEDDED_WALLET_ADDRESS),
+      provider: browserProvider ?? {
+        getNetwork: vi.fn().mockResolvedValue({ chainId: 1n }),
+      },
+    }));
+  });
+
+  it("retries gasless client creation after a transient RPC error, then succeeds", async () => {
+    // The ZeroDev RPC blips once (Jorge's exact "could not coalesce" failure),
+    // then recovers — the retry must keep the user on the gasless path.
+    setupEmailUser();
+    asMock(createGaslessClient)
+      .mockRejectedValueOnce(
+        new Error('could not coalesce error (error={ "message": "HTTP request failed" })')
+      )
+      .mockResolvedValueOnce({ account: {} });
+
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      const promise = result.current.getAttestationSigner(10);
+      await vi.runAllTimersAsync();
+      const signer = await promise;
+
+      expect(await chainIdOf(signer)).toBe(10);
+      expect(createGaslessClient).toHaveBeenCalledTimes(2);
+      // Stayed on gasless — never touched the embedded-direct provider switch.
+      expect(mockPrivyState.wallets[0].getEthereumProvider).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to the embedded-direct path after exhausting gasless retries", async () => {
+    // ZeroDev stays down for every attempt → after the bounded retries the hook
+    // must recover by switching the embedded wallet and signing directly.
+    setupEmailUser();
+    asMock(createGaslessClient).mockRejectedValue(new Error("could not coalesce error"));
+    const provider = await mockPrivyState.wallets[0].getEthereumProvider();
+
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      const promise = result.current.getAttestationSigner(10);
+      await vi.runAllTimersAsync();
+      const signer = await promise;
+
+      expect(await chainIdOf(signer)).toBe(10);
+      // Exhausted the bounded retry budget (GASLESS_MAX_ATTEMPTS).
+      expect(createGaslessClient).toHaveBeenCalledTimes(3);
+      // Recovered via the embedded-direct provider-level switch.
+      expect(provider.request).toHaveBeenCalledWith({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: "0xa" }],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry or fall back on a GaslessProviderError", async () => {
+    // Provider-specific failures are deliberate — surface them immediately so
+    // the real cause reaches Sentry, with no wasted retries or fallback.
+    setupEmailUser();
+    asMock(createGaslessClient).mockRejectedValue(
+      new GaslessProviderError("zerodev provider down", "zerodev", 10)
+    );
+    const embeddedWallet = mockPrivyState.wallets[0];
+
+    const { result } = renderHook(() => useZeroDevSigner());
+
+    await act(async () => {
+      await expect(result.current.getAttestationSigner(10)).rejects.toThrow(
+        /zerodev provider down/i
+      );
+    });
+
+    expect(createGaslessClient).toHaveBeenCalledTimes(1);
+    // Never fell through to the embedded-direct path.
+    expect(embeddedWallet.getEthereumProvider).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/utilities/isRetryableChainError.test.ts
+++ b/__tests__/unit/utilities/isRetryableChainError.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Unit tests for isRetryableChainError.
+ *
+ * Guards the mapping that decides whether project create/update shows the
+ * actionable "try again in a moment" toast (GAP-FRONTEND-23C) instead of the
+ * generic failure message.
+ */
+import { describe, expect, it } from "vitest";
+import { isRetryableChainError } from "@/utilities/isRetryableChainError";
+
+describe("isRetryableChainError", () => {
+  describe("retryable failures", () => {
+    it.each([
+      "Couldn't switch your wallet to the required network (chain 8453); it is still on chain 1. Please try again in a moment.",
+      "Failed to obtain signer from embedded wallet: Couldn't switch your wallet to the required network (chain 8453); it is still on chain 1. Please try again in a moment.",
+      'could not coalesce error (error={ "message": "HTTP request failed" })',
+      "JsonRpcProvider failed to detect network and cannot start up",
+      "network changed: 1 => 8453",
+    ])("returns true for: %s", (message) => {
+      expect(isRetryableChainError(new Error(message))).toBe(true);
+    });
+
+    it("matches case-insensitively", () => {
+      expect(isRetryableChainError(new Error("STILL ON CHAIN 1"))).toBe(true);
+    });
+
+    it("accepts a raw string, not only Error instances", () => {
+      expect(isRetryableChainError("please try again in a moment")).toBe(true);
+    });
+  });
+
+  describe("non-retryable failures", () => {
+    it.each([
+      "There was an error creating Goldsky project.",
+      "Validation failed: title is required",
+      "Request failed with status code 500",
+    ])("returns false for: %s", (message) => {
+      expect(isRetryableChainError(new Error(message))).toBe(false);
+    });
+
+    it("returns false for null/undefined/empty", () => {
+      expect(isRetryableChainError(null)).toBe(false);
+      expect(isRetryableChainError(undefined)).toBe(false);
+      expect(isRetryableChainError(new Error(""))).toBe(false);
+    });
+  });
+});

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -56,6 +56,7 @@ import { walletClientToSigner } from "@/utilities/eas-wagmi-utils";
 import fetchData from "@/utilities/fetchData";
 import { validateGithubInput } from "@/utilities/github";
 import { INDEXER } from "@/utilities/indexer";
+import { isRetryableChainError } from "@/utilities/isRetryableChainError";
 import { MESSAGES } from "@/utilities/messages";
 import { PROJECT_CREATION_DEFAULT_CHAIN_ID } from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
@@ -741,12 +742,18 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
       setContacts([]);
       setCustomLinks([]);
     } catch (error: any) {
-      showError(MESSAGES.PROJECT.CREATE.ERROR(data.title));
+      // A transient chain-switch / bundler-RPC hiccup (GAP-FRONTEND-23C) is
+      // recoverable by retrying — tell the user that instead of a dead-end
+      // generic error. The form data is preserved either way.
+      const userMessage = isRetryableChainError(error)
+        ? MESSAGES.PROJECT.CREATE.RETRYABLE_ERROR
+        : MESSAGES.PROJECT.CREATE.ERROR(data.title);
+      showError(userMessage);
       errorManager(
         MESSAGES.PROJECT.CREATE.ERROR(data.title),
         error,
         { address, data },
-        { error: MESSAGES.PROJECT.CREATE.ERROR(data.title) }
+        { error: userMessage }
       );
       // Don't reset form on error - keep user's data and reopen modal
       setShouldResetOnOpen(false);
@@ -874,12 +881,15 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         }, 1500);
       });
     } catch (error: any) {
-      showError(MESSAGES.PROJECT.UPDATE.ERROR);
+      const userMessage = isRetryableChainError(error)
+        ? MESSAGES.PROJECT.UPDATE.RETRYABLE_ERROR
+        : MESSAGES.PROJECT.UPDATE.ERROR;
+      showError(userMessage);
       errorManager(
         `Error updating project ${projectToUpdate?.details?.slug || projectToUpdate?.uid}`,
         error,
         { ...data, address },
-        { error: MESSAGES.PROJECT.UPDATE.ERROR }
+        { error: userMessage }
       );
       setShouldResetOnOpen(false);
       openModal();

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -111,6 +111,13 @@ interface SwitchableWallet {
 const CHAIN_SWITCH_MAX_ATTEMPTS = 5;
 const CHAIN_SWITCH_BASE_DELAY_MS = 250;
 
+// The gasless client is built against the provider's bundler RPC (e.g. ZeroDev).
+// That RPC can blip transiently — the exact trigger of GAP-FRONTEND-23C, where a
+// momentary RPC failure dropped an email user onto the pay-gas fallback. Retry
+// client creation with backoff so a transient hiccup keeps the user on gasless.
+const GASLESS_MAX_ATTEMPTS = 3;
+const GASLESS_RETRY_BASE_DELAY_MS = 300;
+
 /**
  * Reads the chain a raw EIP-1193 provider reports via `eth_chainId`. Used
  * instead of ethers' `getNetwork()` because a BrowserProvider caches the
@@ -283,40 +290,72 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
 
       // Case 1: Email/Google login with gasless support
       if (isEmailOrSocialLogin && embeddedWallet && isChainSupportedForGasless(targetChainId)) {
-        try {
-          // No embedded-wallet chain switch here on purpose: the gasless signer's
-          // provider is pinned to targetChainId by the provider's toEthersSigner,
-          // and the smart account runs on targetChainId regardless of the embedded
-          // EOA's current chain. Signing (secp256k1/personal/typed-data) is
-          // chain-agnostic, so requiring a switch would only add a failure mode
-          // (embedded wallets that can't switch) without any benefit.
-          const signer = await createPrivySignerForGasless(embeddedWallet, targetChainId);
+        // Retry only the client-creation step (the transient bundler-RPC call).
+        // The chain assertion below is intentionally outside the loop: a
+        // wrong-chain gasless signer is deterministic (chain is fixed by config),
+        // so retrying it would only add latency before the inevitable fallback.
+        let client: Awaited<ReturnType<typeof createGaslessClient>> = null;
+        for (let attempt = 0; attempt < GASLESS_MAX_ATTEMPTS; attempt += 1) {
+          try {
+            // No embedded-wallet chain switch here on purpose: the gasless signer's
+            // provider is pinned to targetChainId by the provider's toEthersSigner,
+            // and the smart account runs on targetChainId regardless of the embedded
+            // EOA's current chain. Signing (secp256k1/personal/typed-data) is
+            // chain-agnostic, so requiring a switch would only add a failure mode
+            // (embedded wallets that can't switch) without any benefit.
+            const signer = await createPrivySignerForGasless(embeddedWallet, targetChainId);
 
-          // Create gasless client (provider is selected automatically based on chain config)
-          const client = await createGaslessClient(targetChainId, signer);
+            // Create gasless client (provider is selected automatically based on chain config)
+            client = await createGaslessClient(targetChainId, signer);
+            if (client) {
+              break;
+            }
 
-          if (client) {
+            // No client returned — record a synthetic diagnostic so the final
+            // throw isn't "No wallet available" when gasless creation silently
+            // returned null.
+            lastError = new Error(
+              `Gasless client creation returned no client for chain ${targetChainId}`
+            );
+          } catch (error) {
+            // Don't retry or fall back for gasless provider errors - surface them.
+            if (error instanceof GaslessProviderError) {
+              console.error(`[Gasless] ${error.provider} provider failed:`, error);
+              throw error;
+            }
+
+            // Transient (e.g. bundler RPC) failure — log and retry with backoff.
+            console.warn(
+              `[Gasless] Client creation failed (attempt ${attempt + 1}/${GASLESS_MAX_ATTEMPTS}):`,
+              error
+            );
+            lastError = error;
+          }
+
+          if (attempt < GASLESS_MAX_ATTEMPTS - 1) {
+            await wait(GASLESS_RETRY_BASE_DELAY_MS * (attempt + 1));
+          }
+        }
+
+        if (client) {
+          try {
             // Convert to ethers.js signer for GAP SDK compatibility
             const ethersSigner = await getGaslessSigner(client, targetChainId);
             return await assertSignerOnChain(ethersSigner, targetChainId);
-          }
+          } catch (error) {
+            // Provider-specific failures are deliberate — surface them.
+            if (error instanceof GaslessProviderError) {
+              console.error(`[Gasless] ${error.provider} provider failed:`, error);
+              throw error;
+            }
 
-          // No client returned — record a synthetic diagnostic so the final
-          // throw isn't "No wallet available" when gasless creation silently
-          // returned null.
-          lastError = new Error(
-            `Gasless client creation returned no client for chain ${targetChainId}`
-          );
-        } catch (error) {
-          // Don't fall back for gasless provider errors - show the actual error
-          if (error instanceof GaslessProviderError) {
-            console.error(`[Gasless] ${error.provider} provider failed:`, error);
-            throw error;
+            // Wrong-chain gasless signer — fall through to the embedded-direct path.
+            console.warn(
+              "[Gasless] Signer validation failed, falling back to embedded wallet:",
+              error
+            );
+            lastError = error;
           }
-
-          // Log and fall back for other errors
-          console.warn("[Gasless] Client creation failed, falling back to embedded wallet:", error);
-          lastError = error;
         }
       }
 

--- a/utilities/isRetryableChainError.ts
+++ b/utilities/isRetryableChainError.ts
@@ -1,0 +1,30 @@
+/**
+ * Detects signer/attestation failures that are transient chain-switch or
+ * bundler-RPC hiccups the user can recover from by simply retrying — as opposed
+ * to a real, persistent error.
+ *
+ * Project creation for email/embedded-wallet users (GAP-FRONTEND-23C) can fail
+ * when the gasless RPC blips and the embedded wallet hasn't finished switching
+ * networks. Those failures bubble up as wrapped `Error`s whose messages contain
+ * recognisable phrases ("still on chain 1", "try again in a moment", the wrapped
+ * "Failed to obtain signer from embedded wallet", or low-level ethers/RPC text).
+ * When we see one we show an actionable "try again" toast instead of the generic
+ * failure message, since the user's form data is preserved and a retry usually
+ * succeeds once the network/RPC settles.
+ */
+const RETRYABLE_ERROR_PATTERNS = [
+  "try again in a moment",
+  "still on chain",
+  "failed to obtain signer",
+  "could not coalesce",
+  "failed to detect network",
+  "network changed",
+] as const;
+
+export function isRetryableChainError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error ?? "")).toLowerCase();
+  if (!message) {
+    return false;
+  }
+  return RETRYABLE_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}

--- a/utilities/messages.ts
+++ b/utilities/messages.ts
@@ -318,10 +318,14 @@ export const MESSAGES = {
     CREATE: {
       SUCCESS: "Project created successfully!",
       ERROR: (title: string) => `There was an error creating ${title} project.`,
+      RETRYABLE_ERROR:
+        "We couldn't reach the network just now. Your details are saved — please try again in a moment.",
     },
     UPDATE: {
       SUCCESS: "Project updated successfully",
       ERROR: "There was an error updating project.",
+      RETRYABLE_ERROR:
+        "We couldn't reach the network just now. Your changes are saved — please try again in a moment.",
     },
     DELETE: {
       SUCCESS: "Project deleted successfully",


### PR DESCRIPTION
## Problem

Email / embedded-wallet users could fail to **create a project** when the gasless
bundler RPC (ZeroDev) had a transient blip. Reported via Telegram and traced to
Sentry **GAP-FRONTEND-23C** (a Goldsky user, Base / chain 8453, vercel-production):

```
Failed to obtain signer from embedded wallet: Couldn't switch your wallet to the
required network (chain 8453); it is still on chain 1. Please try again in a moment.
```

Breadcrumbs showed gasless **was** configured and running, but the ZeroDev RPC
(`rpc.zerodev.app/.../chain/8453`) returned HTTP errors for ~1s (`could not
coalesce error`, `JsonRpcProvider failed to detect network`). Two gaps turned that
brief hiccup into a hard failure:

1. **No retry** — `createGaslessClient` was attempted once; a transient failure
   immediately dropped the user off the gasless path.
2. **Unhelpful message** — the dialog showed the generic *"There was an error
   creating <project>"* and swallowed the underlying *"…try again in a moment"*
   hint, so the user had no idea a retry would work.

> Note: the embedded-wallet chain-switch fix (provider-level `wallet_switchEthereumChain`
> + confirmation polling) already landed in #1645 *after* this incident. This PR
> covers the two remaining resilience gaps.

## Changes

- **`useZeroDevSigner`** — retry gasless client creation with bounded backoff
  (`GASLESS_MAX_ATTEMPTS=3`) before falling back, so a momentary RPC hiccup keeps
  the user on gasless. `GaslessProviderError`s are still surfaced immediately (no
  retry / no silent fallback), and the chain assertion stays *outside* the retry
  loop since a wrong-chain signer is deterministic, not transient.
- **`ProjectDialog`** — on a transient chain-switch / RPC failure, show an
  actionable "try again in a moment" toast (form data is preserved) for both
  create and update, instead of the generic error.
- **`isRetryableChainError`** helper + unit tests.

## Tests

- `__tests__/unit/utilities/isRetryableChainError.test.ts` — pattern matching.
- `__tests__/unit/hooks/useZeroDevSigner-gasless-retry.test.ts` — retry-then-succeed,
  exhaust-retries-then-fall-back, and no-retry-on-`GaslessProviderError`.
- Existing `useZeroDevSigner-chain` / `ProjectDialog` / signer suites still green
  (46 related tests pass).

## Not included (deliberately scoped out)

- Switch-early + gate-submit UX hardening.
- The transient cause itself is on ZeroDev's side; the endpoint is healthy now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic retry mechanism for temporary network failures with improved recovery handling.
  * Enhanced error detection to distinguish between network-related and other failures.
  * New user-facing message for network connectivity issues.

* **Bug Fixes**
  * Improved error handling and fallback behavior during network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->