### PR TITLE
feat(onboarding): pre-fill email from logged-in Privy session

### DIFF
--- a/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
+++ b/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
@@ -318,18 +318,21 @@ describe("OnboardingFlow — email pre-fill from session", () => {
   it("does not clobber an email the advisor has already typed", async () => {
     const user = userEvent.setup();
     // Session resolves with no email at first.
-    renderFlow();
+    const { rerender } = renderFlow();
     await advanceToForm(user);
 
     await user.type(screen.getByLabelText(/email/i), "typed@example.com");
 
-    // Session resolves an email afterwards; a re-render must not overwrite it.
+    // Session resolves an email afterwards. Drive the re-render explicitly so
+    // the regression coverage doesn't depend on an incidental re-render from a
+    // later form interaction — the prefill effect must re-run and still leave
+    // the advisor's typed value untouched.
     mockPrivyValue = {
       ready: true,
       authenticated: true,
       user: { email: { address: "session@example.com" } },
     };
-    await user.type(screen.getByLabelText(/display name/i), "Avery");
+    rerender(<OnboardingFlow />);
 
     expect(screen.getByLabelText(/email/i)).toHaveValue("typed@example.com");
   });

--- a/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
+++ b/__tests__/features/donor-research/onboarding/OnboardingFlow.test.tsx
@@ -33,6 +33,19 @@ vi.mock("@/services/donor-research.service", () => ({
   fetchMyCounters: vi.fn(),
 }));
 
+// Controllable Privy bridge so we can simulate a logged-in email/Google
+// session. Defaults to an unresolved session (no pre-fill).
+interface MockPrivyValue {
+  ready: boolean;
+  authenticated: boolean;
+  user: { email?: { address: string }; google?: { email: string } } | null;
+}
+const DEFAULT_PRIVY: MockPrivyValue = { ready: false, authenticated: false, user: null };
+let mockPrivyValue: MockPrivyValue = DEFAULT_PRIVY;
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => mockPrivyValue,
+}));
+
 // SampleReportPreview pulls in unrelated fixture content; keep the wizard
 // test focused on step semantics.
 vi.mock("@/src/features/donor-research/components/onboarding/SampleReportPreview", () => ({
@@ -71,6 +84,7 @@ function getCurrentStepLabel(): string | null {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPrivyValue = DEFAULT_PRIVY;
 });
 
 describe("OnboardingFlow — loading state", () => {
@@ -218,6 +232,106 @@ describe("OnboardingFlow — form submission", () => {
     const alert = await screen.findByText(/boom from server/i);
     expect(alert).toHaveAttribute("role", "alert");
     expect(mockReplace).not.toHaveBeenCalledWith(PAGES.DONOR_RESEARCH.INDEX);
+  });
+});
+
+describe("OnboardingFlow — email pre-fill from session", () => {
+  beforeEach(() => {
+    mockFetchCurrentAdvisor.mockResolvedValue(null);
+  });
+
+  async function advanceToForm(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(await screen.findByRole("button", { name: /continue to sample report/i }));
+    await user.click(await screen.findByRole("button", { name: /continue to setup/i }));
+    await screen.findByRole("heading", { name: /get started/i });
+  }
+
+  it("pre-fills the email from a Privy email login", async () => {
+    mockPrivyValue = {
+      ready: true,
+      authenticated: true,
+      user: { email: { address: "advisor@example.com" } },
+    };
+    const user = userEvent.setup();
+    renderFlow();
+    await advanceToForm(user);
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue("advisor@example.com");
+  });
+
+  it("pre-fills the email from a Google OAuth login", async () => {
+    mockPrivyValue = {
+      ready: true,
+      authenticated: true,
+      user: { google: { email: "advisor@gmail.com" } },
+    };
+    const user = userEvent.setup();
+    renderFlow();
+    await advanceToForm(user);
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue("advisor@gmail.com");
+  });
+
+  it("leaves the email empty when the session has no email (wallet login)", async () => {
+    mockPrivyValue = { ready: true, authenticated: true, user: {} };
+    const user = userEvent.setup();
+    renderFlow();
+    await advanceToForm(user);
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue("");
+  });
+
+  it("leaves the email empty until Privy resolves an authenticated session", async () => {
+    mockPrivyValue = {
+      ready: false,
+      authenticated: false,
+      user: { email: { address: "advisor@example.com" } },
+    };
+    const user = userEvent.setup();
+    renderFlow();
+    await advanceToForm(user);
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue("");
+  });
+
+  it("submits the pre-filled email without the advisor retyping it", async () => {
+    mockOnboardAdvisor.mockResolvedValue(ADVISOR);
+    mockPrivyValue = {
+      ready: true,
+      authenticated: true,
+      user: { email: { address: "advisor@example.com" } },
+    };
+    const user = userEvent.setup();
+    renderFlow();
+    await advanceToForm(user);
+
+    await user.type(screen.getByLabelText(/display name/i), "Avery Boutique");
+    await user.click(screen.getByRole("button", { name: /^continue$/i }));
+
+    await waitFor(() => {
+      expect(mockOnboardAdvisor).toHaveBeenCalledWith(
+        expect.objectContaining({ email: "advisor@example.com" })
+      );
+    });
+  });
+
+  it("does not clobber an email the advisor has already typed", async () => {
+    const user = userEvent.setup();
+    // Session resolves with no email at first.
+    renderFlow();
+    await advanceToForm(user);
+
+    await user.type(screen.getByLabelText(/email/i), "typed@example.com");
+
+    // Session resolves an email afterwards; a re-render must not overwrite it.
+    mockPrivyValue = {
+      ready: true,
+      authenticated: true,
+      user: { email: { address: "session@example.com" } },
+    };
+    await user.type(screen.getByLabelText(/display name/i), "Avery");
+
+    expect(screen.getByLabelText(/email/i)).toHaveValue("typed@example.com");
   });
 });
 

--- a/src/features/donor-research/components/onboarding/OnboardingFlow.tsx
+++ b/src/features/donor-research/components/onboarding/OnboardingFlow.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useId, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { useDonorAdvisor, useOnboardAdvisor } from "@/hooks/useDonorAdvisor";
 import type { WizardStep } from "@/src/components/ui/WizardStepper";
 import { WizardStepper } from "@/src/components/ui/WizardStepper";
@@ -39,6 +40,18 @@ const DEFAULT_TIMEZONE =
   typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "UTC";
 
 /**
+ * Email from the active Privy session, if one is available. A direct email
+ * login exposes `email.address`; a Google OAuth login exposes `google.email`.
+ * Wallet-only logins expose neither, so this returns `undefined` and the
+ * advisor is asked to type one. Mirrors the navbar's `getUserEmail` resolver.
+ */
+function getLoggedInEmail(
+  user: { email?: { address: string }; google?: { email: string } } | null | undefined
+): string | undefined {
+  return user?.email?.address || user?.google?.email || undefined;
+}
+
+/**
  * 3-screen onboarding (U12). Skips to the index when an advisor row
  * already exists — re-entering the flow is harmless thanks to the
  * idempotent `findOrCreate` upsert on the backend, but routing to the
@@ -54,7 +67,14 @@ export function OnboardingFlow() {
   const router = useRouter();
   const advisorQuery = useDonorAdvisor();
   const onboard = useOnboardAdvisor();
+  const privy = usePrivyBridge();
   const [step, setStep] = useState<Step>("welcome");
+
+  // Email from the logged-in Privy session (email or Google login), used to
+  // pre-fill the Email field below. Only trusted once Privy has resolved an
+  // authenticated session.
+  const loggedInEmail =
+    privy.ready && privy.authenticated ? getLoggedInEmail(privy.user) : undefined;
 
   // A single ref is shared across all three step headings because exactly one
   // step <section> is mounted at a time, so only one heading ever binds it.
@@ -73,6 +93,18 @@ export function OnboardingFlow() {
       timezone: DEFAULT_TIMEZONE,
     },
   });
+
+  // Pre-fill the Email field with the logged-in user's email once Privy
+  // resolves it. The session can resolve after the first render (the Privy
+  // SDK is deferred), so this runs as an effect rather than a default value.
+  // Guarded on the field's dirty state so a value the advisor has already
+  // typed is never clobbered when the session resolves late.
+  useEffect(() => {
+    if (!loggedInEmail) return;
+    if (form.getFieldState("email").isDirty) return;
+    if (form.getValues("email")) return;
+    form.setValue("email", loggedInEmail);
+  }, [loggedInEmail, form]);
 
   useEffect(() => {
     if (advisorQuery.isSuccess && advisorQuery.data) {


### PR DESCRIPTION
## What

On `/nonprofit-research/onboarding`, pre-fill the **Email** field with the authenticated user's email when they signed in via email or Google OAuth.

## How

- Read the session email from the Privy bridge (`usePrivyBridge`) — `email.address`, falling back to `google.email` — mirroring the navbar's existing `getUserEmail` resolver.
- Only trusted once Privy reports `ready && authenticated`.
- Set the value in a `useEffect` (the Privy SDK is deferred and resolves after the first render), guarded on the field's dirty state and current value so an email the advisor already typed is never clobbered.
- Wallet-only logins expose no email, so the field stays empty and editable. The field remains editable in all cases.

## Tests

New `describe` block in `OnboardingFlow.test.tsx` with a controllable Privy bridge mock, covering:
- pre-fill from email login
- pre-fill from Google OAuth login
- empty for wallet login (no email)
- empty until Privy resolves an authenticated session
- submitting the pre-filled email without retyping
- not clobbering an email the advisor already typed

All 15 tests in the file pass; biome + typecheck pass (enforced by pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wkq7bGYJeadRL7bC8GTxEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wkq7bGYJeadRL7bC8GTxEp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The onboarding form now automatically pre-fills the email field when a signed-in session already has an email available.

* **Bug Fixes**
  * Improved handling for accounts without an email so the field stays blank until one is available.
  * Prevented the email field from being overwritten if a user starts typing before session details finish loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->