### PR TITLE
feat(ask-karma): graceful working-limit UX and multi-line inputs

### DIFF
--- a/__tests__/hooks/useAgentStream.limit.test.ts
+++ b/__tests__/hooks/useAgentStream.limit.test.ts
@@ -1,0 +1,254 @@
+/**
+ * @file Tests for useAgentStream's working-limit (`limit_reached`) handling.
+ * Split out of useAgentStream.test.ts to keep each test module under the size
+ * limit. Setup mirrors that file (jscpd ignores test files, so the duplicated
+ * fetch/SSE scaffolding carries no duplication penalty).
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { useAgentStream } from "@/hooks/useAgentStream";
+import { useAgentChatStore } from "@/store/agentChat";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    pathname: "/",
+  })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => ({ get: vi.fn() })),
+  useParams: vi.fn(() => ({})),
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn().mockResolvedValue("mock-token-123"),
+  },
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "https://api.test.com",
+  },
+}));
+
+import { TokenManager } from "@/utilities/auth/token-manager";
+
+const mockGetToken = TokenManager.getToken as vi.Mock;
+
+function formatSSE(events: Array<{ type: string; [key: string]: unknown }>): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+// Mock ReadableStream body — jsdom doesn't reliably support getReader().read().
+function createMockBody(sseText: string) {
+  const encoder = new TextEncoder();
+  const encoded = sseText ? encoder.encode(sseText) : null;
+  let consumed = false;
+
+  return {
+    getReader() {
+      return {
+        async read() {
+          if (!consumed && encoded) {
+            consumed = true;
+            return { done: false as const, value: encoded };
+          }
+          return { done: true as const, value: undefined };
+        },
+        releaseLock() {},
+        cancel: async () => {},
+        closed: Promise.resolve(undefined),
+      };
+    },
+    locked: false,
+    cancel: async () => {},
+    tee: () => [null, null],
+    pipeTo: async () => {},
+    pipeThrough: () => null,
+    [Symbol.asyncIterator]: async function* () {},
+  };
+}
+
+function createStreamResponse(sseText: string): Response {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers({ "content-type": "text/event-stream" }),
+    body: createMockBody(sseText) as unknown as ReadableStream<Uint8Array>,
+    bodyUsed: false,
+    redirected: false,
+    type: "default" as ResponseType,
+    url: "https://api.test.com/v2/agent/stream",
+    text: async () => sseText,
+    json: async () => JSON.parse(sseText),
+    blob: async () => new Blob([sseText]),
+    formData: async () => new FormData(),
+    arrayBuffer: async () => encoder.encode(sseText).buffer,
+    bytes: async () => encoder.encode(sseText),
+    clone() {
+      return createStreamResponse(sseText);
+    },
+  } as Response;
+}
+
+const mockFetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+let savedFetch: typeof globalThis.fetch;
+
+let testQueryClient: QueryClient;
+function createWrapper() {
+  testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: testQueryClient }, children);
+  return Wrapper;
+}
+
+describe("useAgentStream — limit_reached", () => {
+  beforeAll(() => {
+    savedFetch = globalThis.fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = savedFetch;
+  });
+
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+    mockGetToken.mockResolvedValue("mock-token-123");
+    wrapper = createWrapper();
+
+    useAgentChatStore.setState({
+      messages: [],
+      isOpen: false,
+      isStreaming: false,
+      error: null,
+      limitReached: null,
+      agentContext: null,
+      pendingMentions: [],
+      pendingTraceId: null,
+      ratingCommentBoxOpenForMessageId: null,
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+  });
+
+  it("should set limitReached (not error) on a limit_reached event", async () => {
+    const sseText = formatSSE([
+      { type: "assistant", message: { content: [{ type: "text", text: "Partial findings" }] } },
+      { type: "limit_reached", reason: "budget", hadAssistantText: true },
+    ]);
+    mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+    const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("Expensive question");
+    });
+
+    expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+    expect(useAgentChatStore.getState().error).toBeNull();
+  });
+
+  it("should set limitReached with reason 'time' on a per-run timeout abort", async () => {
+    const sseText = formatSSE([{ type: "limit_reached", reason: "time" }]);
+    mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+    const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("Long task");
+    });
+
+    expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "time" });
+    expect(useAgentChatStore.getState().error).toBeNull();
+  });
+
+  it("should seed a fallback message when the limit was hit with no prose", async () => {
+    const sseText = formatSSE([
+      { type: "limit_reached", reason: "turns", hadAssistantText: false },
+    ]);
+    mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+    const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("Tool-spree question");
+    });
+
+    const messages = useAgentChatStore.getState().messages;
+    const lastAssistant = messages.findLast((m) => m.role === "assistant");
+    expect(lastAssistant?.content).toMatch(/working limit/i);
+    expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "turns" });
+  });
+
+  it("should keep streamed prose and not overwrite it with the fallback", async () => {
+    const sseText = formatSSE([
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "Here is what I found" },
+        },
+      },
+      { type: "limit_reached", reason: "budget", hadAssistantText: true },
+    ]);
+    mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+    const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("Question");
+    });
+
+    const lastAssistant = useAgentChatStore
+      .getState()
+      .messages.findLast((m) => m.role === "assistant");
+    expect(lastAssistant?.content).toBe("Here is what I found");
+  });
+
+  it("continueLastRun clears the limit and sends another request with history", async () => {
+    mockFetch.mockResolvedValue(
+      createStreamResponse(
+        formatSSE([{ type: "limit_reached", reason: "budget", hadAssistantText: false }])
+      )
+    );
+
+    const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("First");
+    });
+    expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+
+    mockFetch.mockResolvedValue(createStreamResponse(""));
+    await act(async () => {
+      await result.current.continueLastRun();
+    });
+
+    expect(useAgentChatStore.getState().limitReached).toBeNull();
+    // second fetch carries conversationHistory from the prior turn
+    const lastCall = mockFetch.mock.calls.at(-1);
+    const body = JSON.parse((lastCall?.[1] as RequestInit).body as string);
+    expect(Array.isArray(body.conversationHistory)).toBe(true);
+    expect(body.conversationHistory.length).toBeGreaterThan(0);
+    // the synthetic working-limit fallback must NOT be replayed to the agent
+    expect(
+      body.conversationHistory.some((m: { content: string }) => /working limit/i.test(m.content))
+    ).toBe(false);
+  });
+});

--- a/__tests__/hooks/useAgentStream.test.ts
+++ b/__tests__/hooks/useAgentStream.test.ts
@@ -174,7 +174,6 @@ describe("useAgentStream", () => {
       isOpen: false,
       isStreaming: false,
       error: null,
-      limitReached: null,
       agentContext: null,
       pendingMentions: [],
       pendingTraceId: null,
@@ -286,111 +285,6 @@ describe("useAgentStream", () => {
       });
 
       expect(useAgentChatStore.getState().error).toBe("Rate limit exceeded, Try again later");
-    });
-
-    it("should set limitReached (not error) on a limit_reached event", async () => {
-      const sseText = formatSSE([
-        { type: "assistant", message: { content: [{ type: "text", text: "Partial findings" }] } },
-        { type: "limit_reached", reason: "budget", hadAssistantText: true },
-      ]);
-      mockFetch.mockResolvedValue(createStreamResponse(sseText));
-
-      const { result } = renderHook(() => useAgentStream(), { wrapper });
-
-      await act(async () => {
-        await result.current.sendMessage("Expensive question");
-      });
-
-      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
-      expect(useAgentChatStore.getState().error).toBeNull();
-    });
-
-    it("should set limitReached with reason 'time' on a per-run timeout abort", async () => {
-      const sseText = formatSSE([{ type: "limit_reached", reason: "time" }]);
-      mockFetch.mockResolvedValue(createStreamResponse(sseText));
-
-      const { result } = renderHook(() => useAgentStream(), { wrapper });
-
-      await act(async () => {
-        await result.current.sendMessage("Long task");
-      });
-
-      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "time" });
-      expect(useAgentChatStore.getState().error).toBeNull();
-    });
-
-    it("should seed a fallback message when the limit was hit with no prose", async () => {
-      const sseText = formatSSE([
-        { type: "limit_reached", reason: "turns", hadAssistantText: false },
-      ]);
-      mockFetch.mockResolvedValue(createStreamResponse(sseText));
-
-      const { result } = renderHook(() => useAgentStream(), { wrapper });
-
-      await act(async () => {
-        await result.current.sendMessage("Tool-spree question");
-      });
-
-      const messages = useAgentChatStore.getState().messages;
-      const lastAssistant = messages.findLast((m) => m.role === "assistant");
-      expect(lastAssistant?.content).toMatch(/working limit/i);
-      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "turns" });
-    });
-
-    it("should keep streamed prose and not overwrite it with the fallback", async () => {
-      const sseText = formatSSE([
-        {
-          type: "stream_event",
-          event: {
-            type: "content_block_delta",
-            delta: { type: "text_delta", text: "Here is what I found" },
-          },
-        },
-        { type: "limit_reached", reason: "budget", hadAssistantText: true },
-      ]);
-      mockFetch.mockResolvedValue(createStreamResponse(sseText));
-
-      const { result } = renderHook(() => useAgentStream(), { wrapper });
-
-      await act(async () => {
-        await result.current.sendMessage("Question");
-      });
-
-      const lastAssistant = useAgentChatStore
-        .getState()
-        .messages.findLast((m) => m.role === "assistant");
-      expect(lastAssistant?.content).toBe("Here is what I found");
-    });
-
-    it("continueLastRun clears the limit and sends another request with history", async () => {
-      mockFetch.mockResolvedValue(
-        createStreamResponse(
-          formatSSE([{ type: "limit_reached", reason: "budget", hadAssistantText: false }])
-        )
-      );
-
-      const { result } = renderHook(() => useAgentStream(), { wrapper });
-
-      await act(async () => {
-        await result.current.sendMessage("First");
-      });
-      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
-
-      mockFetch.mockResolvedValue(createStreamResponse(""));
-      await act(async () => {
-        await result.current.continueLastRun();
-      });
-
-      expect(useAgentChatStore.getState().limitReached).toBeNull();
-      // second fetch carries conversationHistory from the prior turn
-      const lastCall = mockFetch.mock.calls.at(-1);
-      const body = JSON.parse((lastCall?.[1] as RequestInit).body as string);
-      expect(Array.isArray(body.conversationHistory)).toBe(true);
-      expect(body.conversationHistory.length).toBeGreaterThan(0);
-      // the synthetic working-limit fallback must NOT be replayed to the agent
-      expect(
-        body.conversationHistory.some((m: { content: string }) => /working limit/i.test(m.content))
-      ).toBe(false);
     });
 
     it("should set streaming to false after request completes", async () => {

--- a/__tests__/hooks/useAgentStream.test.ts
+++ b/__tests__/hooks/useAgentStream.test.ts
@@ -174,6 +174,7 @@ describe("useAgentStream", () => {
       isOpen: false,
       isStreaming: false,
       error: null,
+      limitReached: null,
       agentContext: null,
       pendingMentions: [],
       pendingTraceId: null,
@@ -285,6 +286,107 @@ describe("useAgentStream", () => {
       });
 
       expect(useAgentChatStore.getState().error).toBe("Rate limit exceeded, Try again later");
+    });
+
+    it("should set limitReached (not error) on a limit_reached event", async () => {
+      const sseText = formatSSE([
+        { type: "assistant", message: { content: [{ type: "text", text: "Partial findings" }] } },
+        { type: "limit_reached", reason: "budget", hadAssistantText: true },
+      ]);
+      mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+      const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+      await act(async () => {
+        await result.current.sendMessage("Expensive question");
+      });
+
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+      expect(useAgentChatStore.getState().error).toBeNull();
+    });
+
+    it("should set limitReached with reason 'time' on a per-run timeout abort", async () => {
+      const sseText = formatSSE([{ type: "limit_reached", reason: "time" }]);
+      mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+      const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+      await act(async () => {
+        await result.current.sendMessage("Long task");
+      });
+
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "time" });
+      expect(useAgentChatStore.getState().error).toBeNull();
+    });
+
+    it("should seed a fallback message when the limit was hit with no prose", async () => {
+      const sseText = formatSSE([
+        { type: "limit_reached", reason: "turns", hadAssistantText: false },
+      ]);
+      mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+      const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+      await act(async () => {
+        await result.current.sendMessage("Tool-spree question");
+      });
+
+      const messages = useAgentChatStore.getState().messages;
+      const lastAssistant = messages.findLast((m) => m.role === "assistant");
+      expect(lastAssistant?.content).toMatch(/working limit/i);
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "turns" });
+    });
+
+    it("should keep streamed prose and not overwrite it with the fallback", async () => {
+      const sseText = formatSSE([
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Here is what I found" },
+          },
+        },
+        { type: "limit_reached", reason: "budget", hadAssistantText: true },
+      ]);
+      mockFetch.mockResolvedValue(createStreamResponse(sseText));
+
+      const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+      await act(async () => {
+        await result.current.sendMessage("Question");
+      });
+
+      const lastAssistant = useAgentChatStore
+        .getState()
+        .messages.findLast((m) => m.role === "assistant");
+      expect(lastAssistant?.content).toBe("Here is what I found");
+    });
+
+    it("continueLastRun clears the limit and sends another request with history", async () => {
+      mockFetch.mockResolvedValue(
+        createStreamResponse(
+          formatSSE([{ type: "limit_reached", reason: "budget", hadAssistantText: false }])
+        )
+      );
+
+      const { result } = renderHook(() => useAgentStream(), { wrapper });
+
+      await act(async () => {
+        await result.current.sendMessage("First");
+      });
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+
+      mockFetch.mockResolvedValue(createStreamResponse(""));
+      await act(async () => {
+        await result.current.continueLastRun();
+      });
+
+      expect(useAgentChatStore.getState().limitReached).toBeNull();
+      // second fetch carries conversationHistory from the prior turn
+      const lastCall = mockFetch.mock.calls.at(-1);
+      const body = JSON.parse((lastCall?.[1] as RequestInit).body as string);
+      expect(Array.isArray(body.conversationHistory)).toBe(true);
+      expect(body.conversationHistory.length).toBeGreaterThan(0);
     });
 
     it("should set streaming to false after request completes", async () => {

--- a/__tests__/hooks/useAgentStream.test.ts
+++ b/__tests__/hooks/useAgentStream.test.ts
@@ -387,6 +387,10 @@ describe("useAgentStream", () => {
       const body = JSON.parse((lastCall?.[1] as RequestInit).body as string);
       expect(Array.isArray(body.conversationHistory)).toBe(true);
       expect(body.conversationHistory.length).toBeGreaterThan(0);
+      // the synthetic working-limit fallback must NOT be replayed to the agent
+      expect(
+        body.conversationHistory.some((m: { content: string }) => /working limit/i.test(m.content))
+      ).toBe(false);
     });
 
     it("should set streaming to false after request completes", async () => {

--- a/__tests__/store/agentChat.limit-reached.test.ts
+++ b/__tests__/store/agentChat.limit-reached.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @file Tests for the agentChat store's working-limit (`limitReached`) state.
+ * Split out of agentChat.test.ts to keep each test module under the size limit.
+ */
+
+import { act } from "@testing-library/react";
+import { useAgentChatStore } from "@/store/agentChat";
+
+describe("useAgentChatStore — limitReached", () => {
+  beforeEach(() => {
+    act(() => {
+      useAgentChatStore.setState({
+        messages: [],
+        isStreaming: false,
+        error: null,
+        limitReached: null,
+      });
+    });
+  });
+
+  it("defaults to null", () => {
+    expect(useAgentChatStore.getState().limitReached).toBeNull();
+  });
+
+  describe("setLimitReached", () => {
+    it("should set the limit reason", () => {
+      act(() => {
+        useAgentChatStore.getState().setLimitReached({ reason: "budget" });
+      });
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+    });
+
+    it("should clear the limit when set to null", () => {
+      act(() => {
+        useAgentChatStore.getState().setLimitReached({ reason: "turns" });
+        useAgentChatStore.getState().setLimitReached(null);
+      });
+      expect(useAgentChatStore.getState().limitReached).toBeNull();
+    });
+  });
+
+  it("clearMessages also clears limitReached", () => {
+    act(() => {
+      useAgentChatStore.getState().setLimitReached({ reason: "budget" });
+      useAgentChatStore.getState().clearMessages();
+    });
+    expect(useAgentChatStore.getState().limitReached).toBeNull();
+  });
+});

--- a/__tests__/store/agentChat.test.ts
+++ b/__tests__/store/agentChat.test.ts
@@ -15,6 +15,7 @@ describe("useAgentChatStore", () => {
         isOpen: false,
         isStreaming: false,
         error: null,
+        limitReached: null,
         agentContext: null,
       });
     });
@@ -39,6 +40,27 @@ describe("useAgentChatStore", () => {
 
     it("should have null agent context", () => {
       expect(useAgentChatStore.getState().agentContext).toBeNull();
+    });
+
+    it("should have no limitReached", () => {
+      expect(useAgentChatStore.getState().limitReached).toBeNull();
+    });
+  });
+
+  describe("setLimitReached", () => {
+    it("should set the limit reason", () => {
+      act(() => {
+        useAgentChatStore.getState().setLimitReached({ reason: "budget" });
+      });
+      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
+    });
+
+    it("should clear the limit when set to null", () => {
+      act(() => {
+        useAgentChatStore.getState().setLimitReached({ reason: "turns" });
+        useAgentChatStore.getState().setLimitReached(null);
+      });
+      expect(useAgentChatStore.getState().limitReached).toBeNull();
     });
   });
 
@@ -759,6 +781,15 @@ describe("useAgentChatStore", () => {
       });
 
       expect(useAgentChatStore.getState().error).toBeNull();
+    });
+
+    it("should also clear limitReached", () => {
+      act(() => {
+        useAgentChatStore.getState().setLimitReached({ reason: "budget" });
+        useAgentChatStore.getState().clearMessages();
+      });
+
+      expect(useAgentChatStore.getState().limitReached).toBeNull();
     });
 
     it("should not affect isOpen state", () => {

--- a/__tests__/store/agentChat.test.ts
+++ b/__tests__/store/agentChat.test.ts
@@ -41,27 +41,6 @@ describe("useAgentChatStore", () => {
     it("should have null agent context", () => {
       expect(useAgentChatStore.getState().agentContext).toBeNull();
     });
-
-    it("should have no limitReached", () => {
-      expect(useAgentChatStore.getState().limitReached).toBeNull();
-    });
-  });
-
-  describe("setLimitReached", () => {
-    it("should set the limit reason", () => {
-      act(() => {
-        useAgentChatStore.getState().setLimitReached({ reason: "budget" });
-      });
-      expect(useAgentChatStore.getState().limitReached).toEqual({ reason: "budget" });
-    });
-
-    it("should clear the limit when set to null", () => {
-      act(() => {
-        useAgentChatStore.getState().setLimitReached({ reason: "turns" });
-        useAgentChatStore.getState().setLimitReached(null);
-      });
-      expect(useAgentChatStore.getState().limitReached).toBeNull();
-    });
   });
 
   describe("setOpen", () => {
@@ -781,15 +760,6 @@ describe("useAgentChatStore", () => {
       });
 
       expect(useAgentChatStore.getState().error).toBeNull();
-    });
-
-    it("should also clear limitReached", () => {
-      act(() => {
-        useAgentChatStore.getState().setLimitReached({ reason: "budget" });
-        useAgentChatStore.getState().clearMessages();
-      });
-
-      expect(useAgentChatStore.getState().limitReached).toBeNull();
     });
 
     it("should not affect isOpen state", () => {

--- a/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-chat.test.tsx
@@ -374,6 +374,63 @@ describe("AskKarmaChat", () => {
     expect(alert).toHaveTextContent("Connection failed");
   });
 
+  it("renders a Continue affordance (not an error) when a working limit was reached", () => {
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[
+          buildMsg({ id: "a1", role: "assistant", content: "Partial findings", timestamp: 1 }),
+        ]}
+        isStreaming={false}
+        error={null}
+        limitReached={{ reason: "budget" }}
+        onContinue={vi.fn()}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("invokes onContinue when the Continue button is clicked", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={false}
+        error={null}
+        limitReached={{ reason: "turns" }}
+        onContinue={onContinue}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the Continue affordance while streaming", () => {
+    render(
+      <AskKarmaChat
+        config={config}
+        messages={[]}
+        isStreaming={true}
+        error={null}
+        limitReached={{ reason: "budget" }}
+        onContinue={vi.fn()}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /continue/i })).not.toBeInTheDocument();
+  });
+
   it("invokes onBack when the back button is clicked", async () => {
     const user = userEvent.setup();
     const onBack = vi.fn();

--- a/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-input.test.tsx
@@ -86,8 +86,9 @@ describe("AskKarmaInput", () => {
   it("caps chat message length to prevent oversized prompts", () => {
     render(<AskKarmaInput onSubmit={vi.fn()} isStreaming={false} />);
     const textarea = screen.getByPlaceholderText("Type your message...");
-    // Value is intentional and asserted so it can't be lowered silently.
-    expect(textarea).toHaveAttribute("maxLength", "4000");
+    // Generous but bounded — guards against accidental document pastes.
+    // Value is intentional and asserted so it can't be changed silently.
+    expect(textarea).toHaveAttribute("maxLength", "16000");
   });
 
   it("ignores Enter while IME composition is active", async () => {

--- a/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
+++ b/__tests__/unit/features/ask-karma/ask-karma-start.test.tsx
@@ -160,7 +160,7 @@ describe("AskKarmaStart — direct input submissions", () => {
     // Hard cap surfaced via the HTML maxLength attribute so the browser
     // itself rejects keystrokes/pastes past the limit. Value is intentional
     // and tested so we notice if it changes silently.
-    expect(input).toHaveAttribute("maxLength", "500");
+    expect(input).toHaveAttribute("maxLength", "16000");
   });
 
   it("ignores Enter while IME composition is active", async () => {

--- a/hooks/useAgentStream.ts
+++ b/hooks/useAgentStream.ts
@@ -161,13 +161,13 @@ class AgentStreamReportedError extends Error {}
 
 /**
  * Shown in the assistant bubble when a run hit its working limit without
- * producing any prose (e.g. it spent every turn calling tools). Gives the user
- * something to read alongside the Continue affordance instead of an empty
- * bubble. Kept free of jargon.
+ * producing any prose (e.g. it spent every turn calling tools) — so the bubble
+ * isn't empty. Kept to a plain status statement: it renders on every surface,
+ * but the "Continue" call-to-action only exists on the dedicated page, so the
+ * canned text must not promise an action a given surface can't offer. Seeded as
+ * `synthetic` so it is never replayed to the agent as a real assistant turn.
  */
-const LIMIT_FALLBACK_MESSAGE =
-  "I reached my working limit for this request before I could finish. " +
-  "Continue and I'll pick up where I left off.";
+const LIMIT_FALLBACK_MESSAGE = "I reached my working limit for this request before I could finish.";
 
 /** Directive sent when the user clicks Continue after a working-limit stop. */
 const CONTINUE_DIRECTIVE = "Please continue from where you left off.";
@@ -198,7 +198,7 @@ function buildConversationHistory(
   maxMessages: number = 12
 ): Array<{ role: string; content: string }> {
   return messages
-    .filter((msg) => msg.content && msg.content.trim().length > 0)
+    .filter((msg) => !msg.synthetic && msg.content && msg.content.trim().length > 0)
     .slice(-maxMessages)
     .map((msg) => ({ role: msg.role, content: msg.content }));
 }
@@ -437,7 +437,7 @@ export function useAgentStream() {
                   event.reason === "turns" || event.reason === "time" ? event.reason : "budget";
                 if (!streamingContentRef.current.trim()) {
                   streamingContentRef.current = LIMIT_FALLBACK_MESSAGE;
-                  store.updateLastAssistantMessage(LIMIT_FALLBACK_MESSAGE);
+                  store.updateLastAssistantMessage(LIMIT_FALLBACK_MESSAGE, { synthetic: true });
                 }
                 store.setLimitReached({ reason });
                 break;

--- a/hooks/useAgentStream.ts
+++ b/hooks/useAgentStream.ts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
-import { type ChatMessage, useAgentChatStore } from "@/store/agentChat";
+import { type ChatMessage, type LimitReason, useAgentChatStore } from "@/store/agentChat";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { envVars } from "@/utilities/enviromentVars";
 import { PAGES } from "@/utilities/pages";
@@ -160,6 +160,19 @@ function toFriendlyError(status: number, rawMessage: unknown): string {
 class AgentStreamReportedError extends Error {}
 
 /**
+ * Shown in the assistant bubble when a run hit its working limit without
+ * producing any prose (e.g. it spent every turn calling tools). Gives the user
+ * something to read alongside the Continue affordance instead of an empty
+ * bubble. Kept free of jargon.
+ */
+const LIMIT_FALLBACK_MESSAGE =
+  "I reached my working limit for this request before I could finish. " +
+  "Continue and I'll pick up where I left off.";
+
+/** Directive sent when the user clicks Continue after a working-limit stop. */
+const CONTINUE_DIRECTIVE = "Please continue from where you left off.";
+
+/**
  * True when an error represents the network connection failing — either the
  * initial fetch never reaching the server, or (DEV-394) the SSE stream being
  * severed mid-response by an upstream idle timeout. Browsers report these as a
@@ -226,6 +239,7 @@ export function useAgentStream() {
 
       store.setStreaming(true);
       store.setError(null);
+      store.setLimitReached(null);
       streamingContentRef.current = "";
       newSlugRef.current = null;
 
@@ -404,11 +418,28 @@ export function useAgentStream() {
                 break;
               }
               case "result": {
-                // Query finished — handle errors or success
+                // Query finished — handle errors or success. Working-limit
+                // stops are reclassified by the backend into `limit_reached`,
+                // so anything is_error here is a genuine failure.
                 if (event.is_error) {
                   const errors = event.errors as string[] | undefined;
                   store.setError(errors?.join(", ") ?? "Agent query failed");
                 }
+                break;
+              }
+              case "limit_reached": {
+                // The run stopped at a working limit (max budget, max turns, or
+                // the per-run time limit). Not a crash — surface a status +
+                // Continue affordance, never the red error banner. If the run
+                // produced no prose (e.g. timed out mid tool/think), seed a
+                // deterministic line so the bubble isn't empty.
+                const reason: LimitReason =
+                  event.reason === "turns" || event.reason === "time" ? event.reason : "budget";
+                if (!streamingContentRef.current.trim()) {
+                  streamingContentRef.current = LIMIT_FALLBACK_MESSAGE;
+                  store.updateLastAssistantMessage(LIMIT_FALLBACK_MESSAGE);
+                }
+                store.setLimitReached({ reason });
                 break;
               }
             }
@@ -484,5 +515,13 @@ export function useAgentStream() {
     abortRef.current?.abort();
   }, []);
 
-  return { sendMessage, sendConfirmation, abort };
+  // Resume a run that stopped at a working limit. The partial answer is
+  // already in conversationHistory (sendMessage rebuilds it from the store),
+  // so a fresh per-run budget continues from where it left off.
+  const continueLastRun = useCallback(async () => {
+    useAgentChatStore.getState().setLimitReached(null);
+    await sendMessage(CONTINUE_DIRECTIVE);
+  }, [sendMessage]);
+
+  return { sendMessage, sendConfirmation, abort, continueLastRun };
 }

--- a/src/features/ask-karma/components/ask-karma-chat.tsx
+++ b/src/features/ask-karma/components/ask-karma-chat.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { memo, useEffect, useRef } from "react";
 import { MessageResponse } from "@/src/components/ai-elements/message-response";
-import type { ChatMessage, ToolHistoryEvent } from "@/store/agentChat";
+import type { ChatMessage, LimitReason, ToolHistoryEvent } from "@/store/agentChat";
 import { cn } from "@/utilities/tailwind";
 import type { AskKarmaConfig } from "../types";
 import { AskKarmaInput } from "./ask-karma-input";
@@ -228,6 +228,8 @@ interface AskKarmaChatProps {
   messages: ChatMessage[];
   isStreaming: boolean;
   error: string | null;
+  limitReached?: { reason: LimitReason } | null;
+  onContinue?: () => void;
   onSend: (text: string) => void;
   onStop: () => void;
   onBack: () => void;
@@ -238,6 +240,8 @@ export function AskKarmaChat({
   messages,
   isStreaming,
   error,
+  limitReached,
+  onContinue,
   onSend,
   onStop,
   onBack,
@@ -363,6 +367,30 @@ export function AskKarmaChat({
             <AlertCircleIcon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
             <p>{error}</p>
           </div>
+        )}
+
+        {limitReached && onContinue && !isStreaming && (
+          <output
+            className={cn(
+              "flex flex-col gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800",
+              "animate-in fade-in slide-in-from-bottom-1 duration-300",
+              "dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200"
+            )}
+          >
+            <p>
+              I paused here to keep this request within its limit. Continue when you&apos;re ready.
+            </p>
+            <button
+              type="button"
+              onClick={onContinue}
+              className={cn(
+                "self-start rounded-md bg-[rgb(var(--color-primary))] px-3 py-1.5 text-sm font-medium text-white transition-colors",
+                "hover:bg-[rgb(var(--color-primary-dark))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--color-primary))] focus-visible:ring-offset-2"
+              )}
+            >
+              Continue
+            </button>
+          </output>
         )}
 
         <div ref={endRef} />

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { SendIcon, SquareIcon } from "lucide-react";
-import { type FormEvent, type KeyboardEvent, useCallback, useState } from "react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { cn } from "@/utilities/tailwind";
 
 interface AskKarmaInputProps {
@@ -11,9 +18,10 @@ interface AskKarmaInputProps {
   placeholder?: string;
 }
 
-// Hard cap on a single chat turn. Generous (~1k tokens of English) but
-// prevents pasted-document-sized prompts from being submitted accidentally.
-const CHAT_INPUT_MAX_LENGTH = 4000;
+// Hard cap on a single chat turn. Generous (~4k tokens of English) so long,
+// multi-line prompts work on the dedicated page, while still preventing
+// pasted-document-sized prompts from being submitted accidentally.
+const CHAT_INPUT_MAX_LENGTH = 16000;
 
 export function AskKarmaInput({
   onSubmit,
@@ -22,6 +30,18 @@ export function AskKarmaInput({
   placeholder = "Type your message...",
 }: AskKarmaInputProps) {
   const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow: match the textarea height to its content so multi-line prompts
+  // are fully visible, up to the max-height (then it scrolls). Runs on every
+  // value change — including the reset to "" after send, which collapses it
+  // back to one row.
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
 
   const send = useCallback(() => {
     const trimmed = value.trim();
@@ -68,6 +88,7 @@ export function AskKarmaInput({
       )}
     >
       <textarea
+        ref={textareaRef}
         value={value}
         onChange={(event) => setValue(event.target.value)}
         onKeyDown={handleKeyDown}
@@ -76,7 +97,7 @@ export function AskKarmaInput({
         placeholder={placeholder}
         aria-label="Message Karma Assistant"
         className={cn(
-          "max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-sm",
+          "max-h-64 min-h-[24px] flex-1 resize-none overflow-y-auto bg-transparent text-sm",
           "text-zinc-900 placeholder:text-zinc-400 outline-none",
           "transition-colors duration-200",
           "dark:text-zinc-50 dark:placeholder:text-zinc-500"

--- a/src/features/ask-karma/components/ask-karma-input.tsx
+++ b/src/features/ask-karma/components/ask-karma-input.tsx
@@ -1,15 +1,9 @@
 "use client";
 
 import { SendIcon, SquareIcon } from "lucide-react";
-import {
-  type FormEvent,
-  type KeyboardEvent,
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { type FormEvent, type KeyboardEvent, useCallback, useRef, useState } from "react";
 import { cn } from "@/utilities/tailwind";
+import { useAutoGrowTextarea } from "../hooks/use-auto-grow-textarea";
 
 interface AskKarmaInputProps {
   onSubmit: (text: string) => void;
@@ -32,16 +26,7 @@ export function AskKarmaInput({
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-grow: match the textarea height to its content so multi-line prompts
-  // are fully visible, up to the max-height (then it scrolls). Runs on every
-  // value change — including the reset to "" after send, which collapses it
-  // back to one row.
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  }, [value]);
+  useAutoGrowTextarea(textareaRef, value);
 
   const send = useCallback(() => {
     const trimmed = value.trim();

--- a/src/features/ask-karma/components/ask-karma-page.tsx
+++ b/src/features/ask-karma/components/ask-karma-page.tsx
@@ -30,10 +30,11 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
   const messages = useAgentChatStore((s) => s.messages);
   const isStreaming = useAgentChatStore((s) => s.isStreaming);
   const error = useAgentChatStore((s) => s.error);
+  const limitReached = useAgentChatStore((s) => s.limitReached);
   const clearMessages = useAgentChatStore((s) => s.clearMessages);
   const setAgentContext = useAgentChatStore((s) => s.setAgentContext);
 
-  const { sendMessage, abort } = useAgentStream();
+  const { sendMessage, abort, continueLastRun } = useAgentStream();
   const [view, setView] = useState<AskKarmaView>("start");
 
   // Tailor the start-screen prompts to the visitor (signed out vs. reviewer
@@ -165,6 +166,8 @@ export function AskKarmaPage({ config, communityId }: AskKarmaPageProps) {
             messages={messages}
             isStreaming={isStreaming}
             error={error}
+            limitReached={limitReached}
+            onContinue={continueLastRun}
             onSend={handleSubmit}
             onStop={abort}
             onBack={handleBack}

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -7,6 +7,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -16,10 +17,10 @@ import type { AskKarmaConfig } from "../types";
 import { FeaturedTopicCard } from "./featured-topic-card";
 import { FlyingChip, type FlyingChipRect } from "./flying-chip";
 
-// Hard cap on free-text input. Roughly matches a generous tweet length and
-// well below the LLM's prompt window — protects against accidental paste of
-// a huge document into the search bar.
-const INPUT_MAX_LENGTH = 500;
+// Hard cap on free-text input. Generous (~4k tokens of English) so long,
+// multi-line questions work on the dedicated page, while still protecting
+// against accidental paste of a huge document.
+const INPUT_MAX_LENGTH = 16000;
 
 interface AskKarmaStartProps {
   config: AskKarmaConfig;
@@ -62,7 +63,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
     null
   );
   const [typedValue, setTypedValue] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const submitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
 
@@ -115,7 +116,7 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
   );
 
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLInputElement>) => {
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
       // CJK / IME users press Enter to confirm a composition candidate;
       // without this guard, that confirmation also submits the half-typed
       // message and breaks the input for those locales.
@@ -174,6 +175,16 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
   const inputDisabled = phase !== "idle";
   const submitDisabled = phase !== "idle" || displayValue.trim().length === 0;
 
+  // Auto-grow the textarea to fit multi-line questions, up to its max-height
+  // (then it scrolls). Runs on every rendered-value change — including the
+  // typewriter animation and the reset back to a single row.
+  useLayoutEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [displayValue]);
+
   return (
     <div className="flex flex-col gap-10" data-animation-phase={phase}>
       <section
@@ -191,9 +202,9 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
         className="animate-in fade-in slide-in-from-bottom-1 duration-500 relative"
         style={{ animationDelay: `${SECTION_BASE_DELAY.input}ms`, animationFillMode: "both" }}
       >
-        <input
+        <textarea
           ref={inputRef}
-          type="text"
+          rows={1}
           value={displayValue}
           onChange={(event) => {
             if (phase === "idle") setValue(event.target.value);
@@ -205,7 +216,8 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
           aria-label="Ask Karma Assistant a question"
           data-testid="ask-karma-search-input"
           className={cn(
-            "w-full rounded-xl border border-zinc-200 bg-white px-4 py-3 pr-12 text-sm",
+            "w-full resize-none overflow-y-auto rounded-xl border border-zinc-200 bg-white px-4 py-3 pr-12 text-sm",
+            "max-h-64 min-h-[48px] align-middle",
             "text-zinc-900 placeholder:text-zinc-400",
             "shadow-sm transition-all duration-200",
             "hover:border-zinc-300 hover:shadow-md",
@@ -222,7 +234,10 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
           type="submit"
           aria-label="Ask the Karma Assistant"
           className={cn(
-            "absolute right-2 top-1/2 -translate-y-1/2",
+            // Anchored to the bottom-right so it stays put as the textarea
+            // grows to multiple lines (rather than floating to the vertical
+            // centre of the grown field).
+            "absolute bottom-2 right-2",
             "flex h-8 w-8 items-center justify-center rounded-full",
             "transition-all duration-200 ease-out",
             "hover:scale-110 active:scale-90",

--- a/src/features/ask-karma/components/ask-karma-start.tsx
+++ b/src/features/ask-karma/components/ask-karma-start.tsx
@@ -7,11 +7,11 @@ import {
   type MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
 import { cn } from "@/utilities/tailwind";
+import { useAutoGrowTextarea } from "../hooks/use-auto-grow-textarea";
 import { usePrefersReducedMotion } from "../hooks/use-prefers-reduced-motion";
 import type { AskKarmaConfig } from "../types";
 import { FeaturedTopicCard } from "./featured-topic-card";
@@ -175,15 +175,9 @@ export function AskKarmaStart({ config, onSubmit }: AskKarmaStartProps) {
   const inputDisabled = phase !== "idle";
   const submitDisabled = phase !== "idle" || displayValue.trim().length === 0;
 
-  // Auto-grow the textarea to fit multi-line questions, up to its max-height
-  // (then it scrolls). Runs on every rendered-value change — including the
-  // typewriter animation and the reset back to a single row.
-  useLayoutEffect(() => {
-    const el = inputRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  }, [displayValue]);
+  // Grows with the typewriter animation and the user's typing; collapses back
+  // on reset. `displayValue` is what's rendered across phases.
+  useAutoGrowTextarea(inputRef, displayValue);
 
   return (
     <div className="flex flex-col gap-10" data-animation-phase={phase}>

--- a/src/features/ask-karma/hooks/use-auto-grow-textarea.ts
+++ b/src/features/ask-karma/hooks/use-auto-grow-textarea.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { type RefObject, useLayoutEffect } from "react";
+
+/**
+ * Grow a textarea to fit its content (up to its CSS max-height, then it
+ * scrolls). Re-runs whenever `value` changes — including the reset to "" after
+ * submit, which collapses it back to a single row.
+ *
+ * Shared by the Ask Karma start-screen and in-chat inputs so the auto-grow
+ * behaviour lives in one place.
+ */
+export function useAutoGrowTextarea(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string
+): void {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [ref, value]);
+}

--- a/store/agentChat.ts
+++ b/store/agentChat.ts
@@ -61,11 +61,25 @@ export interface ChatMention {
   parentSlug?: string;
 }
 
+/**
+ * Reason a run stopped at a working limit. `budget` = per-run cost ceiling;
+ * `turns` = per-run turn ceiling; `time` = per-run wall-clock timeout. All are
+ * graceful terminal states (not crashes) — the UI offers to continue rather
+ * than showing an error.
+ */
+export type LimitReason = "budget" | "turns" | "time";
+
 interface AgentChatStore {
   messages: ChatMessage[];
   isOpen: boolean;
   isStreaming: boolean;
   error: string | null;
+
+  /**
+   * Set when the last run stopped at a working limit. Drives the Continue
+   * affordance instead of the red error banner. Cleared on the next send.
+   */
+  limitReached: { reason: LimitReason } | null;
 
   /**
    * Buffered Langfuse trace ID. The backend emits `trace_started` over SSE
@@ -122,6 +136,7 @@ interface AgentChatStore {
   setRatingCommentBoxOpenForMessageId: (messageId: string | null) => void;
   setStreaming: (streaming: boolean) => void;
   setError: (error: string | null) => void;
+  setLimitReached: (limit: { reason: LimitReason } | null) => void;
   setAgentContext: (ctx: AgentChatStore["agentContext"]) => void;
   addMention: (mention: ChatMention) => void;
   removeMention: (id: string) => void;
@@ -134,6 +149,7 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
   isOpen: false,
   isStreaming: false,
   error: null,
+  limitReached: null,
   agentContext: null,
   pendingMentions: [],
   pendingTraceId: null,
@@ -264,6 +280,7 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
 
   setStreaming: (streaming) => set({ isStreaming: streaming }),
   setError: (error) => set({ error }),
+  setLimitReached: (limitReached) => set({ limitReached }),
   setAgentContext: (agentContext) => set({ agentContext }),
   addMention: (mention) =>
     set((state) =>
@@ -278,6 +295,7 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
     set({
       messages: [],
       error: null,
+      limitReached: null,
       isStreaming: false,
       pendingTraceId: null,
       ratingCommentBoxOpenForMessageId: null,

--- a/store/agentChat.ts
+++ b/store/agentChat.ts
@@ -35,6 +35,12 @@ export interface ChatMessage {
   traceId?: string;
   /** User feedback rating: 1 = thumbs up, -1 = thumbs down */
   rating?: 1 | -1;
+  /**
+   * Locally-generated placeholder text (e.g. the working-limit fallback), not
+   * something the agent actually said. Excluded from the replayed
+   * conversation history so it never pollutes the agent's context.
+   */
+  synthetic?: boolean;
 }
 
 /**
@@ -117,7 +123,7 @@ interface AgentChatStore {
   setOpen: (open: boolean) => void;
   toggleOpen: () => void;
   addMessage: (message: ChatMessage) => void;
-  updateLastAssistantMessage: (content: string) => void;
+  updateLastAssistantMessage: (content: string, opts?: { synthetic?: boolean }) => void;
   finalizeLastAssistantMessage: () => void;
   updateLastAssistantToolResult: (toolResult: ToolResultData) => void;
   updateMessageToolResultStatus: (messageId: string, status: "approved" | "denied") => void;
@@ -172,12 +178,16 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       return { messages: [...state.messages, message] };
     }),
 
-  updateLastAssistantMessage: (content) =>
+  updateLastAssistantMessage: (content, opts) =>
     set((state) => {
       const messages = [...state.messages];
       const lastIdx = messages.length - 1;
       if (lastIdx >= 0 && messages[lastIdx].role === "assistant") {
-        messages[lastIdx] = { ...messages[lastIdx], content };
+        messages[lastIdx] = {
+          ...messages[lastIdx],
+          content,
+          ...(opts?.synthetic ? { synthetic: true } : {}),
+        };
       }
       return { messages };
     }),


### PR DESCRIPTION
## Overview

Frontend counterpart to the chatbot graceful-degradation work in gap-indexer (show-karma/gap-indexer#2079). Makes the Ask Karma chat handle a run hitting its working limit cleanly, and lets users write longer, multi-line prompts on the dedicated page.

## What changed

**Working-limit UX**
- Handles the backend's `limit_reached` SSE event (`reason: budget | turns | time`): instead of a red "Agent query failed" banner, the chat finalises the partial answer and shows a **Continue** affordance. If the run produced no prose (e.g. timed out mid-tool), a deterministic fallback line is seeded so the bubble is never empty.
- New `limitReached` store state + `setLimitReached`; `LimitReason` now includes `time`.
- `continueLastRun()` resends the conversation (the partial answer is already in history) so the user picks up where the agent left off — no re-typing.

**Multi-line inputs**
- Both the start-screen hero input and the in-chat input now **auto-grow** to fit multi-line questions (up to a max height, then scroll).
- Character cap raised from **500 / 4000 → 16000** so long, multi-line prompts work on the dedicated page (the cap stays as a guard against accidental document pastes).
- The hero input is converted from a single-line `<input>` to an auto-growing `<textarea>`, keeping the typewriter and chip-fly animations intact.

## Testing

- New/updated tests for the store (`limitReached` set/reset), the stream hook (`limit_reached` handling for budget/turns/time, fallback seeding, `continueLastRun`), and the chat/input components (Continue affordance render + cap assertions).
- Biome clean on touched files.

## Notes

- Pairs with show-karma/gap-indexer#2079, which emits the `limit_reached` event. This PR degrades gracefully if the backend isn't deployed yet (it just won't receive the event).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Continue" button that appears when a working limit is reached, allowing users to resume conversations
  * Input fields now auto-grow to accommodate content
  * Increased maximum input length from 4,000 to 16,000 characters

* **Tests**
  * Expanded test coverage for working limit detection and conversation resume functionality
  * Updated input length validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->