### PR TITLE
feat(navbar): hide homepage banner and unify nav across auth states

### DIFF
--- a/__tests__/navbar/unit/navbar-desktop-navigation.test.tsx
+++ b/__tests__/navbar/unit/navbar-desktop-navigation.test.tsx
@@ -489,7 +489,7 @@ describe("NavbarDesktopNavigation", () => {
       expect(resourcesButton).toBeInTheDocument();
     });
 
-    it("should render quick action buttons and Explore dropdown when logged in", () => {
+    it("should render Dashboard, segment dropdowns and Explore dropdown when logged in", () => {
       const authFixture = getAuthFixture("authenticated-basic");
       renderWithProviders(<NavbarDesktopNavigation />, {
         mockUseAuth: createMockUseAuth(authFixture.authState),
@@ -498,9 +498,12 @@ describe("NavbarDesktopNavigation", () => {
         mockUseContributorProfileModalStore: createMockUseContributorProfileModalStore(),
       });
 
-      // When logged in, For Projects/Funders dropdowns are replaced with direct action buttons
-      // and only Explore dropdown remains
+      // When logged in, the Dashboard button shows alongside the shared
+      // For Projects/Funders/Nonprofits dropdowns and the Explore dropdown.
       expect(screen.getByRole("link", { name: /dashboard/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /for projects/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /for funders/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /for nonprofits/i })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /explore/i })).toBeInTheDocument();
     });
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,7 @@
 import type { Metadata } from "next";
-import { NewFeatureBanner } from "@/components/Pages/Home/NewFeatureBanner";
-import { SectionContainer } from "@/src/components/shared/section-container";
 import { Hero } from "@/src/features/home/components/hero";
 import { WorkflowSection } from "@/src/features/home/components/workflow-section";
-import { marketingLayoutTheme } from "@/src/helper/theme";
 import { customMetadata } from "@/utilities/meta";
-import { cn } from "@/utilities/tailwind";
 
 export const metadata: Metadata = {
   ...customMetadata({
@@ -29,11 +25,6 @@ export default function Index() {
   return (
     <main className="flex w-full flex-col flex-1 items-center bg-background overflow-x-hidden">
       <div className="flex w-full max-w-[1920px] flex-1 flex-col">
-        <div className={cn(marketingLayoutTheme.padding, "w-full pt-8")}>
-          <SectionContainer>
-            <NewFeatureBanner />
-          </SectionContainer>
-        </div>
         <Hero />
         <WorkflowSection />
       </div>

--- a/src/components/navbar/navbar-desktop-navigation.tsx
+++ b/src/components/navbar/navbar-desktop-navigation.tsx
@@ -56,6 +56,42 @@ function NavDropdownTrigger({ children }: { children: React.ReactNode }) {
   );
 }
 
+function NavSegmentDropdowns() {
+  return (
+    <div className="flex items-center gap-1">
+      {/* For Projects Dropdown */}
+      <DropdownMenu>
+        <NavDropdownTrigger>For Projects</NavDropdownTrigger>
+        <DropdownMenuContent align="start" className="p-0">
+          <div className="min-w-[500px] p-4">
+            <ForProjectsContent variant="desktop" />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* For Funders Dropdown */}
+      <DropdownMenu>
+        <NavDropdownTrigger>For Funders</NavDropdownTrigger>
+        <DropdownMenuContent align="start" className="p-0">
+          <div className="min-w-[500px] p-4">
+            <ForFundersContent variant="desktop" />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* For Nonprofits Dropdown */}
+      <DropdownMenu>
+        <NavDropdownTrigger>For Nonprofits</NavDropdownTrigger>
+        <DropdownMenuContent align="start" className="p-0">
+          <div className="min-w-[400px] p-4">
+            <ForNonprofitsContent variant="desktop" />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 function ResourcesDropdown() {
   return (
     <DropdownMenu>
@@ -115,56 +151,18 @@ const socialMediaLinks = [
 ];
 
 export function NavbarDesktopNavigation() {
-  const { isLoggedIn, isRegistryAllowed } = useNavbarPermissions();
+  const { isLoggedIn } = useNavbarPermissions();
 
   return (
     <div className="hidden lg:flex items-center flex-1 lg:justify-between gap-8">
       <div className="flex flex-row items-center gap-3 flex-shrink-0">
         <Logo />
-        {!isLoggedIn ? (
-          <div className="flex items-center gap-1">
-            {/* For Projects Dropdown */}
-            <DropdownMenu>
-              <NavDropdownTrigger>For Projects</NavDropdownTrigger>
-              <DropdownMenuContent align="start" className="p-0">
-                <div className="min-w-[500px] p-4">
-                  <ForProjectsContent variant="desktop" />
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* For Funders Dropdown */}
-            <DropdownMenu>
-              <NavDropdownTrigger>For Funders</NavDropdownTrigger>
-              <DropdownMenuContent align="start" className="p-0">
-                <div className="min-w-[500px] p-4">
-                  <ForFundersContent variant="desktop" />
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* For Nonprofits Dropdown */}
-            <DropdownMenu>
-              <NavDropdownTrigger>For Nonprofits</NavDropdownTrigger>
-              <DropdownMenuContent align="start" className="p-0">
-                <div className="min-w-[400px] p-4">
-                  <ForNonprofitsContent variant="desktop" />
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ) : (
-          <div className="flex flex-row items-center ml-2 gap-2">
-            <Button variant="outline" size="sm" asChild>
-              <Link href={PAGES.DASHBOARD}>Dashboard</Link>
-            </Button>
-            {isRegistryAllowed && (
-              <Button variant="outline" size="sm" asChild>
-                <Link href={PAGES.REGISTRY.MANAGE_PROGRAMS}>Manage Programs</Link>
-              </Button>
-            )}
-          </div>
+        {isLoggedIn && (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={PAGES.DASHBOARD}>Dashboard</Link>
+          </Button>
         )}
+        <NavSegmentDropdowns />
       </div>
 
       <div className="flex flex-1 justify-center flex-row items-center gap-3">
@@ -179,26 +177,12 @@ export function NavbarDesktopNavigation() {
         </DropdownMenu>
       </div>
 
-      {!isLoggedIn ? (
-        <div className="flex flex-row items-center gap-4">
-          <ResourcesDropdown />
-
-          {/* Auth Buttons */}
-          <NavbarAuthButtons />
-          <ThemeToggleButton />
-        </div>
-      ) : null}
-
-      {/* Right Side - Theme Toggle & User Profile (Only when logged in) */}
-      {isLoggedIn && (
-        <div className="hidden lg:flex items-center gap-3">
-          <div className="flex flex-row items-center gap-2">
-            <ResourcesDropdown />
-            <ThemeToggleButton />
-            <NavbarUserMenu />
-          </div>
-        </div>
-      )}
+      {/* Right Side - shared between logged-in and logged-out states */}
+      <div className="flex flex-row items-center gap-3">
+        <ResourcesDropdown />
+        <ThemeToggleButton />
+        {isLoggedIn ? <NavbarUserMenu /> : <NavbarAuthButtons />}
+      </div>
     </div>
   );
 }

--- a/src/components/navbar/navbar-mobile-menu.tsx
+++ b/src/components/navbar/navbar-mobile-menu.tsx
@@ -205,30 +205,23 @@ export function NavbarMobileMenu() {
                 </span>
               </button>
 
-              {!isLoggedIn && (
-                <>
-                  {/* For Projects Section */}
-                  <div className="border-b border-border py-3">
-                    <MenuSection title="For Projects" variant="mobile" />
-                    <ForProjectsContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
-                  </div>
+              {/* For Projects Section */}
+              <div className="border-b border-border py-3">
+                <MenuSection title="For Projects" variant="mobile" />
+                <ForProjectsContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
+              </div>
 
-                  {/* For Funders Section */}
-                  <div className="border-b border-border py-3">
-                    <MenuSection title="For Funders" variant="mobile" />
-                    <ForFundersContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
-                  </div>
+              {/* For Funders Section */}
+              <div className="border-b border-border py-3">
+                <MenuSection title="For Funders" variant="mobile" />
+                <ForFundersContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
+              </div>
 
-                  {/* For Nonprofits Section */}
-                  <div className="border-b border-border py-3">
-                    <MenuSection title="For Nonprofits" variant="mobile" />
-                    <ForNonprofitsContent
-                      variant="mobile"
-                      onClose={() => setMobileMenuOpen(false)}
-                    />
-                  </div>
-                </>
-              )}
+              {/* For Nonprofits Section */}
+              <div className="border-b border-border py-3">
+                <MenuSection title="For Nonprofits" variant="mobile" />
+                <ForNonprofitsContent variant="mobile" onClose={() => setMobileMenuOpen(false)} />
+              </div>
 
               {/* Explore Section */}
               <div className="border-b border-border py-5">


### PR DESCRIPTION
## Summary

Two small homepage/navigation changes:

1. **Hide the homepage "new feature" banner** — the announcement banner ("We just launched funder search for nonprofits") no longer renders on the homepage.
2. **Unify the navbar across logged-in / logged-out states** — logged-in users now see the **Dashboard** button alongside the same **For Projects / For Funders / For Nonprofits** dropdowns shown to logged-out users, instead of the old Dashboard + Manage Programs button pair.

## Problem

- The homepage banner needed to be taken down.
- Logged-in and logged-out navbars used two divergent code paths with duplicated controls (Resources dropdown + theme toggle repeated in both branches), and logged-in users lost access to the segment ("For Projects/Funders/Nonprofits") navigation.

## Solution

**Homepage (`app/page.tsx`)**
- Remove the `NewFeatureBanner` render and its now-unused imports. The component and its tests are intentionally retained so the banner can be re-enabled with a single import for the next announcement.

**Desktop nav (`navbar-desktop-navigation.tsx`)**
- Extract the three segment dropdowns into a single `NavSegmentDropdowns` component, rendered in **both** auth states.
- Logged-in: show the **Dashboard** button + the segment dropdowns (the **Manage Programs** button is removed from here; registry admins still reach it via the user menu).
- Collapse the previously duplicated right-side controls into one shared block; only the auth-specific piece differs inline (`NavbarUserMenu` vs `NavbarAuthButtons`).

**Mobile nav (`navbar-mobile-menu.tsx`)**
- Show the For Projects / For Funders / For Nonprofits sections for **all** users (previously logged-out only) so the responsive menu mirrors desktop.
- **Manage Programs** is kept in the mobile quick actions for registry admins (mobile has no user-menu fallback).

## Testing

- `npx vitest run --project unit __tests__/navbar __tests__/homepage __tests__/integration/pages/home.test.tsx __tests__/components/NewFeatureBanner.test.tsx` → **853 passed**.
- Updated `navbar-desktop-navigation.test.tsx` to assert the new logged-in layout (Dashboard + the three segment dropdowns + Explore).
- `tsc --noEmit` clean; Biome clean on changed lines.

### Manual steps
1. Visit `/` logged out → no announcement banner; navbar shows the three segment dropdowns.
2. Log in → navbar shows **Dashboard** + the three segment dropdowns; user menu still links to **Manage Programs** for registry admins.
3. Resize below `lg` → mobile drawer shows the three sections for all users; registry admins still see **Manage Programs** in quick actions.

## Risk

Low — UI-only, no data or API changes. The main behavioral change is that logged-in users now see marketing segment dropdowns in the top nav and the Manage Programs button moves out of the top bar (still reachable via the user menu / mobile quick actions).