### PR TITLE
feat(find-funders): clearer result formatting and connector UX

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -412,8 +412,8 @@
       "maxBytes": 40000
     },
     "src/features/non-profits/hooks/use-philanthropy-stream.ts": {
-      "lines": 638,
-      "bytes": 21642,
+      "lines": 696,
+      "bytes": 24573,
       "maxLines": 600,
       "maxBytes": 40000
     },

--- a/src/features/non-profits/__tests__/connector-nudge.test.tsx
+++ b/src/features/non-profits/__tests__/connector-nudge.test.tsx
@@ -1,23 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ConnectorNudge } from "../components/connector-nudge";
-
-vi.mock("@/src/components/navigation/Link", () => ({
-  Link: ({
-    children,
-    href,
-    ...props
-  }: {
-    children: React.ReactNode;
-    href: string;
-    className?: string;
-  }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
-}));
 
 describe("ConnectorNudge", () => {
   beforeEach(() => {
@@ -36,6 +20,16 @@ describe("ConnectorNudge", () => {
 
     expect(claudeLink).toHaveAttribute("href", "/nonprofits/find-funders/connect/claude");
     expect(chatgptLink).toHaveAttribute("href", "/nonprofits/find-funders/connect/chatgpt");
+  });
+
+  it("opens the setup guides in a new tab so the conversation is never left", () => {
+    render(<ConnectorNudge />);
+
+    for (const name of [/Add to Claude/i, /Add to ChatGPT/i]) {
+      const link = screen.getByRole("link", { name });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    }
   });
 
   it("hides the banner once dismissed and remembers the dismissal via sessionStorage", () => {

--- a/src/features/non-profits/__tests__/group-entities.test.ts
+++ b/src/features/non-profits/__tests__/group-entities.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { groupEntitiesByType } from "../lib/group-entities";
+import type { PhilanthropyEntityType, RankedEntity } from "../types/philanthropy";
+
+function entity(id: string, entityType: PhilanthropyEntityType): RankedEntity {
+  return {
+    entityType,
+    id,
+    name: `${entityType}-${id}`,
+    description: null,
+    ein: null,
+    location: null,
+    totalAssets: null,
+    amount: null,
+    date: null,
+    filingYear: null,
+    foundationId: null,
+    foundationName: null,
+    nonprofitId: null,
+    nonprofitName: null,
+    scores: { semantic: 0, amount: 0, recency: 0, composite: 0 },
+  };
+}
+
+describe("groupEntitiesByType", () => {
+  it("returns no groups for an empty list", () => {
+    expect(groupEntitiesByType([])).toEqual([]);
+  });
+
+  it("omits groups that have no entities", () => {
+    const groups = groupEntitiesByType([entity("1", "foundation")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].type).toBe("foundation");
+  });
+
+  it("orders groups funders → nonprofits → grants regardless of input order", () => {
+    const groups = groupEntitiesByType([
+      entity("g1", "grant"),
+      entity("n1", "nonprofit"),
+      entity("f1", "foundation"),
+    ]);
+    expect(groups.map((g) => g.type)).toEqual(["foundation", "nonprofit", "grant"]);
+  });
+
+  it("labels each group with a role so funders vs recipients are unambiguous", () => {
+    const groups = groupEntitiesByType([entity("f1", "foundation"), entity("n1", "nonprofit")]);
+    const byType = Object.fromEntries(groups.map((g) => [g.type, g]));
+    expect(byType.foundation.role).toMatch(/funder/i);
+    expect(byType.nonprofit.role).toMatch(/recipient/i);
+  });
+
+  it("keeps the agent's ranking order within a group", () => {
+    const groups = groupEntitiesByType([
+      entity("f1", "foundation"),
+      entity("n1", "nonprofit"),
+      entity("f2", "foundation"),
+    ]);
+    expect(groups[0].entities.map((e) => e.id)).toEqual(["f1", "f2"]);
+  });
+});

--- a/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
+++ b/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePhilanthropyStore } from "../store/philanthropy";
+
+/**
+ * `readOnly` is set when persistence returns 403 (the conversation belongs to
+ * another account); the ChatView disables the composer and shows a read-only
+ * notice. These guard the flag's default and — importantly — that `reset()`
+ * clears it (reset spreads initialState, so the field must live there too).
+ */
+describe("usePhilanthropyStore readOnly", () => {
+  beforeEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("defaults to false", () => {
+    expect(usePhilanthropyStore.getState().readOnly).toBe(false);
+  });
+
+  it("setReadOnly flips the flag", () => {
+    usePhilanthropyStore.getState().setReadOnly(true);
+    expect(usePhilanthropyStore.getState().readOnly).toBe(true);
+  });
+
+  it("reset() clears the flag (e.g. on New chat)", () => {
+    usePhilanthropyStore.getState().setReadOnly(true);
+    usePhilanthropyStore.getState().reset();
+    expect(usePhilanthropyStore.getState().readOnly).toBe(false);
+  });
+});

--- a/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
+++ b/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
@@ -48,3 +48,24 @@ describe("usePhilanthropyStore notFound", () => {
     expect(usePhilanthropyStore.getState().notFound).toBe(false);
   });
 });
+
+describe("usePhilanthropyStore conversationFull", () => {
+  beforeEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("defaults to false", () => {
+    expect(usePhilanthropyStore.getState().conversationFull).toBe(false);
+  });
+
+  it("setConversationFull flips the flag", () => {
+    usePhilanthropyStore.getState().setConversationFull(true);
+    expect(usePhilanthropyStore.getState().conversationFull).toBe(true);
+  });
+
+  it("reset() clears the flag", () => {
+    usePhilanthropyStore.getState().setConversationFull(true);
+    usePhilanthropyStore.getState().reset();
+    expect(usePhilanthropyStore.getState().conversationFull).toBe(false);
+  });
+});

--- a/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
+++ b/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
@@ -27,3 +27,24 @@ describe("usePhilanthropyStore readOnly", () => {
     expect(usePhilanthropyStore.getState().readOnly).toBe(false);
   });
 });
+
+describe("usePhilanthropyStore notFound", () => {
+  beforeEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("defaults to false", () => {
+    expect(usePhilanthropyStore.getState().notFound).toBe(false);
+  });
+
+  it("setNotFound flips the flag", () => {
+    usePhilanthropyStore.getState().setNotFound(true);
+    expect(usePhilanthropyStore.getState().notFound).toBe(true);
+  });
+
+  it("reset() clears the flag", () => {
+    usePhilanthropyStore.getState().setNotFound(true);
+    usePhilanthropyStore.getState().reset();
+    expect(usePhilanthropyStore.getState().notFound).toBe(false);
+  });
+});

--- a/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
+++ b/src/features/non-profits/__tests__/philanthropy-store-readonly.test.ts
@@ -69,3 +69,24 @@ describe("usePhilanthropyStore conversationFull", () => {
     expect(usePhilanthropyStore.getState().conversationFull).toBe(false);
   });
 });
+
+describe("usePhilanthropyStore loginRequired", () => {
+  beforeEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("defaults to false", () => {
+    expect(usePhilanthropyStore.getState().loginRequired).toBe(false);
+  });
+
+  it("setLoginRequired flips the flag", () => {
+    usePhilanthropyStore.getState().setLoginRequired(true);
+    expect(usePhilanthropyStore.getState().loginRequired).toBe(true);
+  });
+
+  it("reset() clears the flag (e.g. on New chat)", () => {
+    usePhilanthropyStore.getState().setLoginRequired(true);
+    usePhilanthropyStore.getState().reset();
+    expect(usePhilanthropyStore.getState().loginRequired).toBe(false);
+  });
+});

--- a/src/features/non-profits/__tests__/remark-autolink-urls.test.ts
+++ b/src/features/non-profits/__tests__/remark-autolink-urls.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { autolinkText, normalizeUrl, remarkAutolinkUrls } from "../lib/remark-autolink-urls";
+
+describe("normalizeUrl", () => {
+  it("keeps absolute http(s) urls unchanged", () => {
+    expect(normalizeUrl("https://fordfoundation.org/grants")).toBe(
+      "https://fordfoundation.org/grants"
+    );
+    expect(normalizeUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("prepends https to www. and scheme-less domains", () => {
+    expect(normalizeUrl("www.macfound.org")).toBe("https://www.macfound.org");
+    expect(normalizeUrl("fordfoundation.org")).toBe("https://fordfoundation.org");
+    expect(normalizeUrl("knightfoundation.org/programs")).toBe(
+      "https://knightfoundation.org/programs"
+    );
+  });
+
+  it("leaves internal/relative and non-web hrefs untouched", () => {
+    expect(normalizeUrl("/nonprofits/find-funders/foundation/123")).toBeNull();
+    expect(normalizeUrl("#section")).toBeNull();
+    expect(normalizeUrl("mailto:hi@example.org")).toBeNull();
+    expect(normalizeUrl("tel:+15551234")).toBeNull();
+  });
+
+  it("ignores prose that merely contains a dot", () => {
+    expect(normalizeUrl("e.g")).toBeNull();
+    expect(normalizeUrl("vs.")).toBeNull();
+    expect(normalizeUrl("3.5")).toBeNull();
+  });
+});
+
+describe("autolinkText", () => {
+  it("returns null when there is nothing to link", () => {
+    expect(autolinkText("just some plain prose")).toBeNull();
+  });
+
+  it("links a scheme-less domain in the middle of a sentence", () => {
+    const nodes = autolinkText("See fordfoundation.org for details.");
+    expect(nodes).toEqual([
+      { type: "text", value: "See " },
+      {
+        type: "link",
+        url: "https://fordfoundation.org",
+        children: [{ type: "text", value: "fordfoundation.org" }],
+      },
+      { type: "text", value: " for details." },
+    ]);
+  });
+
+  it("does not swallow trailing sentence punctuation into the link", () => {
+    const nodes = autolinkText("Apply at macfound.org.");
+    expect(nodes?.[1]).toMatchObject({ type: "link", url: "https://macfound.org" });
+    expect(nodes?.at(-1)).toEqual({ type: "text", value: "." });
+  });
+
+  it("links multiple urls in one string", () => {
+    const nodes = autolinkText("a.org and https://b.com");
+    const links = nodes?.filter((n) => n.type === "link");
+    expect(links).toHaveLength(2);
+  });
+});
+
+describe("remarkAutolinkUrls plugin", () => {
+  function textNode(value: string) {
+    return { type: "text", value };
+  }
+
+  it("autolinks bare domains inside paragraph text", () => {
+    const tree = {
+      type: "root",
+      children: [{ type: "paragraph", children: [textNode("Visit fordfoundation.org now")] }],
+    };
+    remarkAutolinkUrls()(tree as never);
+    const para = (tree.children[0] as { children: unknown[] }).children;
+    expect(para).toEqual([
+      { type: "text", value: "Visit " },
+      {
+        type: "link",
+        url: "https://fordfoundation.org",
+        children: [{ type: "text", value: "fordfoundation.org" }],
+      },
+      { type: "text", value: " now" },
+    ]);
+  });
+
+  it("repairs a scheme-less href on an existing link node", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            { type: "link", url: "fordfoundation.org", children: [textNode("Ford Foundation")] },
+          ],
+        },
+      ],
+    };
+    remarkAutolinkUrls()(tree as never);
+    const link = (tree.children[0] as { children: { url: string }[] }).children[0];
+    expect(link.url).toBe("https://fordfoundation.org");
+  });
+
+  it("never rewrites internal entity links", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            {
+              type: "link",
+              url: "/nonprofits/find-funders/foundation/123",
+              children: [textNode("Ford")],
+            },
+          ],
+        },
+      ],
+    };
+    remarkAutolinkUrls()(tree as never);
+    const link = (tree.children[0] as { children: { url: string }[] }).children[0];
+    expect(link.url).toBe("/nonprofits/find-funders/foundation/123");
+  });
+
+  it("does not autolink inside inline code or code blocks", () => {
+    const tree = {
+      type: "root",
+      children: [
+        { type: "paragraph", children: [{ type: "inlineCode", value: "fordfoundation.org" }] },
+        { type: "code", value: "see example.com" },
+      ],
+    };
+    remarkAutolinkUrls()(tree as never);
+    const para = (tree.children[0] as { children: { type: string }[] }).children;
+    expect(para[0].type).toBe("inlineCode");
+    expect((tree.children[1] as { type: string }).type).toBe("code");
+  });
+});

--- a/src/features/non-profits/__tests__/saved-conversation.test.ts
+++ b/src/features/non-profits/__tests__/saved-conversation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for lib/saved-conversation.ts — mapping between persisted
+ * conversation turns and the in-memory ChatTurn shape.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  chatTurnToTurnPayload,
+  savedTurnsToChatTurns,
+  savedTurnToChatTurn,
+} from "../lib/saved-conversation";
+import type { SavedSearchTurn } from "../services/search-history.service";
+import type { ChatTurn } from "../store/philanthropy";
+import type { RankedEntity } from "../types/philanthropy";
+
+function makeEntity(id: string): RankedEntity {
+  return {
+    entityType: "foundation",
+    id,
+    name: `Foundation ${id}`,
+    description: null,
+    ein: null,
+    location: null,
+    totalAssets: null,
+    amount: null,
+    date: null,
+    filingYear: null,
+    foundationId: null,
+    foundationName: null,
+    nonprofitId: null,
+    nonprofitName: null,
+    scores: { semantic: 1, amount: 0, recency: 0, composite: 1 },
+  };
+}
+
+function makeSavedTurn(overrides: Partial<SavedSearchTurn> = {}): SavedSearchTurn {
+  return {
+    id: "turn-1",
+    searchHistoryId: "sh-1",
+    turnIndex: 0,
+    userQuery: "Foundations in Ohio",
+    narrative: "Top funders…",
+    entities: [makeEntity("f-1")],
+    citations: [{ entityId: "f-1", entityType: "foundation", filingYear: 2023, fieldPath: "x" }],
+    traceId: "trace-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeChatTurn(overrides: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    id: "turn-1",
+    userQuery: "Foundations in Ohio",
+    narrative: "Top funders…",
+    entities: [makeEntity("f-1")],
+    citations: [],
+    traceId: "trace-1",
+    pagination: null,
+    status: "done",
+    error: null,
+    progress: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe("savedTurnToChatTurn", () => {
+  it("restores a completed turn with no streaming residue", () => {
+    const turn = savedTurnToChatTurn(makeSavedTurn());
+
+    expect(turn).toEqual({
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [makeEntity("f-1")],
+      citations: [{ entityId: "f-1", entityType: "foundation", filingYear: 2023, fieldPath: "x" }],
+      traceId: "trace-1",
+      pagination: null,
+      status: "done",
+      error: null,
+      progress: null,
+      attachments: [],
+    });
+  });
+
+  it("preserves turn order in savedTurnsToChatTurns", () => {
+    const turns = savedTurnsToChatTurns([
+      makeSavedTurn({ id: "t-1", turnIndex: 0 }),
+      makeSavedTurn({ id: "t-2", turnIndex: 1 }),
+    ]);
+
+    expect(turns.map((t) => t.id)).toEqual(["t-1", "t-2"]);
+  });
+});
+
+describe("chatTurnToTurnPayload", () => {
+  it("snapshots id, query, narrative, entities, citations and traceId", () => {
+    const payload = chatTurnToTurnPayload(makeChatTurn());
+
+    expect(payload).toEqual({
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [makeEntity("f-1")],
+      citations: [],
+      traceId: "trace-1",
+    });
+  });
+
+  it("clamps oversized fields to the server bounds", () => {
+    const entities = Array.from({ length: 600 }, (_, i) => makeEntity(`f-${i}`));
+    const payload = chatTurnToTurnPayload(
+      makeChatTurn({
+        userQuery: "q".repeat(5000),
+        narrative: "n".repeat(50000),
+        entities,
+      })
+    );
+
+    expect(payload.userQuery).toHaveLength(4000);
+    expect(payload.narrative).toHaveLength(40000);
+    expect(payload.entities).toHaveLength(500);
+  });
+});

--- a/src/features/non-profits/__tests__/saved-conversation.test.ts
+++ b/src/features/non-profits/__tests__/saved-conversation.test.ts
@@ -109,16 +109,24 @@ describe("chatTurnToTurnPayload", () => {
 
   it("clamps oversized fields to the server bounds", () => {
     const entities = Array.from({ length: 600 }, (_, i) => makeEntity(`f-${i}`));
+    const citations = Array.from({ length: 2500 }, (_, i) => ({
+      entityId: `e-${i}`,
+      entityType: "foundation" as const,
+      filingYear: 2023,
+      fieldPath: `path.${i}`,
+    }));
     const payload = chatTurnToTurnPayload(
       makeChatTurn({
         userQuery: "q".repeat(5000),
         narrative: "n".repeat(50000),
         entities,
+        citations,
       })
     );
 
     expect(payload.userQuery).toHaveLength(4000);
     expect(payload.narrative).toHaveLength(40000);
     expect(payload.entities).toHaveLength(500);
+    expect(payload.citations).toHaveLength(2000);
   });
 });

--- a/src/features/non-profits/__tests__/search-history-service.test.ts
+++ b/src/features/non-profits/__tests__/search-history-service.test.ts
@@ -133,6 +133,41 @@ describe("searchHistoryService", () => {
     });
   });
 
+  describe("anonymous (ownerless) responses", () => {
+    // Regression: ownerless chats return `userId: null`. The response schema
+    // must accept it — otherwise create/getById fail to parse, the create is
+    // treated as an error, and the first turn is never persisted while logged
+    // out (the append is chained off a successful create).
+    it("create accepts a null userId", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeOkResponse({ ...HISTORY_ENTRY, userId: null }, 201));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await searchHistoryService.create("anon query", "thread-anon");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.userId).toBeNull();
+      }
+    });
+
+    it("getById accepts a null userId with turns", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeOkResponse({ ...HISTORY_DETAIL, userId: null }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await searchHistoryService.getById("thread-anon");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.userId).toBeNull();
+        expect(result.value.turns).toHaveLength(1);
+      }
+    });
+  });
+
   describe("getById", () => {
     it("calls the GET endpoint for the given id and returns saved turns", async () => {
       const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_DETAIL));

--- a/src/features/non-profits/__tests__/search-history-service.test.ts
+++ b/src/features/non-profits/__tests__/search-history-service.test.ts
@@ -48,6 +48,20 @@ const HISTORY_ENTRY = {
   createdAt: "2024-01-01T00:00:00Z",
 };
 
+const SAVED_TURN = {
+  id: "turn-1",
+  searchHistoryId: "sh-1",
+  turnIndex: 0,
+  userQuery: "Foundations in Ohio",
+  narrative: "Top funders…",
+  entities: [],
+  citations: [],
+  traceId: "trace-1",
+  createdAt: "2024-01-01T00:00:00Z",
+};
+
+const HISTORY_DETAIL = { ...HISTORY_ENTRY, turns: [SAVED_TURN] };
+
 describe("searchHistoryService", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -104,12 +118,24 @@ describe("searchHistoryService", () => {
       if (result.isOk()) {
         expect(result.value.id).toBe("sh-1");
       }
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ query: "Foundations in Ohio" });
+    });
+
+    it("includes the conversation id in the body when supplied", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_ENTRY));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await searchHistoryService.create("Foundations in Ohio", "thread-1");
+
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ query: "Foundations in Ohio", id: "thread-1" });
     });
   });
 
   describe("getById", () => {
-    it("calls the GET endpoint for the given id", async () => {
-      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_ENTRY));
+    it("calls the GET endpoint for the given id and returns saved turns", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(HISTORY_DETAIL));
       vi.stubGlobal("fetch", fetchMock);
 
       const result = await searchHistoryService.getById("sh-1");
@@ -117,6 +143,8 @@ describe("searchHistoryService", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         expect(result.value.id).toBe("sh-1");
+        expect(result.value.turns).toHaveLength(1);
+        expect(result.value.turns[0].userQuery).toBe("Foundations in Ohio");
       }
       const calledUrl = fetchMock.mock.calls[0][0] as string;
       expect(calledUrl).toContain("/v2/search-history/sh-1");
@@ -131,6 +159,45 @@ describe("searchHistoryService", () => {
       if (result.isErr()) {
         expect(result.error.type).toBe("ApiError");
         expect((result.error as { type: string; status: number }).status).toBe(404);
+      }
+    });
+  });
+
+  describe("appendTurn", () => {
+    it("posts the turn snapshot to the turns endpoint", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(SAVED_TURN));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await searchHistoryService.appendTurn("sh-1", {
+        id: "turn-1",
+        userQuery: "Foundations in Ohio",
+        narrative: "Top funders…",
+        entities: [],
+        citations: [],
+        traceId: "trace-1",
+      });
+
+      expect(result.isOk()).toBe(true);
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/v2/search-history/sh-1/turns");
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "POST" });
+    });
+
+    it("returns ApiError when unauthenticated", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(401, "Unauthorized")));
+
+      const result = await searchHistoryService.appendTurn("sh-1", {
+        id: "turn-1",
+        userQuery: "q",
+        narrative: "",
+        entities: [],
+        citations: [],
+        traceId: null,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.type).toBe("ApiError");
       }
     });
   });

--- a/src/features/non-profits/__tests__/search-session.test.ts
+++ b/src/features/non-profits/__tests__/search-session.test.ts
@@ -124,6 +124,18 @@ describe("useSearchSessionStore", () => {
     expect(useSearchSessionStore.getState().consumeFresh("nonexistent")).toBe(false);
   });
 
+  it("keeps an empty-query session after consumeFresh, distinct from an unknown id", () => {
+    // A "New chat" mints an empty-query fresh session. After its one-shot fresh
+    // flag is consumed (e.g. a reload before searching), getSession must still
+    // return it — that's how ChatView tells "my own empty chat" (→ empty
+    // workbench) apart from an unknown/private URL (→ not-found state).
+    const id = useSearchSessionStore.getState().createSession("");
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(true);
+    expect(useSearchSessionStore.getState().getSession(id)).toBeDefined();
+    expect(useSearchSessionStore.getState().getSession(id)?.query).toBe("");
+    expect(useSearchSessionStore.getState().getSession("never-created")).toBeUndefined();
+  });
+
   it("setSession clears the fresh flag for an existing session", () => {
     const id = useSearchSessionStore.getState().createSession("first query");
     useSearchSessionStore.getState().setSession(id, "first query");

--- a/src/features/non-profits/__tests__/search-session.test.ts
+++ b/src/features/non-profits/__tests__/search-session.test.ts
@@ -100,4 +100,33 @@ describe("useSearchSessionStore", () => {
     const id2 = useSearchSessionStore.getState().createSession("query beta");
     expect(id1).not.toBe(id2);
   });
+
+  it("createSession marks the session fresh", () => {
+    const id = useSearchSessionStore.getState().createSession("brand new search");
+    expect(useSearchSessionStore.getState().getSession(id)?.fresh).toBe(true);
+  });
+
+  it("consumeFresh returns true exactly once for a fresh session", () => {
+    const id = useSearchSessionStore.getState().createSession("brand new search");
+
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(true);
+    // Second call: the flag was consumed — this is now a revisit.
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(false);
+    expect(useSearchSessionStore.getState().getSession(id)?.query).toBe("brand new search");
+  });
+
+  it("consumeFresh returns false for sessions written via setSession", () => {
+    useSearchSessionStore.getState().setSession("remote-id", "hydrated from server");
+    expect(useSearchSessionStore.getState().consumeFresh("remote-id")).toBe(false);
+  });
+
+  it("consumeFresh returns false for unknown ids", () => {
+    expect(useSearchSessionStore.getState().consumeFresh("nonexistent")).toBe(false);
+  });
+
+  it("setSession clears the fresh flag for an existing session", () => {
+    const id = useSearchSessionStore.getState().createSession("first query");
+    useSearchSessionStore.getState().setSession(id, "first query");
+    expect(useSearchSessionStore.getState().consumeFresh(id)).toBe(false);
+  });
 });

--- a/src/features/non-profits/__tests__/use-search-history.test.ts
+++ b/src/features/non-profits/__tests__/use-search-history.test.ts
@@ -12,13 +12,18 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useAddSearchHistory,
+  useAppendSearchTurn,
   useClearSearchHistory,
   useDeleteSearchHistoryEntry,
   useSearchHistory,
   useSearchHistoryList,
 } from "../hooks/use-search-history";
 import type { AppError } from "../lib/errors";
-import type { SearchHistoryEntry } from "../services/search-history.service";
+import type {
+  SavedSearchTurn,
+  SearchHistoryDetail,
+  SearchHistoryEntry,
+} from "../services/search-history.service";
 import { searchHistoryService } from "../services/search-history.service";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -28,6 +33,7 @@ vi.mock("../services/search-history.service", () => ({
     list: vi.fn(),
     create: vi.fn(),
     getById: vi.fn(),
+    appendTurn: vi.fn(),
     deleteOne: vi.fn(),
     clearAll: vi.fn(),
   },
@@ -78,7 +84,9 @@ describe("useSearchHistory (getById)", () => {
   });
 
   it("fetches entry by id", async () => {
-    vi.mocked(searchHistoryService.getById).mockReturnValue(okAsync(ENTRY_1));
+    vi.mocked(searchHistoryService.getById).mockReturnValue(
+      okAsync({ ...ENTRY_1, turns: [] } satisfies SearchHistoryDetail)
+    );
 
     const { result } = renderHook(() => useSearchHistory("sh-1"), { wrapper });
 
@@ -171,7 +179,7 @@ describe("useAddSearchHistory", () => {
     const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
 
     await act(async () => {
-      result.current.mutate("Foundations in Ohio");
+      result.current.mutate({ query: "Foundations in Ohio" });
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -181,6 +189,101 @@ describe("useAddSearchHistory", () => {
     const queries = cached?.map((e) => e.query.toLowerCase()) ?? [];
     const unique = [...new Set(queries)];
     expect(unique).toHaveLength(queries.length);
+  });
+
+  it("passes the conversation id through to the service", async () => {
+    vi.mocked(searchHistoryService.create).mockReturnValue(okAsync(ENTRY_1));
+
+    const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({ query: "Foundations in Ohio", id: "thread-1" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(searchHistoryService.create).toHaveBeenCalledWith("Foundations in Ohio", "thread-1");
+  });
+
+  it("leaves cached detail entries (non-list values) untouched", async () => {
+    const detail: SearchHistoryDetail = { ...ENTRY_1, turns: [] };
+    queryClient.setQueryData([...SEARCH_HISTORY_KEY, "sh-1"], detail);
+    vi.mocked(searchHistoryService.create).mockReturnValue(okAsync(ENTRY_2));
+
+    const { result } = renderHook(() => useAddSearchHistory(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({ query: "Youth literacy funders" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData([...SEARCH_HISTORY_KEY, "sh-1"])).toEqual(detail);
+  });
+});
+
+describe("useAppendSearchTurn", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("appends the turn via the service", async () => {
+    const savedTurn: SavedSearchTurn = {
+      id: "turn-1",
+      searchHistoryId: "sh-1",
+      turnIndex: 0,
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [],
+      citations: [],
+      traceId: null,
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    vi.mocked(searchHistoryService.appendTurn).mockReturnValue(okAsync(savedTurn));
+
+    const { result } = renderHook(() => useAppendSearchTurn(), { wrapper });
+
+    const payload = {
+      id: "turn-1",
+      userQuery: "Foundations in Ohio",
+      narrative: "Top funders…",
+      entities: [],
+      citations: [],
+      traceId: null,
+    };
+    await act(async () => {
+      result.current.mutate({ searchId: "sh-1", turn: payload });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(searchHistoryService.appendTurn).toHaveBeenCalledWith("sh-1", payload);
+  });
+
+  it("surfaces errors without throwing", async () => {
+    const appError: AppError = { type: "ApiError", status: 401, message: "Unauthorized" };
+    vi.mocked(searchHistoryService.appendTurn).mockReturnValue(errAsync(appError));
+
+    const { result } = renderHook(() => useAppendSearchTurn(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        searchId: "sh-1",
+        turn: {
+          id: "turn-1",
+          userQuery: "q",
+          narrative: "",
+          entities: [],
+          citations: [],
+          traceId: null,
+        },
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(appError);
   });
 });
 

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -12,7 +12,8 @@
  * - Store: useGrantAtlasStore → usePhilanthropyStore
  * - messages selector: useShallow + EMPTY_MESSAGES constant (Zustand v5 safety)
  * - No motion imports; no retry button on stream error (error card only)
- * - New chat: abort stream + reset() store, STAY on current URL
+ * - New chat: abort stream + reset() store, replace URL with a fresh session
+ *   id (conversations are persisted per URL id)
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
@@ -28,6 +29,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -57,6 +59,7 @@ import {
   useRemoveFromResearchTray,
   useResearchTray,
 } from "../hooks/use-research-tray";
+import { savedTurnsToChatTurns } from "../lib/saved-conversation";
 import { FILINGS_STATS } from "../lib/stats";
 import { decideThreadSeed } from "../lib/thread-seed";
 import { searchHistoryService } from "../services/search-history.service";
@@ -348,6 +351,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
+  const router = useRouter();
 
   const [input, setInput] = useState("");
   const [trayOpen, setTrayOpen] = useState(false);
@@ -383,23 +387,36 @@ export function ChatView({ searchId }: { searchId?: string }) {
       reset();
     }
     usePhilanthropyStore.getState().setThreadId(searchId);
-    // Fast path: local session store
-    const session = useSearchSessionStore.getState().getSession(searchId);
+    const sessionStore = useSearchSessionStore.getState();
+    const session = sessionStore.getSession(searchId);
     const localQuery = session?.query?.trim();
-    if (localQuery) {
-      void search(localQuery, 1, { chat: true });
+    // Fast path: a session minted just now (landing page submit / new chat)
+    // runs its query immediately. `consumeFresh` is one-shot, so any later
+    // visit to the same URL takes the hydration path below instead of
+    // re-running the search.
+    if (sessionStore.consumeFresh(searchId)) {
+      if (localQuery) void search(localQuery, 1, { chat: true });
       return;
     }
-    // Fallback: fetch from server (shared link / cold load)
+    // Revisit / shared link: restore the saved conversation if the server
+    // has turns for it; otherwise fall back to re-running the query.
     void searchHistoryService.getById(searchId).match(
       (entry) => {
+        if (entry.turns.length > 0) {
+          useSearchSessionStore.getState().setSession(searchId, entry.query);
+          usePhilanthropyStore.getState().hydrateTurns(savedTurnsToChatTurns(entry.turns));
+          return;
+        }
         const remoteQuery = entry.query?.trim();
         if (!remoteQuery) return;
         useSearchSessionStore.getState().setSession(searchId, remoteQuery);
         void search(remoteQuery, 1, { chat: true });
       },
       () => {
-        /* 404 or error — render empty workbench, degrade gracefully */
+        // 404 (never persisted — e.g. anonymous search) or network error:
+        // re-run the locally cached query if we have one, else render the
+        // empty workbench and degrade gracefully.
+        if (localQuery) void search(localQuery, 1, { chat: true });
       }
     );
   }, [searchId, messages.length, search, abort, reset]);
@@ -422,15 +439,19 @@ export function ChatView({ searchId }: { searchId?: string }) {
     [search, isSearching]
   );
 
-  // New chat: abort active stream + reset chat store, STAY on current URL.
-  // Clear the session's seed query so the initial-query effect (re-armed by
-  // resetting the ref below) doesn't immediately re-run the original query.
+  // New chat: abort active stream + reset chat store, then move to a fresh
+  // session URL. Conversations are persisted under the URL id, so staying on
+  // the old URL would either resurrect the saved thread (the seeding effect
+  // hydrates it) or append unrelated turns to it — a new id gives the next
+  // conversation its own saved thread. `createSession("")` marks the new id
+  // fresh so the seeding effect renders an empty workbench without fetching.
   const onNewChat = useCallback(() => {
     abort();
     reset();
-    if (searchId) useSearchSessionStore.getState().clearSession(searchId);
     seededSearchIdRef.current = null;
-  }, [abort, reset, searchId]);
+    const newId = useSearchSessionStore.getState().createSession("");
+    router.replace(NON_PROFITS_PAGES.SEARCH(newId));
+  }, [abort, reset, router]);
 
   const showEmpty = messages.length === 0 && !isSearching;
   const lastTurn = messages[messages.length - 1];

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -57,6 +57,7 @@ import {
   useRemoveFromResearchTray,
   useResearchTray,
 } from "../hooks/use-research-tray";
+import { type EntityGroup, groupEntitiesByType } from "../lib/group-entities";
 import { FILINGS_STATS } from "../lib/stats";
 import { decideThreadSeed } from "../lib/thread-seed";
 import { searchHistoryService } from "../services/search-history.service";
@@ -253,16 +254,30 @@ const CompactEntityCard = memo(function CompactEntityCard({
   );
 });
 
-function EntityList({ entities, searchId }: { entities: RankedEntity[]; searchId?: string }) {
+// A single labeled group (e.g. "Foundations · Potential funders") with its own
+// show-more state so each section expands independently.
+const EntityGroupSection = memo(function EntityGroupSection({
+  group,
+  searchId,
+}: {
+  group: EntityGroup;
+  searchId?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
-
-  if (entities.length === 0) return null;
-
-  const visible = expanded ? entities : entities.slice(0, INITIAL_VISIBLE_ENTITIES);
-  const remaining = entities.length - visible.length;
+  const Icon = ENTITY_ICON[group.type];
+  const count = group.entities.length;
+  const visible = expanded ? group.entities : group.entities.slice(0, INITIAL_VISIBLE_ENTITIES);
+  const remaining = count - visible.length;
 
   return (
-    <div className="mt-3 flex flex-col gap-2">
+    <section className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+        <Icon className="size-3.5 text-zinc-500 dark:text-zinc-400" />
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
+          {count} {pluralize(group.label, count)}
+        </h4>
+        <span className="text-xs text-zinc-400 dark:text-zinc-500">· {group.role}</span>
+      </div>
       {visible.map((e) => (
         <CompactEntityCard key={`${e.entityType}-${e.id}`} entity={e} searchId={searchId} />
       ))}
@@ -272,10 +287,24 @@ function EntityList({ entities, searchId }: { entities: RankedEntity[]; searchId
           onClick={() => setExpanded(true)}
           className="flex items-center justify-center gap-1.5 rounded-lg border border-dashed border-zinc-300 bg-white py-2 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
         >
-          Show all {entities.length} results
+          Show all {count} {pluralize(group.label.toLowerCase(), count)}
           <ChevronDown className="size-3" />
         </button>
       )}
+    </section>
+  );
+});
+
+function EntityList({ entities, searchId }: { entities: RankedEntity[]; searchId?: string }) {
+  const groups = useMemo(() => groupEntitiesByType(entities), [entities]);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex flex-col gap-5">
+      {groups.map((group) => (
+        <EntityGroupSection key={group.type} group={group} searchId={searchId} />
+      ))}
     </div>
   );
 }

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -132,6 +132,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const isSearching = usePhilanthropyStore((s) => s.isSearching);
   const readOnly = usePhilanthropyStore((s) => s.readOnly);
   const notFound = usePhilanthropyStore((s) => s.notFound);
+  const conversationFull = usePhilanthropyStore((s) => s.conversationFull);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
@@ -215,11 +216,11 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {
       const text = msg.text.trim();
-      if (!text || isSearching || readOnly) return;
+      if (!text || isSearching || readOnly || conversationFull) return;
       setInput("");
       void search(text, 1, { chat: true });
     },
-    [search, isSearching, readOnly]
+    [search, isSearching, readOnly, conversationFull]
   );
 
   const onStarterClick = useCallback(
@@ -376,15 +377,17 @@ export function ChatView({ searchId }: { searchId?: string }) {
         <ConversationScrollButton />
       </Conversation>
 
-      {/* Composer — replaced by a read-only notice when this conversation
-          belongs to another account (persistence returned 403). */}
+      {/* Composer — replaced by a notice when the conversation can't accept
+          more input: owned by another account (403) or full (409). */}
       <div className="border-t border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
         <div className="mx-auto w-full max-w-3xl">
-          {readOnly ? (
+          {readOnly || conversationFull ? (
             <div className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
               <Lock className="size-4 shrink-0" />
               <span>
-                This conversation belongs to another account and is read-only.{" "}
+                {conversationFull
+                  ? "This conversation has reached its maximum length."
+                  : "This conversation belongs to another account and is read-only."}{" "}
                 <button
                   type="button"
                   onClick={onNewChat}

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -17,7 +17,7 @@
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
-import { Bookmark, Clock, Lock, Sparkles } from "lucide-react";
+import { Bookmark, Clock, Lock, SearchX, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -131,6 +131,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   );
   const isSearching = usePhilanthropyStore((s) => s.isSearching);
   const readOnly = usePhilanthropyStore((s) => s.readOnly);
+  const notFound = usePhilanthropyStore((s) => s.notFound);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
@@ -170,6 +171,8 @@ export function ChatView({ searchId }: { searchId?: string }) {
       reset();
     }
     usePhilanthropyStore.getState().setThreadId(searchId);
+    // Clear any not-found state from a previously-viewed conversation.
+    usePhilanthropyStore.getState().setNotFound(false);
     const sessionStore = useSearchSessionStore.getState();
     const session = sessionStore.getSession(searchId);
     const localQuery = session?.query?.trim();
@@ -196,10 +199,15 @@ export function ChatView({ searchId }: { searchId?: string }) {
         void search(remoteQuery, 1, { chat: true });
       },
       () => {
-        // 404 (never persisted — e.g. anonymous search) or network error:
-        // re-run the locally cached query if we have one, else render the
-        // empty workbench and degrade gracefully.
-        if (localQuery) void search(localQuery, 1, { chat: true });
+        // A local query means this is our own chat that simply isn't persisted
+        // yet (anonymous) — re-run it. Otherwise the server returned 404: the
+        // conversation is private to another account, deleted, or never
+        // existed → show a not-found state instead of a blank workbench.
+        if (localQuery) {
+          void search(localQuery, 1, { chat: true });
+        } else {
+          usePhilanthropyStore.getState().setNotFound(true);
+        }
       }
     );
   }, [searchId, messages.length, search, abort, reset]);
@@ -242,6 +250,29 @@ export function ChatView({ searchId }: { searchId?: string }) {
     () => messages.some((m) => m.status === "done" && m.entities.length > 0),
     [messages]
   );
+
+  // Not-found state: the conversation URL is private to another account,
+  // deleted, or never existed (server 404 with no local query to re-run).
+  if (notFound) {
+    return (
+      <div className="flex h-[calc(100vh-4rem)] flex-col items-center justify-center px-4 text-center">
+        <SearchX className="size-10 text-zinc-400 dark:text-zinc-500" />
+        <h2 className="mt-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          Conversation not found
+        </h2>
+        <p className="mt-1 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
+          This conversation is private to another account, was deleted, or never existed.
+        </p>
+        <button
+          type="button"
+          onClick={onNewChat}
+          className="mt-5 rounded-lg !bg-brand px-4 py-2 text-sm font-medium !text-white transition-colors hover:!bg-brand-emphasis"
+        >
+          Start a new chat
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-[calc(100vh-4rem)] flex-col">

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -17,7 +17,7 @@
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
-import { Bookmark, Clock, Lock, SearchX, Sparkles } from "lucide-react";
+import { Bookmark, Clock, SearchX, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -50,6 +50,7 @@ import { type ChatTurn, EMPTY_MESSAGES, usePhilanthropyStore } from "../store/ph
 import { useSearchSessionStore } from "../store/search-session";
 import { AttachmentsPanel } from "./attachments-panel";
 import { BookmarksDrawer } from "./bookmarks-drawer";
+import { ComposerLockNotice } from "./composer-lock-notice";
 import { ConnectorNudge } from "./connector-nudge";
 import { EntityList } from "./entity-list";
 import { NarrativeBlock } from "./narrative-block";
@@ -133,6 +134,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const readOnly = usePhilanthropyStore((s) => s.readOnly);
   const notFound = usePhilanthropyStore((s) => s.notFound);
   const conversationFull = usePhilanthropyStore((s) => s.conversationFull);
+  const loginRequired = usePhilanthropyStore((s) => s.loginRequired);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
@@ -213,14 +215,22 @@ export function ChatView({ searchId }: { searchId?: string }) {
     );
   }, [searchId, messages.length, search, abort, reset]);
 
+  // The free-limit prompt is only set for logged-out users; once they sign in,
+  // restore the composer so they can continue.
+  useEffect(() => {
+    if (authenticated && loginRequired) {
+      usePhilanthropyStore.getState().setLoginRequired(false);
+    }
+  }, [authenticated, loginRequired]);
+
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {
       const text = msg.text.trim();
-      if (!text || isSearching || readOnly || conversationFull) return;
+      if (!text || isSearching || readOnly || conversationFull || loginRequired) return;
       setInput("");
       void search(text, 1, { chat: true });
     },
-    [search, isSearching, readOnly, conversationFull]
+    [search, isSearching, readOnly, conversationFull, loginRequired]
   );
 
   const onStarterClick = useCallback(
@@ -378,26 +388,16 @@ export function ChatView({ searchId }: { searchId?: string }) {
       </Conversation>
 
       {/* Composer — replaced by a notice when the conversation can't accept
-          more input: owned by another account (403) or full (409). */}
+          more input: owned by another account (403), full (409), or the
+          anonymous free limit was reached (401 → sign-in prompt). */}
       <div className="border-t border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
         <div className="mx-auto w-full max-w-3xl">
-          {readOnly || conversationFull ? (
-            <div className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-              <Lock className="size-4 shrink-0" />
-              <span>
-                {conversationFull
-                  ? "This conversation has reached its maximum length."
-                  : "This conversation belongs to another account and is read-only."}{" "}
-                <button
-                  type="button"
-                  onClick={onNewChat}
-                  className="font-medium text-brand underline-offset-2 hover:underline"
-                >
-                  Start a new chat
-                </button>{" "}
-                to continue.
-              </span>
-            </div>
+          {readOnly || conversationFull || loginRequired ? (
+            <ComposerLockNotice
+              reason={loginRequired ? "login" : conversationFull ? "full" : "readonly"}
+              onNewChat={onNewChat}
+              onSignIn={login}
+            />
           ) : (
             <PromptInput
               onSubmit={onSubmit}

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -202,13 +202,15 @@ export function ChatView({ searchId }: { searchId?: string }) {
         void search(remoteQuery, 1, { chat: true });
       },
       () => {
-        // A local query means this is our own chat that simply isn't persisted
-        // yet (anonymous) — re-run it. Otherwise the server returned 404: the
-        // conversation is private to another account, deleted, or never
-        // existed → show a not-found state instead of a blank workbench.
+        // A local query means this is our own chat that isn't persisted yet
+        // (anonymous) — re-run it. A local session with no query is a freshly
+        // created chat the user hasn't searched in yet (e.g. "New chat" then a
+        // reload, where the one-shot `fresh` flag is already spent) — render the
+        // empty workbench. Only with NO local session at all is the URL
+        // genuinely private to another account, deleted, or nonexistent.
         if (localQuery) {
           void search(localQuery, 1, { chat: true });
-        } else {
+        } else if (!session) {
           usePhilanthropyStore.getState().setNotFound(true);
         }
       }

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -16,18 +16,7 @@
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
-import {
-  Bookmark,
-  BookmarkCheck,
-  Building2,
-  ChevronDown,
-  Clock,
-  HandCoins,
-  Landmark,
-  MapPin,
-  Sparkles,
-} from "lucide-react";
-import Link from "next/link";
+import { Bookmark, Clock, Sparkles } from "lucide-react";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -49,96 +38,20 @@ import {
   PromptInputTextarea,
   PromptInputTools,
 } from "@/src/components/ai-elements/prompt-input";
-import formatCurrency from "@/utilities/formatCurrency";
-import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { usePhilanthropySearch } from "../hooks/use-philanthropy-stream";
-import {
-  useAddToResearchTray,
-  useRemoveFromResearchTray,
-  useResearchTray,
-} from "../hooks/use-research-tray";
-import { type EntityGroup, groupEntitiesByType } from "../lib/group-entities";
 import { FILINGS_STATS } from "../lib/stats";
 import { decideThreadSeed } from "../lib/thread-seed";
 import { searchHistoryService } from "../services/search-history.service";
-import type { FieldRect, PageTransitionFields } from "../store/page-transition";
-import { usePageTransitionStore } from "../store/page-transition";
 import { type ChatTurn, EMPTY_MESSAGES, usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
-import type { PhilanthropyEntityType, RankedEntity } from "../types/philanthropy";
 import { AttachmentsPanel } from "./attachments-panel";
 import { BookmarksDrawer } from "./bookmarks-drawer";
 import { ConnectorNudge } from "./connector-nudge";
+import { EntityList } from "./entity-list";
 import { NarrativeBlock } from "./narrative-block";
 import { ProgressView } from "./progress-view";
 import { SearchFeedback } from "./search-feedback";
 import { SearchHistoryPanel } from "./search-history-panel";
-
-// ── Entity presentation constants ──────────────────────────────────────────
-
-const ENTITY_ICON: Record<PhilanthropyEntityType, React.ElementType> = {
-  foundation: Landmark,
-  nonprofit: Building2,
-  grant: HandCoins,
-};
-
-const ENTITY_LABEL: Record<PhilanthropyEntityType, string> = {
-  foundation: "Foundation",
-  nonprofit: "Nonprofit",
-  grant: "Grant",
-};
-
-const ENTITY_BADGE_CLASS: Record<PhilanthropyEntityType, string> = {
-  foundation: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  nonprofit: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  grant: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-};
-
-const INITIAL_VISIBLE_ENTITIES = 5;
-
-// ── BookmarkButton ──────────────────────────────────────────────────────────
-// Isolated component so it can call hooks without prop-drilling tray state.
-
-const BookmarkButton = memo(function BookmarkButton({ entity }: { entity: RankedEntity }) {
-  const { authenticated, login } = useAuth();
-  const { data: tray = [] } = useResearchTray();
-  const { mutate: addToTray, isPending: isAdding } = useAddToResearchTray();
-  const { mutate: removeFromTray, isPending: isRemoving } = useRemoveFromResearchTray();
-
-  const trayEntry = tray.find((e) => e.entityId === entity.id);
-  const isBookmarked = Boolean(trayEntry);
-
-  const toggle = useCallback(() => {
-    if (!authenticated) {
-      login();
-      return;
-    }
-    if (isBookmarked && trayEntry) {
-      removeFromTray(trayEntry.id);
-    } else {
-      addToTray(entity);
-    }
-  }, [authenticated, login, isBookmarked, trayEntry, removeFromTray, addToTray, entity]);
-
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.preventDefault();
-        toggle();
-      }}
-      aria-label={isBookmarked ? "Remove from bookmarks" : "Add to bookmarks"}
-      disabled={isAdding || isRemoving}
-      className="shrink-0 rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-brand dark:hover:bg-zinc-800 dark:hover:text-brand-subtle disabled:opacity-50"
-    >
-      {isBookmarked ? (
-        <BookmarkCheck className="size-3.5 text-brand" />
-      ) : (
-        <Bookmark className="size-3.5" />
-      )}
-    </button>
-  );
-});
 
 // ── Inline starter prompts (LOCKED decision — do NOT use suggested-queries.tsx) ──
 
@@ -148,166 +61,6 @@ const STARTER_PROMPTS = [
   "Family foundations that funded peers in climate justice last year",
   "Build a tiered prospect list for a $2M capital campaign",
 ] as const;
-
-// ── Helper functions ────────────────────────────────────────────────────────
-
-function getEntityHref(entity: RankedEntity, searchId?: string): string {
-  switch (entity.entityType) {
-    case "foundation":
-      return NON_PROFITS_PAGES.FOUNDATION(entity.id, searchId);
-    case "nonprofit":
-      return NON_PROFITS_PAGES.NONPROFIT(entity.id, searchId ? { searchId } : undefined);
-    case "grant":
-      return NON_PROFITS_PAGES.GRANT(entity.id, searchId);
-  }
-}
-
-// ── Sub-components ──────────────────────────────────────────────────────────
-
-const CompactEntityCard = memo(function CompactEntityCard({
-  entity,
-  searchId,
-}: {
-  entity: RankedEntity;
-  searchId?: string;
-}) {
-  const Icon = ENTITY_ICON[entity.entityType];
-  const href = getEntityHref(entity, searchId);
-  const cardRef = useRef<HTMLDivElement>(null);
-  const setTransition = usePageTransitionStore((s) => s.set);
-
-  const meta: string[] = [];
-  if (entity.totalAssets) meta.push(`$${formatCurrency(entity.totalAssets)} assets`);
-  if (entity.amount) meta.push(`$${formatCurrency(entity.amount)} grant`);
-  if (entity.location) meta.push(entity.location);
-
-  const handleLinkClick = useCallback(() => {
-    if (!cardRef.current) return;
-    const fieldEls = cardRef.current.querySelectorAll<HTMLElement>("[data-field]");
-    const collected: Partial<PageTransitionFields> & { name?: FieldRect } = {};
-    for (const el of fieldEls) {
-      const key = el.dataset.field as keyof PageTransitionFields | undefined;
-      if (!key) continue;
-      const rect = el.getBoundingClientRect();
-      const entry: FieldRect = {
-        text: el.textContent?.trim() ?? "",
-        x: rect.left,
-        y: rect.top,
-        width: rect.width,
-        height: rect.height,
-      };
-      collected[key] = entry;
-    }
-    if (collected.name) {
-      setTransition(entity.id, entity.entityType, collected as PageTransitionFields);
-    }
-  }, [entity.id, entity.entityType, setTransition]);
-
-  return (
-    <div
-      ref={cardRef}
-      className="group relative flex items-start gap-3 rounded-lg border border-zinc-200 bg-white p-3 transition-all hover:border-zinc-300 hover:bg-zinc-50 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
-    >
-      <Link href={href} className="contents" onClick={handleLinkClick}>
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-          <Icon className="size-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-2">
-            <p
-              data-field="name"
-              className="truncate text-sm font-medium text-zinc-900 group-hover:text-brand-emphasis dark:text-zinc-100"
-            >
-              {entity.name ?? "Unnamed"}
-            </p>
-            <span
-              data-field="badge"
-              className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ENTITY_BADGE_CLASS[entity.entityType]}`}
-            >
-              {ENTITY_LABEL[entity.entityType]}
-            </span>
-          </div>
-          {entity.description && (
-            <p className="mt-0.5 line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">
-              {entity.description}
-            </p>
-          )}
-          {meta.length > 0 && (
-            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
-              {meta.map((m, i) => (
-                <span key={`${entity.id}-meta-${i}`} className="inline-flex items-center gap-1">
-                  {i === meta.length - 1 && entity.location === m && (
-                    <>
-                      <MapPin className="size-3" />
-                      <span data-field="location">{m}</span>
-                    </>
-                  )}
-                  {!(i === meta.length - 1 && entity.location === m) && m}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-      </Link>
-      <BookmarkButton entity={entity} />
-    </div>
-  );
-});
-
-// A single labeled group (e.g. "Foundations · Potential funders") with its own
-// show-more state so each section expands independently.
-const EntityGroupSection = memo(function EntityGroupSection({
-  group,
-  searchId,
-}: {
-  group: EntityGroup;
-  searchId?: string;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const Icon = ENTITY_ICON[group.type];
-  const count = group.entities.length;
-  const visible = expanded ? group.entities : group.entities.slice(0, INITIAL_VISIBLE_ENTITIES);
-  const remaining = count - visible.length;
-
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-        <Icon className="size-3.5 text-zinc-500 dark:text-zinc-400" />
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
-          {count} {pluralize(group.label, count)}
-        </h4>
-        <span className="text-xs text-zinc-400 dark:text-zinc-500">· {group.role}</span>
-      </div>
-      {visible.map((e) => (
-        <CompactEntityCard key={`${e.entityType}-${e.id}`} entity={e} searchId={searchId} />
-      ))}
-      {remaining > 0 && (
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          className="flex items-center justify-center gap-1.5 rounded-lg border border-dashed border-zinc-300 bg-white py-2 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
-        >
-          Show all {count} {pluralize(group.label.toLowerCase(), count)}
-          <ChevronDown className="size-3" />
-        </button>
-      )}
-    </section>
-  );
-});
-
-function EntityList({ entities, searchId }: { entities: RankedEntity[]; searchId?: string }) {
-  const groups = useMemo(() => groupEntitiesByType(entities), [entities]);
-
-  if (groups.length === 0) return null;
-
-  return (
-    <div className="mt-3 flex flex-col gap-5">
-      {groups.map((group) => (
-        <EntityGroupSection key={group.type} group={group} searchId={searchId} />
-      ))}
-    </div>
-  );
-}
 
 const AssistantTurn = memo(function AssistantTurn({
   turn,

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -17,7 +17,7 @@
  * - INLINE STARTER_PROMPTS (do NOT use suggested-queries.tsx component)
  */
 
-import { Bookmark, Clock, Sparkles } from "lucide-react";
+import { Bookmark, Clock, Lock, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import pluralize from "pluralize";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -130,6 +130,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
     useShallow((s) => (s.messages.length === 0 ? EMPTY_MESSAGES : s.messages))
   );
   const isSearching = usePhilanthropyStore((s) => s.isSearching);
+  const readOnly = usePhilanthropyStore((s) => s.readOnly);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
   const { authenticated, login } = useAuth();
@@ -206,11 +207,11 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {
       const text = msg.text.trim();
-      if (!text || isSearching) return;
+      if (!text || isSearching || readOnly) return;
       setInput("");
       void search(text, 1, { chat: true });
     },
-    [search, isSearching]
+    [search, isSearching, readOnly]
   );
 
   const onStarterClick = useCallback(
@@ -344,36 +345,54 @@ export function ChatView({ searchId }: { searchId?: string }) {
         <ConversationScrollButton />
       </Conversation>
 
-      {/* Composer */}
+      {/* Composer — replaced by a read-only notice when this conversation
+          belongs to another account (persistence returned 403). */}
       <div className="border-t border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
         <div className="mx-auto w-full max-w-3xl">
-          <PromptInput
-            onSubmit={onSubmit}
-            className="rounded-2xl border border-zinc-200 dark:border-zinc-800"
-          >
-            <PromptInputBody>
-              <PromptInputTextarea
-                placeholder={
-                  messages.length === 0
-                    ? "Ask the prospecting agent…"
-                    : "Ask a follow-up — e.g. narrow to Texas, draft outreach for top 3"
-                }
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-              />
-            </PromptInputBody>
-            <PromptInputFooter>
-              <PromptInputTools>
-                <span className="px-2 text-xs text-zinc-500 dark:text-zinc-400">
-                  Plain English · {FILINGS_STATS.composerFooterLabel}
-                </span>
-              </PromptInputTools>
-              <PromptInputSubmit
-                disabled={!input.trim() || isSearching}
-                status={isSearching ? "streaming" : undefined}
-              />
-            </PromptInputFooter>
-          </PromptInput>
+          {readOnly ? (
+            <div className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+              <Lock className="size-4 shrink-0" />
+              <span>
+                This conversation belongs to another account and is read-only.{" "}
+                <button
+                  type="button"
+                  onClick={onNewChat}
+                  className="font-medium text-brand underline-offset-2 hover:underline"
+                >
+                  Start a new chat
+                </button>{" "}
+                to continue.
+              </span>
+            </div>
+          ) : (
+            <PromptInput
+              onSubmit={onSubmit}
+              className="rounded-2xl border border-zinc-200 dark:border-zinc-800"
+            >
+              <PromptInputBody>
+                <PromptInputTextarea
+                  placeholder={
+                    messages.length === 0
+                      ? "Ask the prospecting agent…"
+                      : "Ask a follow-up — e.g. narrow to Texas, draft outreach for top 3"
+                  }
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                />
+              </PromptInputBody>
+              <PromptInputFooter>
+                <PromptInputTools>
+                  <span className="px-2 text-xs text-zinc-500 dark:text-zinc-400">
+                    Plain English · {FILINGS_STATS.composerFooterLabel}
+                  </span>
+                </PromptInputTools>
+                <PromptInputSubmit
+                  disabled={!input.trim() || isSearching}
+                  status={isSearching ? "streaming" : undefined}
+                />
+              </PromptInputFooter>
+            </PromptInput>
+          )}
         </div>
       </div>
     </div>

--- a/src/features/non-profits/components/composer-lock-notice.tsx
+++ b/src/features/non-profits/components/composer-lock-notice.tsx
@@ -1,0 +1,41 @@
+import { Lock } from "lucide-react";
+
+export type ComposerLockReason = "readonly" | "full" | "login";
+
+const MESSAGE: Record<ComposerLockReason, string> = {
+  login: "You've reached the free limit.",
+  full: "This conversation has reached its maximum length.",
+  readonly: "This conversation belongs to another account and is read-only.",
+};
+
+/**
+ * Replaces the composer when the conversation can't accept more input. The
+ * `login` reason offers a sign-in action; the others offer a new-chat action.
+ */
+export function ComposerLockNotice({
+  reason,
+  onNewChat,
+  onSignIn,
+}: {
+  reason: ComposerLockReason;
+  onNewChat: () => void;
+  onSignIn: () => void;
+}) {
+  const isLogin = reason === "login";
+  return (
+    <div className="flex items-center gap-2 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+      <Lock className="size-4 shrink-0" />
+      <span>
+        {MESSAGE[reason]}{" "}
+        <button
+          type="button"
+          onClick={isLogin ? onSignIn : onNewChat}
+          className="font-medium text-brand underline-offset-2 hover:underline"
+        >
+          {isLogin ? "Sign in" : "Start a new chat"}
+        </button>{" "}
+        to continue.
+      </span>
+    </div>
+  );
+}

--- a/src/features/non-profits/components/connector-nudge.tsx
+++ b/src/features/non-profits/components/connector-nudge.tsx
@@ -10,7 +10,6 @@
 
 import { ArrowUpRight, Sparkles, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Link } from "@/src/components/navigation/Link";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 
 const DISMISS_KEY = "np-connector-nudge-dismissed";
@@ -73,21 +72,28 @@ export function ConnectorNudge() {
               <X className="size-4" />
             </button>
           </div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Link
+          {/* Open the setup guides in a new tab so the user never loses the
+              conversation they're in the middle of. */}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <a
               href={NON_PROFITS_PAGES.CONNECT_CLAUDE}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
             >
               Add to Claude
               <ArrowUpRight className="size-3" />
-            </Link>
-            <Link
+            </a>
+            <a
               href={NON_PROFITS_PAGES.CONNECT_CHATGPT}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
             >
               Add to ChatGPT
               <ArrowUpRight className="size-3" />
-            </Link>
+            </a>
+            <span className="text-xs text-zinc-400 dark:text-zinc-500">Opens in a new tab</span>
           </div>
         </div>
       </div>

--- a/src/features/non-profits/components/entity-list.tsx
+++ b/src/features/non-profits/components/entity-list.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+/**
+ * Entity result rendering for the find-funders chat view.
+ *
+ * Results are grouped by type into labeled sections (Foundations / Nonprofits /
+ * Grants) so funders and grant recipients are unambiguous; each section expands
+ * independently. Extracted from chat-view-client.tsx to keep that file focused
+ * on the conversation shell.
+ */
+
+import {
+  Bookmark,
+  BookmarkCheck,
+  Building2,
+  ChevronDown,
+  HandCoins,
+  Landmark,
+  MapPin,
+} from "lucide-react";
+import Link from "next/link";
+import pluralize from "pluralize";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import formatCurrency from "@/utilities/formatCurrency";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import {
+  useAddToResearchTray,
+  useRemoveFromResearchTray,
+  useResearchTray,
+} from "../hooks/use-research-tray";
+import { type EntityGroup, groupEntitiesByType } from "../lib/group-entities";
+import type { FieldRect, PageTransitionFields } from "../store/page-transition";
+import { usePageTransitionStore } from "../store/page-transition";
+import type { PhilanthropyEntityType, RankedEntity } from "../types/philanthropy";
+
+// ── Entity presentation constants ──────────────────────────────────────────
+
+const ENTITY_ICON: Record<PhilanthropyEntityType, React.ElementType> = {
+  foundation: Landmark,
+  nonprofit: Building2,
+  grant: HandCoins,
+};
+
+const ENTITY_LABEL: Record<PhilanthropyEntityType, string> = {
+  foundation: "Foundation",
+  nonprofit: "Nonprofit",
+  grant: "Grant",
+};
+
+const ENTITY_BADGE_CLASS: Record<PhilanthropyEntityType, string> = {
+  foundation: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  nonprofit: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  grant: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+};
+
+const INITIAL_VISIBLE_ENTITIES = 5;
+
+// ── BookmarkButton ──────────────────────────────────────────────────────────
+// Isolated component so it can call hooks without prop-drilling tray state.
+
+const BookmarkButton = memo(function BookmarkButton({ entity }: { entity: RankedEntity }) {
+  const { authenticated, login } = useAuth();
+  const { data: tray = [] } = useResearchTray();
+  const { mutate: addToTray, isPending: isAdding } = useAddToResearchTray();
+  const { mutate: removeFromTray, isPending: isRemoving } = useRemoveFromResearchTray();
+
+  const trayEntry = tray.find((e) => e.entityId === entity.id);
+  const isBookmarked = Boolean(trayEntry);
+
+  const toggle = useCallback(() => {
+    if (!authenticated) {
+      login();
+      return;
+    }
+    if (isBookmarked && trayEntry) {
+      removeFromTray(trayEntry.id);
+    } else {
+      addToTray(entity);
+    }
+  }, [authenticated, login, isBookmarked, trayEntry, removeFromTray, addToTray, entity]);
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        toggle();
+      }}
+      aria-label={isBookmarked ? "Remove from bookmarks" : "Add to bookmarks"}
+      disabled={isAdding || isRemoving}
+      className="shrink-0 rounded p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-brand dark:hover:bg-zinc-800 dark:hover:text-brand-subtle disabled:opacity-50"
+    >
+      {isBookmarked ? (
+        <BookmarkCheck className="size-3.5 text-brand" />
+      ) : (
+        <Bookmark className="size-3.5" />
+      )}
+    </button>
+  );
+});
+
+// ── Helper functions ────────────────────────────────────────────────────────
+
+function getEntityHref(entity: RankedEntity, searchId?: string): string {
+  switch (entity.entityType) {
+    case "foundation":
+      return NON_PROFITS_PAGES.FOUNDATION(entity.id, searchId);
+    case "nonprofit":
+      return NON_PROFITS_PAGES.NONPROFIT(entity.id, searchId ? { searchId } : undefined);
+    case "grant":
+      return NON_PROFITS_PAGES.GRANT(entity.id, searchId);
+  }
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+const CompactEntityCard = memo(function CompactEntityCard({
+  entity,
+  searchId,
+}: {
+  entity: RankedEntity;
+  searchId?: string;
+}) {
+  const Icon = ENTITY_ICON[entity.entityType];
+  const href = getEntityHref(entity, searchId);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const setTransition = usePageTransitionStore((s) => s.set);
+
+  const meta: string[] = [];
+  if (entity.totalAssets) meta.push(`$${formatCurrency(entity.totalAssets)} assets`);
+  if (entity.amount) meta.push(`$${formatCurrency(entity.amount)} grant`);
+  if (entity.location) meta.push(entity.location);
+
+  const handleLinkClick = useCallback(() => {
+    if (!cardRef.current) return;
+    const fieldEls = cardRef.current.querySelectorAll<HTMLElement>("[data-field]");
+    const collected: Partial<PageTransitionFields> & { name?: FieldRect } = {};
+    for (const el of fieldEls) {
+      const key = el.dataset.field as keyof PageTransitionFields | undefined;
+      if (!key) continue;
+      const rect = el.getBoundingClientRect();
+      const entry: FieldRect = {
+        text: el.textContent?.trim() ?? "",
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      };
+      collected[key] = entry;
+    }
+    if (collected.name) {
+      setTransition(entity.id, entity.entityType, collected as PageTransitionFields);
+    }
+  }, [entity.id, entity.entityType, setTransition]);
+
+  return (
+    <div
+      ref={cardRef}
+      className="group relative flex items-start gap-3 rounded-lg border border-zinc-200 bg-white p-3 transition-all hover:border-zinc-300 hover:bg-zinc-50 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
+    >
+      <Link href={href} className="contents" onClick={handleLinkClick}>
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+          <Icon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <p
+              data-field="name"
+              className="truncate text-sm font-medium text-zinc-900 group-hover:text-brand-emphasis dark:text-zinc-100"
+            >
+              {entity.name ?? "Unnamed"}
+            </p>
+            <span
+              data-field="badge"
+              className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${ENTITY_BADGE_CLASS[entity.entityType]}`}
+            >
+              {ENTITY_LABEL[entity.entityType]}
+            </span>
+          </div>
+          {entity.description && (
+            <p className="mt-0.5 line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">
+              {entity.description}
+            </p>
+          )}
+          {meta.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
+              {meta.map((m, i) => (
+                <span key={`${entity.id}-meta-${i}`} className="inline-flex items-center gap-1">
+                  {i === meta.length - 1 && entity.location === m && (
+                    <>
+                      <MapPin className="size-3" />
+                      <span data-field="location">{m}</span>
+                    </>
+                  )}
+                  {!(i === meta.length - 1 && entity.location === m) && m}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </Link>
+      <BookmarkButton entity={entity} />
+    </div>
+  );
+});
+
+// A single labeled group (e.g. "Foundations · Potential funders") with its own
+// show-more state so each section expands independently.
+const EntityGroupSection = memo(function EntityGroupSection({
+  group,
+  searchId,
+}: {
+  group: EntityGroup;
+  searchId?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = ENTITY_ICON[group.type];
+  const count = group.entities.length;
+  const visible = expanded ? group.entities : group.entities.slice(0, INITIAL_VISIBLE_ENTITIES);
+  const remaining = count - visible.length;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+        <Icon className="size-3.5 text-zinc-500 dark:text-zinc-400" />
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-700 dark:text-zinc-300">
+          {count} {pluralize(group.label, count)}
+        </h4>
+        <span className="text-xs text-zinc-400 dark:text-zinc-500">· {group.role}</span>
+      </div>
+      {visible.map((e) => (
+        <CompactEntityCard key={`${e.entityType}-${e.id}`} entity={e} searchId={searchId} />
+      ))}
+      {remaining > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="flex items-center justify-center gap-1.5 rounded-lg border border-dashed border-zinc-300 bg-white py-2 text-xs font-medium text-zinc-600 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+        >
+          Show all {count} {pluralize(group.label.toLowerCase(), count)}
+          <ChevronDown className="size-3" />
+        </button>
+      )}
+    </section>
+  );
+});
+
+export function EntityList({
+  entities,
+  searchId,
+}: {
+  entities: RankedEntity[];
+  searchId?: string;
+}) {
+  const groups = useMemo(() => groupEntitiesByType(entities), [entities]);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex flex-col gap-5">
+      {groups.map((group) => (
+        <EntityGroupSection key={group.type} group={group} searchId={searchId} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/non-profits/components/narrative-block.tsx
+++ b/src/features/non-profits/components/narrative-block.tsx
@@ -3,12 +3,52 @@
 import { memo, useMemo } from "react";
 import { MessageResponse } from "@/src/components/ai-elements/message-response";
 import { linkifyNarrative } from "../lib/linkify-narrative";
+import { remarkAutolinkUrls } from "../lib/remark-autolink-urls";
 import type { RankedEntity } from "../types/philanthropy";
 
 interface NarrativeBlockProps {
   narrative: string;
   entities: RankedEntity[];
 }
+
+const REMARK_PLUGINS = [remarkAutolinkUrls];
+
+// Render every link the same way, regardless of how the agent formatted it.
+// External links open in a new tab so the user never loses their conversation;
+// internal links (entity detail pages) navigate in place.
+//
+// The `!` (important) modifier on color + underline is deliberate: the
+// ai-elements message container styles descendant anchors (`text-foreground`,
+// no underline) at a higher specificity than single-class utilities, which
+// would otherwise render these as near-black, non-underlined body text — i.e.
+// not looking like links at all. `!important` lets the link styling win.
+const MARKDOWN_COMPONENTS = {
+  // `node` is the mdast node react-markdown injects — strip it so it never
+  // reaches the DOM. `target`/`rel` are also stripped from the incoming props
+  // (the renderer defaults external links to `_blank`): we decide them solely
+  // from the href, so INTERNAL entity links navigate in place instead of
+  // wrongly opening a new tab.
+  a: ({
+    href,
+    children,
+    node: _node,
+    target: _target,
+    rel: _rel,
+    ...props
+  }: React.ComponentProps<"a"> & { node?: unknown }) => {
+    const isExternal = typeof href === "string" && /^https?:\/\//i.test(href);
+    return (
+      <a
+        href={href}
+        className="font-medium !text-brand !underline !decoration-brand/40 underline-offset-2 transition-colors hover:!text-brand-emphasis hover:!decoration-brand"
+        {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+};
 
 export const NarrativeBlock = memo(function NarrativeBlock({
   narrative,
@@ -19,5 +59,9 @@ export const NarrativeBlock = memo(function NarrativeBlock({
     [narrative, entities]
   );
 
-  return <MessageResponse>{linked}</MessageResponse>;
+  return (
+    <MessageResponse remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
+      {linked}
+    </MessageResponse>
+  );
 });

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -22,6 +22,7 @@ import {
 } from "../lib/agentic-philanthropy";
 import { NON_PROFITS_API } from "../lib/api";
 import type { AppError } from "../lib/errors";
+import { chatTurnToTurnPayload } from "../lib/saved-conversation";
 import { type ChatTurn, usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 import type {
@@ -30,7 +31,7 @@ import type {
   QueryResponse,
   RankedEntity,
 } from "../types/philanthropy";
-import { useAddSearchHistory } from "./use-search-history";
+import { useAddSearchHistory, useAppendSearchTurn } from "./use-search-history";
 
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -394,6 +395,7 @@ function buildConversationMessages(
 export function usePhilanthropySearch() {
   const abortRef = useRef<AbortController | null>(null);
   const addHistory = useAddSearchHistory();
+  const appendTurn = useAppendSearchTurn();
 
   const search = useCallback(
     async (
@@ -594,19 +596,56 @@ export function usePhilanthropySearch() {
               status: "done",
               progress: null,
             });
+
+            // Persist the completed turn so revisiting the URL replays the
+            // conversation instead of re-running the search. The first turn
+            // creates the history entry under the thread/URL id; follow-ups
+            // append to it. Both calls fail silently for anonymous users
+            // (the endpoints require auth) — the local session still works.
+            const state = usePhilanthropyStore.getState();
+            const threadId = state.threadId;
+            const completedTurn = state.messages[state.messages.length - 1];
+            if (threadId && completedTurn?.status === "done") {
+              const turnPayload = chatTurnToTurnPayload(completedTurn);
+              const doneCount = state.messages.filter((t) => t.status === "done").length;
+              if (doneCount === 1) {
+                addHistory.mutate(
+                  { query: normalizedQuery, id: threadId },
+                  {
+                    onSuccess: (entry) => {
+                      useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
+                      options?.onSearchId?.(entry.id);
+                      appendTurn.mutate({ searchId: entry.id, turn: turnPayload });
+                    },
+                    onError: () => {
+                      // Anonymous/offline: keep the local session so the
+                      // page keeps working without server persistence.
+                      useSearchSessionStore.getState().setSession(threadId, normalizedQuery);
+                      options?.onSearchId?.(threadId);
+                    },
+                  }
+                );
+              } else {
+                appendTurn.mutate({ searchId: threadId, turn: turnPayload });
+              }
+            }
+            return;
           }
 
           if (!isPagination) {
-            addHistory.mutate(normalizedQuery, {
-              onSuccess: (entry) => {
-                useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
-                options?.onSearchId?.(entry.id);
-              },
-              onError: () => {
-                const sessionId = useSearchSessionStore.getState().createSession(normalizedQuery);
-                options?.onSearchId?.(sessionId);
-              },
-            });
+            addHistory.mutate(
+              { query: normalizedQuery },
+              {
+                onSuccess: (entry) => {
+                  useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
+                  options?.onSearchId?.(entry.id);
+                },
+                onError: () => {
+                  const sessionId = useSearchSessionStore.getState().createSession(normalizedQuery);
+                  options?.onSearchId?.(sessionId);
+                },
+              }
+            );
           }
         },
         (appErr) => {
@@ -627,7 +666,7 @@ export function usePhilanthropySearch() {
 
       usePhilanthropyStore.getState().setSearching(false);
     },
-    [addHistory]
+    [addHistory, appendTurn]
   );
 
   const abort = useCallback(() => {

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -12,6 +12,7 @@
 import { ResultAsync } from "neverthrow";
 import { useCallback, useRef } from "react";
 import { z } from "zod";
+import { useAuth } from "@/hooks/useAuth";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { envVars } from "@/utilities/enviromentVars";
 import {
@@ -24,7 +25,7 @@ import { NON_PROFITS_API } from "../lib/api";
 import { buildConversationMessages, type ConversationMessage } from "../lib/conversation-messages";
 import type { AppError } from "../lib/errors";
 import { chatTurnToTurnPayload } from "../lib/saved-conversation";
-import { type ChatTurn, usePhilanthropyStore } from "../store/philanthropy";
+import { usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 import type {
   QueryIntent,
@@ -363,6 +364,7 @@ export function usePhilanthropySearch() {
   const abortRef = useRef<AbortController | null>(null);
   const addHistory = useAddSearchHistory();
   const appendTurn = useAppendSearchTurn();
+  const { authenticated } = useAuth();
 
   const search = useCallback(
     async (
@@ -577,9 +579,8 @@ export function usePhilanthropySearch() {
               const turnPayload = chatTurnToTurnPayload(completedTurn);
               const doneCount = state.messages.filter((t) => t.status === "done").length;
               // Surface persistence rejections that should stop further input:
-              // 403 → owned by another account (read-only); 409 → the
-              // conversation hit the server's turn cap. Both disable the
-              // composer instead of silently dropping the write.
+              // 403 → owned by another account (read-only); 409 → turn cap; 401
+              // → bad/expired token. Never silently drop the write.
               const handlePersistError = (err: unknown) => {
                 const e = err as AppError;
                 if (e?.type !== "ApiError") return;
@@ -587,6 +588,13 @@ export function usePhilanthropySearch() {
                   usePhilanthropyStore.getState().setReadOnly(true);
                 } else if (e.status === 409) {
                   usePhilanthropyStore.getState().setConversationFull(true);
+                } else if (e.status === 401) {
+                  // Drop the stale cached token so the next request fetches a
+                  // fresh one; prompt sign-in for logged-out users.
+                  TokenManager.clearCache();
+                  if (!authenticated) {
+                    usePhilanthropyStore.getState().setLoginRequired(true);
+                  }
                 }
               };
               if (doneCount === 1) {
@@ -640,6 +648,23 @@ export function usePhilanthropySearch() {
         },
         (appErr) => {
           if (appErr.type === "AbortError") return; // silently swallow
+          // 401 from the agent endpoint: an anonymous user hit the free limit
+          // (login_required), or an authenticated token expired. Drop the
+          // cached token; prompt sign-in for logged-out users. Either way the
+          // turn ends with a clear, non-scary message.
+          if (appErr.type === "ApiError" && appErr.status === 401) {
+            TokenManager.clearCache();
+            if (!authenticated) usePhilanthropyStore.getState().setLoginRequired(true);
+            const msg = authenticated
+              ? "Your session expired. Please try again."
+              : "Sign in to continue your search.";
+            if (isChat) {
+              usePhilanthropyStore.getState().updateLastTurn({ status: "error", error: msg });
+            } else {
+              usePhilanthropyStore.getState().setError(msg);
+            }
+            return;
+          }
           const msg =
             appErr.type === "NetworkError" ||
             appErr.type === "StreamError" ||
@@ -656,7 +681,7 @@ export function usePhilanthropySearch() {
 
       usePhilanthropyStore.getState().setSearching(false);
     },
-    [addHistory, appendTurn]
+    [addHistory, appendTurn, authenticated]
   );
 
   const abort = useCallback(() => {

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -600,8 +600,9 @@ export function usePhilanthropySearch() {
             // Persist the completed turn so revisiting the URL replays the
             // conversation instead of re-running the search. The first turn
             // creates the history entry under the thread/URL id; follow-ups
-            // append to it. Both calls fail silently for anonymous users
-            // (the endpoints require auth) — the local session still works.
+            // append to it. Anonymous and authenticated users both persist —
+            // the endpoints accept ownerless chats, and a chat is claimed on
+            // the first request that carries a JWT.
             const state = usePhilanthropyStore.getState();
             const threadId = state.threadId;
             const completedTurn = state.messages[state.messages.length - 1];
@@ -609,6 +610,8 @@ export function usePhilanthropySearch() {
               const turnPayload = chatTurnToTurnPayload(completedTurn);
               const doneCount = state.messages.filter((t) => t.status === "done").length;
               if (doneCount === 1) {
+                // Create the entry under the URL id, then append the first turn
+                // on success.
                 addHistory.mutate(
                   { query: normalizedQuery, id: threadId },
                   {
@@ -618,8 +621,8 @@ export function usePhilanthropySearch() {
                       appendTurn.mutate({ searchId: entry.id, turn: turnPayload });
                     },
                     onError: () => {
-                      // Anonymous/offline: keep the local session so the
-                      // page keeps working without server persistence.
+                      // Create failed (offline/server error): keep the local
+                      // session so the page keeps working without persistence.
                       useSearchSessionStore.getState().setSession(threadId, normalizedQuery);
                       options?.onSearchId?.(threadId);
                     },

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -609,6 +609,15 @@ export function usePhilanthropySearch() {
             if (threadId && completedTurn?.status === "done") {
               const turnPayload = chatTurnToTurnPayload(completedTurn);
               const doneCount = state.messages.filter((t) => t.status === "done").length;
+              // A 403 means this conversation belongs to another account. Flip
+              // the thread to read-only so the composer is disabled and the user
+              // isn't silently typing into a chat that can't be saved.
+              const handlePersistError = (err: unknown) => {
+                const e = err as AppError;
+                if (e?.type === "ApiError" && e.status === 403) {
+                  usePhilanthropyStore.getState().setReadOnly(true);
+                }
+              };
               if (doneCount === 1) {
                 // Create the entry under the URL id, then append the first turn
                 // on success.
@@ -618,18 +627,25 @@ export function usePhilanthropySearch() {
                     onSuccess: (entry) => {
                       useSearchSessionStore.getState().setSession(entry.id, normalizedQuery);
                       options?.onSearchId?.(entry.id);
-                      appendTurn.mutate({ searchId: entry.id, turn: turnPayload });
+                      appendTurn.mutate(
+                        { searchId: entry.id, turn: turnPayload },
+                        { onError: handlePersistError }
+                      );
                     },
-                    onError: () => {
-                      // Create failed (offline/server error): keep the local
-                      // session so the page keeps working without persistence.
+                    onError: (err) => {
+                      handlePersistError(err);
+                      // Otherwise (offline/server error): keep the local session
+                      // so the page keeps working without persistence.
                       useSearchSessionStore.getState().setSession(threadId, normalizedQuery);
                       options?.onSearchId?.(threadId);
                     },
                   }
                 );
               } else {
-                appendTurn.mutate({ searchId: threadId, turn: turnPayload });
+                appendTurn.mutate(
+                  { searchId: threadId, turn: turnPayload },
+                  { onError: handlePersistError }
+                );
               }
             }
             return;

--- a/src/features/non-profits/hooks/use-philanthropy-stream.ts
+++ b/src/features/non-profits/hooks/use-philanthropy-stream.ts
@@ -21,6 +21,7 @@ import {
   type SearchSortKey,
 } from "../lib/agentic-philanthropy";
 import { NON_PROFITS_API } from "../lib/api";
+import { buildConversationMessages, type ConversationMessage } from "../lib/conversation-messages";
 import type { AppError } from "../lib/errors";
 import { chatTurnToTurnPayload } from "../lib/saved-conversation";
 import { type ChatTurn, usePhilanthropyStore } from "../store/philanthropy";
@@ -150,17 +151,6 @@ interface StreamCallbacks {
   onNarrative: (text: string) => void;
   /** Called for every progress event emitted before final_answer. */
   onProgress: (event: StreamProgressEvent) => void;
-}
-
-/**
- * Conversation message for multi-turn chat history.
- *
- * The indexer accepts the full `messages` array so it can resolve follow-up
- * references ("narrow that to Texas") against prior assistant outputs.
- */
-interface ConversationMessage {
-  role: "user" | "assistant";
-  content: string;
 }
 
 export function streamPhilanthropyQuery(
@@ -367,29 +357,6 @@ export function streamPhilanthropyQuery(
       };
     }
   );
-}
-
-/**
- * Builds the conversation array sent to the indexer for a chat-mode turn.
- *
- * Includes all completed prior turns as alternating user/assistant messages,
- * then appends the new user query as the final message. Streaming and errored
- * turns are skipped — they'd give the indexer half-formed context.
- */
-function buildConversationMessages(
-  priorTurns: ReadonlyArray<ChatTurn>,
-  newUserQuery: string
-): ConversationMessage[] {
-  const completed = priorTurns.filter((t) => t.status === "done");
-  const history: ConversationMessage[] = [];
-  for (const turn of completed) {
-    history.push({ role: "user", content: turn.userQuery });
-    if (turn.narrative.trim()) {
-      history.push({ role: "assistant", content: turn.narrative });
-    }
-  }
-  history.push({ role: "user", content: newUserQuery });
-  return history;
 }
 
 export function usePhilanthropySearch() {
@@ -609,13 +576,17 @@ export function usePhilanthropySearch() {
             if (threadId && completedTurn?.status === "done") {
               const turnPayload = chatTurnToTurnPayload(completedTurn);
               const doneCount = state.messages.filter((t) => t.status === "done").length;
-              // A 403 means this conversation belongs to another account. Flip
-              // the thread to read-only so the composer is disabled and the user
-              // isn't silently typing into a chat that can't be saved.
+              // Surface persistence rejections that should stop further input:
+              // 403 → owned by another account (read-only); 409 → the
+              // conversation hit the server's turn cap. Both disable the
+              // composer instead of silently dropping the write.
               const handlePersistError = (err: unknown) => {
                 const e = err as AppError;
-                if (e?.type === "ApiError" && e.status === 403) {
+                if (e?.type !== "ApiError") return;
+                if (e.status === 403) {
                   usePhilanthropyStore.getState().setReadOnly(true);
+                } else if (e.status === 409) {
+                  usePhilanthropyStore.getState().setConversationFull(true);
                 }
               };
               if (doneCount === 1) {

--- a/src/features/non-profits/hooks/use-search-history.ts
+++ b/src/features/non-profits/hooks/use-search-history.ts
@@ -11,7 +11,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/useAuth";
 import { resultToPromise } from "../lib/result-to-promise";
-import { type SearchHistoryEntry, searchHistoryService } from "../services/search-history.service";
+import {
+  type SearchHistoryEntry,
+  type SearchTurnPayload,
+  searchHistoryService,
+} from "../services/search-history.service";
 
 const SEARCH_HISTORY_KEY = ["non-profits-search-history"] as const;
 
@@ -39,13 +43,32 @@ export function useAddSearchHistory() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (query: string) => resultToPromise(searchHistoryService.create(query)),
+    // `id` is the conversation id (the /search/[id] URL UUID) so turns
+    // appended later attach to the URL the user is already on.
+    mutationFn: ({ query, id }: { query: string; id?: string }) =>
+      resultToPromise(searchHistoryService.create(query, id)),
     onSuccess: (newEntry) => {
       queryClient.setQueriesData<SearchHistoryEntry[]>({ queryKey: SEARCH_HISTORY_KEY }, (old) => {
-        if (!old) return [newEntry];
+        // The key prefix also matches detail entries ([key, id]) which hold
+        // objects, not lists — leave those untouched.
+        if (!Array.isArray(old)) return old;
         const filtered = old.filter((e) => e.query.toLowerCase() !== newEntry.query.toLowerCase());
         return [newEntry, ...filtered].slice(0, 50);
       });
+      queryClient.invalidateQueries({ queryKey: [...SEARCH_HISTORY_KEY, "list"] });
+    },
+  });
+}
+
+export function useAppendSearchTurn() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ searchId, turn }: { searchId: string; turn: SearchTurnPayload }) =>
+      resultToPromise(searchHistoryService.appendTurn(searchId, turn)),
+    onSuccess: (_turn, { searchId }) => {
+      // Refresh the cached detail so a later revisit hydrates the new turn.
+      queryClient.invalidateQueries({ queryKey: [...SEARCH_HISTORY_KEY, searchId] });
     },
   });
 }

--- a/src/features/non-profits/lib/api.ts
+++ b/src/features/non-profits/lib/api.ts
@@ -12,6 +12,7 @@ export const NON_PROFITS_API = {
     LIST: "/v2/search-history",
     GET: (id: string) => `/v2/search-history/${id}`,
     CREATE: "/v2/search-history",
+    APPEND_TURN: (id: string) => `/v2/search-history/${id}/turns`,
     DELETE: (id: string) => `/v2/search-history/${id}`,
     CLEAR: "/v2/search-history",
   },

--- a/src/features/non-profits/lib/conversation-messages.ts
+++ b/src/features/non-profits/lib/conversation-messages.ts
@@ -1,0 +1,35 @@
+import type { ChatTurn } from "../store/philanthropy";
+
+/**
+ * Conversation message for multi-turn chat history.
+ *
+ * The indexer accepts the full `messages` array so it can resolve follow-up
+ * references ("narrow that to Texas") against prior assistant outputs.
+ */
+export interface ConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Builds the conversation array sent to the indexer for a chat-mode turn.
+ *
+ * Includes all completed prior turns as alternating user/assistant messages,
+ * then appends the new user query as the final message. Streaming and errored
+ * turns are skipped — they'd give the indexer half-formed context.
+ */
+export function buildConversationMessages(
+  priorTurns: ReadonlyArray<ChatTurn>,
+  newUserQuery: string
+): ConversationMessage[] {
+  const completed = priorTurns.filter((t) => t.status === "done");
+  const history: ConversationMessage[] = [];
+  for (const turn of completed) {
+    history.push({ role: "user", content: turn.userQuery });
+    if (turn.narrative.trim()) {
+      history.push({ role: "assistant", content: turn.narrative });
+    }
+  }
+  history.push({ role: "user", content: newUserQuery });
+  return history;
+}

--- a/src/features/non-profits/lib/group-entities.ts
+++ b/src/features/non-profits/lib/group-entities.ts
@@ -1,0 +1,45 @@
+/**
+ * Group ranked entities by type for display.
+ *
+ * The agent can return foundations, nonprofits, and grants in a single result
+ * set. Rendered as one flat list they are easy to confuse — users reported not
+ * being able to tell "which table was funders and which was grant recipients".
+ * Grouping them under labeled, role-annotated headers removes that ambiguity.
+ */
+
+import type { PhilanthropyEntityType, RankedEntity } from "../types/philanthropy";
+
+export interface EntityGroup {
+  type: PhilanthropyEntityType;
+  /** Singular noun for the group; pluralize at render time with the count. */
+  label: string;
+  /** Short plain-language role so the user knows what the group represents. */
+  role: string;
+  entities: RankedEntity[];
+}
+
+// Display order + copy. Order is funders first (foundations), then the
+// organizations they support, then individual grant records.
+const GROUP_META: ReadonlyArray<{
+  type: PhilanthropyEntityType;
+  label: string;
+  role: string;
+}> = [
+  { type: "foundation", label: "Foundation", role: "Potential funders" },
+  { type: "nonprofit", label: "Nonprofit", role: "Grant recipients & peers" },
+  { type: "grant", label: "Grant", role: "Example awards" },
+];
+
+/**
+ * Returns entities split into ordered, non-empty groups. Order within each
+ * group is preserved from the input (the agent's ranking).
+ */
+export function groupEntitiesByType(entities: readonly RankedEntity[]): EntityGroup[] {
+  const groups: EntityGroup[] = [];
+  for (const meta of GROUP_META) {
+    const matching = entities.filter((e) => e.entityType === meta.type);
+    if (matching.length === 0) continue;
+    groups.push({ type: meta.type, label: meta.label, role: meta.role, entities: matching });
+  }
+  return groups;
+}

--- a/src/features/non-profits/lib/remark-autolink-urls.ts
+++ b/src/features/non-profits/lib/remark-autolink-urls.ts
@@ -1,0 +1,153 @@
+/**
+ * remark plugin: make every URL in the agent narrative a real, consistent link.
+ *
+ * The agent's markdown is inconsistent about links — it emits some as proper
+ * `[text](https://…)` links, some as bare `https://…` URLs (GFM autolinks
+ * those), and some as scheme-less domains like `fordfoundation.org`. GFM does
+ * NOT autolink scheme-less domains, and react-markdown treats a scheme-less
+ * link href as a *relative* path — so `[Ford](fordfoundation.org)` renders as
+ * an underlined link that navigates nowhere. That is the "some URLs were
+ * underlined but weren't links" report from users.
+ *
+ * This plugin normalizes both cases on the mdast tree (so it never touches code
+ * spans/blocks or existing absolute/internal links):
+ *  - bare URLs and scheme-less domains in text become proper link nodes;
+ *  - existing link nodes with a scheme-less external href get `https://`
+ *    prepended.
+ *
+ * Internal app links (href starting with `/`, `#`, `mailto:`, `tel:`) — e.g.
+ * the entity links injected by `linkifyNarrative` — are left untouched.
+ */
+
+// Minimal mdast shapes — @types/mdast isn't a top-level dependency under pnpm.
+interface MdastText {
+  type: "text";
+  value: string;
+}
+interface MdastLink {
+  type: "link";
+  url: string;
+  title?: string | null;
+  children: MdastNode[];
+}
+interface MdastParent {
+  type: string;
+  children: MdastNode[];
+}
+type MdastNode = (MdastText | MdastLink | MdastParent) & {
+  type: string;
+  children?: MdastNode[];
+  url?: string;
+  value?: string;
+};
+
+// Node types whose subtree must never be autolinked or rewritten.
+const SKIP_TYPES = new Set([
+  "link",
+  "linkReference",
+  "code",
+  "inlineCode",
+  "image",
+  "imageReference",
+  "definition",
+  "html",
+]);
+
+// Conservative TLD allowlist for scheme-less domains, so prose like
+// "e.g." or "vs." is never mistaken for a domain.
+const TLD = "com|org|net|edu|gov|io|co|us|uk|ca|foundation|fund|charity|ngo";
+
+// Order matters: full URLs first, then www., then scheme-less domains.
+// Trailing sentence punctuation is intentionally excluded from the match.
+const URL_PATTERN = new RegExp(
+  [
+    "(https?:\\/\\/[^\\s<>()\\[\\]]+[^\\s<>()\\[\\].,;:!?'\"])",
+    "(www\\.[^\\s<>()\\[\\]]+[^\\s<>()\\[\\].,;:!?'\"])",
+    `((?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+(?:${TLD})(?:\\/[^\\s<>()\\[\\]]*[^\\s<>()\\[\\].,;:!?'"])?)`,
+  ].join("|"),
+  "gi"
+);
+
+/**
+ * Returns an absolute `https://` URL for an external reference, or `null` when
+ * the href is internal/relative and should be left as-is.
+ */
+export function normalizeUrl(raw: string): string | null {
+  const url = raw.trim();
+  if (!url) return null;
+  if (/^https?:\/\//i.test(url)) return url;
+  if (/^(mailto:|tel:|\/|#|\.)/i.test(url)) return null;
+  if (/^www\./i.test(url)) return `https://${url}`;
+  // Scheme-less domain with an allowlisted TLD (optionally a path).
+  const domain = new RegExp(`^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+(?:${TLD})(?:[/?#].*)?$`, "i");
+  if (domain.test(url)) return `https://${url}`;
+  return null;
+}
+
+/**
+ * Splits a plain-text string into a sequence of text + link nodes, autolinking
+ * any bare URL or scheme-less domain. Returns `null` when there is nothing to
+ * link (so callers can leave the original node untouched).
+ */
+export function autolinkText(value: string): MdastNode[] | null {
+  URL_PATTERN.lastIndex = 0;
+  const nodes: MdastNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = URL_PATTERN.exec(value);
+  let linked = false;
+
+  while (match !== null) {
+    const raw = match[0];
+    const href = normalizeUrl(raw);
+    if (href) {
+      if (match.index > lastIndex) {
+        nodes.push({ type: "text", value: value.slice(lastIndex, match.index) });
+      }
+      nodes.push({ type: "link", url: href, children: [{ type: "text", value: raw }] });
+      lastIndex = match.index + raw.length;
+      linked = true;
+    }
+    match = URL_PATTERN.exec(value);
+  }
+
+  if (!linked) return null;
+  if (lastIndex < value.length) {
+    nodes.push({ type: "text", value: value.slice(lastIndex) });
+  }
+  return nodes;
+}
+
+function walk(parent: MdastNode): void {
+  const children = parent.children;
+  if (!children) return;
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+
+    if (child.type === "link") {
+      // Repair scheme-less external hrefs; leave internal links alone.
+      const fixed = normalizeUrl(child.url ?? "");
+      if (fixed) child.url = fixed;
+      continue;
+    }
+    if (SKIP_TYPES.has(child.type)) continue;
+
+    if (child.type === "text" && typeof child.value === "string") {
+      const replacement = autolinkText(child.value);
+      if (replacement) {
+        children.splice(i, 1, ...replacement);
+        i += replacement.length - 1;
+      }
+      continue;
+    }
+
+    if (child.children) walk(child);
+  }
+}
+
+/** remark plugin entry point. */
+export function remarkAutolinkUrls() {
+  return (tree: MdastNode): void => {
+    walk(tree);
+  };
+}

--- a/src/features/non-profits/lib/saved-conversation.ts
+++ b/src/features/non-profits/lib/saved-conversation.ts
@@ -1,0 +1,51 @@
+/**
+ * Mapping between persisted conversation turns (indexer `search_history_turn`
+ * rows) and the in-memory `ChatTurn` shape the chat workbench renders.
+ *
+ * Saved turns are always completed exchanges, so hydrated turns come back
+ * with `status: "done"` and no streaming progress. Attachments (CSV exports)
+ * are intentionally not persisted — they can be large base64 blobs and the
+ * agent can regenerate them on request — so hydrated turns have none.
+ */
+import type { SavedSearchTurn, SearchTurnPayload } from "../services/search-history.service";
+import type { ChatTurn } from "../store/philanthropy";
+
+// Server-side zod bounds on the append-turn endpoint. Snapshots are clamped
+// client-side so an oversized turn degrades (truncated snapshot) instead of
+// failing to persist at all.
+const MAX_SAVED_QUERY_CHARS = 4000;
+const MAX_SAVED_NARRATIVE_CHARS = 40000;
+const MAX_SAVED_ENTITIES = 500;
+const MAX_SAVED_CITATIONS = 2000;
+
+export function savedTurnToChatTurn(turn: SavedSearchTurn): ChatTurn {
+  return {
+    id: turn.id,
+    userQuery: turn.userQuery,
+    narrative: turn.narrative,
+    entities: turn.entities,
+    citations: turn.citations,
+    traceId: turn.traceId,
+    pagination: null,
+    status: "done",
+    error: null,
+    progress: null,
+    attachments: [],
+  };
+}
+
+export function savedTurnsToChatTurns(turns: ReadonlyArray<SavedSearchTurn>): ChatTurn[] {
+  return turns.map(savedTurnToChatTurn);
+}
+
+/** Snapshot a completed in-memory turn for persistence, within server bounds. */
+export function chatTurnToTurnPayload(turn: ChatTurn): SearchTurnPayload {
+  return {
+    id: turn.id,
+    userQuery: turn.userQuery.slice(0, MAX_SAVED_QUERY_CHARS),
+    narrative: turn.narrative.slice(0, MAX_SAVED_NARRATIVE_CHARS),
+    entities: turn.entities.slice(0, MAX_SAVED_ENTITIES),
+    citations: turn.citations.slice(0, MAX_SAVED_CITATIONS),
+    traceId: turn.traceId,
+  };
+}

--- a/src/features/non-profits/services/search-history.service.ts
+++ b/src/features/non-profits/services/search-history.service.ts
@@ -21,7 +21,9 @@ import { CitationSchema, RankedEntitySchema } from "../types/philanthropy";
 
 export const SearchHistoryEntrySchema = z.object({
   id: z.string(),
-  userId: z.string(),
+  // Nullable: an ownerless (logged-out) chat has `userId: null`; it becomes a
+  // wallet address once the chat is claimed on the first authenticated request.
+  userId: z.string().nullable(),
   query: z.string(),
   createdAt: z.string(),
 });

--- a/src/features/non-profits/services/search-history.service.ts
+++ b/src/features/non-profits/services/search-history.service.ts
@@ -5,12 +5,19 @@
  * Uses apiFetch (authenticated via TokenManager) to create and retrieve
  * search history entries. Returns ResultAsync<_, AppError> for neverthrow
  * pipeline compatibility.
+ *
+ * Entries are full saved conversations: the client supplies the conversation
+ * id (the /find-funders/search/[id] URL UUID) at create time and appends a
+ * turn snapshot (query + narrative + entities + citations) after each
+ * completed exchange, so revisiting the URL replays the conversation without
+ * re-running the search.
  */
 import type { ResultAsync } from "neverthrow";
 import { z } from "zod";
 import { NON_PROFITS_API } from "../lib/api";
 import { apiFetch } from "../lib/api-fetch";
 import type { AppError } from "../lib/errors";
+import { CitationSchema, RankedEntitySchema } from "../types/philanthropy";
 
 export const SearchHistoryEntrySchema = z.object({
   id: z.string(),
@@ -19,6 +26,34 @@ export const SearchHistoryEntrySchema = z.object({
   createdAt: z.string(),
 });
 export type SearchHistoryEntry = z.infer<typeof SearchHistoryEntrySchema>;
+
+export const SavedSearchTurnSchema = z.object({
+  id: z.string(),
+  searchHistoryId: z.string(),
+  turnIndex: z.number(),
+  userQuery: z.string(),
+  narrative: z.string(),
+  entities: z.array(RankedEntitySchema),
+  citations: z.array(CitationSchema),
+  traceId: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type SavedSearchTurn = z.infer<typeof SavedSearchTurnSchema>;
+
+export const SearchHistoryDetailSchema = SearchHistoryEntrySchema.extend({
+  turns: z.array(SavedSearchTurnSchema),
+});
+export type SearchHistoryDetail = z.infer<typeof SearchHistoryDetailSchema>;
+
+/** Turn snapshot sent to the indexer after a chat exchange completes. */
+export interface SearchTurnPayload {
+  id: string;
+  userQuery: string;
+  narrative: string;
+  entities: SavedSearchTurn["entities"];
+  citations: SavedSearchTurn["citations"];
+  traceId: string | null;
+}
 
 export const searchHistoryService = {
   list(limit = 20): ResultAsync<SearchHistoryEntry[], AppError> {
@@ -29,14 +64,24 @@ export const searchHistoryService = {
     );
   },
 
-  create(query: string): ResultAsync<SearchHistoryEntry, AppError> {
+  create(query: string, id?: string): ResultAsync<SearchHistoryEntry, AppError> {
     return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.CREATE, SearchHistoryEntrySchema, "POST", {
       query,
+      ...(id ? { id } : {}),
     });
   },
 
-  getById(id: string): ResultAsync<SearchHistoryEntry, AppError> {
-    return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.GET(id), SearchHistoryEntrySchema, "GET");
+  getById(id: string): ResultAsync<SearchHistoryDetail, AppError> {
+    return apiFetch(NON_PROFITS_API.SEARCH_HISTORY.GET(id), SearchHistoryDetailSchema, "GET");
+  },
+
+  appendTurn(searchId: string, turn: SearchTurnPayload): ResultAsync<SavedSearchTurn, AppError> {
+    return apiFetch(
+      NON_PROFITS_API.SEARCH_HISTORY.APPEND_TURN(searchId),
+      SavedSearchTurnSchema,
+      "POST",
+      turn
+    );
   },
 
   deleteOne(id: string): ResultAsync<void, AppError> {

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -129,6 +129,12 @@ interface PhilanthropyStore {
    * a new chat.
    */
   conversationFull: boolean;
+  /**
+   * True when an anonymous user hits the free interaction limit (the agent
+   * endpoint returns 401 `login_required`). The composer prompts sign-in; it
+   * is only ever set for logged-out users and clears once they authenticate.
+   */
+  loginRequired: boolean;
 
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
@@ -147,6 +153,7 @@ interface PhilanthropyStore {
   setReadOnly: (readOnly: boolean) => void;
   setNotFound: (notFound: boolean) => void;
   setConversationFull: (conversationFull: boolean) => void;
+  setLoginRequired: (loginRequired: boolean) => void;
   reset: () => void;
 }
 
@@ -164,6 +171,7 @@ const initialState = {
   readOnly: false,
   notFound: false,
   conversationFull: false,
+  loginRequired: false,
 } satisfies Omit<
   PhilanthropyStore,
   | "appendTurn"
@@ -179,6 +187,7 @@ const initialState = {
   | "setReadOnly"
   | "setNotFound"
   | "setConversationFull"
+  | "setLoginRequired"
   | "reset"
 >;
 
@@ -215,5 +224,6 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
   setReadOnly: (readOnly) => set({ readOnly }),
   setNotFound: (notFound) => set({ notFound }),
   setConversationFull: (conversationFull) => set({ conversationFull }),
+  setLoginRequired: (loginRequired) => set({ loginRequired }),
   reset: () => set({ ...initialState }),
 }));

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -117,6 +117,12 @@ interface PhilanthropyStore {
    * and a read-only notice is shown so the user isn't typing into a void.
    */
   readOnly: boolean;
+  /**
+   * True when opening a conversation URL that the server won't return (HTTP
+   * 404 — private to another account, deleted, or never persisted) and there
+   * is no local query to re-run. The workbench shows a not-found state.
+   */
+  notFound: boolean;
 
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
@@ -133,6 +139,7 @@ interface PhilanthropyStore {
   setSearching: (searching: boolean) => void;
   setError: (error: string | null) => void;
   setReadOnly: (readOnly: boolean) => void;
+  setNotFound: (notFound: boolean) => void;
   reset: () => void;
 }
 
@@ -148,6 +155,7 @@ const initialState = {
   isSearching: false,
   error: null as string | null,
   readOnly: false,
+  notFound: false,
 } satisfies Omit<
   PhilanthropyStore,
   | "appendTurn"
@@ -161,6 +169,7 @@ const initialState = {
   | "setSearching"
   | "setError"
   | "setReadOnly"
+  | "setNotFound"
   | "reset"
 >;
 
@@ -195,5 +204,6 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
   setSearching: (searching) => set({ isSearching: searching }),
   setError: (error) => set({ error }),
   setReadOnly: (readOnly) => set({ readOnly }),
+  setNotFound: (notFound) => set({ notFound }),
   reset: () => set({ ...initialState }),
 }));

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -123,6 +123,12 @@ interface PhilanthropyStore {
    * is no local query to re-run. The workbench shows a not-found state.
    */
   notFound: boolean;
+  /**
+   * True when the conversation has reached the server's per-conversation turn
+   * cap (HTTP 409). The composer is disabled and the user is prompted to start
+   * a new chat.
+   */
+  conversationFull: boolean;
 
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
@@ -140,6 +146,7 @@ interface PhilanthropyStore {
   setError: (error: string | null) => void;
   setReadOnly: (readOnly: boolean) => void;
   setNotFound: (notFound: boolean) => void;
+  setConversationFull: (conversationFull: boolean) => void;
   reset: () => void;
 }
 
@@ -156,6 +163,7 @@ const initialState = {
   error: null as string | null,
   readOnly: false,
   notFound: false,
+  conversationFull: false,
 } satisfies Omit<
   PhilanthropyStore,
   | "appendTurn"
@@ -170,6 +178,7 @@ const initialState = {
   | "setError"
   | "setReadOnly"
   | "setNotFound"
+  | "setConversationFull"
   | "reset"
 >;
 
@@ -205,5 +214,6 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
   setError: (error) => set({ error }),
   setReadOnly: (readOnly) => set({ readOnly }),
   setNotFound: (notFound) => set({ notFound }),
+  setConversationFull: (conversationFull) => set({ conversationFull }),
   reset: () => set({ ...initialState }),
 }));

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -115,6 +115,8 @@ interface PhilanthropyStore {
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
   updateLastTurn: (patch: Partial<ChatTurn>) => void;
+  /** Replace the thread with turns restored from a saved conversation. */
+  hydrateTurns: (turns: ReadonlyArray<ChatTurn>) => void;
   setThreadId: (id: string | null) => void;
 
   // ── Legacy actions ──
@@ -142,6 +144,7 @@ const initialState = {
   PhilanthropyStore,
   | "appendTurn"
   | "updateLastTurn"
+  | "hydrateTurns"
   | "setThreadId"
   | "setQuery"
   | "setNarrative"
@@ -171,6 +174,9 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
       const updated = { ...last, ...patch };
       return { messages: [...s.messages.slice(0, -1), updated] };
     }),
+
+  // Restore a saved conversation in one shot (revisit / shared link).
+  hydrateTurns: (turns) => set({ messages: [...turns] }),
 
   setThreadId: (threadId) => set({ threadId }),
   setQuery: (query) => set({ query }),

--- a/src/features/non-profits/store/philanthropy.ts
+++ b/src/features/non-profits/store/philanthropy.ts
@@ -111,6 +111,12 @@ interface PhilanthropyStore {
   result: SearchResult | null;
   isSearching: boolean;
   error: string | null;
+  /**
+   * True when the backend rejected a persistence write for this conversation
+   * because it belongs to another account (HTTP 403). The composer is disabled
+   * and a read-only notice is shown so the user isn't typing into a void.
+   */
+  readOnly: boolean;
 
   // ── Chat actions (Phase 3 — included now to avoid store refactor) ──
   appendTurn: (turn: ChatTurn) => void;
@@ -126,6 +132,7 @@ interface PhilanthropyStore {
   setResult: (result: SearchResult | null) => void;
   setSearching: (searching: boolean) => void;
   setError: (error: string | null) => void;
+  setReadOnly: (readOnly: boolean) => void;
   reset: () => void;
 }
 
@@ -140,6 +147,7 @@ const initialState = {
   result: null as SearchResult | null,
   isSearching: false,
   error: null as string | null,
+  readOnly: false,
 } satisfies Omit<
   PhilanthropyStore,
   | "appendTurn"
@@ -152,6 +160,7 @@ const initialState = {
   | "setResult"
   | "setSearching"
   | "setError"
+  | "setReadOnly"
   | "reset"
 >;
 
@@ -185,5 +194,6 @@ export const usePhilanthropyStore = create<PhilanthropyStore>((set) => ({
   setResult: (result) => set({ result }),
   setSearching: (searching) => set({ isSearching: searching }),
   setError: (error) => set({ error }),
+  setReadOnly: (readOnly) => set({ readOnly }),
   reset: () => set({ ...initialState }),
 }));

--- a/src/features/non-profits/store/search-session.ts
+++ b/src/features/non-profits/store/search-session.ts
@@ -13,6 +13,15 @@ import { persist } from "zustand/middleware";
 interface SearchSession {
   id: string;
   query: string;
+  /**
+   * True while the session was created locally (landing page / new chat) but
+   * its first search hasn't been kicked off yet. ChatView consumes the flag
+   * exactly once: a fresh session runs the query immediately; a non-fresh
+   * session is a revisit and is hydrated from the saved conversation instead
+   * of re-running the search. Pre-existing persisted sessions lack the flag
+   * and are treated as revisits.
+   */
+  fresh?: boolean;
 }
 
 interface SearchSessionStore {
@@ -21,6 +30,8 @@ interface SearchSessionStore {
   createSession: (query: string) => string;
   setSession: (id: string, query: string) => void;
   getSession: (id: string) => SearchSession | undefined;
+  /** Returns whether the session was fresh, clearing the flag (one-shot). */
+  consumeFresh: (id: string) => boolean;
   clearSession: (id: string) => void;
   setCurrentId: (id: string | null) => void;
 }
@@ -52,7 +63,7 @@ export const useSearchSessionStore = create<SearchSessionStore>()(
             : sessions;
 
         set({
-          sessions: { ...trimmed, [id]: { id, query } },
+          sessions: { ...trimmed, [id]: { id, query, fresh: true } },
           currentId: id,
         });
         return id;
@@ -73,6 +84,16 @@ export const useSearchSessionStore = create<SearchSessionStore>()(
       },
 
       getSession: (id: string) => get().sessions[id],
+
+      consumeFresh: (id: string) => {
+        const { sessions } = get();
+        const session = sessions[id];
+        if (!session?.fresh) return false;
+        set({
+          sessions: { ...sessions, [id]: { id, query: session.query } },
+        });
+        return true;
+      },
 
       clearSession: (id: string) => {
         const { sessions, currentId } = get();


### PR DESCRIPTION
## Overview

Improves how the **find-funders** agent presents its results, based on direct user feedback. Three things: narrative links now render consistently and behave correctly, entity results are grouped under clear labels, and the "take this agent to Claude/ChatGPT" nudge no longer navigates the user away from their conversation.

## Problem

A user reported several issues with the agent's output:

> "The formatting could be better. Some of the suggestions had urls underlined but weren't links. Some had clickable links. It gave me two tables and one appeared to be funders and the other appeared to be grant recipients… it keeps suggesting that I send it to chatgpt, but whenever I click to read the instructions it takes me completely away from my query, and of course everything resets when I try to get back."

Concretely:

1. **Inconsistent links** — the agent emits some links as proper markdown, some as bare URLs, and some as scheme-less domains (`fordfoundation.org`). GFM doesn't autolink scheme-less domains, and the renderer treats a scheme-less href as a *relative* path, so those rendered as underlined text that navigated nowhere. On top of that, the ai-elements message container neutralized link styling, so even valid links looked like body text.
2. **Ambiguous results** — foundations, nonprofits, and grants rendered as one flat, unlabeled list, so "which group is funders vs grant recipients?" was unclear.
3. **Connector nudge hijacked the page** — the Claude/ChatGPT buttons did in-app navigation, abandoning the current conversation.

## Solution

- **Consistent links** (`lib/remark-autolink-urls.ts`, `components/narrative-block.tsx`): a remark plugin autolinks bare URLs and scheme-less domains and repairs scheme-less hrefs to `https://`, operating on the mdast tree so code blocks and internal links are untouched. Every anchor renders through one component: brand color + underline (with `!important` to win over the message container), external links open in a new tab (`rel="noopener noreferrer"`), internal entity links navigate in place.
- **Grouped, labeled results** (`lib/group-entities.ts`, `components/chat-view-client.tsx`): entities are split into ordered, labeled sections — Foundations · *Potential funders*, Nonprofits · *Grant recipients & peers*, Grants · *Example awards* — each with a count and its own "Show all N" expansion. Empty groups are omitted; agent ranking is preserved.
- **Connector nudge** (`components/connector-nudge.tsx`): the setup guides open in a new tab (`target="_blank"`) with an "Opens in a new tab" hint, so an in-progress conversation is never lost.

## Why This Approach

A remark plugin (rather than a string pass) is inherently safe around code spans and existing links. Forcing link styling with `!important` is deliberate and documented in-code: the ai-elements container styles descendant anchors at a higher specificity than single-class utilities, which would otherwise render links as near-black, non-underlined body text. Deciding `target`/`rel` solely from the href (and stripping the renderer's defaults) ensures internal entity links don't get yanked into a new tab.

## Testing Steps

1. `pnpm vitest run --project unit src/features/non-profits/__tests__` — 23 files / 180 tests pass, including new coverage for URL autolinking (`remark-autolink-urls.test.ts`) and entity grouping (`group-entities.test.ts`).
2. Manual: run a find-funders search.
   - Narrative links (markdown, bare URL, and scheme-less domain) all render brand-colored + underlined; external links open in a new tab; clicking an entity name navigates in place.
   - Entity results render as labeled Foundations / Nonprofits / Grants sections with counts and per-section "Show all"; a URL inside inline code is not linked.
   - Complete a search, click "Add to ChatGPT" / "Add to Claude" → the guide opens in a new tab and the conversation tab is preserved.
3. Mobile (375px): groups and nudge wrap without horizontal overflow.

Verified manually in the browser, including a fix caught during QA where internal entity links were incorrectly opening in a new tab.

## Breaking Changes

None.

## Related

Companion to the conversation-persistence work:
- show-karma/gap-indexer#2059
- show-karma/gap-app-v2#1611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity results are grouped by type (funders, nonprofits, grants) with independent expand/collapse controls.
  * Narrative text now auto-detects bare domains/URLs and converts them into clickable links.
  * Saved chat turns can be persisted, restored, and continued across chat sessions.
* **Improvements**
  * External links (including “Add to Claude/ChatGPT”) now open in a new tab with safer handling.
  * Better chat session handling, including “conversation not found” and a locked composer state when applicable.
* **Tests**
  * Expanded coverage for entity grouping, URL auto-linking, saved conversation mapping, and new/external link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->