### PR TITLE
fix: stop project profile request storm (DEV-396)

### DIFF
--- a/hooks/v2/__tests__/useProjectUpdates.test.tsx
+++ b/hooks/v2/__tests__/useProjectUpdates.test.tsx
@@ -448,4 +448,53 @@ describe("useProjectUpdates", () => {
 
     expect(result.current.milestones).toHaveLength(0);
   });
+
+  // Regression: DEV-396 request storm. `milestones` is derived (convert + sort
+  // + order) and used to feed downstream memos/effects (e.g. useProjectProfile's
+  // aggregation). It MUST keep a stable identity across re-renders when the
+  // underlying query data hasn't changed, otherwise every consumer's deps churn
+  // on every render and amplify into a refetch loop.
+  describe("referential stability (DEV-396)", () => {
+    it("keeps the same `milestones` reference across re-renders when data is unchanged", async () => {
+      mockGetProjectUpdates.mockResolvedValue({
+        projectUpdates: [],
+        projectMilestones: [],
+        grantMilestones: [],
+        grantUpdates: [],
+      });
+
+      const { result, rerender } = renderHook(() => useProjectUpdates("test-project"), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const firstMilestones = result.current.milestones;
+      const firstPending = result.current.pendingMilestones;
+      const firstRefetch = result.current.refetch;
+
+      rerender();
+      rerender();
+
+      expect(result.current.milestones).toBe(firstMilestones);
+      expect(result.current.pendingMilestones).toBe(firstPending);
+      expect(result.current.refetch).toBe(firstRefetch);
+    });
+
+    it("returns a stable empty-array reference while loading", () => {
+      mockGetProjectUpdates.mockReturnValue(new Promise(() => {}));
+
+      const { result, rerender } = renderHook(() => useProjectUpdates("test-project"), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      const firstMilestones = result.current.milestones;
+      rerender();
+
+      expect(result.current.milestones).toBe(firstMilestones);
+      expect(result.current.milestones).toHaveLength(0);
+    });
+  });
 });

--- a/hooks/v2/useProjectGrants.ts
+++ b/hooks/v2/useProjectGrants.ts
@@ -1,8 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { getProjectGrants } from "@/services/project-grants.service";
 import type { Grant } from "@/types/v2/grant";
 import { queryClient } from "@/utilities/query-client";
 import { createProjectQueryPredicate, QUERY_KEYS } from "@/utilities/queryKeys";
+
+/**
+ * Shared frozen empty array so the no-data branch returns a STABLE reference
+ * across renders (see DEV-396).
+ */
+const EMPTY_GRANTS: Grant[] = [];
 
 interface UseProjectGrantsOptions {
   /**
@@ -38,9 +45,9 @@ export function useProjectGrants(projectIdOrSlug: string, options: UseProjectGra
     staleTime: 5 * 60 * 1000,
   });
 
-  const grants = data || [];
+  const grants = data ?? EMPTY_GRANTS;
 
-  const refetch = async () => {
+  const refetch = useCallback(async () => {
     // Use predicate-based invalidation to refresh all project-related queries
     // This automatically handles grants, updates, milestones, impacts, and details
     // in a single call, and is more maintainable as new query types are added
@@ -48,7 +55,7 @@ export function useProjectGrants(projectIdOrSlug: string, options: UseProjectGra
       predicate: createProjectQueryPredicate(projectIdOrSlug),
     });
     return originalRefetch();
-  };
+  }, [projectIdOrSlug, originalRefetch]);
 
   return {
     grants,

--- a/hooks/v2/useProjectImpacts.ts
+++ b/hooks/v2/useProjectImpacts.ts
@@ -1,7 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 import { getProjectImpacts, type ProjectImpact } from "@/services/project-impacts.service";
 import { queryClient } from "@/utilities/query-client";
 import { QUERY_KEYS } from "@/utilities/queryKeys";
+
+/**
+ * Shared frozen empty array so the no-data branch returns a STABLE reference
+ * across renders (see DEV-396). A fresh `[]` each render would make every
+ * consumer's deps (e.g. `useProjectProfile`'s aggregation memo) re-run on
+ * every render.
+ */
+const EMPTY_IMPACTS: ProjectImpact[] = [];
 
 interface UseProjectImpactsOptions {
   /**
@@ -21,7 +30,9 @@ interface UseProjectImpactsOptions {
  */
 export function useProjectImpacts(projectIdOrSlug: string, options: UseProjectImpactsOptions = {}) {
   const { isAuthorized = true } = options;
-  const queryKey = QUERY_KEYS.PROJECT.IMPACTS(projectIdOrSlug);
+  // Memoize so the key identity is stable across renders (the refetch callback
+  // depends on it).
+  const queryKey = useMemo(() => QUERY_KEYS.PROJECT.IMPACTS(projectIdOrSlug), [projectIdOrSlug]);
 
   const {
     data,
@@ -35,12 +46,12 @@ export function useProjectImpacts(projectIdOrSlug: string, options: UseProjectIm
     staleTime: 5 * 60 * 1000,
   });
 
-  const impacts = data || [];
+  const impacts = data ?? EMPTY_IMPACTS;
 
-  const refetch = async () => {
+  const refetch = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey });
     return originalRefetch();
-  };
+  }, [queryKey, originalRefetch]);
 
   return {
     impacts,

--- a/hooks/v2/useProjectProfile.ts
+++ b/hooks/v2/useProjectProfile.ts
@@ -6,7 +6,7 @@
  * data sources into a single, cohesive interface.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useProject } from "@/hooks/useProject";
 import { aggregateProjectProfileData } from "@/services/project-profile.service";
 import type { Project } from "@/types/v2/project";
@@ -106,10 +106,12 @@ export function useProjectProfile(
     [normalizedProject, grants, milestones, impacts]
   );
 
-  // Combined refetch function
-  const refetch = async () => {
+  // Combined refetch function. Memoized so its identity is stable across
+  // renders — consumers wire this into onClick/effects and an unstable identity
+  // would re-trigger them (DEV-396).
+  const refetch = useCallback(async () => {
     await Promise.all([refetchGrants(), refetchUpdates(), refetchImpacts()]);
-  };
+  }, [refetchGrants, refetchUpdates, refetchImpacts]);
 
   return {
     project: normalizedProject,

--- a/hooks/v2/useProjectUpdates.ts
+++ b/hooks/v2/useProjectUpdates.ts
@@ -1,4 +1,5 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 import { getProjectUpdates } from "@/services/project-updates.service";
 import type { UpdatesFeedFilters } from "@/types/v2/project-profile.types";
 import type {
@@ -372,6 +373,14 @@ const sortByDateDescending = (milestones: UnifiedMilestone[]): UnifiedMilestone[
  * @param filters - Optional extra filters forwarded to the indexer
  * @returns Object containing unified milestones, loading state, error, and refetch function
  */
+/**
+ * Shared frozen empty array so the no-data branch returns a STABLE reference
+ * across renders. Returning a fresh `[]` each render makes every downstream
+ * memo/effect that depends on `milestones` re-run on every render (the request-
+ * storm amplifier in DEV-396).
+ */
+const EMPTY_MILESTONES: UnifiedMilestone[] = [];
+
 interface UseProjectUpdatesOptions {
   /**
    * Whether the request should attach a Privy bearer token. Defaults to
@@ -390,16 +399,30 @@ export function useProjectUpdates(
 ) {
   const { isAuthorized = true } = options;
   // Build a stable query key that includes all active filter values so that
-  // React Query invalidates the cache whenever any filter changes.
-  const queryKey = [
-    ...QUERY_KEYS.PROJECT.UPDATES(projectIdOrSlug),
-    milestoneStatus ?? null,
-    filters?.dateFrom ?? null,
-    filters?.dateTo ?? null,
-    filters?.hasAIEvaluation ?? null,
-    filters?.aiScoreMin ?? null,
-    filters?.aiScoreMax ?? null,
-  ] as const;
+  // React Query invalidates the cache whenever any filter changes. Memoized on
+  // the underlying primitives so its identity is stable across renders — the
+  // refetch callback below depends on it.
+  const queryKey = useMemo(
+    () =>
+      [
+        ...QUERY_KEYS.PROJECT.UPDATES(projectIdOrSlug),
+        milestoneStatus ?? null,
+        filters?.dateFrom ?? null,
+        filters?.dateTo ?? null,
+        filters?.hasAIEvaluation ?? null,
+        filters?.aiScoreMin ?? null,
+        filters?.aiScoreMax ?? null,
+      ] as const,
+    [
+      projectIdOrSlug,
+      milestoneStatus,
+      filters?.dateFrom,
+      filters?.dateTo,
+      filters?.hasAIEvaluation,
+      filters?.aiScoreMin,
+      filters?.aiScoreMax,
+    ]
+  );
 
   const {
     data,
@@ -416,21 +439,28 @@ export function useProjectUpdates(
     placeholderData: keepPreviousData,
   });
 
-  // Convert response to unified format (no longer needs project data)
-  const milestones = data
-    ? sortByDateDescending(assignGrantMilestoneOrder(convertToUnifiedMilestones(data)))
-    : [];
+  // Convert response to unified format (no longer needs project data). Memoized
+  // on `data` so the derived array keeps a stable identity across renders when
+  // the underlying query result hasn't changed — otherwise the per-render
+  // recompute churns every consumer's deps (DEV-396 request storm).
+  const milestones = useMemo(
+    () =>
+      data
+        ? sortByDateDescending(assignGrantMilestoneOrder(convertToUnifiedMilestones(data)))
+        : EMPTY_MILESTONES,
+    [data]
+  );
 
   // Filter pending milestones (not completed)
-  const pendingMilestones = milestones.filter((m) => !m.completed);
+  const pendingMilestones = useMemo(() => milestones.filter((m) => !m.completed), [milestones]);
 
   // Provide raw data for components that want to use it directly
   const rawData = data;
 
-  const refetch = async () => {
+  const refetch = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey });
     return originalRefetch();
-  };
+  }, [queryKey, originalRefetch]);
 
   return {
     milestones,


### PR DESCRIPTION
## Problem

On a project profile page, the FE fired `GET /v2/projects/:slug` (`useProject`) and `GET /projects/:slug/impacts` (`useProjectImpacts`) over and over (hundreds of requests, growing latency), driven by predicate `invalidateQueries` firing inside a "Maximum update depth exceeded" render recursion. (DEV-396)

## Root cause

Referential instability in `useProjectProfile` and its child hooks made every render emit brand-new identities, so every downstream memo/effect that depends on them re-ran continuously — the amplifier that turns any minor downstream setState/refetch into the request storm:

- **`useProjectUpdates` recomputed its derived `milestones` array on every render** — `convertToUnifiedMilestones` + sort + `assignGrantMilestoneOrder` were never memoized, producing a new array of new objects each render even when the query data was unchanged.
- The data hooks returned a fresh `[]` default (`data || []`) and a freshly-built `refetch` closure each render.

Net effect: `useProjectProfile` emitted new `milestones` / `grants` / `impacts` / `profileData` / `stats` / `refetch` identities on every render, churning ~10 dependent effects/memos across the project tree.

## Fix

Stabilize identities at the source:

- `useProjectUpdates`: memoize the derived `milestones` (on `data`), `pendingMilestones`, and the `queryKey`; `useCallback` the `refetch`.
- `useProjectImpacts` / `useProjectGrants`: return a shared frozen empty-array constant from the no-data branch; `useCallback` the `refetch`; memoize the impacts `queryKey`.
- `useProjectProfile`: `useCallback` the combined `refetch` (now stable because its child refetches are stable).

With the underlying data unchanged, all of these now keep stable references, so dependent effects/memos only run on real data changes.

## Testing

- `useProjectUpdates`, `useProjectImpacts`, `useProjectGrants`, `useProjectProfile` unit suites pass (48 tests).
- Added 2 regression tests asserting referential stability of `milestones`/`pendingMilestones`/`refetch` across re-renders and a stable empty-array reference while loading.
- `biome check` clean on changed files; `tsc --noEmit` clean for the changed files.
- Browser non-regression pass: project profile page renders, single requests per endpoint.

## Note

The exact "Maximum update depth exceeded" loop only manifests for an authenticated project owner; it could not be reproduced in an anonymous/mocked session. This is a root-cause fix for the documented amplification mechanism, verified by tests, but without a recorded live before/after of the storm. A real owner-session check is the final confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test suite for the project updates hook, verifying data consistency and expected behavior during loading states, empty data scenarios, and across multiple component render cycles.

* **Chores**
  * Refactored internal implementations of project-related hooks including grants, impacts, profile, and updates with updated code patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->