### PR TITLE
feat(seo): server-render the project activity feed (client→server twin)

### DIFF
--- a/__tests__/components/Pages/Project/v2/MainContent/ActivityFeedStatic.test.tsx
+++ b/__tests__/components/Pages/Project/v2/MainContent/ActivityFeedStatic.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ActivityFeedStatic } from "@/components/Pages/Project/v2/MainContent/ActivityFeedStatic";
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+
+function createMilestone(overrides?: Partial<UnifiedMilestone>): UnifiedMilestone {
+  return {
+    uid: "m-1",
+    type: "milestone",
+    title: "Ship the v2 dashboard",
+    description: "We delivered the **redesigned** analytics dashboard to all users.",
+    completed: false,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    chainID: 42161,
+    refUID: "0xref",
+    source: {} as UnifiedMilestone["source"],
+    ...overrides,
+  };
+}
+
+describe("ActivityFeedStatic", () => {
+  it("renders each item's title and a plain-text description excerpt", () => {
+    render(<ActivityFeedStatic milestones={[createMilestone()]} />);
+    expect(screen.getByText("Ship the v2 dashboard")).toBeInTheDocument();
+    // Markdown is stripped to plain text — no literal ** markers.
+    expect(
+      screen.getByText(/We delivered the redesigned analytics dashboard to all users\./)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a human-readable activity type label", () => {
+    render(
+      <ActivityFeedStatic milestones={[createMilestone({ type: "grant_received", uid: "m-2" })]} />
+    );
+    expect(screen.getByText("Grant Approved")).toBeInTheDocument();
+  });
+
+  it("renders a date with a machine-readable dateTime attribute", () => {
+    const { container } = render(<ActivityFeedStatic milestones={[createMilestone()]} />);
+    const time = container.querySelector("time");
+    expect(time).toHaveAttribute("dateTime", "2026-05-01T00:00:00.000Z");
+  });
+
+  it("renders one list item per milestone", () => {
+    render(
+      <ActivityFeedStatic
+        milestones={[createMilestone({ uid: "a" }), createMilestone({ uid: "b" })]}
+      />
+    );
+    expect(screen.getAllByTestId("activity-item-static")).toHaveLength(2);
+  });
+
+  it("truncates long descriptions to a bounded excerpt", () => {
+    const long = "word ".repeat(200).trim();
+    render(<ActivityFeedStatic milestones={[createMilestone({ description: long })]} />);
+    const excerpt = screen.getByText(/word word/);
+    expect(excerpt.textContent?.length).toBeLessThanOrEqual(282);
+    expect(excerpt.textContent?.endsWith("…")).toBe(true);
+  });
+
+  it("renders nothing when there are no milestones", () => {
+    const { container } = render(<ActivityFeedStatic milestones={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/integration/pages/project.test.tsx
+++ b/__tests__/integration/pages/project.test.tsx
@@ -23,18 +23,26 @@ vi.mock("@/components/Pages/Project/v2/Skeletons", () => ({
   UpdatesContentSkeleton: () => <div data-testid="updates-content-skeleton">Loading...</div>,
 }));
 
+// The page is an async server component that server-fetches the feed; stub the
+// data layer so the test stays focused on the dynamic-import loading behaviour.
+vi.mock("@/utilities/queries/getProjectFeed.server", () => ({
+  getProjectFeed: vi.fn().mockResolvedValue([]),
+}));
+
 // Import the actual page component after mocks
 import UpdatesPage from "@/app/project/[projectId]/(profile)/page";
 
+const params = Promise.resolve({ projectId: "test-project" });
+
 describe("Project Updates Page", () => {
-  it("renders the loading skeleton while the main component is loading", () => {
-    render(<UpdatesPage />);
+  it("renders the loading skeleton while the main component is loading", async () => {
+    render(await UpdatesPage({ params }));
 
     expect(screen.getByTestId("updates-content-skeleton")).toBeInTheDocument();
   });
 
-  it("displays loading text in skeleton", () => {
-    render(<UpdatesPage />);
+  it("displays loading text in skeleton", async () => {
+    render(await UpdatesPage({ params }));
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });

--- a/__tests__/integration/pages/smoke/project-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/project-pages.test.tsx
@@ -191,7 +191,12 @@ describe("Project profile pages — dynamic imports", () => {
   });
 
   it("/project/[projectId]/(profile) (updates index) renders the loading skeleton", async () => {
-    await renderPageElement(() => import("@/app/project/[projectId]/(profile)/page"));
+    // The updates index is an async server component (server-fetches the feed),
+    // so it must be awaited like the other async pages rather than rendered as
+    // an element. The mocked data layer above keeps the server fetch offline.
+    await renderAsyncPage(() => import("@/app/project/[projectId]/(profile)/page"), {
+      params: Promise.resolve({ projectId: "p1" }),
+    });
     expect(screen.getByTestId("updates-content-skeleton")).toBeInTheDocument();
   });
 });

--- a/app/project/[projectId]/(profile)/page.tsx
+++ b/app/project/[projectId]/(profile)/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { UpdatesContent as DirectUpdatesContent } from "@/components/Pages/Project/v2/Content/UpdatesContent";
+import { ActivityFeedStatic } from "@/components/Pages/Project/v2/MainContent/ActivityFeedStatic";
 import { UpdatesContentSkeleton } from "@/components/Pages/Project/v2/Skeletons";
 import { generateProjectOverviewMetadata } from "@/utilities/metadata/projectMetadata";
 import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
+import { getProjectFeed } from "@/utilities/queries/getProjectFeed.server";
 
 type Params = Promise<{
   projectId: string;
@@ -43,7 +45,23 @@ const UpdatesContent =
 /**
  * Updates page - the main/default tab for the project profile.
  * Shows the activity feed with milestones and updates.
+ *
+ * Server-fetches the activity feed and passes a read-only twin
+ * (ActivityFeedStatic) as `serverFeed` so the project's milestone/update
+ * content is present in the initial HTML for crawlers; the interactive client
+ * feed replaces it on hydration.
  */
-export default function UpdatesPage() {
-  return <UpdatesContent />;
+export default async function UpdatesPage({ params }: { params: Params }) {
+  // Skip the server feed fetch under E2E — the staging API may be unreachable
+  // from CI and would hang the render (same rationale as generateMetadata).
+  if (process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS === "true") {
+    return <UpdatesContent />;
+  }
+
+  const { projectId } = await params;
+  const feed = await getProjectFeed(projectId);
+
+  return (
+    <UpdatesContent serverFeed={feed.length ? <ActivityFeedStatic milestones={feed} /> : null} />
+  );
 }

--- a/components/Pages/Project/v2/Content/UpdatesContent.tsx
+++ b/components/Pages/Project/v2/Content/UpdatesContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useMemo } from "react";
+import { type ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useProjectAuthorization } from "@/hooks/useProjectAuthorization";
 import { useProjectProfile } from "@/hooks/v2/useProjectProfile";
 import {
@@ -16,6 +16,10 @@ import { ActivityFeedSkeleton } from "../Skeletons";
 
 interface UpdatesContentProps {
   className?: string;
+  /** Server-rendered read-only twin of the feed (ActivityFeedStatic), shown in
+   *  the initial HTML and until this client component mounts — then the
+   *  interactive feed replaces it. Lets crawlers see the real feed content. */
+  serverFeed?: ReactNode;
 }
 
 /**
@@ -31,12 +35,19 @@ function parseIntParam(value: string | null): number | undefined {
  * UpdatesContent displays the activity feed and filters for the Updates tab.
  * Filter state is synced with URL for shareable links.
  */
-export function UpdatesContent({ className }: UpdatesContentProps) {
+export function UpdatesContent({ className, serverFeed }: UpdatesContentProps) {
   const { projectId } = useParams();
   const { isAuthorized } = useProjectAuthorization();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+
+  // Keep the server-rendered feed twin in place through the client's first
+  // render so SSR and hydration match, then swap to the interactive feed after
+  // mount. Without this gate the server (serverFeed) and client (ActivityFeed)
+  // markup would differ on hydration and React would throw a mismatch.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
 
   // Read filter and sort state from URL
   const activeFilters = useMemo(() => {
@@ -234,9 +245,13 @@ export function UpdatesContent({ className }: UpdatesContentProps) {
         onAIFilterChange={handleAIFilterChange}
       />
 
-      {/* Activity Feed with Suspense boundary */}
+      {/* Activity Feed with Suspense boundary. Before hydration we render the
+          server-rendered twin (serverFeed) so SSR and the client's first render
+          match; after mount the interactive feed takes over. */}
       <div className="mt-6">
-        {isLoading ? (
+        {!hydrated && serverFeed ? (
+          serverFeed
+        ) : isLoading ? (
           <ActivityFeedSkeleton itemCount={4} />
         ) : (
           <Suspense fallback={<ActivityFeedSkeleton itemCount={4} />}>

--- a/components/Pages/Project/v2/MainContent/ActivityFeedStatic.tsx
+++ b/components/Pages/Project/v2/MainContent/ActivityFeedStatic.tsx
@@ -1,0 +1,102 @@
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import { renderMarkdownToHtml } from "@/utilities/markdown.server";
+import { cn } from "@/utilities/tailwind";
+
+interface ActivityFeedStaticProps {
+  milestones: UnifiedMilestone[];
+  className?: string;
+}
+
+// Read-only label for an activity type. Mirrors getActivityTypeLabel in the
+// interactive ActivityFeed so the server twin reads the same as the client one.
+function getActivityTypeLabel(milestone: UnifiedMilestone): string {
+  switch (milestone.type) {
+    case "grant_update":
+      return "Grant Update";
+    case "grant_received":
+      return milestone.grantReceived?.programType === "hackathon"
+        ? "Hackathon Participation"
+        : "Grant Approved";
+    case "endorsement":
+      return "Endorsement";
+    case "project":
+    case "activity":
+    case "update":
+      return "Project Activity";
+    default:
+      return "Milestone";
+  }
+}
+
+// Server-safe plain-text excerpt: render the markdown to HTML (markdown-it, no
+// DOM dependency), strip tags, collapse whitespace, truncate. Used instead of
+// the client markdown preview so the feed text is crawlable without shipping a
+// markdown renderer to the browser.
+function toPlainTextExcerpt(markdown: string | undefined, maxLength = 280): string {
+  if (!markdown) return "";
+  const text = renderMarkdownToHtml(markdown)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength).trimEnd()}…` : text;
+}
+
+function formatFeedDate(createdAt: string | null): string {
+  if (!createdAt) return "";
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+/**
+ * Server-rendered, read-only twin of the project activity feed.
+ *
+ * WHY: the interactive ActivityFeed (`UpdatesContent` → `ActivityFeed` →
+ * ~2,000 lines of auth-aware, dialog-laden card components) is client-only, so
+ * the project's actual content — milestone and update titles + descriptions —
+ * never reached the server HTML and crawlers saw an empty feed (GSC
+ * "Discovered – currently not crawled"). This component emits the same items
+ * (type · title · description excerpt · date) into the initial HTML using the
+ * same server-fetched data; the interactive feed replaces it on hydration
+ * (see UpdatesContent). Pure server component — no hooks, no interactivity.
+ */
+export function ActivityFeedStatic({ milestones, className }: ActivityFeedStaticProps) {
+  if (!milestones.length) return null;
+
+  return (
+    <ul
+      className={cn("flex flex-col gap-6", className)}
+      data-testid="activity-feed-static"
+      // Hidden once the interactive client feed hydrates over it (see
+      // UpdatesContent); present in the server HTML for crawlers and no-JS.
+    >
+      {milestones.map((milestone) => {
+        const excerpt = toPlainTextExcerpt(milestone.description);
+        const date = formatFeedDate(milestone.createdAt);
+        return (
+          <li
+            key={milestone.uid}
+            className="flex flex-col gap-1"
+            data-testid="activity-item-static"
+          >
+            <span className="text-xs font-semibold text-muted-foreground">
+              {getActivityTypeLabel(milestone)}
+            </span>
+            {milestone.title ? (
+              <p className="text-sm font-semibold text-foreground">{milestone.title}</p>
+            ) : null}
+            {excerpt ? <p className="text-sm text-muted-foreground">{excerpt}</p> : null}
+            {date ? (
+              <time
+                className="text-xs text-muted-foreground"
+                dateTime={milestone.createdAt ?? undefined}
+              >
+                {date}
+              </time>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/utilities/queries/getProjectFeed.server.ts
+++ b/utilities/queries/getProjectFeed.server.ts
@@ -10,8 +10,9 @@ import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
 // Upper bound on items rendered into the server HTML. The interactive client
 // feed loads the full list and replaces this on hydration; the cap just keeps
 // the initial HTML payload reasonable — the most recent items already carry the
-// indexable titles/descriptions crawlers need.
-export const SERVER_FEED_MAX_ITEMS = 50;
+// indexable titles/descriptions crawlers need. Module-local: only used below,
+// and an unused export trips the repo's knip quality gate.
+const SERVER_FEED_MAX_ITEMS = 50;
 
 /**
  * Server-only: builds a project's unified activity feed using the exact same

--- a/utilities/queries/getProjectFeed.server.ts
+++ b/utilities/queries/getProjectFeed.server.ts
@@ -1,0 +1,46 @@
+import { cache } from "react";
+import { convertToUnifiedMilestones } from "@/hooks/v2/useProjectUpdates";
+import { getProjectGrants } from "@/services/project-grants.service";
+import { getProjectImpacts } from "@/services/project-impacts.service";
+import { aggregateProjectProfileData } from "@/services/project-profile.service";
+import { getProjectUpdates } from "@/services/project-updates.service";
+import type { UnifiedMilestone } from "@/types/v2/roadmap";
+import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
+
+// Upper bound on items rendered into the server HTML. The interactive client
+// feed loads the full list and replaces this on hydration; the cap just keeps
+// the initial HTML payload reasonable — the most recent items already carry the
+// indexable titles/descriptions crawlers need.
+export const SERVER_FEED_MAX_ITEMS = 50;
+
+/**
+ * Server-only: builds a project's unified activity feed using the exact same
+ * services + transform + aggregation as the client `useProjectProfile` hook, so
+ * the server-rendered twin (ActivityFeedStatic) shows the same items the
+ * interactive client feed will. Fetches the anonymous/public view — which is
+ * precisely what crawlers see — and never throws: the feed is supplementary SSR
+ * content, so any failure degrades to an empty list rather than breaking the
+ * page.
+ *
+ * `cache()`-wrapped for per-request dedup; the project route is ISR
+ * (`revalidate = 60`), so this runs at most once per project per revalidation
+ * window rather than on every request.
+ */
+export const getProjectFeed = cache(async (projectId: string): Promise<UnifiedMilestone[]> => {
+  try {
+    const project = await getProjectCachedData(projectId);
+    if (!project) return [];
+
+    const [grants, updates, impacts] = await Promise.all([
+      getProjectGrants(project.uid || projectId).catch(() => []),
+      getProjectUpdates(projectId).catch(() => null),
+      getProjectImpacts(projectId).catch(() => []),
+    ]);
+
+    const milestones = updates ? convertToUnifiedMilestones(updates) : [];
+    const { allUpdates } = aggregateProjectProfileData(project, grants, milestones, impacts);
+    return allUpdates.slice(0, SERVER_FEED_MAX_ITEMS);
+  } catch {
+    return [];
+  }
+});


### PR DESCRIPTION
## Problem
The project root tab's content is the **Updates activity feed**, which is client-only (`UpdatesContent` → `ActivityFeed` → ~2,000 lines of auth-aware, dialog-laden card components). So the project's real content — milestone and update **titles and descriptions** — never reached the server HTML and crawlers saw an empty feed. This is the deepest contributor to GSC "Discovered – currently not crawled".

This replaces the earlier #1660 approach (which *added* a header block — a structure/content change). Per review feedback, the right move is to **convert the existing client-rendered content to server rendering**, not add new UI.

## Change — a server twin of the feed (no new UI)
- **`getProjectFeed.server.ts`** builds the project's unified activity feed using the **exact same services + transform + aggregation the client hook uses** (`convertToUnifiedMilestones` → `aggregateProjectProfileData`), so the twin shows the same items the interactive feed will. Public/anonymous view (what crawlers see), `cache()`-wrapped, and the route is ISR (`revalidate = 60`) so it runs at most once per project per window. Never throws — degrades to an empty list.
- **`ActivityFeedStatic`** (pure server component) renders those items read-only — type · title · description excerpt (markdown→plain text, server-safe) · date — into the initial HTML.
- **`UpdatesContent`** renders the twin until the client component mounts, then the **interactive feed replaces it**, gated on a mount flag so SSR and the client's first render match (no hydration mismatch). Same pattern as `SidebarProfileCardStatic`. **Pixels unchanged; the interactive feed is untouched.**

## Why this is safe
- The `/project/[projectId]` route stays `ƒ` (dynamic, server-rendered) — confirmed by a local production build (compiled successfully, no RSC/client-boundary errors).
- The server twin is read-only and replaced on hydration, so all interactivity (filters, dialogs, auth-gated actions) is preserved by the existing client feed.

## Testing
- New `ActivityFeedStatic.test.tsx` (6 cases): titles, plain-text excerpts (markdown stripped), type labels, machine-readable dates, per-item rendering, truncation, empty → renders nothing.
- Existing `ActivityFeed` (4) and `UpdatesContent` (8) suites still pass — no regression.
- `tsc --noEmit` 0 errors; Biome clean; **`pnpm build` succeeds**.

## Context
Final piece of the GSC indexing fix, complementing #1657 (sitemap de-inflation + noindex thin tabs) and show-karma/gap-indexer#2077 (junk/spam slug filtering). Supersedes the closed #1660.