### PR TITLE
fix(wallet): guard connector connection before acquiring wallet client

### DIFF
--- a/utilities/__tests__/wallet-helpers.test.ts
+++ b/utilities/__tests__/wallet-helpers.test.ts
@@ -1,9 +1,19 @@
 import { safeGetWalletClient } from "../wallet-helpers";
 
-vi.mock("@wagmi/core", () => ({
-  getWalletClient: vi.fn(),
-  reconnect: vi.fn(),
-}));
+vi.mock("@wagmi/core", () => {
+  class MockConnectorNotConnectedError extends Error {
+    constructor() {
+      super("Connector not connected.");
+      this.name = "ConnectorNotConnectedError";
+    }
+  }
+  return {
+    getWalletClient: vi.fn(),
+    reconnect: vi.fn(),
+    getAccount: vi.fn(),
+    ConnectorNotConnectedError: MockConnectorNotConnectedError,
+  };
+});
 
 vi.mock("@/components/Utilities/errorManager", () => ({
   errorManager: vi.fn(),
@@ -13,61 +23,155 @@ vi.mock("../wagmi/privy-config", () => ({
   privyConfig: {},
 }));
 
-import { getWalletClient, reconnect } from "@wagmi/core";
+import { ConnectorNotConnectedError, getAccount, getWalletClient, reconnect } from "@wagmi/core";
+import { errorManager } from "@/components/Utilities/errorManager";
 
 const mockGetWalletClient = getWalletClient as vi.MockedFunction<typeof getWalletClient>;
 const mockReconnect = reconnect as vi.MockedFunction<typeof reconnect>;
+const mockGetAccount = getAccount as vi.MockedFunction<typeof getAccount>;
+const mockErrorManager = errorManager as vi.MockedFunction<typeof errorManager>;
+
+const connectedAccount = { status: "connected" } as any;
+const disconnectedAccount = { status: "disconnected" } as any;
 
 describe("safeGetWalletClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
     mockReconnect.mockResolvedValue([]);
+    // Default: connector is connected (no startup race).
+    mockGetAccount.mockReturnValue(connectedAccount);
   });
 
-  it("returns wallet client on success", async () => {
-    const mockClient = { account: { address: "0x123" }, chain: { id: 137 } } as any;
-    mockGetWalletClient.mockResolvedValueOnce(mockClient);
-
-    const result = await safeGetWalletClient(137);
-
-    expect(result.walletClient).toBe(mockClient);
-    expect(result.error).toBeNull();
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it("returns error when getWalletClient throws", async () => {
-    mockGetWalletClient.mockRejectedValueOnce(new Error("Connector not connected"));
+  describe("success", () => {
+    it("returns wallet client on success", async () => {
+      const mockClient = {
+        account: { address: "0x123" },
+        chain: { id: 137 },
+      } as any;
+      mockGetWalletClient.mockResolvedValueOnce(mockClient);
 
-    const result = await safeGetWalletClient(137);
+      const result = await safeGetWalletClient(137);
 
-    expect(result.walletClient).toBeNull();
-    expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(result.walletClient).toBe(mockClient);
+      expect(result.error).toBeNull();
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    });
+
+    it("does not call setLoadingState on success", async () => {
+      const setLoadingState = vi.fn();
+      const mockClient = {
+        account: { address: "0x123" },
+        chain: { id: 137 },
+      } as any;
+      mockGetWalletClient.mockResolvedValueOnce(mockClient);
+
+      await safeGetWalletClient(137, false, setLoadingState);
+
+      expect(setLoadingState).not.toHaveBeenCalled();
+    });
   });
 
-  it("returns error when getWalletClient returns null", async () => {
-    mockGetWalletClient.mockResolvedValueOnce(null as any);
+  describe("connector startup race (transient, not reported)", () => {
+    it("reconnects and acquires the client when the connector connects after a poll", async () => {
+      // Disconnected at first, then connected after reconnect/poll.
+      mockGetAccount
+        .mockReturnValueOnce(disconnectedAccount) // initial guard check
+        .mockReturnValue(connectedAccount); // after reconnect
+      const mockClient = { chain: { id: 137 } } as any;
+      mockGetWalletClient.mockResolvedValueOnce(mockClient);
 
-    const result = await safeGetWalletClient(137);
+      const promise = safeGetWalletClient(137);
+      await vi.runAllTimersAsync();
+      const result = await promise;
 
-    expect(result.walletClient).toBeNull();
-    expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(mockReconnect).toHaveBeenCalled();
+      expect(result.walletClient).toBe(mockClient);
+      expect(result.error).toBeNull();
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    });
+
+    it("returns a typed not-connected result without reporting when the connector never connects", async () => {
+      mockGetAccount.mockReturnValue(disconnectedAccount);
+
+      const promise = safeGetWalletClient(137);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.walletClient).toBeNull();
+      expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(mockGetWalletClient).not.toHaveBeenCalled();
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    });
+
+    it("does not report ConnectorNotConnectedError thrown by getWalletClient after the guard passes", async () => {
+      mockGetWalletClient.mockRejectedValueOnce(new (ConnectorNotConnectedError as any)());
+
+      const promise = safeGetWalletClient(137);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.walletClient).toBeNull();
+      expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(mockErrorManager).not.toHaveBeenCalled();
+    });
+
+    it("calls setLoadingState(false) when the connector never connects", async () => {
+      const setLoadingState = vi.fn();
+      mockGetAccount.mockReturnValue(disconnectedAccount);
+
+      const promise = safeGetWalletClient(137, false, setLoadingState);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(setLoadingState).toHaveBeenCalledWith(false);
+    });
   });
 
-  it("calls setLoadingState(false) on failure", async () => {
-    const setLoadingState = vi.fn();
-    mockGetWalletClient.mockRejectedValueOnce(new Error("Failed"));
+  describe("genuine failures (reported)", () => {
+    it("reports when getWalletClient returns null", async () => {
+      mockGetWalletClient.mockResolvedValueOnce(null as any);
 
-    await safeGetWalletClient(137, false, setLoadingState);
+      const result = await safeGetWalletClient(137);
 
-    expect(setLoadingState).toHaveBeenCalledWith(false);
-  });
+      expect(result.walletClient).toBeNull();
+      expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(mockErrorManager).toHaveBeenCalledWith("Wallet client error", expect.any(Error), {
+        chainId: 137,
+      });
+    });
 
-  it("does not call setLoadingState on success", async () => {
-    const setLoadingState = vi.fn();
-    const mockClient = { account: { address: "0x123" }, chain: { id: 137 } } as any;
-    mockGetWalletClient.mockResolvedValueOnce(mockClient);
+    it("reports a genuine provider error and calls setLoadingState", async () => {
+      const setLoadingState = vi.fn();
+      mockGetWalletClient.mockRejectedValueOnce(new Error("Provider exploded"));
 
-    await safeGetWalletClient(137, false, setLoadingState);
+      const promise = safeGetWalletClient(137, false, setLoadingState);
+      await vi.runAllTimersAsync();
+      const result = await promise;
 
-    expect(setLoadingState).not.toHaveBeenCalled();
+      expect(result.walletClient).toBeNull();
+      expect(result.error).toBe("Failed to connect to wallet. Please try again.");
+      expect(setLoadingState).toHaveBeenCalledWith(false);
+      expect(mockErrorManager).toHaveBeenCalledWith("Wallet client error", expect.any(Error), {
+        chainId: 137,
+      });
+    });
+
+    it("reports and surfaces the wrong-chain error after reconnect fails to fix it", async () => {
+      const wrongChainClient = { chain: { id: 1 } } as any;
+      mockGetWalletClient.mockResolvedValue(wrongChainClient);
+
+      const promise = safeGetWalletClient(137);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.walletClient).toBeNull();
+      expect(result.error).toContain("expected 137");
+      expect(mockErrorManager).toHaveBeenCalled();
+    });
   });
 });

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -24,6 +24,15 @@ const walletProviderErrors = [
   "Failed to connect to MetaMask",
 ];
 
+// wagmi throws `ConnectorNotConnectedError: Connector not connected.` when a
+// wallet client is requested before the connector finishes connecting. This is
+// the documented Privy↔wagmi startup race (Privy reports authenticated while
+// wagmi is still reconnecting). `safeGetWalletClient` now guards/reconnects and
+// no longer routes this through `errorManager`; this entry is defense-in-depth
+// for any other code path that surfaces it.
+// See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-244
+const connectorStartupRaceErrors = ["Connector not connected", "ConnectorNotConnectedError"];
+
 const browserExtensionErrors = [
   // Browser extensions disconnecting ports (Chrome extensions, wallet extensions)
   // See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-1BA
@@ -81,6 +90,7 @@ export const sentryIgnoreErrors = [
   ...unsupportedWalletErrors,
   ...walletConnectErrors,
   ...walletProviderErrors,
+  ...connectorStartupRaceErrors,
   ...browserExtensionErrors,
   ...sentryInstrumentationErrors,
   ...notFoundErrors,

--- a/utilities/wallet-helpers.ts
+++ b/utilities/wallet-helpers.ts
@@ -1,11 +1,65 @@
-import { getWalletClient, reconnect } from "@wagmi/core";
+import { ConnectorNotConnectedError, getAccount, getWalletClient, reconnect } from "@wagmi/core";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { privyConfig as config } from "./wagmi/privy-config";
 
+const CONNECT_RETRIES = 5;
+const CONNECT_RETRY_DELAY_MS = 500;
+
+/**
+ * Detects the transient "connector not connected" condition.
+ * During startup Privy and wagmi initialize independently, so the wagmi
+ * connector can briefly be disconnected while Privy already reports the user
+ * as authenticated. `getWalletClient` throws `ConnectorNotConnectedError` in
+ * that window. This is an expected startup race the user never sees, not a
+ * genuine wallet failure, so it must not be reported to Sentry.
+ */
+const isConnectorNotConnectedError = (error: unknown): boolean => {
+  if (error instanceof ConnectorNotConnectedError) {
+    return true;
+  }
+  return error instanceof Error && error.message.includes("Connector not connected");
+};
+
+/**
+ * Ensures the wagmi connector is connected, reconnecting and polling if needed.
+ * Returns true once the account reaches the "connected" status, false if it
+ * never connects within the bounded retry window.
+ */
+const ensureConnectorConnected = async (): Promise<boolean> => {
+  if (getAccount(config).status === "connected") {
+    return true;
+  }
+
+  // The connector is not connected yet (Privy↔wagmi startup race or a stale
+  // connector after a chain switch). Force wagmi to re-establish connector
+  // state, then poll until it reports connected.
+  try {
+    await reconnect(config);
+  } catch {
+    // Reconnect can fail if already connected/connecting — safe to ignore;
+    // the poll below verifies the final state.
+  }
+
+  let retries = CONNECT_RETRIES;
+  while (retries > 0 && getAccount(config).status !== "connected") {
+    await new Promise((resolve) => setTimeout(resolve, CONNECT_RETRY_DELAY_MS));
+    retries--;
+  }
+
+  return getAccount(config).status === "connected";
+};
+
 /**
  * Safely gets a wallet client with error handling for common issues.
- * After a chain switch, the wagmi wallet client cache can be stale.
- * This function reconnects and retries if the returned client is on the wrong chain.
+ *
+ * Guards on connector connection state before acquiring the client: during the
+ * Privy↔wagmi startup race the connector may not be connected yet, which makes
+ * `getWalletClient` throw `ConnectorNotConnectedError`. That is a transient
+ * startup condition, so it is reconnected/polled for and, if it never resolves,
+ * returned as a typed not-connected result without reporting to Sentry.
+ *
+ * After a chain switch, the wagmi wallet client cache can be stale. This
+ * function reconnects and retries if the returned client is on the wrong chain.
  *
  * @param chainId The chain ID to connect to
  * @param showToast Whether to show toast messages for errors (default: false)
@@ -16,7 +70,24 @@ export const safeGetWalletClient = async (
   chainId: number,
   _showToast: boolean = false,
   setLoadingState?: (state: boolean) => void
-) => {
+): Promise<{
+  walletClient: Awaited<ReturnType<typeof getWalletClient>> | null;
+  error: string | null;
+}> => {
+  // Wait for the connector before acquiring a client so we never throw
+  // ConnectorNotConnectedError during the Privy↔wagmi startup race.
+  const connected = await ensureConnectorConnected();
+  if (!connected) {
+    // Transient startup condition the user never sees — do NOT report to Sentry.
+    if (setLoadingState) {
+      setLoadingState(false);
+    }
+    return {
+      walletClient: null,
+      error: "Failed to connect to wallet. Please try again.",
+    };
+  }
+
   try {
     let walletClient = await getWalletClient(config, {
       chainId,
@@ -36,9 +107,9 @@ export const safeGetWalletClient = async (
         // Reconnect can fail if already connected — safe to ignore
       }
 
-      let retries = 5;
+      let retries = CONNECT_RETRIES;
       while (retries > 0 && walletClient.chain?.id !== chainId) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        await new Promise((resolve) => setTimeout(resolve, CONNECT_RETRY_DELAY_MS));
         walletClient = await getWalletClient(config, { chainId });
         retries--;
       }
@@ -52,17 +123,28 @@ export const safeGetWalletClient = async (
 
     return { walletClient, error: null };
   } catch (error: unknown) {
-    // Use errorManager to track the error
+    if (setLoadingState) {
+      setLoadingState(false);
+    }
+
+    // The connector can disconnect again between the guard above and the call
+    // (or mid-retry). This is the same transient startup race, not a genuine
+    // failure, so it must not be reported to Sentry.
+    if (isConnectorNotConnectedError(error)) {
+      return {
+        walletClient: null,
+        error: "Failed to connect to wallet. Please try again.",
+      };
+    }
+
+    // Use errorManager to track genuine errors (wrong chain after reconnect,
+    // real provider failures).
     errorManager("Wallet client error", error, { chainId });
 
     const errorMsg =
       error instanceof Error && error.message.includes("expected")
         ? error.message
         : "Failed to connect to wallet. Please try again.";
-
-    if (setLoadingState) {
-      setLoadingState(false);
-    }
 
     return {
       walletClient: null,

--- a/utilities/wallet-helpers.ts
+++ b/utilities/wallet-helpers.ts
@@ -13,12 +13,8 @@ const CONNECT_RETRY_DELAY_MS = 500;
  * that window. This is an expected startup race the user never sees, not a
  * genuine wallet failure, so it must not be reported to Sentry.
  */
-const isConnectorNotConnectedError = (error: unknown): boolean => {
-  if (error instanceof ConnectorNotConnectedError) {
-    return true;
-  }
-  return error instanceof Error && error.message.includes("Connector not connected");
-};
+const isConnectorNotConnectedError = (error: unknown): boolean =>
+  error instanceof ConnectorNotConnectedError;
 
 /**
  * Ensures the wagmi connector is connected, reconnecting and polling if needed.


### PR DESCRIPTION
Fixes #1683

## Summary
Fixed issue #1683: ConnectorNotConnectedError leaking to Sentry from safeGetWalletClient during the Privy/wagmi startup race. The function previously called getWalletClient() with no connection guard; when the wagmi connector was not yet connected it threw ConnectorNotConnectedError, was caught, and reported via errorManager("Wallet client error") even though it is a transient startup condition the user never sees.

Definitive fix in utilities/wallet-helpers.ts: added ensureConnectorConnected() which checks getAccount(config).status before acquiring the client; if not connected it calls reconnect(config) and polls (bounded, reusing the existing 5x500ms style) until connected. If it never connects it returns a typed { walletClient: null, error } WITHOUT calling errorManager. Also added isConnectorNotConnectedError() so that if the connector disconnects again between the guard and the getWalletClient call (or mid-retry), that transient error is classified as expected and not reported. Genuine failures (null client, wrong chain after reconnect, real provider errors) still flow through errorManager unchanged. The existing wrong-chain retry path and the { walletClient, error } return contract (consumed by hooks/useGaslessSigner.ts, useZeroDevSigner.ts, ensureCorrectChain.ts, etc.) are preserved.

Added defense-in-depth Sentry filtering in utilities/sentry/ignoreErrors.ts (connectorStartupRaceErrors: "Connector not connected" / "ConnectorNotConnectedError") for any other code path that surfaces the same race.

## Root cause
See issue #1683 for the full Sentry analysis.

## Why this is a definitive fix
This is a root-cause fix, not a workaround. The root cause is that safeGetWalletClient acquired the wallet client unconditionally, ignoring connector connection state, so the documented Privy/wagmi init race produced a hard throw that was misclassified as a real error. The fix addresses both halves: (1) it actively resolves the race by reconnecting and polling on connection state before acquiring the client (the connector typically becomes connected, so the user-facing flow now succeeds where it previously failed), and (2) it correctly classifies the genuinely transient case as expected rather than reporting it. Sentry muting was added only as defense-in-depth in addition to the real fix, not as the fix itself. Genuine error reporting (wrong chain, provider failures, null client) is fully preserved, verified by tests.

## Files changed
- utilities/wallet-helpers.ts
- utilities/sentry/ignoreErrors.ts
- utilities/__tests__/wallet-helpers.test.ts

## Testing
Lint: `pnpm exec biome check utilities/wallet-helpers.ts utilities/sentry/ignoreErrors.ts utilities/__tests__/wallet-helpers.test.ts` -> 'Checked 3 files. No fixes applied.' (clean). Typecheck: `pnpm typecheck` (tsc --noEmit) -> 0 errors, fully green. Unit tests: `pnpm exec vitest run --project unit utilities/__tests__/wallet-helpers.test.ts` -> 1 file passed, 9 tests passed. New/updated tests cover: success path (no errorManager); connector reconnect+poll then success (no errorManager); connector never connects -> typed not-connected result, getWalletClient never called, no errorManager, setLoadingState(false) called; ConnectorNotConnectedError thrown by getWalletClient after guard -> not reported; genuine failures (null client, provider error, wrong chain after reconnect) -> errorManager called and error surfaced.
