### PR TITLE
feat(seo): server-render project header (h1 + description) on every project tab

### DIFF
--- a/__tests__/components/Pages/Project/v2/MainContent/ProjectHeaderServer.test.tsx
+++ b/__tests__/components/Pages/Project/v2/MainContent/ProjectHeaderServer.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ProjectHeaderServer } from "@/components/Pages/Project/v2/MainContent/ProjectHeaderServer";
+import type { Project } from "@/types/v2/project";
+
+function createMockProject(overrides?: Partial<Project["details"]>): Project {
+  return {
+    uid: "0xabc",
+    chainID: 42161,
+    owner: "0xowner",
+    details: {
+      title: "BuidlGuidl",
+      slug: "buidlguidl",
+      description: "A curated group of builders creating open-source Ethereum tools.",
+      tags: ["Developer Tooling", "Education"],
+      ...overrides,
+    },
+  } as Project;
+}
+
+describe("ProjectHeaderServer", () => {
+  it("renders the project title as the page <h1>", () => {
+    render(<ProjectHeaderServer project={createMockProject()} />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("BuidlGuidl");
+  });
+
+  it("server-renders the full description text (not the 200-char sidebar excerpt)", () => {
+    const longDescription = `${"word ".repeat(120)}end.`;
+    render(<ProjectHeaderServer project={createMockProject({ description: longDescription })} />);
+    const header = screen.getByTestId("project-header-server");
+    expect(header.textContent).toContain("end.");
+    expect(header.textContent?.length).toBeGreaterThan(200);
+  });
+
+  it("renders category tags", () => {
+    render(<ProjectHeaderServer project={createMockProject()} />);
+    expect(screen.getByText("Developer Tooling")).toBeInTheDocument();
+    expect(screen.getByText("Education")).toBeInTheDocument();
+  });
+
+  it("omits the tags list when there are no tags", () => {
+    render(<ProjectHeaderServer project={createMockProject({ tags: [] })} />);
+    expect(screen.queryByTestId("project-header-tags")).not.toBeInTheDocument();
+  });
+
+  it("still renders the h1 when the project has no description", () => {
+    render(<ProjectHeaderServer project={createMockProject({ description: undefined })} />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("BuidlGuidl");
+  });
+
+  it("renders nothing when the project has no title", () => {
+    const { container } = render(
+      <ProjectHeaderServer project={createMockProject({ title: "" })} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/project/[projectId]/(profile)/layout.tsx
+++ b/app/project/[projectId]/(profile)/layout.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, Suspense } from "react";
 import { ProjectProfileLayout } from "@/components/Pages/Project/v2/Layout/ProjectProfileLayout";
+import { ProjectHeaderServer } from "@/components/Pages/Project/v2/MainContent/ProjectHeaderServer";
 import { SidebarProfileCardStatic } from "@/components/Pages/Project/v2/SidePanel/SidebarProfileCardStatic";
 import { ProjectProfileLayoutSkeleton } from "@/components/Pages/Project/v2/Skeletons";
 import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
@@ -25,19 +26,26 @@ export default async function ProfileLayout({
   const { projectId } = await params;
 
   let serverSidePanel: ReactNode = null;
+  let serverHeader: ReactNode = null;
   try {
     const project = await getProjectCachedData(projectId);
     if (project) {
       serverSidePanel = <SidebarProfileCardStatic project={project} />;
+      // Renders the project <h1> + full description + tags into the initial
+      // HTML of every tab so crawlers see real, indexable content (the root
+      // tab otherwise ships only the client-rendered Updates feed).
+      serverHeader = <ProjectHeaderServer project={project} />;
     }
   } catch {
-    // If server fetch fails, serverSidePanel stays null.
+    // If server fetch fails, serverSidePanel/serverHeader stay null.
     // Client-side hooks will fetch data as fallback.
   }
 
   return (
     <Suspense fallback={<ProjectProfileLayoutSkeleton />}>
-      <ProjectProfileLayout serverSidePanel={serverSidePanel}>{children}</ProjectProfileLayout>
+      <ProjectProfileLayout serverSidePanel={serverSidePanel} serverHeader={serverHeader}>
+        {children}
+      </ProjectProfileLayout>
     </Suspense>
   );
 }

--- a/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
+++ b/components/Pages/Project/v2/Layout/ProjectProfileLayout.tsx
@@ -81,6 +81,10 @@ interface ProjectProfileLayoutProps {
   /** Server-rendered sidebar panel (RSC slot pattern). When provided, renders
    *  project content in the initial HTML before client hydration. */
   serverSidePanel?: ReactNode;
+  /** Server-rendered project header (<h1> + description + tags) rendered at the
+   *  top of the main content column. Same RSC slot pattern as serverSidePanel —
+   *  puts real, indexable content in the initial HTML of every tab. */
+  serverHeader?: ReactNode;
 }
 
 /**
@@ -105,6 +109,7 @@ export function ProjectProfileLayout({
   children,
   className,
   serverSidePanel,
+  serverHeader,
 }: ProjectProfileLayoutProps) {
   const { projectId } = useParams();
   const pathname = usePathname();
@@ -243,6 +248,7 @@ export function ProjectProfileLayout({
               </div>
             </aside>
             <div className="flex flex-col gap-6 flex-1 min-w-0">
+              {serverHeader}
               <div className="hidden lg:block">
                 <ContentTabsSkeleton />
               </div>
@@ -357,6 +363,10 @@ export function ProjectProfileLayout({
             className="flex flex-col gap-6 flex-1 min-w-0"
             data-testid="project-main-content-area"
           >
+            {/* Server-rendered project header (<h1> + description + tags) — the
+                indexable content crawlers see in the initial HTML of every tab. */}
+            {serverHeader}
+
             {/* Desktop: Post an update + Project Settings above tabs */}
             <div className="hidden lg:flex lg:justify-end items-center gap-2">
               <PostUpdateButton />

--- a/components/Pages/Project/v2/MainContent/ProjectHeaderServer.tsx
+++ b/components/Pages/Project/v2/MainContent/ProjectHeaderServer.tsx
@@ -1,0 +1,67 @@
+import styles from "@/styles/markdown.module.css";
+import type { Project } from "@/types/v2/project";
+import { renderMarkdownToHtml } from "@/utilities/markdown.server";
+import { cn } from "@/utilities/tailwind";
+
+interface ProjectHeaderServerProps {
+  project: Project;
+  className?: string;
+}
+
+/**
+ * Server-rendered project header injected into the initial HTML of every
+ * project tab.
+ *
+ * WHY: the canonical project page (`/project/{slug}`) defaults to the
+ * client-only Updates feed, so before this only the sidebar (project name +
+ * a 200-char description excerpt) reached crawlers, and no project page had an
+ * `<h1>` at all. Google saw thin, heading-less pages and deprioritized crawling
+ * (GSC "Discovered – currently not crawled"). Emitting the project name as an
+ * `<h1>` plus the full description and category tags into the server HTML gives
+ * every tab real, unique, indexable content above the interactive feed.
+ *
+ * Pure server component — no hooks, no interactivity — so its markup is present
+ * in the streamed HTML regardless of client hydration.
+ */
+export function ProjectHeaderServer({ project, className }: ProjectHeaderServerProps) {
+  const details = project?.details;
+  const title = details?.title?.trim();
+
+  // Without a title there is no meaningful heading to render; let the rest of
+  // the page (sidebar, feed) stand on its own rather than emit an empty <h1>.
+  if (!title) return null;
+
+  const descriptionHtml = renderMarkdownToHtml(details?.description);
+  const tags = (details?.tags ?? []).filter((tag) => tag?.trim());
+
+  return (
+    <header className={cn("flex flex-col gap-4", className)} data-testid="project-header-server">
+      <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+
+      {descriptionHtml ? (
+        <div
+          className={cn(
+            "preview wmdeMarkdown",
+            styles.wmdeMarkdown,
+            "text-sm text-muted-foreground leading-relaxed"
+          )}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized server markdown
+          dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+        />
+      ) : null}
+
+      {tags.length > 0 ? (
+        <ul className="flex flex-wrap gap-2" data-testid="project-header-tags">
+          {tags.map((tag) => (
+            <li
+              key={tag}
+              className="rounded-full border border-border bg-secondary px-3 py-1 text-xs text-muted-foreground"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </header>
+  );
+}


### PR DESCRIPTION
## Problem
The canonical project page `/project/{slug}` defaults to the **client-only** Updates feed, so crawlers received only the server-rendered sidebar card — ~1.1k chars (project name + a 200-char description excerpt) — and **no project page had an `<h1>` at all** (the name renders as an `<h2>` inside the sidebar). Google saw thin, heading-less pages and deprioritized crawling — the deepest root cause behind GSC "Discovered – currently not crawled".

Measured before this change (real project, Googlebot UA, JS disabled):
| Page | Server-rendered text | `<h1>` |
|---|---|---|
| `/project/-buidlguidl` (root) | ~1,130 chars | none |
| `/project/-buidlguidl/about` | ~5,030 chars | none |

## Change
New pure server component **`ProjectHeaderServer`** that emits into the initial HTML of **every** project tab:
- the project name as an **`<h1>`**,
- the **full description** (server-rendered markdown via the existing `renderMarkdownToHtml`, same sanitized pipeline as `AboutContentServer`),
- the project's **category tags**.

It's threaded through the existing `(profile)/layout.tsx` into the main content column of `ProjectProfileLayout` using the **same RSC-slot pattern as `serverSidePanel`** (already proven to reach the streamed HTML). Rendered once at the top of the main column, so it shows on mobile + desktop with no duplication, above the interactive feed — **the Updates feed itself is unchanged**.

This is "Tier 1" of the project-content SSR plan (header on all tabs). Deeper SSR of the Updates feed body is a possible follow-up.

## Testing
- New unit test `ProjectHeaderServer.test.tsx` (6 cases): h1 = title, full description (not the 200-char excerpt), tags rendered, tags omitted when empty, h1 still present with no description, renders nothing without a title.
- `pnpm vitest run` on the new test + existing `ProjectProfileLayout` suites → **16/16 pass**.
- `tsc --noEmit` → **0 errors**; Biome clean.

## Context
Third PR in the GSC indexing fix, complementing show-karma/gap-app-v2#1657 (sitemap de-inflation + noindex thin tabs) and show-karma/gap-indexer#2077 (junk/spam slug filtering). Those shrink and clean the URL set; this one makes the pages themselves worth indexing.