### PR TITLE
feat(donor-research): shared-report commenting frontend

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -49,6 +49,22 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
 
+      # Persist the Privy auth session (e2e/.auth/user.json) across runs.
+      # auth.setup.ts has a fast path that refreshes privy:token from a
+      # restored session instead of sending a new OTP email — sending OTPs
+      # is what trips Privy's per-address rate limit and is the dominant
+      # cause of flaky smoke logins. The rolling key + prefix restore-keys
+      # mean each run restores the most recently refreshed session and
+      # saves the freshly refreshed one, so an OTP is sent only when the
+      # cached refresh token has fully expired.
+      - name: Restore cached Privy auth session
+        uses: actions/cache@v4
+        with:
+          path: e2e/.auth/user.json
+          key: privy-auth-state-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            privy-auth-state-
+
       - name: Run smoke tests
         run: pnpm exec playwright test --config e2e/playwright.config.ts --project=setup --project=chromium e2e/tests/smoke/
         env:

--- a/__tests__/app/api/donor-research/shared-comments.route.test.ts
+++ b/__tests__/app/api/donor-research/shared-comments.route.test.ts
@@ -98,6 +98,23 @@ describe("GET /api/donor-research/shared/[token]/comments", () => {
     expect(res.status).toBe(200);
   });
 
+  it("forwards the Authorization header so the indexer can resolve the advisor branch", async () => {
+    headerStore.get.mockImplementation((k: string) => {
+      if (k === "authorization") return "Bearer privy-jwt-xyz";
+      return null;
+    });
+    cookieStore.get.mockReturnValue(undefined);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(fetchResponse({ status: 200, body: { roots: [] } }));
+
+    await GET(makeRequest(), ctx());
+
+    const [, options] = fetchSpy.mock.calls[0];
+    const h = options?.headers as Record<string, string>;
+    expect(h["Authorization"]).toBe("Bearer privy-jwt-xyz");
+  });
+
   it("returns 502 when the indexer is unreachable", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
     const res = await GET(makeRequest(), ctx());

--- a/__tests__/app/api/donor-research/shared-comments.route.test.ts
+++ b/__tests__/app/api/donor-research/shared-comments.route.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @file Tests for the Next.js API-route proxy on the FE origin that
+ * forwards donor-shared comment reads and writes to the indexer (KTD13).
+ * Validates header forwarding (x-forwarded-for, x-drsc-session, Origin,
+ * Idempotency-Key), Set-Cookie translation onto the FE origin, and the
+ * unreachable-indexer fallback.
+ */
+
+import type { NextRequest } from "next/server";
+
+const cookieStore = {
+  get: vi.fn(),
+};
+
+const headerStore = {
+  get: vi.fn(),
+};
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => cookieStore),
+  headers: vi.fn(async () => headerStore),
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: {
+    NEXT_PUBLIC_GAP_INDEXER_URL: "http://indexer.test",
+  },
+}));
+
+import { GET, POST } from "@/app/api/donor-research/shared/[token]/comments/route";
+
+function makeRequest(
+  url = "http://localhost/api/donor-research/shared/tk/comments",
+  init?: { body?: string }
+): NextRequest {
+  return {
+    url,
+    text: async () => init?.body ?? "",
+  } as unknown as NextRequest;
+}
+
+function ctx() {
+  return { params: Promise.resolve({ token: "share-tk" }) };
+}
+
+function fetchResponse(opts: { status?: number; body?: unknown; setCookies?: string[] } = {}) {
+  const headers = new Headers();
+  if (opts.setCookies) {
+    for (const c of opts.setCookies) headers.append("set-cookie", c);
+  }
+  // The route's copySetCookies reads getSetCookie(); polyfill on the Response.
+  return {
+    status: opts.status ?? 200,
+    headers: {
+      getSetCookie: () => opts.setCookies ?? [],
+      get: (k: string) => headers.get(k),
+    },
+    json: async () => opts.body ?? {},
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cookieStore.get.mockReset();
+  headerStore.get.mockReset();
+});
+
+describe("GET /api/donor-research/shared/[token]/comments", () => {
+  it("forwards x-forwarded-for, x-drsc-session, and Origin to the indexer", async () => {
+    headerStore.get.mockImplementation((k: string) => {
+      if (k === "x-forwarded-for") return "1.2.3.4, 5.6.7.8";
+      if (k === "origin") return "http://localhost:3000";
+      return null;
+    });
+    cookieStore.get.mockImplementation((name: string) =>
+      name === "drsc_session" ? { value: "cookie-payload" } : undefined
+    );
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(fetchResponse({ status: 200, body: { roots: [] } }));
+
+    const res = await GET(
+      makeRequest("http://localhost/api/donor-research/shared/tk/comments?cursor=abc&limit=10"),
+      ctx()
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = fetchSpy.mock.calls[0];
+    expect(String(calledUrl)).toContain(
+      "http://indexer.test/v2/donor-research/shared/share-tk/comments"
+    );
+    expect(String(calledUrl)).toContain("cursor=abc");
+    expect(String(calledUrl)).toContain("limit=10");
+    const h = options?.headers as Record<string, string>;
+    expect(h["x-forwarded-for"]).toBe("1.2.3.4");
+    expect(h["x-drsc-session"]).toBe("cookie-payload");
+    expect(h["Origin"]).toBe("http://localhost:3000");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 502 when the indexer is unreachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await GET(makeRequest(), ctx());
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json).toEqual({ error: "indexer_unreachable" });
+  });
+
+  it("translates Set-Cookie from indexer onto the FE origin with the proxy path", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      fetchResponse({
+        status: 200,
+        body: {},
+        setCookies: ["drsc_session=abc123", "drsc_name=Dana"],
+      })
+    );
+    const res = await GET(makeRequest(), ctx());
+    // NextResponse emits one Set-Cookie header per cookie; use the
+    // multi-value accessor so we read every entry, not just the last.
+    const setCookies = res.headers.getSetCookie();
+    const sessionSegment = setCookies.find((s) => s.startsWith("drsc_session=")) ?? "";
+    const nameSegment = setCookies.find((s) => s.startsWith("drsc_name=")) ?? "";
+    expect(sessionSegment).toContain("drsc_session=abc123");
+    expect(sessionSegment).toContain("Path=/api/donor-research/shared/");
+    expect(nameSegment).toContain("drsc_name=Dana");
+    expect(nameSegment).toContain("Path=/api/donor-research/shared/");
+    // drsc_session must remain HttpOnly; drsc_name must NOT be HttpOnly.
+    expect(sessionSegment.toLowerCase()).toContain("httponly");
+    expect(nameSegment.toLowerCase()).not.toContain("httponly");
+  });
+
+  it("includes no-store cache headers on success and error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(fetchResponse({ status: 200, body: {} }));
+    const res = await GET(makeRequest(), ctx());
+    expect(res.headers.get("Cache-Control")).toContain("no-store");
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
+  });
+});
+
+describe("POST /api/donor-research/shared/[token]/comments", () => {
+  it("passes through the Idempotency-Key header", async () => {
+    headerStore.get.mockImplementation((k: string) => {
+      if (k === "idempotency-key") return "client-uuid";
+      return null;
+    });
+    cookieStore.get.mockReturnValue(undefined);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(fetchResponse({ status: 201, body: { id: "c1" } }));
+
+    const res = await POST(makeRequest(undefined, { body: '{"body":"hi"}' }), ctx());
+
+    expect(res.status).toBe(201);
+    const [, options] = fetchSpy.mock.calls[0];
+    const h = options?.headers as Record<string, string>;
+    expect(h["Idempotency-Key"]).toBe("client-uuid");
+    expect(h["Content-Type"]).toBe("application/json");
+    expect(options?.body).toBe('{"body":"hi"}');
+  });
+
+  it("returns 502 when the indexer is unreachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    const res = await POST(makeRequest(undefined, { body: "{}" }), ctx());
+    expect(res.status).toBe(502);
+  });
+
+  it("propagates non-2xx status from the indexer (e.g., 429)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      fetchResponse({ status: 429, body: { error: "rate_limited" } })
+    );
+    const res = await POST(makeRequest(undefined, { body: "{}" }), ctx());
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toBe("rate_limited");
+  });
+});

--- a/__tests__/app/api/donor-research/shared-comments.route.test.ts
+++ b/__tests__/app/api/donor-research/shared-comments.route.test.ts
@@ -140,7 +140,12 @@ describe("GET /api/donor-research/shared/[token]/comments", () => {
     expect(sessionSegment).toContain("drsc_session=abc123");
     expect(sessionSegment).toContain("Path=/api/donor-research/shared/");
     expect(nameSegment).toContain("drsc_name=Dana");
-    expect(nameSegment).toContain("Path=/api/donor-research/shared/");
+    // drsc_name is JS-readable and scoped to root "/" so the shared page
+    // (/nonprofit-research/shared/...) can read it via document.cookie.
+    // It must NOT be scoped to the proxy path (that would hide it from the
+    // page and force the identity dialog on every comment).
+    expect(nameSegment).toMatch(/Path=\/(;|$)/);
+    expect(nameSegment).not.toContain("Path=/api/donor-research/shared/");
     // drsc_session must remain HttpOnly; drsc_name must NOT be HttpOnly.
     expect(sessionSegment.toLowerCase()).toContain("httponly");
     expect(nameSegment.toLowerCase()).not.toContain("httponly");

--- a/__tests__/features/donor-research/IdentityCaptureDialog.test.tsx
+++ b/__tests__/features/donor-research/IdentityCaptureDialog.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file Tests for the identity-capture modal — open gating, zod
+ * validation (display name + email), edit-name-only mode, submitting
+ * copy on the action button.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// Radix Dialog renders via a portal that the test env's `screen` query
+// resolves to fine, but the Radix focus-trap layers interfere with
+// label↔input id wiring. Mock the dialog primitives the same way the
+// existing DeleteDialog test does — see __tests__/components/Dialogs/.
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-panel">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { IdentityCaptureDialog } from "@/src/features/donor-research/components/shared-view/IdentityCaptureDialog";
+
+describe("IdentityCaptureDialog", () => {
+  it("renders nothing when closed", () => {
+    render(
+      <IdentityCaptureDialog open={false} onOpenChange={() => {}} onSubmit={async () => {}} />
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders both fields by default", () => {
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={async () => {}} />);
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+
+  it("hides the email field in nameOnly mode", () => {
+    render(
+      <IdentityCaptureDialog open nameOnly onOpenChange={() => {}} onSubmit={async () => {}} />
+    );
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
+  });
+
+  it("rejects empty display name with an inline error", async () => {
+    const onSubmit = vi.fn();
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "donor@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(await screen.findByText(/enter your name/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid email with an inline error", async () => {
+    const onSubmit = vi.fn();
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: "Dana" } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(await screen.findByText(/enter a valid email/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits valid values to the onSubmit callback", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: "Dana" } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "dana@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        displayName: "Dana",
+        email: "dana@example.com",
+      });
+    });
+  });
+
+  it("submits with only the display name in nameOnly mode", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<IdentityCaptureDialog open nameOnly onOpenChange={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: "Dana 2" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit.mock.calls[0][0].displayName).toBe("Dana 2");
+    });
+  });
+
+  it("shows 'Saving…' copy on the submit button while pending", () => {
+    render(
+      <IdentityCaptureDialog open isSubmitting onOpenChange={() => {}} onSubmit={async () => {}} />
+    );
+    const btn = screen.getByRole("button", { name: /saving/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("caps display name at 80 chars via maxLength", () => {
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={async () => {}} />);
+    expect(screen.getByLabelText(/display name/i)).toHaveAttribute("maxLength", "80");
+  });
+
+  it("caps email at 254 chars via maxLength", () => {
+    render(<IdentityCaptureDialog open onOpenChange={() => {}} onSubmit={async () => {}} />);
+    expect(screen.getByLabelText(/email/i)).toHaveAttribute("maxLength", "254");
+  });
+});

--- a/__tests__/features/donor-research/anchor/capture.test.ts
+++ b/__tests__/features/donor-research/anchor/capture.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @file Tests for the anchor capture utility used by the donor-shared
+ * report comment surface. captureTextRangeAnchor reads from the live
+ * window.getSelection() and walks the DOM looking for an anchorable
+ * ancestor (`data-section` / `data-candidate-id`). captureElementAnchor
+ * builds a pin anchor directly from an element.
+ */
+
+import {
+  captureElementAnchor,
+  captureTextRangeAnchor,
+} from "@/src/features/donor-research/components/anchor/capture";
+
+function makeAnchoredDocument(html: string): { root: HTMLElement; cleanup: () => void } {
+  const root = document.createElement("div");
+  root.setAttribute("data-brief", "");
+  root.innerHTML = html;
+  document.body.appendChild(root);
+  return {
+    root,
+    cleanup: () => {
+      document.body.removeChild(root);
+    },
+  };
+}
+
+function selectRange(start: Node, startOffset: number, end: Node, endOffset: number): Selection {
+  const sel = window.getSelection();
+  if (!sel) throw new Error("Selection unavailable in jsdom");
+  sel.removeAllRanges();
+  const range = document.createRange();
+  range.setStart(start, startOffset);
+  range.setEnd(end, endOffset);
+  sel.addRange(range);
+  return sel;
+}
+
+describe("captureTextRangeAnchor", () => {
+  let cleanup: () => void = () => {};
+
+  beforeEach(() => {
+    window.getSelection()?.removeAllRanges();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanup = () => {};
+  });
+
+  it("returns null when the selection is collapsed", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="masthead"><p id="p">Hello world</p></section>`
+    );
+    cleanup = c;
+    const text = root.querySelector("#p")!.firstChild!;
+    selectRange(text, 3, text, 3);
+    expect(captureTextRangeAnchor(window.getSelection() as Selection)).toBeNull();
+  });
+
+  it("returns null when no anchorable ancestor exists", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(`<p id="p">Hello world</p>`);
+    cleanup = c;
+    const text = root.querySelector("#p")!.firstChild!;
+    selectRange(text, 0, text, 5);
+    expect(captureTextRangeAnchor(window.getSelection() as Selection)).toBeNull();
+  });
+
+  it("captures a text-range anchor scoped to a section", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="methodology">
+         <p id="p">The methodology used by the engine is described here in detail.</p>
+       </section>`
+    );
+    cleanup = c;
+    const text = root.querySelector("#p")!.firstChild!;
+    selectRange(text, 4, text, 15); // "methodology"
+    const anchor = captureTextRangeAnchor(window.getSelection() as Selection);
+    expect(anchor).not.toBeNull();
+    expect(anchor!.kind).toBe("text_range");
+    if (anchor!.kind === "text_range") {
+      expect(anchor.targetKind).toBe("section");
+      expect(anchor.targetId).toBe("methodology");
+      expect(anchor.quote).toBe("methodology");
+      expect(anchor.suffix.startsWith(" used by")).toBe(true);
+      expect(anchor.prefix.endsWith("The ")).toBe(true);
+    }
+  });
+
+  it("captures a text-range anchor scoped to a candidate", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="lead-candidate" data-candidate-id="cand-1">
+         <p id="p">Best Friends Animal Society leads the field on dogs.</p>
+       </section>`
+    );
+    cleanup = c;
+    const text = root.querySelector("#p")!.firstChild!;
+    selectRange(text, 0, text, 27); // "Best Friends Animal Society"
+    const anchor = captureTextRangeAnchor(window.getSelection() as Selection);
+    expect(anchor).not.toBeNull();
+    if (anchor && anchor.kind === "text_range") {
+      expect(anchor.targetKind).toBe("candidate");
+      expect(anchor.targetId).toBe("cand-1");
+      expect(anchor.quote).toBe("Best Friends Animal Society");
+    }
+  });
+
+  it("returns null when the selection straddles two different anchor targets", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="lead-candidate" data-candidate-id="cand-1">
+         <p id="a">Lead candidate paragraph.</p>
+       </section>
+       <section data-section="runners-up" data-candidate-id="cand-2">
+         <p id="b">Runner-up paragraph.</p>
+       </section>`
+    );
+    cleanup = c;
+    const a = root.querySelector("#a")!.firstChild!;
+    const b = root.querySelector("#b")!.firstChild!;
+    selectRange(a, 0, b, 5);
+    expect(captureTextRangeAnchor(window.getSelection() as Selection)).toBeNull();
+  });
+
+  it("returns null when the quote exceeds the bound", () => {
+    const long = "x".repeat(700);
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="methodology"><p id="p">${long}</p></section>`
+    );
+    cleanup = c;
+    const text = root.querySelector("#p")!.firstChild!;
+    selectRange(text, 0, text, 700);
+    expect(captureTextRangeAnchor(window.getSelection() as Selection)).toBeNull();
+  });
+});
+
+describe("captureElementAnchor", () => {
+  let cleanup: () => void = () => {};
+
+  afterEach(() => {
+    cleanup();
+    cleanup = () => {};
+  });
+
+  it("returns null when no anchor ancestor exists", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(`<p id="p">Hello</p>`);
+    cleanup = c;
+    expect(captureElementAnchor(root.querySelector("#p"))).toBeNull();
+  });
+
+  it("builds a candidate anchor when on a candidate root", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="lead-candidate" data-candidate-id="cand-9"><p id="p">Hi</p></section>`
+    );
+    cleanup = c;
+    const anchor = captureElementAnchor(root.querySelector("#p"));
+    expect(anchor).toEqual({ kind: "candidate", candidateId: "cand-9" });
+  });
+
+  it("builds a section anchor when only a section ancestor exists", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="methodology"><p id="p">Hi</p></section>`
+    );
+    cleanup = c;
+    const anchor = captureElementAnchor(root.querySelector("#p"));
+    expect(anchor).toEqual({ kind: "section", sectionKey: "methodology" });
+  });
+
+  it("ignores section keys outside the bounded enum", () => {
+    const { root, cleanup: c } = makeAnchoredDocument(
+      `<section data-section="bogus"><p id="p">Hi</p></section>`
+    );
+    cleanup = c;
+    expect(captureElementAnchor(root.querySelector("#p"))).toBeNull();
+  });
+});

--- a/__tests__/features/donor-research/anchor/resolve.test.ts
+++ b/__tests__/features/donor-research/anchor/resolve.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @file Tests for the anchor resolver. resolveAnchor takes a stored
+ * anchor + a root DOM element and returns either an element handle, a
+ * Range covering the resolved quote, or an orphan marker.
+ */
+
+import { resolveAnchor } from "@/src/features/donor-research/components/anchor/resolve";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+
+function makeRoot(html: string): { root: HTMLElement; cleanup: () => void } {
+  const root = document.createElement("div");
+  root.setAttribute("data-brief", "");
+  root.innerHTML = html;
+  document.body.appendChild(root);
+  return {
+    root,
+    cleanup: () => {
+      document.body.removeChild(root);
+    },
+  };
+}
+
+describe("resolveAnchor — section / candidate", () => {
+  let cleanup: () => void = () => {};
+  afterEach(() => {
+    cleanup();
+    cleanup = () => {};
+  });
+
+  it("returns an element handle for a section anchor that exists", () => {
+    const { root, cleanup: c } = makeRoot(`<section data-section="methodology">Body</section>`);
+    cleanup = c;
+    const anchor: CommentAnchor = { kind: "section", sectionKey: "methodology" };
+    const resolved = resolveAnchor(anchor, root);
+    expect(resolved.kind).toBe("element");
+    if (resolved.kind === "element") {
+      expect(resolved.element.getAttribute("data-section")).toBe("methodology");
+    }
+  });
+
+  it("returns orphan for a missing section anchor", () => {
+    const { root, cleanup: c } = makeRoot(`<section data-section="masthead">Body</section>`);
+    cleanup = c;
+    const anchor: CommentAnchor = { kind: "section", sectionKey: "methodology" };
+    expect(resolveAnchor(anchor, root).kind).toBe("orphan");
+  });
+
+  it("returns an element handle for a candidate anchor that exists", () => {
+    const { root, cleanup: c } = makeRoot(`<div data-candidate-id="abc">Card</div>`);
+    cleanup = c;
+    expect(resolveAnchor({ kind: "candidate", candidateId: "abc" }, root).kind).toBe("element");
+  });
+
+  it("returns orphan when the candidate id is no longer present", () => {
+    const { root, cleanup: c } = makeRoot(`<div data-candidate-id="abc">Card</div>`);
+    cleanup = c;
+    expect(resolveAnchor({ kind: "candidate", candidateId: "missing" }, root).kind).toBe("orphan");
+  });
+});
+
+describe("resolveAnchor — text-range", () => {
+  let cleanup: () => void = () => {};
+  afterEach(() => {
+    cleanup();
+    cleanup = () => {};
+  });
+
+  it("returns a Range when the quote resolves in the target", () => {
+    const { root, cleanup: c } = makeRoot(
+      `<section data-section="methodology"><p>The methodology used by the engine is described here in detail.</p></section>`
+    );
+    cleanup = c;
+    const anchor: CommentAnchor = {
+      kind: "text_range",
+      targetKind: "section",
+      targetId: "methodology",
+      quote: "methodology",
+      prefix: "The ",
+      suffix: " used",
+    };
+    const resolved = resolveAnchor(anchor, root);
+    expect(resolved.kind).toBe("range");
+    if (resolved.kind === "range") {
+      expect(resolved.range.toString()).toContain("methodology");
+    }
+  });
+
+  it("falls back to quote-only when the prefix shifted", () => {
+    const { root, cleanup: c } = makeRoot(
+      `<section data-section="methodology"><p>Enriched text the methodology used by the engine.</p></section>`
+    );
+    cleanup = c;
+    const anchor: CommentAnchor = {
+      kind: "text_range",
+      targetKind: "section",
+      targetId: "methodology",
+      quote: "methodology",
+      prefix: "ORIGINAL ",
+      suffix: " used",
+    };
+    const resolved = resolveAnchor(anchor, root);
+    expect(resolved.kind).toBe("range");
+  });
+
+  it("returns orphan when the quote no longer appears in the target", () => {
+    const { root, cleanup: c } = makeRoot(
+      `<section data-section="methodology"><p>An entirely rewritten paragraph.</p></section>`
+    );
+    cleanup = c;
+    const anchor: CommentAnchor = {
+      kind: "text_range",
+      targetKind: "section",
+      targetId: "methodology",
+      quote: "methodology",
+      prefix: "",
+      suffix: "",
+    };
+    expect(resolveAnchor(anchor, root).kind).toBe("orphan");
+  });
+
+  it("returns orphan when the target element itself disappeared", () => {
+    const { root, cleanup: c } = makeRoot(`<div>nothing matches</div>`);
+    cleanup = c;
+    const anchor: CommentAnchor = {
+      kind: "text_range",
+      targetKind: "candidate",
+      targetId: "missing",
+      quote: "something",
+      prefix: "",
+      suffix: "",
+    };
+    expect(resolveAnchor(anchor, root).kind).toBe("orphan");
+  });
+});

--- a/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
+++ b/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
@@ -191,6 +191,7 @@ describe("OnboardingFlow — form submission", () => {
     await advanceToForm(user);
 
     await user.type(screen.getByLabelText(/display name/i), "Avery Boutique");
+    await user.type(screen.getByLabelText(/email/i), "avery@example.com");
     await user.click(screen.getByRole("button", { name: /^continue$/i }));
 
     await waitFor(() => {
@@ -211,6 +212,7 @@ describe("OnboardingFlow — form submission", () => {
     await advanceToForm(user);
 
     await user.type(screen.getByLabelText(/display name/i), "Avery Boutique");
+    await user.type(screen.getByLabelText(/email/i), "avery@example.com");
     await user.click(screen.getByRole("button", { name: /^continue$/i }));
 
     const alert = await screen.findByText(/boom from server/i);

--- a/__tests__/features/donor-research/shared-view/CommentComposer.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentComposer.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @file Tests for CommentComposer — body input, submit gating, anchor
+ * descriptor rendering, reply mode context, error surfacing, and
+ * pending-state copy on the submit button.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CommentComposer } from "@/src/features/donor-research/components/shared-view/CommentComposer";
+
+describe("CommentComposer", () => {
+  it("disables submit when the body is empty", () => {
+    render(<CommentComposer onCancel={() => {}} onSubmit={() => {}} />);
+    expect(screen.getByRole("button", { name: /^comment$/i })).toBeDisabled();
+  });
+
+  it("calls onSubmit with the trimmed body on form submit", async () => {
+    const onSubmit = vi.fn();
+    render(<CommentComposer onCancel={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByPlaceholderText(/add a comment/i), {
+      target: { value: "  hi there  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^comment$/i }));
+    expect(onSubmit).toHaveBeenCalledWith("hi there");
+  });
+
+  it("renders the anchor descriptor for section anchors", () => {
+    render(
+      <CommentComposer
+        anchor={{ kind: "section", sectionKey: "methodology" }}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+    expect(screen.getByText(/on methodology/i)).toBeInTheDocument();
+  });
+
+  it("renders the anchor descriptor for candidate anchors", () => {
+    render(
+      <CommentComposer
+        anchor={{ kind: "candidate", candidateId: "c1" }}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+    expect(screen.getByText(/on this candidate/i)).toBeInTheDocument();
+  });
+
+  it("truncates long quote anchors in the descriptor", () => {
+    const longQuote = "x".repeat(100);
+    render(
+      <CommentComposer
+        anchor={{
+          kind: "text_range",
+          targetKind: "candidate",
+          targetId: "c1",
+          quote: longQuote,
+          prefix: "p",
+          suffix: "s",
+        }}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+    expect(screen.getByText(/on "x{80}…"/i)).toBeInTheDocument();
+  });
+
+  it("switches to reply mode when parentDisplayName is supplied", () => {
+    render(
+      <CommentComposer parentDisplayName="Donor Dana" onCancel={() => {}} onSubmit={() => {}} />
+    );
+    expect(screen.getByText(/replying to donor dana/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/write a reply/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^reply$/i })).toBeInTheDocument();
+  });
+
+  it("caps the textarea at 5000 chars via maxLength", () => {
+    render(<CommentComposer onCancel={() => {}} onSubmit={() => {}} />);
+    expect(screen.getByPlaceholderText(/add a comment/i)).toHaveAttribute("maxLength", "5000");
+  });
+
+  it("renders the external error inline with role=alert", () => {
+    render(
+      <CommentComposer
+        externalError="Slow down — try again in 30s."
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/slow down/i);
+  });
+
+  it("shows 'Posting…' copy while submitting and disables submit", () => {
+    render(<CommentComposer isSubmitting onCancel={() => {}} onSubmit={() => {}} />);
+    expect(screen.getByRole("button", { name: /posting/i })).toBeDisabled();
+  });
+
+  it("invokes onCancel when Cancel is clicked", () => {
+    const onCancel = vi.fn();
+    render(<CommentComposer onCancel={onCancel} onSubmit={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @file Tests for the text-range highlight overlay. Covers the kind
+ * gate (only `text_range` renders), orphan suppression, and re-resolve
+ * on window resize.
+ */
+
+import { act, render } from "@testing-library/react";
+import * as resolveModule from "@/src/features/donor-research/components/anchor/resolve";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+import { CommentHighlight } from "@/src/features/donor-research/components/shared-view/CommentHighlight";
+
+function makeRangeMock(rects: DOMRect[]): Range {
+  const list: { [k: number]: DOMRect } & {
+    length: number;
+    item: (i: number) => DOMRect | null;
+  } = {
+    length: rects.length,
+    item: (i: number) => rects[i] ?? null,
+  };
+  for (let i = 0; i < rects.length; i += 1) list[i] = rects[i];
+  return {
+    getClientRects: () => list as unknown as DOMRectList,
+  } as unknown as Range;
+}
+
+function rect(x: number, y: number, w: number, h: number): DOMRect {
+  return {
+    top: y,
+    left: x,
+    right: x + w,
+    bottom: y + h,
+    width: w,
+    height: h,
+    x,
+    y,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+const textRangeAnchor: CommentAnchor = {
+  kind: "text_range",
+  targetKind: "candidate",
+  targetId: "c1",
+  quote: "promising work",
+  prefix: "the",
+  suffix: ".",
+};
+
+describe("CommentHighlight", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (window as { scrollX?: number }).scrollX = 0;
+    (window as { scrollY?: number }).scrollY = 0;
+  });
+
+  it("renders nothing for section anchors", () => {
+    const sectionAnchor: CommentAnchor = { kind: "section", sectionKey: "methodology" };
+    const root = document.createElement("div");
+    const { container } = render(<CommentHighlight anchor={sectionAnchor} root={root} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for candidate anchors", () => {
+    const candidateAnchor: CommentAnchor = { kind: "candidate", candidateId: "c1" };
+    const root = document.createElement("div");
+    const { container } = render(<CommentHighlight anchor={candidateAnchor} root={root} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when resolveAnchor returns orphan", () => {
+    vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({ kind: "orphan" });
+    const root = document.createElement("div");
+    const { container } = render(<CommentHighlight anchor={textRangeAnchor} root={root} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("paints one absolute span per visual line rect", () => {
+    vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({
+      kind: "range",
+      range: makeRangeMock([rect(10, 20, 100, 18), rect(10, 40, 80, 18)]),
+      element: document.createElement("div"),
+    });
+    const root = document.createElement("div");
+    const { container } = render(<CommentHighlight anchor={textRangeAnchor} root={root} />);
+    const spans = container.querySelectorAll("[data-comment-highlight]");
+    expect(spans).toHaveLength(2);
+    expect((spans[0] as HTMLElement).style.top).toBe("20px");
+    expect((spans[1] as HTMLElement).style.top).toBe("40px");
+  });
+
+  it("re-resolves on window resize", () => {
+    const resolveSpy = vi
+      .spyOn(resolveModule, "resolveAnchor")
+      .mockReturnValueOnce({
+        kind: "range",
+        range: makeRangeMock([rect(0, 0, 50, 18)]),
+        element: document.createElement("div"),
+      })
+      .mockReturnValueOnce({
+        kind: "range",
+        range: makeRangeMock([rect(0, 0, 100, 18)]),
+        element: document.createElement("div"),
+      });
+    const root = document.createElement("div");
+    render(<CommentHighlight anchor={textRangeAnchor} root={root} />);
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(resolveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders skip when root is null", () => {
+    const { container } = render(<CommentHighlight anchor={textRangeAnchor} root={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders interactive <button> when onActivate is supplied", () => {
+    vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({
+      kind: "range",
+      range: makeRangeMock([rect(0, 0, 50, 18)]),
+      element: document.createElement("div"),
+    });
+    const onActivate = vi.fn();
+    const root = document.createElement("div");
+    const { container } = render(
+      <CommentHighlight anchor={textRangeAnchor} root={root} onActivate={onActivate} />
+    );
+    const btn = container.querySelector("button[data-comment-highlight]");
+    expect(btn).not.toBeNull();
+    btn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onActivate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
@@ -115,6 +115,20 @@ describe("CommentHighlight", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("renders the active variant with data-active when isActive=true", () => {
+    vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({
+      kind: "range",
+      range: makeRangeMock([rect(0, 0, 50, 18)]),
+      element: document.createElement("div"),
+    });
+    const root = document.createElement("div");
+    const { container } = render(
+      <CommentHighlight anchor={textRangeAnchor} root={root} isActive />
+    );
+    const span = container.querySelector("[data-comment-highlight]");
+    expect(span?.getAttribute("data-active")).toBe("true");
+  });
+
   it("renders interactive <button> when onActivate is supplied", () => {
     vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({
       kind: "range",

--- a/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentHighlight.test.tsx
@@ -129,7 +129,7 @@ describe("CommentHighlight", () => {
     expect(span?.getAttribute("data-active")).toBe("true");
   });
 
-  it("renders interactive <button> when onActivate is supplied", () => {
+  it("renders an interactive marker <button> when onActivate is supplied", () => {
     vi.spyOn(resolveModule, "resolveAnchor").mockReturnValue({
       kind: "range",
       range: makeRangeMock([rect(0, 0, 50, 18)]),
@@ -140,7 +140,11 @@ describe("CommentHighlight", () => {
     const { container } = render(
       <CommentHighlight anchor={textRangeAnchor} root={root} onActivate={onActivate} />
     );
-    const btn = container.querySelector("button[data-comment-highlight]");
+    // The highlight bands stay non-interactive (pointer-events:none) so text
+    // is re-selectable; the clickable affordance is a separate marker button.
+    const band = container.querySelector("[data-comment-highlight]") as HTMLElement | null;
+    expect(band?.style.pointerEvents).toBe("none");
+    const btn = container.querySelector("button[data-comment-marker]");
     expect(btn).not.toBeNull();
     btn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onActivate).toHaveBeenCalled();

--- a/__tests__/features/donor-research/shared-view/CommentOverlay.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentOverlay.test.tsx
@@ -140,7 +140,9 @@ describe("CommentOverlay", () => {
       })
     );
     render(<CommentOverlay token="tk" />);
-    expect(screen.getByRole("alert")).toHaveTextContent(/couldn’t load comments/i);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/couldn.t load the comments/i);
+    expect(alert).toHaveTextContent(/try again/i);
   });
 
   it("renders 'Be the first to comment' and no '0 comments' literal in empty state", () => {

--- a/__tests__/features/donor-research/shared-view/CommentOverlay.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentOverlay.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * @file Shell-level tests for CommentOverlay. Mocks the orchestration
+ * hook `useCommenting` and the heavier sub-tree primitives so the test
+ * exercises only the overlay's own behaviors: loading skeleton, error
+ * copy, empty state without "0 comments" literal, orphan lane render,
+ * aria-live verb selection, and the reportRevoked hide.
+ */
+
+import { render, screen } from "@testing-library/react";
+
+import type { SharedReportCommentNode } from "@/types/donor-research-comments";
+
+// ── Heavy sub-tree mocks ────────────────────────────────────────────
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="sheet" data-open={open ?? false}>
+      {children}
+    </div>
+  ),
+  SheetTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sheet-trigger">{children}</div>
+  ),
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sheet-content">{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/AnchoredAffordances", () => ({
+  AnchoredAffordances: () => <div data-testid="anchored-affordances" />,
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/SelectionAffordance", () => ({
+  SelectionAffordance: () => <div data-testid="selection-affordance" />,
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/IdentityBadge", () => ({
+  IdentityBadge: () => <div data-testid="identity-badge" />,
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/IdentityCaptureDialog", () => ({
+  IdentityCaptureDialog: () => null,
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/CommentRow", () => ({
+  CommentRow: ({ node }: { node: SharedReportCommentNode }) => (
+    <div data-testid={`comment-row-${node.id}`}>{node.displayName}</div>
+  ),
+}));
+
+vi.mock("@/src/features/donor-research/components/shared-view/CommentComposer", () => ({
+  CommentComposer: () => <div data-testid="comment-composer" />,
+}));
+
+// ── useCommenting mock ──────────────────────────────────────────────
+import { useCommenting } from "@/src/features/donor-research/components/shared-view/useCommenting";
+
+vi.mock("@/src/features/donor-research/components/shared-view/useCommenting");
+const mockUseCommenting = vi.mocked(useCommenting);
+
+import { CommentOverlay } from "@/src/features/donor-research/components/shared-view/CommentOverlay";
+
+function makeNode(overrides: Partial<SharedReportCommentNode> = {}): SharedReportCommentNode {
+  return {
+    id: "n1",
+    parentCommentId: null,
+    isAdvisor: false,
+    displayName: "Donor Dana",
+    anchor: { kind: "section", sectionKey: "methodology" },
+    body: "Looks good",
+    createdAt: "2026-06-19T00:00:00.000Z",
+    children: [],
+    ...overrides,
+  } as SharedReportCommentNode;
+}
+
+type UseCommentingReturn = ReturnType<typeof useCommenting>;
+
+function makeUseCommenting(overrides: Partial<UseCommentingReturn> = {}): UseCommentingReturn {
+  return {
+    query: { isLoading: false, error: null } as UseCommentingReturn["query"],
+    tree: [],
+    identity: {
+      displayName: null,
+      isAdvisor: false,
+      hasIdentity: false,
+      refresh: vi.fn(),
+      clearIdentity: vi.fn(),
+    } as UseCommentingReturn["identity"],
+    isPosting: false,
+    composer: { mode: "closed" },
+    composerError: null,
+    openRootComposer: vi.fn(),
+    openReplyComposer: vi.fn(),
+    closeComposer: vi.fn(),
+    sheetOpen: false,
+    setSheetOpen: vi.fn(),
+    activatePin: vi.fn(),
+    counts: {
+      byKey: new Map(),
+      rootsByKey: new Map(),
+      orphanRoots: [],
+    },
+    selectionAffordance: null,
+    dismissSelectionAffordance: vi.fn(),
+    submitComposer: vi.fn(),
+    identityModalMode: null,
+    setIdentityModalMode: vi.fn(),
+    retryPendingPost: vi.fn(),
+    scrollTargetCommentId: null,
+    clearScrollTarget: vi.fn(),
+    highlightRefreshKey: 0,
+    ...overrides,
+  } as UseCommentingReturn;
+}
+
+describe("CommentOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the loading skeleton when the query is fetching", () => {
+    mockUseCommenting.mockReturnValue(
+      makeUseCommenting({
+        query: { isLoading: true, error: null } as UseCommentingReturn["query"],
+      })
+    );
+    render(<CommentOverlay token="tk" />);
+    expect(screen.getByTestId("comments-loading")).toBeInTheDocument();
+  });
+
+  it("renders the error state when the query errors out", () => {
+    mockUseCommenting.mockReturnValue(
+      makeUseCommenting({
+        query: {
+          isLoading: false,
+          error: new Error("net"),
+        } as UseCommentingReturn["query"],
+      })
+    );
+    render(<CommentOverlay token="tk" />);
+    expect(screen.getByRole("alert")).toHaveTextContent(/couldn’t load comments/i);
+  });
+
+  it("renders 'Be the first to comment' and no '0 comments' literal in empty state", () => {
+    mockUseCommenting.mockReturnValue(makeUseCommenting({ tree: [] }));
+    const { container } = render(<CommentOverlay token="tk" />);
+    expect(screen.getByText(/be the first to comment/i)).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/0 comments/i);
+  });
+
+  it("labels the comments trigger with the total when comments exist", () => {
+    const tree = [makeNode({ id: "r1" }), makeNode({ id: "r2" })];
+    mockUseCommenting.mockReturnValue(makeUseCommenting({ tree }));
+    render(<CommentOverlay token="tk" />);
+    // The trigger button shows "N comments" via pluralize.
+    expect(screen.getByRole("button", { name: /^2 comments$/ })).toBeInTheDocument();
+  });
+
+  it("renders an orphan-lane section with pluralized header when orphan roots exist", () => {
+    const orphan = makeNode({
+      id: "orphan-1",
+      anchor: {
+        kind: "text_range",
+        targetKind: "candidate",
+        targetId: "c1",
+        quote: "moved text",
+        prefix: "before",
+        suffix: "after",
+      },
+    });
+    mockUseCommenting.mockReturnValue(
+      makeUseCommenting({
+        counts: {
+          byKey: new Map(),
+          rootsByKey: new Map(),
+          orphanRoots: [orphan],
+        },
+      })
+    );
+    render(<CommentOverlay token="tk" />);
+    expect(screen.getByLabelText(/orphan comments/i)).toBeInTheDocument();
+    expect(screen.getByText(/^1 orphan comment$/i)).toBeInTheDocument();
+    // The preserved quote is rendered as a blockquote.
+    expect(screen.getByText(/moved text/i)).toBeInTheDocument();
+  });
+
+  it("emits 'Comment added by X' in the aria-live region on a new root arrival", () => {
+    mockUseCommenting.mockReturnValueOnce(makeUseCommenting({ tree: [] }));
+    const { rerender } = render(<CommentOverlay token="tk" />);
+    // Sanity: aria-live is empty on initial render.
+    expect(screen.getByTestId("comment-announce")).toHaveTextContent("");
+    // New root arrives.
+    mockUseCommenting.mockReturnValueOnce(
+      makeUseCommenting({
+        tree: [makeNode({ id: "n1", displayName: "Donor Dana" })],
+      })
+    );
+    rerender(<CommentOverlay token="tk" />);
+    expect(screen.getByTestId("comment-announce")).toHaveTextContent(
+      /comment added by donor dana/i
+    );
+  });
+
+  it("emits 'Reply added by X' when the newest arrival is a reply", () => {
+    mockUseCommenting.mockReturnValueOnce(
+      makeUseCommenting({
+        tree: [makeNode({ id: "root-1", displayName: "Root Roger" })],
+      })
+    );
+    const { rerender } = render(<CommentOverlay token="tk" />);
+    mockUseCommenting.mockReturnValueOnce(
+      makeUseCommenting({
+        tree: [
+          makeNode({
+            id: "root-1",
+            displayName: "Root Roger",
+            children: [
+              makeNode({
+                id: "reply-1",
+                parentCommentId: "root-1",
+                displayName: "Replier Renee",
+                anchor: null,
+              }),
+            ],
+          }),
+        ],
+      })
+    );
+    rerender(<CommentOverlay token="tk" />);
+    expect(screen.getByTestId("comment-announce")).toHaveTextContent(
+      /reply added by replier renee/i
+    );
+  });
+
+  it("renders nothing when reportRevoked is true", () => {
+    // useCommenting still returns its shape but we don't expect anything to render.
+    mockUseCommenting.mockReturnValue(makeUseCommenting());
+    const { container } = render(<CommentOverlay token="tk" reportRevoked />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("passes isAdvisor through to useCommenting", () => {
+    mockUseCommenting.mockReturnValue(makeUseCommenting());
+    render(<CommentOverlay token="tk" isAdvisor />);
+    expect(mockUseCommenting).toHaveBeenCalledWith(
+      "tk",
+      expect.objectContaining({ enabled: true, isAdvisor: true })
+    );
+  });
+
+  it("disables useCommenting when reportRevoked is true", () => {
+    mockUseCommenting.mockReturnValue(makeUseCommenting());
+    // Even though overlay renders nothing, the hook is called with enabled=false.
+    render(<CommentOverlay token="tk" reportRevoked />);
+    expect(mockUseCommenting).toHaveBeenCalledWith(
+      "tk",
+      expect.objectContaining({ enabled: false })
+    );
+  });
+});

--- a/__tests__/features/donor-research/shared-view/CommentPin.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentPin.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @file Tests for the pin badge rendered next to each anchored target.
+ * Validates count + label pluralization, render-suppression at zero,
+ * `<button>` semantics, keyboard activation, and aria-label composition.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CommentPin } from "@/src/features/donor-research/components/shared-view/CommentPin";
+
+describe("CommentPin", () => {
+  it("renders nothing when count is zero", () => {
+    const { container } = render(
+      <CommentPin count={0} targetKey="section:methodology" onActivate={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("pluralizes the count via the pluralize library", () => {
+    const { rerender } = render(
+      <CommentPin count={1} targetKey="section:methodology" onActivate={() => {}} />
+    );
+    expect(screen.getByRole("button")).toHaveTextContent(/^1 comment$/);
+    rerender(<CommentPin count={3} targetKey="section:methodology" onActivate={() => {}} />);
+    expect(screen.getByRole("button")).toHaveTextContent(/^3 comments$/);
+  });
+
+  it("renders as a <button> with the target key in data-target-key", () => {
+    render(<CommentPin count={2} targetKey="candidate:abc" onActivate={() => {}} />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("data-comment-pin");
+    expect(btn).toHaveAttribute("data-target-key", "candidate:abc");
+  });
+
+  it("invokes onActivate(targetKey) on click", () => {
+    const onActivate = vi.fn();
+    render(<CommentPin count={2} targetKey="section:lead-candidate" onActivate={onActivate} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onActivate).toHaveBeenCalledWith("section:lead-candidate");
+  });
+
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+  ])("activates on %s key", (_, key) => {
+    const onActivate = vi.fn();
+    render(<CommentPin count={1} targetKey="section:masthead" onActivate={onActivate} />);
+    fireEvent.keyDown(screen.getByRole("button"), { key: key === "{Enter}" ? "Enter" : " " });
+    expect(onActivate).toHaveBeenCalledWith("section:masthead");
+  });
+
+  it("composes the aria-label with optional human label", () => {
+    render(
+      <CommentPin
+        count={2}
+        targetKey="candidate:c1"
+        onActivate={() => {}}
+        ariaLabel="lead candidate"
+      />
+    );
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "aria-label",
+      "2 comments on lead candidate"
+    );
+  });
+
+  it("uses the bare label when ariaLabel is omitted", () => {
+    render(<CommentPin count={4} targetKey="section:runners-up" onActivate={() => {}} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "4 comments");
+  });
+});

--- a/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
@@ -25,10 +25,11 @@ function makeNode(overrides: Partial<SharedReportCommentNode> = {}): SharedRepor
 }
 
 describe("CommentRow", () => {
-  it("renders displayName, relative time, and body", () => {
+  it("renders displayName, absolute local timestamp, and body", () => {
     render(<CommentRow node={makeNode({ body: "Hello there" })} onReply={() => {}} />);
     expect(screen.getByText("Donor Dana")).toBeInTheDocument();
-    expect(screen.getByText("just now")).toBeInTheDocument();
+    // Timestamps are absolute local time suffixed with "(Local)" — not relative.
+    expect(screen.getByText(/\(Local\)$/)).toBeInTheDocument();
     expect(screen.getByText("Hello there")).toBeInTheDocument();
   });
 

--- a/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @file Tests for CommentRow — display name + relative time, advisor
+ * badge, body sanitization fidelity (entity decode, no script eval),
+ * newline-to-<br>, recursive replies with the depth-4 collapse, and
+ * the Reply button wiring.
+ */
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { CommentRow } from "@/src/features/donor-research/components/shared-view/CommentRow";
+import type { SharedReportCommentNode } from "@/types/donor-research-comments";
+
+function makeNode(overrides: Partial<SharedReportCommentNode> = {}): SharedReportCommentNode {
+  return {
+    id: "n1",
+    parentCommentId: null,
+    isAdvisor: false,
+    displayName: "Donor Dana",
+    anchor: { kind: "section", sectionKey: "methodology" },
+    body: "Looks good",
+    createdAt: new Date(Date.now() - 30_000).toISOString(),
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("CommentRow", () => {
+  it("renders displayName, relative time, and body", () => {
+    render(<CommentRow node={makeNode({ body: "Hello there" })} onReply={() => {}} />);
+    expect(screen.getByText("Donor Dana")).toBeInTheDocument();
+    expect(screen.getByText("just now")).toBeInTheDocument();
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it("renders the Advisor badge when isAdvisor=true", () => {
+    render(<CommentRow node={makeNode({ isAdvisor: true })} onReply={() => {}} />);
+    expect(screen.getByText(/advisor/i)).toBeInTheDocument();
+  });
+
+  it("does NOT render the Advisor badge when isAdvisor=false", () => {
+    render(<CommentRow node={makeNode({ isAdvisor: false })} onReply={() => {}} />);
+    expect(screen.queryByText(/^advisor$/i)).not.toBeInTheDocument();
+  });
+
+  it("escapes HTML in the body — a <script> stays inert text", () => {
+    const malicious = "&lt;script&gt;alert(1)&lt;/script&gt;";
+    const { container } = render(
+      <CommentRow node={makeNode({ body: malicious })} onReply={() => {}} />
+    );
+    // The decoded payload is rendered as text (React auto-escapes children).
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("<script>alert(1)</script>");
+  });
+
+  it("renders newlines as visual line breaks", () => {
+    const { container } = render(
+      <CommentRow node={makeNode({ body: "line1\nline2\nline3" })} onReply={() => {}} />
+    );
+    const brs = container.querySelectorAll("br");
+    expect(brs.length).toBe(2);
+  });
+
+  it("decodes the four backend-sanitized entities", () => {
+    const { container } = render(
+      <CommentRow
+        node={makeNode({ body: "5 &gt; 2 &amp;&amp; 3 &lt; 4 &quot;ok&quot; &#39;y&#39;" })}
+        onReply={() => {}}
+      />
+    );
+    expect(container.textContent).toContain(`5 > 2 && 3 < 4 "ok" 'y'`);
+  });
+
+  it("invokes onReply(node.id) when the Reply button is clicked", () => {
+    const onReply = vi.fn();
+    render(<CommentRow node={makeNode({ id: "abc" })} onReply={onReply} />);
+    fireEvent.click(screen.getByRole("button", { name: /reply/i }));
+    expect(onReply).toHaveBeenCalledWith("abc");
+  });
+
+  it("recursively renders child replies up to depth 4", () => {
+    const tree = makeNode({
+      id: "root",
+      children: [
+        makeNode({
+          id: "c1",
+          displayName: "L1",
+          children: [
+            makeNode({
+              id: "c2",
+              displayName: "L2",
+              children: [makeNode({ id: "c3", displayName: "L3" })],
+            }),
+          ],
+        }),
+      ],
+    });
+    render(<CommentRow node={tree} onReply={() => {}} />);
+    expect(screen.getByText("L1")).toBeInTheDocument();
+    expect(screen.getByText("L2")).toBeInTheDocument();
+    expect(screen.getByText("L3")).toBeInTheDocument();
+  });
+
+  it("collapses replies at depth >= 4 behind a 'Show N more replies' disclosure", () => {
+    const depth5 = makeNode({
+      id: "depth5",
+      displayName: "Deep",
+      children: [makeNode({ id: "depth6", displayName: "Even Deeper" })],
+    });
+    // Render the depth-5 row directly to exercise the per-row collapse.
+    render(<CommentRow node={depth5} depth={5} onReply={() => {}} />);
+    expect(screen.queryByText("Even Deeper")).not.toBeInTheDocument();
+    const disclosure = screen.getByRole("button", { name: /show 1 more reply/i });
+    fireEvent.click(disclosure);
+    expect(screen.getByText("Even Deeper")).toBeInTheDocument();
+  });
+
+  it("renders the 'Sending…' indicator on optimistic rows", () => {
+    render(<CommentRow node={makeNode({ _optimistic: true })} onReply={() => {}} />);
+    expect(screen.getByText(/sending/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
+++ b/__tests__/features/donor-research/shared-view/CommentRow.test.tsx
@@ -118,4 +118,41 @@ describe("CommentRow", () => {
     render(<CommentRow node={makeNode({ _optimistic: true })} onReply={() => {}} />);
     expect(screen.getByText(/sending/i)).toBeInTheDocument();
   });
+
+  it("invokes onActivate(node.id) when the row body is clicked", () => {
+    const onActivate = vi.fn();
+    render(
+      <CommentRow node={makeNode({ id: "n42" })} onReply={() => {}} onActivate={onActivate} />
+    );
+    // Find the row body button (role from onActivate wiring) — there's
+    // also a Reply button, so target by data-comment-row attribute.
+    const row = document.querySelector("[data-comment-row]") as HTMLElement;
+    fireEvent.click(row);
+    expect(onActivate).toHaveBeenCalledWith("n42");
+  });
+
+  it("Reply button does NOT bubble into the row activate handler", () => {
+    const onActivate = vi.fn();
+    const onReply = vi.fn();
+    render(<CommentRow node={makeNode({ id: "n42" })} onReply={onReply} onActivate={onActivate} />);
+    // With onActivate set, the row's <article> picks up role=button
+    // too — disambiguate via the exact text "Reply".
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    expect(onReply).toHaveBeenCalledWith("n42");
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("marks itself aria-current=true when activeCommentId matches", () => {
+    render(
+      <CommentRow
+        node={makeNode({ id: "n42" })}
+        onReply={() => {}}
+        onActivate={() => {}}
+        activeCommentId="n42"
+      />
+    );
+    const row = document.querySelector("[data-comment-row]") as HTMLElement;
+    expect(row.getAttribute("aria-current")).toBe("true");
+    expect(row.getAttribute("data-active")).toBe("true");
+  });
 });

--- a/__tests__/hooks/useCommenterIdentity.test.tsx
+++ b/__tests__/hooks/useCommenterIdentity.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @file Tests for the commenter-identity hook. Reads `drsc_name` from
+ * the FE-origin cookie, exposes the advisor flag plumbed in from the
+ * parent, derives `hasIdentity`, and exposes a `clearIdentity()` action
+ * that POSTs to the proxy clear-identity route.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { useCommenterIdentity } from "@/hooks/useCommenterIdentity";
+import { clearCommenterIdentity } from "@/services/donor-research-comments.service";
+
+vi.mock("@/services/donor-research-comments.service", async () => {
+  const actual = await vi.importActual<typeof import("@/services/donor-research-comments.service")>(
+    "@/services/donor-research-comments.service"
+  );
+  return {
+    ...actual,
+    clearCommenterIdentity: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockClear = vi.mocked(clearCommenterIdentity);
+
+const TOKEN = "share-token-1";
+
+function setNameCookie(value: string | null) {
+  // jsdom's document.cookie setter appends rather than replaces; expire any
+  // existing value first.
+  document.cookie = "drsc_name=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+  if (value !== null) {
+    document.cookie = `drsc_name=${encodeURIComponent(value)}; path=/`;
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setNameCookie(null);
+});
+
+afterEach(() => {
+  setNameCookie(null);
+});
+
+describe("useCommenterIdentity — displayName", () => {
+  it("returns null displayName when no drsc_name cookie is present", () => {
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.displayName).toBeNull();
+  });
+
+  it("returns the cookie value when drsc_name is present", () => {
+    setNameCookie("Donor Dana");
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.displayName).toBe("Donor Dana");
+  });
+
+  it("URI-decodes the cookie value", () => {
+    setNameCookie("José Müller");
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.displayName).toBe("José Müller");
+  });
+});
+
+describe("useCommenterIdentity — isAdvisor + hasIdentity", () => {
+  it("reflects the isAdvisor input prop", () => {
+    const { result, rerender } = renderHook(
+      ({ advisor }: { advisor: boolean }) => useCommenterIdentity(TOKEN, advisor),
+      { initialProps: { advisor: false } }
+    );
+    expect(result.current.isAdvisor).toBe(false);
+    rerender({ advisor: true });
+    expect(result.current.isAdvisor).toBe(true);
+  });
+
+  it("hasIdentity is true when displayName is set even if not advisor", () => {
+    setNameCookie("Donor Dana");
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.hasIdentity).toBe(true);
+  });
+
+  it("hasIdentity is true when isAdvisor is true even without a cookie", () => {
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, true));
+    expect(result.current.hasIdentity).toBe(true);
+  });
+
+  it("hasIdentity is false when neither displayName nor isAdvisor is set", () => {
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.hasIdentity).toBe(false);
+  });
+});
+
+describe("useCommenterIdentity — clearIdentity", () => {
+  it("calls the proxy clear-identity route via the service and resets displayName", async () => {
+    setNameCookie("Donor Dana");
+    const { result } = renderHook(() => useCommenterIdentity(TOKEN, false));
+    expect(result.current.displayName).toBe("Donor Dana");
+
+    await act(async () => {
+      await result.current.clearIdentity();
+    });
+
+    expect(mockClear).toHaveBeenCalledWith(TOKEN);
+    await waitFor(() => expect(result.current.displayName).toBeNull());
+    expect(result.current.hasIdentity).toBe(false);
+  });
+});

--- a/__tests__/hooks/useSharedReportComments.test.tsx
+++ b/__tests__/hooks/useSharedReportComments.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @file Tests for the React Query hook that powers the donor-shared
+ * report comment surface. Asserts polling pause when disabled,
+ * optimistic root + reply append, error rollback to the previous
+ * snapshot, and tree assembly correctness.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { useSharedReportComments } from "@/hooks/useSharedReportComments";
+import {
+  listSharedReportComments,
+  postSharedReportComment,
+} from "@/services/donor-research-comments.service";
+import type {
+  SharedReportComment,
+  SharedReportCommentsResponse,
+} from "@/types/donor-research-comments";
+
+vi.mock("@/services/donor-research-comments.service", async () => {
+  const actual = await vi.importActual<typeof import("@/services/donor-research-comments.service")>(
+    "@/services/donor-research-comments.service"
+  );
+  return {
+    ...actual,
+    listSharedReportComments: vi.fn(),
+    postSharedReportComment: vi.fn(),
+  };
+});
+
+const mockList = vi.mocked(listSharedReportComments);
+const mockPost = vi.mocked(postSharedReportComment);
+
+function makeRoot(overrides: Partial<SharedReportComment> = {}): SharedReportComment {
+  return {
+    id: "root-1",
+    parentCommentId: null,
+    isAdvisor: false,
+    displayName: "Donor Dana",
+    anchor: { kind: "section", sectionKey: "methodology" },
+    body: "Looks good",
+    createdAt: "2026-06-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeReply(
+  parentId: string,
+  overrides: Partial<SharedReportComment> = {}
+): SharedReportComment {
+  return {
+    id: `reply-${parentId}`,
+    parentCommentId: parentId,
+    isAdvisor: false,
+    displayName: "Advisor Avi",
+    anchor: null,
+    body: "Thanks for flagging",
+    createdAt: "2026-06-19T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+let queryClient: QueryClient;
+const TOKEN = "share-token-1";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+});
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe("useSharedReportComments — loading + success", () => {
+  it("starts in loading state and resolves with an assembled tree", async () => {
+    const root = makeRoot();
+    const reply = makeReply(root.id);
+    const response: SharedReportCommentsResponse = {
+      roots: [root],
+      replies: [reply],
+      pageInfo: { nextCursor: null },
+    };
+    mockList.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    expect(result.current.query.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.query.isLoading).toBe(false));
+    expect(result.current.tree).toHaveLength(1);
+    expect(result.current.tree[0].children).toHaveLength(1);
+    expect(result.current.tree[0].children[0].id).toBe(reply.id);
+  });
+
+  it("returns an empty tree when no comments exist", async () => {
+    mockList.mockResolvedValue({ roots: [], replies: [], pageInfo: { nextCursor: null } });
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    await waitFor(() => expect(result.current.query.isLoading).toBe(false));
+    expect(result.current.tree).toEqual([]);
+  });
+
+  it("surfaces an error when the list service fails", async () => {
+    mockList.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    await waitFor(() => expect(result.current.query.error).toBeInstanceOf(Error));
+    expect(result.current.tree).toEqual([]);
+  });
+});
+
+describe("useSharedReportComments — enabled gate", () => {
+  it("does not call the list service when disabled", () => {
+    renderHook(() => useSharedReportComments(TOKEN, { enabled: false }), { wrapper });
+    expect(mockList).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSharedReportComments — optimistic mutations", () => {
+  it("optimistically appends a new root and clears it on settled invalidate", async () => {
+    const initial: SharedReportCommentsResponse = {
+      roots: [makeRoot({ id: "existing" })],
+      replies: [],
+      pageInfo: { nextCursor: null },
+    };
+    mockList.mockResolvedValue(initial);
+    const created = makeRoot({ id: "new-root", body: "Optimistic body" });
+    mockPost.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(created), 10);
+        })
+    );
+
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    await waitFor(() => expect(result.current.tree).toHaveLength(1));
+
+    act(() => {
+      void result.current.postComment.mutate({
+        request: {
+          body: "Optimistic body",
+          displayName: "Donor",
+          anchor: { kind: "section", sectionKey: "methodology" },
+        },
+        idempotencyKey: "key-1",
+      });
+    });
+
+    // Optimistic add — the new root appears immediately.
+    await waitFor(() => expect(result.current.tree[0].id).toContain("optimistic-key-1"));
+    await waitFor(() => expect(result.current.postComment.isPending).toBe(false));
+  });
+
+  it("rolls back the snapshot when the mutation fails", async () => {
+    const existing = makeRoot({ id: "existing" });
+    mockList.mockResolvedValue({
+      roots: [existing],
+      replies: [],
+      pageInfo: { nextCursor: null },
+    });
+    mockPost.mockRejectedValue(new Error("nope"));
+
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    await waitFor(() => expect(result.current.tree).toHaveLength(1));
+    await act(async () => {
+      try {
+        await result.current.postComment.mutateAsync({
+          request: { body: "x", displayName: "Donor" },
+          idempotencyKey: "key-2",
+        });
+      } catch {
+        // expected
+      }
+    });
+    // After failure + rollback only the pre-existing comment remains.
+    expect(result.current.tree.map((n) => n.id)).toEqual(["existing"]);
+  });
+
+  it("appends a reply under its parent on optimistic add", async () => {
+    const root = makeRoot({ id: "p1" });
+    mockList.mockResolvedValue({
+      roots: [root],
+      replies: [],
+      pageInfo: { nextCursor: null },
+    });
+    mockPost.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(makeReply("p1")), 10);
+        })
+    );
+    const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });
+    await waitFor(() => expect(result.current.tree).toHaveLength(1));
+    act(() => {
+      void result.current.postComment.mutate({
+        request: { body: "reply body", displayName: "Avi", parentCommentId: "p1" },
+        idempotencyKey: "key-3",
+      });
+    });
+    await waitFor(() => expect(result.current.tree[0].children).toHaveLength(1));
+  });
+});

--- a/__tests__/hooks/useSharedReportComments.test.tsx
+++ b/__tests__/hooks/useSharedReportComments.test.tsx
@@ -159,7 +159,7 @@ describe("useSharedReportComments — optimistic mutations", () => {
     await waitFor(() => expect(result.current.postComment.isPending).toBe(false));
   });
 
-  it("rolls back the snapshot when the mutation fails", async () => {
+  it("keeps the failed optimistic comment (flagged for retry) instead of rolling back", async () => {
     const existing = makeRoot({ id: "existing" });
     mockList.mockResolvedValue({
       roots: [existing],
@@ -180,8 +180,19 @@ describe("useSharedReportComments — optimistic mutations", () => {
         // expected
       }
     });
-    // After failure + rollback only the pre-existing comment remains.
-    expect(result.current.tree.map((n) => n.id)).toEqual(["existing"]);
+    // On failure we deliberately do NOT roll back: vanishing the row would
+    // throw away the donor's text. The optimistic row stays in place, its
+    // pending state cleared and `_failed` set, so the UI can surface a Retry
+    // affordance. Invalidation (which would wipe it) only runs on success.
+    await waitFor(() => {
+      const failed = result.current.tree.find((n) => n._failed);
+      expect(failed).toBeDefined();
+    });
+    const failedRow = result.current.tree.find((n) => n._failed);
+    expect(failedRow?.id).toContain("optimistic-key-2");
+    expect(failedRow?._optimistic).toBe(false);
+    // The pre-existing comment is untouched.
+    expect(result.current.tree.some((n) => n.id === "existing")).toBe(true);
   });
 
   it("appends a reply under its parent on optimistic add", async () => {

--- a/__tests__/hooks/useSharedReportComments.test.tsx
+++ b/__tests__/hooks/useSharedReportComments.test.tsx
@@ -136,7 +136,7 @@ describe("useSharedReportComments — optimistic mutations", () => {
     mockPost.mockImplementation(
       () =>
         new Promise((resolve) => {
-          setTimeout(() => resolve(created), 10);
+          setTimeout(() => resolve(created), 300);
         })
     );
 
@@ -194,7 +194,7 @@ describe("useSharedReportComments — optimistic mutations", () => {
     mockPost.mockImplementation(
       () =>
         new Promise((resolve) => {
-          setTimeout(() => resolve(makeReply("p1")), 10);
+          setTimeout(() => resolve(makeReply("p1")), 300);
         })
     );
     const { result } = renderHook(() => useSharedReportComments(TOKEN), { wrapper });

--- a/app/api/donor-research/shared/[token]/clear-identity/route.ts
+++ b/app/api/donor-research/shared/[token]/clear-identity/route.ts
@@ -7,7 +7,11 @@ import { NextResponse } from "next/server";
  * unreachable from the browser since the FE-origin cookie is gone.
  */
 
+// Must mirror the paths the comments proxy uses when setting these
+// cookies, or the clear no-ops: drsc_session lives at the proxy path,
+// drsc_name at root "/" (so the shared page can read it via document.cookie).
 const FE_COOKIE_PATH = "/api/donor-research/shared/";
+const FE_NAME_COOKIE_PATH = "/";
 
 export function POST(): NextResponse {
   const res = NextResponse.json({ ok: true });
@@ -22,7 +26,7 @@ export function POST(): NextResponse {
     httpOnly: false,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
-    path: FE_COOKIE_PATH,
+    path: FE_NAME_COOKIE_PATH,
     maxAge: 0,
   });
   res.headers.set("Cache-Control", "no-store");

--- a/app/api/donor-research/shared/[token]/clear-identity/route.ts
+++ b/app/api/donor-research/shared/[token]/clear-identity/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Q2 "Not me — switch" affordance. Clears the comment-identity cookies
+ * on the FE origin so the next post forces a fresh identity-capture
+ * prompt. The indexer's drsc_session bound by HMAC remains valid but
+ * unreachable from the browser since the FE-origin cookie is gone.
+ */
+
+const FE_COOKIE_PATH = "/api/donor-research/shared/";
+
+export function POST(): NextResponse {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set("drsc_session", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: FE_COOKIE_PATH,
+    maxAge: 0,
+  });
+  res.cookies.set("drsc_name", "", {
+    httpOnly: false,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: FE_COOKIE_PATH,
+    maxAge: 0,
+  });
+  res.headers.set("Cache-Control", "no-store");
+  return res;
+}

--- a/app/api/donor-research/shared/[token]/comments/[commentId]/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/[commentId]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Placeholder for per-comment operations (advisor mark-seen in v1.1,
+ * delete-own in v1.5). v1 has no per-comment route on the indexer side
+ * either; this file exists so the API surface is allocated and adding
+ * the operations later is a route-shape change only.
+ */
+
+export function GET(): NextResponse {
+  return NextResponse.json({ error: "not_implemented" }, { status: 405 });
+}
+
+export function PATCH(): NextResponse {
+  return NextResponse.json({ error: "not_implemented" }, { status: 405 });
+}
+
+export function DELETE(): NextResponse {
+  return NextResponse.json({ error: "not_implemented" }, { status: 405 });
+}

--- a/app/api/donor-research/shared/[token]/comments/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/route.ts
@@ -37,6 +37,10 @@ const COOKIE_NAME = "drsc_name";
 const FE_COOKIE_PATH = "/api/donor-research/shared/";
 const FE_NAME_COOKIE_PATH = "/";
 
+// Bound the server-to-server proxy call so a hung indexer can't pin the
+// Next.js route worker indefinitely — abort and surface a 502 instead.
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
 const NO_STORE = {
   "Cache-Control": "no-store, no-cache, must-revalidate",
   Pragma: "no-cache",
@@ -92,7 +96,16 @@ function copySetCookies(upstream: Response, next: NextResponse, isProd: boolean)
     const idx = pair.indexOf("=");
     if (idx === -1) continue;
     const name = pair.slice(0, idx);
-    const value = decodeURIComponent(pair.slice(idx + 1));
+    const rawValue = pair.slice(idx + 1);
+    // Guard decoding: a malformed percent-sequence from upstream would
+    // otherwise throw and 500 the whole proxy response. Fall back to the
+    // raw value (re-encoded on set) rather than failing the request.
+    let value: string;
+    try {
+      value = decodeURIComponent(rawValue);
+    } catch {
+      value = rawValue;
+    }
     if (name === COOKIE_SESSION) {
       next.cookies.set(COOKIE_SESSION, value, {
         httpOnly: true,
@@ -133,6 +146,7 @@ export async function GET(request: NextRequest, ctx: Params): Promise<NextRespon
       method: "GET",
       headers: forwardHeaders,
       cache: "no-store",
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch {
     return applyNoStore(NextResponse.json({ error: "indexer_unreachable" }, { status: 502 }));
@@ -156,6 +170,7 @@ export async function POST(request: NextRequest, ctx: Params): Promise<NextRespo
       headers: forwardHeaders,
       body: rawBody,
       cache: "no-store",
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch {
     return applyNoStore(NextResponse.json({ error: "indexer_unreachable" }, { status: 502 }));

--- a/app/api/donor-research/shared/[token]/comments/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/route.ts
@@ -52,6 +52,7 @@ async function buildForwardHeaders(token: string, contentType?: string): Promise
   const ip = await extractClientIp();
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get(COOKIE_SESSION)?.value ?? "";
+  const h = await nextHeaders();
   const out: Record<string, string> = {
     Accept: "application/json",
   };
@@ -59,11 +60,17 @@ async function buildForwardHeaders(token: string, contentType?: string): Promise
   if (ip) out["x-forwarded-for"] = ip;
   if (sessionCookie) out["x-drsc-session"] = sessionCookie;
   // Pass-through standard Origin for the indexer's CSRF posture
-  const origin = (await nextHeaders()).get("origin");
+  const origin = h.get("origin");
   if (origin) out["Origin"] = origin;
   // Pass-through Idempotency-Key for write requests
-  const idem = (await nextHeaders()).get("idempotency-key");
+  const idem = h.get("idempotency-key");
   if (idem) out["Idempotency-Key"] = idem;
+  // Forward the Privy JWT (KTD13 / KTD14). The indexer's
+  // `optionalAuthentication` reads this header to resolve the advisor
+  // identity branch on writes. Anonymous donors never carry one and
+  // pass through unchanged.
+  const authz = h.get("authorization");
+  if (authz) out["Authorization"] = authz;
   return out;
 }
 

--- a/app/api/donor-research/shared/[token]/comments/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
 import { cookies, headers as nextHeaders } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
 
 import { envVars } from "@/utilities/enviromentVars";
 
@@ -67,11 +67,7 @@ async function buildForwardHeaders(token: string, contentType?: string): Promise
   return out;
 }
 
-function copySetCookies(
-  upstream: Response,
-  next: NextResponse,
-  isProd: boolean
-): void {
+function copySetCookies(upstream: Response, next: NextResponse, isProd: boolean): void {
   // Re-issue every Set-Cookie from the indexer on the FE origin with a
   // path scoped to the proxy. The indexer issues drsc_session
   // (HttpOnly) and drsc_name (HttpOnly=false). We preserve those
@@ -125,9 +121,7 @@ export async function GET(request: NextRequest, ctx: Params): Promise<NextRespon
       cache: "no-store",
     });
   } catch {
-    return applyNoStore(
-      NextResponse.json({ error: "indexer_unreachable" }, { status: 502 })
-    );
+    return applyNoStore(NextResponse.json({ error: "indexer_unreachable" }, { status: 502 }));
   }
 
   const body = await upstream.json().catch(() => ({}));
@@ -150,9 +144,7 @@ export async function POST(request: NextRequest, ctx: Params): Promise<NextRespo
       cache: "no-store",
     });
   } catch {
-    return applyNoStore(
-      NextResponse.json({ error: "indexer_unreachable" }, { status: 502 })
-    );
+    return applyNoStore(NextResponse.json({ error: "indexer_unreachable" }, { status: 502 }));
   }
 
   const body = await upstream.json().catch(() => ({}));

--- a/app/api/donor-research/shared/[token]/comments/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/route.ts
@@ -28,7 +28,14 @@ import { envVars } from "@/utilities/enviromentVars";
 
 const COOKIE_SESSION = "drsc_session";
 const COOKIE_NAME = "drsc_name";
+// drsc_session is HttpOnly and only needs to reach the proxy, so it stays
+// scoped to the proxy path. drsc_name is the JS-readable "Commenting as X"
+// cookie the SHARED PAGE (/nonprofit-research/shared/...) reads via
+// document.cookie — it must live at root path "/" or the page can't see it
+// (the proxy path is not a prefix of the page path), which would force the
+// identity dialog on every comment.
 const FE_COOKIE_PATH = "/api/donor-research/shared/";
+const FE_NAME_COOKIE_PATH = "/";
 
 const NO_STORE = {
   "Cache-Control": "no-store, no-cache, must-revalidate",
@@ -99,7 +106,7 @@ function copySetCookies(upstream: Response, next: NextResponse, isProd: boolean)
         httpOnly: false,
         sameSite: "lax",
         secure: isProd,
-        path: FE_COOKIE_PATH,
+        path: FE_NAME_COOKIE_PATH,
         maxAge: 7 * 24 * 60 * 60,
       });
     }

--- a/app/api/donor-research/shared/[token]/comments/route.ts
+++ b/app/api/donor-research/shared/[token]/comments/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies, headers as nextHeaders } from "next/headers";
+
+import { envVars } from "@/utilities/enviromentVars";
+
+/**
+ * Next.js API-route proxy for the donor-shared report comment endpoints
+ * (KTD13 in the shared-report-commenting plan). Forwards GET + POST to
+ * the gap-indexer server-to-server and translates cookies between the
+ * indexer's origin and the FE origin.
+ *
+ *   FE origin (gap.karmahq.xyz):          cookie scope /api/donor-research/shared/
+ *   Indexer origin (gap-indexer.karmahq.xyz): cookie scope /v2/donor-research/shared/
+ *
+ * The indexer's controller sets cookies on its origin; we re-issue them
+ * on the FE origin so the browser sends them on subsequent same-origin
+ * proxy calls. The donor's IP is forwarded via x-forwarded-for so the
+ * indexer's per-IP rate limit stays accurate.
+ *
+ * Security posture preserved:
+ *   - drsc_session stays HttpOnly + SameSite=Lax on the FE origin
+ *   - drsc_name stays JS-readable (HttpOnly=false) for the
+ *     "Commenting as X" affordance
+ *   - x-drsc-session carries the cookie value to the indexer as a
+ *     server-only header; the cookie never leaves the FE origin in the
+ *     browser's view
+ */
+
+const COOKIE_SESSION = "drsc_session";
+const COOKIE_NAME = "drsc_name";
+const FE_COOKIE_PATH = "/api/donor-research/shared/";
+
+const NO_STORE = {
+  "Cache-Control": "no-store, no-cache, must-revalidate",
+  Pragma: "no-cache",
+  "Referrer-Policy": "no-referrer",
+} as const;
+
+function indexerUrl(token: string, query?: URLSearchParams): string {
+  const base = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/donor-research/shared/${encodeURIComponent(token)}/comments`;
+  return query && Array.from(query).length > 0 ? `${base}?${query.toString()}` : base;
+}
+
+async function extractClientIp(): Promise<string | null> {
+  const h = await nextHeaders();
+  const xff = h.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return h.get("x-real-ip");
+}
+
+async function buildForwardHeaders(token: string, contentType?: string): Promise<HeadersInit> {
+  const ip = await extractClientIp();
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(COOKIE_SESSION)?.value ?? "";
+  const out: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (contentType) out["Content-Type"] = contentType;
+  if (ip) out["x-forwarded-for"] = ip;
+  if (sessionCookie) out["x-drsc-session"] = sessionCookie;
+  // Pass-through standard Origin for the indexer's CSRF posture
+  const origin = (await nextHeaders()).get("origin");
+  if (origin) out["Origin"] = origin;
+  // Pass-through Idempotency-Key for write requests
+  const idem = (await nextHeaders()).get("idempotency-key");
+  if (idem) out["Idempotency-Key"] = idem;
+  return out;
+}
+
+function copySetCookies(
+  upstream: Response,
+  next: NextResponse,
+  isProd: boolean
+): void {
+  // Re-issue every Set-Cookie from the indexer on the FE origin with a
+  // path scoped to the proxy. The indexer issues drsc_session
+  // (HttpOnly) and drsc_name (HttpOnly=false). We preserve those
+  // distinctions explicitly.
+  const setCookieList = upstream.headers.getSetCookie?.() ?? [];
+  for (const raw of setCookieList) {
+    const [pair] = raw.split(";", 1);
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    const name = pair.slice(0, idx);
+    const value = decodeURIComponent(pair.slice(idx + 1));
+    if (name === COOKIE_SESSION) {
+      next.cookies.set(COOKIE_SESSION, value, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: isProd,
+        path: FE_COOKIE_PATH,
+        maxAge: 7 * 24 * 60 * 60,
+      });
+    } else if (name === COOKIE_NAME) {
+      next.cookies.set(COOKIE_NAME, value, {
+        httpOnly: false,
+        sameSite: "lax",
+        secure: isProd,
+        path: FE_COOKIE_PATH,
+        maxAge: 7 * 24 * 60 * 60,
+      });
+    }
+  }
+}
+
+function applyNoStore(res: NextResponse): NextResponse {
+  for (const [k, v] of Object.entries(NO_STORE)) res.headers.set(k, v);
+  return res;
+}
+
+interface Params {
+  params: Promise<{ token: string }>;
+}
+
+export async function GET(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  const { token } = await ctx.params;
+  const { searchParams } = new URL(request.url);
+
+  const forwardHeaders = await buildForwardHeaders(token);
+  let upstream: Response;
+  try {
+    upstream = await fetch(indexerUrl(token, searchParams), {
+      method: "GET",
+      headers: forwardHeaders,
+      cache: "no-store",
+    });
+  } catch {
+    return applyNoStore(
+      NextResponse.json({ error: "indexer_unreachable" }, { status: 502 })
+    );
+  }
+
+  const body = await upstream.json().catch(() => ({}));
+  const next = NextResponse.json(body, { status: upstream.status });
+  copySetCookies(upstream, next, process.env.NODE_ENV === "production");
+  return applyNoStore(next);
+}
+
+export async function POST(request: NextRequest, ctx: Params): Promise<NextResponse> {
+  const { token } = await ctx.params;
+  const rawBody = await request.text();
+
+  const forwardHeaders = await buildForwardHeaders(token, "application/json");
+  let upstream: Response;
+  try {
+    upstream = await fetch(indexerUrl(token), {
+      method: "POST",
+      headers: forwardHeaders,
+      body: rawBody,
+      cache: "no-store",
+    });
+  } catch {
+    return applyNoStore(
+      NextResponse.json({ error: "indexer_unreachable" }, { status: 502 })
+    );
+  }
+
+  const body = await upstream.json().catch(() => ({}));
+  const next = NextResponse.json(body, { status: upstream.status });
+  copySetCookies(upstream, next, process.env.NODE_ENV === "production");
+  return applyNoStore(next);
+}

--- a/docs/qa/donor-comments-qa-plan.md
+++ b/docs/qa/donor-comments-qa-plan.md
@@ -1,0 +1,584 @@
+# Donor-Shared Report Commenting — QA Test Plan (LLM agent-browser execution)
+
+> Scope: the **commenting feature** on the donor-shared report view in `gap-app-v2`,
+> plus the advisor onboarding/report flows that surround it. Executed by **5 parallel
+> LLM agents** driving a browser (agent-browser / playwright MCP) against
+> **http://localhost:3000**. This document is the plan only — do not treat it as a
+> record of results; fill in Pass/Fail/Notes as you execute.
+
+Legend:
+- 🔴 = unhappy / negative path
+- 🐞 = regression guard for a specific recent fix (the fix it guards is named in the case)
+- "coordination" note = the case requires two lanes to act in sequence; both lanes must read it
+
+---
+
+## 1. Environment & parallel-execution rules
+
+### 1.1 Target & routing
+- Base URL: `http://localhost:3000`. **Always test locally**, never a preview/staging URL.
+- The donor-facing share route is **`/nonprofit-research/shared/[token]`** (NOT `/donor-research/...`).
+  The `/donor-research/...` path is the internal API proxy mount, not a user page.
+- Existing live share link: `http://localhost:3000/nonprofit-research/shared/XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`
+- Advisor dashboard / onboarding live under the `/nonprofit-research` tree (advisor-facing).
+- Comment traffic goes browser → Next API proxy `/api/donor-research/shared/[token]/comments`
+  → gap-indexer `/v2/donor-research/shared/[token]/comments`.
+
+### 1.2 Isolated browser profiles (MANDATORY)
+Auth/session state for this feature is **origin-scoped** and lives in cookies + localStorage:
+- `drsc_session` — HttpOnly, `SameSite=Lax`, scoped to `/api/donor-research/shared/` on the FE origin.
+- `drsc_name` — **JS-readable** (HttpOnly=false), scoped to `Path=/` so the share page can read it.
+- Privy auth tokens (for advisor / authenticated lanes) in localStorage.
+
+Therefore **each lane MUST run in its own browser context/profile** with NO shared
+cookies or localStorage. If two lanes share a context they will clobber each other's
+`drsc_session`/`drsc_name` and Privy tokens and produce false failures. Use a fresh
+`browser_new_context` (playwright MCP) or a dedicated profile per lane. Do not reuse the
+anonymous lane's context for any authenticated lane.
+
+### 1.3 Accounts (one login per lane — do not hammer Privy)
+Privy login is **rate-limited** when hammered. Each authenticated lane logs in **exactly
+once** at the start of its run and reuses that session for all its cases. Use the
+email + fixed-OTP flow (no real inbox needed).
+
+| Lane | Role | Account | Fixed OTP | Notes |
+|------|------|---------|-----------|-------|
+| A | Anonymous donor | none (never log in) | — | Pure public capability via token |
+| B | Advisor (owner of report) | `test-8970@privy.io` | `598767` | Owns report `ad3947ae`; share token `XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw` |
+| C | Authenticated non-advisor | `test-9744@privy.io` | `630970` | Logged-in with email; NOT the report owner |
+| D | Onboarded advisor | `test-7095@privy.io` | `466874` | Already onboarded; has dashboard + can create/share reports |
+| E | Fresh / unonboarded | `test-3620@privy.io` | `363295` | NO advisor row yet → sees onboarding flow |
+
+Login procedure (lanes B–E): open the app, trigger Privy login, choose **email**, enter
+the lane's email, submit, then enter the lane's fixed OTP. Confirm authenticated state
+before proceeding. If login returns a Privy rate-limit (429) or "too many attempts",
+wait 60s and retry once; if it still fails, mark the lane BLOCKED (env), not FAIL.
+
+### 1.4 Backend flakiness (colleague's ngrok — READ THIS)
+The gap-indexer backend is a colleague's **ngrok tunnel that flaps intermittently**.
+Symptoms: comment GET/POST returns **500 or 502**, or the Next proxy returns
+`{"error":"indexer_unreachable"}` (proxy emits 502 when it can't reach the indexer).
+Rules for every case that touches comments:
+1. On a 500/502/`indexer_unreachable`, **retry up to 3 times with ~5s backoff** before
+   concluding anything.
+2. Distinguish a **flap** (intermittent; a retry succeeds within 3 tries) from a **real
+   failure** (reproducible across all 3 retries AND across a fresh reload). Only a
+   reproducible failure is a 🔴 FAIL; a flap that recovers is a Note ("backend flapped, recovered").
+3. Cases that *intentionally* assert error UI (B-/A- error cases) are the exception —
+   there you are validating the FE's handling of the 5xx, not the backend health.
+4. If the backend is down for >5 min across all lanes, pause and report environment
+   blocked rather than logging mass FAILs.
+
+### 1.5 Concurrency guardrail
+- Run **at most 5 parallel lanes**. Do NOT spin up more browser contexts than that —
+  ~10 concurrent contexts has historically crashed the local dev server.
+- Lanes A–E are designed to NOT overlap on accounts or on the same report mutations,
+  except in the explicitly-marked **Cross-lane / multi-user** cases (§7), which require
+  Lane A + Lane B to coordinate.
+- Each lane runs its scenarios sequentially within its own context.
+
+### 1.6 Evidence
+For every case capture: a screenshot of the end state; on any anomaly, a screenshot +
+the exact repro steps + relevant console/network entries. For 🐞 cases, screenshot the
+specific element the fix concerns.
+
+### 1.7 Key selectors / affordance text (grounded in code)
+- Comment overlay container: fixed bottom-right cluster (`bottom-24 right-6`).
+- Sheet trigger button text: **"Comments"** when count is 0, else pluralized e.g. **"3 comments"** (`pluralize("comment", n, true)`).
+- Sheet title: **"Comments"**.
+- Loading skeleton: `[data-testid="comments-loading"]`.
+- Empty state copy: exactly **"Be the first to comment."** (never "0 comments").
+- Comments-load error: `role="alert"` block with heading **"We couldn't load the comments"** + a **"Try again"** button (label flips to **"Retrying…"** while fetching).
+- Comment row: `[data-comment-row]`; wrapper carries `[data-comment-id="<id>"]`; active row has `[data-active]` and `aria-current="true"`.
+- Pending state text: **"Sending…"**; failed state text: **"Couldn't send"** + a **"Retry"** button; failed card background tint red (`bg-red-50` / dark `bg-red-900/20`).
+- Name skeleton while sending without a resolved name: `Skeleton` (h-3 w-20) in the row header.
+- Timestamp: a `<time>` element on its **own line** below the name, text ending in **"(Local)"**, format like `Jun 23, 2026, 5:17 PM (Local)`.
+- Advisor badge in a row: `Badge` text **"Advisor"** (uppercase).
+- Identity badge (overlay): **"Commenting as <name>"** with a pencil (aria-label "Edit display name") and a **"Not me — switch"** link; advisor variant reads **"Commenting as Advisor"** (no edit/switch).
+- Pin badge: `[data-comment-pin]`, `[data-target-key]`, label = `pluralize("comment", count, true)`, amber dot.
+- Add-comment "+" button: `[data-add-comment]`, aria-label `Add comment on <label>` (e.g. "Add comment on lead candidate"). Pin + "+" are clustered top-right (`absolute right-2 top-2`).
+- Selection affordance (floating): `[data-selection-affordance]`, text **"Comment"** with a message icon.
+- Text-range highlight band: `[data-comment-highlight]` (always `pointer-events:none`); thread marker: `[data-comment-marker]`, aria-label **"View comment thread"**, glyph `≡`, `pointer-events:auto`.
+- Composer: textarea placeholder **"Add a comment…"** (root/general) or **"Write a reply…"** (reply); submit button **"Comment"** / **"Reply"**, flips to **"Posting…"** while submitting; **"Cancel"** button. Context line above textarea: **"On the whole report"** (general), **"Replying to <name>"** (reply), **"On <sectionKey>"** / **"On this candidate"** / `On "<quote…>"` (anchored). Textarea `maxLength=5000`.
+- Collapsed-replies toggle (depth ≥ 4): **"Show N more replies"** (pluralized).
+- Orphan lane: `<section aria-label="Orphan comments">`, heading `pluralize("orphan comment", n, true)`, original quote in a blockquote.
+- aria-live announcer: `[data-testid="comment-announce"]`, `aria-live="polite"`, sr-only; text **"Comment added by X"** / **"Reply added by X"**.
+- Karma AI chat button: `button[aria-label="Open chat"]` (and its fixed-positioned container). Must be **hidden** (visibility:hidden) while the sheet is open.
+- Identity dialog title: **"Add your name and email"** (post) / **"Update your display name"** (edit-name). Inputs `#displayName`, `#email`; locked-email hint text **"From your signed-in account."**; submit **"Continue"** / **"Save"** (→ **"Saving…"**).
+- Masthead: `[data-section="masthead"]`; eyebrow line includes **"Issued <Month D, YYYY>"** and conditionally **"Updated <Month D, YYYY>"**.
+- Onboarding: WizardStepper steps **"Welcome" → "Sample report" → "Get started"**; step-3 fields in order Display name, **Email** (`#onboarding-email`, type=email), Organization (optional), Timezone.
+
+---
+
+## 2. Lane A — ANONYMOUS donor (no login)
+
+Context: fresh browser context, never authenticated. Start each run by clearing
+`drsc_name`/`drsc_session` so the "first comment" identity flow is exercised cleanly.
+All cases use share token `XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw` unless noted.
+
+### A1 — Open share view & comment overlay loads (happy)
+- Account/Profile: Lane A (anonymous).
+- Preconditions: cleared cookies for the FE origin.
+- Steps: 1) Navigate to `/nonprofit-research/shared/XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`. 2) Wait for report body `[data-brief]` to render (retry on 500/502 per §1.4). 3) Confirm the fixed bottom-right "Comments" trigger button exists. 4) Click it to open the Sheet.
+- Expected: report renders; trigger reads **"Comments"** (count 0) or **"N comments"** (>0); Sheet opens with title "Comments"; composer textarea (placeholder "Add a comment…") is present at the bottom.
+- Pass/Fail/Notes:
+
+### A2 — Empty state copy (boundary) 🐞 (guards: no "0 comments")
+- Preconditions: a report/token with zero comments (if `XogX...` already has comments, note count and skip the empty assertion, validating instead via the loading→list transition).
+- Steps: open the Sheet on an empty thread.
+- Expected: body shows exactly **"Be the first to comment."** — NOT "0 comments" anywhere; trigger button reads "Comments", not "0 comments".
+- Pass/Fail/Notes:
+
+### A3 — First comment triggers identity dialog (happy)
+- Preconditions: no `drsc_name` cookie.
+- Steps: 1) Open sheet. 2) Type "Looks great, thank you" in the composer. 3) Click **"Comment"**.
+- Expected: because the anonymous viewer has no identity and cannot defer to backend, the **identity dialog** ("Add your name and email") opens immediately (no backend round-trip needed). The email field is **editable** (anonymous → no locked email).
+- Pass/Fail/Notes:
+
+### A4 — Identity capture + post completes; optimistic row (happy)
+- Steps: 1) From A3's dialog, enter Display name "Dana Donor", email "dana@example.com", click **"Continue"**. 2) Observe the composer area.
+- Expected: dialog closes; an optimistic comment row appears showing **"Sending…"**, card slightly dimmed (opacity-70); after the POST settles the row resolves to the real comment with name "Dana Donor" and an absolute "(Local)" timestamp. Retry on 500/502 per §1.4.
+- Pass/Fail/Notes:
+
+### A5 — Identity persists; "Commenting as" badge; no re-prompt on 2nd comment 🐞 (guards: identity persistence, drsc_name JS-readable at Path=/)
+- Preconditions: A4 completed (cookie `drsc_name=Dana Donor` set).
+- Steps: 1) Verify the **"Commenting as Dana Donor"** badge is visible in the overlay cluster. 2) In DevTools/console read `document.cookie` and confirm `drsc_name` is present and JS-readable. 3) Post a SECOND comment "Second one".
+- Expected: the identity dialog does **NOT** reappear on the second post; the comment posts directly using the stored name; badge still shows "Commenting as Dana Donor".
+- Pass/Fail/Notes:
+
+### A6 — Identity persists across reload 🐞 (guards: persistence across reload)
+- Steps: 1) Reload the page. 2) Re-open the sheet.
+- Expected: badge still shows **"Commenting as Dana Donor"** without any dialog; prior comments still listed.
+- Pass/Fail/Notes:
+
+### A7 — Ordering oldest→newest + auto-scroll to latest 🐞 (guards: ordering + auto-scroll)
+- Preconditions: ≥3 comments exist (post more if needed).
+- Steps: 1) Close and re-open the sheet. 2) Inspect the order of `[data-comment-row]` root items and the scroll position of the scroll container.
+- Expected: roots render oldest→newest (newest at the **bottom**); on open, the body auto-scrolls to the bottom (latest visible). Post one more and confirm it appears at the bottom and the body scrolls to it.
+- Pass/Fail/Notes:
+
+### A8 — Absolute local timestamp on its own line 🐞 (guards: timestamp format)
+- Steps: inspect a comment row's `<time>` element.
+- Expected: timestamp is an ABSOLUTE local time ending in **"(Local)"** (e.g. "Jun 23, 2026, 5:17 PM (Local)"); NOT relative ("2 minutes ago"); the date is NOT duplicated; the `<time>` sits on its OWN line below the name (block-level).
+- Pass/Fail/Notes:
+
+### A9 — General / whole-report comment via always-present composer 🐞 (guards: general composer always present)
+- Steps: 1) Open the sheet but do NOT click any pin or "+". 2) Confirm the composer at the bottom shows context line **"On the whole report"**. 3) Type "Overall this is helpful" and submit.
+- Expected: comment posts successfully as a general comment (anchored to masthead under the hood); appears in the list. No 422 surfaced to the user (the general path satisfies the backend's non-null-anchor rule).
+- Pass/Fail/Notes:
+
+### A10 — Section anchoring via "+" affordance (happy, core)
+- Steps: 1) Hover/locate a section (e.g. the lead-candidate section, `[data-section="lead-candidate"]`). 2) Click its `[data-add-comment]` "+" button (aria-label "Add comment on lead candidate"). 3) Confirm composer context line reads **"On lead-candidate"**. 4) Submit "Strong lead pick".
+- Expected: comment posts anchored to that section; a pin badge `[data-comment-pin]` appears top-right of that section reading "1 comment".
+- Pass/Fail/Notes:
+
+### A11 — Candidate anchoring via "+" (happy, core)
+- Steps: locate a candidate card `[data-candidate-id]`; click its "+" (aria-label "Add comment on this candidate"); confirm composer reads **"On this candidate"**; submit.
+- Expected: comment posts; candidate card shows a pin badge.
+- Pass/Fail/Notes:
+
+### A12 — Text selection → floating "Comment" affordance → text-range anchor (happy, core)
+- Steps: 1) Select a phrase of text inside one section (single target). 2) Wait ~100ms for the debounced affordance. 3) Confirm a floating `[data-selection-affordance]` "Comment" button appears near the selection end. 4) Click it; confirm composer context reads `On "<the selected text…>"`. 5) Submit "Quoting this line".
+- Expected: text-range comment posts; a yellow highlight band `[data-comment-highlight]` appears over the quoted text and a `[data-comment-marker]` (≡) sits at the end of the range.
+- Pass/Fail/Notes:
+
+### A13 — Re-select previously-commented text 🐞 (guards: highlight pointer-events:none, marker opens thread)
+- Preconditions: A12 created a highlight.
+- Steps: 1) Click-drag to RE-SELECT text that overlaps the existing highlight band. 2) Confirm a new floating "Comment" affordance appears (the band did not intercept the drag). 3) Separately, click the `[data-comment-marker]` ≡ badge.
+- Expected: the highlight band is `pointer-events:none` so re-selection works and a fresh affordance appears; clicking the marker opens the sheet and focuses/scrolls to that comment's row (row gets `[data-active]`).
+- Pass/Fail/Notes:
+
+### A14 — Selection straddling two targets → NO affordance (boundary, core) 🔴
+- Steps: select text that starts in one section/candidate and ends in a different one.
+- Expected: NO floating "Comment" affordance appears (capture returns null when start/end anchor ancestors differ).
+- Pass/Fail/Notes:
+
+### A15 — Quote > 500 chars → NO affordance (boundary, core) 🔴
+- Steps: select a contiguous block of text whose normalized length exceeds 500 characters within a single target.
+- Expected: NO affordance appears (`QUOTE_MAX = 500`).
+- Pass/Fail/Notes:
+
+### A16 — Threaded reply (happy, core)
+- Steps: 1) Open sheet, pick a root comment, click its **"Reply"** button. 2) Confirm composer reads **"Replying to <name>"** with placeholder "Write a reply…". 3) Submit "Replying here".
+- Expected: reply nests under the parent (indented, left border), submit button read "Reply" → "Posting…".
+- Pass/Fail/Notes:
+
+### A17 — Pin pluralized counts (boundary) 🐞 (guards: pluralized counts)
+- Steps: create exactly 1 then 2 comments on the same section; inspect the pin label and the trigger button.
+- Expected: pin reads **"1 comment"** then **"2 comments"** (never "1 comments"); trigger reads "1 comment"/"2 comments".
+- Pass/Fail/Notes:
+
+### A18 — Post failure leaves a "Couldn't send" row (NOT silent vanish) 🐞 🔴 (guards: failed optimistic row)
+- Steps: 1) In DevTools, set network offline OR block the `/api/donor-research/shared/.../comments` POST. 2) Submit a comment. 3) Restore network is NOT required for the assertion.
+- Expected: the optimistic row does NOT disappear; it transitions to a **"Couldn't send"** state with red tint (`bg-red-50`) and a **"Retry"** button. (Distinguish from a real backend flap: this is a deliberately-induced failure.)
+- Pass/Fail/Notes:
+
+### A19 — Retry a failed comment (error/recovery) 🐞
+- Steps: from A18 (or re-induce), restore network, click the row's **"Retry"** button.
+- Expected: row attempts the post again; on success it reconciles to a normal posted row (no duplicate).
+- Pass/Fail/Notes:
+
+### A20 — Comments-load error shows message + working "Try again" 🐞 🔴 (guards: load-error UI)
+- Steps: 1) Block/fail the comments **GET** so the query errors (or catch a genuine 500 — but force it to be reproducible by blocking in DevTools). 2) Open the sheet.
+- Expected: `role="alert"` block with **"We couldn't load the comments"** and a **"Try again"** button. 3) Unblock, click "Try again" → button shows "Retrying…" then the list loads.
+- Pass/Fail/Notes:
+
+### A21 — "Not me — switch" clears identity (happy)
+- Preconditions: a `drsc_name` exists ("Commenting as Dana Donor").
+- Steps: click **"Not me — switch"** in the identity badge.
+- Expected: badge disappears; `drsc_name` cleared (verify `document.cookie`); next comment attempt re-opens the identity dialog.
+- Pass/Fail/Notes:
+
+### A22 — Chat button hidden while drawer open; no overlap 🐞 (guards: chat button hide + overlay non-overlap)
+- Steps: 1) With sheet CLOSED, confirm the Karma AI chat button (`button[aria-label="Open chat"]`) is visible and the comment trigger/badge does NOT visually overlap it. 2) Open the sheet; check the chat button's fixed container visibility. 3) Close the sheet.
+- Expected: while the sheet is open the chat button's fixed container is `visibility:hidden`; on close it returns to its prior visibility; at no point do the comment overlay and chat button overlap.
+- Pass/Fail/Notes:
+
+### A23 — 30s polling + pause on tab blur (core)
+- Steps: 1) Open the sheet with comments visible. 2) Watch network for the comments GET to repeat roughly every 30s while the tab is focused. 3) Switch to a different tab (blur) for ~40s, then return.
+- Expected: polling fires ~every 30s while focused; while the tab is hidden the interval does NOT fire (`refetchIntervalInBackground:false`); on refocus it refetches.
+- Pass/Fail/Notes:
+
+### A24 — Cookie scoping & HttpOnly in DevTools (security)
+- Steps: in DevTools → Application → Cookies for the FE origin, inspect `drsc_session` and `drsc_name` after posting a comment.
+- Expected: `drsc_session` is **HttpOnly**, SameSite=Lax, Path `/api/donor-research/shared/`; `drsc_name` is **NOT HttpOnly** (JS-readable), Path `/`. The session value never appears in `document.cookie`.
+- Pass/Fail/Notes:
+
+### A25 — XSS / sanitization in comment body (security) 🔴
+- Steps: post a comment with body: `<img src=x onerror=alert(1)>` and another with `<script>alert('x')</script>` and `"><b>bold</b>`.
+- Expected: NO script executes, NO alert dialog; the markup renders as **literal text** (the backend escapes `& < > " '`, FE `decodeEntities` shows the literal characters the user typed). Confirm no `<img>`/`<script>` node is injected into the DOM.
+- Pass/Fail/Notes:
+
+### A26 — HTML entities round-trip (security/boundary)
+- Steps: post a comment containing `5 < 10 & "quotes" don't break`.
+- Expected: renders exactly as typed (`5 < 10 & "quotes" don't break`), no double-escaping (no visible `&lt;`/`&amp;`).
+- Pass/Fail/Notes:
+
+### A27 — Long body boundary (boundary) 🔴
+- Steps: paste a 5000-char body, then try to add a 5001st char; submit at exactly 5000.
+- Expected: textarea hard-caps at 5000 (`maxLength=5000`); the 5000-char comment posts and renders with preserved newlines (`whitespace-pre-wrap`).
+- Pass/Fail/Notes:
+
+### A28 — Empty / whitespace-only submit blocked (boundary) 🔴
+- Steps: focus composer, type spaces/newlines only; observe submit button.
+- Expected: submit button is disabled while body trims to empty; pressing it does nothing.
+- Pass/Fail/Notes:
+
+### A29 — Keyboard / a11y on the comment surface (a11y)
+- Steps: 1) Tab to the "Comments" trigger and open with Enter. 2) Tab through the sheet (rows are `role="button"` tabindex 0, activate with Enter/Space). 3) Tab to a pin and activate with Enter/Space. 4) Open the identity dialog and confirm focus trap + Escape closes it.
+- Expected: all interactive affordances are keyboard reachable and operable; focus-visible rings show; dialog traps focus and Escape dismisses; row activation via Enter/Space sets `[data-active]`.
+- Pass/Fail/Notes:
+
+### A30 — Responsive / mobile / touch (responsive)
+- Steps: 1) Resize to 375×812 (mobile). 2) Open the sheet — confirm it takes full width (`w-full`, `sm:max-w-md`). 3) Use a touch tap to open a pin and submit a comment. 4) Test text selection via touch → affordance (touchend listener).
+- Expected: sheet is usable full-width on mobile; pins/"+"/composer all tappable; touch text selection produces the affordance; no horizontal overflow.
+- Pass/Fail/Notes:
+
+### A31 — Dark mode (dark mode)
+- Steps: toggle dark mode; open sheet; create a comment; induce a failed row.
+- Expected: rows, badges, highlights (`dark:bg-amber-300/30`), failed tint (`dark:bg-red-900/20`), active tint (`dark:bg-amber-900/20`) all render with correct dark contrast; no unreadable text.
+- Pass/Fail/Notes:
+
+### A-DOG1 — Dogfooding: break the anonymous comment surface
+- Steps (open-ended, ~15 min): rapidly double-click submit; spam the "+" buttons; select-deselect text repeatedly; resize between mobile/desktop mid-compose; back/forward navigation while the sheet is open; paste emoji + RTL text + 4-byte unicode; open the sheet, scroll up to old comments while a new poll lands; very long single-word (no spaces) body to test wrapping.
+- Expected: no crashes, no duplicate posts from double-submit, no layout breakage, no orphaned dialogs. Log every anomaly with repro steps + screenshot.
+- Pass/Fail/Notes:
+
+---
+
+## 3. Lane B — ADVISOR (owner of report `ad3947ae`)
+
+Context: own browser context. Log in ONCE as `test-8970@privy.io` / OTP `598767`.
+This account is the **advisor/owner** for share token `XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`.
+
+### B1 — Advisor opens the shared view; "Commenting as Advisor" badge (happy) 🐞 (guards: advisor identity badge)
+- Steps: 1) While authenticated, navigate to `/nonprofit-research/shared/XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`. 2) Wait for the advisor-resolution to settle. 3) Inspect the identity badge.
+- Expected: badge reads **"Commenting as Advisor"** (no edit pencil, no "Not me — switch"). The advisor branch is active because the Privy session resolves to the report's advisor.
+- Pass/Fail/Notes:
+
+### B2 — Advisor posts without identity dialog (JWT-forwarding) 🐞 (guards: defer-to-backend for advisor)
+- Steps: 1) Open the sheet. 2) Type "Advisor note: confirmed EIN" and submit.
+- Expected: NO identity dialog appears (advisor defers to backend; the Privy JWT is forwarded via the proxy `Authorization` header and the BE stamps `is_advisor`). The posted row shows an **"Advisor"** badge.
+- Pass/Fail/Notes:
+
+### B3 🔴 — Advisor name Skeleton while sending (advisor optimistic name) 🐞 (guards: name Skeleton while sending)
+- Steps: 1) Throttle network to "Slow 3G" so the POST is slow. 2) Submit an advisor comment. 3) Immediately inspect the optimistic row header.
+- Expected: while the optimistic row has no resolved displayName yet, the header shows a **Skeleton** (h-3 w-20) in place of the name (not an empty/blank line); status shows **"Sending…"**; once settled the real name + "Advisor" badge appear.
+- Pass/Fail/Notes:
+
+### B4 — Advisor reply to a donor comment (happy)
+- Coordination: depends on Lane A having posted at least one comment (or post one yourself first from a second tab is NOT allowed — instead coordinate with Lane A, or use a pre-existing donor comment).
+- Steps: reply to an existing non-advisor comment; submit.
+- Expected: reply nests under the donor comment, carries the **"Advisor"** badge.
+- Pass/Fail/Notes:
+
+### B5 — Advisor on shared view sees pins, highlights, orphan lane (core)
+- Steps: with multiple anchored comments present, confirm pins on sections/candidates, text highlights, and (if any unresolved anchors) the orphan lane render the same for the advisor as for anonymous.
+- Expected: full comment surface renders; advisor sees identical anchoring UI.
+- Pass/Fail/Notes:
+
+### B6 — Advisor: comment header long name wraps with Advisor badge 🐞 (guards: long-name wrap)
+- Steps: ensure a comment exists whose displayName is very long (e.g. an advisor-set or donor-set 80-char name). Inspect the row header where the name + "Advisor" badge co-exist.
+- Expected: long name **wraps cleanly** (`flex-wrap`, `break-words`, `min-w-0`); the "Advisor" badge stays intact (`shrink-0`); layout not broken, no overflow.
+- Pass/Fail/Notes:
+
+### B7 🔴 — Advisor JWT NOT forwarded path (negative, defensive)
+- Steps: in a controlled way, strip/expire the Privy session (log out in this context) then attempt to post on the shared view.
+- Expected: the viewer is no longer treated as advisor; behaves like an anonymous donor → identity dialog appears on first post. (Confirms advisor stamping is driven by the forwarded JWT, not a sticky FE flag.)
+- Pass/Fail/Notes (re-login afterward to restore Lane B state):
+
+### B8 — Dark mode + a11y spot-check for advisor badge (dark mode / a11y)
+- Steps: dark mode on; inspect "Commenting as Advisor" badge and row "Advisor" badge contrast; keyboard-reach the composer.
+- Expected: legible in dark mode; composer keyboard operable.
+- Pass/Fail/Notes:
+
+### B-DOG2 — Dogfooding: advisor commenting edge cases
+- Steps (open-ended): post as advisor, then immediately use "Not me — switch" is absent (good) — verify there's no way to spoof a donor name as advisor; rapidly toggle the sheet; post advisor comment then reload and confirm "Advisor" badge persists (BE-stamped, authoritative); try posting with the session mid-expiry. Log anomalies with repro + screenshot.
+- Pass/Fail/Notes:
+
+---
+
+## 4. Lane C — AUTHENTICATED NON-ADVISOR
+
+Context: own browser context. Log in ONCE as `test-9744@privy.io` / OTP `630970`.
+This account is authenticated but is **NOT** the owner of report `ad3947ae`.
+
+### C1 — Email-lock identity dialog (logged-in-with-email) 🐞 (guards: email prefilled + locked)
+- Steps: 1) While authenticated, navigate to `/nonprofit-research/shared/XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`. 2) Open the sheet, type a comment, submit. 3) Because this viewer is authenticated, the FE first defers to the backend; the BE returns `requiresIdentity:true` (not the advisor) → the identity dialog opens. 4) Inspect the dialog's email field.
+- Expected: the dialog's **email field is PREFILLED with the signed-in email and read-only** (`readOnly`, `aria-readonly`, muted styling), with helper text **"From your signed-in account."** The Display name field is editable.
+- Pass/Fail/Notes:
+
+### C2 — Defer-to-backend gate (no premature dialog) 🐞 (guards: authenticated defers to BE)
+- Steps: 1) Clear any `drsc_name`. 2) Submit a comment as this authenticated non-advisor.
+- Expected: the dialog does NOT open immediately on click (unlike anonymous A3); the FE posts first, and only opens the dialog after the BE responds `requiresIdentity`. (Observe a POST attempt in the network tab before the dialog appears.)
+- Pass/Fail/Notes:
+
+### C3 — Complete identity + post (happy)
+- Steps: in the C1 dialog, enter Display name "Casey Client" (email already locked), click **"Continue"**.
+- Expected: post completes; row shows "Casey Client" with NO "Advisor" badge (this account is not the report's advisor); `drsc_name` set so subsequent posts skip the dialog.
+- Pass/Fail/Notes:
+
+### C4 — Locked email cannot be edited (security/boundary) 🔴
+- Steps: in the identity dialog, attempt to type into / clear the email field.
+- Expected: email field is non-editable (readOnly); value stays the signed-in address; no validation error path needed since it's pre-filled valid.
+- Pass/Fail/Notes:
+
+### C5 — Wallet-without-email comparison note (boundary)
+- Steps: N/A to execute if no wallet login is available; document expectation: a wallet login with no email would get an **editable** email field (no lock). Mark SKIPPED-no-wallet if not testable.
+- Expected (documented): editable email for wallet-without-email.
+- Pass/Fail/Notes:
+
+### C6 — Persistence + reload for authenticated non-advisor (happy)
+- Steps: after C3, reload; reopen sheet.
+- Expected: "Commenting as Casey Client" badge persists; no re-prompt.
+- Pass/Fail/Notes:
+
+### C7 — Dark mode + responsive spot-check (dark mode / responsive)
+- Steps: dark mode; mobile width; open dialog and confirm locked-email styling is legible and the dialog fits the viewport.
+- Pass/Fail/Notes:
+
+### C-DOG3 — Dogfooding: authenticated non-advisor
+- Steps (open-ended): submit before the advisor-resolution settles to probe the race; rapidly open/close the dialog; verify you are never mislabeled "Advisor"; try editing the display name via the pencil and confirm the email stays locked there too. Log anomalies with repro + screenshot.
+- Pass/Fail/Notes:
+
+---
+
+## 5. Lane D — ONBOARDED ADVISOR (dashboard + create/share)
+
+Context: own browser context. Log in ONCE as `test-7095@privy.io` / OTP `466874`.
+Already onboarded → lands on the advisor dashboard, not onboarding.
+
+### D1 — Onboarded advisor reaches dashboard, not onboarding (happy)
+- Steps: navigate to the nonprofit-research index; confirm the dashboard renders (report list / create affordance), not the welcome onboarding wizard.
+- Expected: dashboard view; no "Welcome" wizard.
+- Pass/Fail/Notes:
+
+### D2 — Create a report (happy, dogfood-adjacent)
+- Steps: use the dashboard's create/generate flow to start a new report with sample criteria (e.g. "Pacific Northwest climate nonprofits, $25K"). Wait for it to reach a terminal status (retry on backend flaps).
+- Expected: report generates and reaches `fast_complete`/`complete`; masthead, candidates, sections render.
+- Pass/Fail/Notes:
+
+### D3 — Share the report; obtain a token (happy)
+- Steps: on the terminal report, use the **ShareTokenControls** (advisor variant masthead, top-right) to create/copy a share link.
+- Expected: a share token is generated; the link copies; opening it (in a SEPARATE anonymous context, or hand to Lane A) renders the shared view.
+- Pass/Fail/Notes:
+
+### D4 — Masthead "Updated <date>" when completion is later than issue 🐞 (guards: masthead Updated date)
+- Steps: 1) Open a report whose `completedAt` is later than `fastCompletedAt`/issue date (a deep-enriched report). 2) Inspect the masthead eyebrow line.
+- Expected: shows both **"Issued <date>"** and **"Updated <date>"** with DIFFERENT dates; if issue and update are the same day, "Updated" is HIDDEN (no duplicate date). Validate both branches if two reports are available.
+- Pass/Fail/Notes:
+
+### D5 — Multi-candidate report anchoring (core)
+- Steps: open a report with multiple candidate cards (`[data-candidate-id]`). For 2 different candidates, add a comment via each card's "+".
+- Expected: each candidate card independently shows its own pin badge with the correct count; comments do not cross-anchor; the comparison/runners-up sections also expose "+"/pins.
+- Pass/Fail/Notes:
+
+### D6 — "+" / pin clustering does NOT overlap chapter-mark label 🐞 (guards: top-right cluster vs ChapterMark)
+- Steps: on a section that has a chapter-mark label (e.g. "Lead" via ChapterMark), inspect the top-right cluster of pin + "+".
+- Expected: pin and "+" are clustered together at `right-2 top-2` and do NOT overlap or sit on top of the chapter-mark label; both remain readable and clickable.
+- Pass/Fail/Notes:
+
+### D7 — Advisor comments on own shared report show "Advisor" badge (core)
+- Steps: from the shared link of D3's report (advisor still authenticated), post a comment.
+- Expected: "Commenting as Advisor"; row carries "Advisor" badge.
+- Pass/Fail/Notes:
+
+### D8 — Dark mode dashboard + masthead (dark mode)
+- Steps: dark mode; inspect dashboard, masthead eyebrow ("Issued"/"Updated"), and share controls.
+- Pass/Fail/Notes:
+
+### D-DOG4 — Dogfooding: advisor dashboard + report generation
+- Steps (open-ended): generate a report with edge criteria (empty-ish niche → "No candidates" headline), zero-candidate state, very long org/cause strings, rapid create clicks (double-submit), share then revoke then re-open the link, resize tables (ComparisonTable) on mobile, back/forward through dashboard↔report. Log anomalies with repro + screenshot.
+- Pass/Fail/Notes:
+
+---
+
+## 6. Lane E — FRESH / UNONBOARDED ADVISOR (onboarding flow)
+
+Context: own browser context. Log in ONCE as `test-3620@privy.io` / OTP `363295`.
+No advisor row → the onboarding wizard renders.
+
+### E1 — Onboarding wizard appears (welcome → sample → get-started) (happy)
+- Steps: navigate to the nonprofit-research advisor entry; confirm the WizardStepper with steps **"Welcome"**, **"Sample report"**, **"Get started"**, starting on Welcome.
+- Expected: Welcome step renders with the value-prop cards and a Continue button; stepper shows aria-current on the active step.
+- Pass/Fail/Notes:
+
+### E2 — Step transitions move focus to step heading (a11y)
+- Steps: click Continue (welcome→sample), then Continue (sample→form), then Back.
+- Expected: on each transition focus moves to the active step's heading (`tabIndex=-1` heading focused); the first mount does NOT steal focus.
+- Pass/Fail/Notes:
+
+### E3 — Sample report cards do NOT overflow 🐞 (guards: sample card overflow)
+- Steps: on the "Sample report" step, inspect `SampleReportPreview` cards at desktop AND mobile (375px) widths.
+- Expected: sample cards fit their container with NO horizontal overflow / clipping at either width.
+- Pass/Fail/Notes:
+
+### E4 — Step 3 has Email input directly below Display name 🐞 (guards: onboarding email field)
+- Steps: on "Get started", inspect field order and the email input.
+- Expected: fields in order Display name → **Email** → Organization (optional) → Timezone; the Email field (`#onboarding-email`) is `type="email"`, **required**, and is positioned directly below Display name.
+- Pass/Fail/Notes:
+
+### E5 🔴 — Email validation enforced (boundary/negative)
+- Steps: 1) Submit step 3 with Display name filled but Email EMPTY. 2) Then enter an invalid email "not-an-email" and submit.
+- Expected: empty → error **"Email is required"** (role="alert"); invalid → **"Enter a valid email"**; submission blocked until a valid email is entered.
+- Pass/Fail/Notes:
+
+### E6 — Onboarding completes (happy)
+- Steps: fill Display name "Erin Advisor", Email "erin@example.com", leave Org blank, accept default timezone, submit **"Continue"**.
+- Expected: button shows "Setting up…", onboarding succeeds, redirect to the donor-research index (now onboarded). Retry on backend flap.
+- Pass/Fail/Notes (NOTE: this consumes Lane E's unonboarded state; run E1–E5 before E6).
+
+### E7 🔴 — Timezone validation (negative/boundary)
+- Steps: before E6, set timezone to an invalid value like "Mars/Phobos!!" and submit.
+- Expected: error "Use an IANA timezone like America/Los_Angeles" (regex `^[A-Za-z_/+\-0-9]{1,64}$` rejects `!`).
+- Pass/Fail/Notes:
+
+### E8 — Dark mode + responsive onboarding (dark mode / responsive)
+- Steps: dark mode through all 3 steps at mobile width.
+- Expected: legible, no overflow, buttons reachable.
+- Pass/Fail/Notes:
+
+### E-DOG5 — Dogfooding: onboarding flow
+- Steps (open-ended, BEFORE E6 completes onboarding): rapidly click Continue/Back; double-submit the form; paste a 120-char display name and 200-char org; resize mid-step; back/forward browser nav across steps; reload on step 3 (state resets to welcome — note behavior); very long timezone string. Log anomalies with repro + screenshot.
+- Pass/Fail/Notes:
+
+---
+
+## 7. Cross-lane / multi-user (Lane A + Lane B coordinate)
+
+These cases require **two lanes acting in sequence on the SAME report**
+(`XogX5KpUwKhoQUZ1A3FpFRHVDv0loCTeAFsSoEinGzw`). They are the only intentional overlap.
+Coordinate timing explicitly (one lane posts, the other waits for its poll/refetch).
+
+### X1 — Anonymous posts → Advisor sees within 30s poll → aria-live announces (multi-user, polling)
+- Coordination: Lane A acts first; Lane B observes. Keep Lane B's sheet OPEN and tab FOCUSED (so the 30s poll runs).
+- Steps:
+  1. **Lane B**: open the shared view, open the sheet, keep tab focused, note current comment count.
+  2. **Lane A**: post a NEW comment "Hello from the donor" (with a unique marker string).
+  3. **Lane B**: within ~30s (one poll cycle) confirm the new comment appears at the BOTTOM of the list; confirm the body auto-scrolls to it; confirm the `[data-testid="comment-announce"]` region text becomes **"Comment added by Dana Donor"** (or whatever name Lane A used).
+- Expected: new comment surfaces within one poll interval; aria-live announces "Comment added by <name>"; ordering keeps it at the bottom.
+- Pass/Fail/Notes:
+
+### X2 — Advisor replies → Anonymous sees the reply + "Reply added by" announce (multi-user)
+- Coordination: Lane B acts; Lane A observes (sheet open, focused).
+- Steps:
+  1. **Lane B**: reply to Lane A's X1 comment with "Thanks — confirmed."
+  2. **Lane A**: within ~30s confirm the reply nests under the original comment, shows the **"Advisor"** badge, and the announcer reads **"Reply added by Advisor"** (or the advisor's display name).
+- Expected: reply appears nested with Advisor badge; aria-live announces a reply (not a root "Comment added").
+- Pass/Fail/Notes:
+
+### X3 — Polling pause on blur is visible across lanes (multi-user, polling)
+- Coordination: Lane A observes; Lane B posts while Lane A's tab is BLURRED.
+- Steps:
+  1. **Lane A**: open sheet, then blur the tab (switch away) for ~40s.
+  2. **Lane B**: post a comment during that window.
+  3. **Lane A**: while still blurred, confirm NO refetch fired; then refocus and confirm the comment appears (refetch-on-focus).
+- Expected: no background poll while hidden; refetch on refocus brings in Lane B's comment.
+- Pass/Fail/Notes:
+
+### X4 — Idempotency key per attempt (idempotency, coordinate) 🔴
+- Coordination: single lane (A) can execute, but log under cross-lane since it concerns server-side dedupe.
+- Steps:
+  1. **Lane A**: throttle to Slow 3G, submit a comment, and rapidly click submit again / or trigger a retry on the SAME optimistic row.
+  2. Inspect network: each POST carries an `Idempotency-Key` header (UUID v4). A genuine retry of the same logical submission should not create a duplicate server-side; a fresh attempt uses a NEW key.
+- Expected: no duplicate comment is created from a double-submit of the same attempt; the FE surfaces "That submission was already received — try again." on an idempotency collision (HTTP 409 → `IdempotencyCollisionError`). Each new attempt uses a distinct key.
+- Pass/Fail/Notes:
+
+### X5 — Rate limit handling (rate-limit) 🔴
+- Coordination: Lane A; do this LAST (it may trip the per-IP limit for the lane's context).
+- Steps: rapidly post many comments in quick succession until the backend returns a rate-limit (429).
+- Expected: the composer surfaces **"Slow down — try again in Ns."** (`RateLimitedError.retryAfter`); the optimistic row is handled gracefully; after the retry-after window a post succeeds. (If backend flaps 500/502 instead of 429, retry per §1.4 and note that 429 could not be reached.)
+- Pass/Fail/Notes:
+
+---
+
+## 8. Dogfooding charters (per lane — exploratory bug hunting)
+
+Each lane MUST run its dogfood charter (the `*-DOG*` case above) in addition to scripted
+cases. General charter for all lanes — try to BREAK it and log every anomaly with exact
+repro steps + a screenshot + console/network evidence:
+
+- **Weird inputs**: emoji, RTL/bidi text, zero-width chars, 4-byte unicode, very long
+  single unbroken words, only-newlines, markdown/HTML-ish strings, SQL-ish strings.
+- **Rapid actions**: double/triple-click submit; spam "+" and pins; open/close the sheet
+  fast; open the identity dialog and dismiss repeatedly; rapid reply on the same thread.
+- **Layout stress**: resize between 320px and 1920px mid-interaction; zoom to 200%;
+  long display names + Advisor badge; deeply nested replies (depth ≥ 4 → "Show N more replies").
+- **Navigation**: browser back/forward while the sheet is open; reload mid-compose;
+  open the share link in a second tab of the SAME context (note cookie sharing within a context).
+- **Theme**: toggle dark mode mid-interaction; confirm no flashes of unreadable contrast.
+- **State**: post → reload → verify persistence; switch identity → verify re-prompt;
+  let a poll land while scrolled up reading old comments (does it yank scroll?).
+- **Anchoring**: comment on text, then imagine the report re-enriches (poll) — confirm the
+  highlight re-resolves or moves to the orphan lane with the original quote preserved.
+- **Backend resilience**: deliberately go offline/online to see optimistic→failed→retry;
+  distinguish induced failures from real backend flaps.
+
+For each finding: severity guess, repro steps, screenshot, and which fix/area it touches.
+
+---
+
+## 9. Coverage map (recent fixes → cases)
+
+| Fix # | Description | Dedicated case(s) |
+|-------|-------------|-------------------|
+| 1 | Identity persists; "Commenting as X"; drsc_name JS-readable; survives reload | A5, A6, A24 |
+| 2 | Ordering oldest→newest + auto-scroll to latest | A7, X1 |
+| 3 | Pending "Sending…" / failed row stays; advisor name Skeleton | A4, A18, A19, B3 |
+| 4 | Absolute local "(Local)" timestamp, own line, no dup date | A8 |
+| 5 | Email lock for logged-in-with-email; editable for anon/wallet | C1, C4, C5 |
+| 6 | Re-select commented text; highlight pointer-events:none; marker opens thread | A13 |
+| 7 | Chat button hidden while drawer open; no overlap | A22 |
+| 8 | Comments-load error + working "Try again" | A20 |
+| 9 | Masthead "Updated <date>" when later completion | D4 |
+| 10 | Onboarding sample cards no overflow | E3 |
+| 11 | Onboarding step 3 email input below Display name, validated | E4, E5 |
+| 12 | Long display names wrap with Advisor badge | B6 |
+| 13 | "+"/pin cluster top-right, no overlap with chapter-mark | D6 |
+| 14 | General/whole-report composer always present; anchored to masthead; anchorless root blocked (422) | A9 |
+
+Core behaviors: anchoring/capture (A10, A11, A12, D5), straddle→no affordance (A14),
+>500 char→no affordance (A15), threaded replies + depth collapse (A16, dogfood),
+pins pluralized (A17), highlights multi-line (A12, A13), orphan lane (B5, dogfood),
+30s polling + blur pause (A23, X3), idempotency (X4), cookie scoping/HttpOnly (A24),
+loading/empty/error states (A1, A2, A20).

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -12,7 +12,11 @@ const STORAGE_STATE_PATH = path.join(__dirname, "..", ".auth", "user.json");
  * Only runs when QA_TEST_EMAIL is set (CI). Locally with E2E bypass,
  * auth is handled per-test via localStorage injection.
  */
-setup.setTimeout(120_000);
+// The OTP path can legitimately take ~60s (Privy email dispatch under load)
+// plus token minting and navigation, so 120s left almost no headroom and a
+// slightly slow login tripped the overall timeout. 180s covers a worst-case
+// OTP login; the cached-session fast path returns in a few seconds.
+setup.setTimeout(180_000);
 
 setup("authenticate via Privy", async ({ page, browser }) => {
   const email = process.env.QA_TEST_EMAIL;

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -37,28 +37,45 @@ setup("authenticate via Privy", async ({ page, browser }) => {
   // rate limits (the dominant cause of flaky CI logins).
   const fs = await import("node:fs");
   if (fs.existsSync(STORAGE_STATE_PATH) && fs.statSync(STORAGE_STATE_PATH).size > 0) {
-    try {
-      const context = await browser.newContext({ storageState: STORAGE_STATE_PATH });
-      const probe = await context.newPage();
-      await probe.goto("/", { waitUntil: "domcontentloaded" });
-      const refreshed = await probe
-        .waitForFunction(() => localStorage.getItem("privy:token") !== null, {
-          timeout: 15_000,
-        })
-        .then(() => true)
-        .catch(() => false);
-      if (refreshed) {
-        // Re-save so the freshly refreshed token is what gets cached.
-        await probe.waitForTimeout(1000);
-        await context.storageState({ path: STORAGE_STATE_PATH });
-        await context.close();
+    // Probe the cached session in a throwaway context, fully isolated and
+    // tightly bounded. Two hazards this guards against (both seen failing CI):
+    //   1. A slow probe.goto against staging must not consume the OTP
+    //      fallback's time budget — bound it to 20s.
+    //   2. A teardown protocol race (Target.disposeBrowserContext) must never
+    //      propagate; it previously bubbled up and left the fixture `page`
+    //      dead, so the OTP fallback's page.goto failed and the whole setup
+    //      timed out. The probe never touches the fixture `page`, and close
+    //      is best-effort.
+    const probeContext = await browser
+      .newContext({ storageState: STORAGE_STATE_PATH })
+      .catch(() => null);
+    if (probeContext) {
+      let reused = false;
+      try {
+        const probe = await probeContext.newPage();
+        await probe.goto("/", { waitUntil: "domcontentloaded", timeout: 20_000 });
+        const refreshed = await probe
+          .waitForFunction(() => localStorage.getItem("privy:token") !== null, {
+            timeout: 15_000,
+          })
+          .then(() => true)
+          .catch(() => false);
+        if (refreshed) {
+          // Re-save so the freshly refreshed token is what gets cached.
+          await probe.waitForTimeout(1000);
+          await probeContext.storageState({ path: STORAGE_STATE_PATH });
+          reused = true;
+        }
+      } catch (err) {
+        console.log(`Cached session probe failed (${err}) — falling back to OTP login`);
+      } finally {
+        await probeContext.close().catch(() => {});
+      }
+      if (reused) {
         console.log("Reused cached Privy session — skipped OTP login");
         return;
       }
-      await context.close();
       console.log("Cached Privy session expired — falling back to OTP login");
-    } catch (err) {
-      console.log(`Cached session probe failed (${err}) — falling back to OTP login`);
     }
   }
 

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -108,27 +108,27 @@ setup("authenticate via Privy", async ({ page, browser }) => {
     );
   }
 
-  // Privy may use multiple single-digit inputs or a single input for OTP
-  const otpInputs = privyModal.locator(
-    'input[aria-label*="code" i], input[autocomplete="one-time-code"], input[type="tel"], input[inputmode="numeric"]'
-  );
-  const inputCount = await otpInputs.count();
+  // Privy renders the OTP as six segmented single-digit boxes that advance on
+  // each keystroke. locator.fill() sets the value programmatically and does
+  // NOT fire the per-digit keydown/input handlers Privy listens to, so the
+  // boxes stayed empty and auth never completed (the boxes are blank in the
+  // failure screenshot). Type the code as real keypresses instead: focus the
+  // first box and let page.keyboard.type follow Privy's auto-advance, which
+  // distributes the digits across the boxes. This also works for the
+  // single-field variant (all digits land in the one input).
+  await otpInput.click();
+  await page.keyboard.type(otp, { delay: 60 });
 
-  if (inputCount > 1) {
-    for (let i = 0; i < otp.length && i < inputCount; i++) {
-      await otpInputs.nth(i).fill(otp[i]);
-    }
-  } else {
-    await otpInput.fill(otp);
-  }
-
-  // Wait for authentication to complete — privy:token should appear in localStorage
+  // Wait for authentication to complete — privy:token should appear in
+  // localStorage. Give it more room than before: token minting after the
+  // final digit can lag a few seconds on staging, and a premature failure
+  // here wastes the OTP we just spent against the per-address rate limit.
   await page.waitForFunction(
     () => {
       const token = localStorage.getItem("privy:token");
       return token !== null;
     },
-    { timeout: 30000 }
+    { timeout: 45000 }
   );
 
   // Wait for auth state to propagate

--- a/hooks/useCommenterIdentity.ts
+++ b/hooks/useCommenterIdentity.ts
@@ -49,8 +49,17 @@ export function useCommenterIdentity(token: string, isAdvisor: boolean): Comment
   }, []);
 
   const clearIdentity = useCallback(async () => {
-    await clearCommenterIdentity(token);
-    setDisplayName(null);
+    // Best-effort: callers fire this without awaiting (`void clearIdentity()`),
+    // so swallow a server-side failure to avoid an unhandled rejection. The
+    // local display name is cleared regardless so "Not me — switch" is
+    // immediate; the next post re-establishes identity server-side.
+    try {
+      await clearCommenterIdentity(token);
+    } catch {
+      // ignore — local clear below still gives the user the switch affordance
+    } finally {
+      setDisplayName(null);
+    }
   }, [token]);
 
   // Re-read on mount so server-rendered pages pick up an existing cookie.

--- a/hooks/useCommenterIdentity.ts
+++ b/hooks/useCommenterIdentity.ts
@@ -41,13 +41,8 @@ export interface CommenterIdentity {
  * flag is plumbed in from the parent (the SharedReportView knows
  * whether the Privy session matches the report's advisor_id).
  */
-export function useCommenterIdentity(
-  token: string,
-  isAdvisor: boolean,
-): CommenterIdentity {
-  const [displayName, setDisplayName] = useState<string | null>(() =>
-    readNameCookie(),
-  );
+export function useCommenterIdentity(token: string, isAdvisor: boolean): CommenterIdentity {
+  const [displayName, setDisplayName] = useState<string | null>(() => readNameCookie());
 
   const refresh = useCallback(() => {
     setDisplayName(readNameCookie());

--- a/hooks/useCommenterIdentity.ts
+++ b/hooks/useCommenterIdentity.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { clearCommenterIdentity } from "@/services/donor-research-comments.service";
+
+const COOKIE_NAME = "drsc_name";
+
+function readNameCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const parts = document.cookie.split(";");
+  for (const part of parts) {
+    const [name, ...rest] = part.trim().split("=");
+    if (name === COOKIE_NAME) {
+      try {
+        return decodeURIComponent(rest.join("="));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+export interface CommenterIdentity {
+  /** Display name from the JS-readable cookie, null when not present. */
+  displayName: string | null;
+  /** True when the viewer is the advisor (Privy-authenticated as report owner). */
+  isAdvisor: boolean;
+  /** True when displayName OR isAdvisor is true. */
+  hasIdentity: boolean;
+  /** Forces a re-read of the cookie (call after a mutation that may have Set-Cookie'd a new name). */
+  refresh: () => void;
+  /** "Not me — switch" affordance — clears cookies then refreshes. */
+  clearIdentity: () => Promise<void>;
+}
+
+/**
+ * Reads the `drsc_name` cookie on the FE origin and exposes the
+ * "Commenting as X" affordance plus a clear action (Q2). The advisor
+ * flag is plumbed in from the parent (the SharedReportView knows
+ * whether the Privy session matches the report's advisor_id).
+ */
+export function useCommenterIdentity(
+  token: string,
+  isAdvisor: boolean,
+): CommenterIdentity {
+  const [displayName, setDisplayName] = useState<string | null>(() =>
+    readNameCookie(),
+  );
+
+  const refresh = useCallback(() => {
+    setDisplayName(readNameCookie());
+  }, []);
+
+  const clearIdentity = useCallback(async () => {
+    await clearCommenterIdentity(token);
+    setDisplayName(null);
+  }, [token]);
+
+  // Re-read on mount so server-rendered pages pick up an existing cookie.
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return {
+    displayName,
+    isAdvisor,
+    hasIdentity: isAdvisor || displayName !== null,
+    refresh,
+    clearIdentity,
+  };
+}

--- a/hooks/useDonorAdvisor.ts
+++ b/hooks/useDonorAdvisor.ts
@@ -10,6 +10,11 @@ import type { DonorAdvisor, DonorResearchCountersSnapshot } from "@/types/donor-
 export const donorAdvisorQueryKey = ["donor-research", "advisor", "me"] as const;
 export const donorCountersQueryKey = ["donor-research", "advisor", "counters"] as const;
 
+interface UseDonorAdvisorOptions {
+  /** Skip the query when authentication is not yet ready / unauthenticated. */
+  enabled?: boolean;
+}
+
 /**
  * Loads the current advisor row.
  *
@@ -17,12 +22,17 @@ export const donorCountersQueryKey = ["donor-research", "advisor", "counters"] a
  * advisor hasn't onboarded yet — callers should branch on that explicit
  * null and route to the onboarding flow rather than treating it as an
  * error.
+ *
+ * The optional `enabled` flag lets unauthenticated callers (e.g., the
+ * donor-share route) skip the request entirely instead of provoking a
+ * 401 just to detect advisor identity.
  */
-export function useDonorAdvisor() {
+export function useDonorAdvisor(opts: UseDonorAdvisorOptions = {}) {
   return useQuery<DonorAdvisor | null>({
     queryKey: donorAdvisorQueryKey,
     queryFn: fetchCurrentAdvisor,
     staleTime: 5 * 60_000, // advisor row rarely changes
+    enabled: opts.enabled !== false,
   });
 }
 

--- a/hooks/useSharedReportComments.ts
+++ b/hooks/useSharedReportComments.ts
@@ -5,7 +5,8 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 import {
   assembleCommentTree,
@@ -36,6 +37,8 @@ interface SharedReportCommentsHookResult {
     Error,
     { request: CreateCommentRequest; idempotencyKey: string }
   >;
+  /** Re-post a comment whose optimistic POST failed (removes the failed row, re-submits). */
+  retryFailed: (commentId: string) => void;
 }
 
 /**
@@ -82,14 +85,19 @@ export function useSharedReportComments(
       const snapshot = queryClient.getQueryData<SharedReportCommentsResponse>(
         sharedReportCommentsKey(token)
       );
-      const optimistic: SharedReportComment = {
-        id: `optimistic-${idempotencyKey}`,
+      const optimisticId = `optimistic-${idempotencyKey}`;
+      // `_optimistic` drives the row's "Sending…" pending indicator. The flag
+      // is spread into the tree node by `assembleCommentTree`, so the row
+      // renders a clear in-flight state until the POST settles.
+      const optimistic: SharedReportComment & { _optimistic?: boolean; _failed?: boolean } = {
+        id: optimisticId,
         parentCommentId: request.parentCommentId ?? null,
         isAdvisor: false,
         displayName: request.displayName,
         anchor: request.anchor ?? null,
         body: request.body,
         createdAt: new Date().toISOString(),
+        _optimistic: true,
       };
       queryClient.setQueryData<SharedReportCommentsResponse>(
         sharedReportCommentsKey(token),
@@ -105,18 +113,67 @@ export function useSharedReportComments(
           return { ...base, replies: [...base.replies, optimistic] };
         }
       );
-      return { snapshot };
+      return { snapshot, optimisticId };
     },
     onError: (_err, _vars, ctx) => {
-      const snapshot = (ctx as { snapshot?: SharedReportCommentsResponse } | undefined)?.snapshot;
-      if (snapshot) {
-        queryClient.setQueryData(sharedReportCommentsKey(token), snapshot);
-      }
+      // Keep the optimistic row visible in a FAILED state instead of rolling
+      // back (which looked like the comment was added then deleted) so the
+      // donor can retry. We do NOT invalidate on error (that refetch would
+      // immediately wipe this row) — invalidation happens in onSuccess only.
+      const optimisticId = (ctx as { optimisticId?: string } | undefined)?.optimisticId;
+      if (!optimisticId) return;
+      const markFailed = <T extends SharedReportComment>(comment: T): T =>
+        comment.id === optimisticId ? { ...comment, _optimistic: false, _failed: true } : comment;
+      queryClient.setQueryData<SharedReportCommentsResponse>(
+        sharedReportCommentsKey(token),
+        (current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            roots: current.roots.map(markFailed),
+            replies: current.replies.map(markFailed),
+          };
+        }
+      );
     },
-    onSettled: () => {
+    onSuccess: () => {
+      // Reconcile with the server only on success — the optimistic row is
+      // replaced by the real one. (Failed rows are preserved by skipping
+      // invalidation on error.)
       void queryClient.invalidateQueries({ queryKey: sharedReportCommentsKey(token) });
     },
   });
 
-  return { query, tree, postComment };
+  // Re-post a failed comment: drop the failed row from the cache, then submit
+  // again with a fresh idempotency key.
+  const retryFailed = useCallback(
+    (commentId: string) => {
+      const current = queryClient.getQueryData<SharedReportCommentsResponse>(
+        sharedReportCommentsKey(token)
+      );
+      const failed = current
+        ? [...current.roots, ...current.replies].find((c) => c.id === commentId)
+        : undefined;
+      if (!failed) return;
+      queryClient.setQueryData<SharedReportCommentsResponse>(sharedReportCommentsKey(token), (c) =>
+        c
+          ? {
+              ...c,
+              roots: c.roots.filter((x) => x.id !== commentId),
+              replies: c.replies.filter((x) => x.id !== commentId),
+            }
+          : c
+      );
+      const request: CreateCommentRequest = {
+        body: failed.body,
+        displayName: failed.displayName,
+        ...(failed.anchor ? { anchor: failed.anchor } : {}),
+        ...(failed.parentCommentId ? { parentCommentId: failed.parentCommentId } : {}),
+      };
+      postComment.mutate({ request, idempotencyKey: uuidv4() });
+    },
+    [queryClient, token, postComment]
+  );
+
+  return { query, tree, postComment, retryFailed };
 }

--- a/hooks/useSharedReportComments.ts
+++ b/hooks/useSharedReportComments.ts
@@ -1,9 +1,9 @@
 import {
+  type UseMutationResult,
+  type UseQueryResult,
   useMutation,
   useQuery,
   useQueryClient,
-  type UseMutationResult,
-  type UseQueryResult,
 } from "@tanstack/react-query";
 import { useMemo } from "react";
 
@@ -50,7 +50,7 @@ interface SharedReportCommentsHookResult {
  */
 export function useSharedReportComments(
   token: string,
-  opts: UseSharedReportCommentsOptions = {},
+  opts: UseSharedReportCommentsOptions = {}
 ): SharedReportCommentsHookResult {
   const queryClient = useQueryClient();
   const enabled = opts.enabled !== false;
@@ -80,7 +80,7 @@ export function useSharedReportComments(
     onMutate: async ({ request, idempotencyKey }) => {
       await queryClient.cancelQueries({ queryKey: sharedReportCommentsKey(token) });
       const snapshot = queryClient.getQueryData<SharedReportCommentsResponse>(
-        sharedReportCommentsKey(token),
+        sharedReportCommentsKey(token)
       );
       const optimistic: SharedReportComment = {
         id: `optimistic-${idempotencyKey}`,
@@ -103,7 +103,7 @@ export function useSharedReportComments(
             return { ...base, roots: [optimistic, ...base.roots] };
           }
           return { ...base, replies: [...base.replies, optimistic] };
-        },
+        }
       );
       return { snapshot };
     },

--- a/hooks/useSharedReportComments.ts
+++ b/hooks/useSharedReportComments.ts
@@ -1,0 +1,122 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  assembleCommentTree,
+  listSharedReportComments,
+  postSharedReportComment,
+} from "@/services/donor-research-comments.service";
+import type {
+  CreateCommentRequest,
+  SharedReportComment,
+  SharedReportCommentNode,
+  SharedReportCommentsResponse,
+} from "@/types/donor-research-comments";
+
+const POLL_INTERVAL_MS = 30_000;
+
+export const sharedReportCommentsKey = (token: string) =>
+  ["shared-report-comments", token] as const;
+
+interface UseSharedReportCommentsOptions {
+  enabled?: boolean;
+}
+
+interface SharedReportCommentsHookResult {
+  query: UseQueryResult<SharedReportCommentsResponse, Error>;
+  tree: SharedReportCommentNode[];
+  postComment: UseMutationResult<
+    SharedReportComment,
+    Error,
+    { request: CreateCommentRequest; idempotencyKey: string }
+  >;
+}
+
+/**
+ * React Query hook for the donor-shared report comments surface.
+ *
+ *   - Polls every 30s, pauses on hidden tabs
+ *     (`refetchIntervalInBackground: false`)
+ *   - Disables polling when `enabled=false` (e.g., report 404 — token
+ *     revoked / expired)
+ *   - `postComment` is a mutation with optimistic root + reply append.
+ *     The component generates `idempotencyKey` per attempt (UUID v4).
+ */
+export function useSharedReportComments(
+  token: string,
+  opts: UseSharedReportCommentsOptions = {},
+): SharedReportCommentsHookResult {
+  const queryClient = useQueryClient();
+  const enabled = opts.enabled !== false;
+
+  const query = useQuery<SharedReportCommentsResponse, Error>({
+    queryKey: sharedReportCommentsKey(token),
+    queryFn: ({ signal }) => listSharedReportComments(token, { limit: 50 }, signal),
+    refetchInterval: enabled ? POLL_INTERVAL_MS : false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: enabled,
+    retry: false,
+    enabled,
+  });
+
+  const tree = useMemo(() => {
+    if (!query.data) return [] as SharedReportCommentNode[];
+    return assembleCommentTree(query.data.roots, query.data.replies);
+  }, [query.data]);
+
+  const postComment = useMutation<
+    SharedReportComment,
+    Error,
+    { request: CreateCommentRequest; idempotencyKey: string }
+  >({
+    mutationFn: ({ request, idempotencyKey }) =>
+      postSharedReportComment(token, request, idempotencyKey),
+    onMutate: async ({ request, idempotencyKey }) => {
+      await queryClient.cancelQueries({ queryKey: sharedReportCommentsKey(token) });
+      const snapshot = queryClient.getQueryData<SharedReportCommentsResponse>(
+        sharedReportCommentsKey(token),
+      );
+      const optimistic: SharedReportComment = {
+        id: `optimistic-${idempotencyKey}`,
+        parentCommentId: request.parentCommentId ?? null,
+        isAdvisor: false,
+        displayName: request.displayName,
+        anchor: request.anchor ?? null,
+        body: request.body,
+        createdAt: new Date().toISOString(),
+      };
+      queryClient.setQueryData<SharedReportCommentsResponse>(
+        sharedReportCommentsKey(token),
+        (current) => {
+          const base: SharedReportCommentsResponse = current ?? {
+            roots: [],
+            replies: [],
+            pageInfo: { nextCursor: null },
+          };
+          if (optimistic.parentCommentId === null) {
+            return { ...base, roots: [optimistic, ...base.roots] };
+          }
+          return { ...base, replies: [...base.replies, optimistic] };
+        },
+      );
+      return { snapshot };
+    },
+    onError: (_err, _vars, ctx) => {
+      const snapshot = (ctx as { snapshot?: SharedReportCommentsResponse } | undefined)?.snapshot;
+      if (snapshot) {
+        queryClient.setQueryData(sharedReportCommentsKey(token), snapshot);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: sharedReportCommentsKey(token) });
+    },
+  });
+
+  return { query, tree, postComment };
+}

--- a/services/donor-research-comments.service.ts
+++ b/services/donor-research-comments.service.ts
@@ -1,11 +1,11 @@
 import {
   type CreateCommentRequest,
-  type SharedReportComment,
-  type SharedReportCommentNode,
-  type SharedReportCommentsResponse,
   IdempotencyCollisionError,
   IdentityRequiredError,
   RateLimitedError,
+  type SharedReportComment,
+  type SharedReportCommentNode,
+  type SharedReportCommentsResponse,
 } from "@/types/donor-research-comments";
 
 /**
@@ -24,7 +24,7 @@ function clearIdentityUrl(token: string): string {
 export async function listSharedReportComments(
   token: string,
   params: { cursor?: string; limit?: number } = {},
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<SharedReportCommentsResponse> {
   const qs = new URLSearchParams();
   if (params.cursor) qs.set("cursor", params.cursor);
@@ -44,7 +44,7 @@ export async function listSharedReportComments(
 export async function postSharedReportComment(
   token: string,
   body: CreateCommentRequest,
-  idempotencyKey: string,
+  idempotencyKey: string
 ): Promise<SharedReportComment> {
   const res = await fetch(proxyUrl(token), {
     method: "POST",
@@ -88,7 +88,7 @@ export async function clearCommenterIdentity(token: string): Promise<void> {
  */
 export function assembleCommentTree(
   roots: SharedReportComment[],
-  replies: SharedReportComment[],
+  replies: SharedReportComment[]
 ): SharedReportCommentNode[] {
   const byId = new Map<string, SharedReportCommentNode>();
   const rootNodes: SharedReportCommentNode[] = [];

--- a/services/donor-research-comments.service.ts
+++ b/services/donor-research-comments.service.ts
@@ -7,6 +7,27 @@ import {
   type SharedReportCommentNode,
   type SharedReportCommentsResponse,
 } from "@/types/donor-research-comments";
+import { TokenManager } from "@/utilities/auth/token-manager";
+
+/**
+ * Returns a `{ Authorization: "Bearer <Privy JWT>" }` header when a
+ * Privy session is available, otherwise an empty object. Donors viewing
+ * the shared report anonymously have no Privy session — the proxy +
+ * indexer treat that as the anonymous path. The authenticated advisor
+ * viewing their own report carries the JWT so the indexer's
+ * `optionalAuthentication` + advisor branch can stamp `is_advisor=true`
+ * (KTD13 + KTD14).
+ */
+async function maybeAuthHeader(): Promise<Record<string, string>> {
+  try {
+    const token = await TokenManager.getToken();
+    if (token) return { Authorization: `Bearer ${token}` };
+  } catch {
+    // TokenManager throws when Privy isn't initialized yet — treat as
+    // anonymous rather than failing the comment post.
+  }
+  return {};
+}
 
 /**
  * Calls the Next.js API-route proxy on the FE origin. The proxy
@@ -30,9 +51,11 @@ export async function listSharedReportComments(
   if (params.cursor) qs.set("cursor", params.cursor);
   if (params.limit) qs.set("limit", String(params.limit));
   const url = `${proxyUrl(token)}${qs.toString() ? `?${qs.toString()}` : ""}`;
+  const auth = await maybeAuthHeader();
   const res = await fetch(url, {
     method: "GET",
     credentials: "same-origin",
+    headers: auth,
     signal,
   });
   if (!res.ok) {
@@ -46,12 +69,14 @@ export async function postSharedReportComment(
   body: CreateCommentRequest,
   idempotencyKey: string
 ): Promise<SharedReportComment> {
+  const auth = await maybeAuthHeader();
   const res = await fetch(proxyUrl(token), {
     method: "POST",
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
       "Idempotency-Key": idempotencyKey,
+      ...auth,
     },
     body: JSON.stringify(body),
   });

--- a/services/donor-research-comments.service.ts
+++ b/services/donor-research-comments.service.ts
@@ -1,0 +1,117 @@
+import {
+  type CreateCommentRequest,
+  type SharedReportComment,
+  type SharedReportCommentNode,
+  type SharedReportCommentsResponse,
+  IdempotencyCollisionError,
+  IdentityRequiredError,
+  RateLimitedError,
+} from "@/types/donor-research-comments";
+
+/**
+ * Calls the Next.js API-route proxy on the FE origin. The proxy
+ * forwards to the indexer server-to-server and translates cookies.
+ */
+
+function proxyUrl(token: string): string {
+  return `/api/donor-research/shared/${encodeURIComponent(token)}/comments`;
+}
+
+function clearIdentityUrl(token: string): string {
+  return `/api/donor-research/shared/${encodeURIComponent(token)}/clear-identity`;
+}
+
+export async function listSharedReportComments(
+  token: string,
+  params: { cursor?: string; limit?: number } = {},
+  signal?: AbortSignal,
+): Promise<SharedReportCommentsResponse> {
+  const qs = new URLSearchParams();
+  if (params.cursor) qs.set("cursor", params.cursor);
+  if (params.limit) qs.set("limit", String(params.limit));
+  const url = `${proxyUrl(token)}${qs.toString() ? `?${qs.toString()}` : ""}`;
+  const res = await fetch(url, {
+    method: "GET",
+    credentials: "same-origin",
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`listSharedReportComments failed: ${res.status}`);
+  }
+  return (await res.json()) as SharedReportCommentsResponse;
+}
+
+export async function postSharedReportComment(
+  token: string,
+  body: CreateCommentRequest,
+  idempotencyKey: string,
+): Promise<SharedReportComment> {
+  const res = await fetch(proxyUrl(token), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 400) {
+    const data = await res.json().catch(() => ({}));
+    if (data?.requiresIdentity) throw new IdentityRequiredError();
+    throw new Error("Bad request");
+  }
+  if (res.status === 409) {
+    throw new IdempotencyCollisionError();
+  }
+  if (res.status === 429) {
+    const retryAfterHeader = res.headers.get("Retry-After");
+    throw new RateLimitedError(retryAfterHeader ? Number(retryAfterHeader) : 60);
+  }
+  if (!res.ok) {
+    throw new Error(`postSharedReportComment failed: ${res.status}`);
+  }
+  return (await res.json()) as SharedReportComment;
+}
+
+export async function clearCommenterIdentity(token: string): Promise<void> {
+  await fetch(clearIdentityUrl(token), {
+    method: "POST",
+    credentials: "same-origin",
+  });
+}
+
+/**
+ * Assembles a depth-N comment tree from a flat list of roots + replies.
+ * Replies whose parent is missing (e.g., parent soft-deleted upstream)
+ * are dropped silently; the orphan-text-range lane handles missing
+ * anchors but missing parent rows are a backend invariant violation.
+ */
+export function assembleCommentTree(
+  roots: SharedReportComment[],
+  replies: SharedReportComment[],
+): SharedReportCommentNode[] {
+  const byId = new Map<string, SharedReportCommentNode>();
+  const rootNodes: SharedReportCommentNode[] = [];
+
+  for (const r of roots) {
+    const node: SharedReportCommentNode = { ...r, children: [] };
+    byId.set(node.id, node);
+    rootNodes.push(node);
+  }
+
+  for (const reply of replies) {
+    if (!reply.parentCommentId) continue;
+    const node: SharedReportCommentNode = { ...reply, children: [] };
+    byId.set(node.id, node);
+  }
+
+  for (const reply of replies) {
+    if (!reply.parentCommentId) continue;
+    const child = byId.get(reply.id);
+    const parent = byId.get(reply.parentCommentId);
+    if (!child || !parent) continue;
+    parent.children.push(child);
+  }
+
+  return rootNodes;
+}

--- a/services/donor-research-comments.service.ts
+++ b/services/donor-research-comments.service.ts
@@ -89,8 +89,10 @@ export async function postSharedReportComment(
     throw new IdempotencyCollisionError();
   }
   if (res.status === 429) {
-    const retryAfterHeader = res.headers.get("Retry-After");
-    throw new RateLimitedError(retryAfterHeader ? Number(retryAfterHeader) : 60);
+    // Guard against a missing / non-numeric Retry-After (e.g. an HTTP-date
+    // form or absent header) so we never surface "try again in NaNs".
+    const parsed = Number(res.headers.get("Retry-After"));
+    throw new RateLimitedError(Number.isFinite(parsed) && parsed > 0 ? parsed : 60);
   }
   if (!res.ok) {
     throw new Error(`postSharedReportComment failed: ${res.status}`);
@@ -99,10 +101,13 @@ export async function postSharedReportComment(
 }
 
 export async function clearCommenterIdentity(token: string): Promise<void> {
-  await fetch(clearIdentityUrl(token), {
+  const res = await fetch(clearIdentityUrl(token), {
     method: "POST",
     credentials: "same-origin",
   });
+  if (!res.ok) {
+    throw new Error(`clearCommenterIdentity failed: ${res.status}`);
+  }
 }
 
 /**

--- a/services/donor-research.service.ts
+++ b/services/donor-research.service.ts
@@ -52,6 +52,8 @@ export const fetchCurrentAdvisor = async (): Promise<DonorAdvisor | null> => {
 
 export interface OnboardAdvisorRequest {
   displayName: string;
+  /** Advisor contact email — where report notifications are sent. */
+  email?: string;
   orgName?: string | null;
   timezone: string;
 }

--- a/src/features/donor-research/components/anchor/capture.ts
+++ b/src/features/donor-research/components/anchor/capture.ts
@@ -49,10 +49,7 @@ export function captureTextRangeAnchor(selection: Selection): CommentAnchor | nu
   const startAncestor = findAnchorAncestor(range.startContainer);
   const endAncestor = findAnchorAncestor(range.endContainer);
   if (!startAncestor || !endAncestor) return null;
-  if (
-    startAncestor.kind !== endAncestor.kind ||
-    startAncestor.id !== endAncestor.id
-  ) {
+  if (startAncestor.kind !== endAncestor.kind || startAncestor.id !== endAncestor.id) {
     return null;
   }
 
@@ -61,18 +58,14 @@ export function captureTextRangeAnchor(selection: Selection): CommentAnchor | nu
 
   const targetEl =
     startAncestor.kind === "candidate"
-      ? (
-          (range.startContainer instanceof Element
-            ? range.startContainer
-            : range.startContainer.parentElement
-          )?.closest(`[data-candidate-id="${startAncestor.id}"]`) ?? null
-        )
-      : (
-          (range.startContainer instanceof Element
-            ? range.startContainer
-            : range.startContainer.parentElement
-          )?.closest(`[data-section="${startAncestor.id}"]`) ?? null
-        );
+      ? ((range.startContainer instanceof Element
+          ? range.startContainer
+          : range.startContainer.parentElement
+        )?.closest(`[data-candidate-id="${startAncestor.id}"]`) ?? null)
+      : ((range.startContainer instanceof Element
+          ? range.startContainer
+          : range.startContainer.parentElement
+        )?.closest(`[data-section="${startAncestor.id}"]`) ?? null);
   if (!targetEl) return null;
 
   const targetText = normalizeWhitespace(targetEl.textContent ?? "");

--- a/src/features/donor-research/components/anchor/capture.ts
+++ b/src/features/donor-research/components/anchor/capture.ts
@@ -69,7 +69,24 @@ export function captureTextRangeAnchor(selection: Selection): CommentAnchor | nu
   if (!targetEl) return null;
 
   const targetText = normalizeWhitespace(targetEl.textContent ?? "");
-  const quoteIndex = targetText.indexOf(quote);
+  // Derive the quote's position from the actual selection boundary rather
+  // than a global first-match: when the same text appears more than once in
+  // the target block, indexOf(quote) would pick the wrong occurrence and the
+  // stored prefix/suffix (and later resolution) would drift to it. The
+  // normalized length of everything preceding the selection start gives the
+  // quote's offset (±1 for a whitespace boundary that normalization trims),
+  // so we search forward from there to snap to the selected occurrence.
+  const preRange = document.createRange();
+  preRange.selectNodeContents(targetEl);
+  try {
+    preRange.setEnd(range.startContainer, range.startOffset);
+  } catch {
+    // startContainer outside targetEl (shouldn't happen past the ancestor
+    // check) — fall through to a first-match search below.
+  }
+  const precedingLen = normalizeWhitespace(preRange.toString()).length;
+  let quoteIndex = targetText.indexOf(quote, Math.max(0, precedingLen - 1));
+  if (quoteIndex === -1) quoteIndex = targetText.indexOf(quote);
   if (quoteIndex === -1) return null;
 
   const prefix = targetText

--- a/src/features/donor-research/components/anchor/capture.ts
+++ b/src/features/donor-research/components/anchor/capture.ts
@@ -1,0 +1,114 @@
+import {
+  COMMENT_ANCHOR_BOUNDS,
+  type CommentAnchor,
+  type CommentSectionKey,
+  isCommentSectionKey,
+} from "./types";
+
+/**
+ * Walks up from `node` until it hits an element carrying either
+ * `data-candidate-id` or `data-section`. Returns null when no anchorable
+ * ancestor exists.
+ */
+function findAnchorAncestor(
+  node: Node | null
+): { kind: "section"; id: CommentSectionKey } | { kind: "candidate"; id: string } | null {
+  let current: Node | null = node;
+  while (current) {
+    if (current instanceof Element) {
+      const candidateId = current.getAttribute("data-candidate-id");
+      if (candidateId) return { kind: "candidate", id: candidateId };
+      const sectionKey = current.getAttribute("data-section");
+      if (sectionKey && isCommentSectionKey(sectionKey)) {
+        return { kind: "section", id: sectionKey };
+      }
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Captures a text-range anchor from a DOM Selection. Returns null when:
+ *   - the selection is empty (collapsed)
+ *   - the selection straddles two different anchor targets
+ *   - no anchor target ancestor exists for the selection
+ *
+ * The captured quote, prefix, and suffix are whitespace-normalized so
+ * re-resolution survives React rerender churn.
+ */
+export function captureTextRangeAnchor(selection: Selection): CommentAnchor | null {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  const startAncestor = findAnchorAncestor(range.startContainer);
+  const endAncestor = findAnchorAncestor(range.endContainer);
+  if (!startAncestor || !endAncestor) return null;
+  if (
+    startAncestor.kind !== endAncestor.kind ||
+    startAncestor.id !== endAncestor.id
+  ) {
+    return null;
+  }
+
+  const quote = normalizeWhitespace(selection.toString());
+  if (!quote || quote.length > COMMENT_ANCHOR_BOUNDS.QUOTE_MAX) return null;
+
+  const targetEl =
+    startAncestor.kind === "candidate"
+      ? (
+          (range.startContainer instanceof Element
+            ? range.startContainer
+            : range.startContainer.parentElement
+          )?.closest(`[data-candidate-id="${startAncestor.id}"]`) ?? null
+        )
+      : (
+          (range.startContainer instanceof Element
+            ? range.startContainer
+            : range.startContainer.parentElement
+          )?.closest(`[data-section="${startAncestor.id}"]`) ?? null
+        );
+  if (!targetEl) return null;
+
+  const targetText = normalizeWhitespace(targetEl.textContent ?? "");
+  const quoteIndex = targetText.indexOf(quote);
+  if (quoteIndex === -1) return null;
+
+  const prefix = targetText
+    .slice(Math.max(0, quoteIndex - COMMENT_ANCHOR_BOUNDS.PREFIX_MAX), quoteIndex)
+    .slice(-COMMENT_ANCHOR_BOUNDS.PREFIX_MAX);
+  const suffix = targetText
+    .slice(quoteIndex + quote.length, quoteIndex + quote.length + COMMENT_ANCHOR_BOUNDS.SUFFIX_MAX)
+    .slice(0, COMMENT_ANCHOR_BOUNDS.SUFFIX_MAX);
+
+  return {
+    kind: "text_range",
+    targetKind: startAncestor.kind,
+    targetId: startAncestor.id,
+    quote,
+    prefix,
+    suffix,
+  };
+}
+
+/**
+ * Builds a pin anchor (section or candidate) for the supplied element.
+ * Returns null when the element is not anchorable.
+ */
+export function captureElementAnchor(element: Element | null): CommentAnchor | null {
+  if (!element) return null;
+  const anchorEl = element.closest("[data-candidate-id], [data-section]");
+  if (!anchorEl) return null;
+  const candidateId = anchorEl.getAttribute("data-candidate-id");
+  if (candidateId) return { kind: "candidate", candidateId };
+  const sectionKey = anchorEl.getAttribute("data-section");
+  if (sectionKey && isCommentSectionKey(sectionKey)) {
+    return { kind: "section", sectionKey };
+  }
+  return null;
+}

--- a/src/features/donor-research/components/anchor/resolve.ts
+++ b/src/features/donor-research/components/anchor/resolve.ts
@@ -29,10 +29,7 @@ function normalizeWhitespace(text: string): string {
  *
  * Returns null on miss; the caller routes that to the orphan lane.
  */
-function buildRangeForQuote(
-  targetEl: Element,
-  anchor: TextRangeAnchor
-): Range | null {
+function buildRangeForQuote(targetEl: Element, anchor: TextRangeAnchor): Range | null {
   const normalized = normalizeWhitespace(targetEl.textContent ?? "");
   const search = anchor.prefix + anchor.quote + anchor.suffix;
   let startIdx = normalized.indexOf(search);
@@ -62,7 +59,8 @@ function buildRangeForQuote(
     // For each character in `original`, compute how it contributes to
     // the normalized form. We treat any run of whitespace as a single
     // space — same rule used in `normalizeWhitespace`.
-    let lastWasSpace = normalizedSoFar > 0 && normalizedNeighbourEndsWith(targetEl, walker, textNode) === " ";
+    let lastWasSpace =
+      normalizedSoFar > 0 && normalizedNeighbourEndsWith(targetEl, walker, textNode) === " ";
     for (let i = 0; i < original.length; i += 1) {
       const ch = original[i];
       const isWs = /\s/.test(ch);
@@ -104,18 +102,11 @@ function buildRangeForQuote(
 // Placeholder helper — the resolver walks left-to-right so we don't
 // actually need lookahead; declaring this keeps the contribution
 // algorithm readable without adding a runtime dep.
-function normalizedNeighbourEndsWith(
-  _targetEl: Element,
-  _walker: TreeWalker,
-  _node: Text
-): string {
+function normalizedNeighbourEndsWith(_targetEl: Element, _walker: TreeWalker, _node: Text): string {
   return "";
 }
 
-export function resolveAnchor(
-  anchor: CommentAnchor,
-  root: Element
-): ResolvedAnchor {
+export function resolveAnchor(anchor: CommentAnchor, root: Element): ResolvedAnchor {
   const target = findTargetElement(anchor, root);
   if (!target) return { kind: "orphan" };
 

--- a/src/features/donor-research/components/anchor/resolve.ts
+++ b/src/features/donor-research/components/anchor/resolve.ts
@@ -1,0 +1,129 @@
+import type { CommentAnchor, TextRangeAnchor } from "./types";
+
+export type ResolvedAnchor =
+  | { kind: "element"; element: Element }
+  | { kind: "range"; range: Range; element: Element }
+  | { kind: "orphan" };
+
+function findTargetElement(anchor: CommentAnchor, root: Element): Element | null {
+  if (anchor.kind === "section") {
+    return root.querySelector(`[data-section="${anchor.sectionKey}"]`);
+  }
+  if (anchor.kind === "candidate") {
+    return root.querySelector(`[data-candidate-id="${anchor.candidateId}"]`);
+  }
+  if (anchor.targetKind === "section") {
+    return root.querySelector(`[data-section="${anchor.targetId}"]`);
+  }
+  return root.querySelector(`[data-candidate-id="${anchor.targetId}"]`);
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Builds a DOM Range covering the resolved quote within `targetEl`.
+ * Walks text nodes accumulating normalized lengths until we find the
+ * start + end offsets matching the captured quote.
+ *
+ * Returns null on miss; the caller routes that to the orphan lane.
+ */
+function buildRangeForQuote(
+  targetEl: Element,
+  anchor: TextRangeAnchor
+): Range | null {
+  const normalized = normalizeWhitespace(targetEl.textContent ?? "");
+  const search = anchor.prefix + anchor.quote + anchor.suffix;
+  let startIdx = normalized.indexOf(search);
+  if (startIdx === -1) {
+    // Fall back to quote-only match — degrades gracefully when prefix
+    // or suffix changed but the quote survives.
+    startIdx = normalized.indexOf(anchor.quote);
+    if (startIdx === -1) return null;
+  } else {
+    startIdx += anchor.prefix.length;
+  }
+  const endIdx = startIdx + anchor.quote.length;
+
+  // Walk text nodes building up a normalized offset → original-node map.
+  const walker = document.createTreeWalker(targetEl, NodeFilter.SHOW_TEXT);
+  let normalizedSoFar = 0;
+  let range: Range | null = null;
+  const cursor: { node: Text | null; nodeOffset: number } = {
+    node: null,
+    nodeOffset: 0,
+  };
+  let pendingStart = false;
+  let pendingEnd = false;
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text;
+    const original = textNode.data;
+    // For each character in `original`, compute how it contributes to
+    // the normalized form. We treat any run of whitespace as a single
+    // space — same rule used in `normalizeWhitespace`.
+    let lastWasSpace = normalizedSoFar > 0 && normalizedNeighbourEndsWith(targetEl, walker, textNode) === " ";
+    for (let i = 0; i < original.length; i += 1) {
+      const ch = original[i];
+      const isWs = /\s/.test(ch);
+      let contributes: number;
+      if (isWs) {
+        contributes = lastWasSpace ? 0 : 1;
+        lastWasSpace = true;
+      } else {
+        contributes = 1;
+        lastWasSpace = false;
+      }
+      if (contributes === 0) continue;
+      if (!range && normalizedSoFar === startIdx) {
+        range = document.createRange();
+        range.setStart(textNode, i);
+        pendingStart = false;
+      } else if (!range) {
+        pendingStart = true;
+      }
+      if (range && normalizedSoFar === endIdx - 1) {
+        // After consuming this char we're at endIdx. Set end after
+        // this position.
+        range.setEnd(textNode, i + 1);
+        pendingEnd = true;
+      }
+      normalizedSoFar += 1;
+    }
+    if (range && pendingEnd) break;
+    cursor.node = textNode;
+    cursor.nodeOffset = original.length;
+  }
+  // Reference unused vars to keep TS happy under noUnusedLocals.
+  void pendingStart;
+  void cursor;
+  if (!range || !pendingEnd) return null;
+  return range;
+}
+
+// Placeholder helper — the resolver walks left-to-right so we don't
+// actually need lookahead; declaring this keeps the contribution
+// algorithm readable without adding a runtime dep.
+function normalizedNeighbourEndsWith(
+  _targetEl: Element,
+  _walker: TreeWalker,
+  _node: Text
+): string {
+  return "";
+}
+
+export function resolveAnchor(
+  anchor: CommentAnchor,
+  root: Element
+): ResolvedAnchor {
+  const target = findTargetElement(anchor, root);
+  if (!target) return { kind: "orphan" };
+
+  if (anchor.kind === "section" || anchor.kind === "candidate") {
+    return { kind: "element", element: target };
+  }
+
+  const range = buildRangeForQuote(target, anchor);
+  if (!range) return { kind: "orphan" };
+  return { kind: "range", range, element: target };
+}

--- a/src/features/donor-research/components/anchor/resolve.ts
+++ b/src/features/donor-research/components/anchor/resolve.ts
@@ -53,14 +53,19 @@ function buildRangeForQuote(targetEl: Element, anchor: TextRangeAnchor): Range |
   };
   let pendingStart = false;
   let pendingEnd = false;
+  // Whitespace-collapse state MUST persist across text-node boundaries:
+  // `normalizeWhitespace` collapses a run of whitespace that straddles two
+  // adjacent text nodes into a single space, so the walker has to remember
+  // whether the previous character (in the previous node) was whitespace.
+  // Resetting per node double-counts boundary whitespace and drifts the
+  // offsets, making valid quotes unresolvable.
+  let lastWasSpace = false;
   while (walker.nextNode()) {
     const textNode = walker.currentNode as Text;
     const original = textNode.data;
     // For each character in `original`, compute how it contributes to
     // the normalized form. We treat any run of whitespace as a single
     // space — same rule used in `normalizeWhitespace`.
-    let lastWasSpace =
-      normalizedSoFar > 0 && normalizedNeighbourEndsWith(targetEl, walker, textNode) === " ";
     for (let i = 0; i < original.length; i += 1) {
       const ch = original[i];
       const isWs = /\s/.test(ch);
@@ -97,13 +102,6 @@ function buildRangeForQuote(targetEl: Element, anchor: TextRangeAnchor): Range |
   void cursor;
   if (!range || !pendingEnd) return null;
   return range;
-}
-
-// Placeholder helper — the resolver walks left-to-right so we don't
-// actually need lookahead; declaring this keeps the contribution
-// algorithm readable without adding a runtime dep.
-function normalizedNeighbourEndsWith(_targetEl: Element, _walker: TreeWalker, _node: Text): string {
-  return "";
 }
 
 export function resolveAnchor(anchor: CommentAnchor, root: Element): ResolvedAnchor {

--- a/src/features/donor-research/components/anchor/types.ts
+++ b/src/features/donor-research/components/anchor/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Mirrors the backend `CommentAnchor` discriminated union exactly so the
+ * Next.js API-route proxy can pass-through without translation.
+ *
+ * Source of truth: `gap-indexer/app/modules/v2/domain/donor-research/value-object/comment-anchor.ts`.
+ */
+
+export const COMMENT_SECTION_KEYS = [
+  "masthead",
+  "lead-candidate",
+  "runners-up",
+  "comparison",
+  "also-considered",
+  "methodology",
+] as const;
+export type CommentSectionKey = (typeof COMMENT_SECTION_KEYS)[number];
+
+export const COMMENT_ANCHOR_BOUNDS = {
+  QUOTE_MAX: 500,
+  PREFIX_MAX: 64,
+  SUFFIX_MAX: 64,
+} as const;
+
+export interface SectionAnchor {
+  kind: "section";
+  sectionKey: CommentSectionKey;
+}
+
+export interface CandidateAnchor {
+  kind: "candidate";
+  candidateId: string;
+}
+
+export interface TextRangeAnchor {
+  kind: "text_range";
+  targetKind: "section" | "candidate";
+  targetId: string;
+  quote: string;
+  prefix: string;
+  suffix: string;
+}
+
+export type CommentAnchor = SectionAnchor | CandidateAnchor | TextRangeAnchor;
+
+export function isCommentSectionKey(value: string): value is CommentSectionKey {
+  return (COMMENT_SECTION_KEYS as readonly string[]).includes(value);
+}

--- a/src/features/donor-research/components/onboarding/OnboardingFlow.tsx
+++ b/src/features/donor-research/components/onboarding/OnboardingFlow.tsx
@@ -16,6 +16,7 @@ const TIMEZONE_REGEX = /^[A-Za-z_/+\-0-9]{1,64}$/;
 
 const OnboardingSchema = z.object({
   displayName: z.string().min(1, "Display name is required").max(120),
+  email: z.string().min(1, "Email is required").email("Enter a valid email").max(254),
   orgName: z.string().max(200).optional(),
   timezone: z
     .string()
@@ -67,6 +68,7 @@ export function OnboardingFlow() {
     resolver: zodResolver(OnboardingSchema),
     defaultValues: {
       displayName: "",
+      email: "",
       orgName: "",
       timezone: DEFAULT_TIMEZONE,
     },
@@ -114,6 +116,7 @@ export function OnboardingFlow() {
     onboard.mutate(
       {
         displayName: values.displayName,
+        email: values.email,
         orgName: values.orgName || null,
         timezone: values.timezone,
       },
@@ -186,6 +189,23 @@ export function OnboardingFlow() {
                     {...field}
                     className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
                     placeholder="Avery Boutique"
+                  />
+                )}
+              </Field>
+              <Field
+                id="onboarding-email"
+                label="Email"
+                hint="Where we send notifications about your reports."
+                error={form.formState.errors.email?.message}
+              >
+                {(field) => (
+                  <input
+                    {...form.register("email")}
+                    {...field}
+                    type="email"
+                    autoComplete="email"
+                    className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+                    placeholder="you@example.com"
                   />
                 )}
               </Field>

--- a/src/features/donor-research/components/onboarding/SampleReportPreview.tsx
+++ b/src/features/donor-research/components/onboarding/SampleReportPreview.tsx
@@ -222,7 +222,10 @@ interface SampleCardProps {
 function SampleCandidateCard({ candidate, variant }: SampleCardProps) {
   const band = compositeBand(candidate.composite, false);
   return (
-    <article className="rounded-lg border border-border bg-card p-3">
+    // min-w-0 lets the card shrink inside the grid (grid items default to
+    // min-width:auto, which otherwise forces the wide social table to
+    // overflow the narrow lg:grid-cols-3 columns).
+    <article className="min-w-0 rounded-lg border border-border bg-card p-3">
       <header className="mb-2 flex items-start justify-between gap-2">
         <div className="min-w-0">
           <h4 className="truncate text-sm font-semibold">{candidate.name}</h4>
@@ -244,7 +247,7 @@ function SampleCandidateCard({ candidate, variant }: SampleCardProps) {
         <p className="mt-2 rounded-md bg-muted/40 p-2 text-xs">{candidate.onePager}</p>
       ) : null}
       {candidate.social ? (
-        <div className="mt-3">
+        <div className="mt-3 overflow-x-auto">
           <SocialPresence metrics={candidate.social} />
         </div>
       ) : null}

--- a/src/features/donor-research/components/report-brief/AlsoConsidered.tsx
+++ b/src/features/donor-research/components/report-brief/AlsoConsidered.tsx
@@ -25,7 +25,7 @@ export function AlsoConsidered({ candidates, startRank }: AlsoConsideredProps) {
   if (candidates.length === 0) return null;
 
   return (
-    <section className="mb-20 sm:mb-24">
+    <section className="mb-20 sm:mb-24" data-section="also-considered">
       <header className="mb-6 sm:mb-8">
         <p
           className={`${briefDisplay.className} text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground`}

--- a/src/features/donor-research/components/report-brief/ComparisonTable.tsx
+++ b/src/features/donor-research/components/report-brief/ComparisonTable.tsx
@@ -69,7 +69,7 @@ export function ComparisonTable({ candidates }: ComparisonTableProps) {
   if (candidates.length < 2) return null;
 
   return (
-    <section className="mb-20 sm:mb-24">
+    <section className="mb-20 sm:mb-24" data-section="comparison">
       <header className="mb-6 sm:mb-8">
         <p
           className={`${briefDisplay.className} text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground`}

--- a/src/features/donor-research/components/report-brief/LeadCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/LeadCandidate.tsx
@@ -49,7 +49,11 @@ export function LeadCandidate({ candidate }: LeadCandidateProps) {
   const mostRecentLabel = relativeDays(mostRecentMs);
 
   return (
-    <section className="mb-24 sm:mb-32">
+    <section
+      className="mb-24 sm:mb-32"
+      data-section="lead-candidate"
+      data-candidate-id={candidate.id}
+    >
       <ChapterMark number="01" label="Lead" tone="lead" />
 
       <div className="mt-8 grid grid-cols-1 gap-x-12 gap-y-10 lg:mt-10 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">

--- a/src/features/donor-research/components/report-brief/Masthead.tsx
+++ b/src/features/donor-research/components/report-brief/Masthead.tsx
@@ -43,7 +43,10 @@ export function Masthead({
   const issueNumber = `No. ${report.id.slice(0, 6).toUpperCase()}`;
 
   return (
-    <header className="mb-14 grid grid-cols-1 gap-8 sm:mb-20 sm:grid-cols-[1fr_auto] sm:gap-12">
+    <header
+      className="mb-14 grid grid-cols-1 gap-8 sm:mb-20 sm:grid-cols-[1fr_auto] sm:gap-12"
+      data-section="masthead"
+    >
       <div className="min-w-0">
         {isShared ? null : (
           <Link

--- a/src/features/donor-research/components/report-brief/Masthead.tsx
+++ b/src/features/donor-research/components/report-brief/Masthead.tsx
@@ -40,6 +40,11 @@ export function Masthead({
   const isShared = variant === "shared";
   const issuedAt = report.fastCompletedAt ?? report.completedAt ?? report.createdAt;
   const issuedLabel = formatIssueDate(issuedAt);
+  const updatedAt = report.completedAt ?? report.fastCompletedAt ?? report.createdAt;
+  // Only surface "Updated" when a later completion (e.g. deep enrichment) moved the
+  // date past the issue date — otherwise the same day would render twice.
+  const updatedLabel = formatIssueDate(updatedAt);
+  const showUpdated = updatedLabel !== "—" && updatedLabel !== issuedLabel;
   const issueNumber = `No. ${report.id.slice(0, 6).toUpperCase()}`;
 
   return (
@@ -66,6 +71,12 @@ export function Masthead({
           <span className="tabular-nums">{issueNumber}</span>
           <Bullet />
           <span className="text-brand-emphasis dark:text-brand-subtle">Issued {issuedLabel}</span>
+          {showUpdated ? (
+            <>
+              <Bullet />
+              <span>Updated {updatedLabel}</span>
+            </>
+          ) : null}
         </div>
 
         <h1

--- a/src/features/donor-research/components/report-brief/Methodology.tsx
+++ b/src/features/donor-research/components/report-brief/Methodology.tsx
@@ -24,7 +24,10 @@ export function Methodology({
   geographyDiagnostic,
 }: MethodologyProps) {
   return (
-    <section className="mt-8 border-t border-border/70 pt-10">
+    <section
+      className="mt-8 border-t border-border/70 pt-10"
+      data-section="methodology"
+    >
       <details className="group">
         <summary className="flex cursor-pointer list-none items-baseline justify-between gap-4">
           <div className="min-w-0">

--- a/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
@@ -51,7 +51,11 @@ export function RunnerUpCandidate({ candidate, number, label }: RunnerUpCandidat
   const lastMention = relativeDays(mostRecentMentionDate(mentions));
 
   return (
-    <section className="mb-20 sm:mb-24">
+    <section
+      className="mb-20 sm:mb-24"
+      data-section="runners-up"
+      data-candidate-id={candidate.id}
+    >
       <ChapterMark number={number} label={label} tone="runner-up" />
 
       <div className="mt-8 grid grid-cols-1 gap-x-12 gap-y-8 lg:grid-cols-[minmax(0,8fr)_minmax(0,4fr)]">

--- a/src/features/donor-research/components/shared-view/AddCommentAffordance.tsx
+++ b/src/features/donor-research/components/shared-view/AddCommentAffordance.tsx
@@ -21,7 +21,7 @@ const AddCommentAffordanceComponent = ({ onClick, ariaLabel }: AddCommentAfforda
     onClick={onClick}
     aria-label={ariaLabel}
     data-add-comment
-    className="absolute right-2 top-12 z-10 inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
   >
     <PlusIcon className="h-3.5 w-3.5" aria-hidden />
   </button>

--- a/src/features/donor-research/components/shared-view/AddCommentAffordance.tsx
+++ b/src/features/donor-research/components/shared-view/AddCommentAffordance.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+import { memo } from "react";
+
+interface AddCommentAffordanceProps {
+  /** Click handler — opens the root composer with this target's anchor. */
+  onClick: () => void;
+  /** Label for assistive tech, e.g. "Add comment on lead candidate". */
+  ariaLabel: string;
+}
+
+/**
+ * Tiny "+" button rendered alongside the CommentPin on each anchored
+ * target. Triggers the root composer with a section/candidate anchor
+ * when no text is selected.
+ */
+const AddCommentAffordanceComponent = ({ onClick, ariaLabel }: AddCommentAffordanceProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={ariaLabel}
+    data-add-comment
+    className="absolute right-2 top-12 z-10 inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+  >
+    <PlusIcon className="h-3.5 w-3.5" aria-hidden />
+  </button>
+);
+
+export const AddCommentAffordance = memo(AddCommentAffordanceComponent);

--- a/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
+++ b/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
@@ -25,6 +25,14 @@ interface AnchoredAffordancesProps {
   onPinActivate: (targetKey: string) => void;
   /** Open the root composer with the supplied anchor. */
   onOpenRootComposer: (anchor: CommentAnchor) => void;
+  /**
+   * Id of the comment row currently focused in the sidebar. The
+   * highlight whose node.id matches renders in the emphasized variant
+   * so the donor can trace a row to its highlighted text.
+   */
+  activeCommentId?: string | null;
+  /** Set the active comment when a highlight is clicked. */
+  onActivateComment?: (commentId: string) => void;
 }
 
 interface AnchorTarget {
@@ -102,6 +110,8 @@ export function AnchoredAffordances({
   highlightRefreshKey,
   onPinActivate,
   onOpenRootComposer,
+  activeCommentId,
+  onActivateComment,
 }: AnchoredAffordancesProps) {
   const [targets, setTargets] = useState<AnchorTarget[]>([]);
   const [root, setRoot] = useState<Element | null>(null);
@@ -180,10 +190,16 @@ export function AnchoredAffordances({
             anchor={anchor}
             root={root}
             refreshKey={highlightRefreshKey}
+            isActive={activeCommentId === node.id}
             onActivate={() => {
               const key =
                 anchor.kind === "text_range" ? `${anchor.targetKind}:${anchor.targetId}` : null;
               if (key) onPinActivate(key);
+              // Promote this specific comment to active so the
+              // corresponding sidebar row gets the focus indicator
+              // (the pin activate only knows the target, not which
+              // specific comment was clicked).
+              onActivateComment?.(node.id);
             }}
           />
         ) : null

--- a/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
+++ b/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
@@ -158,7 +158,10 @@ export function AnchoredAffordances({
       {targets.map((t) => {
         const count = countsByKey.get(t.key) ?? 0;
         return createPortal(
-          <>
+          // Single top-right cluster so the pin + "+" sit together above the
+          // section's chapter-mark label (which is tucked at the top-right)
+          // instead of stacking down onto it.
+          <div className="absolute right-2 top-2 z-10 flex items-center gap-1">
             {count > 0 && (
               <CommentPin
                 count={count}
@@ -177,7 +180,7 @@ export function AnchoredAffordances({
                 )
               }
             />
-          </>,
+          </div>,
           t.element,
           `affordance-${t.key}`
         );

--- a/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
+++ b/src/features/donor-research/components/shared-view/AnchoredAffordances.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { resolveAnchor } from "@/src/features/donor-research/components/anchor/resolve";
+import {
+  COMMENT_SECTION_KEYS,
+  type CommentAnchor,
+  type CommentSectionKey,
+} from "@/src/features/donor-research/components/anchor/types";
+import type { SharedReportCommentNode } from "@/types/donor-research-comments";
+
+import { AddCommentAffordance } from "./AddCommentAffordance";
+import { CommentHighlight } from "./CommentHighlight";
+import { CommentPin } from "./CommentPin";
+
+interface AnchoredAffordancesProps {
+  /** The currently rendered report tree (used to harvest highlight anchors). */
+  tree: SharedReportCommentNode[];
+  /** counts.byKey from useCommenting. */
+  countsByKey: Map<string, number>;
+  /** Refresh key passed to CommentHighlight for re-resolve on payload changes. */
+  highlightRefreshKey: number;
+  /** Click handler for pins — opens the sheet and scrolls the matching root into view. */
+  onPinActivate: (targetKey: string) => void;
+  /** Open the root composer with the supplied anchor. */
+  onOpenRootComposer: (anchor: CommentAnchor) => void;
+}
+
+interface AnchorTarget {
+  /** `${kind}:${id}` */
+  key: string;
+  /** Section key or candidate id. */
+  id: string;
+  /** Container element to portal pins/affordances into. */
+  element: Element;
+  /** "section" | "candidate" */
+  kind: "section" | "candidate";
+  /** Human-readable label for aria. */
+  label: string;
+}
+
+const SECTION_LABELS: Record<CommentSectionKey, string> = {
+  masthead: "masthead",
+  "lead-candidate": "lead candidate",
+  "runners-up": "runners up",
+  comparison: "comparison",
+  "also-considered": "also considered",
+  methodology: "methodology",
+};
+
+function discoverTargets(): AnchorTarget[] {
+  if (typeof document === "undefined") return [];
+  const root = document.querySelector("[data-brief]");
+  if (!root) return [];
+  const out: AnchorTarget[] = [];
+
+  for (const sectionKey of COMMENT_SECTION_KEYS) {
+    const el = root.querySelector(`[data-section="${sectionKey}"]`);
+    if (!el) continue;
+    out.push({
+      key: `section:${sectionKey}`,
+      id: sectionKey,
+      element: el,
+      kind: "section",
+      label: SECTION_LABELS[sectionKey],
+    });
+  }
+
+  const candidateEls = root.querySelectorAll("[data-candidate-id]");
+  for (const el of Array.from(candidateEls)) {
+    const id = el.getAttribute("data-candidate-id");
+    if (!id) continue;
+    out.push({
+      key: `candidate:${id}`,
+      id,
+      element: el,
+      kind: "candidate",
+      label: "this candidate",
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Discovers anchored targets in the live DOM and portals pin + "+"
+ * affordances into each of them. Also renders highlight overlays for
+ * every text-range anchor in the comment tree.
+ *
+ * Targets are re-discovered on `highlightRefreshKey` changes (a new
+ * report payload may have added or removed candidate cards). The
+ * containers themselves must carry `position: relative` for the
+ * absolutely-positioned pins to land at the top-right; existing
+ * section / candidate components already render block-level wrappers,
+ * and adding `relative` to each anchored root is a one-line edit upstream
+ * — handled below by adding the class via the portal parent.
+ */
+export function AnchoredAffordances({
+  tree,
+  countsByKey,
+  highlightRefreshKey,
+  onPinActivate,
+  onOpenRootComposer,
+}: AnchoredAffordancesProps) {
+  const [targets, setTargets] = useState<AnchorTarget[]>([]);
+  const [root, setRoot] = useState<Element | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-discover on poll.
+  useEffect(() => {
+    setTargets(discoverTargets());
+    setRoot(document.querySelector("[data-brief]") ?? null);
+  }, [highlightRefreshKey]);
+
+  // Ensure each anchored container is positioning context for the
+  // absolutely-positioned pins. Adding the class directly is the
+  // lightest-touch alternative to editing each ReportBrief subcomponent.
+  useEffect(() => {
+    const added: Element[] = [];
+    for (const t of targets) {
+      const el = t.element as HTMLElement;
+      const style = window.getComputedStyle(el);
+      if (style.position === "static") {
+        el.style.position = "relative";
+        added.push(el);
+      }
+    }
+    return () => {
+      for (const el of added) {
+        (el as HTMLElement).style.position = "";
+      }
+    };
+  }, [targets]);
+
+  const highlightAnchors: { node: SharedReportCommentNode; anchor: CommentAnchor }[] = [];
+  const walk = (nodes: SharedReportCommentNode[]) => {
+    for (const node of nodes) {
+      if (node.anchor && node.anchor.kind === "text_range") {
+        highlightAnchors.push({ node, anchor: node.anchor });
+      }
+      walk(node.children);
+    }
+  };
+  walk(tree);
+
+  return (
+    <>
+      {targets.map((t) => {
+        const count = countsByKey.get(t.key) ?? 0;
+        return createPortal(
+          <>
+            {count > 0 && (
+              <CommentPin
+                count={count}
+                targetKey={t.key}
+                onActivate={onPinActivate}
+                ariaLabel={t.label}
+              />
+            )}
+            <AddCommentAffordance
+              ariaLabel={`Add comment on ${t.label}`}
+              onClick={() =>
+                onOpenRootComposer(
+                  t.kind === "section"
+                    ? { kind: "section", sectionKey: t.id as CommentSectionKey }
+                    : { kind: "candidate", candidateId: t.id }
+                )
+              }
+            />
+          </>,
+          t.element,
+          `affordance-${t.key}`
+        );
+      })}
+
+      {highlightAnchors.map(({ node, anchor }) =>
+        root ? (
+          <CommentHighlight
+            key={node.id}
+            anchor={anchor}
+            root={root}
+            refreshKey={highlightRefreshKey}
+            onActivate={() => {
+              const key =
+                anchor.kind === "text_range" ? `${anchor.targetKind}:${anchor.targetId}` : null;
+              if (key) onPinActivate(key);
+            }}
+          />
+        ) : null
+      )}
+    </>
+  );
+}

--- a/src/features/donor-research/components/shared-view/CommentComposer.tsx
+++ b/src/features/donor-research/components/shared-view/CommentComposer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+
+interface CommentComposerProps {
+  /** When set, the composer is in reply mode. Visible parent context. */
+  parentDisplayName?: string;
+  /** Pre-captured anchor for root composers; null for replies. */
+  anchor?: CommentAnchor | null;
+  /** When the parent surfaces a rate-limit / collision error from the mutation. */
+  externalError?: string | null;
+  /** True while the mutation is in flight — disables submit. */
+  isSubmitting?: boolean;
+  /** Cancel handler — closes the composer. */
+  onCancel: () => void;
+  /** Submit handler — body string. */
+  onSubmit: (body: string) => Promise<void> | void;
+}
+
+export function CommentComposer({
+  parentDisplayName,
+  anchor,
+  externalError,
+  isSubmitting = false,
+  onCancel,
+  onSubmit,
+}: CommentComposerProps) {
+  const [body, setBody] = useState("");
+  const trimmed = body.trim();
+  const isReply = Boolean(parentDisplayName);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!trimmed) return;
+    await onSubmit(trimmed);
+    setBody("");
+  };
+
+  return (
+    <form className="space-y-2 rounded-md border border-border bg-background p-3" onSubmit={handleSubmit}>
+      {isReply ? (
+        <div className="text-xs text-muted-foreground">Replying to {parentDisplayName}</div>
+      ) : anchor ? (
+        <div className="text-xs text-muted-foreground">
+          {anchor.kind === "section"
+            ? `On ${anchor.sectionKey}`
+            : anchor.kind === "candidate"
+              ? "On this candidate"
+              : `On "${anchor.quote.slice(0, 80)}${anchor.quote.length > 80 ? "…" : ""}"`}
+        </div>
+      ) : null}
+
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder={isReply ? "Write a reply…" : "Add a comment…"}
+        maxLength={5000}
+        rows={3}
+        className="text-sm"
+        autoFocus
+      />
+
+      {externalError && (
+        <p className="text-sm text-destructive" role="alert">
+          {externalError}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={!trimmed || isSubmitting}>
+          {isSubmitting ? "Posting…" : isReply ? "Reply" : "Comment"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/donor-research/components/shared-view/CommentComposer.tsx
+++ b/src/features/donor-research/components/shared-view/CommentComposer.tsx
@@ -41,7 +41,10 @@ export function CommentComposer({
   };
 
   return (
-    <form className="space-y-2 rounded-md border border-border bg-background p-3" onSubmit={handleSubmit}>
+    <form
+      className="space-y-2 rounded-md border border-border bg-background p-3"
+      onSubmit={handleSubmit}
+    >
       {isReply ? (
         <div className="text-xs text-muted-foreground">Replying to {parentDisplayName}</div>
       ) : anchor ? (

--- a/src/features/donor-research/components/shared-view/CommentComposer.tsx
+++ b/src/features/donor-research/components/shared-view/CommentComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -40,12 +40,22 @@ export function CommentComposer({
   const [body, setBody] = useState("");
   const trimmed = body.trim();
   const isReply = Boolean(parentDisplayName);
+  // Guard against rapid double/triple-clicks: the isSubmitting prop only
+  // disables the button after a render, so several clicks can fire before
+  // it propagates — each minting a fresh idempotency key → duplicate
+  // comments. This ref blocks re-entry synchronously.
+  const inFlightRef = useRef(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!trimmed) return;
-    await onSubmit(trimmed);
-    setBody("");
+    if (!trimmed || inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      await onSubmit(trimmed);
+      setBody("");
+    } finally {
+      inFlightRef.current = false;
+    }
   };
 
   return (

--- a/src/features/donor-research/components/shared-view/CommentComposer.tsx
+++ b/src/features/donor-research/components/shared-view/CommentComposer.tsx
@@ -11,6 +11,13 @@ interface CommentComposerProps {
   parentDisplayName?: string;
   /** Pre-captured anchor for root composers; null for replies. */
   anchor?: CommentAnchor | null;
+  /**
+   * General (whole-report) comment mode. The wire anchor is still a
+   * valid section anchor (the backend requires a non-null anchor), but
+   * the descriptor reads "On the whole report" instead of the section
+   * name so the donor understands it isn't pinned to a specific block.
+   */
+  general?: boolean;
   /** When the parent surfaces a rate-limit / collision error from the mutation. */
   externalError?: string | null;
   /** True while the mutation is in flight — disables submit. */
@@ -24,6 +31,7 @@ interface CommentComposerProps {
 export function CommentComposer({
   parentDisplayName,
   anchor,
+  general = false,
   externalError,
   isSubmitting = false,
   onCancel,
@@ -47,6 +55,8 @@ export function CommentComposer({
     >
       {isReply ? (
         <div className="text-xs text-muted-foreground">Replying to {parentDisplayName}</div>
+      ) : general ? (
+        <div className="text-xs text-muted-foreground">On the whole report</div>
       ) : anchor ? (
         <div className="text-xs text-muted-foreground">
           {anchor.kind === "section"

--- a/src/features/donor-research/components/shared-view/CommentHighlight.tsx
+++ b/src/features/donor-research/components/shared-view/CommentHighlight.tsx
@@ -19,6 +19,12 @@ interface CommentHighlightProps {
   refreshKey?: string | number;
   /** Click handler — when supplied the highlight is interactive. */
   onActivate?: () => void;
+  /**
+   * True when this highlight's source comment is the currently
+   * focused row in the sidebar. The highlight renders in a stronger
+   * color so the donor can see which highlight a row maps to.
+   */
+  isActive?: boolean;
 }
 
 interface HighlightRect {
@@ -56,7 +62,13 @@ function collectRects(resolved: ResolvedAnchor): HighlightRect[] {
  * payload). Section / candidate / orphan anchors render nothing — the
  * caller routes those to pins and the orphan lane respectively.
  */
-export function CommentHighlight({ anchor, root, refreshKey, onActivate }: CommentHighlightProps) {
+export function CommentHighlight({
+  anchor,
+  root,
+  refreshKey,
+  onActivate,
+  isActive = false,
+}: CommentHighlightProps) {
   const [rects, setRects] = useState<HighlightRect[]>([]);
 
   const isTextRange = anchor.kind === "text_range";
@@ -90,6 +102,14 @@ export function CommentHighlight({ anchor, root, refreshKey, onActivate }: Comme
         height: `${r.height}px`,
         pointerEvents: onActivate ? ("auto" as const) : ("none" as const),
       };
+      // Two visual states: idle (subtle yellow) vs active (stronger
+      // amber + ring). Active = this highlight's source comment row
+      // is currently focused in the sidebar, giving the donor a
+      // visual rope between the comment and the highlighted text.
+      const idleClass = "bg-amber-200/40 mix-blend-multiply dark:bg-amber-300/30";
+      const idleHover = "hover:bg-amber-200/60 dark:hover:bg-amber-300/45";
+      const activeClass =
+        "bg-amber-300/70 mix-blend-multiply ring-2 ring-amber-500 dark:bg-amber-300/55 dark:ring-amber-400";
       if (onActivate) {
         return (
           <button
@@ -98,8 +118,11 @@ export function CommentHighlight({ anchor, root, refreshKey, onActivate }: Comme
             onClick={onActivate}
             aria-label="View comment thread"
             data-comment-highlight
+            data-active={isActive || undefined}
             style={style}
-            className="rounded-sm bg-amber-200/40 mix-blend-multiply hover:bg-amber-200/60 dark:bg-amber-300/30 dark:hover:bg-amber-300/45"
+            className={`rounded-sm transition-colors ${
+              isActive ? activeClass : `${idleClass} ${idleHover}`
+            }`}
           />
         );
       }
@@ -108,12 +131,13 @@ export function CommentHighlight({ anchor, root, refreshKey, onActivate }: Comme
           key={idx}
           aria-hidden
           data-comment-highlight
+          data-active={isActive || undefined}
           style={style}
-          className="rounded-sm bg-amber-200/40 mix-blend-multiply dark:bg-amber-300/30"
+          className={`rounded-sm transition-colors ${isActive ? activeClass : idleClass}`}
         />
       );
     });
-  }, [rects, onActivate]);
+  }, [rects, onActivate, isActive]);
 
   if (!isTextRange || rects.length === 0) return null;
 

--- a/src/features/donor-research/components/shared-view/CommentHighlight.tsx
+++ b/src/features/donor-research/components/shared-view/CommentHighlight.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  type ResolvedAnchor,
+  resolveAnchor,
+} from "@/src/features/donor-research/components/anchor/resolve";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+
+interface CommentHighlightProps {
+  /** Anchor to resolve. Only text-range anchors render a highlight. */
+  anchor: CommentAnchor;
+  /** Root element used as the resolver search scope. */
+  root: Element | null;
+  /**
+   * Bumps every time the resolved root payload changes — forces a
+   * recompute when the report re-enriches and the DOM rewrites.
+   */
+  refreshKey?: string | number;
+  /** Click handler — when supplied the highlight is interactive. */
+  onActivate?: () => void;
+}
+
+interface HighlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function collectRects(resolved: ResolvedAnchor): HighlightRect[] {
+  if (resolved.kind !== "range") return [];
+  const rects = resolved.range.getClientRects();
+  // The Range API returns one rect per visual line so multi-line
+  // highlights render correctly. Each rect is window-relative; we add
+  // window scroll so the absolutely-positioned span lands in document
+  // coordinates.
+  const out: HighlightRect[] = [];
+  for (let i = 0; i < rects.length; i += 1) {
+    const r = rects[i];
+    if (r.width <= 0 || r.height <= 0) continue;
+    out.push({
+      top: r.top + window.scrollY,
+      left: r.left + window.scrollX,
+      width: r.width,
+      height: r.height,
+    });
+  }
+  return out;
+}
+
+/**
+ * Renders yellow highlight bands over the resolved text range of a
+ * text-range anchor. Re-resolves on window resize and on `refreshKey`
+ * changes (which is how SharedReportView signals a re-enriched report
+ * payload). Section / candidate / orphan anchors render nothing — the
+ * caller routes those to pins and the orphan lane respectively.
+ */
+export function CommentHighlight({ anchor, root, refreshKey, onActivate }: CommentHighlightProps) {
+  const [rects, setRects] = useState<HighlightRect[]>([]);
+
+  const isTextRange = anchor.kind === "text_range";
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `refreshKey` triggers re-resolve.
+  useEffect(() => {
+    if (!isTextRange || !root || typeof window === "undefined") {
+      setRects([]);
+      return;
+    }
+
+    const compute = () => {
+      const resolved = resolveAnchor(anchor, root);
+      setRects(collectRects(resolved));
+    };
+
+    compute();
+
+    const onResize = () => compute();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [anchor, root, refreshKey, isTextRange]);
+
+  const elements = useMemo(() => {
+    return rects.map((r, idx) => {
+      const style = {
+        position: "absolute" as const,
+        top: `${r.top}px`,
+        left: `${r.left}px`,
+        width: `${r.width}px`,
+        height: `${r.height}px`,
+        pointerEvents: onActivate ? ("auto" as const) : ("none" as const),
+      };
+      if (onActivate) {
+        return (
+          <button
+            key={idx}
+            type="button"
+            onClick={onActivate}
+            aria-label="View comment thread"
+            data-comment-highlight
+            style={style}
+            className="rounded-sm bg-amber-200/40 mix-blend-multiply hover:bg-amber-200/60 dark:bg-amber-300/30 dark:hover:bg-amber-300/45"
+          />
+        );
+      }
+      return (
+        <span
+          key={idx}
+          aria-hidden
+          data-comment-highlight
+          style={style}
+          className="rounded-sm bg-amber-200/40 mix-blend-multiply dark:bg-amber-300/30"
+        />
+      );
+    });
+  }, [rects, onActivate]);
+
+  if (!isTextRange || rects.length === 0) return null;
+
+  return <>{elements}</>;
+}

--- a/src/features/donor-research/components/shared-view/CommentHighlight.tsx
+++ b/src/features/donor-research/components/shared-view/CommentHighlight.tsx
@@ -93,42 +93,32 @@ export function CommentHighlight({
   }, [anchor, root, refreshKey, isTextRange]);
 
   const elements = useMemo(() => {
-    return rects.map((r, idx) => {
+    // Two visual states: idle (subtle yellow) vs active (stronger
+    // amber + ring). Active = this highlight's source comment row
+    // is currently focused in the sidebar, giving the donor a
+    // visual rope between the comment and the highlighted text.
+    const idleClass = "bg-amber-200/40 mix-blend-multiply dark:bg-amber-300/30";
+    const activeClass =
+      "bg-amber-300/70 mix-blend-multiply ring-2 ring-amber-500 dark:bg-amber-300/55 dark:ring-amber-400";
+
+    // The highlight bands themselves are ALWAYS pointer-events: none so
+    // they never intercept a mouse-down/drag — the donor must be able to
+    // re-select previously-commented text to comment on (or overlap) it
+    // again. The "view comment thread" interaction lives on a separate
+    // marker badge rendered at the end of the range (see below), which
+    // sits beside the text rather than on top of it.
+    return rects.map((r) => {
       const style = {
         position: "absolute" as const,
         top: `${r.top}px`,
         left: `${r.left}px`,
         width: `${r.width}px`,
         height: `${r.height}px`,
-        pointerEvents: onActivate ? ("auto" as const) : ("none" as const),
+        pointerEvents: "none" as const,
       };
-      // Two visual states: idle (subtle yellow) vs active (stronger
-      // amber + ring). Active = this highlight's source comment row
-      // is currently focused in the sidebar, giving the donor a
-      // visual rope between the comment and the highlighted text.
-      const idleClass = "bg-amber-200/40 mix-blend-multiply dark:bg-amber-300/30";
-      const idleHover = "hover:bg-amber-200/60 dark:hover:bg-amber-300/45";
-      const activeClass =
-        "bg-amber-300/70 mix-blend-multiply ring-2 ring-amber-500 dark:bg-amber-300/55 dark:ring-amber-400";
-      if (onActivate) {
-        return (
-          <button
-            key={idx}
-            type="button"
-            onClick={onActivate}
-            aria-label="View comment thread"
-            data-comment-highlight
-            data-active={isActive || undefined}
-            style={style}
-            className={`rounded-sm transition-colors ${
-              isActive ? activeClass : `${idleClass} ${idleHover}`
-            }`}
-          />
-        );
-      }
       return (
         <span
-          key={idx}
+          key={`${r.top}:${r.left}:${r.width}:${r.height}`}
           aria-hidden
           data-comment-highlight
           data-active={isActive || undefined}
@@ -137,9 +127,50 @@ export function CommentHighlight({
         />
       );
     });
+  }, [rects, isActive]);
+
+  // A small clickable marker pinned to the end of the last highlight
+  // rect. It does NOT cover the selectable text, so text remains
+  // re-selectable, while still offering a click-to-open-thread target
+  // and preserving the bidirectional highlight↔row focus emphasis.
+  const marker = useMemo(() => {
+    if (!onActivate) return null;
+    const last = rects[rects.length - 1];
+    if (!last) return null;
+    const markerActiveClass =
+      "bg-amber-500 text-white ring-2 ring-amber-300 dark:bg-amber-400 dark:ring-amber-500";
+    const markerIdleClass =
+      "bg-amber-300/80 text-amber-900 hover:bg-amber-400 dark:bg-amber-400/70 dark:text-amber-950 dark:hover:bg-amber-400";
+    return (
+      <button
+        type="button"
+        onClick={onActivate}
+        aria-label="View comment thread"
+        data-comment-marker
+        data-active={isActive || undefined}
+        style={{
+          position: "absolute",
+          top: `${last.top + last.height / 2 - 7}px`,
+          left: `${last.left + last.width + 2}px`,
+          width: "14px",
+          height: "14px",
+          pointerEvents: "auto",
+        }}
+        className={`z-20 inline-flex items-center justify-center rounded-full text-[9px] font-bold leading-none shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${
+          isActive ? markerActiveClass : markerIdleClass
+        }`}
+      >
+        <span aria-hidden>≡</span>
+      </button>
+    );
   }, [rects, onActivate, isActive]);
 
   if (!isTextRange || rects.length === 0) return null;
 
-  return <>{elements}</>;
+  return (
+    <>
+      {elements}
+      {marker}
+    </>
+  );
 }

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -90,6 +90,7 @@ export function CommentOverlay({
     tree,
     identity,
     isPosting,
+    retryFailed,
     composer,
     composerError,
     openRootComposer,
@@ -147,6 +148,58 @@ export function CommentOverlay({
     }, 50);
     return () => clearTimeout(t);
   }, [scrollTargetCommentId, clearScrollTarget]);
+
+  // Chat-style: keep the newest comment in view. Scroll the sheet body to
+  // the bottom when the sheet opens and whenever a new comment arrives —
+  // unless a pin/highlight is currently steering the scroll to a specific
+  // row (read via ref so clearing that target doesn't re-trigger us).
+  const scrollTargetRef = useRef(scrollTargetCommentId);
+  scrollTargetRef.current = scrollTargetCommentId;
+  useEffect(() => {
+    if (!sheetOpen || scrollTargetRef.current || total === 0) return;
+    const scrollToEnd = () => {
+      const container = sheetBodyRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
+    };
+    // Fire twice: once promptly (new comment while already open) and once
+    // after the sheet's slide-in + Radix focus settle, which otherwise
+    // resets the scroll position to the top on first open.
+    const t1 = setTimeout(scrollToEnd, 80);
+    const t2 = setTimeout(scrollToEnd, 400);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [sheetOpen, total]);
+
+  // While the comments drawer is open, hide the global "Karma Assistant"
+  // floating chat button. Its very high z-index (9999) otherwise keeps it
+  // floating on top of the Sheet, which looks broken. We toggle the chat
+  // button's fixed-positioned container's visibility and restore the prior
+  // value on close / unmount.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const chatButton = document.querySelector<HTMLElement>('button[aria-label="Open chat"]');
+    if (!chatButton) return;
+    // Prefer the nearest fixed-positioned ancestor (the chat widget's
+    // floating container); fall back to the button itself.
+    let target: HTMLElement = chatButton;
+    let node: HTMLElement | null = chatButton;
+    while (node) {
+      if (typeof window !== "undefined" && window.getComputedStyle(node).position === "fixed") {
+        target = node;
+        break;
+      }
+      node = node.parentElement;
+    }
+
+    if (!sheetOpen) return;
+    const previousVisibility = target.style.visibility;
+    target.style.visibility = "hidden";
+    return () => {
+      target.style.visibility = previousVisibility;
+    };
+  }, [sheetOpen]);
 
   if (reportRevoked) return null;
 
@@ -248,12 +301,16 @@ export function CommentOverlay({
               )}
               {tree.length > 0 && (
                 <div className="space-y-3">
-                  {tree.map((node) => (
+                  {/* Roots arrive newest-first; render oldest-first so the
+                      newest sits at the bottom (chat-style). Replies within
+                      a thread are already oldest→newest. */}
+                  {[...tree].reverse().map((node) => (
                     <div key={node.id} data-comment-id={node.id}>
                       <CommentRow
                         node={node}
                         depth={0}
                         onReply={openReplyComposer}
+                        onRetry={retryFailed}
                         activeCommentId={activeCommentId}
                         onActivate={activateComment}
                       />

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
 import pluralize from "pluralize";
-import { v4 as uuidv4 } from "uuid";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
-import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
-import { useCommenterIdentity } from "@/hooks/useCommenterIdentity";
-import { useSharedReportComments } from "@/hooks/useSharedReportComments";
-import {
-  IdempotencyCollisionError,
-  IdentityRequiredError,
-  RateLimitedError,
-  type CreateCommentRequest,
-  type SharedReportCommentNode,
-} from "@/types/donor-research-comments";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import type { SharedReportCommentNode } from "@/types/donor-research-comments";
 
+import { AnchoredAffordances } from "./AnchoredAffordances";
 import { CommentComposer } from "./CommentComposer";
 import { CommentRow } from "./CommentRow";
 import { IdentityBadge } from "./IdentityBadge";
 import { IdentityCaptureDialog } from "./IdentityCaptureDialog";
+import { SelectionAffordance } from "./SelectionAffordance";
+import { useCommenting } from "./useCommenting";
 
 interface CommentOverlayProps {
   token: string;
@@ -40,162 +27,126 @@ function totalCount(tree: SharedReportCommentNode[]): number {
   let n = 0;
   const stack = [...tree];
   while (stack.length > 0) {
-    const node = stack.pop()!;
+    const node = stack.pop();
+    if (!node) break;
     n += 1;
     stack.push(...node.children);
   }
   return n;
 }
 
-function findNodeById(
-  tree: SharedReportCommentNode[],
-  id: string,
-): SharedReportCommentNode | null {
-  const stack = [...tree];
-  while (stack.length > 0) {
-    const node = stack.pop()!;
-    if (node.id === id) return node;
-    stack.push(...node.children);
-  }
-  return null;
-}
-
 /**
- * Comment sidebar: lists all root comments + their reply threads in
- * one Sheet on desktop / full-screen drawer on mobile. Drives the
- * composer (root + reply) and orchestrates the IdentityCaptureDialog
- * round-trip when the donor lacks a cookie.
+ * Comment overlay — sidebar listing all comment threads, pin badges
+ * floating next to anchored targets, text-range highlights, an orphan
+ * lane for anchors that no longer resolve in the live DOM, and the
+ * composer (root + reply).
  *
- * Q2 "Not me — switch" affordance lives in the IdentityBadge — clears
- * the cookies via the proxy clear-identity route and re-prompts on the
- * next post.
+ * Wires together {@link useCommenting} (state machine + mutations) and
+ * {@link AnchoredAffordances} (per-target pins / "+" buttons / highlight
+ * overlays). All anchor capture flows through {@link useCommenting} so
+ * the floating "Comment" affordance, the section "+" buttons, and the
+ * pin clicks all share one source of truth.
  *
- * aria-live="polite" region (per DL-007) announces new comments and
- * replies so screen readers don't miss arrivals after the initial
- * render.
+ * aria-live="polite" region announces new comment additions per
+ * DL-007 ("Comment added by X" / "Reply added by X").
  */
 export function CommentOverlay({
   token,
   reportRevoked = false,
   isAdvisor = false,
 }: CommentOverlayProps) {
-  const { query, tree, postComment } = useSharedReportComments(token, {
+  const commenting = useCommenting(token, {
     enabled: !reportRevoked,
+    isAdvisor,
   });
-  const identity = useCommenterIdentity(token, isAdvisor);
 
-  const [sheetOpen, setSheetOpen] = useState(false);
-  const [composerOpenFor, setComposerOpenFor] = useState<string | "root" | null>(
-    null,
-  );
-  const [rootAnchor, setRootAnchor] = useState<CommentAnchor | null>({
-    kind: "section",
-    sectionKey: "methodology",
-  });
-  const [identityModalMode, setIdentityModalMode] = useState<
-    "post" | "edit-name" | null
-  >(null);
-  const [pendingPost, setPendingPost] = useState<CreateCommentRequest | null>(
-    null,
-  );
-  const [composerError, setComposerError] = useState<string | null>(null);
+  const {
+    query,
+    tree,
+    identity,
+    isPosting,
+    composer,
+    composerError,
+    openRootComposer,
+    openReplyComposer,
+    closeComposer,
+    sheetOpen,
+    setSheetOpen,
+    activatePin,
+    counts,
+    selectionAffordance,
+    dismissSelectionAffordance,
+    submitComposer,
+    identityModalMode,
+    setIdentityModalMode,
+    retryPendingPost,
+    scrollTargetCommentId,
+    clearScrollTarget,
+    highlightRefreshKey,
+  } = commenting;
 
   const total = totalCount(tree);
 
-  const handleReplyClick = useCallback((parentId: string) => {
-    setComposerError(null);
-    setComposerOpenFor(parentId);
-  }, []);
-
-  const handleRootClick = useCallback(() => {
-    setComposerError(null);
-    setRootAnchor({ kind: "section", sectionKey: "methodology" });
-    setComposerOpenFor("root");
-  }, []);
-
-  const submitComment = useCallback(
-    async (request: CreateCommentRequest) => {
-      setComposerError(null);
-      try {
-        await postComment.mutateAsync({ request, idempotencyKey: uuidv4() });
-        setComposerOpenFor(null);
-      } catch (err) {
-        if (err instanceof IdentityRequiredError) {
-          setPendingPost(request);
-          setIdentityModalMode("post");
-          return;
-        }
-        if (err instanceof RateLimitedError) {
-          setComposerError(`Slow down — try again in ${err.retryAfter}s.`);
-          return;
-        }
-        if (err instanceof IdempotencyCollisionError) {
-          setComposerError("That key was already used — try again.");
-          return;
-        }
-        setComposerError("Something went wrong. Try again.");
-      }
-    },
-    [postComment],
-  );
-
-  const handleComposerSubmit = useCallback(
-    async (body: string) => {
-      if (composerOpenFor === null) return;
-      const parentId = composerOpenFor === "root" ? undefined : composerOpenFor;
-      const request: CreateCommentRequest = {
-        body,
-        displayName: identity.displayName ?? "",
-        ...(parentId ? { parentCommentId: parentId } : {}),
-        ...(parentId ? {} : rootAnchor ? { anchor: rootAnchor } : {}),
-      };
-      await submitComment(request);
-    },
-    [composerOpenFor, identity.displayName, rootAnchor, submitComment],
-  );
-
-  const handleIdentitySubmit = useCallback(
-    async (values: { displayName: string; email: string }) => {
-      if (identityModalMode === "edit-name") {
-        // Edit-name-only mode: the parent cookie carries email; the FE
-        // re-fires the same comment but with the updated name. v1
-        // simply closes — the donor's next comment uses the new name.
-        identity.refresh();
-        setIdentityModalMode(null);
-        return;
-      }
-      if (!pendingPost) {
-        setIdentityModalMode(null);
-        return;
-      }
-      const enriched: CreateCommentRequest = {
-        ...pendingPost,
-        displayName: values.displayName,
-        email: values.email,
-      };
-      await submitComment(enriched);
-      identity.refresh();
-      setIdentityModalMode(null);
-      setPendingPost(null);
-    },
-    [identity, identityModalMode, pendingPost, submitComment],
-  );
-
+  // Track previous total so we only fire the polite announcement on
+  // additions (not on initial render or removals).
+  const previousTotalRef = useRef(0);
+  const lastRoot = tree[0];
+  const lastReply = lastRoot?.children[lastRoot.children.length - 1];
   const announceText = useMemo(() => {
-    const last = tree[0];
+    if (typeof window === "undefined") return "";
+    if (total <= previousTotalRef.current) {
+      previousTotalRef.current = total;
+      return "";
+    }
+    previousTotalRef.current = total;
+    const last = lastReply ?? lastRoot;
     if (!last) return "";
-    return `${last.displayName} ${last.parentCommentId ? "replied" : "commented"}`;
-  }, [tree]);
+    const verb = last.parentCommentId ? "Reply added by" : "Comment added by";
+    return `${verb} ${last.displayName}`;
+  }, [total, lastRoot, lastReply]);
+
+  // Scroll the matching root row into view whenever a pin is activated.
+  const sheetBodyRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!scrollTargetCommentId) return;
+    const id = scrollTargetCommentId;
+    const t = setTimeout(() => {
+      const container = sheetBodyRef.current;
+      if (!container) return;
+      const el = container.querySelector<HTMLElement>(`[data-comment-id="${id}"]`);
+      el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      clearScrollTarget();
+    }, 50);
+    return () => clearTimeout(t);
+  }, [scrollTargetCommentId, clearScrollTarget]);
 
   if (reportRevoked) return null;
 
-  const activeReply =
-    composerOpenFor && composerOpenFor !== "root"
-      ? findNodeById(tree, composerOpenFor)
-      : null;
+  const composerHeader = composer.mode === "reply" ? composer.parent?.displayName : undefined;
+  const composerAnchor = composer.mode === "root" ? composer.anchor : undefined;
+
+  const orphanRoots = counts.orphanRoots;
 
   return (
     <>
+      <AnchoredAffordances
+        tree={tree}
+        countsByKey={counts.byKey}
+        highlightRefreshKey={highlightRefreshKey}
+        onPinActivate={activatePin}
+        onOpenRootComposer={openRootComposer}
+      />
+
+      {selectionAffordance && (
+        <SelectionAffordance
+          position={selectionAffordance.position}
+          onClick={() => {
+            openRootComposer(selectionAffordance.anchor);
+            dismissSelectionAffordance();
+          }}
+        />
+      )}
+
       <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-2">
         <IdentityBadge
           displayName={identity.displayName}
@@ -214,15 +165,15 @@ export function CommentOverlay({
               <SheetTitle>Comments</SheetTitle>
             </SheetHeader>
 
-            <div className="flex-1 overflow-y-auto pr-2">
+            <div ref={sheetBodyRef} className="flex-1 overflow-y-auto pr-2">
               {query.isLoading && (
-                <div className="space-y-3">
+                <div className="space-y-3" data-testid="comments-loading">
                   <div className="h-16 animate-pulse rounded bg-muted" />
                   <div className="h-12 animate-pulse rounded bg-muted" />
                 </div>
               )}
               {query.error && !query.isLoading && (
-                <p className="text-sm text-destructive">
+                <p className="text-sm text-destructive" role="alert">
                   Couldn’t load comments — retry coming up on next poll.
                 </p>
               )}
@@ -232,47 +183,71 @@ export function CommentOverlay({
               {tree.length > 0 && (
                 <div className="space-y-3">
                   {tree.map((node) => (
-                    <CommentRow
-                      key={node.id}
-                      node={node}
-                      depth={0}
-                      onReply={handleReplyClick}
-                    />
+                    <div key={node.id} data-comment-id={node.id}>
+                      <CommentRow node={node} depth={0} onReply={openReplyComposer} />
+                    </div>
                   ))}
                 </div>
               )}
+
+              {orphanRoots.length > 0 && (
+                <section className="mt-6 border-t border-border pt-3" aria-label="Orphan comments">
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {pluralize("orphan comment", orphanRoots.length, true)}
+                  </h3>
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    The highlighted text these comments referenced has changed; the original quotes
+                    are preserved below.
+                  </p>
+                  <div className="space-y-3">
+                    {orphanRoots.map((node) => (
+                      <div key={node.id} data-comment-id={node.id} data-orphan>
+                        {node.anchor && node.anchor.kind === "text_range" ? (
+                          <blockquote className="mb-1 border-l-2 border-amber-400 pl-2 text-xs italic text-muted-foreground">
+                            “{node.anchor.quote}”
+                          </blockquote>
+                        ) : null}
+                        <CommentRow node={node} depth={0} onReply={openReplyComposer} />
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
             </div>
 
-            {composerOpenFor !== null ? (
+            {composer.mode !== "closed" ? (
               <CommentComposer
-                parentDisplayName={activeReply?.displayName ?? undefined}
-                anchor={composerOpenFor === "root" ? rootAnchor : undefined}
+                parentDisplayName={composerHeader}
+                anchor={composerAnchor}
                 externalError={composerError}
-                isSubmitting={postComment.isPending}
-                onCancel={() => setComposerOpenFor(null)}
-                onSubmit={handleComposerSubmit}
+                isSubmitting={isPosting}
+                onCancel={closeComposer}
+                onSubmit={(body) => submitComposer(body)}
               />
-            ) : (
-              <Button variant="outline" onClick={handleRootClick}>
-                Add a comment
-              </Button>
-            )}
+            ) : null}
           </SheetContent>
         </Sheet>
       </div>
 
-      <div aria-live="polite" className="sr-only">
+      <div aria-live="polite" className="sr-only" data-testid="comment-announce">
         {announceText}
       </div>
 
       <IdentityCaptureDialog
         open={identityModalMode !== null}
         nameOnly={identityModalMode === "edit-name"}
-        isSubmitting={postComment.isPending}
+        isSubmitting={isPosting}
         onOpenChange={(open) => {
           if (!open) setIdentityModalMode(null);
         }}
-        onSubmit={handleIdentitySubmit}
+        onSubmit={async (values) => {
+          if (identityModalMode === "edit-name") {
+            identity.refresh();
+            setIdentityModalMode(null);
+            return;
+          }
+          await retryPendingPost(values);
+        }}
       />
     </>
   );

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import pluralize from "pluralize";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -34,6 +34,13 @@ interface CommentOverlayProps {
    * (race: user clicks submit before the /me query lands).
    */
   isAdvisorResolving?: boolean;
+  /**
+   * The signed-in viewer's email (Privy email login), if any. When set,
+   * the identity-capture dialog pre-fills and locks the email field
+   * instead of asking for it. Null for anonymous viewers or wallet
+   * logins with no email.
+   */
+  viewerEmail?: string | null;
 }
 
 function totalCount(tree: SharedReportCommentNode[]): number {
@@ -69,6 +76,7 @@ export function CommentOverlay({
   isAdvisor = false,
   isAuthenticated = false,
   isAdvisorResolving = false,
+  viewerEmail = null,
 }: CommentOverlayProps) {
   const commenting = useCommenting(token, {
     enabled: !reportRevoked,
@@ -144,6 +152,15 @@ export function CommentOverlay({
 
   const composerHeader = composer.mode === "reply" ? composer.parent?.displayName : undefined;
   const composerAnchor = composer.mode === "root" ? composer.anchor : undefined;
+  const composerGeneral = composer.mode === "root" ? composer.general === true : false;
+  // Remount the always-on composer when its context changes so the body
+  // input resets between general / specific-anchor / reply modes.
+  const composerKey =
+    composer.mode === "reply"
+      ? `reply-${composer.parentCommentId}`
+      : composer.mode === "root"
+        ? `root-${composerAnchor ? JSON.stringify(composerAnchor) : "x"}`
+        : "general";
 
   const orphanRoots = counts.orphanRoots;
 
@@ -169,7 +186,7 @@ export function CommentOverlay({
         />
       )}
 
-      <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-2">
+      <div className="fixed bottom-24 right-6 z-40 flex flex-col items-end gap-2">
         <IdentityBadge
           displayName={identity.displayName}
           isAdvisor={identity.isAdvisor}
@@ -204,9 +221,27 @@ export function CommentOverlay({
                 </div>
               )}
               {query.error && !query.isLoading && (
-                <p className="text-sm text-destructive" role="alert">
-                  Couldn’t load comments — retry coming up on next poll.
-                </p>
+                <div
+                  className="flex flex-col items-start gap-2 rounded-md border border-border bg-muted/40 p-3"
+                  role="alert"
+                >
+                  <p className="text-sm font-medium text-foreground">
+                    We couldn’t load the comments
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Something went wrong on our end. Your connection is fine — we’ll keep trying, or
+                    you can retry now.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void query.refetch()}
+                    disabled={query.isFetching}
+                  >
+                    {query.isFetching ? "Retrying…" : "Try again"}
+                  </Button>
+                </div>
               )}
               {!query.isLoading && !query.error && tree.length === 0 && (
                 <p className="text-sm text-muted-foreground">Be the first to comment.</p>
@@ -258,16 +293,16 @@ export function CommentOverlay({
               )}
             </div>
 
-            {composer.mode !== "closed" ? (
-              <CommentComposer
-                parentDisplayName={composerHeader}
-                anchor={composerAnchor}
-                externalError={composerError}
-                isSubmitting={isPosting}
-                onCancel={closeComposer}
-                onSubmit={(body) => submitComposer(body)}
-              />
-            ) : null}
+            <CommentComposer
+              key={composerKey}
+              parentDisplayName={composerHeader}
+              anchor={composer.mode === "root" ? composerAnchor : undefined}
+              general={composer.mode === "closed" ? true : composerGeneral}
+              externalError={composerError}
+              isSubmitting={isPosting}
+              onCancel={closeComposer}
+              onSubmit={(body) => submitComposer(body)}
+            />
           </SheetContent>
         </Sheet>
       </div>
@@ -279,6 +314,7 @@ export function CommentOverlay({
       <IdentityCaptureDialog
         open={identityModalMode !== null}
         nameOnly={identityModalMode === "edit-name"}
+        lockedEmail={viewerEmail}
         isSubmitting={isPosting}
         onOpenChange={(open) => {
           if (!open) setIdentityModalMode(null);

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -99,6 +99,9 @@ export function CommentOverlay({
     retryPendingPost,
     scrollTargetCommentId,
     clearScrollTarget,
+    activeCommentId,
+    activateComment,
+    clearActiveComment,
     highlightRefreshKey,
   } = commenting;
 
@@ -152,6 +155,8 @@ export function CommentOverlay({
         highlightRefreshKey={highlightRefreshKey}
         onPinActivate={activatePin}
         onOpenRootComposer={openRootComposer}
+        activeCommentId={activeCommentId}
+        onActivateComment={activateComment}
       />
 
       {selectionAffordance && (
@@ -171,7 +176,16 @@ export function CommentOverlay({
           onEditName={() => setIdentityModalMode("edit-name")}
           onSwitch={() => void identity.clearIdentity()}
         />
-        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <Sheet
+          open={sheetOpen}
+          onOpenChange={(open) => {
+            setSheetOpen(open);
+            // Closing the sheet drops the focus indicator on the
+            // report's highlights so the donor doesn't see lingering
+            // emphasis after dismissing the comment surface.
+            if (!open) clearActiveComment();
+          }}
+        >
           <SheetTrigger asChild>
             <Button variant="default" className="shadow-lg">
               {total === 0 ? "Comments" : pluralize("comment", total, true)}
@@ -201,7 +215,13 @@ export function CommentOverlay({
                 <div className="space-y-3">
                   {tree.map((node) => (
                     <div key={node.id} data-comment-id={node.id}>
-                      <CommentRow node={node} depth={0} onReply={openReplyComposer} />
+                      <CommentRow
+                        node={node}
+                        depth={0}
+                        onReply={openReplyComposer}
+                        activeCommentId={activeCommentId}
+                        onActivate={activateComment}
+                      />
                     </div>
                   ))}
                 </div>
@@ -224,7 +244,13 @@ export function CommentOverlay({
                             “{node.anchor.quote}”
                           </blockquote>
                         ) : null}
-                        <CommentRow node={node} depth={0} onReply={openReplyComposer} />
+                        <CommentRow
+                          node={node}
+                          depth={0}
+                          onReply={openReplyComposer}
+                          activeCommentId={activeCommentId}
+                          onActivate={activateComment}
+                        />
                       </div>
                     ))}
                   </div>

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import pluralize from "pluralize";
+import { v4 as uuidv4 } from "uuid";
+
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+import { useCommenterIdentity } from "@/hooks/useCommenterIdentity";
+import { useSharedReportComments } from "@/hooks/useSharedReportComments";
+import {
+  IdempotencyCollisionError,
+  IdentityRequiredError,
+  RateLimitedError,
+  type CreateCommentRequest,
+  type SharedReportCommentNode,
+} from "@/types/donor-research-comments";
+
+import { CommentComposer } from "./CommentComposer";
+import { CommentRow } from "./CommentRow";
+import { IdentityBadge } from "./IdentityBadge";
+import { IdentityCaptureDialog } from "./IdentityCaptureDialog";
+
+interface CommentOverlayProps {
+  token: string;
+  /** True when token has been revoked / expired — hides the overlay entirely. */
+  reportRevoked?: boolean;
+  /** True when the viewer's Privy session matches the report's advisor. */
+  isAdvisor?: boolean;
+}
+
+function totalCount(tree: SharedReportCommentNode[]): number {
+  let n = 0;
+  const stack = [...tree];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    n += 1;
+    stack.push(...node.children);
+  }
+  return n;
+}
+
+function findNodeById(
+  tree: SharedReportCommentNode[],
+  id: string,
+): SharedReportCommentNode | null {
+  const stack = [...tree];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.id === id) return node;
+    stack.push(...node.children);
+  }
+  return null;
+}
+
+/**
+ * Comment sidebar: lists all root comments + their reply threads in
+ * one Sheet on desktop / full-screen drawer on mobile. Drives the
+ * composer (root + reply) and orchestrates the IdentityCaptureDialog
+ * round-trip when the donor lacks a cookie.
+ *
+ * Q2 "Not me — switch" affordance lives in the IdentityBadge — clears
+ * the cookies via the proxy clear-identity route and re-prompts on the
+ * next post.
+ *
+ * aria-live="polite" region (per DL-007) announces new comments and
+ * replies so screen readers don't miss arrivals after the initial
+ * render.
+ */
+export function CommentOverlay({
+  token,
+  reportRevoked = false,
+  isAdvisor = false,
+}: CommentOverlayProps) {
+  const { query, tree, postComment } = useSharedReportComments(token, {
+    enabled: !reportRevoked,
+  });
+  const identity = useCommenterIdentity(token, isAdvisor);
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [composerOpenFor, setComposerOpenFor] = useState<string | "root" | null>(
+    null,
+  );
+  const [rootAnchor, setRootAnchor] = useState<CommentAnchor | null>({
+    kind: "section",
+    sectionKey: "methodology",
+  });
+  const [identityModalMode, setIdentityModalMode] = useState<
+    "post" | "edit-name" | null
+  >(null);
+  const [pendingPost, setPendingPost] = useState<CreateCommentRequest | null>(
+    null,
+  );
+  const [composerError, setComposerError] = useState<string | null>(null);
+
+  const total = totalCount(tree);
+
+  const handleReplyClick = useCallback((parentId: string) => {
+    setComposerError(null);
+    setComposerOpenFor(parentId);
+  }, []);
+
+  const handleRootClick = useCallback(() => {
+    setComposerError(null);
+    setRootAnchor({ kind: "section", sectionKey: "methodology" });
+    setComposerOpenFor("root");
+  }, []);
+
+  const submitComment = useCallback(
+    async (request: CreateCommentRequest) => {
+      setComposerError(null);
+      try {
+        await postComment.mutateAsync({ request, idempotencyKey: uuidv4() });
+        setComposerOpenFor(null);
+      } catch (err) {
+        if (err instanceof IdentityRequiredError) {
+          setPendingPost(request);
+          setIdentityModalMode("post");
+          return;
+        }
+        if (err instanceof RateLimitedError) {
+          setComposerError(`Slow down — try again in ${err.retryAfter}s.`);
+          return;
+        }
+        if (err instanceof IdempotencyCollisionError) {
+          setComposerError("That key was already used — try again.");
+          return;
+        }
+        setComposerError("Something went wrong. Try again.");
+      }
+    },
+    [postComment],
+  );
+
+  const handleComposerSubmit = useCallback(
+    async (body: string) => {
+      if (composerOpenFor === null) return;
+      const parentId = composerOpenFor === "root" ? undefined : composerOpenFor;
+      const request: CreateCommentRequest = {
+        body,
+        displayName: identity.displayName ?? "",
+        ...(parentId ? { parentCommentId: parentId } : {}),
+        ...(parentId ? {} : rootAnchor ? { anchor: rootAnchor } : {}),
+      };
+      await submitComment(request);
+    },
+    [composerOpenFor, identity.displayName, rootAnchor, submitComment],
+  );
+
+  const handleIdentitySubmit = useCallback(
+    async (values: { displayName: string; email: string }) => {
+      if (identityModalMode === "edit-name") {
+        // Edit-name-only mode: the parent cookie carries email; the FE
+        // re-fires the same comment but with the updated name. v1
+        // simply closes — the donor's next comment uses the new name.
+        identity.refresh();
+        setIdentityModalMode(null);
+        return;
+      }
+      if (!pendingPost) {
+        setIdentityModalMode(null);
+        return;
+      }
+      const enriched: CreateCommentRequest = {
+        ...pendingPost,
+        displayName: values.displayName,
+        email: values.email,
+      };
+      await submitComment(enriched);
+      identity.refresh();
+      setIdentityModalMode(null);
+      setPendingPost(null);
+    },
+    [identity, identityModalMode, pendingPost, submitComment],
+  );
+
+  const announceText = useMemo(() => {
+    const last = tree[0];
+    if (!last) return "";
+    return `${last.displayName} ${last.parentCommentId ? "replied" : "commented"}`;
+  }, [tree]);
+
+  if (reportRevoked) return null;
+
+  const activeReply =
+    composerOpenFor && composerOpenFor !== "root"
+      ? findNodeById(tree, composerOpenFor)
+      : null;
+
+  return (
+    <>
+      <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-2">
+        <IdentityBadge
+          displayName={identity.displayName}
+          isAdvisor={identity.isAdvisor}
+          onEditName={() => setIdentityModalMode("edit-name")}
+          onSwitch={() => void identity.clearIdentity()}
+        />
+        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <SheetTrigger asChild>
+            <Button variant="default" className="shadow-lg">
+              {total === 0 ? "Comments" : pluralize("comment", total, true)}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="flex w-full flex-col gap-4 sm:max-w-md">
+            <SheetHeader>
+              <SheetTitle>Comments</SheetTitle>
+            </SheetHeader>
+
+            <div className="flex-1 overflow-y-auto pr-2">
+              {query.isLoading && (
+                <div className="space-y-3">
+                  <div className="h-16 animate-pulse rounded bg-muted" />
+                  <div className="h-12 animate-pulse rounded bg-muted" />
+                </div>
+              )}
+              {query.error && !query.isLoading && (
+                <p className="text-sm text-destructive">
+                  Couldn’t load comments — retry coming up on next poll.
+                </p>
+              )}
+              {!query.isLoading && !query.error && tree.length === 0 && (
+                <p className="text-sm text-muted-foreground">Be the first to comment.</p>
+              )}
+              {tree.length > 0 && (
+                <div className="space-y-3">
+                  {tree.map((node) => (
+                    <CommentRow
+                      key={node.id}
+                      node={node}
+                      depth={0}
+                      onReply={handleReplyClick}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {composerOpenFor !== null ? (
+              <CommentComposer
+                parentDisplayName={activeReply?.displayName ?? undefined}
+                anchor={composerOpenFor === "root" ? rootAnchor : undefined}
+                externalError={composerError}
+                isSubmitting={postComment.isPending}
+                onCancel={() => setComposerOpenFor(null)}
+                onSubmit={handleComposerSubmit}
+              />
+            ) : (
+              <Button variant="outline" onClick={handleRootClick}>
+                Add a comment
+              </Button>
+            )}
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      <div aria-live="polite" className="sr-only">
+        {announceText}
+      </div>
+
+      <IdentityCaptureDialog
+        open={identityModalMode !== null}
+        nameOnly={identityModalMode === "edit-name"}
+        isSubmitting={postComment.isPending}
+        onOpenChange={(open) => {
+          if (!open) setIdentityModalMode(null);
+        }}
+        onSubmit={handleIdentitySubmit}
+      />
+    </>
+  );
+}

--- a/src/features/donor-research/components/shared-view/CommentOverlay.tsx
+++ b/src/features/donor-research/components/shared-view/CommentOverlay.tsx
@@ -21,6 +21,19 @@ interface CommentOverlayProps {
   reportRevoked?: boolean;
   /** True when the viewer's Privy session matches the report's advisor. */
   isAdvisor?: boolean;
+  /**
+   * True when the viewer carries any Privy session (advisor-or-not).
+   * Used by the composer's identity gate: an authenticated viewer might
+   * still be loading the `isAdvisor` resolution, so we defer to the BE
+   * `requiresIdentity` round-trip instead of pre-opening the dialog.
+   */
+  isAuthenticated?: boolean;
+  /**
+   * True while the advisor-resolution query is in flight. When set, the
+   * composer waits on the BE rather than opening the dialog optimistically
+   * (race: user clicks submit before the /me query lands).
+   */
+  isAdvisorResolving?: boolean;
 }
 
 function totalCount(tree: SharedReportCommentNode[]): number {
@@ -54,10 +67,14 @@ export function CommentOverlay({
   token,
   reportRevoked = false,
   isAdvisor = false,
+  isAuthenticated = false,
+  isAdvisorResolving = false,
 }: CommentOverlayProps) {
   const commenting = useCommenting(token, {
     enabled: !reportRevoked,
     isAdvisor,
+    isAuthenticated,
+    isAdvisorResolving,
   });
 
   const {

--- a/src/features/donor-research/components/shared-view/CommentPin.tsx
+++ b/src/features/donor-research/components/shared-view/CommentPin.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import pluralize from "pluralize";
+import { type KeyboardEvent, memo } from "react";
+
+interface CommentPinProps {
+  /** Number of comments (root + all descendants) anchored to this target. */
+  count: number;
+  /** Stable key used by parents to identify which pin was clicked. */
+  targetKey: string;
+  /** Click handler. Opens the sidebar with the matching root scrolled into view. */
+  onActivate: (targetKey: string) => void;
+  /** Optional label for screen readers, e.g. "lead candidate". */
+  ariaLabel?: string;
+}
+
+/**
+ * Pin badge rendered absolutely-positioned at the top-right of an
+ * anchored target (section root or candidate card root). Click /
+ * Enter / Space opens the comment sidebar with the root row for this
+ * target scrolled into view.
+ */
+const CommentPinComponent = ({ count, targetKey, onActivate, ariaLabel }: CommentPinProps) => {
+  if (count <= 0) return null;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onActivate(targetKey);
+    }
+  };
+
+  const label = pluralize("comment", count, true);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onActivate(targetKey)}
+      onKeyDown={handleKeyDown}
+      aria-label={ariaLabel ? `${label} on ${ariaLabel}` : label}
+      data-comment-pin
+      data-target-key={targetKey}
+      className="absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded-full border border-border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
+      {label}
+    </button>
+  );
+};
+
+export const CommentPin = memo(CommentPinComponent);

--- a/src/features/donor-research/components/shared-view/CommentPin.tsx
+++ b/src/features/donor-research/components/shared-view/CommentPin.tsx
@@ -40,7 +40,7 @@ const CommentPinComponent = ({ count, targetKey, onActivate, ariaLabel }: Commen
       aria-label={ariaLabel ? `${label} on ${ariaLabel}` : label}
       data-comment-pin
       data-target-key={targetKey}
-      className="absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded-full border border-border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="inline-flex items-center gap-1 rounded-full border border-border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
       {label}

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -159,7 +159,7 @@ const CommentRowComponent = ({
             {formatCommentTimestamp(node.createdAt)}
           </time>
         </header>
-        <div className="whitespace-pre-wrap text-sm leading-relaxed">
+        <div className="overflow-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-sm leading-relaxed">
           {lines.map((line, idx) => (
             <span key={idx}>
               {line}

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -4,7 +4,9 @@ import pluralize from "pluralize";
 import { memo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { SharedReportCommentNode } from "@/types/donor-research-comments";
+import { formatDate } from "@/utilities/formatDate";
 
 const MAX_VISUAL_DEPTH = 4;
 
@@ -16,17 +18,69 @@ interface CommentRowProps {
   activeCommentId?: string | null;
   /** Click on the row body sets this as the active comment (highlights its anchor in the report). */
   onActivate?: (commentId: string) => void;
+  /** Retry a comment whose optimistic POST failed. Optional — only failed rows surface it. */
+  onRetry?: (commentId: string) => void;
 }
 
-function formatRelative(iso: string): string {
-  const ts = Date.parse(iso);
-  if (Number.isNaN(ts)) return "";
-  const deltaSeconds = (Date.now() - ts) / 1000;
-  if (deltaSeconds < 60) return "just now";
-  if (deltaSeconds < 3600) return `${Math.floor(deltaSeconds / 60)}m ago`;
-  if (deltaSeconds < 86400) return `${Math.floor(deltaSeconds / 3600)}h ago`;
-  return `${Math.floor(deltaSeconds / 86400)}d ago`;
+/**
+ * Absolute comment timestamp in the viewer's LOCAL timezone, suffixed
+ * with "(Local)" so the donor knows it's their own time, not UTC.
+ * Composed from the platform's `formatDate` date + time options
+ * (the combined datetime option hardcodes a "UTC" label, so we join two).
+ */
+function formatCommentTimestamp(iso: string): string {
+  const date = formatDate(iso, "local", "MMM D, YYYY");
+  const d = new Date(iso);
+  if (!date || Number.isNaN(d.getTime())) return "";
+  // Format the local clock time inline. We deliberately don't use
+  // formatDate's "h:mm a" option here: it omits the date for "today" but
+  // PREPENDS the full date on other days, which double-prints the date
+  // once composed with the date part above.
+  const hours = d.getHours();
+  const minutes = d.getMinutes().toString().padStart(2, "0");
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const h12 = hours % 12 || 12;
+  return `${date}, ${h12}:${minutes} ${ampm} (Local)`;
 }
+
+const INDENT_CLASS_BY_LEVEL = ["", "pl-4", "pl-8", "pl-12", "pl-16"] as const;
+
+/** Background tint for the comment card: failed > active > default. */
+function articleBackgroundClass(node: SharedReportCommentNode, isActive: boolean): string {
+  if (node._failed) return "bg-red-50 dark:bg-red-900/20";
+  if (isActive) return "bg-amber-50 dark:bg-amber-900/20";
+  return "bg-background";
+}
+
+interface CommentStatusProps {
+  node: SharedReportCommentNode;
+  onRetry?: (commentId: string) => void;
+}
+
+/** Pending ("Sending…") and failed ("Couldn't send — Retry") affordances. */
+const CommentStatus = ({ node, onRetry }: CommentStatusProps) => {
+  if (node._optimistic) {
+    return <span className="text-muted-foreground">Sending…</span>;
+  }
+  if (!node._failed) return null;
+  return (
+    <span className="flex items-center gap-1.5 text-red-600 dark:text-red-400">
+      Couldn&apos;t send
+      {onRetry && (
+        <button
+          type="button"
+          className="underline underline-offset-2 hover:no-underline focus-visible:no-underline focus-visible:outline-none"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry(node.id);
+          }}
+        >
+          Retry
+        </button>
+      )}
+    </span>
+  );
+};
 
 function decodeEntities(body: string): string {
   // The backend sanitizer escapes & < > " '. Render those entities as
@@ -49,20 +103,12 @@ const CommentRowComponent = ({
   onReply,
   activeCommentId,
   onActivate,
+  onRetry,
 }: CommentRowProps) => {
   const [expanded, setExpanded] = useState(depth < MAX_VISUAL_DEPTH);
   const isActive = activeCommentId === node.id;
   const indentLevel = Math.min(depth, MAX_VISUAL_DEPTH);
-  const indentClasses =
-    indentLevel === 0
-      ? ""
-      : indentLevel === 1
-        ? "pl-4"
-        : indentLevel === 2
-          ? "pl-8"
-          : indentLevel === 3
-            ? "pl-12"
-            : "pl-16";
+  const indentClasses = INDENT_CLASS_BY_LEVEL[indentLevel];
 
   const showCollapsed = !expanded && node.children.length > 0;
   const visibleChildren = expanded ? node.children : [];
@@ -74,8 +120,8 @@ const CommentRowComponent = ({
       className={`border-l ${isActive ? "border-amber-500" : "border-border/50"} ${indentClasses}`}
     >
       <article
-        className={`rounded-md p-3 transition-colors ${
-          isActive ? "bg-amber-50 dark:bg-amber-900/20" : "bg-background"
+        className={`rounded-md p-3 transition-colors ${articleBackgroundClass(node, isActive)} ${
+          node._optimistic ? "opacity-70" : ""
         } ${onActivate ? "cursor-pointer" : ""}`}
         onClick={() => onActivate?.(node.id)}
         onKeyDown={(e) => {
@@ -91,15 +137,27 @@ const CommentRowComponent = ({
         data-comment-row
         data-active={isActive || undefined}
       >
-        <header className="mb-1 flex items-center gap-2 text-xs">
-          <span className="font-medium">{node.displayName}</span>
-          {node.isAdvisor && (
-            <Badge variant="secondary" className="h-5 px-1.5 text-[10px] uppercase">
-              Advisor
-            </Badge>
-          )}
-          <span className="text-muted-foreground">{formatRelative(node.createdAt)}</span>
-          {node._optimistic && <span className="text-muted-foreground">Sending…</span>}
+        <header className="mb-1 text-xs">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            {!node.displayName && node._optimistic ? (
+              <Skeleton className="h-3 w-20 rounded" />
+            ) : (
+              <span className="min-w-0 break-words font-medium">{node.displayName}</span>
+            )}
+            {node.isAdvisor && (
+              <Badge variant="secondary" className="h-5 shrink-0 px-1.5 text-[10px] uppercase">
+                Advisor
+              </Badge>
+            )}
+            <CommentStatus node={node} onRetry={onRetry} />
+          </div>
+          <time
+            className="mt-0.5 block text-muted-foreground"
+            dateTime={node.createdAt}
+            title={formatCommentTimestamp(node.createdAt)}
+          >
+            {formatCommentTimestamp(node.createdAt)}
+          </time>
         </header>
         <div className="whitespace-pre-wrap text-sm leading-relaxed">
           {lines.map((line, idx) => (
@@ -144,6 +202,7 @@ const CommentRowComponent = ({
           onReply={onReply}
           activeCommentId={activeCommentId}
           onActivate={onActivate}
+          onRetry={onRetry}
         />
       ))}
     </div>

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { SharedReportCommentNode } from "@/types/donor-research-comments";
 import { formatDate } from "@/utilities/formatDate";
+import { cn } from "@/utilities/tailwind";
 
 const MAX_VISUAL_DEPTH = 4;
 
@@ -117,15 +118,22 @@ const CommentRowComponent = ({
 
   return (
     <div
-      className={`border-l ${isActive ? "border-amber-500" : "border-border/50"} ${indentClasses}`}
+      className={cn("border-l", isActive ? "border-amber-500" : "border-border/50", indentClasses)}
     >
       <article
-        className={`rounded-md p-3 transition-colors ${articleBackgroundClass(node, isActive)} ${
-          node._optimistic ? "opacity-70" : ""
-        } ${onActivate ? "cursor-pointer" : ""}`}
+        className={cn(
+          "rounded-md p-3 transition-colors",
+          articleBackgroundClass(node, isActive),
+          node._optimistic && "opacity-70",
+          onActivate && "cursor-pointer"
+        )}
         onClick={() => onActivate?.(node.id)}
         onKeyDown={(e) => {
           if (!onActivate) return;
+          // Only activate when the keypress originated on the row itself.
+          // Without this guard, pressing Enter while the nested Reply
+          // button is focused bubbles up here and double-fires onActivate.
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onActivate(node.id);

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { memo, useState } from "react";
+import pluralize from "pluralize";
+
+import { Badge } from "@/components/ui/badge";
+import type { SharedReportCommentNode } from "@/types/donor-research-comments";
+
+const MAX_VISUAL_DEPTH = 4;
+
+interface CommentRowProps {
+  node: SharedReportCommentNode;
+  depth?: number;
+  onReply: (parentId: string) => void;
+}
+
+function formatRelative(iso: string): string {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return "";
+  const deltaSeconds = (Date.now() - ts) / 1000;
+  if (deltaSeconds < 60) return "just now";
+  if (deltaSeconds < 3600) return `${Math.floor(deltaSeconds / 60)}m ago`;
+  if (deltaSeconds < 86400) return `${Math.floor(deltaSeconds / 3600)}h ago`;
+  return `${Math.floor(deltaSeconds / 86400)}d ago`;
+}
+
+function decodeEntities(body: string): string {
+  // The backend sanitizer escapes & < > " '. Render those entities as
+  // their decoded characters via DOM textContent (which is the React
+  // default for string children). React's auto-escape will re-escape
+  // for display, so a passed-through &lt; renders as the literal
+  // "&lt;" string — that's correct: a donor who typed "<" intended to
+  // see "<" rendered.
+  return body
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
+  const [expanded, setExpanded] = useState(depth < MAX_VISUAL_DEPTH);
+  const indentLevel = Math.min(depth, MAX_VISUAL_DEPTH);
+  const indentClasses =
+    indentLevel === 0
+      ? ""
+      : indentLevel === 1
+        ? "pl-4"
+        : indentLevel === 2
+          ? "pl-8"
+          : indentLevel === 3
+            ? "pl-12"
+            : "pl-16";
+
+  const showCollapsed = !expanded && node.children.length > 0;
+  const visibleChildren = expanded ? node.children : [];
+  const decodedBody = decodeEntities(node.body);
+  const lines = decodedBody.split(/\n/);
+
+  return (
+    <div className={`border-l border-border/50 ${indentClasses}`}>
+      <article className="rounded-md bg-background p-3">
+        <header className="mb-1 flex items-center gap-2 text-xs">
+          <span className="font-medium">{node.displayName}</span>
+          {node.isAdvisor && (
+            <Badge variant="secondary" className="h-5 px-1.5 text-[10px] uppercase">
+              Advisor
+            </Badge>
+          )}
+          <span className="text-muted-foreground">{formatRelative(node.createdAt)}</span>
+          {node._optimistic && (
+            <span className="text-muted-foreground">Sending…</span>
+          )}
+        </header>
+        <div className="whitespace-pre-wrap text-sm leading-relaxed">
+          {lines.map((line, idx) => (
+            <span key={idx}>
+              {line}
+              {idx < lines.length - 1 ? <br /> : null}
+            </span>
+          ))}
+        </div>
+        <div className="mt-1.5">
+          <button
+            type="button"
+            className="text-xs text-muted-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:underline"
+            onClick={() => onReply(node.id)}
+          >
+            Reply
+          </button>
+        </div>
+      </article>
+
+      {showCollapsed && (
+        <button
+          type="button"
+          className="ml-3 text-xs text-muted-foreground underline-offset-2 hover:underline"
+          onClick={() => setExpanded(true)}
+        >
+          Show {pluralize("more reply", node.children.length, true)}
+        </button>
+      )}
+
+      {visibleChildren.map((child) => (
+        <CommentRow key={child.id} node={child} depth={depth + 1} onReply={onReply} />
+      ))}
+    </div>
+  );
+};
+
+export const CommentRow = memo(CommentRowComponent);

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -12,6 +12,10 @@ interface CommentRowProps {
   node: SharedReportCommentNode;
   depth?: number;
   onReply: (parentId: string) => void;
+  /** Bidirectional focus: id of the row whose anchored highlight is currently emphasized. */
+  activeCommentId?: string | null;
+  /** Click on the row body sets this as the active comment (highlights its anchor in the report). */
+  onActivate?: (commentId: string) => void;
 }
 
 function formatRelative(iso: string): string {
@@ -39,8 +43,15 @@ function decodeEntities(body: string): string {
     .replace(/&#39;/g, "'");
 }
 
-const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
+const CommentRowComponent = ({
+  node,
+  depth = 0,
+  onReply,
+  activeCommentId,
+  onActivate,
+}: CommentRowProps) => {
   const [expanded, setExpanded] = useState(depth < MAX_VISUAL_DEPTH);
+  const isActive = activeCommentId === node.id;
   const indentLevel = Math.min(depth, MAX_VISUAL_DEPTH);
   const indentClasses =
     indentLevel === 0
@@ -59,8 +70,27 @@ const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
   const lines = decodedBody.split(/\n/);
 
   return (
-    <div className={`border-l border-border/50 ${indentClasses}`}>
-      <article className="rounded-md bg-background p-3">
+    <div
+      className={`border-l ${isActive ? "border-amber-500" : "border-border/50"} ${indentClasses}`}
+    >
+      <article
+        className={`rounded-md p-3 transition-colors ${
+          isActive ? "bg-amber-50 dark:bg-amber-900/20" : "bg-background"
+        } ${onActivate ? "cursor-pointer" : ""}`}
+        onClick={() => onActivate?.(node.id)}
+        onKeyDown={(e) => {
+          if (!onActivate) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onActivate(node.id);
+          }
+        }}
+        role={onActivate ? "button" : undefined}
+        tabIndex={onActivate ? 0 : undefined}
+        aria-current={isActive ? "true" : undefined}
+        data-comment-row
+        data-active={isActive || undefined}
+      >
         <header className="mb-1 flex items-center gap-2 text-xs">
           <span className="font-medium">{node.displayName}</span>
           {node.isAdvisor && (
@@ -83,7 +113,13 @@ const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
           <button
             type="button"
             className="text-xs text-muted-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:underline"
-            onClick={() => onReply(node.id)}
+            onClick={(e) => {
+              // Don't bubble into the row's activate handler — the Reply
+              // button is its own affordance and shouldn't also flash
+              // the highlight.
+              e.stopPropagation();
+              onReply(node.id);
+            }}
           >
             Reply
           </button>
@@ -101,7 +137,14 @@ const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
       )}
 
       {visibleChildren.map((child) => (
-        <CommentRow key={child.id} node={child} depth={depth + 1} onReply={onReply} />
+        <CommentRow
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          onReply={onReply}
+          activeCommentId={activeCommentId}
+          onActivate={onActivate}
+        />
       ))}
     </div>
   );

--- a/src/features/donor-research/components/shared-view/CommentRow.tsx
+++ b/src/features/donor-research/components/shared-view/CommentRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { memo, useState } from "react";
 import pluralize from "pluralize";
+import { memo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import type { SharedReportCommentNode } from "@/types/donor-research-comments";
@@ -69,9 +69,7 @@ const CommentRowComponent = ({ node, depth = 0, onReply }: CommentRowProps) => {
             </Badge>
           )}
           <span className="text-muted-foreground">{formatRelative(node.createdAt)}</span>
-          {node._optimistic && (
-            <span className="text-muted-foreground">Sending…</span>
-          )}
+          {node._optimistic && <span className="text-muted-foreground">Sending…</span>}
         </header>
         <div className="whitespace-pre-wrap text-sm leading-relaxed">
           {lines.map((line, idx) => (

--- a/src/features/donor-research/components/shared-view/IdentityBadge.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityBadge.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { PencilIcon, UserRoundIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface IdentityBadgeProps {
+  /** Display name from useCommenterIdentity. */
+  displayName: string | null;
+  /** True when viewer is the report's advisor. */
+  isAdvisor: boolean;
+  /** Opens IdentityCaptureDialog in edit-name-only mode. */
+  onEditName: () => void;
+  /** Q2 "Not me — switch" — clears cookies and forces a fresh prompt. */
+  onSwitch: () => void;
+}
+
+/**
+ * Renders "Commenting as <name>" with an edit pencil and a "Not me —
+ * switch" link. Visible above the comment composer / overlay opener
+ * once the donor has posted (or the advisor is authenticated).
+ */
+export function IdentityBadge({
+  displayName,
+  isAdvisor,
+  onEditName,
+  onSwitch,
+}: IdentityBadgeProps) {
+  if (isAdvisor) {
+    return (
+      <div className="inline-flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-sm">
+        <UserRoundIcon className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+        <span>Commenting as Advisor</span>
+      </div>
+    );
+  }
+
+  if (!displayName) return null;
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-sm">
+      <UserRoundIcon className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+      <span>
+        Commenting as <strong className="font-medium">{displayName}</strong>
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-auto px-1 py-0.5"
+        onClick={onEditName}
+        aria-label="Edit display name"
+      >
+        <PencilIcon className="h-3 w-3" />
+      </Button>
+      <button
+        type="button"
+        onClick={onSwitch}
+        className="text-xs text-muted-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:underline"
+      >
+        Not me — switch
+      </button>
+    </div>
+  );
+}

--- a/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
@@ -43,6 +43,13 @@ interface IdentityCaptureDialogProps {
   nameOnly?: boolean;
   /** Pending submit flag from the upstream mutation. */
   isSubmitting?: boolean;
+  /**
+   * When the viewer is logged in with an email (Privy email login), pass
+   * it here. The email field is pre-filled and locked (read-only) since
+   * we already hold a verified address. Leave null/empty for anonymous
+   * viewers or wallet logins with no email — they get an editable field.
+   */
+  lockedEmail?: string | null;
 }
 
 /**
@@ -63,10 +70,12 @@ export function IdentityCaptureDialog({
   onSubmit,
   nameOnly = false,
   isSubmitting = false,
+  lockedEmail = null,
 }: IdentityCaptureDialogProps) {
+  const hasLockedEmail = Boolean(lockedEmail && lockedEmail.trim().length > 0);
   const form = useForm<FormValues>({
     resolver: zodResolver(nameOnly ? NameOnlySchema : FullSchema),
-    defaultValues: { displayName: "", email: "" },
+    defaultValues: { displayName: "", email: hasLockedEmail ? (lockedEmail as string) : "" },
   });
 
   const handleSubmit = form.handleSubmit(async (values) => {
@@ -112,8 +121,16 @@ export function IdentityCaptureDialog({
                 type="email"
                 autoComplete="email"
                 maxLength={254}
+                readOnly={hasLockedEmail}
+                aria-readonly={hasLockedEmail || undefined}
+                className={
+                  hasLockedEmail ? "cursor-not-allowed bg-muted text-muted-foreground" : undefined
+                }
                 {...form.register("email")}
               />
+              {hasLockedEmail && (
+                <p className="text-xs text-muted-foreground">From your signed-in account.</p>
+              )}
               {form.formState.errors.email && (
                 <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
               )}

--- a/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
@@ -105,9 +105,7 @@ export function IdentityCaptureDialog({
                 {...form.register("email")}
               />
               {form.formState.errors.email && (
-                <p className="text-sm text-destructive">
-                  {form.formState.errors.email.message}
-                </p>
+                <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
               )}
             </div>
           )}

--- a/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
@@ -16,12 +16,22 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-const FormSchema = z.object({
+const FullSchema = z.object({
   displayName: z.string().trim().min(1, "Enter your name").max(80),
   email: z.string().trim().email("Enter a valid email").max(254),
 });
 
-type FormValues = z.infer<typeof FormSchema>;
+// nameOnly mode hides the email field. The schema still types `email`
+// as a required string (so FormValues stays a single shape across both
+// modes), but skips the `.email()` validator so the hidden empty field
+// doesn't block submission — U10 ships display-name-only edits, email
+// edits are deferred.
+const NameOnlySchema = z.object({
+  displayName: z.string().trim().min(1, "Enter your name").max(80),
+  email: z.string(),
+});
+
+type FormValues = z.infer<typeof FullSchema>;
 
 interface IdentityCaptureDialogProps {
   /** Controls the dialog open state. Parent owns it so submit can close on success. */
@@ -55,7 +65,7 @@ export function IdentityCaptureDialog({
   isSubmitting = false,
 }: IdentityCaptureDialogProps) {
   const form = useForm<FormValues>({
-    resolver: zodResolver(FormSchema),
+    resolver: zodResolver(nameOnly ? NameOnlySchema : FullSchema),
     defaultValues: { displayName: "", email: "" },
   });
 

--- a/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -77,6 +78,18 @@ export function IdentityCaptureDialog({
     resolver: zodResolver(nameOnly ? NameOnlySchema : FullSchema),
     defaultValues: { displayName: "", email: hasLockedEmail ? (lockedEmail as string) : "" },
   });
+
+  // The dialog is persistently mounted, so useForm's defaultValues are
+  // captured before the Privy session (and thus lockedEmail) resolves —
+  // leaving the field locked-but-empty, which dead-ends on the email
+  // validator. Re-apply the locked email whenever it resolves or the
+  // dialog (re)opens.
+  const { setValue } = form;
+  useEffect(() => {
+    if (open && hasLockedEmail) {
+      setValue("email", lockedEmail as string, { shouldValidate: false });
+    }
+  }, [open, hasLockedEmail, lockedEmail, setValue]);
 
   const handleSubmit = form.handleSubmit(async (values) => {
     await onSubmit(values);

--- a/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
+++ b/src/features/donor-research/components/shared-view/IdentityCaptureDialog.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const FormSchema = z.object({
+  displayName: z.string().trim().min(1, "Enter your name").max(80),
+  email: z.string().trim().email("Enter a valid email").max(254),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+
+interface IdentityCaptureDialogProps {
+  /** Controls the dialog open state. Parent owns it so submit can close on success. */
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  /** Called with the validated fields. Parent threads them into the next mutation. */
+  onSubmit: (values: FormValues) => Promise<void>;
+  /** Edit-name-only mode hides the email field — used by the IdentityBadge edit affordance. */
+  nameOnly?: boolean;
+  /** Pending submit flag from the upstream mutation. */
+  isSubmitting?: boolean;
+}
+
+/**
+ * Identity-capture modal triggered on first comment attempt when the
+ * commenter has no cookie yet. Uses shadcn Dialog (Radix-backed) so
+ * focus trap, escape handling, and aria semantics come for free.
+ *
+ *   - "use client" because Radix imports run in the client tree.
+ *   - displayName max 80, email max 254 — matches backend bounds.
+ *   - Pre-PR rule: every data-touching component renders loading,
+ *     empty, and error. The Dialog has no fetch surface; the submit
+ *     button toggles between idle and submitting, validation errors
+ *     render inline.
+ */
+export function IdentityCaptureDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  nameOnly = false,
+  isSubmitting = false,
+}: IdentityCaptureDialogProps) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: { displayName: "", email: "" },
+  });
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await onSubmit(values);
+    form.reset();
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {nameOnly ? "Update your display name" : "Add your name and email"}
+          </DialogTitle>
+          <DialogDescription>
+            {nameOnly
+              ? "Your future comments will use this name."
+              : "Your name appears next to your comments. Your email is private — the report owner uses it to follow up if needed."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-2">
+            <Label htmlFor="displayName">Display name</Label>
+            <Input
+              id="displayName"
+              autoComplete="name"
+              maxLength={80}
+              {...form.register("displayName")}
+            />
+            {form.formState.errors.displayName && (
+              <p className="text-sm text-destructive">
+                {form.formState.errors.displayName.message}
+              </p>
+            )}
+          </div>
+
+          {!nameOnly && (
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                maxLength={254}
+                {...form.register("email")}
+              />
+              {form.formState.errors.email && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.email.message}
+                </p>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving…" : nameOnly ? "Save" : "Continue"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/donor-research/components/shared-view/SelectionAffordance.tsx
+++ b/src/features/donor-research/components/shared-view/SelectionAffordance.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { MessageSquarePlusIcon } from "lucide-react";
+
+interface SelectionAffordanceProps {
+  /** Document-coordinate position the button anchors to. */
+  position: { top: number; left: number };
+  /** Click handler — opens the root composer with the captured anchor. */
+  onClick: () => void;
+}
+
+/**
+ * Floating "Comment" button that appears next to a non-collapsed text
+ * selection inside an anchorable region. Positioned in document
+ * coordinates so it follows scroll and survives reflow until dismissed.
+ */
+export function SelectionAffordance({ position, onClick }: SelectionAffordanceProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => {
+        // Avoid clearing the active selection before the click fires.
+        e.preventDefault();
+      }}
+      onClick={onClick}
+      data-selection-affordance
+      style={{
+        position: "absolute",
+        top: `${position.top}px`,
+        left: `${position.left}px`,
+      }}
+      className="z-30 inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium shadow-md hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <MessageSquarePlusIcon className="h-3.5 w-3.5" aria-hidden />
+      Comment
+    </button>
+  );
+}

--- a/src/features/donor-research/components/shared-view/SharedReportView.tsx
+++ b/src/features/donor-research/components/shared-view/SharedReportView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { fetchSharedReport } from "@/services/donor-research.service";
 import type { DonorResearchReportStatus, ResearchReportDetail } from "@/types/donor-research";
 import { ReportBrief } from "../report-brief/ReportBrief";
+import { CommentOverlay } from "./CommentOverlay";
 
 interface SharedReportViewProps {
   token: string;
@@ -153,5 +154,13 @@ export function SharedReportView({ token }: SharedReportViewProps) {
     );
   }
 
-  return <ReportBrief report={payload} isTerminal={isTerminal(payload)} variant="shared" />;
+  return (
+    <>
+      <ReportBrief report={payload} isTerminal={isTerminal(payload)} variant="shared" />
+      {/* Comment overlay (U11). The donor-shared route is anonymous; the
+       *  advisor flag is wired up once the Privy session shape is
+       *  available on this route (deferred — defaults to false in v1). */}
+      <CommentOverlay token={token} isAdvisor={false} />
+    </>
+  );
 }

--- a/src/features/donor-research/components/shared-view/SharedReportView.tsx
+++ b/src/features/donor-research/components/shared-view/SharedReportView.tsx
@@ -177,7 +177,12 @@ export function SharedReportView({ token }: SharedReportViewProps) {
   return (
     <>
       <ReportBrief report={payload} isTerminal={isTerminal(payload)} variant="shared" />
-      <CommentOverlay token={token} isAdvisor={isAdvisorViewer} />
+      <CommentOverlay
+        token={token}
+        isAdvisor={isAdvisorViewer}
+        isAuthenticated={Boolean(privy.ready && privy.authenticated)}
+        isAdvisorResolving={Boolean(privy.ready && privy.authenticated) && advisorQuery.isLoading}
+      />
     </>
   );
 }

--- a/src/features/donor-research/components/shared-view/SharedReportView.tsx
+++ b/src/features/donor-research/components/shared-view/SharedReportView.tsx
@@ -74,6 +74,11 @@ export function SharedReportView({ token }: SharedReportViewProps) {
     enabled: privy.ready && privy.authenticated,
   });
   const isAdvisorViewer = Boolean(privy.ready && privy.authenticated && advisorQuery.data);
+  // Email from a Privy email login, if present. Used to pre-fill + lock
+  // the identity-capture email field. Wallet logins expose no email, so
+  // this stays null and the donor is asked for one.
+  const viewerEmail =
+    privy.ready && privy.authenticated ? (privy.user?.email?.address ?? null) : null;
 
   useEffect(() => {
     let cancelled = false;
@@ -182,6 +187,7 @@ export function SharedReportView({ token }: SharedReportViewProps) {
         isAdvisor={isAdvisorViewer}
         isAuthenticated={Boolean(privy.ready && privy.authenticated)}
         isAdvisorResolving={Boolean(privy.ready && privy.authenticated) && advisorQuery.isLoading}
+        viewerEmail={viewerEmail}
       />
     </>
   );

--- a/src/features/donor-research/components/shared-view/SharedReportView.tsx
+++ b/src/features/donor-research/components/shared-view/SharedReportView.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePrivyBridge } from "@/contexts/privy-bridge-context";
+import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { fetchSharedReport } from "@/services/donor-research.service";
 import type { DonorResearchReportStatus, ResearchReportDetail } from "@/types/donor-research";
 import { ReportBrief } from "../report-brief/ReportBrief";
@@ -54,6 +56,24 @@ export function SharedReportView({ token }: SharedReportViewProps) {
   const [payload, setPayload] = useState<ResearchReportDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // KTD14 advisor identity wiring (v1 best-effort).
+  //
+  // The shared-report payload omits `advisorId` (PII-redacted on the
+  // backend per KTD12), so we can't compare it directly to the Privy
+  // session. We use the inherited root Privy bridge to detect that a
+  // session exists, and the existing `useDonorAdvisor` hook to confirm
+  // the session is an onboarded advisor account. The indexer remains
+  // the source of truth: comments are stamped `is_advisor` at write
+  // time when the Privy JWT resolves to the report's advisor (see
+  // KTD14). The FE flag below only governs the IdentityBadge text and
+  // gates the IdentityCaptureDialog — the persisted advisor flag on
+  // each comment row is authoritative for the row badge.
+  const privy = usePrivyBridge();
+  const advisorQuery = useDonorAdvisor({
+    enabled: privy.ready && privy.authenticated,
+  });
+  const isAdvisorViewer = Boolean(privy.ready && privy.authenticated && advisorQuery.data);
 
   useEffect(() => {
     let cancelled = false;
@@ -157,10 +177,7 @@ export function SharedReportView({ token }: SharedReportViewProps) {
   return (
     <>
       <ReportBrief report={payload} isTerminal={isTerminal(payload)} variant="shared" />
-      {/* Comment overlay (U11). The donor-shared route is anonymous; the
-       *  advisor flag is wired up once the Privy session shape is
-       *  available on this route (deferred — defaults to false in v1). */}
-      <CommentOverlay token={token} isAdvisor={false} />
+      <CommentOverlay token={token} isAdvisor={isAdvisorViewer} />
     </>
   );
 }

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -112,7 +112,12 @@ const SELECTION_DEBOUNCE_MS = 80;
  */
 export function useCommenting(
   token: string,
-  opts: { enabled?: boolean; isAdvisor?: boolean } = {}
+  opts: {
+    enabled?: boolean;
+    isAdvisor?: boolean;
+    isAuthenticated?: boolean;
+    isAdvisorResolving?: boolean;
+  } = {}
 ): UseCommentingResult {
   const enabled = opts.enabled !== false;
   const isAdvisor = opts.isAdvisor ?? false;
@@ -314,20 +319,37 @@ export function useCommenting(
               anchor: composer.anchor,
               ...(extraIdentity?.email ? { email: extraIdentity.email } : {}),
             };
-      // Gate the post on identity. Without a captured name (and not an
-      // advisor), the BE's schema validation rejects with a generic 400
-      // *before* the controller can return `requiresIdentity: true` —
-      // which used to surface as "Something went wrong" in the composer.
-      // Open the IdentityCaptureDialog first and stash the request so
-      // `retryPendingPost` can replay it with the captured values.
-      if (!extraIdentity && !identity.isAdvisor && !baseDisplayName) {
+      // Gate the post on identity for anonymous (not-Privy-authed)
+      // viewers only. Three reasons to skip the gate and go straight
+      // to the BE:
+      //   - identity.isAdvisor is already true → BE accepts the post
+      //   - opts.isAdvisorResolving is true → the /me query is mid-
+      //     flight; pre-opening the dialog would race with the answer
+      //   - opts.isAuthenticated is true (Privy session present) → the
+      //     viewer might be an advisor whose advisor query just hasn't
+      //     landed yet; let the BE be the source of truth. If they're
+      //     NOT actually the advisor for this report, the BE returns
+      //     `requiresIdentity: true` and `performPost` opens the dialog
+      //     via the IdentityRequiredError catch.
+      // Anonymous donors with no identity get the dialog immediately so
+      // they don't pay the round-trip.
+      const canDeferToBackend =
+        identity.isAdvisor || opts.isAdvisorResolving === true || opts.isAuthenticated === true;
+      if (!extraIdentity && !canDeferToBackend && !baseDisplayName) {
         setPendingPost(request);
         setIdentityModalMode("post");
         return;
       }
       await performPost(request);
     },
-    [composer, identity.displayName, identity.isAdvisor, performPost]
+    [
+      composer,
+      identity.displayName,
+      identity.isAdvisor,
+      opts.isAuthenticated,
+      opts.isAdvisorResolving,
+      performPost,
+    ]
   );
 
   const retryPendingPost = useCallback(

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -92,6 +92,18 @@ export interface UseCommentingResult {
   scrollTargetCommentId: string | null;
   /** Clears the scroll target after the consumer has used it. */
   clearScrollTarget: () => void;
+  /**
+   * The comment row the donor is currently focused on. Bidirectional
+   * link between the sidebar and the report DOM: clicking a row sets
+   * this id so its anchored highlight gets emphasized in the report;
+   * clicking a highlight sets it so the matching sidebar row gets
+   * emphasized + scrolled into view.
+   */
+  activeCommentId: string | null;
+  /** Focus a comment + scroll its anchor into view in the report. */
+  activateComment: (commentId: string) => void;
+  /** Clear the focus indicator (called on sheet close or composer open). */
+  clearActiveComment: () => void;
   /** Refresh key for the highlight resolver — bumps on each successful poll. */
   highlightRefreshKey: number;
 }
@@ -133,6 +145,7 @@ export function useCommenting(
   const [identityModalMode, setIdentityModalMode] = useState<"post" | "edit-name" | null>(null);
   const [pendingPost, setPendingPost] = useState<CreateCommentRequest | null>(null);
   const [scrollTargetCommentId, setScrollTargetCommentId] = useState<string | null>(null);
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [selectionAffordance, setSelectionAffordance] = useState<SelectionAffordance | null>(null);
   const [highlightRefreshKey, setHighlightRefreshKey] = useState(0);
 
@@ -265,13 +278,27 @@ export function useCommenting(
       const roots = counts.rootsByKey.get(targetKey) ?? [];
       const first = roots[0];
       setSheetOpen(true);
-      if (first) setScrollTargetCommentId(first.id);
+      if (first) {
+        setScrollTargetCommentId(first.id);
+        // Mark the row active so the source highlight in the report
+        // gets the focused emphasis simultaneously.
+        setActiveCommentId(first.id);
+      }
     },
     [counts.rootsByKey]
   );
 
   const clearScrollTarget = useCallback(() => {
     setScrollTargetCommentId(null);
+  }, []);
+
+  const activateComment = useCallback((commentId: string) => {
+    setActiveCommentId(commentId);
+    setScrollTargetCommentId(commentId);
+  }, []);
+
+  const clearActiveComment = useCallback(() => {
+    setActiveCommentId(null);
   }, []);
 
   const performPost = useCallback(
@@ -393,6 +420,9 @@ export function useCommenting(
     retryPendingPost,
     scrollTargetCommentId,
     clearScrollTarget,
+    activeCommentId,
+    activateComment,
+    clearActiveComment,
     highlightRefreshKey,
   };
 }

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -1,0 +1,367 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { useCommenterIdentity } from "@/hooks/useCommenterIdentity";
+import { useSharedReportComments } from "@/hooks/useSharedReportComments";
+import { captureTextRangeAnchor } from "@/src/features/donor-research/components/anchor/capture";
+import { resolveAnchor } from "@/src/features/donor-research/components/anchor/resolve";
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+import {
+  type CreateCommentRequest,
+  IdempotencyCollisionError,
+  IdentityRequiredError,
+  RateLimitedError,
+  type SharedReportCommentNode,
+} from "@/types/donor-research-comments";
+
+interface SelectionAffordance {
+  /** Anchor captured at the moment the user released the selection. */
+  anchor: CommentAnchor;
+  /** Document-coordinate position for the floating Comment button. */
+  position: { top: number; left: number };
+}
+
+interface CountsByTarget {
+  /** key = `${targetKind}:${targetId}` — counts root + descendant comments. */
+  byKey: Map<string, number>;
+  /** Root nodes scoped to each key, used for "scroll into view" navigation. */
+  rootsByKey: Map<string, SharedReportCommentNode[]>;
+  /** Orphan-lane roots whose anchor failed to resolve in the current DOM. */
+  orphanRoots: SharedReportCommentNode[];
+}
+
+function totalDescendants(node: SharedReportCommentNode): number {
+  let n = 1;
+  for (const c of node.children) n += totalDescendants(c);
+  return n;
+}
+
+function targetKeyOf(anchor: CommentAnchor | null): string | null {
+  if (!anchor) return null;
+  if (anchor.kind === "section") return `section:${anchor.sectionKey}`;
+  if (anchor.kind === "candidate") return `candidate:${anchor.candidateId}`;
+  return `${anchor.targetKind}:${anchor.targetId}`;
+}
+
+export interface UseCommentingResult {
+  /** React Query handle around the shared comments endpoint. */
+  query: ReturnType<typeof useSharedReportComments>["query"];
+  /** Assembled comment tree. */
+  tree: SharedReportCommentNode[];
+  /** Identity helpers (display name, advisor flag, switch action). */
+  identity: ReturnType<typeof useCommenterIdentity>;
+  /** True while the post mutation is in flight. */
+  isPosting: boolean;
+  /** Latest mutation error, captured for the composer to surface. */
+  composerError: string | null;
+  /** Imperative composer state, keyed by anchor or "root". */
+  composer:
+    | { mode: "closed" }
+    | { mode: "root"; anchor: CommentAnchor }
+    | { mode: "reply"; parentCommentId: string; parent: SharedReportCommentNode | null };
+  /** Open a root composer for the supplied anchor. */
+  openRootComposer: (anchor: CommentAnchor) => void;
+  /** Open a reply composer for the supplied parent comment. */
+  openReplyComposer: (parentCommentId: string) => void;
+  /** Close any open composer. */
+  closeComposer: () => void;
+  /** Sidebar open / closed state. */
+  sheetOpen: boolean;
+  setSheetOpen: (open: boolean) => void;
+  /** Pin click handler — opens the sheet and scrolls the matching root into view. */
+  activatePin: (targetKey: string) => void;
+  /** Lookup table for pin badges + orphan rendering. */
+  counts: CountsByTarget;
+  /** Floating "Comment" affordance state derived from text selection. */
+  selectionAffordance: SelectionAffordance | null;
+  /** Dismiss the floating "Comment" affordance (e.g. after the user clicks it). */
+  dismissSelectionAffordance: () => void;
+  /** Submit handler called by CommentComposer. Wraps the mutation. */
+  submitComposer: (
+    body: string,
+    extraIdentity?: { displayName?: string; email?: string }
+  ) => Promise<void>;
+  /** Identity dialog mode (null = closed, "post" = capture before retry, "edit-name" = edit-only). */
+  identityModalMode: "post" | "edit-name" | null;
+  setIdentityModalMode: (mode: "post" | "edit-name" | null) => void;
+  /** When the identity dialog resolves we replay the pending post with the new values. */
+  retryPendingPost: (values: { displayName: string; email: string }) => Promise<void>;
+  /** Imperative scroll target — a ref set when a pin is activated. */
+  scrollTargetCommentId: string | null;
+  /** Clears the scroll target after the consumer has used it. */
+  clearScrollTarget: () => void;
+  /** Refresh key for the highlight resolver — bumps on each successful poll. */
+  highlightRefreshKey: number;
+}
+
+const SELECTION_DEBOUNCE_MS = 80;
+
+/**
+ * Orchestration hook for the donor-shared report comment surface. Owns
+ * the composer state machine, the floating-affordance state derived
+ * from text selection inside anchorable regions, the identity dialog
+ * gating, and the bridge to the React Query polling layer.
+ *
+ * Why this lives in `shared-view/` rather than `hooks/`: it composes
+ * `useSharedReportComments` + `useCommenterIdentity` and is only
+ * meaningful inside the donor-share UI tree. Hoisting it would tempt
+ * other surfaces to depend on the FE proxy and the shared-report
+ * cookie scope, neither of which apply elsewhere.
+ */
+export function useCommenting(
+  token: string,
+  opts: { enabled?: boolean; isAdvisor?: boolean } = {}
+): UseCommentingResult {
+  const enabled = opts.enabled !== false;
+  const isAdvisor = opts.isAdvisor ?? false;
+
+  const { query, tree, postComment } = useSharedReportComments(token, { enabled });
+  const identity = useCommenterIdentity(token, isAdvisor);
+
+  const [composer, setComposer] = useState<UseCommentingResult["composer"]>({
+    mode: "closed",
+  });
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [composerError, setComposerError] = useState<string | null>(null);
+  const [identityModalMode, setIdentityModalMode] = useState<"post" | "edit-name" | null>(null);
+  const [pendingPost, setPendingPost] = useState<CreateCommentRequest | null>(null);
+  const [scrollTargetCommentId, setScrollTargetCommentId] = useState<string | null>(null);
+  const [selectionAffordance, setSelectionAffordance] = useState<SelectionAffordance | null>(null);
+  const [highlightRefreshKey, setHighlightRefreshKey] = useState(0);
+
+  // Bump the highlight refresh key whenever a new payload lands so the
+  // resolver re-runs against the freshly rendered DOM.
+  useEffect(() => {
+    if (query.data) setHighlightRefreshKey((n) => n + 1);
+  }, [query.data]);
+
+  const counts = useMemo<CountsByTarget>(() => {
+    const byKey = new Map<string, number>();
+    const rootsByKey = new Map<string, SharedReportCommentNode[]>();
+    const orphans: SharedReportCommentNode[] = [];
+    if (typeof document === "undefined") {
+      return { byKey, rootsByKey, orphanRoots: orphans };
+    }
+    const root = document.querySelector("[data-brief]");
+    for (const node of tree) {
+      if (!node.anchor) {
+        orphans.push(node);
+        continue;
+      }
+      const key = targetKeyOf(node.anchor);
+      if (!key) continue;
+      // Treat unresolved text-range anchors as orphaned.
+      if (root && node.anchor.kind === "text_range") {
+        const resolved = resolveAnchor(node.anchor, root);
+        if (resolved.kind === "orphan") {
+          orphans.push(node);
+          continue;
+        }
+      }
+      const count = totalDescendants(node);
+      byKey.set(key, (byKey.get(key) ?? 0) + count);
+      const bucket = rootsByKey.get(key) ?? [];
+      bucket.push(node);
+      rootsByKey.set(key, bucket);
+    }
+    return { byKey, rootsByKey, orphanRoots: orphans };
+  }, [tree, highlightRefreshKey]);
+
+  // Text-selection listener — fires the floating Comment affordance
+  // when the user releases a non-empty selection inside an anchorable
+  // ancestor. Debounced so dragging doesn't thrash state.
+  const selectionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const handleSelection = () => {
+      if (selectionTimer.current) clearTimeout(selectionTimer.current);
+      selectionTimer.current = setTimeout(() => {
+        const sel = window.getSelection();
+        if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+          setSelectionAffordance(null);
+          return;
+        }
+        const anchor = captureTextRangeAnchor(sel);
+        if (!anchor) {
+          setSelectionAffordance(null);
+          return;
+        }
+        const range = sel.getRangeAt(0);
+        const rects = range.getClientRects();
+        const last = rects[rects.length - 1];
+        if (!last) {
+          setSelectionAffordance(null);
+          return;
+        }
+        setSelectionAffordance({
+          anchor,
+          position: {
+            top: last.bottom + window.scrollY + 4,
+            left: last.right + window.scrollX - 16,
+          },
+        });
+      }, SELECTION_DEBOUNCE_MS);
+    };
+
+    document.addEventListener("selectionchange", handleSelection);
+    document.addEventListener("mouseup", handleSelection);
+    document.addEventListener("touchend", handleSelection);
+    return () => {
+      if (selectionTimer.current) clearTimeout(selectionTimer.current);
+      document.removeEventListener("selectionchange", handleSelection);
+      document.removeEventListener("mouseup", handleSelection);
+      document.removeEventListener("touchend", handleSelection);
+    };
+  }, []);
+
+  const dismissSelectionAffordance = useCallback(() => {
+    setSelectionAffordance(null);
+    const sel = typeof window !== "undefined" ? window.getSelection() : null;
+    sel?.removeAllRanges();
+  }, []);
+
+  const openRootComposer = useCallback((anchor: CommentAnchor) => {
+    setComposerError(null);
+    setComposer({ mode: "root", anchor });
+    setSheetOpen(true);
+  }, []);
+
+  const openReplyComposer = useCallback(
+    (parentCommentId: string) => {
+      setComposerError(null);
+      const findNode = (nodes: SharedReportCommentNode[]): SharedReportCommentNode | null => {
+        for (const n of nodes) {
+          if (n.id === parentCommentId) return n;
+          const inChildren = findNode(n.children);
+          if (inChildren) return inChildren;
+        }
+        return null;
+      };
+      setComposer({
+        mode: "reply",
+        parentCommentId,
+        parent: findNode(tree),
+      });
+      setSheetOpen(true);
+    },
+    [tree]
+  );
+
+  const closeComposer = useCallback(() => {
+    setComposer({ mode: "closed" });
+    setComposerError(null);
+  }, []);
+
+  const activatePin = useCallback(
+    (targetKey: string) => {
+      const roots = counts.rootsByKey.get(targetKey) ?? [];
+      const first = roots[0];
+      setSheetOpen(true);
+      if (first) setScrollTargetCommentId(first.id);
+    },
+    [counts.rootsByKey]
+  );
+
+  const clearScrollTarget = useCallback(() => {
+    setScrollTargetCommentId(null);
+  }, []);
+
+  const performPost = useCallback(
+    async (request: CreateCommentRequest) => {
+      setComposerError(null);
+      try {
+        await postComment.mutateAsync({ request, idempotencyKey: uuidv4() });
+        setComposer({ mode: "closed" });
+        setSelectionAffordance(null);
+      } catch (err) {
+        if (err instanceof IdentityRequiredError) {
+          setPendingPost(request);
+          setIdentityModalMode("post");
+          return;
+        }
+        if (err instanceof RateLimitedError) {
+          setComposerError(`Slow down — try again in ${err.retryAfter}s.`);
+          return;
+        }
+        if (err instanceof IdempotencyCollisionError) {
+          setComposerError("That submission was already received — try again.");
+          return;
+        }
+        setComposerError("Something went wrong. Try again.");
+      }
+    },
+    [postComment]
+  );
+
+  const submitComposer = useCallback(
+    async (body: string, extraIdentity?: { displayName?: string; email?: string }) => {
+      if (composer.mode === "closed") return;
+      const baseDisplayName = extraIdentity?.displayName ?? identity.displayName ?? "";
+      const request: CreateCommentRequest =
+        composer.mode === "reply"
+          ? {
+              body,
+              displayName: baseDisplayName,
+              parentCommentId: composer.parentCommentId,
+              ...(extraIdentity?.email ? { email: extraIdentity.email } : {}),
+            }
+          : {
+              body,
+              displayName: baseDisplayName,
+              anchor: composer.anchor,
+              ...(extraIdentity?.email ? { email: extraIdentity.email } : {}),
+            };
+      await performPost(request);
+    },
+    [composer, identity.displayName, performPost]
+  );
+
+  const retryPendingPost = useCallback(
+    async (values: { displayName: string; email: string }) => {
+      if (!pendingPost) {
+        setIdentityModalMode(null);
+        return;
+      }
+      const enriched: CreateCommentRequest = {
+        ...pendingPost,
+        displayName: values.displayName,
+        email: values.email,
+      };
+      await performPost(enriched);
+      identity.refresh();
+      setIdentityModalMode(null);
+      setPendingPost(null);
+    },
+    [identity, pendingPost, performPost]
+  );
+
+  return {
+    query,
+    tree,
+    identity,
+    isPosting: postComment.isPending,
+    composerError,
+    composer,
+    openRootComposer,
+    openReplyComposer,
+    closeComposer,
+    sheetOpen,
+    setSheetOpen,
+    activatePin,
+    counts,
+    selectionAffordance,
+    dismissSelectionAffordance,
+    submitComposer,
+    identityModalMode,
+    setIdentityModalMode,
+    retryPendingPost,
+    scrollTargetCommentId,
+    clearScrollTarget,
+    highlightRefreshKey,
+  };
+}
+
+export { targetKeyOf };

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -59,10 +59,16 @@ export interface UseCommentingResult {
   /** Imperative composer state, keyed by anchor or "root". */
   composer:
     | { mode: "closed" }
-    | { mode: "root"; anchor: CommentAnchor }
+    | { mode: "root"; anchor: CommentAnchor; general?: boolean }
     | { mode: "reply"; parentCommentId: string; parent: SharedReportCommentNode | null };
   /** Open a root composer for the supplied anchor. */
   openRootComposer: (anchor: CommentAnchor) => void;
+  /**
+   * Open a composer for a general (whole-report) comment. The backend
+   * requires a non-null anchor, so this anchors to the report masthead
+   * under the hood while presenting as a general comment in the UI.
+   */
+  openGeneralComposer: () => void;
   /** Open a reply composer for the supplied parent comment. */
   openReplyComposer: (parentCommentId: string) => void;
   /** Close any open composer. */
@@ -109,6 +115,14 @@ export interface UseCommentingResult {
 }
 
 const SELECTION_DEBOUNCE_MS = 80;
+
+/**
+ * Anchor used for general (whole-report) comments. The backend rejects
+ * root comments with a null anchor (422), so a general comment is
+ * anchored to the always-present masthead section while the composer
+ * presents it as a whole-report comment.
+ */
+const GENERAL_COMMENT_ANCHOR: CommentAnchor = { kind: "section", sectionKey: "masthead" };
 
 /**
  * Orchestration hook for the donor-shared report comment surface. Owns
@@ -247,6 +261,12 @@ export function useCommenting(
     setSheetOpen(true);
   }, []);
 
+  const openGeneralComposer = useCallback(() => {
+    setComposerError(null);
+    setComposer({ mode: "root", anchor: GENERAL_COMMENT_ANCHOR, general: true });
+    setSheetOpen(true);
+  }, []);
+
   const openReplyComposer = useCallback(
     (parentCommentId: string) => {
       setComposerError(null);
@@ -330,8 +350,12 @@ export function useCommenting(
 
   const submitComposer = useCallback(
     async (body: string, extraIdentity?: { displayName?: string; email?: string }) => {
-      if (composer.mode === "closed") return;
       const baseDisplayName = extraIdentity?.displayName ?? identity.displayName ?? "";
+      // The composer is always mounted at the bottom of the sheet; when
+      // no specific composer is open it defaults to a general
+      // (whole-report) comment anchored to the masthead so the backend's
+      // non-null-anchor rule is satisfied.
+      const rootAnchor = composer.mode === "root" ? composer.anchor : GENERAL_COMMENT_ANCHOR;
       const request: CreateCommentRequest =
         composer.mode === "reply"
           ? {
@@ -343,7 +367,7 @@ export function useCommenting(
           : {
               body,
               displayName: baseDisplayName,
-              anchor: composer.anchor,
+              anchor: rootAnchor,
               ...(extraIdentity?.email ? { email: extraIdentity.email } : {}),
             };
       // Gate the post on identity for anonymous (not-Privy-authed)
@@ -406,6 +430,7 @@ export function useCommenting(
     composerError,
     composer,
     openRootComposer,
+    openGeneralComposer,
     openReplyComposer,
     closeComposer,
     sheetOpen,

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -54,6 +54,8 @@ export interface UseCommentingResult {
   identity: ReturnType<typeof useCommenterIdentity>;
   /** True while the post mutation is in flight. */
   isPosting: boolean;
+  /** Re-post a comment whose optimistic POST failed. */
+  retryFailed: (commentId: string) => void;
   /** Latest mutation error, captured for the composer to surface. */
   composerError: string | null;
   /** Imperative composer state, keyed by anchor or "root". */
@@ -148,7 +150,7 @@ export function useCommenting(
   const enabled = opts.enabled !== false;
   const isAdvisor = opts.isAdvisor ?? false;
 
-  const { query, tree, postComment } = useSharedReportComments(token, { enabled });
+  const { query, tree, postComment, retryFailed } = useSharedReportComments(token, { enabled });
   const identity = useCommenterIdentity(token, isAdvisor);
 
   const [composer, setComposer] = useState<UseCommentingResult["composer"]>({
@@ -427,6 +429,7 @@ export function useCommenting(
     tree,
     identity,
     isPosting: postComment.isPending,
+    retryFailed,
     composerError,
     composer,
     openRootComposer,

--- a/src/features/donor-research/components/shared-view/useCommenting.ts
+++ b/src/features/donor-research/components/shared-view/useCommenting.ts
@@ -314,9 +314,20 @@ export function useCommenting(
               anchor: composer.anchor,
               ...(extraIdentity?.email ? { email: extraIdentity.email } : {}),
             };
+      // Gate the post on identity. Without a captured name (and not an
+      // advisor), the BE's schema validation rejects with a generic 400
+      // *before* the controller can return `requiresIdentity: true` —
+      // which used to surface as "Something went wrong" in the composer.
+      // Open the IdentityCaptureDialog first and stash the request so
+      // `retryPendingPost` can replay it with the captured values.
+      if (!extraIdentity && !identity.isAdvisor && !baseDisplayName) {
+        setPendingPost(request);
+        setIdentityModalMode("post");
+        return;
+      }
       await performPost(request);
     },
-    [composer, identity.displayName, performPost]
+    [composer, identity.displayName, identity.isAdvisor, performPost]
   );
 
   const retryPendingPost = useCallback(

--- a/types/donor-research-comments.ts
+++ b/types/donor-research-comments.ts
@@ -20,7 +20,10 @@ export interface SharedReportCommentsResponse {
 /** Tree node used by the FE renderer — built client-side from flat lists. */
 export interface SharedReportCommentNode extends SharedReportComment {
   children: SharedReportCommentNode[];
+  /** True while the optimistic POST is in flight (renders a "Sending…" state). */
   _optimistic?: boolean;
+  /** True when the optimistic POST failed — the row stays visible in a failed state. */
+  _failed?: boolean;
 }
 
 export interface CreateCommentRequest {

--- a/types/donor-research-comments.ts
+++ b/types/donor-research-comments.ts
@@ -1,0 +1,59 @@
+import type { CommentAnchor } from "@/src/features/donor-research/components/anchor/types";
+
+/** Public projection — mirrors the backend's read response shape. */
+export interface SharedReportComment {
+  id: string;
+  parentCommentId: string | null;
+  isAdvisor: boolean;
+  displayName: string;
+  anchor: CommentAnchor | null;
+  body: string;
+  createdAt: string;
+}
+
+export interface SharedReportCommentsResponse {
+  roots: SharedReportComment[];
+  replies: SharedReportComment[];
+  pageInfo: { nextCursor: string | null };
+}
+
+/** Tree node used by the FE renderer — built client-side from flat lists. */
+export interface SharedReportCommentNode extends SharedReportComment {
+  children: SharedReportCommentNode[];
+  _optimistic?: boolean;
+}
+
+export interface CreateCommentRequest {
+  parentCommentId?: string;
+  anchor?: CommentAnchor;
+  body: string;
+  displayName: string;
+  email?: string;
+}
+
+export interface CreateCommentErrorBody {
+  error?: string;
+  requiresIdentity?: boolean;
+  retryAfter?: number;
+}
+
+export class IdentityRequiredError extends Error {
+  constructor() {
+    super("Identity capture required");
+    this.name = "IdentityRequiredError";
+  }
+}
+
+export class RateLimitedError extends Error {
+  constructor(public readonly retryAfter: number) {
+    super("Rate limited");
+    this.name = "RateLimitedError";
+  }
+}
+
+export class IdempotencyCollisionError extends Error {
+  constructor() {
+    super("Idempotency key collision — regenerate and retry");
+    this.name = "IdempotencyCollisionError";
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,18 @@ import { defineConfig } from "vitest/config";
 const dirname =
   typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
+// The Storybook browser-test project is opt-in (set VITEST_STORYBOOK=true).
+// It is never invoked by CI or any package script — everything runs
+// `vitest --project unit` — yet defining it unconditionally makes vitest
+// evaluate `storybookTest()` on every run, which loads `.storybook/main.ts`
+// and resolves its `@storybook/nextjs` webpack5 builder. That builder isn't
+// installed (addon-vitest expects a Vite framework), so the preset load
+// throws ERR_MODULE_NOT_FOUND. It's a no-op warning on most runs but can be
+// fatal on a constrained CI worker, failing the unit shard that happened to
+// load it first. Gating the project off by default removes that coupling
+// without touching the unit suite or the Storybook dev/build commands.
+const ENABLE_STORYBOOK_PROJECT = process.env.VITEST_STORYBOOK === "true";
+
 // Shared tsconfig path aliases (mirrors tsconfig.json "paths")
 const tsconfigAliases = [
   { find: /^@\/features\/(.*)$/, replacement: `${dirname}/src/features/$1` },
@@ -92,21 +104,25 @@ export default defineConfig({
           ],
         },
       },
-      // Storybook test project
-      {
-        extends: true,
-        plugins: [storybookTest({ configDir: path.join(dirname, ".storybook") })],
-        test: {
-          name: "storybook",
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: playwright({}),
-            instances: [{ browser: "chromium" }],
-          },
-          setupFiles: [".storybook/vitest.setup.ts"],
-        },
-      },
+      // Storybook test project (opt-in via VITEST_STORYBOOK=true — see note above)
+      ...(ENABLE_STORYBOOK_PROJECT
+        ? [
+            {
+              extends: true as const,
+              plugins: [storybookTest({ configDir: path.join(dirname, ".storybook") })],
+              test: {
+                name: "storybook",
+                browser: {
+                  enabled: true,
+                  headless: true,
+                  provider: playwright({}),
+                  instances: [{ browser: "chromium" }],
+                },
+                setupFiles: [".storybook/vitest.setup.ts"],
+              },
+            },
+          ]
+        : []),
     ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -116,7 +116,12 @@ export default defineConfig({
                   enabled: true,
                   headless: true,
                   provider: playwright({}),
-                  instances: [{ browser: "chromium" }],
+                  // `as const` keeps the literal type — inside the conditional
+                  // spread below the contextual narrowing from defineConfig is
+                  // lost, so without this "chromium" widens to `string` and no
+                  // longer satisfies BrowserInstanceOption (breaks `next build`
+                  // type-checking, which Vercel enforces).
+                  instances: [{ browser: "chromium" as const }],
                 },
                 setupFiles: [".storybook/vitest.setup.ts"],
               },


### PR DESCRIPTION
## Summary

Frontend half of donor-shared report commenting per [`docs/plans/2026-06-17-001-feat-shared-report-commenting-plan.md`](../super-gap/blob/main/docs/plans/2026-06-17-001-feat-shared-report-commenting-plan.md) (U8–U11 + KTD9/11/13/14). Recipients of a share link can select text or click a section/card pin to attach a comment, thread arbitrary-depth replies, see live polling, and a Privy-authenticated advisor gets the "Advisor" badge automatically.

**Pairs with backend PR show-karma/gap-indexer#2096** — frontend posts go through the FE-origin Next.js proxy (`app/api/donor-research/shared/[token]/comments`) to the indexer.

## What ships

**Anchor surface (U8)**
- Stable `data-section` / `data-candidate-id` attributes on every `ReportBrief` subcomponent.
- `captureTextRangeAnchor` walks the live selection up to the closest anchor target, captures `(quote, prefix, suffix, targetKind, targetId)` with whitespace normalization.
- `resolveAnchor` re-finds the highlight at render time; orphans (quote no longer in DOM) surface as `{ kind: "orphan" }` so the overlay can route them to the orphan lane.

**Data layer (U9 — KTD13 proxy posture)**
- Next.js API-route proxy on the FE origin (`/api/donor-research/shared/[token]/comments`) forwards to the indexer server-to-server and translates cookies between origins. Donor's IP forwarded via `x-forwarded-for`; `drsc_session` carried as `x-drsc-session` server-only header; `Set-Cookie` from the indexer re-scoped to `Path=/api/donor-research/shared/` with `HttpOnly` preserved on `drsc_session` and not on `drsc_name`.
- React Query polling hook (30s, paused on background/revoke) + optimistic-append mutation + tree assembly.
- Companion `clear-identity` proxy route for the IdentityBadge "Not me — switch" affordance (Q2).

**Identity capture (U10)**
- shadcn Dialog with React Hook Form + Zod. Display name (≤80) + email (≤254). `nameOnly` mode hides the email field AND swaps to a schema variant that doesn't require it (regression fix uncovered by tests).
- `IdentityBadge` shows "Commenting as X" with edit + switch affordances.

**UI shell (U11 — KTD11/14)**
- `CommentOverlay` Sheet with all root threads + nested replies (indent caps at depth 4; deeper replies collapse behind "Show N more replies"), pin badges anchored per target via `AnchoredAffordances`, text-range highlights via `CommentHighlight`, orphan lane preserving the original quote.
- Floating "Comment" affordance triggered by text selection inside any `data-section` / `data-candidate-id` ancestor.
- "+" affordance per anchored target opens a root composer pre-loaded with the section/candidate anchor.
- aria-live region emits "Comment added by X" / "Reply added by X" on new arrivals (DL-007).
- Pin click opens the sheet + smooth-scrolls to the matching root.
- Advisor identity via `useDonorAdvisor` — Privy-authenticated viewer whose advisor row matches the report's `advisorId` gets `isAdvisor=true` propagated through, skipping the identity modal and surfacing the badge.

## Test plan

- [x] `pnpm lint:fix` clean. New tests pass: anchor `capture` + `resolve`, `useSharedReportComments`, `useCommenterIdentity`, proxy route, `IdentityCaptureDialog`, `CommentRow`, `CommentComposer`, `CommentPin`, `CommentHighlight`, `CommentOverlay`.
- [ ] Manual smoke against staging once the indexer PR lands:
  - [ ] Load a shared link, select text in a candidate paragraph → floating Comment button appears → submit → highlight + pin render → comment shows in sidebar.
  - [ ] Refresh → comment persists with pin in the same place; text-range rehydrates as a highlight.
  - [ ] Open a second browser → comment shows up within the next 30s poll.
  - [ ] Reply to a comment → threaded child renders; depth ≥ 4 collapses behind "Show N more replies".
  - [ ] Log in as the report advisor → composer skips the identity modal; new comment shows the "Advisor" badge.
  - [ ] Revoke the share token → overlay hides + "report not available" copy renders.

## Out of scope / deferred

- Testcontainer-backed end-to-end smoke (the existing route-layer integration test on the indexer side covers wiring).
- Commenting on the authenticated advisor report view (only the shared view ships commenting in v1 per plan Scope Boundaries).
- Editing email in the IdentityBadge (display-name only in v1 per U10).

## Companion PR

Backend (gap-indexer): show-karma/gap-indexer#2096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared donor-research commenting with section/candidate + quote anchoring, threaded replies, pin controls, selection-based entry, quote highlighting, and periodic refresh.
  - Introduced identity capture (display name/email, name-only mode), identity badge, and a clear-identity flow; onboarding now collects an email address.
  - Added/expanded the shared comments API proxy with improved forwarding and client-facing error handling.

- **Updates / Configuration**
  - Enabled optional disabling for advisor data fetching.
  - Improved test and smoke-test reliability (workflow/e2e/vitest).

- **Tests**
  - Added comprehensive coverage for proxy behavior, anchoring/highlights, composer/overlay/row interactions, optimistic/retry flows, and identity behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->