### PR TITLE
fix(find-funders): markdown rendering, New chat reset, and private-search sign-in

### DIFF
--- a/__tests__/unit/components/ai-elements/message-response-markdown.test.tsx
+++ b/__tests__/unit/components/ai-elements/message-response-markdown.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MessageResponse } from "@/src/components/ai-elements/message-response";
+
+// End-to-end render tests (Streamdown NOT mocked). These guard the actual
+// markdown output, which the prop-forwarding unit tests can't see. The
+// find-funders narrative bug had two layers: remark-gfm being dropped (tables
+// rendered as raw `| pipes |`) and `@streamdown/cjk` re-enabling single-tilde
+// strikethrough (a lone `~` for "approximately" struck through everything to the
+// next `~`). Render in "static" mode so output is synchronous.
+describe("MessageResponse markdown rendering", () => {
+  it("renders GFM tables as a <table>, not raw pipes", () => {
+    const md = "| Funder | Grants |\n|---|---|\n| Patagonia.org | 2 |";
+    const { container } = render(<MessageResponse mode="static">{md}</MessageResponse>);
+
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).not.toContain("|---|");
+  });
+
+  it("does NOT strike through a single `~` used as 'approximately'", () => {
+    const md = "made 9 grants totaling ~$182K (~$20K average) — a good fit";
+    const { container } = render(<MessageResponse mode="static">{md}</MessageResponse>);
+
+    expect(container.querySelector("del, s, strike")).toBeNull();
+    expect(container.textContent).toContain("~$182K");
+  });
+
+  it("still strikes through genuine `~~double~~` tildes", () => {
+    const { container } = render(
+      <MessageResponse mode="static">{"price ~~$182K~~"}</MessageResponse>
+    );
+
+    expect(container.querySelector("del, s, strike")).not.toBeNull();
+  });
+});

--- a/__tests__/unit/components/ai-elements/message-response.test.tsx
+++ b/__tests__/unit/components/ai-elements/message-response.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import remarkGfm from "remark-gfm";
 import { describe, expect, it, vi } from "vitest";
 import { MessageResponse } from "@/src/components/ai-elements/message-response";
 
@@ -20,7 +21,7 @@ vi.mock("streamdown", () => ({
 // effect resolves synchronously enough for the test and doesn't throw.
 vi.mock("@streamdown/math", () => ({ math: {} }));
 vi.mock("@streamdown/mermaid", () => ({ mermaid: {} }));
-vi.mock("@streamdown/cjk", () => ({ cjk: {} }));
+vi.mock("@streamdown/cjk", () => ({ cjk: { remarkPluginsAfter: [] } }));
 vi.mock("@streamdown/code", () => ({ code: {} }));
 
 describe("MessageResponse memo comparator", () => {
@@ -56,5 +57,48 @@ describe("MessageResponse memo comparator", () => {
     expect(streamdownSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({ className: expect.stringContaining("second") })
     );
+  });
+});
+
+describe("MessageResponse remark-gfm", () => {
+  // remark-gfm is forwarded as a `[plugin, options]` tuple so we can pass
+  // `singleTilde: false`. Pull it back out of the forwarded remarkPlugins array.
+  const findGfm = (remarkPlugins: unknown[]) =>
+    remarkPlugins.find((p) => p === remarkGfm || (Array.isArray(p) && p[0] === remarkGfm));
+
+  // Streamdown enables remark-gfm by default, but a custom `remarkPlugins` array
+  // REPLACES that default — which silently dropped GFM table rendering for
+  // consumers passing their own plugins (find-funders narratives rendered tables
+  // as raw `| pipes |`). MessageResponse must always merge remark-gfm back in.
+  it("forwards remark-gfm even when no remarkPlugins are passed", () => {
+    streamdownSpy.mockClear();
+
+    render(<MessageResponse>{"| a | b |\n|---|---|\n| 1 | 2 |"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    expect(findGfm(props.remarkPlugins)).toBeDefined();
+  });
+
+  // A single `~` means "approximately" in AI narratives ("~$182K ... ~$20K");
+  // default GFM pairs those two tildes and strikes through everything between.
+  it("disables single-tilde strikethrough so `~` reads as 'approximately'", () => {
+    streamdownSpy.mockClear();
+
+    render(<MessageResponse>{"~$182K"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    const gfm = findGfm(props.remarkPlugins);
+    expect(gfm).toEqual([remarkGfm, { singleTilde: false }]);
+  });
+
+  it("preserves consumer remarkPlugins AND keeps remark-gfm", () => {
+    streamdownSpy.mockClear();
+    const customPlugin = () => {};
+
+    render(<MessageResponse remarkPlugins={[customPlugin]}>{"text"}</MessageResponse>);
+
+    const props = streamdownSpy.mock.calls.at(-1)?.[0];
+    expect(findGfm(props.remarkPlugins)).toBeDefined();
+    expect(props.remarkPlugins).toContain(customPlugin);
   });
 });

--- a/src/components/ai-elements/message-response.tsx
+++ b/src/components/ai-elements/message-response.tsx
@@ -23,13 +23,18 @@ const lazyMermaid = () => import("@streamdown/mermaid").then((m) => m.mermaid);
 // literally. Matched by function name because the plugin isn't exported
 // separately; if a future @streamdown/cjk renames it, we fall back to the
 // default (no crash, just the old behavior).
+// Defensive: this runs at module eval, so a throw here would break ALL markdown
+// rendering. If a future @streamdown/cjk drops/renames the array, pass it
+// through untouched (degrades to the default behavior) instead of crashing.
 const cjkSingleTildeOff = {
   ...cjk,
-  remarkPluginsAfter: cjk.remarkPluginsAfter.map((plugin) =>
-    typeof plugin === "function" && plugin.name === "remarkGfmStrikethroughCjkFriendly"
-      ? [plugin, { singleTilde: false }]
-      : plugin
-  ),
+  remarkPluginsAfter: Array.isArray(cjk.remarkPluginsAfter)
+    ? cjk.remarkPluginsAfter.map((plugin) =>
+        typeof plugin === "function" && plugin.name === "remarkGfmStrikethroughCjkFriendly"
+          ? [plugin, { singleTilde: false }]
+          : plugin
+      )
+    : cjk.remarkPluginsAfter,
 };
 
 function useStreamdownPlugins() {

--- a/src/components/ai-elements/message-response.tsx
+++ b/src/components/ai-elements/message-response.tsx
@@ -3,7 +3,8 @@
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import type { ComponentProps } from "react";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
+import remarkGfm from "remark-gfm";
 import { Streamdown } from "streamdown";
 import { cn } from "@/utilities/tailwind";
 
@@ -12,14 +13,36 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 const lazyMath = () => import("@streamdown/math").then((m) => m.math);
 const lazyMermaid = () => import("@streamdown/mermaid").then((m) => m.mermaid);
 
+// `@streamdown/cjk` injects its own CJK-aware GFM strikethrough plugin
+// (`remarkGfmStrikethroughCjkFriendly`) via `remarkPluginsAfter`, and it
+// defaults to single-tilde strikethrough — independently of the remark-gfm
+// config in MessageResponse below. AI narratives use a lone `~` to mean
+// "approximately" (e.g. "~$182K ... ~$20K average"); single-tilde strikethrough
+// pairs those tildes and strikes through the whole span between them. Rebuild
+// the plugin entry to require `~~double~~` tildes so a single `~` renders
+// literally. Matched by function name because the plugin isn't exported
+// separately; if a future @streamdown/cjk renames it, we fall back to the
+// default (no crash, just the old behavior).
+const cjkSingleTildeOff = {
+  ...cjk,
+  remarkPluginsAfter: cjk.remarkPluginsAfter.map((plugin) =>
+    typeof plugin === "function" && plugin.name === "remarkGfmStrikethroughCjkFriendly"
+      ? [plugin, { singleTilde: false }]
+      : plugin
+  ),
+};
+
 function useStreamdownPlugins() {
-  const [plugins, setPlugins] = useState<Record<string, unknown>>({ cjk, code });
+  const [plugins, setPlugins] = useState<Record<string, unknown>>({
+    cjk: cjkSingleTildeOff,
+    code,
+  });
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([lazyMath(), lazyMermaid()]).then(([mathPlugin, mermaidPlugin]) => {
       if (!cancelled) {
-        setPlugins({ cjk, code, math: mathPlugin, mermaid: mermaidPlugin });
+        setPlugins({ cjk: cjkSingleTildeOff, code, math: mathPlugin, mermaid: mermaidPlugin });
       }
     });
     return () => {
@@ -30,15 +53,32 @@ function useStreamdownPlugins() {
   return plugins;
 }
 
-export const MessageResponse = memo(({ className, ...props }: MessageResponseProps) => {
-  const plugins = useStreamdownPlugins();
-  return (
-    <Streamdown
-      className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
-      plugins={plugins}
-      {...props}
-    />
-  );
-});
+export const MessageResponse = memo(
+  ({ className, remarkPlugins, ...props }: MessageResponseProps) => {
+    const plugins = useStreamdownPlugins();
+    // Streamdown enables remark-gfm (tables, strikethrough, task lists) via its
+    // default `remarkPlugins`, but passing a custom array REPLACES that default
+    // instead of extending it. Always include remark-gfm so consumers that add
+    // their own remark plugins (e.g. URL autolinking) don't silently lose table
+    // rendering. remark-gfm is already bundled by Streamdown, so this is free.
+    //
+    // `singleTilde: false` requires `~~double~~` tildes for strikethrough. AI
+    // narratives routinely use a single `~` to mean "approximately" (e.g.
+    // "~$182K ... ~$20K average"); with the default (singleTilde: true) GFM
+    // pairs those two tildes and strikes through the whole span between them.
+    const mergedRemarkPlugins = useMemo<MessageResponseProps["remarkPlugins"]>(
+      () => [[remarkGfm, { singleTilde: false }], ...(remarkPlugins ?? [])],
+      [remarkPlugins]
+    );
+    return (
+      <Streamdown
+        className={cn("size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0", className)}
+        plugins={plugins}
+        remarkPlugins={mergedRemarkPlugins}
+        {...props}
+      />
+    );
+  }
+);
 
 MessageResponse.displayName = "MessageResponse";

--- a/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
@@ -1,0 +1,102 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard: opening a conversation that's private to your account while
+// logged OUT fails getById (403 → "Conversation not found"). After signing in,
+// the saved chat becomes readable, but the seeding effect keys on `searchId` and
+// previously didn't re-fetch — the user had to refresh. ChatView must re-seed on
+// the logged-out → in transition.
+
+const { replace, search, abort, getById, authState } = vi.hoisted(() => ({
+  replace: vi.fn(),
+  search: vi.fn(),
+  abort: vi.fn(),
+  // Logged out → 403; logged in → an existing (empty-turn) entry that resolves
+  // to a non-not-found state. We assert the RE-FETCH, not the hydration.
+  getById: vi.fn((_id: string) => ({
+    match: (
+      ok: (entry: { turns: unknown[]; query: string }) => void,
+      err: (e: { type: string; status: number; message: string }) => void
+    ) => {
+      if (authState.value) ok({ turns: [], query: "climate funders" });
+      else err({ type: "ApiError", status: 403, message: "forbidden" });
+      return Promise.resolve();
+    },
+  })),
+  authState: { value: false },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: authState.value, login: vi.fn() }),
+}));
+vi.mock("../hooks/use-philanthropy-stream", () => ({
+  usePhilanthropySearch: () => ({ search, abort }),
+}));
+vi.mock("../services/search-history.service", () => ({
+  searchHistoryService: { getById },
+}));
+
+vi.mock("@/components/ui/spinner", () => ({ Spinner: () => <div /> }));
+vi.mock("@/src/components/ai-elements/conversation", () => ({
+  Conversation: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationEmptyState: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationScrollButton: () => <div />,
+}));
+vi.mock("@/src/components/ai-elements/message", () => ({
+  Message: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  MessageContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/src/components/ai-elements/prompt-input", () => ({
+  PromptInput: ({ children }: { children?: React.ReactNode }) => <form>{children}</form>,
+  PromptInputBody: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputFooter: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputSubmit: () => <button type="submit">send</button>,
+  PromptInputTextarea: () => <textarea />,
+  PromptInputTools: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../components/attachments-panel", () => ({ AttachmentsPanel: () => <div /> }));
+vi.mock("../components/bookmarks-drawer", () => ({ BookmarksDrawer: () => <div /> }));
+vi.mock("../components/composer-lock-notice", () => ({ ComposerLockNotice: () => <div /> }));
+vi.mock("../components/connector-nudge", () => ({ ConnectorNudge: () => <div /> }));
+vi.mock("../components/entity-list", () => ({ EntityList: () => <div /> }));
+vi.mock("../components/narrative-block", () => ({ NarrativeBlock: () => <div /> }));
+vi.mock("../components/progress-view", () => ({ ProgressView: () => <div /> }));
+vi.mock("../components/search-feedback", () => ({ SearchFeedback: () => <div /> }));
+vi.mock("../components/search-history-panel", () => ({ SearchHistoryPanel: () => <div /> }));
+
+import { ChatView } from "../components/chat-view-client";
+import { usePhilanthropyStore } from "../store/philanthropy";
+import { useSearchSessionStore } from "../store/search-session";
+
+describe("ChatView — re-seeds a private conversation after sign-in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.value = false;
+    usePhilanthropyStore.getState().reset();
+    useSearchSessionStore.setState({ sessions: {} });
+  });
+
+  afterEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("re-fetches and clears not-found when the user logs in", () => {
+    // Logged out: the private conversation 403s → "not found".
+    const { rerender } = render(<ChatView searchId="B" />);
+    expect(getById).toHaveBeenCalledTimes(1);
+    expect(usePhilanthropyStore.getState().notFound).toBe(true);
+
+    // The user signs in.
+    authState.value = true;
+    rerender(<ChatView searchId="B" />);
+
+    // The conversation is re-fetched and the not-found state is cleared without
+    // a manual refresh.
+    expect(getById).toHaveBeenCalledTimes(2);
+    expect(usePhilanthropyStore.getState().notFound).toBe(false);
+  });
+});

--- a/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
@@ -1,39 +1,46 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Regression guard: opening a conversation that's private to your account while
 // logged OUT fails getById (403 → "Conversation not found"). After signing in,
 // the saved chat becomes readable, but the seeding effect keys on `searchId` and
-// previously didn't re-fetch — the user had to refresh. ChatView must re-seed on
-// the logged-out → in transition.
+// previously didn't re-fetch — the user had to refresh. ChatView must recover it.
+//
+// The recovery gates on the actual auth TOKEN (what apiFetch uses), not on
+// `authenticated` or a wallet address: Privy flips `authenticated` true before
+// the JWT is minted (and flickers during wagmi sync), and email/social logins
+// never expose a wallet address. So we must NOT re-fetch until a token exists.
 
-const { replace, search, abort, getById, authState } = vi.hoisted(() => ({
+const { replace, search, abort, getById, getToken, authState } = vi.hoisted(() => ({
   replace: vi.fn(),
   search: vi.fn(),
   abort: vi.fn(),
-  // Without a ready wallet (no token) → 403; with an address → an existing
-  // (empty-turn) entry that resolves to a non-not-found state. We assert the
-  // RE-FETCH, not the hydration.
+  // With a token the server returns an existing (empty-turn) entry that resolves
+  // to a non-not-found state; without one it 403s. We assert the RE-FETCH.
   getById: vi.fn((_id: string) => ({
     match: (
       ok: (entry: { turns: unknown[]; query: string }) => void,
       err: (e: { type: string; status: number; message: string }) => void
     ) => {
-      if (authState.address) ok({ turns: [], query: "climate funders" });
+      if (authState.token) ok({ turns: [], query: "climate funders" });
       else err({ type: "ApiError", status: 403, message: "forbidden" });
       return Promise.resolve();
     },
   })),
-  // Models the Privy hydration race: `authenticated` flips true before the
-  // wallet `address` (and thus the auth token) is populated.
-  authState: { value: false, address: undefined as string | undefined },
+  getToken: vi.fn(async () => authState.token),
+  // `value` = Privy `authenticated`; `token` = the JWT, which lags and can be
+  // absent while authenticated is already true (the flicker window).
+  authState: { value: false, token: null as string | null },
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
 }));
 vi.mock("@/hooks/useAuth", () => ({
-  useAuth: () => ({ authenticated: authState.value, address: authState.address, login: vi.fn() }),
+  useAuth: () => ({ authenticated: authState.value, login: vi.fn() }),
+}));
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken },
 }));
 vi.mock("../hooks/use-philanthropy-stream", () => ({
   usePhilanthropySearch: () => ({ search, abort }),
@@ -75,11 +82,11 @@ import { ChatView } from "../components/chat-view-client";
 import { usePhilanthropyStore } from "../store/philanthropy";
 import { useSearchSessionStore } from "../store/search-session";
 
-describe("ChatView — re-seeds a private conversation after sign-in", () => {
+describe("ChatView — recovers a private conversation after sign-in", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authState.value = false;
-    authState.address = undefined;
+    authState.token = null;
     usePhilanthropyStore.getState().reset();
     useSearchSessionStore.setState({ sessions: {} });
   });
@@ -88,25 +95,35 @@ describe("ChatView — re-seeds a private conversation after sign-in", () => {
     usePhilanthropyStore.getState().reset();
   });
 
-  it("waits for the wallet address (not just authenticated) before re-fetching", () => {
+  it("does NOT re-fetch while authenticated but the token isn't ready yet", async () => {
     // Logged out: the private conversation 403s → "not found".
     const { rerender } = render(<ChatView searchId="B" />);
     expect(getById).toHaveBeenCalledTimes(1);
     expect(usePhilanthropyStore.getState().notFound).toBe(true);
 
-    // Privy flips `authenticated` true, but the address/token haven't hydrated
-    // yet. Re-fetching now would 401 again, so we must NOT re-seed here.
+    // Privy flips `authenticated` true during the flicker window, but the JWT
+    // isn't minted yet. Re-fetching now would 401 again — so we must not.
     authState.value = true;
     rerender(<ChatView searchId="B" />);
+
+    // Give the token poll a chance to (not) act.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(getById).toHaveBeenCalledTimes(1);
+    expect(usePhilanthropyStore.getState().notFound).toBe(true);
+  });
+
+  it("re-fetches and clears not-found once a token is available", async () => {
+    const { rerender } = render(<ChatView searchId="B" />);
     expect(getById).toHaveBeenCalledTimes(1);
     expect(usePhilanthropyStore.getState().notFound).toBe(true);
 
-    // The wallet address becomes available — auth is truly ready.
-    authState.address = "0xabc";
+    // Auth settles: authenticated AND a usable token.
+    authState.value = true;
+    authState.token = "jwt-abc";
     rerender(<ChatView searchId="B" />);
 
-    // Now the conversation is re-fetched and not-found is cleared, no refresh.
-    expect(getById).toHaveBeenCalledTimes(2);
+    // The conversation is re-fetched and not-found cleared — no manual refresh.
+    await waitFor(() => expect(getById).toHaveBeenCalledTimes(2));
     expect(usePhilanthropyStore.getState().notFound).toBe(false);
   });
 });

--- a/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
@@ -126,4 +126,32 @@ describe("ChatView — recovers a private conversation after sign-in", () => {
     await waitFor(() => expect(getById).toHaveBeenCalledTimes(2));
     expect(usePhilanthropyStore.getState().notFound).toBe(false);
   });
+
+  it("recovers a 'Sign in to continue' (loginRequired) chat once a token is available", async () => {
+    // Logged-out reconstruct hit the anonymous limit: an error turn + composer
+    // lock, nothing usable loaded.
+    const errorTurn = {
+      id: "t1",
+      userQuery: "climate funders",
+      narrative: "",
+      entities: [],
+      citations: [],
+      traceId: null,
+      pagination: null,
+      status: "error" as const,
+      error: "Sign in to continue your search.",
+      progress: null,
+      attachments: [],
+    };
+    authState.value = true;
+    authState.token = "jwt-abc";
+    usePhilanthropyStore.setState({ messages: [errorTurn], threadId: "B", loginRequired: true });
+
+    render(<ChatView searchId="B" />);
+
+    // Sign-in recovers it: the composer unlocks and the chat is re-seeded
+    // (fetched) instead of staying stuck on the error turn.
+    await waitFor(() => expect(usePhilanthropyStore.getState().loginRequired).toBe(false));
+    expect(getById).toHaveBeenCalled();
+  });
 });

--- a/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-login-reseed.test.tsx
@@ -11,26 +11,29 @@ const { replace, search, abort, getById, authState } = vi.hoisted(() => ({
   replace: vi.fn(),
   search: vi.fn(),
   abort: vi.fn(),
-  // Logged out → 403; logged in → an existing (empty-turn) entry that resolves
-  // to a non-not-found state. We assert the RE-FETCH, not the hydration.
+  // Without a ready wallet (no token) → 403; with an address → an existing
+  // (empty-turn) entry that resolves to a non-not-found state. We assert the
+  // RE-FETCH, not the hydration.
   getById: vi.fn((_id: string) => ({
     match: (
       ok: (entry: { turns: unknown[]; query: string }) => void,
       err: (e: { type: string; status: number; message: string }) => void
     ) => {
-      if (authState.value) ok({ turns: [], query: "climate funders" });
+      if (authState.address) ok({ turns: [], query: "climate funders" });
       else err({ type: "ApiError", status: 403, message: "forbidden" });
       return Promise.resolve();
     },
   })),
-  authState: { value: false },
+  // Models the Privy hydration race: `authenticated` flips true before the
+  // wallet `address` (and thus the auth token) is populated.
+  authState: { value: false, address: undefined as string | undefined },
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
 }));
 vi.mock("@/hooks/useAuth", () => ({
-  useAuth: () => ({ authenticated: authState.value, login: vi.fn() }),
+  useAuth: () => ({ authenticated: authState.value, address: authState.address, login: vi.fn() }),
 }));
 vi.mock("../hooks/use-philanthropy-stream", () => ({
   usePhilanthropySearch: () => ({ search, abort }),
@@ -76,6 +79,7 @@ describe("ChatView — re-seeds a private conversation after sign-in", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authState.value = false;
+    authState.address = undefined;
     usePhilanthropyStore.getState().reset();
     useSearchSessionStore.setState({ sessions: {} });
   });
@@ -84,18 +88,24 @@ describe("ChatView — re-seeds a private conversation after sign-in", () => {
     usePhilanthropyStore.getState().reset();
   });
 
-  it("re-fetches and clears not-found when the user logs in", () => {
+  it("waits for the wallet address (not just authenticated) before re-fetching", () => {
     // Logged out: the private conversation 403s → "not found".
     const { rerender } = render(<ChatView searchId="B" />);
     expect(getById).toHaveBeenCalledTimes(1);
     expect(usePhilanthropyStore.getState().notFound).toBe(true);
 
-    // The user signs in.
+    // Privy flips `authenticated` true, but the address/token haven't hydrated
+    // yet. Re-fetching now would 401 again, so we must NOT re-seed here.
     authState.value = true;
     rerender(<ChatView searchId="B" />);
+    expect(getById).toHaveBeenCalledTimes(1);
+    expect(usePhilanthropyStore.getState().notFound).toBe(true);
 
-    // The conversation is re-fetched and the not-found state is cleared without
-    // a manual refresh.
+    // The wallet address becomes available — auth is truly ready.
+    authState.address = "0xabc";
+    rerender(<ChatView searchId="B" />);
+
+    // Now the conversation is re-fetched and not-found is cleared, no refresh.
     expect(getById).toHaveBeenCalledTimes(2);
     expect(usePhilanthropyStore.getState().notFound).toBe(false);
   });

--- a/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression guard for the "New chat" bounce-back bug: from a loaded
+// conversation, clicking "New chat" flashed an empty page and then snapped back
+// to the previous search. Cause: the seeding effect depended on
+// `messages.length`, so reset() re-fired it while the URL (searchId) was still
+// the OLD id (router.replace is async) — re-fetching and re-hydrating the old
+// conversation. This test pins the invariant: after "New chat", the old
+// conversation must NOT be re-fetched via searchHistoryService.getById.
+
+// vi.mock factories are hoisted above the module body, so the spies they close
+// over must be created via vi.hoisted (which runs first).
+const { replace, search, abort, getById } = vi.hoisted(() => ({
+  replace: vi.fn(),
+  // Stable search/abort identities so the seeding effect doesn't re-run on their
+  // account (only `searchId` should drive it).
+  search: vi.fn(),
+  abort: vi.fn(),
+  getById: vi.fn(() => ({ match: vi.fn() })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ authenticated: true, login: vi.fn() }),
+}));
+
+vi.mock("../hooks/use-philanthropy-stream", () => ({
+  usePhilanthropySearch: () => ({ search, abort }),
+}));
+
+vi.mock("../services/search-history.service", () => ({
+  searchHistoryService: { getById },
+}));
+
+// Thin stubs for child components — irrelevant to the navigation logic.
+vi.mock("@/components/ui/spinner", () => ({ Spinner: () => <div /> }));
+vi.mock("@/src/components/ai-elements/conversation", () => ({
+  Conversation: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationEmptyState: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ConversationScrollButton: () => <div />,
+}));
+vi.mock("@/src/components/ai-elements/message", () => ({
+  Message: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  MessageContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/src/components/ai-elements/prompt-input", () => ({
+  PromptInput: ({ children }: { children?: React.ReactNode }) => <form>{children}</form>,
+  PromptInputBody: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputFooter: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PromptInputSubmit: () => <button type="submit">send</button>,
+  PromptInputTextarea: () => <textarea />,
+  PromptInputTools: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../components/attachments-panel", () => ({ AttachmentsPanel: () => <div /> }));
+vi.mock("../components/bookmarks-drawer", () => ({ BookmarksDrawer: () => <div /> }));
+vi.mock("../components/composer-lock-notice", () => ({ ComposerLockNotice: () => <div /> }));
+vi.mock("../components/connector-nudge", () => ({ ConnectorNudge: () => <div /> }));
+vi.mock("../components/entity-list", () => ({ EntityList: () => <div /> }));
+vi.mock("../components/narrative-block", () => ({ NarrativeBlock: () => <div /> }));
+vi.mock("../components/progress-view", () => ({ ProgressView: () => <div /> }));
+vi.mock("../components/search-feedback", () => ({ SearchFeedback: () => <div /> }));
+vi.mock("../components/search-history-panel", () => ({ SearchHistoryPanel: () => <div /> }));
+
+import { ChatView } from "../components/chat-view-client";
+import { usePhilanthropyStore } from "../store/philanthropy";
+import { useSearchSessionStore } from "../store/search-session";
+
+const turnA = {
+  id: "turn-1",
+  userQuery: "climate funders in CA",
+  narrative: "Here are some funders.",
+  entities: [],
+  citations: [],
+  traceId: null,
+  pagination: null,
+  status: "done" as const,
+  error: null,
+  progress: null,
+  attachments: [],
+};
+
+describe("ChatView — New chat does not resurrect the previous conversation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePhilanthropyStore.getState().reset();
+    // Session "A" exists (so the buggy path would have a query to re-run) but is
+    // NOT marked fresh — a revisit, i.e. exactly the case that re-fetches.
+    useSearchSessionStore.getState().setSession("A", "climate funders in CA");
+    // Store already holds session A's loaded thread.
+    usePhilanthropyStore.setState({ messages: [turnA], threadId: "A" });
+  });
+
+  afterEach(() => {
+    usePhilanthropyStore.getState().reset();
+  });
+
+  it("does not call searchHistoryService.getById for the old id after New chat", () => {
+    render(<ChatView searchId="A" />);
+
+    // Mount adopts the in-memory thread for A — no fetch.
+    expect(getById).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+
+    // router.replace fired (navigation to the fresh session was requested)...
+    expect(replace).toHaveBeenCalledTimes(1);
+    // ...but the OLD conversation must NOT be re-fetched. With `messages.length`
+    // back in the effect deps, reset() re-ran the effect against the stale
+    // searchId="A" and called getById("A"), hydrating the old chat back in.
+    expect(getById).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
+++ b/src/features/non-profits/__tests__/chat-view-new-chat.test.tsx
@@ -2,19 +2,18 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Regression guard for the "New chat" bounce-back bug: from a loaded
-// conversation, clicking "New chat" flashed an empty page and then snapped back
-// to the previous search. Cause: the seeding effect depended on
-// `messages.length`, so reset() re-fired it while the URL (searchId) was still
-// the OLD id (router.replace is async) — re-fetching and re-hydrating the old
-// conversation. This test pins the invariant: after "New chat", the old
-// conversation must NOT be re-fetched via searchHistoryService.getById.
+// conversation, clicking "New chat" flashed an empty page and then re-fetched
+// the previous search onto the new URL. Two compounding causes: the seeding
+// effect depended on `messages.length` (reset() re-fired it) AND on the churning
+// `search`/`abort` identities (reset()'s re-render changed them) — both re-ran
+// the effect while the URL (searchId) was still the OLD id (router.replace is
+// async). This test pins the invariant: after "New chat", the old conversation
+// must NOT be re-fetched via searchHistoryService.getById.
 
 // vi.mock factories are hoisted above the module body, so the spies they close
 // over must be created via vi.hoisted (which runs first).
 const { replace, search, abort, getById } = vi.hoisted(() => ({
   replace: vi.fn(),
-  // Stable search/abort identities so the seeding effect doesn't re-run on their
-  // account (only `searchId` should drive it).
   search: vi.fn(),
   abort: vi.fn(),
   getById: vi.fn(() => ({ match: vi.fn() })),
@@ -29,7 +28,13 @@ vi.mock("@/hooks/useAuth", () => ({
 }));
 
 vi.mock("../hooks/use-philanthropy-stream", () => ({
-  usePhilanthropySearch: () => ({ search, abort }),
+  // Fresh `search`/`abort` identities each render, mirroring the real hook
+  // (search depends on React Query mutations + authenticated). The seeding
+  // effect must NOT re-run on this churn.
+  usePhilanthropySearch: () => ({
+    search: (...args: unknown[]) => search(...args),
+    abort: (...args: unknown[]) => abort(...args),
+  }),
 }));
 
 vi.mock("../services/search-history.service", () => ({

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -149,7 +149,9 @@ export function ChatView({ searchId }: { searchId?: string }) {
   // enough: navigating between two session URLs reuses the same instance
   // (same dynamic segment), so the ref must be keyed by session.
   const seededSearchIdRef = useRef<string | null>(null);
-  // Bumped to force the seeding effect to re-run after sign-in (see below).
+  // Bumped to force the seeding effect (which lists `reseedKey` in its deps) to
+  // re-run after sign-in. Must be state, not a ref — a ref mutation wouldn't
+  // re-trigger the effect.
   const [reseedKey, setReseedKey] = useState(0);
 
   // Seed the thread for the session in the URL. The philanthropy store is
@@ -276,34 +278,41 @@ export function ChatView({ searchId }: { searchId?: string }) {
     if (!notFound && !loginRequired) return;
     if (authRecoveredRef.current === searchId) return;
     let cancelled = false;
-    (async () => {
-      for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
-        const token = await TokenManager.getToken();
-        if (cancelled) return;
-        if (!token) {
-          await new Promise((resolve) => setTimeout(resolve, 400));
-          continue;
-        }
-        if (authRecoveredRef.current === searchId) return;
-        authRecoveredRef.current = searchId;
-        const store = usePhilanthropyStore.getState();
-        // A readable conversation is already loaded — the block was only the
-        // composer lock from an anonymous "continue" attempt. Unlock and keep it.
-        if (store.messages.some((turn) => turn.status === "done")) {
-          store.setLoginRequired(false);
-          return;
-        }
-        // Nothing usable is loaded (private 403, or an anonymous-limit error
-        // turn): re-seed from a clean slate now that auth is in place. reset()
-        // also clears notFound/loginRequired.
-        store.reset();
-        seededSearchIdRef.current = null;
-        setReseedKey((k) => k + 1);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let attempts = 0;
+    const recover = () => {
+      if (authRecoveredRef.current === searchId) return;
+      authRecoveredRef.current = searchId;
+      const store = usePhilanthropyStore.getState();
+      // A readable conversation is already loaded — the block was only the
+      // composer lock from an anonymous "continue" attempt. Unlock and keep it.
+      if (store.messages.some((turn) => turn.status === "done")) {
+        store.setLoginRequired(false);
         return;
       }
-    })();
+      // Nothing usable is loaded (private 403, or an anonymous-limit error
+      // turn): re-seed from a clean slate now that auth is in place. reset()
+      // also clears notFound/loginRequired.
+      store.reset();
+      seededSearchIdRef.current = null;
+      setReseedKey((k) => k + 1);
+    };
+    // Recursive scheduling (not a loop) so each retry is its own tick.
+    const tryRecover = () => {
+      void TokenManager.getToken().then((token) => {
+        if (cancelled) return;
+        if (token) {
+          recover();
+        } else if (attempts < 8) {
+          attempts += 1;
+          timer = setTimeout(tryRecover, 400);
+        }
+      });
+    };
+    tryRecover();
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [authenticated, searchId, notFound, loginRequired]);
 

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -40,6 +40,7 @@ import {
   PromptInputTextarea,
   PromptInputTools,
 } from "@/src/components/ai-elements/prompt-input";
+import { TokenManager } from "@/utilities/auth/token-manager";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { usePhilanthropySearch } from "../hooks/use-philanthropy-stream";
 import { decideRevisitAction, type RevisitAction } from "../lib/revisit-action";
@@ -138,7 +139,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const loginRequired = usePhilanthropyStore((s) => s.loginRequired);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
-  const { authenticated, address, login } = useAuth();
+  const { authenticated, login } = useAuth();
   const router = useRouter();
 
   const [input, setInput] = useState("");
@@ -264,30 +265,46 @@ export function ChatView({ searchId }: { searchId?: string }) {
     }
   }, [authenticated, loginRequired]);
 
-  // Re-seed once auth is READY. Opening a conversation that's private to your
-  // account while logged out fails getById (403 → "Conversation not found"); the
-  // saved chat only becomes readable once authenticated, but the seeding effect
-  // keys on `searchId` and wouldn't otherwise re-fetch — so the user had to
-  // refresh. We must wait for the wallet `address`, NOT just `authenticated`:
-  // Privy flips `authenticated` true before the address/token hydrate, so a
-  // refetch fired on `authenticated` alone still 401s and the not-found state
-  // sticks (see useAuth's AUTH-READY REFETCH BARRIER). When the address first
-  // becomes available, drop this instance's seed mark + not-found state and bump
-  // `reseedKey` to re-run the fetch with auth in place. Guarded so it never
-  // disturbs a conversation that's already loaded.
-  const prevAddressRef = useRef(address);
+  // Recover a private conversation after sign-in. Opening a chat that's private
+  // to your account while logged out fails getById (403 → "Conversation not
+  // found"); it only becomes readable once authenticated. But two Privy quirks
+  // make a naive `authenticated`-transition refetch unreliable, which is why the
+  // not-found state used to stick until a manual refresh:
+  //   1. `authenticated` flips true BEFORE the JWT is minted, and it flickers
+  //      for ~10-15s while Privy/wagmi sync — a one-shot transition latches on
+  //      the first (token-less) blip and never retries.
+  //   2. Some login methods (email/social) never expose a wallet address, so a
+  //      wallet-address signal never fires for them.
+  // So we gate on the actual token instead: while we're authenticated and this
+  // conversation is in the not-found state, poll TokenManager.getToken() (what
+  // apiFetch itself uses) until a real token exists, then re-seed exactly once.
+  // `authRecoveredRef` keys the one-shot to the searchId so a genuinely private
+  // (someone else's) chat can't loop.
+  const authRecoveredRef = useRef<string | null>(null);
   useEffect(() => {
-    const hadAddress = prevAddressRef.current;
-    prevAddressRef.current = address;
-    const authJustReady = authenticated && Boolean(address) && !hadAddress;
-    if (!authJustReady || !searchId) return;
-    const store = usePhilanthropyStore.getState();
-    const alreadyLoaded = store.threadId === searchId && store.messages.length > 0;
-    if (alreadyLoaded) return;
-    seededSearchIdRef.current = null;
-    store.setNotFound(false);
-    setReseedKey((k) => k + 1);
-  }, [authenticated, address, searchId]);
+    if (!authenticated || !searchId) return;
+    if (authRecoveredRef.current === searchId) return;
+    if (!usePhilanthropyStore.getState().notFound) return;
+    let cancelled = false;
+    (async () => {
+      for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
+        const token = await TokenManager.getToken();
+        if (cancelled) return;
+        if (token) {
+          if (authRecoveredRef.current === searchId) return;
+          authRecoveredRef.current = searchId;
+          seededSearchIdRef.current = null;
+          usePhilanthropyStore.getState().setNotFound(false);
+          setReseedKey((k) => k + 1);
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, searchId]);
 
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -148,6 +148,8 @@ export function ChatView({ searchId }: { searchId?: string }) {
   // enough: navigating between two session URLs reuses the same instance
   // (same dynamic segment), so the ref must be keyed by session.
   const seededSearchIdRef = useRef<string | null>(null);
+  // Bumped to force the seeding effect to re-run after sign-in (see below).
+  const [reseedKey, setReseedKey] = useState(0);
 
   // Seed the thread for the session in the URL. The philanthropy store is
   // global and survives client-side navigation, so arriving here can mean:
@@ -251,7 +253,8 @@ export function ChatView({ searchId }: { searchId?: string }) {
     // re-runs this effect while `searchId` is still the OLD id — re-seeding it
     // and re-fetching the old conversation, which flashes empty then snaps back
     // to the previous search. The count is still read fresh via getState above.
-  }, [searchId, search, abort, reset]);
+    // `reseedKey` is the one allowed re-trigger: it fires only on sign-in (below).
+  }, [searchId, search, abort, reset, reseedKey]);
 
   // The free-limit prompt is only set for logged-out users; once they sign in,
   // restore the composer so they can continue.
@@ -260,6 +263,26 @@ export function ChatView({ searchId }: { searchId?: string }) {
       usePhilanthropyStore.getState().setLoginRequired(false);
     }
   }, [authenticated, loginRequired]);
+
+  // Re-seed on sign-in. Opening a conversation that's private to your account
+  // while logged out fails getById (403 → "Conversation not found"); the saved
+  // chat only becomes readable once authenticated, but the seeding effect keys
+  // on `searchId` and wouldn't otherwise re-fetch — so the user had to refresh.
+  // On the logged-out→in transition, drop this instance's seed mark + not-found
+  // state and bump `reseedKey` to re-run the fetch. Guarded so it never disturbs
+  // a conversation that's already loaded (covers a Privy auth flip mid-chat).
+  const wasAuthenticatedRef = useRef(authenticated);
+  useEffect(() => {
+    const justSignedIn = authenticated && !wasAuthenticatedRef.current;
+    wasAuthenticatedRef.current = authenticated;
+    if (!justSignedIn || !searchId) return;
+    const store = usePhilanthropyStore.getState();
+    const alreadyLoaded = store.threadId === searchId && store.messages.length > 0;
+    if (alreadyLoaded) return;
+    seededSearchIdRef.current = null;
+    store.setNotFound(false);
+    setReseedKey((k) => k + 1);
+  }, [authenticated, searchId]);
 
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -138,7 +138,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const loginRequired = usePhilanthropyStore((s) => s.loginRequired);
   const reset = usePhilanthropyStore((s) => s.reset);
   const { search, abort } = usePhilanthropySearch();
-  const { authenticated, login } = useAuth();
+  const { authenticated, address, login } = useAuth();
   const router = useRouter();
 
   const [input, setInput] = useState("");
@@ -264,25 +264,30 @@ export function ChatView({ searchId }: { searchId?: string }) {
     }
   }, [authenticated, loginRequired]);
 
-  // Re-seed on sign-in. Opening a conversation that's private to your account
-  // while logged out fails getById (403 → "Conversation not found"); the saved
-  // chat only becomes readable once authenticated, but the seeding effect keys
-  // on `searchId` and wouldn't otherwise re-fetch — so the user had to refresh.
-  // On the logged-out→in transition, drop this instance's seed mark + not-found
-  // state and bump `reseedKey` to re-run the fetch. Guarded so it never disturbs
-  // a conversation that's already loaded (covers a Privy auth flip mid-chat).
-  const wasAuthenticatedRef = useRef(authenticated);
+  // Re-seed once auth is READY. Opening a conversation that's private to your
+  // account while logged out fails getById (403 → "Conversation not found"); the
+  // saved chat only becomes readable once authenticated, but the seeding effect
+  // keys on `searchId` and wouldn't otherwise re-fetch — so the user had to
+  // refresh. We must wait for the wallet `address`, NOT just `authenticated`:
+  // Privy flips `authenticated` true before the address/token hydrate, so a
+  // refetch fired on `authenticated` alone still 401s and the not-found state
+  // sticks (see useAuth's AUTH-READY REFETCH BARRIER). When the address first
+  // becomes available, drop this instance's seed mark + not-found state and bump
+  // `reseedKey` to re-run the fetch with auth in place. Guarded so it never
+  // disturbs a conversation that's already loaded.
+  const prevAddressRef = useRef(address);
   useEffect(() => {
-    const justSignedIn = authenticated && !wasAuthenticatedRef.current;
-    wasAuthenticatedRef.current = authenticated;
-    if (!justSignedIn || !searchId) return;
+    const hadAddress = prevAddressRef.current;
+    prevAddressRef.current = address;
+    const authJustReady = authenticated && Boolean(address) && !hadAddress;
+    if (!authJustReady || !searchId) return;
     const store = usePhilanthropyStore.getState();
     const alreadyLoaded = store.threadId === searchId && store.messages.length > 0;
     if (alreadyLoaded) return;
     seededSearchIdRef.current = null;
     store.setNotFound(false);
     setReseedKey((k) => k + 1);
-  }, [authenticated, searchId]);
+  }, [authenticated, address, searchId]);
 
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -148,6 +148,16 @@ export function ChatView({ searchId }: { searchId?: string }) {
   const { authenticated, login } = useAuth();
   const router = useRouter();
 
+  // `search`/`abort` identities churn — `search` depends on React Query mutations
+  // and `authenticated`. The seeding effect reads them through refs so a mere
+  // identity change can't re-run it. Without this, reset() during "New chat"
+  // re-fires seeding against the still-current (old) searchId — router.replace is
+  // async — and re-fetches the old conversation onto the new URL.
+  const searchRef = useRef(search);
+  searchRef.current = search;
+  const abortRef = useRef(abort);
+  abortRef.current = abort;
+
   const [input, setInput] = useState("");
   const [trayOpen, setTrayOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -182,7 +192,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
     seededSearchIdRef.current = searchId;
     if (decision === "adopt-existing-thread") return;
     if (decision === "reset-then-seed") {
-      abort();
+      abortRef.current();
       reset();
     }
     usePhilanthropyStore.getState().setThreadId(searchId);
@@ -196,7 +206,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
     // visit to the same URL takes the hydration path below instead of
     // re-running the search.
     if (sessionStore.consumeFresh(searchId)) {
-      if (localQuery) void search(localQuery, 1, { chat: true });
+      if (localQuery) void searchRef.current(localQuery, 1, { chat: true });
       return;
     }
     // Revisit / shared link: fetch the saved conversation and act on the result
@@ -226,7 +236,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
           return;
         }
         case "reconstruct":
-          void search(action.query, 1, { chat: true });
+          void searchRef.current(action.query, 1, { chat: true });
           return;
         case "not-found":
           usePhilanthropyStore.getState().setNotFound(true);
@@ -256,14 +266,14 @@ export function ChatView({ searchId }: { searchId?: string }) {
           })
         )
     );
-    // Keyed on `searchId` only. `messages.length` must NOT be a dependency:
-    // "New chat" calls reset() (clearing messages) and then router.replace() to
-    // the new session, but the replace is async, so a messages.length trigger
-    // re-runs this effect while `searchId` is still the OLD id — re-seeding it
-    // and re-fetching the old conversation, which flashes empty then snaps back
-    // to the previous search. The count is still read fresh via getState above.
-    // `reseedKey` is the one allowed re-trigger: it fires only on sign-in (below).
-  }, [searchId, search, abort, reset, reseedKey]);
+    // Keyed on `searchId` + `reseedKey` ONLY. `messages.length`, `search`, and
+    // `abort` must NOT be dependencies: "New chat" calls reset() then an async
+    // router.replace(), so any of those changing (a cleared count, or a churned
+    // search/abort identity) re-runs this effect while `searchId` is still the
+    // OLD id — re-seeding it and re-fetching the old conversation onto the new
+    // URL. The count is read fresh via getState; search/abort via refs.
+    // `reseedKey` is the one allowed re-trigger: it fires only on sign-in.
+  }, [searchId, reset, reseedKey]);
 
   // Recover a blocked conversation after sign-in. Opening one while logged out
   // leaves it in one of two auth-recoverable states that used to stick until a

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -194,6 +194,12 @@ export function ChatView({ searchId }: { searchId?: string }) {
     // fetch (our own unpersisted chat, or an anonymous user who can't read
     // history). See `lib/revisit-action.ts`.
     const apply = (action: RevisitAction, entry?: SearchHistoryDetail) => {
+      // Stale-resolution guard: `getById` is async and uncancellable. If the
+      // session changed while it was in flight (e.g. "New chat" or switching
+      // history items), this instance has already re-seeded a different id —
+      // dropping the late result keeps it from hydrating the old conversation
+      // back into the current session.
+      if (seededSearchIdRef.current !== searchId) return;
       switch (action.kind) {
         case "hydrate":
           if (!entry) return;
@@ -239,7 +245,13 @@ export function ChatView({ searchId }: { searchId?: string }) {
           })
         )
     );
-  }, [searchId, messages.length, search, abort, reset]);
+    // Keyed on `searchId` only. `messages.length` must NOT be a dependency:
+    // "New chat" calls reset() (clearing messages) and then router.replace() to
+    // the new session, but the replace is async, so a messages.length trigger
+    // re-runs this effect while `searchId` is still the OLD id — re-seeding it
+    // and re-fetching the old conversation, which flashes empty then snaps back
+    // to the previous search. The count is still read fresh via getState above.
+  }, [searchId, search, abort, reset]);
 
   // The free-limit prompt is only set for logged-out users; once they sign in,
   // restore the composer so they can continue.

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -257,54 +257,55 @@ export function ChatView({ searchId }: { searchId?: string }) {
     // `reseedKey` is the one allowed re-trigger: it fires only on sign-in (below).
   }, [searchId, search, abort, reset, reseedKey]);
 
-  // The free-limit prompt is only set for logged-out users; once they sign in,
-  // restore the composer so they can continue.
-  useEffect(() => {
-    if (authenticated && loginRequired) {
-      usePhilanthropyStore.getState().setLoginRequired(false);
-    }
-  }, [authenticated, loginRequired]);
-
-  // Recover a private conversation after sign-in. Opening a chat that's private
-  // to your account while logged out fails getById (403 → "Conversation not
-  // found"); it only becomes readable once authenticated. But two Privy quirks
-  // make a naive `authenticated`-transition refetch unreliable, which is why the
-  // not-found state used to stick until a manual refresh:
-  //   1. `authenticated` flips true BEFORE the JWT is minted, and it flickers
-  //      for ~10-15s while Privy/wagmi sync — a one-shot transition latches on
-  //      the first (token-less) blip and never retries.
-  //   2. Some login methods (email/social) never expose a wallet address, so a
-  //      wallet-address signal never fires for them.
-  // So we gate on the actual token instead: while we're authenticated and this
-  // conversation is in the not-found state, poll TokenManager.getToken() (what
-  // apiFetch itself uses) until a real token exists, then re-seed exactly once.
-  // `authRecoveredRef` keys the one-shot to the searchId so a genuinely private
-  // (someone else's) chat can't loop.
+  // Recover a blocked conversation after sign-in. Opening one while logged out
+  // leaves it in one of two auth-recoverable states that used to stick until a
+  // manual refresh:
+  //   - `notFound`: a chat private to your account 403s on getById.
+  //   - `loginRequired`: a chat the seeding effect tried to reconstruct hit the
+  //     agent's anonymous limit (401) → "Sign in to continue your search."
+  // Both become resolvable once authenticated, but a naive `authenticated`
+  // refetch is unreliable: Privy flips `authenticated` true BEFORE the JWT is
+  // minted and flickers for ~10-15s during the wagmi sync, and email/social
+  // logins never expose a wallet address. So we gate on the actual token —
+  // polling TokenManager.getToken() (exactly what apiFetch uses) until a real
+  // JWT exists — then recover exactly once. `authRecoveredRef` keys the one-shot
+  // to the searchId so a genuinely private (someone else's) chat can't loop.
   const authRecoveredRef = useRef<string | null>(null);
   useEffect(() => {
     if (!authenticated || !searchId) return;
+    if (!notFound && !loginRequired) return;
     if (authRecoveredRef.current === searchId) return;
-    if (!usePhilanthropyStore.getState().notFound) return;
     let cancelled = false;
     (async () => {
       for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
         const token = await TokenManager.getToken();
         if (cancelled) return;
-        if (token) {
-          if (authRecoveredRef.current === searchId) return;
-          authRecoveredRef.current = searchId;
-          seededSearchIdRef.current = null;
-          usePhilanthropyStore.getState().setNotFound(false);
-          setReseedKey((k) => k + 1);
+        if (!token) {
+          await new Promise((resolve) => setTimeout(resolve, 400));
+          continue;
+        }
+        if (authRecoveredRef.current === searchId) return;
+        authRecoveredRef.current = searchId;
+        const store = usePhilanthropyStore.getState();
+        // A readable conversation is already loaded — the block was only the
+        // composer lock from an anonymous "continue" attempt. Unlock and keep it.
+        if (store.messages.some((turn) => turn.status === "done")) {
+          store.setLoginRequired(false);
           return;
         }
-        await new Promise((resolve) => setTimeout(resolve, 400));
+        // Nothing usable is loaded (private 403, or an anonymous-limit error
+        // turn): re-seed from a clean slate now that auth is in place. reset()
+        // also clears notFound/loginRequired.
+        store.reset();
+        seededSearchIdRef.current = null;
+        setReseedKey((k) => k + 1);
+        return;
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [authenticated, searchId]);
+  }, [authenticated, searchId, notFound, loginRequired]);
 
   const onSubmit = useCallback(
     (msg: PromptInputMessage) => {

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -60,6 +60,12 @@ import { ProgressView } from "./progress-view";
 import { SearchFeedback } from "./search-feedback";
 import { SearchHistoryPanel } from "./search-history-panel";
 
+// Sign-in recovery polls for the auth JWT. The Privy↔wagmi sync can lag the
+// token by ~10-15s, so poll across a window that comfortably covers it rather
+// than giving up early and leaving the chat stuck until a manual refresh.
+const AUTH_RECOVERY_POLL_INTERVAL_MS = 400;
+const AUTH_RECOVERY_POLL_TIMEOUT_MS = 16_000;
+
 // ── Inline starter prompts (LOCKED decision — do NOT use suggested-queries.tsx) ──
 
 const STARTER_PROMPTS = [
@@ -279,7 +285,7 @@ export function ChatView({ searchId }: { searchId?: string }) {
     if (authRecoveredRef.current === searchId) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
-    let attempts = 0;
+    const pollDeadline = Date.now() + AUTH_RECOVERY_POLL_TIMEOUT_MS;
     const recover = () => {
       if (authRecoveredRef.current === searchId) return;
       authRecoveredRef.current = searchId;
@@ -303,9 +309,8 @@ export function ChatView({ searchId }: { searchId?: string }) {
         if (cancelled) return;
         if (token) {
           recover();
-        } else if (attempts < 8) {
-          attempts += 1;
-          timer = setTimeout(tryRecover, 400);
+        } else if (Date.now() < pollDeadline) {
+          timer = setTimeout(tryRecover, AUTH_RECOVERY_POLL_INTERVAL_MS);
         }
       });
     };


### PR DESCRIPTION
Three related fixes to the find-funders AI chat (`/nonprofits/find-funders/search/[id]`). Consolidates #1676 and #1677.

---

## 1. Markdown: tables rendered as raw pipes; `~` struck through text

AI narratives render through `MessageResponse` → Streamdown.

- **Tables shown as `| pipes |`.** Streamdown enables `remark-gfm` by default, but passing a custom `remarkPlugins` array (NarrativeBlock adds URL autolinking) **replaces** that default rather than extending it, silently dropping table support. `MessageResponse` now always merges `remark-gfm` into whatever a consumer passes.
- **A lone `~` struck through text** (e.g. `~$182K … ~$20K average`). `@streamdown/cjk` injects its own CJK-aware strikethrough plugin via `remarkPluginsAfter` that defaults to single-tilde strikethrough, independent of the remark-gfm config. Reconfigured both to require `~~double~~` tildes (`singleTilde: false`).

## 2. "New chat" bounced back to the previous search

`onNewChat` calls `reset()` then `router.replace(newId)` — but the replace is async. The seeding effect depended on `messages.length`, so `reset()` re-fired it while `searchId` was still the OLD id, re-fetching and re-hydrating the old conversation (empty flash → old search returns). Fixed by keying the seeding effect on `searchId` only (the turn count is still read fresh via `getState`), plus a stale-resolution guard on the async `getById`.

## 3. Private conversation didn't appear after sign-in

Opening a search private to your account while logged out 403s (`getById` → "Conversation not found"). The saved chat only becomes readable once authenticated, but the seeding effect keys on `searchId`, so signing in didn't re-fetch — you had to refresh. Added a sign-in transition effect that drops the seed mark + not-found state and bumps a dedicated `reseedKey` to re-run the fetch, guarded so it never disturbs an already-loaded chat.

---

## Testing

- Real-render markdown tests (Streamdown not mocked): tables → `<table>`, single `~` literal, `~~double~~` still strikes.
- Two ChatView regression tests, each **verified to fail against the buggy code**: "New chat" must not re-fetch the old conversation; sign-in must re-fetch a private conversation and clear not-found.
- Full non-profits + ai-elements suites green (238 tests). Biome + tsc clean.

### Manual QA
- Find-funders search page: funder table renders; dollar approximations not struck through.
- From a loaded conversation, **New chat** → clean composer that stays put.
- Open your own private search logged out, then sign in → conversation appears without a refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Markdown rendering for single tildes in message responses (single tildes now render as intended; strikethrough only applies to double tildes).
  * Fixed chat recovery when signing in after attempting to access a private conversation.
  * Fixed "New Chat" functionality to prevent accidental re-loading of the previous conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->