### PR TITLE
fix(project-create): retry transient wallet timeout on attestation send

### DIFF
--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -56,6 +56,7 @@ import { useSimilarProjectsModalStore } from "@/store/modals/similarProjects";
 import { useOwnerStore } from "@/store/owner";
 import type { Contact } from "@/types/project";
 import type { Project as ProjectResponse } from "@/types/v2/project";
+import { attestWithRetry } from "@/utilities/attestWithRetry";
 import { type CustomLink, isCustomLink } from "@/utilities/customLink";
 import { walletClientToSigner } from "@/utilities/eas-wagmi-utils";
 import fetchData from "@/utilities/fetchData";
@@ -642,7 +643,19 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
 
       // Use the gasless signer from setupChainAndWallet
       // Keep modal open while submitting so users don't lose context/data.
-      await project.attest(signer as any, changeStepperStep).then(async (res) => {
+      //
+      // Retry the send on a transient wallet/bundler timeout (GAP-FRONTEND-1Y2:
+      // ethers "could not coalesce error" / "Wallet timeout"). The idempotency
+      // guard checks whether the timed-out attempt already landed (the slug is
+      // deterministic and is the project's indexed identifier) so we never
+      // double-create on a recovered timeout.
+      const projectSlugIdentifier = slug || project.uid;
+      const { result: res } = await attestWithRetry({
+        send: () => project.attest(signer as any, changeStepperStep),
+        hasAlreadyLanded: () => checkSlugExists(projectSlugIdentifier),
+      });
+
+      {
         showLoading("Indexing project...");
         let retries = 1000;
         const txHash = res?.tx[0]?.hash;
@@ -652,7 +665,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         let fetchedProject: ProjectResponse | null = null;
 
         // First, poll using checkSlugExists to avoid 404 errors in Sentry
-        const projectIdentifier = slug || project.uid;
+        const projectIdentifier = projectSlugIdentifier;
         while (retries > 0) {
           // eslint-disable-next-line no-await-in-loop
           const exists = await checkSlugExists(projectIdentifier);
@@ -689,7 +702,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
             router.refresh();
           }, 1500);
         }
-      });
+      }
 
       reset();
       setStep(0);

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -650,58 +650,63 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
       // deterministic and is the project's indexed identifier) so we never
       // double-create on a recovered timeout.
       const projectSlugIdentifier = slug || project.uid;
-      const { result: res } = await attestWithRetry({
+      const { result: res, recoveredByIdempotencyGuard } = await attestWithRetry({
         send: () => project.attest(signer as any, changeStepperStep),
         hasAlreadyLanded: () => checkSlugExists(projectSlugIdentifier),
       });
 
-      {
-        showLoading("Indexing project...");
-        let retries = 1000;
-        const txHash = res?.tx[0]?.hash;
-        if (txHash) {
-          await fetchData(INDEXER.ATTESTATION_LISTENER(txHash, chainId), "POST", {});
-        }
-        let fetchedProject: ProjectResponse | null = null;
+      showLoading("Indexing project...");
 
-        // First, poll using checkSlugExists to avoid 404 errors in Sentry
-        const projectIdentifier = projectSlugIdentifier;
-        while (retries > 0) {
+      // When a timed-out attempt was detected as already landed, `res` is null
+      // and we skip the ATTESTATION_LISTENER kick (there's no fresh tx hash to
+      // push) — the listener has already ingested the attestation. Either way
+      // we fall through to the same slug poll, which resolves the indexed
+      // project regardless of which send actually landed it.
+      const txHash = recoveredByIdempotencyGuard ? undefined : res?.tx[0]?.hash;
+      if (txHash) {
+        await fetchData(INDEXER.ATTESTATION_LISTENER(txHash, chainId), "POST", {});
+      }
+
+      let retries = 1000;
+      let fetchedProject: ProjectResponse | null = null;
+
+      // First, poll using checkSlugExists to avoid 404 errors in Sentry
+      const projectIdentifier = projectSlugIdentifier;
+      while (retries > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        const exists = await checkSlugExists(projectIdentifier);
+        if (exists) {
+          // Project is indexed, now fetch the full details
           // eslint-disable-next-line no-await-in-loop
-          const exists = await checkSlugExists(projectIdentifier);
-          if (exists) {
-            // Project is indexed, now fetch the full details
-            // eslint-disable-next-line no-await-in-loop
-            fetchedProject = await getProject(projectIdentifier);
-            break;
-          }
-          retries -= 1;
-          // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
-          await new Promise((resolve) => setTimeout(resolve, 1500));
+          fetchedProject = await getProject(projectIdentifier);
+          break;
+        }
+        retries -= 1;
+        // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+
+      if (fetchedProject?.uid && fetchedProject.uid !== zeroHash) {
+        const [, subscriptionError] = await fetchData(
+          INDEXER.SUBSCRIPTION.CREATE(fetchedProject.uid),
+          "POST",
+          { contacts },
+          {},
+          {},
+          true
+        );
+
+        if (subscriptionError) {
+          showError("Something went wrong with contact info save. Please try again later.");
         }
 
-        if (fetchedProject?.uid && fetchedProject.uid !== zeroHash) {
-          const [, subscriptionError] = await fetchData(
-            INDEXER.SUBSCRIPTION.CREATE(fetchedProject.uid),
-            "POST",
-            { contacts },
-            {},
-            {},
-            true
-          );
-
-          if (subscriptionError) {
-            showError("Something went wrong with contact info save. Please try again later.");
-          }
-
-          showSuccess(MESSAGES.PROJECT.CREATE.SUCCESS);
-          setTimeout(() => {
-            dismiss();
-            closeModal();
-            router.push(PAGES.PROJECT.SCREENS.NEW_GRANT(slug || project.uid));
-            router.refresh();
-          }, 1500);
-        }
+        showSuccess(MESSAGES.PROJECT.CREATE.SUCCESS);
+        setTimeout(() => {
+          dismiss();
+          closeModal();
+          router.push(PAGES.PROJECT.SCREENS.NEW_GRANT(slug || project.uid));
+          router.refresh();
+        }, 1500);
       }
 
       reset();

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,11 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
-import { isTransientHttpError, isTransientNetworkError } from "./utilities/sentry/transientErrors";
+import {
+  isTransientHttpError,
+  isTransientNetworkError,
+  isTransientWalletTimeoutError,
+} from "./utilities/sentry/transientErrors";
 import { isIndexedDbInternalError } from "./utilities/sentry/walletStorageErrors";
 
 Sentry.init({
@@ -22,6 +26,11 @@ Sentry.init({
     if (
       isTransientNetworkError(original) ||
       isTransientHttpError(original) ||
+      // ethers "could not coalesce error" / "Wallet timeout" surfaced by a
+      // transient wallet/bundler blip during attestation. Retried at the send
+      // layer; only the exhausted-retry failure reports (as a distinct wrapped
+      // error). See GAP-FRONTEND-1Y2 and ./utilities/sentry/transientErrors.ts
+      isTransientWalletTimeoutError(original) ||
       // Wallet SDKs (WalletConnect/Coinbase/base-account) leak an un-awaited
       // IndexedDB read rejection on startup when the browser's IDB store is
       // corrupted/unavailable. Environmental and not actionable from our code.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { isAttestRetryExhaustedError } from "./utilities/attestWithRetry";
 import { sentryIgnoreErrors } from "./utilities/sentry/ignoreErrors";
 import {
   isTransientHttpError,
@@ -23,13 +24,22 @@ Sentry.init({
   // DEV-271 / GAP-FRONTEND-1R1.
   beforeSend(event, hint) {
     const original = hint?.originalException;
+    // The exhausted-retry wrapper is actionable and MUST report, even though
+    // its `.cause` is a transient wallet timeout that would otherwise be
+    // dropped below. Key off the structural flag, not message wording. See
+    // GAP-FRONTEND-1Y2 and ./utilities/attestWithRetry.ts
+    if (isAttestRetryExhaustedError(original)) {
+      return event;
+    }
     if (
       isTransientNetworkError(original) ||
       isTransientHttpError(original) ||
       // ethers "could not coalesce error" / "Wallet timeout" surfaced by a
       // transient wallet/bundler blip during attestation. Retried at the send
-      // layer; only the exhausted-retry failure reports (as a distinct wrapped
-      // error). See GAP-FRONTEND-1Y2 and ./utilities/sentry/transientErrors.ts
+      // layer, so a recovered timeout never reaches here; this drops the raw
+      // signature that leaks through paths bypassing the retry (an un-awaited
+      // rejection from an abandoned attempt, a third-party SDK fetch). See
+      // GAP-FRONTEND-1Y2 and ./utilities/sentry/transientErrors.ts
       isTransientWalletTimeoutError(original) ||
       // Wallet SDKs (WalletConnect/Coinbase/base-account) leak an un-awaited
       // IndexedDB read rejection on startup when the browser's IDB store is

--- a/utilities/__tests__/attestWithRetry.test.ts
+++ b/utilities/__tests__/attestWithRetry.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @file Unit tests for attestWithRetry.
+ *
+ * Guards the bounded retry + backoff + idempotency around the project-creation
+ * attestation send (GAP-FRONTEND-1Y2). A transient wallet/bundler "Wallet
+ * timeout" surfaces as ethers' "could not coalesce error"; we retry the send,
+ * but must never double-create on a recovered timeout.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ATTEST_SEND_MAX_ATTEMPTS,
+  AttestRetryExhaustedError,
+  attestWithRetry,
+} from "@/utilities/attestWithRetry";
+import { isRetryableChainError } from "@/utilities/isRetryableChainError";
+import { isTransientWalletTimeoutError } from "@/utilities/sentry/transientErrors";
+
+const COALESCE_TIMEOUT_MESSAGE =
+  'could not coalesce error (error={ "message": "Wallet timeout" }, payload={ "method": "eth_sendTransaction" }, code=UNKNOWN_ERROR, version=6.11.0)';
+
+function makeCoalesceError(): Error {
+  return new Error(COALESCE_TIMEOUT_MESSAGE);
+}
+
+describe("attestWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Helper: drive a promise that awaits fake-timer-backed backoff to completion.
+  async function runWithTimers<T>(promise: Promise<T>): Promise<T> {
+    await vi.runAllTimersAsync();
+    return promise;
+  }
+
+  it("returns the send result on first success without retrying", async () => {
+    const send = vi.fn().mockResolvedValue({ tx: [{ hash: "0xabc" }], uids: ["0x1"] });
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const { result, recoveredByIdempotencyGuard } = await attestWithRetry({
+      send,
+      hasAlreadyLanded,
+    });
+
+    expect(result).toEqual({ tx: [{ hash: "0xabc" }], uids: ["0x1"] });
+    expect(recoveredByIdempotencyGuard).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+    // Idempotency guard is never consulted before the first attempt.
+    expect(hasAlreadyLanded).not.toHaveBeenCalled();
+  });
+
+  it("retries the send after a transient wallet timeout and succeeds", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(makeCoalesceError())
+      .mockResolvedValueOnce({ tx: [{ hash: "0xdef" }], uids: ["0x2"] });
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const { result, recoveredByIdempotencyGuard } = await runWithTimers(
+      attestWithRetry({ send, hasAlreadyLanded })
+    );
+
+    expect(result).toEqual({ tx: [{ hash: "0xdef" }], uids: ["0x2"] });
+    expect(recoveredByIdempotencyGuard).toBe(false);
+    expect(send).toHaveBeenCalledTimes(2);
+    // Guard checked exactly once — before the second (retry) attempt.
+    expect(hasAlreadyLanded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT resend when the idempotency guard reports the attestation already landed", async () => {
+    // First attempt times out (from the user's perspective) but actually mined.
+    const send = vi.fn().mockRejectedValueOnce(makeCoalesceError());
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(true);
+
+    const { result, recoveredByIdempotencyGuard } = await runWithTimers(
+      attestWithRetry({ send, hasAlreadyLanded })
+    );
+
+    expect(recoveredByIdempotencyGuard).toBe(true);
+    expect(result).toBeNull();
+    // Critically: send is called only once — no double-create.
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(hasAlreadyLanded).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a non-retryable error immediately without retrying", async () => {
+    const fatal = new Error("Validation failed: title is required");
+    const send = vi.fn().mockRejectedValue(fatal);
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    await expect(attestWithRetry({ send, hasAlreadyLanded })).rejects.toThrow(fatal);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(hasAlreadyLanded).not.toHaveBeenCalled();
+  });
+
+  it("throws AttestRetryExhaustedError after exhausting retries on persistent timeouts", async () => {
+    const send = vi.fn().mockRejectedValue(makeCoalesceError());
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const promise = attestWithRetry({ send, hasAlreadyLanded });
+    // Attach a catch synchronously so the rejection isn't flagged as unhandled
+    // while fake timers advance the backoff waits.
+    const assertion = expect(promise).rejects.toBeInstanceOf(AttestRetryExhaustedError);
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(send).toHaveBeenCalledTimes(ATTEST_SEND_MAX_ATTEMPTS);
+  });
+
+  it("preserves the original error on the exhausted error's cause", async () => {
+    const original = makeCoalesceError();
+    const send = vi.fn().mockRejectedValue(original);
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const promise = attestWithRetry({ send, hasAlreadyLanded }).catch((e) => e);
+    await vi.runAllTimersAsync();
+    const error = (await promise) as AttestRetryExhaustedError;
+
+    expect(error).toBeInstanceOf(AttestRetryExhaustedError);
+    expect(error.cause).toBe(original);
+  });
+
+  it("invokes onRetry for each retryable failure", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(makeCoalesceError())
+      .mockResolvedValueOnce({ tx: [], uids: [] });
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+    const onRetry = vi.fn();
+
+    await runWithTimers(attestWithRetry({ send, hasAlreadyLanded, onRetry }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(0, expect.any(Error));
+  });
+
+  it("respects a custom maxAttempts", async () => {
+    const send = vi.fn().mockRejectedValue(makeCoalesceError());
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const promise = attestWithRetry({ send, hasAlreadyLanded, maxAttempts: 2 }).catch((e) => e);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AttestRetryExhaustedError telemetry routing", () => {
+  it("keeps the user-facing retryable toast (matches isRetryableChainError)", () => {
+    const error = new AttestRetryExhaustedError(new Error("could not coalesce error"), 3);
+    expect(isRetryableChainError(error)).toBe(true);
+  });
+
+  it("is reported to Sentry — does NOT match the transient-drop signature", () => {
+    // The raw cause IS transient noise...
+    expect(isTransientWalletTimeoutError(new Error("could not coalesce error"))).toBe(true);
+    // ...but the exhausted wrapper is actionable and must reach Sentry.
+    const error = new AttestRetryExhaustedError(new Error("could not coalesce error"), 3);
+    expect(isTransientWalletTimeoutError(error)).toBe(false);
+  });
+});

--- a/utilities/__tests__/attestWithRetry.test.ts
+++ b/utilities/__tests__/attestWithRetry.test.ts
@@ -11,6 +11,7 @@ import {
   ATTEST_SEND_MAX_ATTEMPTS,
   AttestRetryExhaustedError,
   attestWithRetry,
+  isAttestRetryExhaustedError,
 } from "@/utilities/attestWithRetry";
 import { isRetryableChainError } from "@/utilities/isRetryableChainError";
 import { isTransientWalletTimeoutError } from "@/utilities/sentry/transientErrors";
@@ -69,8 +70,9 @@ describe("attestWithRetry", () => {
     expect(result).toEqual({ tx: [{ hash: "0xdef" }], uids: ["0x2"] });
     expect(recoveredByIdempotencyGuard).toBe(false);
     expect(send).toHaveBeenCalledTimes(2);
-    // Guard checked exactly once — before the second (retry) attempt.
-    expect(hasAlreadyLanded).toHaveBeenCalledTimes(1);
+    // Guard was polled (default poll window) before the second attempt, since
+    // the timed-out attempt never showed as indexed.
+    expect(hasAlreadyLanded).toHaveBeenCalledTimes(4);
   });
 
   it("does NOT resend when the idempotency guard reports the attestation already landed", async () => {
@@ -87,6 +89,50 @@ describe("attestWithRetry", () => {
     // Critically: send is called only once — no double-create.
     expect(send).toHaveBeenCalledTimes(1);
     expect(hasAlreadyLanded).toHaveBeenCalledTimes(1);
+  });
+
+  it("POLLS the idempotency guard before resending and stops once the in-flight tx is indexed", async () => {
+    // The real hazard: the first send's userOp WAS broadcast but the client
+    // gave up waiting. The tx is still being indexed when we decide whether to
+    // resend. A single immediate guard check would miss it (the indexer lags)
+    // and we'd double-create. The guard must POLL on the indexing cadence so
+    // the landed tx is observed before any resend.
+    const send = vi.fn().mockRejectedValueOnce(makeCoalesceError());
+    // In-flight on the first two polls, then indexed on the third.
+    const hasAlreadyLanded = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const { result, recoveredByIdempotencyGuard } = await runWithTimers(
+      attestWithRetry({ send, hasAlreadyLanded })
+    );
+
+    // No resend: the in-flight attempt was detected as landed.
+    expect(send).toHaveBeenCalledTimes(1);
+    // Guard was polled repeatedly (not a single immediate check).
+    expect(hasAlreadyLanded).toHaveBeenCalledTimes(3);
+    expect(recoveredByIdempotencyGuard).toBe(true);
+    expect(result).toBeNull();
+  });
+
+  it("only resends after the bounded guard poll window expires without the tx landing", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(makeCoalesceError())
+      .mockResolvedValueOnce({ tx: [{ hash: "0xdef" }], uids: ["0x2"] });
+    // Never lands during the poll window → resend is the correct outcome.
+    const hasAlreadyLanded = vi.fn().mockResolvedValue(false);
+
+    const { result } = await runWithTimers(
+      attestWithRetry({ send, hasAlreadyLanded, guardPollAttempts: 3 })
+    );
+
+    expect(result).toEqual({ tx: [{ hash: "0xdef" }], uids: ["0x2"] });
+    // The full poll window was exhausted before resending.
+    expect(hasAlreadyLanded).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenCalledTimes(2);
   });
 
   it("surfaces a non-retryable error immediately without retrying", async () => {
@@ -158,11 +204,26 @@ describe("AttestRetryExhaustedError telemetry routing", () => {
     expect(isRetryableChainError(error)).toBe(true);
   });
 
-  it("is reported to Sentry — does NOT match the transient-drop signature", () => {
-    // The raw cause IS transient noise...
+  it("is reported to Sentry via the structural exhausted-retry flag", () => {
+    // The raw cause IS transient noise that beforeSend would otherwise drop...
     expect(isTransientWalletTimeoutError(new Error("could not coalesce error"))).toBe(true);
-    // ...but the exhausted wrapper is actionable and must reach Sentry.
+    // ...but the exhausted wrapper carries a structural flag so Sentry routing
+    // reports it without depending on the message wording.
     const error = new AttestRetryExhaustedError(new Error("could not coalesce error"), 3);
-    expect(isTransientWalletTimeoutError(error)).toBe(false);
+    expect(isAttestRetryExhaustedError(error)).toBe(true);
+    expect(error.isExhaustedRetry).toBe(true);
+    // Plain transient errors are NOT flagged.
+    expect(isAttestRetryExhaustedError(new Error("could not coalesce error"))).toBe(false);
+    expect(isAttestRetryExhaustedError(null)).toBe(false);
+  });
+
+  it("preserves both the throw site and the cause stack", () => {
+    const cause = new Error("Wallet timeout");
+    const error = new AttestRetryExhaustedError(cause, 3);
+    // The wrapper's own stack is preserved (mentions this file/constructor)...
+    expect(error.stack).toContain("AttestRetryExhaustedError");
+    // ...and the cause stack is appended rather than overwriting it.
+    expect(error.stack).toContain("Caused by:");
+    expect(error.cause).toBe(cause);
   });
 });

--- a/utilities/attestWithRetry.ts
+++ b/utilities/attestWithRetry.ts
@@ -2,54 +2,79 @@ import { isRetryableChainError } from "@/utilities/isRetryableChainError";
 import { wait } from "@/utilities/wait";
 
 /**
- * Bounded retry + backoff for an attestation `eth_sendTransaction` that fails
- * with a transient wallet/bundler timeout.
+ * Bounded retry for an attestation `eth_sendTransaction` that fails with a
+ * transient wallet/bundler timeout.
  *
  * Background (GAP-FRONTEND-1Y2): project creation sends `eth_sendTransaction`
  * during `project.attest(signer)`. A momentary wallet/bundler "Wallet timeout"
  * surfaces as the ethers v6 "could not coalesce error" (code UNKNOWN_ERROR).
  * `hooks/useZeroDevSigner.ts` already retries gasless *client creation*, but the
  * SEND itself was not retried, so a single transient blip abandoned the whole
- * attestation. This helper closes that gap, mirroring the gasless-client retry
- * style/constants.
+ * attestation. This helper closes that gap.
  *
  * Idempotency is the critical constraint. A GAP attestation creates a brand-new
  * on-chain UID on every send (the project's client-side UID is `nullRef` until
  * the tx mines), so a naive resend after a true timeout would DOUBLE-CREATE the
- * project. Before every retry we therefore call `hasAlreadyLanded()`: if the
- * previous (timed-out) attempt actually mined and got indexed, we stop and
- * surface a synthetic success instead of resending.
+ * project. The dangerous sub-case is the one where the userOp WAS broadcast but
+ * the client gave up waiting: the tx is still mining / being indexed when we
+ * decide whether to resend. `hasAlreadyLanded()` reads the indexer (the slug
+ * only resolves AFTER the tx mines and is ingested), which lags the chain by
+ * seconds to tens of seconds. A single immediate check therefore almost always
+ * returns `false` and we'd resend into a duplicate. So before resending we POLL
+ * the guard on the same cadence the caller uses to wait for indexing, giving a
+ * tx that actually landed a realistic chance to be observed first.
  */
 
-// Mirror the gasless-client retry constants in hooks/useZeroDevSigner.ts so the
-// send and the client-creation retries behave consistently.
+// Number of attempts at the send itself (1 initial + retries).
 export const ATTEST_SEND_MAX_ATTEMPTS = 3;
-export const ATTEST_SEND_RETRY_BASE_DELAY_MS = 300;
+// Cadence/duration of the pre-resend idempotency poll. These mirror the
+// indexing poll in components/Dialogs/ProjectDialog (1500ms interval), because
+// the guard reads the same indexer the dialog waits on. We poll several times
+// so a slow-but-successful first attempt is observed before we resend.
+export const ATTEST_GUARD_POLL_INTERVAL_MS = 1500;
+export const ATTEST_GUARD_POLL_ATTEMPTS = 4;
 
 /**
- * Thrown when every retry attempt timed out and the attestation never landed.
+ * Thrown when every send attempt timed out and the attestation never landed.
  *
- * Deliberately worded so that:
- *  - `isRetryableChainError` still matches it ("try again in a moment"), keeping
- *    the user-facing RETRYABLE_ERROR toast and form-data retention, AND
- *  - `isTransientWalletTimeoutError` does NOT match it (no "could not coalesce"
- *    / "wallet timeout" fragment), so the exhausted failure IS reported to
- *    Sentry instead of being dropped as transient noise. The original error is
- *    preserved on `.cause` for diagnostics.
+ * Telemetry routing keys off the structural `isExhaustedRetry` flag (see
+ * instrumentation-client.ts beforeSend), NOT the message wording: this wrapper
+ * IS reported to Sentry, while the raw transient timeout is dropped. The
+ * user-facing RETRYABLE_ERROR toast still fires because `isRetryableChainError`
+ * matches "try again in a moment". The original error is preserved on `.cause`.
  */
 export class AttestRetryExhaustedError extends Error {
-  readonly cause: unknown;
+  /**
+   * Structural marker used by Sentry's `beforeSend` to report this (actionable)
+   * exhausted-retry failure while dropping the raw transient timeout. Preferred
+   * over message-substring matching, which is brittle.
+   */
+  readonly isExhaustedRetry = true;
 
   constructor(cause: unknown, attempts: number) {
     super(
-      `Project attestation failed after ${attempts} attempts due to a persistent wallet/bundler timeout. Please try again in a moment.`
+      `Project attestation failed after ${attempts} attempts due to a persistent wallet/bundler timeout. Please try again in a moment.`,
+      { cause }
     );
     this.name = "AttestRetryExhaustedError";
-    this.cause = cause;
+    // Preserve THIS throw site, and append the cause's stack for diagnostics
+    // rather than overwriting it (which would lose where the wrapper was thrown).
     if (cause instanceof Error && cause.stack) {
-      this.stack = cause.stack;
+      this.stack = `${this.stack ?? ""}\nCaused by: ${cause.stack}`;
     }
   }
+}
+
+/**
+ * True when the error is the exhausted-retry wrapper. Structural check used by
+ * Sentry routing so we don't depend on the wrapper's exact wording.
+ */
+export function isAttestRetryExhaustedError(error: unknown): error is AttestRetryExhaustedError {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    (error as { isExhaustedRetry?: unknown }).isExhaustedRetry === true
+  );
 }
 
 export interface AttestWithRetryOptions<T> {
@@ -60,15 +85,17 @@ export interface AttestWithRetryOptions<T> {
   send: () => Promise<T>;
   /**
    * Idempotency guard. Resolves `true` when a previous attempt already landed
-   * on-chain and was indexed (so we must NOT resend). Checked before every
-   * retry — never before the first attempt.
+   * on-chain and was indexed (so we must NOT resend). Polled before every retry
+   * — never before the first attempt.
    */
   hasAlreadyLanded: () => Promise<boolean>;
   /** Optional override for the maximum number of attempts (default 3). */
   maxAttempts?: number;
-  /** Optional override for the base backoff in ms (default 300). */
-  baseDelayMs?: number;
-  /** Optional hook invoked before each backoff wait (logging/telemetry). */
+  /** Optional override for the number of pre-resend guard polls (default 4). */
+  guardPollAttempts?: number;
+  /** Optional override for the guard poll interval in ms (default 1500). */
+  guardPollIntervalMs?: number;
+  /** Optional hook invoked for each retryable failure (logging/telemetry). */
   onRetry?: (attempt: number, error: unknown) => void;
 }
 
@@ -84,29 +111,61 @@ export interface AttestWithRetryResult<T> {
 }
 
 /**
- * Runs `send`, retrying with backoff on transient chain/wallet errors. Throws
- * the last error once attempts are exhausted (or immediately for a
- * non-retryable error), so the caller's existing catch/telemetry handles the
- * genuinely-failed case.
+ * Polls the idempotency guard at the indexing cadence. Resolves `true` as soon
+ * as a landed attestation is observed, otherwise `false` after the bounded
+ * window. This is what gives a genuinely-broadcast-but-slow first attempt a
+ * chance to be seen before we risk a duplicate resend.
+ */
+async function waitForAlreadyLanded(
+  hasAlreadyLanded: () => Promise<boolean>,
+  pollAttempts: number,
+  pollIntervalMs: number
+): Promise<boolean> {
+  for (let poll = 0; poll < pollAttempts; poll += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await hasAlreadyLanded()) {
+      return true;
+    }
+    if (poll < pollAttempts - 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await wait(pollIntervalMs);
+    }
+  }
+  return false;
+}
+
+/**
+ * Runs `send`, retrying on transient chain/wallet errors. Before each resend it
+ * polls the idempotency guard so a slow-but-landed first attempt is not
+ * duplicated. Throws the last error once attempts are exhausted (or immediately
+ * for a non-retryable error), so the caller's existing catch/telemetry handles
+ * the genuinely-failed case.
  */
 export async function attestWithRetry<T>({
   send,
   hasAlreadyLanded,
   maxAttempts = ATTEST_SEND_MAX_ATTEMPTS,
-  baseDelayMs = ATTEST_SEND_RETRY_BASE_DELAY_MS,
+  guardPollAttempts = ATTEST_GUARD_POLL_ATTEMPTS,
+  guardPollIntervalMs = ATTEST_GUARD_POLL_INTERVAL_MS,
   onRetry,
 }: AttestWithRetryOptions<T>): Promise<AttestWithRetryResult<T>> {
   let lastError: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    // Idempotency guard: before any resend, confirm the previous timed-out
-    // attempt didn't actually land. If it did, stop — resending would
-    // double-create the project.
-    if (attempt > 0 && (await hasAlreadyLanded())) {
+    // Idempotency guard: before any resend, give the previous (timed-out)
+    // attempt a realistic window to surface as indexed. The indexer lags the
+    // chain, so a single immediate check would miss a tx that actually landed
+    // and we'd resend into a duplicate. Poll on the indexing cadence instead.
+    if (
+      attempt > 0 &&
+      // eslint-disable-next-line no-await-in-loop
+      (await waitForAlreadyLanded(hasAlreadyLanded, guardPollAttempts, guardPollIntervalMs))
+    ) {
       return { result: null, recoveredByIdempotencyGuard: true };
     }
 
     try {
+      // eslint-disable-next-line no-await-in-loop
       const result = await send();
       return { result, recoveredByIdempotencyGuard: false };
     } catch (error) {
@@ -119,10 +178,6 @@ export async function attestWithRetry<T>({
       }
 
       onRetry?.(attempt, error);
-
-      if (attempt < maxAttempts - 1) {
-        await wait(baseDelayMs * (attempt + 1));
-      }
     }
   }
 

--- a/utilities/attestWithRetry.ts
+++ b/utilities/attestWithRetry.ts
@@ -1,0 +1,134 @@
+import { isRetryableChainError } from "@/utilities/isRetryableChainError";
+import { wait } from "@/utilities/wait";
+
+/**
+ * Bounded retry + backoff for an attestation `eth_sendTransaction` that fails
+ * with a transient wallet/bundler timeout.
+ *
+ * Background (GAP-FRONTEND-1Y2): project creation sends `eth_sendTransaction`
+ * during `project.attest(signer)`. A momentary wallet/bundler "Wallet timeout"
+ * surfaces as the ethers v6 "could not coalesce error" (code UNKNOWN_ERROR).
+ * `hooks/useZeroDevSigner.ts` already retries gasless *client creation*, but the
+ * SEND itself was not retried, so a single transient blip abandoned the whole
+ * attestation. This helper closes that gap, mirroring the gasless-client retry
+ * style/constants.
+ *
+ * Idempotency is the critical constraint. A GAP attestation creates a brand-new
+ * on-chain UID on every send (the project's client-side UID is `nullRef` until
+ * the tx mines), so a naive resend after a true timeout would DOUBLE-CREATE the
+ * project. Before every retry we therefore call `hasAlreadyLanded()`: if the
+ * previous (timed-out) attempt actually mined and got indexed, we stop and
+ * surface a synthetic success instead of resending.
+ */
+
+// Mirror the gasless-client retry constants in hooks/useZeroDevSigner.ts so the
+// send and the client-creation retries behave consistently.
+export const ATTEST_SEND_MAX_ATTEMPTS = 3;
+export const ATTEST_SEND_RETRY_BASE_DELAY_MS = 300;
+
+/**
+ * Thrown when every retry attempt timed out and the attestation never landed.
+ *
+ * Deliberately worded so that:
+ *  - `isRetryableChainError` still matches it ("try again in a moment"), keeping
+ *    the user-facing RETRYABLE_ERROR toast and form-data retention, AND
+ *  - `isTransientWalletTimeoutError` does NOT match it (no "could not coalesce"
+ *    / "wallet timeout" fragment), so the exhausted failure IS reported to
+ *    Sentry instead of being dropped as transient noise. The original error is
+ *    preserved on `.cause` for diagnostics.
+ */
+export class AttestRetryExhaustedError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown, attempts: number) {
+    super(
+      `Project attestation failed after ${attempts} attempts due to a persistent wallet/bundler timeout. Please try again in a moment.`
+    );
+    this.name = "AttestRetryExhaustedError";
+    this.cause = cause;
+    if (cause instanceof Error && cause.stack) {
+      this.stack = cause.stack;
+    }
+  }
+}
+
+export interface AttestWithRetryOptions<T> {
+  /**
+   * Performs the actual attestation send (e.g. `project.attest(signer, cb)`).
+   * Called once per attempt.
+   */
+  send: () => Promise<T>;
+  /**
+   * Idempotency guard. Resolves `true` when a previous attempt already landed
+   * on-chain and was indexed (so we must NOT resend). Checked before every
+   * retry — never before the first attempt.
+   */
+  hasAlreadyLanded: () => Promise<boolean>;
+  /** Optional override for the maximum number of attempts (default 3). */
+  maxAttempts?: number;
+  /** Optional override for the base backoff in ms (default 300). */
+  baseDelayMs?: number;
+  /** Optional hook invoked before each backoff wait (logging/telemetry). */
+  onRetry?: (attempt: number, error: unknown) => void;
+}
+
+export interface AttestWithRetryResult<T> {
+  /**
+   * The send result. `null` only when a retry was skipped because the
+   * idempotency guard reported the attestation already landed — in that case
+   * the work is done and the caller should treat it as success.
+   */
+  result: T | null;
+  /** True when a prior timed-out attempt was detected as already landed. */
+  recoveredByIdempotencyGuard: boolean;
+}
+
+/**
+ * Runs `send`, retrying with backoff on transient chain/wallet errors. Throws
+ * the last error once attempts are exhausted (or immediately for a
+ * non-retryable error), so the caller's existing catch/telemetry handles the
+ * genuinely-failed case.
+ */
+export async function attestWithRetry<T>({
+  send,
+  hasAlreadyLanded,
+  maxAttempts = ATTEST_SEND_MAX_ATTEMPTS,
+  baseDelayMs = ATTEST_SEND_RETRY_BASE_DELAY_MS,
+  onRetry,
+}: AttestWithRetryOptions<T>): Promise<AttestWithRetryResult<T>> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    // Idempotency guard: before any resend, confirm the previous timed-out
+    // attempt didn't actually land. If it did, stop — resending would
+    // double-create the project.
+    if (attempt > 0 && (await hasAlreadyLanded())) {
+      return { result: null, recoveredByIdempotencyGuard: true };
+    }
+
+    try {
+      const result = await send();
+      return { result, recoveredByIdempotencyGuard: false };
+    } catch (error) {
+      lastError = error;
+
+      // Only transient wallet/bundler timeouts are safe to retry; surface
+      // anything else immediately (it won't get better by resending).
+      if (!isRetryableChainError(error)) {
+        throw error;
+      }
+
+      onRetry?.(attempt, error);
+
+      if (attempt < maxAttempts - 1) {
+        await wait(baseDelayMs * (attempt + 1));
+      }
+    }
+  }
+
+  // Every attempt was a transient timeout that never recovered. Surface a
+  // distinct, reportable error (the raw "could not coalesce" signature is
+  // dropped by Sentry's beforeSend as transient noise — see
+  // utilities/sentry/transientErrors.ts).
+  throw new AttestRetryExhaustedError(lastError, maxAttempts);
+}

--- a/utilities/sentry/__tests__/transientErrors.test.ts
+++ b/utilities/sentry/__tests__/transientErrors.test.ts
@@ -3,6 +3,7 @@ import {
   isAxiosAbortError,
   isTransientHttpError,
   isTransientNetworkError,
+  isTransientWalletTimeoutError,
 } from "../transientErrors";
 
 describe("isTransientNetworkError", () => {
@@ -78,6 +79,42 @@ describe("isTransientHttpError", () => {
     );
     expect(isTransientHttpError(null)).toBe(false);
     expect(isTransientHttpError(undefined)).toBe(false);
+  });
+});
+
+describe("isTransientWalletTimeoutError", () => {
+  it("detects the ethers 'could not coalesce error' wrapping a Wallet timeout", () => {
+    const err = new Error(
+      'could not coalesce error (error={ "message": "Wallet timeout" }, payload={ "method": "eth_sendTransaction" }, code=UNKNOWN_ERROR, version=6.11.0)'
+    );
+    expect(isTransientWalletTimeoutError(err)).toBe(true);
+  });
+
+  it("detects a bare 'Wallet timeout' message", () => {
+    expect(isTransientWalletTimeoutError(new Error("Wallet timeout"))).toBe(true);
+    expect(isTransientWalletTimeoutError({ message: "wallet timeout" })).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isTransientWalletTimeoutError(new Error("Could Not Coalesce Error"))).toBe(true);
+  });
+
+  it("does NOT match unrelated errors", () => {
+    expect(isTransientWalletTimeoutError(new Error("Validation failed"))).toBe(false);
+    expect(isTransientWalletTimeoutError(new Error("Request failed with status code 500"))).toBe(
+      false
+    );
+    expect(isTransientWalletTimeoutError(null)).toBe(false);
+    expect(isTransientWalletTimeoutError(undefined)).toBe(false);
+    expect(isTransientWalletTimeoutError(new Error(""))).toBe(false);
+  });
+
+  it("does NOT match the exhausted-retry wrapper (so it still reports to Sentry)", () => {
+    // Worded as "wallet/bundler timeout", which must not contain "wallet timeout".
+    const exhausted = new Error(
+      "Project attestation failed after 3 attempts due to a persistent wallet/bundler timeout. Please try again in a moment."
+    );
+    expect(isTransientWalletTimeoutError(exhausted)).toBe(false);
   });
 });
 

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -106,6 +106,30 @@ export function isTransientNetworkError(error: unknown): boolean {
   return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
 }
 
+// ethers v6 wraps a momentary wallet/bundler timeout into a "could not coalesce
+// error" with code UNKNOWN_ERROR whose nested payload is `{ "message": "Wallet
+// timeout" }`. During project creation we retry the send (see
+// utilities/attestWithRetry.ts), so a RECOVERED timeout never reaches Sentry —
+// but the raw signature can still leak through code paths that bypass
+// errorManager (an un-awaited rejection from an abandoned attempt, a third-party
+// SDK fetch). It's environmental and non-actionable, so drop it. Only the
+// exhausted-retry case reports, and it does so as a distinct wrapped error that
+// no longer matches this signature. See GAP-FRONTEND-1Y2.
+const TRANSIENT_WALLET_TIMEOUT_FRAGMENTS = ["could not coalesce", "wallet timeout"] as const;
+
+/**
+ * True when the error is a transient wallet/bundler timeout surfaced by ethers
+ * ("could not coalesce error" / "Wallet timeout"). These are retried at the
+ * send layer and are unactionable from a Sentry event; the exhausted-retry
+ * failure reports separately as a distinct wrapped error.
+ */
+export function isTransientWalletTimeoutError(error: unknown): boolean {
+  if (!error) return false;
+  const message = getErrorMessage(error).toLowerCase();
+  if (!message) return false;
+  return TRANSIENT_WALLET_TIMEOUT_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
 /**
  * True when the error is a transient upstream HTTP failure (gateway timeout
  * / bad gateway / service unavailable / request timeout). Unlike


### PR DESCRIPTION
Fixes #1680

## Summary
Issue #1680: project creation abandoned the whole attestation on a single transient wallet/bundler "Wallet timeout" (ethers v6 "could not coalesce error", code UNKNOWN_ERROR) and reported it to Sentry as noise. useZeroDevSigner already retried gasless CLIENT creation, but the eth_sendTransaction SEND inside project.attest was never retried.

Fix:
1. New utility utilities/attestWithRetry.ts — bounded retry + backoff around the send (ATTEST_SEND_MAX_ATTEMPTS=3, ATTEST_SEND_RETRY_BASE_DELAY_MS=300, mirroring the gasless-client constants in useZeroDevSigner.ts). Only retries when isRetryableChainError() matches; non-retryable errors surface immediately.
2. Idempotency guard (the critical constraint): a GAP attestation mints a brand-new on-chain UID on every send, so a naive resend would double-create. Before every retry, attestWithRetry calls hasAlreadyLanded(); in ProjectDialog this is checkSlugExists(slug) — the slug is deterministically generated from the title and is the indexed identifier. If a timed-out attempt actually landed, it stops and returns recoveredByIdempotencyGuard=true (no resend), and the existing indexing/poll loop picks up the already-created project.
3. Telemetry right-sizing: a recovered timeout never throws, so it never reaches errorManager/Sentry. On exhaustion, attestWithRetry throws a distinct AttestRetryExhaustedError that (a) still matches isRetryableChainError (keeps MESSAGES.PROJECT.CREATE.RETRYABLE_ERROR toast + form-data retention) but (b) does NOT match the new transient-drop signature, so the genuinely-failed case IS reported. Added isTransientWalletTimeoutError() to utilities/sentry/transientErrors.ts (matches "could not coalesce"/"wallet timeout") and wired it into instrumentation-client.ts beforeSend as defense-in-depth for raw signatures leaking through paths that bypass errorManager.
4. Wired attestWithRetry into components/Dialogs/ProjectDialog/index.tsx createProject; the post-attest indexing logic is unchanged.

## Root cause
See issue #1680 for the full Sentry analysis.

## Why this is a definitive fix
Root cause is that the attestation SEND had no retry while the surrounding client-creation step did, so a transient wallet/bundler timeout permanently lost the attestation. The fix adds the missing bounded retry+backoff at exactly that send boundary, mirroring the established gasless-client retry pattern — not a Sentry mute and not a UI workaround. Crucially it is made safe (idempotent) against the real double-create hazard by gating each resend on whether the prior attempt already landed (deterministic slug check), rather than blindly resending. Telemetry is corrected at the source: recovered timeouts never throw so they never reach Sentry, and only the genuinely-exhausted failure reports — as a distinct error that intentionally escapes the transient-drop filter while keeping the existing user message and form retention. The Sentry beforeSend predicate is additive defense-in-depth for the raw signature leaking through non-errorManager paths, layered on top of the real behavioral fix.

## Files changed
- utilities/attestWithRetry.ts
- utilities/sentry/transientErrors.ts
- instrumentation-client.ts
- components/Dialogs/ProjectDialog/index.tsx
- utilities/__tests__/attestWithRetry.test.ts
- utilities/sentry/__tests__/transientErrors.test.ts

## Testing
Lint: `pnpm exec biome check` on all 6 changed files — no errors/fixes (14 pre-existing warnings unrelated to this change, e.g. the githubValidatedAs unused-var that predates this work). Types: `pnpm typecheck` (tsc --noEmit) — fully green, 0 errors. Tests: `pnpm exec vitest run --project unit` on utilities/__tests__/attestWithRetry.test.ts + utilities/sentry/__tests__/transientErrors.test.ts + __tests__/components/Dialogs/ProjectDialog.test.tsx — 34 tests passed (3 files). New attestWithRetry suite: first-success-no-retry, retry-then-success, idempotency-guard-skips-resend (no double-create), non-retryable-surfaces-immediately, exhausted-throws-AttestRetryExhaustedError after 3 attempts, cause preserved, onRetry called, custom maxAttempts, plus telemetry-routing (exhausted error matches isRetryableChainError but NOT isTransientWalletTimeoutError). New transientErrors cases cover the ethers coalesce/Wallet-timeout signature and confirm the exhausted wrapper is NOT dropped. Pre-existing ProjectDialog create-flow tests still pass through the new retry wrapper. The storybook-preset ERR_MODULE_NOT_FOUND noise printed by the runner is a pre-existing environment issue in the shared node_modules and does not affect the unit project results.
