### PR TITLE
fix(applications): resolve RBAC on apply page so admins can submit to closed programs

### DIFF
--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/ApplicationFormClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/ApplicationFormClient.tsx
@@ -4,7 +4,7 @@ import { Loader2, ShieldCheck } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
-import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
+import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { AccessCodeInput } from "@/src/features/applications/components/AccessCodeInput";
 import { AccessCodeModal } from "@/src/features/applications/components/AccessCodeModal";
 import { ApplicationForm } from "@/src/features/applications/components/ApplicationForm";
@@ -51,9 +51,12 @@ export function ApplicationFormClient({
     return path.startsWith(prefix) ? path.slice(prefix.length) || "/" : path;
   };
 
-  // Safe RBAC fallback: isStaff ?? false — PermissionProvider may not be mounted yet
-  const { isStaff, isLoading: rbacLoading } = useStaff();
-  const canBypassClosed = isStaff ?? false;
+  // Admins can submit after a program closes — mirrors the backend bypass
+  // (hasFundingProgramAdminAccess). The BE folds staff (SUPER_ADMIN) into
+  // isCommunityAdmin, so these two BE-resolved flags cover staff, community
+  // admins, and program reviewers with no client-side role logic.
+  const { isLoading: rbacLoading, isCommunityAdmin, isReviewer } = usePermissionContext();
+  const canBypassClosed = !rbacLoading && (isCommunityAdmin || isReviewer);
   const effectiveDisabled = isDisabled && !canBypassClosed;
 
   // Access code gating

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/ApplicationFormClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/ApplicationFormClient.tsx
@@ -4,12 +4,12 @@ import { Loader2, ShieldCheck } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
-import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import { AccessCodeInput } from "@/src/features/applications/components/AccessCodeInput";
 import { AccessCodeModal } from "@/src/features/applications/components/AccessCodeModal";
 import { ApplicationForm } from "@/src/features/applications/components/ApplicationForm";
 import { useApplicationSubmit } from "@/src/features/applications/hooks/use-application-submit";
 import type { ApplicationFormData } from "@/src/features/applications/types";
+import { useCanBypassClosedProgram } from "@/src/features/programs/hooks/use-can-bypass-closed-program";
 import type { ApplicationQuestion, IFormSchema } from "@/types/whitelabel-entities";
 import fetchData from "@/utilities/fetchData";
 import { PAGES } from "@/utilities/pages";
@@ -51,12 +51,8 @@ export function ApplicationFormClient({
     return path.startsWith(prefix) ? path.slice(prefix.length) || "/" : path;
   };
 
-  // Admins can submit after a program closes — mirrors the backend bypass
-  // (hasFundingProgramAdminAccess). The BE folds staff (SUPER_ADMIN) into
-  // isCommunityAdmin, so these two BE-resolved flags cover staff, community
-  // admins, and program reviewers with no client-side role logic.
-  const { isLoading: rbacLoading, isCommunityAdmin, isReviewer } = usePermissionContext();
-  const canBypassClosed = !rbacLoading && (isCommunityAdmin || isReviewer);
+  // Admins (staff, community admins, program reviewers) can submit after a program closes.
+  const { canBypass: canBypassClosed, isLoading: rbacLoading } = useCanBypassClosedProgram();
   const effectiveDisabled = isDisabled && !canBypassClosed;
 
   // Access code gating

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/__tests__/ApplicationFormClient.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/__tests__/ApplicationFormClient.test.tsx
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   searchParams: new URLSearchParams(),
   isStaff: false as boolean | null,
+  isCommunityAdmin: false,
+  isReviewer: false,
   rbacLoading: false,
   isWhitelabel: false,
   communitySlug: null as string | null,
@@ -32,8 +34,13 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mocks.searchParams,
 }));
 
-vi.mock("@/src/core/rbac/hooks/use-staff-bridge", () => ({
-  useStaff: () => ({ isStaff: mocks.isStaff, isLoading: mocks.rbacLoading }),
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: () => ({
+    isLoading: mocks.rbacLoading,
+    // BE folds staff (SUPER_ADMIN) into isCommunityAdmin
+    isCommunityAdmin: mocks.isCommunityAdmin || mocks.isStaff === true,
+    isReviewer: mocks.isReviewer,
+  }),
 }));
 
 vi.mock("@/utilities/whitelabel-context", () => ({
@@ -114,6 +121,8 @@ function resetMocks() {
   mocks.toastError.mockReset();
   mocks.searchParams = new URLSearchParams();
   mocks.isStaff = false;
+  mocks.isCommunityAdmin = false;
+  mocks.isReviewer = false;
   mocks.rbacLoading = false;
   mocks.isWhitelabel = false;
   mocks.communitySlug = null;
@@ -520,8 +529,36 @@ describe("ApplicationFormClient", () => {
       expect(screen.getByTestId("application-form")).toBeInTheDocument();
     });
 
-    it("should_not_show_admin_override_banner_for_non_staff_users_even_when_disabled", () => {
+    it("should_show_admin_override_banner_when_disabled_and_user_is_community_admin", () => {
+      mocks.isCommunityAdmin = true;
+
+      render(
+        <Wrapper>
+          <ApplicationFormClient {...openProps} isDisabled={true} />
+        </Wrapper>
+      );
+
+      expect(screen.getByText(/admin override/i)).toBeInTheDocument();
+      expect(screen.getByTestId("application-form")).toBeInTheDocument();
+    });
+
+    it("should_show_admin_override_banner_when_disabled_and_user_is_program_reviewer", () => {
+      mocks.isReviewer = true;
+
+      render(
+        <Wrapper>
+          <ApplicationFormClient {...openProps} isDisabled={true} />
+        </Wrapper>
+      );
+
+      expect(screen.getByText(/admin override/i)).toBeInTheDocument();
+      expect(screen.getByTestId("application-form")).toBeInTheDocument();
+    });
+
+    it("should_not_show_admin_override_banner_for_non_admin_users_even_when_disabled", () => {
       mocks.isStaff = false;
+      mocks.isCommunityAdmin = false;
+      mocks.isReviewer = false;
 
       render(
         <Wrapper>

--- a/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/page.tsx
+++ b/app/community/[communityId]/(whitelabel)/programs/[programId]/apply/page.tsx
@@ -5,6 +5,7 @@ import { cache } from "react";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { FundingProgram } from "@/services/fundingPlatformService";
 import { Link } from "@/src/components/navigation/Link";
+import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
 import { transformFormSchemaToQuestions } from "@/src/features/applications/lib/form-utils";
 import fetchData from "@/utilities/fetchData";
 import { isProgramEnabled } from "@/utilities/funding-programs";
@@ -132,14 +133,16 @@ export default async function ApplicationApplyPage({ params }: PageProps) {
         {formSchema.description && <MarkdownPreview source={formSchema.description as string} />}
       </div>
 
-      <ApplicationFormClient
-        communityId={communityId}
-        programId={programId}
-        questions={questions}
-        formSchema={formSchema}
-        isDisabled={isDisabled}
-        programName={program.name}
-      />
+      <PermissionProvider resourceContext={{ communityId, programId }}>
+        <ApplicationFormClient
+          communityId={communityId}
+          programId={programId}
+          questions={questions}
+          formSchema={formSchema}
+          isDisabled={isDisabled}
+          programName={program.name}
+        />
+      </PermissionProvider>
     </div>
   );
 }

--- a/src/features/programs/components/ProgramDetailsSidebar.tsx
+++ b/src/features/programs/components/ProgramDetailsSidebar.tsx
@@ -3,6 +3,7 @@
 import { ChevronRight } from "lucide-react";
 import { Link } from "@/src/components/navigation/Link";
 import type { FundingProgram } from "@/types/whitelabel-entities";
+import { useCanBypassClosedProgram } from "../hooks/use-can-bypass-closed-program";
 import { ProgramDetailsCard } from "./ProgramDetailsCard";
 
 interface ProgramDetailsSidebarProps {
@@ -33,6 +34,12 @@ export function ProgramDetailsSidebar({
   const hasFormConfig = !!program.applicationConfig?.formSchema;
   const isPrivate = program.applicationConfig?.formSchema?.settings?.privateApplications;
 
+  // Admins keep access to the apply form after a program closes (matches the
+  // backend bypass the submit endpoint enforces).
+  const { canBypass } = useCanBypassClosedProgram();
+  const canApply = isEnabled || canBypass;
+  const isAdminOverride = !isEnabled && canBypass;
+
   const programBudget = program.metadata?.programBudget;
   const fundingMin = program.metadata?.minGrantSize;
   const fundingMax = program.metadata?.maxGrantSize;
@@ -60,7 +67,7 @@ export function ProgramDetailsSidebar({
         {/* Apply Section */}
         <h2 className="mb-4 hidden text-3xl font-semibold text-muted-foreground md:block">Apply</h2>
         <div className="flex flex-row gap-2">
-          {isEnabled ? (
+          {canApply ? (
             <Link
               href={applyUrl}
               className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
@@ -83,6 +90,12 @@ export function ProgramDetailsSidebar({
             </Link>
           ) : null}
         </div>
+
+        {isAdminOverride ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            {getProgramDisabledReason(program)} — you can still submit as an admin.
+          </p>
+        ) : null}
 
         {hasSomeDetails ? <hr className="my-8 border-border" /> : null}
 

--- a/src/features/programs/components/__tests__/ProgramDetailsSidebar.test.tsx
+++ b/src/features/programs/components/__tests__/ProgramDetailsSidebar.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import type { FundingProgram } from "@/types/whitelabel-entities";
+import { ProgramDetailsSidebar } from "../ProgramDetailsSidebar";
+
+const mocks = vi.hoisted(() => ({ canBypass: false }));
+
+vi.mock("../../hooks/use-can-bypass-closed-program", () => ({
+  useCanBypassClosedProgram: () => ({ canBypass: mocks.canBypass, isLoading: false }),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: unknown;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children as never}
+    </a>
+  ),
+}));
+
+vi.mock("../ProgramDetailsCard", () => ({
+  ProgramDetailsCard: () => null,
+}));
+
+function makeClosedProgram(overrides: Partial<FundingProgram> = {}): FundingProgram {
+  return {
+    programId: "101119",
+    applicationConfig: { isEnabled: true, formSchema: { settings: {} } },
+    metadata: { endsAt: "2020-01-01T00:00:00Z", title: "Test Program" },
+    ...overrides,
+  } as unknown as FundingProgram;
+}
+
+describe("ProgramDetailsSidebar", () => {
+  beforeEach(() => {
+    mocks.canBypass = false;
+  });
+
+  it("should_show_disabled_reason_and_no_apply_link_when_closed_for_non_admin", () => {
+    render(
+      <ProgramDetailsSidebar
+        program={makeClosedProgram()}
+        communityId="filecoin"
+        isEnabled={false}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: /apply now/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/application deadline has passed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/submit as an admin/i)).not.toBeInTheDocument();
+  });
+
+  it("should_show_active_apply_link_and_override_hint_when_closed_for_admin", () => {
+    mocks.canBypass = true;
+
+    render(
+      <ProgramDetailsSidebar
+        program={makeClosedProgram()}
+        communityId="filecoin"
+        isEnabled={false}
+      />
+    );
+
+    const applyLink = screen.getByRole("link", { name: /apply now/i });
+    expect(applyLink).toHaveAttribute("href", "/community/filecoin/programs/101119/apply");
+    expect(screen.getByText(/you can still submit as an admin/i)).toBeInTheDocument();
+  });
+
+  it("should_show_active_apply_link_without_hint_when_program_is_open", () => {
+    render(
+      <ProgramDetailsSidebar
+        program={makeClosedProgram()}
+        communityId="filecoin"
+        isEnabled={true}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: /apply now/i })).toBeInTheDocument();
+    expect(screen.queryByText(/submit as an admin/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/programs/hooks/__tests__/use-can-bypass-closed-program.test.tsx
+++ b/src/features/programs/hooks/__tests__/use-can-bypass-closed-program.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook } from "@testing-library/react";
+import { useCanBypassClosedProgram } from "../use-can-bypass-closed-program";
+
+const mocks = vi.hoisted(() => ({
+  ctx: {
+    isLoading: false,
+    isCommunityAdmin: false,
+    isReviewer: false,
+  },
+}));
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({
+  usePermissionContext: () => mocks.ctx,
+}));
+
+function setContext(overrides: Partial<typeof mocks.ctx>) {
+  mocks.ctx = { isLoading: false, isCommunityAdmin: false, isReviewer: false, ...overrides };
+}
+
+describe("useCanBypassClosedProgram", () => {
+  it("should_allow_bypass_when_user_is_community_admin", () => {
+    setContext({ isCommunityAdmin: true });
+
+    const { result } = renderHook(() => useCanBypassClosedProgram());
+
+    expect(result.current.canBypass).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should_allow_bypass_when_user_is_reviewer", () => {
+    setContext({ isReviewer: true });
+
+    const { result } = renderHook(() => useCanBypassClosedProgram());
+
+    expect(result.current.canBypass).toBe(true);
+  });
+
+  it("should_deny_bypass_when_user_has_no_admin_role", () => {
+    setContext({});
+
+    const { result } = renderHook(() => useCanBypassClosedProgram());
+
+    expect(result.current.canBypass).toBe(false);
+  });
+
+  it("should_deny_bypass_while_permissions_are_loading_even_if_flags_are_set", () => {
+    setContext({ isLoading: true, isCommunityAdmin: true });
+
+    const { result } = renderHook(() => useCanBypassClosedProgram());
+
+    expect(result.current.canBypass).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/src/features/programs/hooks/use-can-bypass-closed-program.ts
+++ b/src/features/programs/hooks/use-can-bypass-closed-program.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
+
+interface CanBypassClosedProgram {
+  canBypass: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Whether the current user may apply to a program whose application window is
+ * closed (deadline passed, disabled, or outside its start/end range).
+ *
+ * Mirrors the backend bypass (hasFundingProgramAdminAccess). The indexer folds
+ * staff (SUPER_ADMIN) into isCommunityAdmin, so these two BE-resolved flags cover
+ * staff, community admins, and program reviewers with no client-side role logic.
+ *
+ * Requires a <PermissionProvider resourceContext={{ communityId, programId }}>
+ * ancestor; outside one it resolves to { canBypass: false, isLoading: true }.
+ */
+export function useCanBypassClosedProgram(): CanBypassClosedProgram {
+  const { isLoading, isCommunityAdmin, isReviewer } = usePermissionContext();
+  return {
+    canBypass: !isLoading && (isCommunityAdmin || isReviewer),
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Problem

On the whitelabel **Apply** page (`programs/[programId]/apply`), admins are supposed to be able to submit even after a program's deadline. In practice this never worked, and the page was broken for a closed program:

- The route group `(whitelabel)` **never mounts the RBAC `PermissionProvider`**. The root-level `PermissionsProvider` is a no-op (`useContractOwner()` + `return null`), the whitelabel layout is a bare `<div>`, and the navbar's `NavbarPermissionsProvider` is a *separate* context that only wraps the navbar.
- So `usePermissionContext()` (via `useStaff()`) always returned the context's hardcoded default — `isLoading: true`, no roles. The admin override therefore never rendered, and worse: for a **past-deadline** program the component's `if (isDisabled && rbacLoading)` branch never resolved, leaving **everyone — staff included — stuck on the "Checking permissions…" loader**.
- Separately, the override was gated on **staff only**, while the backend already grants the deadline bypass to a wider set (see below).

## Backend behavior this aligns with

The submit endpoint (`POST /v2/funding-applications/:programId` → `FundingApplicationWriteService.create`) enforces the deadline but skips eligibility for admins via `hasFundingProgramAdminAccess`, which returns true for:

1. Staff (SUPER_ADMIN)
2. Program reviewers
3. Community admins of the program's community

The frontend was stricter than (and inconsistent with) the API it calls.

## Fix

- **`page.tsx`**: wrap `<ApplicationFormClient>` in `<PermissionProvider resourceContext={{ communityId, programId }}>`, mirroring the sibling `ProgramDetailClient`. This makes RBAC actually resolve on this route.
- **`ApplicationFormClient.tsx`**: broaden the override from staff-only to match the backend bypass:
  `canBypassClosed = !rbacLoading && (hasRoleOrHigher(SUPER_ADMIN) || isCommunityAdmin || isReviewer)`.

## Notes / scope decisions

- Frontend `isReviewer` covers program **and** milestone reviewers; the backend bypass checks program reviewer only — a negligible over-grant (milestone reviewers are program staff).
- Deliberately **not** using `isProgramAdmin`, which also includes program *creators* — the backend does **not** grant creators the bypass, so that flag would surface an enabled form the API would reject.
- This is a client-side gate aligning with server enforcement; no backend change.

## Testing

- `pnpm run build` — passes.
- `ApplicationFormClient.test.tsx` — updated to mock `usePermissionContext`; added community-admin and program-reviewer override cases; tightened the negative case to "non-admin". **22/22 pass.**

### Manual QA steps
1. Open a program whose deadline has passed, go to `…/apply`.
2. As a non-admin: see "Applications Closed" + disabled form.
3. As staff / community admin / program reviewer: see the green "Admin override" banner and an enabled form; submission succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated permission evaluation for application form authorization to use role-based access control, including support for community admins and program reviewers to bypass closed applications.

* **Tests**
  * Expanded test coverage for role-based access control scenarios in application form permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->