### PR TITLE
fix(seo): de-inflate sitemap index and noindex thin project tabs

### DIFF
--- a/__tests__/app/sitemap-routes.test.ts
+++ b/__tests__/app/sitemap-routes.test.ts
@@ -98,7 +98,12 @@ describe("sitemap index route", () => {
     expect(res.headers.get("Content-Type")).toContain("application/xml");
     expect(body).toContain("<sitemapindex");
     expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
+    expect(body).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
     expect(body).toContain(`<loc>${SITE}/sitemaps/static/sitemap.xml</loc>`);
+    // Thin tab kinds are noindexed and dropped from the advertised index.
+    expect(body).not.toContain(`<loc>${SITE}/sitemaps/impacts/sitemap.xml</loc>`);
+    expect(body).not.toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect(body).not.toContain(`<loc>${SITE}/sitemaps/milestones/sitemap.xml</loc>`);
   });
 
   it("falls back to chunked children when a kind exceeds the per-file limit", async () => {
@@ -120,7 +125,7 @@ describe("sitemap index route", () => {
 
     expect(body).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
     expect(body).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
-    expect(body).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect(body).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
   });
 
   it("serves the identical index at the fresh /sitemap_index.xml URL", async () => {
@@ -180,6 +185,25 @@ describe("consolidated per-kind sitemap route", () => {
     expect(body).toContain(`<loc>${SITE}/project/a</loc>`);
     expect(body).not.toContain("staging.karmahq.xyz");
   });
+
+  // The index no longer advertises these kinds, but Google already holds their
+  // child-sitemap URLs from past submissions — the routes must keep serving 200
+  // so those legacy URLs don't start 404ing.
+  it.each(["impacts", "grants", "milestones"])(
+    "still serves 200 for the de-advertised legacy kind %s",
+    async (kind) => {
+      stubKindFetch(["https://staging.karmahq.xyz/project/a"]);
+
+      const res = await kindGet(new Request(`${SITE}/sitemaps/${kind}/sitemap.xml`), {
+        params: Promise.resolve({ kind }),
+      });
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("application/xml");
+      expect(body).toContain(`<loc>${SITE}/project/a</loc>`);
+    }
+  );
 
   it("404s an unknown kind without calling the indexer", async () => {
     const fetchMock = vi.fn();

--- a/__tests__/utilities/metadata/projectMetadata.test.ts
+++ b/__tests__/utilities/metadata/projectMetadata.test.ts
@@ -1,13 +1,27 @@
+import type { Grant } from "@/types/v2/grant";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import {
+  generateGrantImpactCriteriaMetadata,
+  generateGrantMilestonesMetadata,
+  generateGrantOverviewMetadata,
   generateProjectAboutMetadata,
   generateProjectContactMetadata,
+  generateProjectFundingMetadata,
+  generateProjectImpactMetadata,
+  generateProjectOverviewMetadata,
+  generateProjectTeamMetadata,
+  generateProjectUpdatesMetadata,
 } from "@/utilities/metadata/projectMetadata";
 
 const project = {
   uid: "0x1",
   details: { title: "Acme", slug: "acme", description: "A grant project" },
 } as unknown as ProjectResponse;
+
+const grant = {
+  uid: "0xgrant",
+  details: { title: "Seed Grant", description: "A seed grant" },
+} as unknown as Grant;
 
 describe("generateProjectContactMetadata", () => {
   it("marks the auth-gated contact-info page as noindex but followable", () => {
@@ -29,5 +43,40 @@ describe("generateProjectAboutMetadata", () => {
 
     expect(meta.robots).toBeUndefined();
     expect(meta.alternates?.canonical).toBe("/project/acme/about");
+  });
+});
+
+describe("noindexed thin tab generators", () => {
+  it("marks the impact tab as noindex but followable", () => {
+    const meta = generateProjectImpactMetadata(project, "acme");
+
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("marks the grant overview tab as noindex but followable", () => {
+    const meta = generateGrantOverviewMetadata(project, grant, "acme", "0xgrant");
+
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("marks the grant milestones tab as noindex but followable", () => {
+    const meta = generateGrantMilestonesMetadata(project, grant, "acme", "0xgrant");
+
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it("marks the grant impact-criteria tab as noindex but followable", () => {
+    const meta = generateGrantImpactCriteriaMetadata(project, grant, "acme", "0xgrant");
+
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+});
+
+describe("indexable project tab generators", () => {
+  it("keeps the overview, team, updates, and funding tabs indexable", () => {
+    expect(generateProjectOverviewMetadata(project, "acme").robots).toBeUndefined();
+    expect(generateProjectTeamMetadata(project, "acme").robots).toBeUndefined();
+    expect(generateProjectUpdatesMetadata(project, "acme").robots).toBeUndefined();
+    expect(generateProjectFundingMetadata(project, "acme").robots).toBeUndefined();
   });
 });

--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -163,7 +163,7 @@ describe("fetchSitemapKindPage", () => {
 });
 
 describe("buildSitemapIndexBody", () => {
-  it("lists one consolidated child per kind plus the local children", async () => {
+  it("advertises only the high-value canonical kinds plus the local children", async () => {
     const counts: SitemapCounts = {
       projects: 7678,
       impacts: 0,
@@ -181,13 +181,14 @@ describe("buildSitemapIndexBody", () => {
     expect(xml).toContain(`<loc>${SITE}/sitemaps/static/sitemap.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/communities/sitemap.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/impacts/sitemap.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/milestones/sitemap.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
+    // The thin tab kinds are noindexed and no longer advertised by the index.
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/impacts/sitemap.xml</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/milestones/sitemap.xml</loc>`);
     expect(xml).not.toContain("/sitemap/1.xml");
-    // static + communities + one per kind = 7
-    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(7);
+    // static + communities + projects + funding-programs = 4
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(4);
   });
 
   it("falls back to chunked children for a kind past the per-file URL limit", async () => {
@@ -208,9 +209,10 @@ describe("buildSitemapIndexBody", () => {
     expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/1.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
-    // static + communities + projects 46 chunks + 4 consolidated kinds = 52
-    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(52);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    // static + communities + projects 46 chunks + funding-programs = 49
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(49);
   });
 
   it("falls back to chunked children for a kind exactly at the per-file URL limit", async () => {
@@ -235,7 +237,7 @@ describe("buildSitemapIndexBody", () => {
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/1.xml</loc>`);
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap/45.xml</loc>`);
     expect(xml).not.toContain(`<loc>${SITE}/sitemaps/projects/sitemap/46.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
   });
 
   it("throws when counts is unreachable so SWR keeps the last good index", async () => {
@@ -257,8 +259,9 @@ describe("buildSitemapIndexBody", () => {
     const xml = await buildSitemapIndexBody();
 
     expect(xml).toContain(`<loc>${SITE}/sitemaps/projects/sitemap.xml</loc>`);
-    expect(xml).toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
-    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(7);
+    expect(xml).toContain(`<loc>${SITE}/sitemaps/funding-programs/sitemap.xml</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/sitemaps/grants/sitemap.xml</loc>`);
+    expect((xml.match(/<sitemap>/g) ?? []).length).toBe(4);
   });
 });
 

--- a/utilities/metadata/projectMetadata.ts
+++ b/utilities/metadata/projectMetadata.ts
@@ -132,6 +132,8 @@ export const generateProjectImpactMetadata = (
       getRealDescriptionExcerpt(project) ||
       `Explore the impact and outcomes of ${projectTitle} on ${PROJECT_NAME}.`,
     canonicalPath: `/project/${projectId}/impact`,
+    // Thin near-duplicate of the project root; de-indexed to protect crawl budget.
+    robots: { index: false, follow: true },
   });
 };
 
@@ -209,6 +211,8 @@ export const generateGrantOverviewMetadata = (
     canonicalPath: grantUid
       ? PAGES.PROJECT.GRANT(projectId, grantUid)
       : PAGES.PROJECT.GRANTS(projectId),
+    // Thin near-duplicate of the project root; de-indexed to protect crawl budget.
+    robots: { index: false, follow: true },
   });
 };
 
@@ -227,6 +231,8 @@ export const generateGrantMilestonesMetadata = (
     canonicalPath: grantUid
       ? PAGES.PROJECT.MILESTONES_AND_UPDATES(projectId, grantUid)
       : PAGES.PROJECT.GRANTS(projectId),
+    // Thin near-duplicate of the project root; de-indexed to protect crawl budget.
+    robots: { index: false, follow: true },
   });
 };
 
@@ -245,6 +251,8 @@ export const generateGrantImpactCriteriaMetadata = (
     canonicalPath: grantUid
       ? PAGES.PROJECT.SCREENS.SELECTED_SCREEN(projectId, grantUid, "impact-criteria")
       : PAGES.PROJECT.GRANTS(projectId),
+    // Thin near-duplicate of the project root; de-indexed to protect crawl budget.
+    robots: { index: false, follow: true },
   });
 };
 

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -73,7 +73,9 @@ export const SITEMAP_KINDS: readonly SitemapKindMeta[] = [
 // near-duplicates of the project root, are now noindexed, and would dilute
 // crawl budget if listed — so they are dropped from the index. Their per-kind
 // routes still serve (see SITEMAP_KINDS) so already-submitted URLs stay 200.
-export const INDEXED_SITEMAP_KINDS: readonly SitemapKindMeta[] = SITEMAP_KINDS.filter(
+// Module-local (not exported): only buildSitemapIndexBody consumes it, and an
+// unused export trips the repo's knip quality gate.
+const INDEXED_SITEMAP_KINDS: readonly SitemapKindMeta[] = SITEMAP_KINDS.filter(
   (meta) => meta.kind === "projects" || meta.kind === "funding-programs"
 );
 

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -54,9 +54,12 @@ export interface SitemapKindMeta {
   changeFrequency: "daily" | "weekly" | "monthly";
 }
 
-// The per-kind children listed in the index, in order. `static` and
-// `communities` are separate Next sitemap routes (local data) and are added to
-// the index directly.
+// Every kind whose per-kind route still serves. `static` and `communities` are
+// separate Next sitemap routes (local data) and are added to the index
+// directly. The impacts/grants/milestones routes keep returning 200 because
+// Google already holds those child-sitemap URLs from past submissions — we must
+// not start 404ing them — but they are no longer advertised by the index (see
+// INDEXED_SITEMAP_KINDS).
 export const SITEMAP_KINDS: readonly SitemapKindMeta[] = [
   { kind: "projects", priority: 0.8, changeFrequency: "daily" },
   { kind: "impacts", priority: 0.7, changeFrequency: "weekly" },
@@ -64,6 +67,15 @@ export const SITEMAP_KINDS: readonly SitemapKindMeta[] = [
   { kind: "milestones", priority: 0.5, changeFrequency: "weekly" },
   { kind: "funding-programs", priority: 0.6, changeFrequency: "weekly" },
 ];
+
+// The subset the sitemap index actually advertises: only the high-value,
+// canonical kinds. The thin tab variants (impacts/grants/milestones) are
+// near-duplicates of the project root, are now noindexed, and would dilute
+// crawl budget if listed — so they are dropped from the index. Their per-kind
+// routes still serve (see SITEMAP_KINDS) so already-submitted URLs stay 200.
+export const INDEXED_SITEMAP_KINDS: readonly SitemapKindMeta[] = SITEMAP_KINDS.filter(
+  (meta) => meta.kind === "projects" || meta.kind === "funding-programs"
+);
 
 export interface SitemapCounts {
   projects: number;
@@ -206,7 +218,7 @@ export async function buildSitemapIndexBody(): Promise<string> {
     `${SITE_URL}/sitemaps/communities/sitemap.xml`,
   ];
 
-  for (const { kind } of SITEMAP_KINDS) {
+  for (const { kind } of INDEXED_SITEMAP_KINDS) {
     const total = countForKind(counts, kind);
     // A missing count (partial payload) lists the consolidated child rather
     // than dropping the kind — the child route derives completeness from the


### PR DESCRIPTION
## Problem
The sitemap turned ~3.8k projects into ~25k URLs by advertising five self-canonical near-duplicate URLs per project: root, `/about`, `/impact`, `/funding/<uid>`, and `/funding/<uid>/milestones-and-updates`. Google reads that as a thin/duplicate, low-value site and deprioritizes crawling — the root cause behind GSC "Discovered – currently not crawled". Months of sitemap-format PRs didn't help because the format was never the issue; the URL set's quality was.

## Change
**1. De-inflate the sitemap index** (`utilities/sitemap.ts`)
- New `INDEXED_SITEMAP_KINDS` = `projects` + `funding-programs` only. `buildSitemapIndexBody` now iterates it, so the index advertises `static`, `communities`, `projects`, `funding-programs`.
- `SITEMAP_KINDS` still lists all five, so the per-kind routes for `impacts`/`grants`/`milestones` keep returning **200** — already-submitted child sitemaps must not start 404ing.

**2. Noindex the thin tab pages** (`utilities/metadata/projectMetadata.ts`)
- `robots: { index: false, follow: true }` added to exactly the four thin tab generators: impact, grant overview, grant milestones, grant impact-criteria (reusing the existing pattern from contact/edit pages).
- Project **root**, `/about`, `/team`, `/updates`, and the funding list stay indexable.

Net effect: the advertised + indexable surface drops from ~25k mostly-thin pages to the high-value canonical set, while `follow` keeps link equity flowing to the canonical project pages.

## Testing
`pnpm vitest run` on the three affected suites → **55/55 pass**, including a new test proving the legacy `impacts`/`grants`/`milestones` routes still serve 200, and metadata tests asserting `robots.index === false` on the four de-indexed tabs and indexable elsewhere. Biome clean.

## Context
Pairs with show-karma/gap-indexer #2077 (junk/spam slug filtering at the source). Server-rendering richer project content is the recommended follow-up (separate, larger effort).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Search & Indexing**
  * Refined the sitemap index to emphasize primary content (including funding programs) and stop advertising de-indexed thin-tab sitemap variants.
  * Added `robots` directives to specific impact/milestones/criteria tab pages to prevent indexing while allowing follow-through.
  * Preserved access to legacy per-kind sitemap routes so previously submitted child sitemap URLs still return successfully.
* **Tests**
  * Updated sitemap and metadata test coverage to match the new indexing and `robots` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->