### PR TITLE
fix: render GFM tables and stop single-tilde strikethrough in AI narratives

### DIFF
--- a/__tests__/unit/components/ai-elements/message-response-markdown.test.tsx
+++ b/__tests__/unit/components/ai-elements/message-response-markdown.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MessageResponse } from "@/src/components/ai-elements/message-response";
+
+// End-to-end render tests (Streamdown NOT mocked). These guard the actual
+// markdown output, which the prop-forwarding unit tests can't see. The
+// find-funders narrative bug had two layers: remark-gfm being dropped (tables
+// rendered as raw `| pipes |`) and `@streamdown/cjk` re-enabling single-tilde
+// strikethrough (a lone `~` for "approximately" struck through everything to the
+// next `~`). Render in "static" mode so output is synchronous.
+describe("MessageResponse markdown rendering", () => {
+  it("renders GFM tables as a <table>, not raw pipes", () => {
+    const md = "| Funder | Grants |\n|---|---|\n| Patagonia.org | 2 |";
+    const { container } = render(<MessageResponse mode="static">{md}</MessageResponse>);
+
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).not.toContain("|---|");
+  });
+
+  it("does NOT strike through a single `~` used as 'approximately'", () => {
+    const md = "made 9 grants totaling ~$182K (~$20K average) — a good fit";
+    const { container } = render(<MessageResponse mode="static">{md}</MessageResponse>);
+
+    expect(container.querySelector("del, s, strike")).toBeNull();
+    expect(container.textContent).toContain("~$182K");
+  });
+
+  it("still strikes through genuine `~~double~~` tildes", () => {
+    const { container } = render(
+      <MessageResponse mode="static">{"price ~~$182K~~"}</MessageResponse>
+    );
+
+    expect(container.querySelector("del, s, strike")).not.toBeNull();
+  });
+});

--- a/__tests__/unit/components/ai-elements/message-response.test.tsx
+++ b/__tests__/unit/components/ai-elements/message-response.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import remarkGfm from "remark-gfm";
 import { describe, expect, it, vi } from "vitest";
 import { MessageResponse } from "@/src/components/ai-elements/message-response";
 
@@ -20,7 +21,7 @@ vi.mock("streamdown", () => ({
 // effect resolves synchronously enough for the test and doesn't throw.
 vi.mock("@streamdown/math", () => ({ math: {} }));
 vi.mock("@streamdown/mermaid", () => ({ mermaid: {} }));
-vi.mock("@streamdown/cjk", () => ({ cjk: {} }));
+vi.mock("@streamdown/cjk", () => ({ cjk: { remarkPluginsAfter: [] } }));
 vi.mock("@streamdown/code", () => ({ code: {} }));
 
 describe("MessageResponse memo comparator", () => {
@@ -56,5 +57,48 @@ describe("MessageResponse memo comparator", () => {
     expect(streamdownSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({ className: expect.stringContaining("second") })
     );
+  });
+});
+
+describe("MessageResponse remark-gfm", () => {
+  // remark-gfm is forwarded as a `[plugin, options]` tuple so we can pass
+  // `singleTilde: false`. Pull it back out of the forwarded remarkPlugins array.
+  const findGfm = (remarkPlugins: unknown[]) =>
+    remarkPlugins.find((p) => p === remarkGfm || (Array.isArray(p) && p[0] === remarkGfm));
+
+  // Streamdown enables remark-gfm by default, but a custom `remarkPlugins` array
+  // REPLACES that default — which silently dropped GFM table rendering for
+  // consumers passing their own plugins (find-funders narratives rendered tables
+  // as raw `| pipes |`). MessageResponse must always merge remark-gfm back in.
+  it("forwards remark-gfm even when no remarkPlugins are passed", () => {
+    streamdownSpy.mockClear();
+
+    render(<MessageResponse>{"| a | b |\n|---|---|\n| 1 | 2 |"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    expect(findGfm(props.remarkPlugins)).toBeDefined();
+  });
+
+  // A single `~` means "approximately" in AI narratives ("~$182K ... ~$20K");
+  // default GFM pairs those two tildes and strikes through everything between.
+  it("disables single-tilde strikethrough so `~` reads as 'approximately'", () => {
+    streamdownSpy.mockClear();
+
+    render(<MessageResponse>{"~$182K"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    const gfm = findGfm(props.remarkPlugins);
+    expect(gfm).toEqual([remarkGfm, { singleTilde: false }]);
+  });
+
+  it("preserves consumer remarkPlugins AND keeps remark-gfm", () => {
+    streamdownSpy.mockClear();
+    const customPlugin = () => {};
+
+    render(<MessageResponse remarkPlugins={[customPlugin]}>{"text"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    expect(findGfm(props.remarkPlugins)).toBeDefined();
+    expect(props.remarkPlugins).toContain(customPlugin);
   });
 });

--- a/src/components/ai-elements/message-response.tsx
+++ b/src/components/ai-elements/message-response.tsx
@@ -3,7 +3,8 @@
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import type { ComponentProps } from "react";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
+import remarkGfm from "remark-gfm";
 import { Streamdown } from "streamdown";
 import { cn } from "@/utilities/tailwind";
 
@@ -12,14 +13,36 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 const lazyMath = () => import("@streamdown/math").then((m) => m.math);
 const lazyMermaid = () => import("@streamdown/mermaid").then((m) => m.mermaid);
 
+// `@streamdown/cjk` injects its own CJK-aware GFM strikethrough plugin
+// (`remarkGfmStrikethroughCjkFriendly`) via `remarkPluginsAfter`, and it
+// defaults to single-tilde strikethrough — independently of the remark-gfm
+// config in MessageResponse below. AI narratives use a lone `~` to mean
+// "approximately" (e.g. "~$182K ... ~$20K average"); single-tilde strikethrough
+// pairs those tildes and strikes through the whole span between them. Rebuild
+// the plugin entry to require `~~double~~` tildes so a single `~` renders
+// literally. Matched by function name because the plugin isn't exported
+// separately; if a future @streamdown/cjk renames it, we fall back to the
+// default (no crash, just the old behavior).
+const cjkSingleTildeOff = {
+  ...cjk,
+  remarkPluginsAfter: cjk.remarkPluginsAfter.map((plugin) =>
+    typeof plugin === "function" && plugin.name === "remarkGfmStrikethroughCjkFriendly"
+      ? [plugin, { singleTilde: false }]
+      : plugin
+  ),
+};
+
 function useStreamdownPlugins() {
-  const [plugins, setPlugins] = useState<Record<string, unknown>>({ cjk, code });
+  const [plugins, setPlugins] = useState<Record<string, unknown>>({
+    cjk: cjkSingleTildeOff,
+    code,
+  });
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([lazyMath(), lazyMermaid()]).then(([mathPlugin, mermaidPlugin]) => {
       if (!cancelled) {
-        setPlugins({ cjk, code, math: mathPlugin, mermaid: mermaidPlugin });
+        setPlugins({ cjk: cjkSingleTildeOff, code, math: mathPlugin, mermaid: mermaidPlugin });
       }
     });
     return () => {
@@ -30,15 +53,32 @@ function useStreamdownPlugins() {
   return plugins;
 }
 
-export const MessageResponse = memo(({ className, ...props }: MessageResponseProps) => {
-  const plugins = useStreamdownPlugins();
-  return (
-    <Streamdown
-      className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
-      plugins={plugins}
-      {...props}
-    />
-  );
-});
+export const MessageResponse = memo(
+  ({ className, remarkPlugins, ...props }: MessageResponseProps) => {
+    const plugins = useStreamdownPlugins();
+    // Streamdown enables remark-gfm (tables, strikethrough, task lists) via its
+    // default `remarkPlugins`, but passing a custom array REPLACES that default
+    // instead of extending it. Always include remark-gfm so consumers that add
+    // their own remark plugins (e.g. URL autolinking) don't silently lose table
+    // rendering. remark-gfm is already bundled by Streamdown, so this is free.
+    //
+    // `singleTilde: false` requires `~~double~~` tildes for strikethrough. AI
+    // narratives routinely use a single `~` to mean "approximately" (e.g.
+    // "~$182K ... ~$20K average"); with the default (singleTilde: true) GFM
+    // pairs those two tildes and strikes through the whole span between them.
+    const mergedRemarkPlugins = useMemo<MessageResponseProps["remarkPlugins"]>(
+      () => [[remarkGfm, { singleTilde: false }], ...(remarkPlugins ?? [])],
+      [remarkPlugins]
+    );
+    return (
+      <Streamdown
+        className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+        plugins={plugins}
+        remarkPlugins={mergedRemarkPlugins}
+        {...props}
+      />
+    );
+  }
+);
 
 MessageResponse.displayName = "MessageResponse";


### PR DESCRIPTION
## Problem

AI-generated narratives (find-funders search, Ask Karma, agent chat) render through `MessageResponse` → Streamdown. Two markdown bugs made the output unreadable on pages like `/nonprofits/find-funders/search/[id]`:

1. **Tables rendered as raw `| pipes |`** instead of an HTML table.
2. **A lone `~` struck through text** — e.g. `~$182K ... ~$20K average` rendered with a line through the whole span, because `~` was meant as "approximately".

| Before | After |
|--------|-------|
| `\| Funder \| Kind \| ... \|---\|---\|` shown as literal text | Proper `<table>` |
| ~~$182K, suggesting ... ($20K~~ average) struck through | "~$182K ... ~$20K average" reads literally |

## Root cause

1. **Dropped GFM.** Streamdown enables `remark-gfm` (tables, etc.) via its *default* `remarkPlugins`. But passing a custom `remarkPlugins` array — `NarrativeBlock` adds URL autolinking — **replaces** that default rather than extending it, so `remark-gfm` was silently dropped.

2. **Single-tilde strikethrough.** `@streamdown/cjk` injects its own CJK-aware strikethrough plugin (`remarkGfmStrikethroughCjkFriendly`) via `remarkPluginsAfter`, and it defaults to **single-tilde** strikethrough — independent of the `remark-gfm` config. Two `~` (approximations) got paired and everything between them struck through.

## Fix

Both fixes live in the shared `MessageResponse` component, so every AI-narrative surface benefits:

- Always **merge `remark-gfm`** into whatever remark plugins a consumer passes (with `singleTilde: false`).
- Rebuild the **`cjk` plugin** so its strikethrough requires `~~double~~` tildes (`singleTilde: false`), matched by function name with a safe fallback.

## Testing

- Added real-render regression tests (Streamdown **not** mocked) covering: GFM tables render as `<table>`, single `~` renders literally, genuine `~~double~~` still strikes through.
- Updated the existing mocked unit tests for the new merged-plugin shape.
- `8/8` tests pass; Biome and `tsc` clean.

### Manual QA
Visit a find-funders search results page (e.g. `/nonprofits/find-funders/search/<id>`) — the funder table renders as a real table and dollar approximations no longer appear struck through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for Markdown table rendering and strikethrough syntax handling.

* **Bug Fixes**
  * Fixed single tilde (~) characters being incorrectly interpreted as strikethrough markers; double tildes (~~) continue to work as expected.

* **New Features**
  * Enhanced Markdown rendering with consistent GitHub Flavored Markdown support, including proper HTML table rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->