### PR TITLE
fix(filecoin): clean up ProPGF nav dropdown copy

### DIFF
--- a/src/infrastructure/config/tenant-config.ts
+++ b/src/infrastructure/config/tenant-config.ts
@@ -316,13 +316,13 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
                 isExternal: true,
               },
               {
-                label: "Batch 2 - Pods Track",
-                href: "https://app.filpgf.io/projects?programId=1039",
+                label: "Batch 3",
+                href: "https://app.filpgf.io/programs/1479/",
                 isExternal: true,
               },
               {
-                label: "Batch 3 - Apply Now",
-                href: "https://app.filpgf.io/programs/1479/",
+                label: "Pods Track",
+                href: "https://app.filpgf.io/projects?programId=1039",
                 isExternal: true,
               },
             ],
@@ -341,7 +341,7 @@ const tenantNavigation: Record<TenantId, TenantNavigation> = {
                 isExternal: true,
               },
               {
-                label: "Batch 2 - Pods Track",
+                label: "Pods Track",
                 href: "https://app.filpgf.io/browse-applications?programId=1039",
                 isExternal: true,
               },


### PR DESCRIPTION
## Overview

Cleans up the Filecoin ProPGF navigation dropdown copy reported by the customer (Erin O'Connor, Filecoin). Covers two tickets, both of which are the same nav-copy fix in `src/infrastructure/config/tenant-config.ts`.

## Changes

**Grants submenu** (DEV-415)
| Before | After |
| --- | --- |
| Batch 1 | Batch 1 |
| Batch 2 | Batch 2 |
| Batch 2 - Pods Track | Batch 3 |
| Batch 3 - Apply Now | Pods Track |

- `Batch 3 - Apply Now` → `Batch 3`
- `Batch 2 - Pods Track` → `Pods Track`, moved to the end of the list

**Applications submenu** (DEV-416)
- `Batch 2 - Pods Track` → `Pods Track`

Links (`href`) are unchanged — only labels and ordering are updated.

## Testing

- `biome check` passes on the modified file
- No tests assert these nav labels (verified via repo-wide search)

Closes DEV-415
Closes DEV-416
