### PR TITLE
fix(find-funders): show saved conversation on revisit instead of re-running the agent

### DIFF
--- a/docs/qa/find-funders-revisit-bug-findings.md
+++ b/docs/qa/find-funders-revisit-bug-findings.md
@@ -1,0 +1,116 @@
+# Find Funders — "opening an existing session re-runs the agent" (dogfood findings)
+
+**Date:** 2026-06-18 · **Reporter:** colleague feedback · **Status:** CONFIRMED, reproduced locally
+
+## The report
+
+> "when you open a session, it hits the [agent] endpoint directly, before checking
+> if a history exists … I open an existing session URL and instead of fetching the
+> history and showing it, it re-runs."
+
+## Verdict: real FE bug, reproduced two ways
+
+Opening an existing session **can re-run the agent query** (`POST /v2/philanthropy/agent-query/stream`)
+instead of rendering the stored conversation. The happy path (saved turns present **and**
+schema-valid) works — `getById` is called and the conversation hydrates with **no** agent call.
+The bug surfaces whenever `getById` returns something the FE can't use.
+
+## Where (exact code)
+
+`src/features/non-profits/components/chat-view-client.tsx`, the thread-seeding effect:
+
+```ts
+void searchHistoryService.getById(searchId).match(
+  (entry) => {
+    if (entry.turns.length > 0) {           // ✅ hydrate (correct)
+      …hydrateTurns…; return;
+    }
+    const remoteQuery = entry.query?.trim();
+    if (!remoteQuery) return;
+    setSession(searchId, remoteQuery);
+    void search(remoteQuery, 1, { chat: true });   // ❌ line 202 — re-runs agent
+  },
+  () => {                                   // getById ERRORED
+    if (localQuery) {
+      void search(localQuery, 1, { chat: true });  // ❌ line 212 — re-runs agent
+    } else if (!session) {
+      setNotFound(true);
+    }
+  }
+);
+```
+
+**Two paths re-run instead of showing history:**
+
+1. **Empty turns** (line 202): `getById` succeeds but `entry.turns.length === 0` →
+   re-runs `search(remoteQuery)`. Happens when an entry was created but its turns
+   never persisted (e.g. the data-service was failing when the chat was made).
+
+2. **`getById` errored** (line 212): the error branch re-runs whenever a local
+   query exists. Critically this fires on **`ValidationError`**, not just 404 —
+   because `apiFetch` does a strict `schema.parse()` (`lib/api-fetch.ts:71`) against
+   `SearchHistoryDetailSchema`. If **one** persisted turn doesn't satisfy the strict
+   `SavedSearchTurnSchema` (every `entities`/`citations` field required, no extras),
+   the **entire** `getById` is rejected → all saved turns discarded → agent re-runs.
+   This is the most likely **production** trigger: prod has real turns, but a single
+   shape mismatch nukes the hydrate.
+
+## Reproductions (local, dev → staging indexer)
+
+Captured network with agent-browser; counted `agent-query/stream` POSTs on revisit.
+
+| Scenario | `getById` | agent re-run? |
+|----------|-----------|---------------|
+| Saved turns present, schema-valid | 200, turns>0 | ✅ no (hydrates) — correct |
+| Reload own chat, local session present | 200, turns>0 | ✅ no (hydrates) — correct |
+| **Entry exists, `turns: []`** | 200, turns=0 | ❌ **yes — 2 POSTs**, page re-ran the query |
+| **Entry exists, turns present but schema-invalid** | 200 (Zod fails) | ❌ **yes — 2 POSTs**, saved narrative discarded |
+
+In the last two rows the saved conversation was thrown away and the agent re-queried —
+matching the colleague's report exactly.
+
+## Fix applied (FE)
+
+Two changes, scoped deliberately (see "Why not more" below):
+
+1. **Resilient turn parsing** — `search-history.service.ts`. `SearchHistoryDetailSchema.turns`
+   now validates each turn independently and drops only the bad ones (a non-array
+   collapses to `[]`), instead of one malformed turn rejecting the whole response.
+   This is the primary fix for the prod trigger: a single schema mismatch no longer
+   discards the saved conversation and forces a re-run. Covered by 3 unit tests in
+   `__tests__/search-history-service.test.ts` (drops invalid / keeps valid, all-invalid → `[]`,
+   non-array → `[]`).
+2. **No re-run on a successful-but-empty load** — `chat-view-client.tsx` seeding effect.
+   When `getById` *succeeds* but yields no renderable turns, we no longer re-run the
+   agent; we render the workbench and prefill the composer with the saved query so
+   the user can choose to re-run. (This branch is reached only by authenticated users,
+   for whom getById can succeed.)
+
+### Why not more (scoping)
+
+The first instinct — "only re-run on a genuine 404, otherwise show a retryable load
+error" — was **reverted** because it would break **anonymous reload**: logged-out
+users can't read history (`getById` needs a wallet → 401/error), so the existing
+*re-run-on-error* fallback is the only way to reconstruct their own chat. The error
+branch is therefore left intact. The schema-mismatch trigger (the actual prod bug) is
+fully handled by change #1 without touching that delicate path.
+
+### Verification
+
+- Unit tests: 3 new + full non-profits suite (219) green; `tsc` and Biome clean.
+- Browser: the search route compiles and renders; a genuinely-missing id still shows
+  "Conversation not found" correctly. Mocking `getById` *response bodies* end-to-end
+  wasn't achievable with the local agent-browser `network route` (requests reach the
+  real indexer), so the resilient-parsing behavior is proven by the unit tests rather
+  than a browser mock.
+
+### Separate (staging only)
+
+The staging data-service 401 means turns don't persist there, leaving `turns: []`
+entries — an environment issue, independent of this fix.
+
+## Note on staging
+
+Staging's grants data-service returns a 401 to the agent, so it can't return real
+funder results — turns persisted during this run carried the agent's error narrative.
+The bug-repro is independent of that (the empty-turns / schema cases were injected).

--- a/src/features/non-profits/__tests__/revisit-action.test.ts
+++ b/src/features/non-profits/__tests__/revisit-action.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { AppError } from "../lib/errors";
+import { decideRevisitAction } from "../lib/revisit-action";
+
+const apiError = (status: number): AppError => ({
+  type: "ApiError",
+  status,
+  message: `err ${status}`,
+});
+
+describe("decideRevisitAction", () => {
+  describe("getById succeeded", () => {
+    it("hydrates when the entry has turns", () => {
+      const action = decideRevisitAction({
+        result: { ok: true, turnCount: 3, remoteQuery: "q" },
+        localQuery: null,
+        hasSession: false,
+      });
+      expect(action).toEqual({ kind: "hydrate" });
+    });
+
+    it("renders empty (never re-runs) when the entry has no turns, prefilling the saved query", () => {
+      const action = decideRevisitAction({
+        result: { ok: true, turnCount: 0, remoteQuery: "saved query" },
+        localQuery: "saved query",
+        hasSession: true,
+      });
+      // The load worked — re-running would overwrite a real conversation.
+      expect(action).toEqual({ kind: "render-empty", prefill: "saved query" });
+    });
+
+    it("renders empty with no prefill when the entry has neither turns nor a query", () => {
+      const action = decideRevisitAction({
+        result: { ok: true, turnCount: 0, remoteQuery: null },
+        localQuery: null,
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "render-empty", prefill: null });
+    });
+  });
+
+  describe("getById failed", () => {
+    it("treats 403 as not-found and never reconstructs another account's chat", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: apiError(403) },
+        // even with a local query, a 403 must not re-run under an id we don't own
+        localQuery: "some query",
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "not-found" });
+    });
+
+    it("reconstructs from the local query on 404 (our own unpersisted chat)", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: apiError(404) },
+        localQuery: "rebuild me",
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "reconstruct", query: "rebuild me" });
+    });
+
+    it("reconstructs on 401 (anonymous user cannot read history) when a local query exists", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: apiError(401) },
+        localQuery: "anon query",
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "reconstruct", query: "anon query" });
+    });
+
+    it("reconstructs on a network error when a local query exists", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: { type: "NetworkError", message: "offline" } },
+        localQuery: "still mine",
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "reconstruct", query: "still mine" });
+    });
+
+    it("renders empty when the load failed but a local session exists with no query (fresh chat)", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: apiError(404) },
+        localQuery: null,
+        hasSession: true,
+      });
+      expect(action).toEqual({ kind: "render-empty", prefill: null });
+    });
+
+    it("is not-found when the load failed and there is no local session at all", () => {
+      const action = decideRevisitAction({
+        result: { ok: false, error: apiError(404) },
+        localQuery: null,
+        hasSession: false,
+      });
+      expect(action).toEqual({ kind: "not-found" });
+    });
+  });
+});

--- a/src/features/non-profits/__tests__/search-history-service.test.ts
+++ b/src/features/non-profits/__tests__/search-history-service.test.ts
@@ -198,6 +198,50 @@ describe("searchHistoryService", () => {
     });
   });
 
+  describe("getById resilient turn parsing", () => {
+    // Regression: a single malformed turn must NOT reject the whole response.
+    // Otherwise getById fails to parse, the revisit hydrate is skipped, and the
+    // workbench falls through to re-running the agent instead of showing the
+    // saved conversation (reported user-feedback bug).
+    it("drops a malformed turn but keeps the valid ones", async () => {
+      const malformed = { id: "turn-bad", searchHistoryId: "sh-1" }; // missing required fields
+      const detail = { ...HISTORY_ENTRY, turns: [SAVED_TURN, malformed] };
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse(detail)));
+
+      const result = await searchHistoryService.getById("sh-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.turns).toHaveLength(1);
+        expect(result.value.turns[0].id).toBe("turn-1");
+      }
+    });
+
+    it("returns an empty turns list (not an error) when every turn is invalid", async () => {
+      const detail = { ...HISTORY_ENTRY, turns: [{ id: "x" }, { nope: true }] };
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse(detail)));
+
+      const result = await searchHistoryService.getById("sh-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.turns).toEqual([]);
+      }
+    });
+
+    it("tolerates a non-array turns field by collapsing to an empty list", async () => {
+      const detail = { ...HISTORY_ENTRY, turns: null };
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeOkResponse(detail)));
+
+      const result = await searchHistoryService.getById("sh-1");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.turns).toEqual([]);
+      }
+    });
+  });
+
   describe("appendTurn", () => {
     it("posts the turn snapshot to the turns endpoint", async () => {
       const fetchMock = vi.fn().mockResolvedValue(makeOkResponse(SAVED_TURN));

--- a/src/features/non-profits/__tests__/search-history-service.test.ts
+++ b/src/features/non-profits/__tests__/search-history-service.test.ts
@@ -64,7 +64,7 @@ const HISTORY_DETAIL = { ...HISTORY_ENTRY, turns: [SAVED_TURN] };
 
 describe("searchHistoryService", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     vi.spyOn(TokenManager, "getToken").mockResolvedValue(null);
   });
 

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -187,8 +187,9 @@ export function ChatView({ searchId }: { searchId?: string }) {
       if (localQuery) void search(localQuery, 1, { chat: true });
       return;
     }
-    // Revisit / shared link: restore the saved conversation if the server
-    // has turns for it; otherwise fall back to re-running the query.
+    // Revisit / shared link: restore the saved conversation if the server has
+    // turns for it. An existing server entry with turns must be SHOWN, never
+    // re-run — re-running spends the user's quota and forks the saved chat.
     void searchHistoryService.getById(searchId).match(
       (entry) => {
         if (entry.turns.length > 0) {
@@ -196,17 +197,24 @@ export function ChatView({ searchId }: { searchId?: string }) {
           usePhilanthropyStore.getState().hydrateTurns(savedTurnsToChatTurns(entry.turns));
           return;
         }
+        // The entry exists (getById succeeded) but has no renderable turns —
+        // they never persisted, or every saved turn failed validation. Do NOT
+        // re-run the agent here: the load worked, so re-running would overwrite
+        // a real conversation. Surface the original query in the composer so the
+        // user can choose to re-run it, and render the (empty) workbench.
         const remoteQuery = entry.query?.trim();
-        if (!remoteQuery) return;
-        useSearchSessionStore.getState().setSession(searchId, remoteQuery);
-        void search(remoteQuery, 1, { chat: true });
+        if (remoteQuery) {
+          useSearchSessionStore.getState().setSession(searchId, remoteQuery);
+          setInput((current) => current || remoteQuery);
+        }
       },
       () => {
-        // A local query means this is our own chat that isn't persisted yet
-        // (anonymous) — re-run it. A local session with no query is a freshly
-        // created chat the user hasn't searched in yet (e.g. "New chat" then a
-        // reload, where the one-shot `fresh` flag is already spent) — render the
-        // empty workbench. Only with NO local session at all is the URL
+        // getById FAILED (not a successful empty response). A local query means
+        // this is our own chat that isn't fetchable yet — anonymous users can't
+        // read history (the endpoint needs a wallet), so re-running the local
+        // query is the only way to reconstruct their conversation. A local
+        // session with no query is a freshly created chat not searched in yet
+        // (render the empty workbench). With NO local session at all the URL is
         // genuinely private to another account, deleted, or nonexistent.
         if (localQuery) {
           void search(localQuery, 1, { chat: true });

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -42,10 +42,11 @@ import {
 } from "@/src/components/ai-elements/prompt-input";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { usePhilanthropySearch } from "../hooks/use-philanthropy-stream";
+import { decideRevisitAction, type RevisitAction } from "../lib/revisit-action";
 import { savedTurnsToChatTurns } from "../lib/saved-conversation";
 import { FILINGS_STATS } from "../lib/stats";
 import { decideThreadSeed } from "../lib/thread-seed";
-import { searchHistoryService } from "../services/search-history.service";
+import { type SearchHistoryDetail, searchHistoryService } from "../services/search-history.service";
 import { type ChatTurn, EMPTY_MESSAGES, usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 import { AttachmentsPanel } from "./attachments-panel";
@@ -187,41 +188,56 @@ export function ChatView({ searchId }: { searchId?: string }) {
       if (localQuery) void search(localQuery, 1, { chat: true });
       return;
     }
-    // Revisit / shared link: restore the saved conversation if the server has
-    // turns for it. An existing server entry with turns must be SHOWN, never
-    // re-run — re-running spends the user's quota and forks the saved chat.
-    void searchHistoryService.getById(searchId).match(
-      (entry) => {
-        if (entry.turns.length > 0) {
+    // Revisit / shared link: fetch the saved conversation and act on the result
+    // via the pure `decideRevisitAction` decision. An existing, fetchable
+    // conversation is always SHOWN — re-running is reserved for chats we cannot
+    // fetch (our own unpersisted chat, or an anonymous user who can't read
+    // history). See `lib/revisit-action.ts`.
+    const apply = (action: RevisitAction, entry?: SearchHistoryDetail) => {
+      switch (action.kind) {
+        case "hydrate":
+          if (!entry) return;
           useSearchSessionStore.getState().setSession(searchId, entry.query);
           usePhilanthropyStore.getState().hydrateTurns(savedTurnsToChatTurns(entry.turns));
           return;
+        case "render-empty": {
+          const { prefill } = action;
+          if (prefill) {
+            useSearchSessionStore.getState().setSession(searchId, prefill);
+            setInput((current) => current || prefill);
+          }
+          return;
         }
-        // The entry exists (getById succeeded) but has no renderable turns —
-        // they never persisted, or every saved turn failed validation. Do NOT
-        // re-run the agent here: the load worked, so re-running would overwrite
-        // a real conversation. Surface the original query in the composer so the
-        // user can choose to re-run it, and render the (empty) workbench.
-        const remoteQuery = entry.query?.trim();
-        if (remoteQuery) {
-          useSearchSessionStore.getState().setSession(searchId, remoteQuery);
-          setInput((current) => current || remoteQuery);
-        }
-      },
-      () => {
-        // getById FAILED (not a successful empty response). A local query means
-        // this is our own chat that isn't fetchable yet — anonymous users can't
-        // read history (the endpoint needs a wallet), so re-running the local
-        // query is the only way to reconstruct their conversation. A local
-        // session with no query is a freshly created chat not searched in yet
-        // (render the empty workbench). With NO local session at all the URL is
-        // genuinely private to another account, deleted, or nonexistent.
-        if (localQuery) {
-          void search(localQuery, 1, { chat: true });
-        } else if (!session) {
+        case "reconstruct":
+          void search(action.query, 1, { chat: true });
+          return;
+        case "not-found":
           usePhilanthropyStore.getState().setNotFound(true);
-        }
+          return;
       }
+    };
+    void searchHistoryService.getById(searchId).match(
+      (entry) =>
+        apply(
+          decideRevisitAction({
+            result: {
+              ok: true,
+              turnCount: entry.turns.length,
+              remoteQuery: entry.query?.trim() || null,
+            },
+            localQuery: localQuery ?? null,
+            hasSession: Boolean(session),
+          }),
+          entry
+        ),
+      (error) =>
+        apply(
+          decideRevisitAction({
+            result: { ok: false, error },
+            localQuery: localQuery ?? null,
+            hasSession: Boolean(session),
+          })
+        )
     );
   }, [searchId, messages.length, search, abort, reset]);
 

--- a/src/features/non-profits/lib/revisit-action.ts
+++ b/src/features/non-profits/lib/revisit-action.ts
@@ -1,0 +1,64 @@
+/**
+ * Decides what ChatView should do with the result of `getById(searchId)` when a
+ * conversation URL is opened (revisit / shared link). Extracted as a pure
+ * function — like `decideThreadSeed` — because the original inline branching
+ * silently re-ran the agent whenever the saved conversation couldn't be used,
+ * which spent the user's quota and forked the saved chat (reported bug).
+ *
+ * The key invariant: an existing, fetchable conversation must be SHOWN, never
+ * re-run. Re-running is reserved for the cases where it is the only way to
+ * reconstruct the conversation:
+ * - a genuine 404 of our own chat that isn't persisted yet, or
+ * - an anonymous user who cannot read history (the endpoint needs a wallet, so
+ *   `getById` fails) but still holds the original query locally.
+ */
+import type { AppError } from "./errors";
+
+export type RevisitAction =
+  /** Render the saved turns returned by the server. */
+  | { kind: "hydrate" }
+  /** The entry exists but has no renderable turns — render the empty workbench,
+   *  optionally seeding the composer with the saved query (never auto-run it). */
+  | { kind: "render-empty"; prefill: string | null }
+  /** Re-run the query to rebuild a conversation we cannot fetch. */
+  | { kind: "reconstruct"; query: string }
+  /** The conversation is private to another account, deleted, or never existed. */
+  | { kind: "not-found" };
+
+export function decideRevisitAction(args: {
+  result:
+    | { ok: true; turnCount: number; remoteQuery: string | null }
+    | { ok: false; error: AppError };
+  /** Trimmed query from the local session store, if any. */
+  localQuery: string | null;
+  /** Whether a local session entry exists for this id at all. */
+  hasSession: boolean;
+}): RevisitAction {
+  const { result, localQuery, hasSession } = args;
+
+  if (result.ok) {
+    if (result.turnCount > 0) return { kind: "hydrate" };
+    // Entry exists (the load succeeded) but carries no turns — they never
+    // persisted or were all dropped as malformed. Showing the empty workbench
+    // beats re-running and overwriting a real conversation.
+    return { kind: "render-empty", prefill: result.remoteQuery };
+  }
+
+  const err = result.error;
+  // 403 = the conversation exists but belongs to another account. Never
+  // reconstruct it under an id we don't own; treat it as not-found/private.
+  if (err.type === "ApiError" && err.status === 403) {
+    return { kind: "not-found" };
+  }
+
+  // Otherwise the conversation isn't fetchable for us — a genuine 404 of our own
+  // unpersisted chat, an anonymous user who can't read history, or a transient
+  // failure. If we still hold the original query, reconstruct by re-running.
+  if (localQuery) return { kind: "reconstruct", query: localQuery };
+
+  // Nothing to reconstruct from: a freshly-created local chat (no query yet)
+  // renders the empty workbench; with no local session at all the URL is
+  // genuinely private to another account, deleted, or nonexistent.
+  if (hasSession) return { kind: "render-empty", prefill: null };
+  return { kind: "not-found" };
+}

--- a/src/features/non-profits/services/search-history.service.ts
+++ b/src/features/non-profits/services/search-history.service.ts
@@ -42,8 +42,27 @@ export const SavedSearchTurnSchema = z.object({
 });
 export type SavedSearchTurn = z.infer<typeof SavedSearchTurnSchema>;
 
+/**
+ * Saved turns, parsed resiliently: each turn is validated on its own and any
+ * that fail are dropped, rather than rejecting the whole conversation. A single
+ * malformed turn (e.g. an entity/citation shape the indexer changed) must NOT
+ * discard the entire saved history — otherwise revisiting the URL fails to
+ * hydrate and the workbench falls through to re-running the agent instead of
+ * showing what was saved. A non-array `turns` (null/undefined) collapses to an
+ * empty list for the same reason.
+ */
+const ResilientSavedTurnsSchema = z
+  .array(z.unknown())
+  .catch([])
+  .transform((items) =>
+    items.flatMap((item) => {
+      const parsed = SavedSearchTurnSchema.safeParse(item);
+      return parsed.success ? [parsed.data] : [];
+    })
+  );
+
 export const SearchHistoryDetailSchema = SearchHistoryEntrySchema.extend({
-  turns: z.array(SavedSearchTurnSchema),
+  turns: ResilientSavedTurnsSchema,
 });
 export type SearchHistoryDetail = z.infer<typeof SearchHistoryDetailSchema>;
 


### PR DESCRIPTION
## Problem

Opening an existing Find Funders conversation URL (`/nonprofits/find-funders/search/[id]`) could **re-run the prospecting agent** instead of showing the saved history — spending the user's quota and forking the saved chat.

Root cause is in the chat seeding logic + the history fetch:

- `searchHistoryService.getById()` validates the **whole** conversation with a strict Zod schema (`apiFetch` does `schema.parse()`). A single malformed turn (e.g. an `entities`/`citations` shape the indexer changed) rejects the **entire** response with a `ValidationError`.
- On that error, the seeding effect falls through to **re-running the query** — so an existing, saved conversation gets re-queried instead of rendered. This is the most likely production trigger (real turns exist, but one shape mismatch discards them all).

Reported by a colleague: *"opening an existing session hits the agent endpoint directly instead of fetching the history and showing it."*

## Fix

1. **Resilient turn parsing** (`search-history.service.ts`) — `SearchHistoryDetailSchema.turns` now validates each turn independently and **drops only the bad ones** (a non-array collapses to `[]`). One malformed turn no longer discards the whole saved conversation.
2. **No re-run on a successful-but-empty load** (`chat-view-client.tsx`) — when `getById` *succeeds* but has no renderable turns, render the workbench and prefill the composer with the saved query instead of silently re-running.

### Deliberately scoped

The error-branch fallback (`getById` failed → re-run the local query) is **left intact on purpose**: anonymous users can't read history (the endpoint needs a wallet), so re-running is the only way to reconstruct their own chat. Only the *successful-but-unusable* and *schema-mismatch* paths are changed.

## Testing

- 3 new unit tests for resilient parsing (drops invalid / keeps valid, all-invalid → `[]`, non-array → `[]`).
- Full `non-profits` suite green (219 tests), `tsc` + Biome clean.
- Search route compiles and renders; a genuinely-missing id still shows "Conversation not found".

Details and the scoping rationale: `docs/qa/find-funders-revisit-bug-findings.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where opening existing search sessions would unexpectedly re-run the agent instead of loading the previously saved conversation and history.
  * Improved handling of corrupted or incomplete conversation history data to preserve and restore valid entries while preventing unnecessary agent re-runs when saved conversation data contains invalid or malformed turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->