### PR TITLE
feat(nonprofits): deep research request page + search promo

### DIFF
--- a/app/nonprofits/find-funders-deep-research/error.tsx
+++ b/app/nonprofits/find-funders-deep-research/error.tsx
@@ -28,7 +28,7 @@ export default function DeepResearchError({
           <button
             type="button"
             onClick={reset}
-            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            className="flex items-center gap-2 rounded-lg !bg-primary px-4 py-2 text-sm font-medium !text-primary-foreground transition-colors hover:!bg-primary/90"
           >
             <RefreshCw className="h-4 w-4" />
             Try again

--- a/app/nonprofits/find-funders-deep-research/error.tsx
+++ b/app/nonprofits/find-funders-deep-research/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Link } from "@/src/components/navigation/Link";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+export default function DeepResearchError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading this page. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href={NON_PROFITS_PAGES.HOME}
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Back to search
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/nonprofits/find-funders-deep-research/layout.tsx
+++ b/app/nonprofits/find-funders-deep-research/layout.tsx
@@ -1,0 +1,20 @@
+import "../../../styles/non-profits-landing.css";
+
+import { NonProfitsFooter } from "@/src/features/non-profits/components/non-profits-footer";
+import { NonProfitsNavbar } from "@/src/features/non-profits/components/non-profits-navbar";
+
+/**
+ * Reuses the Karma Find Funders chrome (standalone navbar + footer) for the
+ * deep-research intake page, which sits as a sibling of /nonprofits/find-funders.
+ */
+export default function DeepResearchLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="landing">
+      <div className="lp-page">
+        <NonProfitsNavbar />
+        {children}
+        <NonProfitsFooter />
+      </div>
+    </div>
+  );
+}

--- a/app/nonprofits/find-funders-deep-research/loading.tsx
+++ b/app/nonprofits/find-funders-deep-research/loading.tsx
@@ -1,7 +1,13 @@
 export default function DeepResearchLoading() {
   return (
     <main className="flex w-full min-h-screen items-center justify-center bg-background">
-      <div className="h-10 w-10 animate-spin rounded-full border-2 border-border border-t-primary" />
+      <output className="flex flex-col items-center gap-2">
+        <div
+          className="h-10 w-10 animate-spin rounded-full border-2 border-border border-t-primary"
+          aria-hidden="true"
+        />
+        <span className="sr-only">Loading deep research page</span>
+      </output>
     </main>
   );
 }

--- a/app/nonprofits/find-funders-deep-research/loading.tsx
+++ b/app/nonprofits/find-funders-deep-research/loading.tsx
@@ -1,0 +1,7 @@
+export default function DeepResearchLoading() {
+  return (
+    <main className="flex w-full min-h-screen items-center justify-center bg-background">
+      <div className="h-10 w-10 animate-spin rounded-full border-2 border-border border-t-primary" />
+    </main>
+  );
+}

--- a/app/nonprofits/find-funders-deep-research/page.tsx
+++ b/app/nonprofits/find-funders-deep-research/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { DeepResearchForm } from "@/src/features/non-profits/components/deep-research-form";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "Deep Research — Karma Find Funders",
+  description:
+    "Get a hand-researched shortlist of funders. Tell us about your mission and we'll do the deep digging for you.",
+  path: "/nonprofits/find-funders-deep-research",
+});
+
+export default function FindFundersDeepResearchPage() {
+  return (
+    <main className="mx-auto w-full max-w-2xl px-4 py-12 sm:py-16">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-3xl">
+          Deep research
+        </h1>
+        <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400 sm:text-base">
+          Want better results than a single search can give you? Tell us as much as you can about
+          what you&apos;re after and our team will dig deep across millions of filings to build a
+          tailored funder shortlist for you.
+        </p>
+      </div>
+      <DeepResearchForm />
+    </main>
+  );
+}

--- a/app/nonprofits/find-funders/search/[id]/page.tsx
+++ b/app/nonprofits/find-funders/search/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ChatViewDynamic } from "@/src/features/non-profits/components/chat-view-dynamic";
+import { DeepResearchPromo } from "@/src/features/non-profits/components/deep-research-promo";
 import { customMetadata } from "@/utilities/meta";
 
 interface SearchPageParams {
@@ -29,8 +30,11 @@ export default async function SearchResultsPage({ params }: { params: Promise<Se
   const { id } = await params;
 
   return (
-    <main className="flex w-full flex-col">
-      <ChatViewDynamic searchId={id} />
+    <main className="flex w-full">
+      <div className="min-w-0 flex-1">
+        <ChatViewDynamic searchId={id} />
+      </div>
+      <DeepResearchPromo />
     </main>
   );
 }

--- a/src/features/non-profits/__tests__/use-deep-research-request.test.tsx
+++ b/src/features/non-profits/__tests__/use-deep-research-request.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for non-profits/hooks/use-deep-research-request.ts
+ *
+ * Tests:
+ * - delegates to philanthropyService.submitDeepResearchRequest
+ * - resolves on success
+ * - surfaces AppError on failure
+ * - deepResearchErrorMessage maps 429 + falls back sensibly
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { errAsync, okAsync } from "neverthrow";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deepResearchErrorMessage,
+  useDeepResearchRequest,
+} from "../hooks/use-deep-research-request";
+import type { AppError } from "../lib/errors";
+import { philanthropyService } from "../services/philanthropy.service";
+
+vi.mock("../services/philanthropy.service", () => ({
+  philanthropyService: {
+    submitDeepResearchRequest: vi.fn(),
+  },
+}));
+
+const submitMock = vi.mocked(philanthropyService.submitDeepResearchRequest);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const input = { email: "dev@example.org", query: "Funders for youth literacy in Ohio" };
+
+describe("useDeepResearchRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates to the service and resolves on success", async () => {
+    submitMock.mockReturnValue(okAsync({ success: true }));
+
+    const { result } = renderHook(() => useDeepResearchRequest(), { wrapper });
+    result.current.mutate(input);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(submitMock).toHaveBeenCalledWith(input);
+  });
+
+  it("surfaces the AppError on failure", async () => {
+    const err: AppError = { type: "ApiError", status: 429, message: "Too Many Requests" };
+    submitMock.mockReturnValue(errAsync(err));
+
+    const { result } = renderHook(() => useDeepResearchRequest(), { wrapper });
+    result.current.mutate(input);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(err);
+  });
+});
+
+describe("deepResearchErrorMessage", () => {
+  it("returns a friendly message for a 429", () => {
+    const err: AppError = { type: "ApiError", status: 429, message: "Too Many Requests" };
+    expect(deepResearchErrorMessage(err)).toMatch(/try again a little later/i);
+  });
+
+  it("returns the error message when present", () => {
+    const err: AppError = { type: "NetworkError", message: "boom" };
+    expect(deepResearchErrorMessage(err)).toBe("boom");
+  });
+
+  it("falls back to a generic message when no message exists", () => {
+    const err: AppError = { type: "AbortError" };
+    expect(deepResearchErrorMessage(err)).toMatch(/couldn't submit your request/i);
+  });
+});

--- a/src/features/non-profits/components/deep-research-form.tsx
+++ b/src/features/non-profits/components/deep-research-form.tsx
@@ -108,7 +108,7 @@ export function DeepResearchForm() {
         <button
           type="submit"
           disabled={isPending}
-          className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-emphasis focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:opacity-60"
+          className="inline-flex items-center justify-center gap-2 rounded-lg !bg-brand px-5 py-3 text-sm font-semibold !text-white transition-colors hover:!bg-brand-emphasis focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:opacity-60"
         >
           {isPending ? (
             <>

--- a/src/features/non-profits/components/deep-research-form.tsx
+++ b/src/features/non-profits/components/deep-research-form.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * DeepResearchForm — intake form for /nonprofits/find-funders-deep-research.
+ * Collects a free-text research brief plus the requester's email and submits
+ * via a React Query mutation to the indexer (which emails the Karma team).
+ */
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CheckCircle2, Sparkles } from "lucide-react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { z } from "zod";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  deepResearchErrorMessage,
+  useDeepResearchRequest,
+} from "../hooks/use-deep-research-request";
+
+const schema = z.object({
+  email: z.string().trim().email("Please enter a valid email address."),
+  query: z
+    .string()
+    .trim()
+    .min(10, "Please describe what you're looking for in a little more detail.")
+    .max(5000, "Please keep your request under 5000 characters."),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const labelStyle = "text-sm font-medium text-zinc-900 dark:text-zinc-100";
+const inputStyle =
+  "mt-2 w-full rounded-lg border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-brand-subtle focus:outline-none focus:ring-2 focus:ring-brand/30 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100";
+
+export function DeepResearchForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    mode: "onSubmit",
+    defaultValues: { email: "", query: "" },
+  });
+
+  const { mutate, isPending, isSuccess } = useDeepResearchRequest();
+
+  const onSubmit: SubmitHandler<FormValues> = (values) => {
+    mutate(values, {
+      onError: (error) => {
+        toast.error(deepResearchErrorMessage(error));
+      },
+    });
+  };
+
+  if (isSuccess) {
+    return (
+      <div className="rounded-2xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400">
+          <CheckCircle2 className="size-6" />
+        </div>
+        <h2 className="mt-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          Request received
+        </h2>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          Thanks — our team will review your deep research request and follow up by email.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="rounded-2xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex flex-col gap-5">
+        <div>
+          <label htmlFor="deep-research-query" className={labelStyle}>
+            What are you looking for?
+          </label>
+          <textarea
+            id="deep-research-query"
+            rows={8}
+            className={`${inputStyle} resize-y`}
+            placeholder="Tell us as much as you can — your mission, the kind of funders you're after, geography, check size, timelines, and anything that's worked or not worked so far."
+            aria-invalid={errors.query ? "true" : "false"}
+            {...register("query")}
+          />
+          {errors.query && <p className="mt-1.5 text-sm text-red-500">{errors.query.message}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="deep-research-email" className={labelStyle}>
+            Your email
+          </label>
+          <input
+            id="deep-research-email"
+            type="email"
+            className={inputStyle}
+            placeholder="you@organization.org"
+            aria-invalid={errors.email ? "true" : "false"}
+            {...register("email")}
+          />
+          {errors.email && <p className="mt-1.5 text-sm text-red-500">{errors.email.message}</p>}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-emphasis focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 disabled:opacity-60"
+        >
+          {isPending ? (
+            <>
+              <Spinner className="size-4" />
+              Submitting…
+            </>
+          ) : (
+            <>
+              <Sparkles className="size-4" />
+              Perform deep research
+            </>
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/non-profits/components/deep-research-form.tsx
+++ b/src/features/non-profits/components/deep-research-form.tsx
@@ -43,7 +43,10 @@ export function DeepResearchForm() {
     defaultValues: { email: "", query: "" },
   });
 
-  const { mutate, isPending, isSuccess } = useDeepResearchRequest();
+  const { mutate, isPending, data } = useDeepResearchRequest();
+  // Gate the confirmation on the payload's `success` flag, not just transport
+  // success — a 200 with `{ success: false }` must not render a confirmation.
+  const isSubmitted = data?.success === true;
 
   const onSubmit: SubmitHandler<FormValues> = (values) => {
     mutate(values, {
@@ -53,7 +56,7 @@ export function DeepResearchForm() {
     });
   };
 
-  if (isSuccess) {
+  if (isSubmitted) {
     return (
       <div className="rounded-2xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
         <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400">

--- a/src/features/non-profits/components/deep-research-promo.tsx
+++ b/src/features/non-profits/components/deep-research-promo.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * DeepResearchPromo — right-rail advertisement shown on the search workbench
+ * pointing users to the hand-curated deep research intake page. Opens the
+ * deep-research page in a new tab so the active search is preserved.
+ */
+
+import { ArrowUpRight, Telescope } from "lucide-react";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+export function DeepResearchPromo() {
+  return (
+    <aside className="hidden w-72 shrink-0 border-l border-zinc-200 p-4 xl:block dark:border-zinc-800">
+      <div className="sticky top-4 overflow-hidden rounded-xl border border-zinc-200 bg-gradient-to-br from-brand-faint via-white to-blue-50 p-4 dark:border-zinc-800 dark:from-brand/10 dark:via-zinc-900 dark:to-blue-900/10">
+        <div className="flex size-9 items-center justify-center rounded-lg bg-brand text-white">
+          <Telescope className="size-4" />
+        </div>
+        <p className="mt-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Want better results?
+        </p>
+        <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+          Let our team dig deep across millions of filings and build a funder shortlist tailored to
+          your mission.
+        </p>
+        <a
+          href={NON_PROFITS_PAGES.DEEP_RESEARCH}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+        >
+          Try deep research
+          <ArrowUpRight className="size-3" />
+        </a>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/non-profits/hooks/use-deep-research-request.ts
+++ b/src/features/non-profits/hooks/use-deep-research-request.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import type { AppError } from "../lib/errors";
+import { resultToPromise } from "../lib/result-to-promise";
+import {
+  type DeepResearchRequestInput,
+  philanthropyService,
+} from "../services/philanthropy.service";
+
+/**
+ * Human-readable message for a deep-research submission failure.
+ */
+export function deepResearchErrorMessage(error: AppError): string {
+  if (error.type === "ApiError" && error.status === 429) {
+    return "You've sent a few requests already. Please try again a little later.";
+  }
+  if ("message" in error && error.message) {
+    return error.message;
+  }
+  return "We couldn't submit your request. Please try again later.";
+}
+
+/**
+ * Submits a deep-research request via the philanthropy service (indexer).
+ */
+export function useDeepResearchRequest() {
+  return useMutation<{ success: boolean }, AppError, DeepResearchRequestInput>({
+    mutationFn: (input) => resultToPromise(philanthropyService.submitDeepResearchRequest(input)),
+  });
+}

--- a/src/features/non-profits/lib/api.ts
+++ b/src/features/non-profits/lib/api.ts
@@ -24,6 +24,7 @@ export const NON_PROFITS_API = {
   PHILANTHROPY: {
     QUERY: "/v2/philanthropy/agent-query",
     QUERY_STREAM: "/v2/philanthropy/agent-query/stream",
+    DEEP_RESEARCH: "/v2/philanthropy/deep-research-request",
     FEEDBACK: "/v2/agent/rating",
     FOUNDATIONS: {
       GET: (id: string) => `/v2/philanthropy/foundations/${id}`,

--- a/src/features/non-profits/services/philanthropy.service.ts
+++ b/src/features/non-profits/services/philanthropy.service.ts
@@ -46,7 +46,29 @@ function buildSortQs(sort?: SortOption): string {
   return qs ? `?${qs}` : "";
 }
 
+export interface DeepResearchRequestInput {
+  email: string;
+  query: string;
+}
+
+const DeepResearchResponseSchema = z.object({ success: z.boolean() });
+
 export const philanthropyService = {
+  /**
+   * Submits a free-text deep-research brief plus the requester's email to the
+   * indexer, which emails the Karma team for manual follow-up.
+   */
+  submitDeepResearchRequest(
+    input: DeepResearchRequestInput
+  ): ResultAsync<{ success: boolean }, AppError> {
+    return apiFetch(
+      NON_PROFITS_API.PHILANTHROPY.DEEP_RESEARCH,
+      DeepResearchResponseSchema,
+      "POST",
+      input
+    );
+  },
+
   getFoundation(id: string): ResultAsync<Foundation, AppError> {
     return apiFetch(NON_PROFITS_API.PHILANTHROPY.FOUNDATIONS.GET(id), FoundationSchema);
   },

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -247,6 +247,7 @@ const FIND_FUNDERS = "/nonprofits/find-funders";
 
 export const NON_PROFITS_PAGES = {
   HOME: FIND_FUNDERS,
+  DEEP_RESEARCH: "/nonprofits/find-funders-deep-research" as const,
   SEARCH: (id: string) => `${FIND_FUNDERS}/search/${id}`,
   FOUNDATION: (id: string, searchId?: string) =>
     `${FIND_FUNDERS}/foundations/${id}${searchId ? `?searchId=${searchId}` : ""}`,


### PR DESCRIPTION
## Overview

Adds a "deep research" intake flow to Find Funders. On the search (Prospecting Agent) page, a right-rail promo invites users to try deep research; it opens a new page where they describe what they're after and leave an email. The request is sent to the indexer, which emails the Karma team for manual follow-up.

> Backend endpoint is in a companion PR: show-karma/gap-indexer#2083. This PR depends on that endpoint (`POST /v2/philanthropy/deep-research-request`).

## What's included

- **Page** at `/nonprofits/find-funders-deep-research` (`page` + `layout` + `loading` + `error`). It's a sibling of `find-funders`, so it has its own `layout.tsx` that reuses the standalone Find Funders navbar/footer chrome.
- **Form** (`deep-research-form.tsx`) — details textarea + email input + "Perform deep research" button. React Hook Form + Zod validation, submits via a React Query `useMutation`, with pending / error (toast) / success states.
- **Right-rail promo** (`deep-research-promo.tsx`) on the search workbench — "Want better results? Try deep research" → opens the page in a new tab. Hidden below `xl` so it doesn't crowd the conversation column.
- **Service + hook** — `philanthropyService.submitDeepResearchRequest` (neverthrow `apiFetch`) and `useDeepResearchRequest`, plus `NON_PROFITS_PAGES.DEEP_RESEARCH` and the `NON_PROFITS_API.PHILANTHROPY.DEEP_RESEARCH` path.
- **Tests** — `use-deep-research-request.test.tsx` (delegation, success, error surfacing, and the 429/fallback message mapping).

## Notes

- No new env vars — the request goes through the existing `NEXT_PUBLIC_GAP_INDEXER_URL`.
- Route path: kept literally as `/nonprofits/find-funders-deep-research` (a sibling segment with its own layout). The alternative would be a child route `/nonprofits/find-funders/deep-research` that inherits the layout automatically — easy to switch if preferred.

## Testing

```bash
pnpm test src/features/non-profits/__tests__/use-deep-research-request.test.tsx   # green
pnpm tsc --noEmit
pnpm lint
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Deep Research" page where nonprofits can submit detailed funder research requests via email and text query
  * Added a promotional callout on search results directing users to the new deep research feature
  * Included loading indicators and intelligent error messaging for request submission feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->