### PR TITLE
fix: stop New chat from bouncing back to the previous search

### DIFF
--- a/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard for the "New chat" bounce-back bug: from a loaded
+// conversation, clicking "New chat" flashed an empty page and then snapped back
+// to the previous search. Cause: the seeding effect depended on
+// `messages.length`, so reset() re-fired it while the URL (searchId) was still
+// the OLD id (router.replace is async) — re-fetching and re-hydrating the old
+// conversation. This test pins the invariant: after "New chat", the old
+// conversation must NOT be re-fetched via searchHistoryService.getById.
+
+// vi.mock factories are hoisted above the module body, so the spies they close
+// over must be created via vi.hoisted (which runs first).
+const { replace, search, abort, getById } = vi.hoisted(() => ({
+  replace: vi.fn(),
+  // Stable search/abort identities so the seeding effect doesn't re-run on their
+  // account (only `searchId` should drive it).
+  search: vi.fn(),
+  abort: vi.fn(),
+  getById: vi.fn(() => ({ match: vi.fn() })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: true, login: vi.fn() }),
+}));
+
+vi.mock("../hooks/use-philanthropy-stream", () => ({
+  usePhilanthropySearch: () => ({ search, abort }),
+}));
+
+vi.mock("../services/search-history.service", () => ({
+  searchHistoryService: { getById },
+}));
+
+// Thin stubs for child components — irrelevant to the navigation logic.
+vi.mock("@/components/ui/spinner", () => ({ Spinner: () => <div /> }));
+vi.mock("@/src/components/ai-elements/conversation", () => ({
+  Conversation: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationEmptyState: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationScrollButton: () => <div />,
+}));
+vi.mock("@/src/components/ai-elements/message", () => ({
+  Message: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  MessageContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/src/components/ai-elements/prompt-input", () => ({
+  PromptInput: ({ children }: { children?: React.ReactNode }) => <form>{children}</form>,
+  PromptInputBody: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputFooter: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputSubmit: () => <button type="submit">send</button>,
+  PromptInputTextarea: () => <textarea />,
+  PromptInputTools: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../components/attachments-panel", () => ({ AttachmentsPanel: () => <div /> }));
+vi.mock("../components/bookmarks-drawer", () => ({ BookmarksDrawer: () => <div /> }));
+vi.mock("../components/composer-lock-notice", () => ({ ComposerLockNotice: () => <div /> }));
+vi.mock("../components/connector-nudge", () => ({ ConnectorNudge: () => <div /> }));
+vi.mock("../components/entity-list", () => ({ EntityList: () => <div /> }));
+vi.mock("../components/narrative-block", () => ({ NarrativeBlock: () => <div /> }));
+vi.mock("../components/progress-view", () => ({ ProgressView: () => <div /> }));
+vi.mock("../components/search-feedback", () => ({ SearchFeedback: () => <div /> }));
+vi.mock("../components/search-history-panel", () => ({ SearchHistoryPanel: () => <div /> }));
+
+import { ChatView } from "../components/chat-view-client";
+import { usePhilanthropyStore } from "../store/philanthropy";
+import { useSearchSessionStore } from "../store/search-session";
+
+const turnA = {
+  id: "turn-1",
+  userQuery: "climate funders in CA",
+  narrative: "Here are some funders.",
+  entities: [],
+  citations: [],
+  traceId: null,
+  pagination: null,
+  status: "done" as const,
+  error: null,
+  progress: null,
+  attachments: [],
+};
+
+describe("ChatView — New chat does not resurrect the previous conversation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePhilanthropyStore.getState().reset();
+    // Session "A" exists (so the buggy path would have a query to re-run) but is
+    // NOT marked fresh — a revisit, i.e. exactly the case that re-fetches.
+    useSearchSessionStore.getState().setSession("A", "climate funders in CA");
+    // Store already holds session A's loaded thread.
+    usePhilanthropyStore.setState({ messages: [turnA], threadId: "A" });
+  });
+
+  afterEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("does not call searchHistoryService.getById for the old id after New chat", () => {
+    render(<ChatView searchId="A" />);
+
+    // Mount adopts the in-memory thread for A — no fetch.
+    expect(getById).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+
+    // router.replace fired (navigation to the fresh session was requested)...
+    expect(replace).toHaveBeenCalledTimes(1);
+    // ...but the OLD conversation must NOT be re-fetched. With `messages.length`
+    // back in the effect deps, reset() re-ran the effect against the stale
+    // searchId="A" and called getById("A"), hydrating the old chat back in.
+    expect(getById).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -194,6 +194,12 @@ export function ChatView({ searchId }: { searchId?: string }) {
     // fetch (our own unpersisted chat, or an anonymous user who can't read
     // history). See `lib/revisit-action.ts`.
     const apply = (action: RevisitAction, entry?: SearchHistoryDetail) => {
+      // Stale-resolution guard: `getById` is async and uncancellable. If the
+      // session changed while it was in flight (e.g. "New chat" or switching
+      // history items), this instance has already re-seeded a different id —
+      // dropping the late result keeps it from hydrating the old conversation
+      // back into the current session.
+      if (seededSearchIdRef.current !== searchId) return;
       switch (action.kind) {
         case "hydrate":
           if (!entry) return;
@@ -239,7 +245,13 @@ export function ChatView({ searchId }: { searchId?: string }) {
           })
         )
     );
-  }, [searchId, messages.length, search, abort, reset]);
+    // Keyed on `searchId` only. `messages.length` must NOT be a dependency:
+    // "New chat" calls reset() (clearing messages) and then router.replace() to
+    // the new session, but the replace is async, so a messages.length trigger
+    // re-runs this effect while `searchId` is still the OLD id — re-seeding it
+    // and re-fetching the old conversation, which flashes empty then snaps back
+    // to the previous search. The count is still read fresh via getState above.
+  }, [searchId, search, abort, reset]);
 
   // The free-limit prompt is only set for logged-out users; once they sign in,
   // restore the composer so they can continue.


### PR DESCRIPTION
## Problem

In find-funders chat, clicking **New chat** from a page with a loaded conversation flashes a clean/empty page and then snaps back to the previous search.

## Root cause

`ChatView`'s seeding effect (`chat-view-client.tsx`) depended on `messages.length`. `onNewChat` does:

```ts
abort();
reset();                                  // clears messages → messages.length N → 0
seededSearchIdRef.current = null;
const newId = createSession("");
router.replace(SEARCH(newId));            // async — searchId prop is still the OLD id
```

Because `router.replace` is async, the `reset()` re-fired the seeding effect **while `searchId` was still the old id**. With the per-instance seed ref nulled and the store empty, `decideThreadSeed` returned `"seed"`, so the effect re-seeded the old id and called `searchHistoryService.getById(oldId)` — an uncancellable fetch whose result `hydrateTurns(...)` the **old conversation back into the fresh session**. Hence: empty flash → old search returns.

## Fix

- **Key the seeding effect on `searchId` only.** `messages.length` was only a *trigger* — the turn count is already read fresh via `getState()` inside the effect, so the seed decision is unchanged; it just no longer re-fires when messages are cleared. (Aligns with the CLAUDE.md rule against effect-driven navigation races.)
- **Stale-resolution guard** on the async `getById`: if the session changed while the fetch was in flight, drop the result. Defense-in-depth that also covers rapid history-item switching.

## Testing

- New regression test `chat-view-new-chat.test.tsx`: from a loaded conversation, clicking **New chat** must not re-fetch the old conversation. **Verified it fails** if `messages.length` is reintroduced into the dependency array (`getById` called once) and passes with the fix.
- Full non-profits suite green (229 tests). Biome + tsc clean.

### Manual QA
On `/nonprofits/find-funders/search/<id>` with a conversation loaded, click **New chat** → lands on a clean composer and stays there; the previous conversation does not reappear.