### PR TITLE
fix(sitemap,seo): prevent sitemap 504s and give program pages a self-canonical

### DIFF
--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { AlertCircle, ArrowLeft, RefreshCw } from "lucide-react";
+import { useParams } from "next/navigation";
+import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
+import { ProgramByline } from "@/features/programs/components/ProgramByline";
+import { ProgramDetailsSidebar } from "@/features/programs/components/ProgramDetailsSidebar";
+import { useProgram } from "@/features/programs/hooks/use-program";
+import { Link } from "@/src/components/navigation/Link";
+import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
+
+function isProgramEnabled(program: {
+  applicationConfig: { isEnabled: boolean; formSchema?: unknown } | null;
+  metadata: { startsAt?: string; endsAt?: string };
+}): boolean {
+  const isEnabled = program.applicationConfig?.isEnabled ?? false;
+  const hasFormConfig = !!program.applicationConfig?.formSchema;
+  const isDeadlinePassed = program.metadata?.endsAt
+    ? new Date(program.metadata.endsAt) < new Date()
+    : false;
+  const now = new Date();
+  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
+  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
+  const isOpen = startsAt && endsAt ? now >= startsAt && now <= endsAt : true;
+  return hasFormConfig && isEnabled && isOpen && !isDeadlinePassed;
+}
+
+function ProgramDetailContent() {
+  const { communityId, programId } = useParams<{
+    communityId: string;
+    programId: string;
+  }>();
+
+  const { program, loading, error, refetch } = useProgram(programId);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-5">
+        <div className="mb-6 h-5 w-32 animate-pulse rounded bg-muted" />
+        <div className="flex flex-col gap-8 lg:flex-row">
+          <div className="flex-1 space-y-4">
+            <div className="h-10 w-3/4 animate-pulse rounded-lg bg-muted" />
+            <div className="h-5 w-1/2 animate-pulse rounded bg-muted" />
+            <div className="space-y-2">
+              <div className="h-4 w-full animate-pulse rounded bg-muted" />
+              <div className="h-4 w-full animate-pulse rounded bg-muted" />
+              <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+          <div className="h-80 w-full animate-pulse rounded-xl bg-muted lg:w-96" />
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+          <AlertCircle className="h-12 w-12 text-destructive" />
+          <h1 className="text-xl font-semibold">Failed to load program</h1>
+          <p className="text-sm text-muted-foreground">{error.message}</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (!program) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+          <h1 className="text-xl font-semibold">Program not found</h1>
+          <p className="text-sm text-muted-foreground">
+            The program you are looking for does not exist or has been removed.
+          </p>
+          <Link
+            href={`/community/${communityId}/programs`}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Browse programs
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const isEnabled = isProgramEnabled(program);
+  const description = program.metadata?.description || "No description available";
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Back link */}
+      <Link
+        href={`/community/${communityId}/programs`}
+        className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to programs
+      </Link>
+
+      <div className="flex flex-col gap-8 lg:flex-row">
+        {/* Main Content */}
+        <div className="flex-1">
+          {/* Banner Image */}
+          {program.metadata?.bannerImg ? (
+            <div className="mb-6 overflow-hidden rounded-xl">
+              <img
+                src={program.metadata.bannerImg}
+                alt={`${program.metadata?.title || program.name} banner`}
+                className="h-48 w-full object-cover"
+              />
+            </div>
+          ) : null}
+
+          {/* Title */}
+          <h1 className="mb-2 text-3xl font-bold text-foreground">
+            {program.metadata?.title || program.name}
+          </h1>
+
+          {/* Byline */}
+          {program.communitySlug ? (
+            <div className="mb-6">
+              <ProgramByline
+                tenantName={program.communitySlug}
+                tenantLogo={program.metadata?.logoImg}
+                socialLinks={program.metadata?.socialLinks}
+              />
+            </div>
+          ) : null}
+
+          {/* Description — rendered as markdown to preserve formatting */}
+          <MarkdownPreview source={description} />
+        </div>
+
+        {/* Sidebar */}
+        <ProgramDetailsSidebar program={program} communityId={communityId} isEnabled={isEnabled} />
+      </div>
+    </div>
+  );
+}
+
+export default function ProgramDetailClient() {
+  const { communityId, programId } = useParams<{
+    communityId: string;
+    programId: string;
+  }>();
+
+  return (
+    <PermissionProvider resourceContext={{ communityId, programId }}>
+      <ProgramDetailContent />
+    </PermissionProvider>
+  );
+}

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/ProgramDetailClient.tsx
@@ -8,22 +8,7 @@ import { ProgramDetailsSidebar } from "@/features/programs/components/ProgramDet
 import { useProgram } from "@/features/programs/hooks/use-program";
 import { Link } from "@/src/components/navigation/Link";
 import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
-
-function isProgramEnabled(program: {
-  applicationConfig: { isEnabled: boolean; formSchema?: unknown } | null;
-  metadata: { startsAt?: string; endsAt?: string };
-}): boolean {
-  const isEnabled = program.applicationConfig?.isEnabled ?? false;
-  const hasFormConfig = !!program.applicationConfig?.formSchema;
-  const isDeadlinePassed = program.metadata?.endsAt
-    ? new Date(program.metadata.endsAt) < new Date()
-    : false;
-  const now = new Date();
-  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
-  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
-  const isOpen = startsAt && endsAt ? now >= startsAt && now <= endsAt : true;
-  return hasFormConfig && isEnabled && isOpen && !isDeadlinePassed;
-}
+import { isProgramEnabled } from "@/utilities/funding-programs";
 
 function ProgramDetailContent() {
   const { communityId, programId } = useParams<{

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
@@ -1,33 +1,45 @@
 import type { Metadata } from "next";
+import { cache } from "react";
 import { PROJECT_NAME } from "@/constants/brand";
 import type { FundingProgram } from "@/types/whitelabel-entities";
 import { envVars } from "@/utilities/enviromentVars";
+import fetchData from "@/utilities/fetchData";
 import { cleanMarkdownForPlainText } from "@/utilities/markdown";
 import { DEFAULT_DESCRIPTION, SITE_URL, twitterMeta } from "@/utilities/meta";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 import ProgramDetailClient from "./ProgramDetailClient";
+
+// generateMetadata blocks on the indexer, so give a cold render headroom over
+// the platform default (~10s) — the same 504 class this PR hardens the sitemap
+// routes against. The fetch is light (one program) and cached, so this is a
+// ceiling, not a budget.
+export const maxDuration = 30;
 
 type Params = Promise<{
   communityId: string;
   programId: string;
 }>;
 
-// Server-side program fetch for metadata only. The endpoint is public (these
-// pages ship in the funding-programs sitemap), cached in the Data Cache so the
-// metadata render never blocks on a cold indexer. A failed fetch falls back to
-// generic copy — the canonical below does not depend on it.
-async function fetchProgram(programId: string): Promise<FundingProgram | null> {
+// Server-side program fetch for metadata only. Public endpoint (isAuthorized
+// false) — these pages ship in the funding-programs sitemap. Reuses fetchData
+// (base-URL resolution + error shaping) and React.cache, matching the sibling
+// apply/ route. A failed fetch falls back to generic copy — the canonical
+// below does not depend on it.
+const getProgramDetails = cache(async (programId: string): Promise<FundingProgram | null> => {
   try {
-    const res = await fetch(
-      `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/funding-program-configs/${programId}`,
-      { next: { revalidate: 3600 } }
+    const [data] = await fetchData<FundingProgram>(
+      `/v2/funding-program-configs/${encodeURIComponent(programId)}`,
+      "GET",
+      {},
+      {},
+      {},
+      false
     );
-    if (!res.ok) return null;
-    return (await res.json()) as FundingProgram;
+    return data;
   } catch {
     return null;
   }
-}
+});
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { communityId, programId } = await params;
@@ -41,7 +53,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
     ? `/programs/${programId}`
     : `/community/${communityId}/programs/${programId}`;
 
-  const program = await fetchProgram(programId);
+  const program = await getProgramDetails(programId);
   const programName = program?.metadata?.title || program?.name || "Funding Program";
   const description =
     cleanMarkdownForPlainText(

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/page.tsx
@@ -1,164 +1,80 @@
-"use client";
+import type { Metadata } from "next";
+import { PROJECT_NAME } from "@/constants/brand";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import { envVars } from "@/utilities/enviromentVars";
+import { cleanMarkdownForPlainText } from "@/utilities/markdown";
+import { DEFAULT_DESCRIPTION, SITE_URL, twitterMeta } from "@/utilities/meta";
+import { getWhitelabelContext } from "@/utilities/whitelabel-server";
+import ProgramDetailClient from "./ProgramDetailClient";
 
-import { AlertCircle, ArrowLeft, RefreshCw } from "lucide-react";
-import { useParams } from "next/navigation";
-import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
-import { ProgramByline } from "@/features/programs/components/ProgramByline";
-import { ProgramDetailsSidebar } from "@/features/programs/components/ProgramDetailsSidebar";
-import { useProgram } from "@/features/programs/hooks/use-program";
-import { Link } from "@/src/components/navigation/Link";
-import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
+type Params = Promise<{
+  communityId: string;
+  programId: string;
+}>;
 
-function isProgramEnabled(program: {
-  applicationConfig: { isEnabled: boolean; formSchema?: unknown } | null;
-  metadata: { startsAt?: string; endsAt?: string };
-}): boolean {
-  const isEnabled = program.applicationConfig?.isEnabled ?? false;
-  const hasFormConfig = !!program.applicationConfig?.formSchema;
-  const isDeadlinePassed = program.metadata?.endsAt
-    ? new Date(program.metadata.endsAt) < new Date()
-    : false;
-  const now = new Date();
-  const startsAt = program.metadata?.startsAt ? new Date(program.metadata.startsAt) : null;
-  const endsAt = program.metadata?.endsAt ? new Date(program.metadata.endsAt) : null;
-  const isOpen = startsAt && endsAt ? now >= startsAt && now <= endsAt : true;
-  return hasFormConfig && isEnabled && isOpen && !isDeadlinePassed;
+// Server-side program fetch for metadata only. The endpoint is public (these
+// pages ship in the funding-programs sitemap), cached in the Data Cache so the
+// metadata render never blocks on a cold indexer. A failed fetch falls back to
+// generic copy — the canonical below does not depend on it.
+async function fetchProgram(programId: string): Promise<FundingProgram | null> {
+  try {
+    const res = await fetch(
+      `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/funding-program-configs/${programId}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as FundingProgram;
+  } catch {
+    return null;
+  }
 }
 
-function ProgramDetailContent() {
-  const { communityId, programId } = useParams<{
-    communityId: string;
-    programId: string;
-  }>();
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const { communityId, programId } = await params;
+  const { isWhitelabel, config: wlConfig } = await getWhitelabelContext();
 
-  const { program, loading, error, refetch } = useProgram(programId);
+  // Self-referential canonical. Without it the page inherits the community
+  // layout's canonical (/community/<id>), so Google treats every program as a
+  // duplicate of the community root and none of the funding-programs sitemap
+  // URLs get indexed as themselves.
+  const canonical = isWhitelabel
+    ? `/programs/${programId}`
+    : `/community/${communityId}/programs/${programId}`;
 
-  // Loading state
-  if (loading) {
-    return (
-      <div className="flex flex-col gap-5">
-        <div className="mb-6 h-5 w-32 animate-pulse rounded bg-muted" />
-        <div className="flex flex-col gap-8 lg:flex-row">
-          <div className="flex-1 space-y-4">
-            <div className="h-10 w-3/4 animate-pulse rounded-lg bg-muted" />
-            <div className="h-5 w-1/2 animate-pulse rounded bg-muted" />
-            <div className="space-y-2">
-              <div className="h-4 w-full animate-pulse rounded bg-muted" />
-              <div className="h-4 w-full animate-pulse rounded bg-muted" />
-              <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
-            </div>
-          </div>
-          <div className="h-80 w-full animate-pulse rounded-xl bg-muted lg:w-96" />
-        </div>
-      </div>
-    );
-  }
+  const program = await fetchProgram(programId);
+  const programName = program?.metadata?.title || program?.name || "Funding Program";
+  const description =
+    cleanMarkdownForPlainText(
+      program?.metadata?.shortDescription || program?.metadata?.description || "",
+      160
+    ) || DEFAULT_DESCRIPTION;
 
-  // Error state
-  if (error) {
-    return (
-      <div className="mx-auto max-w-xl">
-        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
-          <AlertCircle className="h-12 w-12 text-destructive" />
-          <h1 className="text-xl font-semibold">Failed to load program</h1>
-          <p className="text-sm text-muted-foreground">{error.message}</p>
-          <button
-            type="button"
-            onClick={() => refetch()}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Try again
-          </button>
-        </div>
-      </div>
-    );
-  }
+  const siteUrl = isWhitelabel && wlConfig ? `https://${wlConfig.domain}` : SITE_URL;
+  const ogImageBase = isWhitelabel && wlConfig ? `https://${wlConfig.domain}` : envVars.VERCEL_URL;
+  const ogImage = `${ogImageBase}/api/metadata/communities/${communityId}`;
 
-  // Empty state
-  if (!program) {
-    return (
-      <div className="mx-auto max-w-xl">
-        <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
-          <h1 className="text-xl font-semibold">Program not found</h1>
-          <p className="text-sm text-muted-foreground">
-            The program you are looking for does not exist or has been removed.
-          </p>
-          <Link
-            href={`/community/${communityId}/programs`}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Browse programs
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
-  const isEnabled = isProgramEnabled(program);
-  const description = program.metadata?.description || "No description available";
-
-  return (
-    <div className="flex flex-col gap-5">
-      {/* Back link */}
-      <Link
-        href={`/community/${communityId}/programs`}
-        className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back to programs
-      </Link>
-
-      <div className="flex flex-col gap-8 lg:flex-row">
-        {/* Main Content */}
-        <div className="flex-1">
-          {/* Banner Image */}
-          {program.metadata?.bannerImg ? (
-            <div className="mb-6 overflow-hidden rounded-xl">
-              <img
-                src={program.metadata.bannerImg}
-                alt={`${program.metadata?.title || program.name} banner`}
-                className="h-48 w-full object-cover"
-              />
-            </div>
-          ) : null}
-
-          {/* Title */}
-          <h1 className="mb-2 text-3xl font-bold text-foreground">
-            {program.metadata?.title || program.name}
-          </h1>
-
-          {/* Byline */}
-          {program.communitySlug ? (
-            <div className="mb-6">
-              <ProgramByline
-                tenantName={program.communitySlug}
-                tenantLogo={program.metadata?.logoImg}
-                socialLinks={program.metadata?.socialLinks}
-              />
-            </div>
-          ) : null}
-
-          {/* Description — rendered as markdown to preserve formatting */}
-          <MarkdownPreview source={description} />
-        </div>
-
-        {/* Sidebar */}
-        <ProgramDetailsSidebar program={program} communityId={communityId} isEnabled={isEnabled} />
-      </div>
-    </div>
-  );
+  return {
+    title: { absolute: `${programName} | ${PROJECT_NAME}` },
+    description,
+    alternates: { canonical },
+    twitter: {
+      card: "summary_large_image",
+      title: programName,
+      description,
+      creator: twitterMeta.creator,
+      site: twitterMeta.site,
+      images: [{ url: ogImage, alt: programName }],
+    },
+    openGraph: {
+      type: "website",
+      url: `${siteUrl}${canonical}`,
+      title: programName,
+      description,
+      images: [{ url: ogImage, alt: programName }],
+    },
+  };
 }
 
 export default function ProgramDetailPage() {
-  const { communityId, programId } = useParams<{
-    communityId: string;
-    programId: string;
-  }>();
-
-  return (
-    <PermissionProvider resourceContext={{ communityId, programId }}>
-      <ProgramDetailContent />
-    </PermissionProvider>
-  );
+  return <ProgramDetailClient />;
 }

--- a/app/sitemap-index.xml/route.ts
+++ b/app/sitemap-index.xml/route.ts
@@ -4,6 +4,8 @@ import { sitemapIndexResponse } from "@/utilities/sitemap";
 // Never prerender at build time — render on demand only. The indexer fetch is
 // still cached via the Data Cache (see fetchSitemapCounts).
 export const dynamic = "force-dynamic";
+// Headroom for the cold counts fetch so the index itself never 504s.
+export const maxDuration = 60;
 
 // Legacy index URL. Google's stored state for it is stuck on a degraded May
 // 2026 parse, so robots.txt now advertises /sitemap_index.xml instead (see

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -7,6 +7,8 @@ import { sitemapIndexResponse } from "@/utilities/sitemap";
 // indexer is down. Force dynamic so the route is only ever rendered on demand;
 // the indexer fetch is still cached via the Data Cache (see fetchSitemapCounts).
 export const dynamic = "force-dynamic";
+// Headroom for the cold counts fetch so the index itself never 504s.
+export const maxDuration = 60;
 
 // Legacy alias of the index. robots.txt now advertises /sitemap_index.xml
 // instead (see that route for why); this URL keeps serving identical content

--- a/app/sitemap_index.xml/route.ts
+++ b/app/sitemap_index.xml/route.ts
@@ -4,6 +4,8 @@ import { sitemapIndexResponse } from "@/utilities/sitemap";
 // Never prerender at build time — render on demand only. The indexer fetch is
 // still cached via the Data Cache (see fetchSitemapCounts).
 export const dynamic = "force-dynamic";
+// Headroom for the cold counts fetch so the index itself never 504s.
+export const maxDuration = 60;
 
 // Fresh-URL copy of /sitemap-index.xml. Google pinned its parsed model of the
 // old URL to a degraded 5-child snapshot (May 2026) and successful re-reads

--- a/app/sitemaps/[kind]/sitemap.xml/route.ts
+++ b/app/sitemaps/[kind]/sitemap.xml/route.ts
@@ -10,6 +10,15 @@ import {
   type SitemapKind,
 } from "@/utilities/sitemap";
 
+// Render on demand only (never prerendered with a baked indexer response) and
+// give the cold build room to page the whole kind from the indexer. Without an
+// explicit cap a cold render runs against the platform default (~10s) and a
+// large kind like projects — already ~10s to assemble — 504s, which is exactly
+// what Search Console reports as "Couldn't fetch". The warmer keeps the Data
+// Cache hot so this full duration is only ever spent off the crawler path.
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
 // Consolidated per-kind child sitemap (/sitemaps/projects/sitemap.xml, …): the
 // kind's complete URL list in one file. One file per kind gives Google 7 child
 // fetches instead of 29 — every extra file is another fetch it can delay or

--- a/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
+++ b/app/sitemaps/[kind]/sitemap/[chunk]/route.ts
@@ -8,6 +8,12 @@ import {
   type SitemapKind,
 } from "@/utilities/sitemap";
 
+// Render on demand and allow the cold indexer fetch the same headroom as the
+// consolidated route, so a slow chunk fetch never 504s the way the platform
+// default (~10s) would. See ../../sitemap.xml/route.ts.
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
 // LEGACY per-kind child sitemap chunk (1,000 URLs per file). The index now
 // lists one consolidated file per kind (/sitemaps/<kind>/sitemap.xml) and only
 // falls back to these chunked URLs for a kind past the per-file URL limit.


### PR DESCRIPTION
## Problem

Google Search Console reports the `grants` and `funding-programs` sitemaps as failing:

- `grants/sitemap.xml` → **Couldn't fetch** (Last read N/A, 0 URLs)
- `funding-programs/sitemap.xml` → **1 error**, HTTP **504**

Two root causes:

1. **Sitemap routes time out.** The per-kind sitemap routes generate on demand by paging the indexer. Cold, the `projects` sitemap already takes ~10s to assemble (measured against prod). None of the sitemap routes set `maxDuration`, so they run against the platform default (~10s) and intermittently 504 — which GSC surfaces as "Couldn't fetch".
2. **Funding-program pages fold into the community root.** `programs/[programId]/page.tsx` was a `"use client"` component with no `generateMetadata`, so it inherited `community/[communityId]/layout.tsx`'s canonical (`/community/<id>`). Google treats every program as a duplicate of the community root, so none of the `funding-programs` sitemap URLs index as themselves.

## Changes

**Sitemap timeouts**
- Add `export const maxDuration = 60` to all five sitemap routes (`[kind]/sitemap.xml`, `[kind]/sitemap/[chunk]`, `sitemap.xml`, `sitemap_index.xml`, `sitemap-index.xml`).
- Add `export const dynamic = "force-dynamic"` to the two `[kind]` routes that lacked it.
- The warm-sitemaps cron keeps the Data Cache hot, so the full duration is only ever spent off the crawler path.

**Program page canonical**
- Split `programs/[programId]/page.tsx` into a server component (`generateMetadata` with a self-referential, whitelabel-aware canonical + real title/description fetched server-side) and `ProgramDetailClient.tsx` (the existing UI, unchanged).

## Not in this PR (deploy follow-up)

The SEO commits #1603/#1604 (merged 2026-06-10) are on `main` but production appears to be running older code: the live `/sitemap_index.xml` still omits `grants` (so the warmer never warms it) and live grant pages still return `noindex`, both already fixed in `main`. **Confirm production is deployed at a commit ≥ `dbbe4a5b9`** — that resolves the orphaned `grants` sitemap and the grant-page `noindex` on its own.

## Testing
- `biome check` passes on all touched files (one pre-existing `<img>` warning carried over verbatim).
- Program UI is unchanged (moved verbatim into the client component).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Program detail pages now display complete program information including descriptions, images, and sidebar details.
  * Added SEO metadata generation for program pages, improving search engine visibility and social media preview display.

* **Infrastructure**
  * Improved sitemap rendering reliability for search engine crawlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->