### PR TITLE
feat(funding-platform): AI Insights admin field for program settings (DEV-409)

### DIFF
--- a/__tests__/components/QuestionBuilder/ProgramAIInsightsConfiguration.test.tsx
+++ b/__tests__/components/QuestionBuilder/ProgramAIInsightsConfiguration.test.tsx
@@ -56,7 +56,10 @@ describe("ProgramAIInsightsConfiguration", () => {
     await user.click(screen.getByRole("button", { name: /save ai insights/i }));
 
     await waitFor(() =>
-      expect(mockUpdateConfig).toHaveBeenCalledWith({ aiInsights: "Disclose Batch 1 caveat" })
+      expect(mockUpdateConfig).toHaveBeenCalledWith(
+        { aiInsights: "Disclose Batch 1 caveat" },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
     );
   });
 
@@ -70,7 +73,27 @@ describe("ProgramAIInsightsConfiguration", () => {
     await user.clear(textarea);
     await user.click(screen.getByRole("button", { name: /save ai insights/i }));
 
-    await waitFor(() => expect(mockUpdateConfig).toHaveBeenCalledWith({ aiInsights: null }));
+    await waitFor(() =>
+      expect(mockUpdateConfig).toHaveBeenCalledWith(
+        { aiInsights: null },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+    );
+  });
+
+  it("should_keep_form_editable_when_save_fails", async () => {
+    const user = userEvent.setup();
+    // updateConfig never invokes its onSuccess callback → simulates a failed
+    // save. The form must stay dirty so the admin can retry.
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    const textarea = screen.getByLabelText("Guidance for the AI assistant");
+    await user.type(textarea, "Retryable note");
+    const saveButton = screen.getByRole("button", { name: /save ai insights/i });
+    await user.click(saveButton);
+
+    expect(saveButton).toBeEnabled();
+    expect((textarea as HTMLTextAreaElement).value).toBe("Retryable note");
   });
 
   it("should_render_skeleton_while_loading", () => {

--- a/__tests__/components/QuestionBuilder/ProgramAIInsightsConfiguration.test.tsx
+++ b/__tests__/components/QuestionBuilder/ProgramAIInsightsConfiguration.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProgramAIInsightsConfiguration } from "@/components/QuestionBuilder/ProgramAIInsightsConfiguration";
+
+const { mockUseProgramConfig } = vi.hoisted(() => ({
+  mockUseProgramConfig: vi.fn(),
+}));
+
+vi.mock("@/hooks/useFundingPlatform", () => ({
+  useProgramConfig: mockUseProgramConfig,
+}));
+
+interface ConfigReturnOverrides {
+  aiInsights?: string | null;
+  isLoading?: boolean;
+  error?: unknown;
+  isUpdating?: boolean;
+}
+
+const mockUpdateConfig = vi.fn();
+const mockRefetch = vi.fn();
+
+function setConfigReturn(overrides: ConfigReturnOverrides = {}) {
+  const { aiInsights = "", isLoading = false, error = null, isUpdating = false } = overrides;
+  mockUseProgramConfig.mockReturnValue({
+    config: { aiInsights },
+    isLoading,
+    error,
+    updateConfig: mockUpdateConfig,
+    isUpdating,
+    refetch: mockRefetch,
+  });
+}
+
+describe("ProgramAIInsightsConfiguration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setConfigReturn();
+  });
+
+  it("should_prefill_textarea_with_saved_aiInsights", async () => {
+    setConfigReturn({ aiInsights: "Batch 1 data was imported retrospectively." });
+
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    const textarea = screen.getByLabelText("Guidance for the AI assistant") as HTMLTextAreaElement;
+    await waitFor(() => expect(textarea.value).toBe("Batch 1 data was imported retrospectively."));
+  });
+
+  it("should_save_trimmed_value_via_updateConfig", async () => {
+    const user = userEvent.setup();
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    const textarea = screen.getByLabelText("Guidance for the AI assistant");
+    await user.type(textarea, "  Disclose Batch 1 caveat  ");
+    await user.click(screen.getByRole("button", { name: /save ai insights/i }));
+
+    await waitFor(() =>
+      expect(mockUpdateConfig).toHaveBeenCalledWith({ aiInsights: "Disclose Batch 1 caveat" })
+    );
+  });
+
+  it("should_send_null_when_cleared_to_remove_guidance", async () => {
+    const user = userEvent.setup();
+    setConfigReturn({ aiInsights: "Existing note" });
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    const textarea = screen.getByLabelText("Guidance for the AI assistant");
+    await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe("Existing note"));
+    await user.clear(textarea);
+    await user.click(screen.getByRole("button", { name: /save ai insights/i }));
+
+    await waitFor(() => expect(mockUpdateConfig).toHaveBeenCalledWith({ aiInsights: null }));
+  });
+
+  it("should_render_skeleton_while_loading", () => {
+    setConfigReturn({ isLoading: true });
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    expect(screen.queryByLabelText("Guidance for the AI assistant")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save ai insights/i })).not.toBeInTheDocument();
+  });
+
+  it("should_render_retry_on_error_and_call_refetch", async () => {
+    const user = userEvent.setup();
+    setConfigReturn({ error: new Error("boom") });
+    render(<ProgramAIInsightsConfiguration programId="785" />);
+
+    const retry = screen.getByRole("button", { name: /try again/i });
+    await user.click(retry);
+
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("should_hide_save_button_in_readOnly_mode", () => {
+    setConfigReturn({ aiInsights: "Note" });
+    render(<ProgramAIInsightsConfiguration programId="785" readOnly />);
+
+    expect(screen.queryByRole("button", { name: /save ai insights/i })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Guidance for the AI assistant")).toBeDisabled();
+  });
+});

--- a/components/QuestionBuilder/AIPromptConfiguration.tsx
+++ b/components/QuestionBuilder/AIPromptConfiguration.tsx
@@ -12,6 +12,7 @@ import type { FormSchema } from "@/types/question-builder";
 import { TabContent } from "../Utilities/Tabs/TabContent";
 import { Tabs } from "../Utilities/Tabs/Tabs";
 import { TabTrigger } from "../Utilities/Tabs/TabTrigger";
+import { ProgramAIInsightsConfiguration } from "./ProgramAIInsightsConfiguration";
 
 const DEFAULT_AI_MODEL = "gpt-4o";
 
@@ -315,6 +316,8 @@ export function AIPromptConfiguration({
           )}
         </div>
       </div>
+
+      {programId && <ProgramAIInsightsConfiguration programId={programId} readOnly={readOnly} />}
     </div>
   );
 }

--- a/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
+++ b/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { SparklesIcon } from "@heroicons/react/24/outline";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { useProgramConfig } from "@/hooks/useFundingPlatform";
+import { zodResolver } from "@/utilities/zodResolver";
+import { PageHeader } from "../FundingPlatform/PageHeader";
+import { Button } from "../Utilities/Button";
+
+const MAX_AI_INSIGHTS_LENGTH = 2000;
+
+const aiInsightsSchema = z.object({
+  aiInsights: z
+    .string()
+    .max(MAX_AI_INSIGHTS_LENGTH, `Keep guidance under ${MAX_AI_INSIGHTS_LENGTH} characters`),
+});
+
+type AIInsightsFormData = z.infer<typeof aiInsightsSchema>;
+
+interface ProgramAIInsightsConfigurationProps {
+  programId: string;
+  readOnly?: boolean;
+}
+
+export function ProgramAIInsightsConfiguration({
+  programId,
+  readOnly = false,
+}: ProgramAIInsightsConfigurationProps) {
+  const { config, isLoading, error, updateConfig, isUpdating, refetch } =
+    useProgramConfig(programId);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<AIInsightsFormData>({
+    resolver: zodResolver(aiInsightsSchema),
+    defaultValues: { aiInsights: "" },
+  });
+
+  // Seed the form once the saved value loads (and re-seed after a save
+  // refetches it), so the textarea reflects what is persisted.
+  useEffect(() => {
+    reset({ aiInsights: config?.aiInsights ?? "" });
+  }, [config?.aiInsights, reset]);
+
+  const currentLength = (watch("aiInsights") ?? "").length;
+
+  const onSubmit = (data: AIInsightsFormData) => {
+    if (readOnly) return;
+
+    const trimmed = data.aiInsights.trim();
+    // Empty clears the field server-side (null), rather than storing "".
+    updateConfig({ aiInsights: trimmed.length > 0 ? trimmed : null });
+    reset({ aiInsights: trimmed });
+  };
+
+  const header = (
+    <PageHeader
+      title="AI Insights"
+      description="Guidance for the Karma AI assistant when it answers questions about this program. Use it to flag data-quality caveats — e.g. a funding round whose records were imported after the fact, so processing-time metrics may be unreliable. The assistant discloses this alongside the affected numbers."
+      icon={SparklesIcon}
+    />
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        {header}
+        <div className="bg-white dark:bg-zinc-800 rounded-lg border border-gray-200 dark:border-zinc-700 p-6">
+          <div className="h-32 w-full animate-pulse rounded-md bg-gray-100 dark:bg-zinc-700" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        {header}
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+          <p className="text-sm text-red-700 dark:text-red-400 mb-3">
+            Unable to load this program&apos;s AI insights.
+          </p>
+          <Button onClick={() => refetch()} className="bg-red-600 hover:bg-red-700 text-sm">
+            Try again
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {header}
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="bg-white dark:bg-zinc-800 rounded-lg border border-gray-200 dark:border-zinc-700 p-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="aiInsights"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Guidance for the AI assistant
+            </label>
+            <textarea
+              {...register("aiInsights")}
+              id="aiInsights"
+              rows={5}
+              disabled={readOnly}
+              maxLength={MAX_AI_INSIGHTS_LENGTH}
+              placeholder="e.g. Batch 1 records were imported retrospectively rather than captured live, so milestone and payout processing-time metrics may not be reliable for that round."
+              aria-invalid={!!errors.aiInsights}
+              aria-describedby={errors.aiInsights ? "aiInsights-error" : undefined}
+              className={`w-full px-3 py-2 border rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 dark:bg-zinc-700 dark:text-white ${
+                errors.aiInsights
+                  ? "border-red-500 dark:border-red-500 focus:ring-red-500 focus:border-red-500"
+                  : "border-gray-300 dark:border-zinc-600"
+              } ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+            />
+            <div className="flex items-center justify-between">
+              {errors.aiInsights ? (
+                <p
+                  id="aiInsights-error"
+                  className="text-sm text-red-500 dark:text-red-400"
+                  role="alert"
+                >
+                  {errors.aiInsights.message}
+                </p>
+              ) : (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Leave empty if there is nothing the assistant should disclose.
+                </p>
+              )}
+              <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                {currentLength}/{MAX_AI_INSIGHTS_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          {!readOnly && (
+            <div className="flex justify-end pt-4 mt-4 border-t border-gray-200 dark:border-zinc-700">
+              <Button
+                type="submit"
+                disabled={!isDirty || isUpdating}
+                className="bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isUpdating ? "Saving..." : "Save AI Insights"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
+++ b/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
@@ -113,7 +113,7 @@ export function ProgramAIInsightsConfiguration({
               rows={5}
               disabled={readOnly}
               maxLength={MAX_AI_INSIGHTS_LENGTH}
-              placeholder="e.g. Batch 1 records were imported retrospectively rather than captured live, so milestone and payout processing-time metrics may not be reliable for that round."
+              placeholder="e.g. Some of this program's records were entered in bulk after the fact, so timing-based metrics may be less reliable — mention this when reporting them."
               aria-invalid={!!errors.aiInsights}
               aria-describedby={errors.aiInsights ? "aiInsights-error" : undefined}
               className={`w-full px-3 py-2 border rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 dark:bg-zinc-700 dark:text-white ${

--- a/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
+++ b/components/QuestionBuilder/ProgramAIInsightsConfiguration.tsx
@@ -55,8 +55,13 @@ export function ProgramAIInsightsConfiguration({
 
     const trimmed = data.aiInsights.trim();
     // Empty clears the field server-side (null), rather than storing "".
-    updateConfig({ aiInsights: trimmed.length > 0 ? trimmed : null });
-    reset({ aiInsights: trimmed });
+    // Reset (clearing the dirty state) only AFTER a successful save — on
+    // failure the hook surfaces a toast and the form stays dirty so the
+    // admin can retry without re-typing.
+    updateConfig(
+      { aiInsights: trimmed.length > 0 ? trimmed : null },
+      { onSuccess: () => reset({ aiInsights: trimmed }) }
+    );
   };
 
   const header = (

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -51,6 +51,7 @@ import { AIPromptConfiguration } from "./AIPromptConfiguration";
 import { FieldEditor } from "./FieldEditor";
 import { FieldTypeSelector, fieldTypes } from "./FieldTypeSelector";
 import { KycSettingsConfiguration } from "./KycSettingsConfiguration";
+import { ProgramAIInsightsConfiguration } from "./ProgramAIInsightsConfiguration";
 import { SettingsConfiguration } from "./SettingsConfiguration";
 
 const TAB_KEYS = [
@@ -928,6 +929,12 @@ export function QuestionBuilder({
               />
               {/* Save Button at bottom of AI Config tab */}
               {renderSaveButton()}
+              {/* AI Insights — admin steering surfaced to the Karma AI
+                  assistant. Self-contained: saves a top-level config field
+                  via its own mutation, independent of the form-schema save. */}
+              <div className="mt-8 pt-8 border-t border-gray-200 dark:border-gray-700">
+                <ProgramAIInsightsConfiguration programId={programId} readOnly={readOnly} />
+              </div>
             </div>
           </div>
         ) : activeTab === "reviewers" ? (

--- a/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/components/QuestionBuilder/QuestionBuilder.tsx
@@ -51,7 +51,6 @@ import { AIPromptConfiguration } from "./AIPromptConfiguration";
 import { FieldEditor } from "./FieldEditor";
 import { FieldTypeSelector, fieldTypes } from "./FieldTypeSelector";
 import { KycSettingsConfiguration } from "./KycSettingsConfiguration";
-import { ProgramAIInsightsConfiguration } from "./ProgramAIInsightsConfiguration";
 import { SettingsConfiguration } from "./SettingsConfiguration";
 
 const TAB_KEYS = [
@@ -929,12 +928,6 @@ export function QuestionBuilder({
               />
               {/* Save Button at bottom of AI Config tab */}
               {renderSaveButton()}
-              {/* AI Insights — admin steering surfaced to the Karma AI
-                  assistant. Self-contained: saves a top-level config field
-                  via its own mutation, independent of the form-schema save. */}
-              <div className="mt-8 pt-8 border-t border-gray-200 dark:border-gray-700">
-                <ProgramAIInsightsConfiguration programId={programId} readOnly={readOnly} />
-              </div>
             </div>
           </div>
         ) : activeTab === "reviewers" ? (

--- a/types/funding-platform.ts
+++ b/types/funding-platform.ts
@@ -131,6 +131,9 @@ export interface IFundingProgramConfig {
   aiModel?: string;
   enableRealTimeEvaluation?: boolean;
   evaluationConfig?: Record<string, any>;
+  // Admin-authored guidance surfaced to the Karma AI agent for any response
+  // about this program (e.g. a data-quality caveat). null clears it.
+  aiInsights?: string | null;
   isEnabled: boolean;
   createdAt: string | Date;
   updatedAt: string | Date;

--- a/types/whitelabel-entities.ts
+++ b/types/whitelabel-entities.ts
@@ -167,6 +167,9 @@ export interface FundingProgramConfig {
   aiModel?: string;
   enableRealTimeEvaluation?: boolean;
   evaluationConfig?: Record<string, unknown>;
+  // Admin-authored guidance surfaced to the Karma AI agent for any response
+  // about this program (e.g. a data-quality caveat). null clears it.
+  aiInsights?: string | null;
   isEnabled: boolean;
   createdAt?: string | Date;
   updatedAt?: string | Date;


### PR DESCRIPTION
## Overview

Frontend companion to the gap-indexer change [show-karma/gap-indexer#2100](https://github.com/show-karma/gap-indexer/pull/2100) for **DEV-409** (Filecoin). The backend added a per-program `aiInsights` steering field that the Karma AI assistant surfaces when answering questions about a program (e.g. a data-quality caveat for a funding round whose records were imported retrospectively, so processing-time metrics are unreliable). This PR adds the **admin entry point** to set it.

> ⚠️ Depends on gap-indexer#2100 being deployed — the field is a no-op until the backend supports `aiInsights`.

## What changed

- **New `ProgramAIInsightsConfiguration` card** in the program's **AI Configuration** tab (`components/QuestionBuilder`). A labelled textarea (2000-char cap, live counter) + Save button.
- **Self-contained save** — backed by the existing `useProgramConfig(programId)` hook. It saves a **top-level partial config** (`{ aiInsights }`) via its own mutation, independent of the form-schema save. This matters: `aiInsights` lives at the top level of the config (where the agent reads it), **not** inside `formSchema.settings`. An empty textarea sends `null` to clear the value; the backend's conditional merge leaves the rest of the config untouched.
- **Types** — `aiInsights?: string | null` added to `IFundingProgramConfig` (`types/funding-platform.ts`) and `FundingProgramConfig` (`types/whitelabel-entities.ts`).
- **States** — loading skeleton, error + retry, and a read-only mode (reviewers see the value but can't edit/save).

## Testing
- New Vitest + RTL suite (`__tests__/components/QuestionBuilder/ProgramAIInsightsConfiguration.test.tsx`): prefill from saved value, save trimmed value, clear → `null`, loading skeleton, error → retry, read-only hides Save. 6/6 pass.
- `pnpm typecheck` clean, `biome check` clean on changed files, `pnpm build` succeeds.

## Screenshot
_(AI Configuration tab → "AI Insights" section below the prompt/model settings.)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI insights configuration interface allowing administrators to input guidance text (max 2,000 characters) with real-time character count, save/clear operations, and error handling with retry capability. Includes read-only mode support and validation feedback.

* **Tests**
  * Added test suite for AI insights configuration functionality, covering save/clear operations, error states, and read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->