### PR TITLE
feat(project-creation): restore network selector on staging

### DIFF
--- a/__tests__/components/Dialogs/ProjectDialog.test.tsx
+++ b/__tests__/components/Dialogs/ProjectDialog.test.tsx
@@ -347,12 +347,20 @@ vi.mock("@/utilities/indexer", () => ({
   },
 }));
 
+// Mutable holder so individual tests can flip the network-selector flag to
+// simulate production (hidden) vs staging (shown). Read via a getter below so
+// the live import binding reflects mutations made inside a test.
+const networkMockState = vi.hoisted(() => ({ showNetworkSelector: false }));
+
 vi.mock("@/utilities/network", () => ({
   gapSupportedNetworks: [
     { id: 10, name: "Optimism" },
     { id: 42161, name: "Arbitrum" },
   ],
   PROJECT_CREATION_DEFAULT_CHAIN_ID: 8453,
+  get SHOW_PROJECT_CREATION_NETWORK_SELECTOR() {
+    return networkMockState.showNetworkSelector;
+  },
 }));
 
 vi.mock("@/utilities/pages", () => ({
@@ -488,6 +496,9 @@ vi.mock("@show-karma/karma-gap-sdk", () => ({
 describe("ProjectDialog", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+
+    // Default to production behavior (no network selector) unless a test opts in.
+    networkMockState.showNetworkSelector = false;
 
     mockProjectAttest = vi.fn(
       () =>
@@ -687,6 +698,65 @@ describe("ProjectDialog", () => {
     await waitFor(() => {
       expect(mockSetupChainAndWallet).toHaveBeenCalledWith(
         expect.objectContaining({ targetChainId: 8453 })
+      );
+    });
+    expect(screen.queryByText("Network is required")).not.toBeInTheDocument();
+  });
+
+  it("shows the network selector on staging and creates on the chosen network", async () => {
+    // Staging keeps the network list so projects can be created on other chains.
+    networkMockState.showNetworkSelector = true;
+
+    const { ProjectDialog } = await import("@/components/Dialogs/ProjectDialog");
+    const user = userEvent.setup();
+
+    render(<ProjectDialog />);
+    await openDialog(user);
+
+    // Fill all step-0 required fields with valid values so navigation can proceed.
+    await user.type(screen.getByPlaceholderText('e.g. "My awesome project"'), "My awesome project");
+    const markdownEditors = screen.getAllByTestId("markdown-editor");
+    await user.type(markdownEditors[0], "Description");
+    await user.type(markdownEditors[1], "Problem");
+    await user.type(markdownEditors[2], "Solution");
+    await user.type(markdownEditors[3], "Mission summary");
+
+    // Advance through steps 0 -> 1 -> 2 -> 3 (Contact info).
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Your/organization handle")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Describe your business model")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /add contact/i })).toBeInTheDocument();
+    });
+
+    // The network selector renders with the gap-supported networks.
+    const networkSelect = screen.getByLabelText("Network *");
+    expect(networkSelect).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Optimism" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Arbitrum" })).toBeInTheDocument();
+
+    // Pick Arbitrum (42161) instead of the Base default.
+    await user.selectOptions(networkSelect, "42161");
+
+    await user.click(screen.getByRole("button", { name: /add contact/i }));
+    submitForm();
+
+    await waitFor(() => {
+      expect(mockStartAttestation).toHaveBeenCalledWith("Creating project...");
+    });
+
+    // Creation targets the selected chain (Arbitrum / 42161), not the Base default.
+    await waitFor(() => {
+      expect(mockSetupChainAndWallet).toHaveBeenCalledWith(
+        expect.objectContaining({ targetChainId: 42161 })
       );
     });
     expect(screen.queryByText("Network is required")).not.toBeInTheDocument();

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -57,7 +57,11 @@ import fetchData from "@/utilities/fetchData";
 import { validateGithubInput } from "@/utilities/github";
 import { INDEXER } from "@/utilities/indexer";
 import { MESSAGES } from "@/utilities/messages";
-import { PROJECT_CREATION_DEFAULT_CHAIN_ID } from "@/utilities/network";
+import {
+  gapSupportedNetworks,
+  PROJECT_CREATION_DEFAULT_CHAIN_ID,
+  SHOW_PROJECT_CREATION_NETWORK_SELECTOR,
+} from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
 import { sanitizeObject } from "@/utilities/sanitize";
 import { getProjectById } from "@/utilities/sdk";
@@ -1492,6 +1496,28 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
       desc: "How can we contact you?",
       fields: (
         <div className="flex w-full min-w-[320px] flex-col gap-8">
+          {SHOW_PROJECT_CREATION_NETWORK_SELECTOR && !projectToUpdate && (
+            <div className="flex w-full flex-col gap-2">
+              <label htmlFor="network-select" className={labelStyle}>
+                Network *
+              </label>
+              <select
+                id="network-select"
+                className={inputStyle}
+                value={watch("chainID") ?? PROJECT_CREATION_DEFAULT_CHAIN_ID}
+                onChange={(e) => {
+                  setValue("chainID", +e.target.value, { shouldValidate: true });
+                }}
+              >
+                {gapSupportedNetworks.map((chain) => (
+                  <option key={chain.id} value={chain.id}>
+                    {chain.name}
+                  </option>
+                ))}
+              </select>
+              <p className="text-red-500">{errors.chainID?.message}</p>
+            </div>
+          )}
           <ContactInfoSection
             existingContacts={contacts}
             isEditing={!!projectToUpdate}

--- a/utilities/network.ts
+++ b/utilities/network.ts
@@ -60,14 +60,23 @@ export const gapSupportedNetworks = appNetwork.filter(
 ) as [Chain, ...Chain[]];
 
 /**
- * Network that new projects are created on.
+ * Network that new projects are created on by default.
  *
- * Project creation no longer exposes a network selector — every new project is
- * created on this chain. Existing projects on other chains keep working
- * everywhere else (editing, attestations, donations, etc.); `appNetwork` and
- * `gapSupportedNetworks` are intentionally left untouched.
+ * In production, project creation does not expose a network selector — every new
+ * project is created on this chain. Existing projects on other chains keep
+ * working everywhere else (editing, attestations, donations, etc.); `appNetwork`
+ * and `gapSupportedNetworks` are intentionally left untouched.
  */
 export const PROJECT_CREATION_DEFAULT_CHAIN_ID = base.id;
+
+/**
+ * Whether the project-creation flow exposes a network selector.
+ *
+ * Production hides it and always creates on `PROJECT_CREATION_DEFAULT_CHAIN_ID`.
+ * Non-production (staging/dev) keeps the network list so projects can be created
+ * on test networks.
+ */
+export const SHOW_PROJECT_CREATION_NETWORK_SELECTOR = includeTestNetworks;
 
 /**
  * Networks where projects can configure payout addresses for donations.


### PR DESCRIPTION
## Summary

Restores the network selector in the project-creation flow **on staging/dev only**, while keeping production exactly as it is today (single default-chain creation, no selector).

## Problem

A recent change removed the network selection list from project creation so every new project is created on the default chain (Base). That is the desired behavior for **production**, but it also removed the list from **staging**, where the ability to create projects on test networks (Optimism Sepolia, Base Sepolia, Sepolia) is needed for QA.

## Solution

- Add `SHOW_PROJECT_CREATION_NETWORK_SELECTOR` to `utilities/network.ts`, gated on environment (`true` only when `NEXT_PUBLIC_ENV !== "production"`, reusing the existing `includeTestNetworks` flag).
- In `ProjectDialog`, render a network `<select>` (the `gapSupportedNetworks` list, same pattern as `CommunityDialog`) in the final "Contact info" step — only when the flag is on **and** creating a new project (`!projectToUpdate`). Edits keep their existing chain.
- Production path is untouched: flag is `false`, no selector, `chainID` defaults to `PROJECT_CREATION_DEFAULT_CHAIN_ID` (Base).

## Testing Steps

- `pnpm test` — full unit suite green (13,057 passing).
- New/updated tests in `ProjectDialog.test.tsx`:
  - **Production**: no selector renders; creation targets Base (8453); "Network is required" never appears.
  - **Staging**: selector renders with the supported networks; selecting Arbitrum routes creation to that chain (`targetChainId: 42161`).
- Manual: with `NEXT_PUBLIC_ENV=staging`, open "Create a new project" → Contact info step shows the Network dropdown; with `production` it does not.

## Risk

Low. Behavior change is confined to non-production via an env flag; production rendering and the create flow are unchanged. No schema/API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a network selector in the project creation dialog, allowing users to choose between supported networks (Optimism, Arbitrum, etc.) when creating a project in non-production environments.

* **Tests**
  * Added regression test to verify network selection and proper chain initialization during project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->