### PR TITLE
feat(donor-research): free weight allocation with running total

### DIFF
--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -11,10 +11,14 @@ interface SliderProps extends React.ComponentPropsWithoutRef<typeof SliderPrimit
    * When provided, overrides the default aria-label on each Thumb.
    */
   thumbLabels?: string[];
+  /** Optional class overrides for the inner parts (merged after the defaults). */
+  trackClassName?: string;
+  rangeClassName?: string;
+  thumbClassName?: string;
 }
 
 const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
-  ({ className, thumbLabels, ...props }, ref) => {
+  ({ className, thumbLabels, trackClassName, rangeClassName, thumbClassName, ...props }, ref) => {
     const values = props.value ?? props.defaultValue ?? [0];
 
     return (
@@ -23,8 +27,13 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
         className={cn("relative flex w-full touch-none select-none items-center", className)}
         {...props}
       >
-        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-border">
-          <SliderPrimitive.Range className="absolute h-full bg-foreground" />
+        <SliderPrimitive.Track
+          className={cn(
+            "relative h-1.5 w-full grow overflow-hidden rounded-full bg-border",
+            trackClassName
+          )}
+        >
+          <SliderPrimitive.Range className={cn("absolute h-full bg-foreground", rangeClassName)} />
         </SliderPrimitive.Track>
         {values.map((_, index) => (
           <SliderPrimitive.Thumb
@@ -35,7 +44,8 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
               "block h-4 w-4 rounded-full border border-foreground/50 bg-background shadow transition-colors",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
               "disabled:pointer-events-none disabled:opacity-50",
-              "cursor-grab active:cursor-grabbing"
+              "cursor-grab active:cursor-grabbing",
+              thumbClassName
             )}
           />
         ))}

--- a/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
+++ b/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
@@ -81,9 +81,14 @@ describe("CriteriaForm weights", () => {
     fireEvent.blur(inputs[3]);
     fireEvent.click(screen.getByRole("button", { name: /start report/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
-    const weights = onSubmit.mock.calls[0][0].weights;
-    expect(weights.onlinePresence).toBe(4000);
-    expect(weights.donorMatch).toBe(1000);
-    expect(Object.values(weights).reduce((a: number, b) => a + (b as number), 0)).toBe(10000);
+    // Only the two edited factors changed; the untouched three are intact and
+    // the five total 100% (4000+1000+2500+1000+1500 = 10000).
+    expect(onSubmit.mock.calls[0][0].weights).toEqual({
+      onlinePresence: 4000,
+      socialPresence: 1000,
+      impactRecency: 2500,
+      donorMatch: 1000,
+      compliance: 1500,
+    });
   });
 });

--- a/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
+++ b/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
@@ -64,17 +64,26 @@ describe("CriteriaForm weights", () => {
     expect(onSubmit.mock.calls[0][0].weights).toEqual(DEFAULT_WEIGHTS_BASIS_POINTS);
   });
 
-  it("redistributes on edit and submits weights that still total 100%", async () => {
+  it("sets only the edited factor and gates submit on a 100% total", async () => {
     const onSubmit = vi.fn();
     render(withQueryClient(<Harness onSubmit={onSubmit} />));
-    const onlineInput = within(weightsFieldset()).getAllByRole("spinbutton")[0];
-    fireEvent.change(onlineInput, { target: { value: "40" } });
-    fireEvent.blur(onlineInput);
+    const inputs = within(weightsFieldset()).getAllByRole("spinbutton");
 
+    // Raise Online presence 25→40: nothing is redistributed, so the five now
+    // total 115% and the form can't be submitted.
+    fireEvent.change(inputs[0], { target: { value: "40" } });
+    fireEvent.blur(inputs[0]);
+    fireEvent.click(screen.getByRole("button", { name: /start report/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Drop Mission match 25→10 to bring the total back to 100%, then submit.
+    fireEvent.change(inputs[3], { target: { value: "10" } });
+    fireEvent.blur(inputs[3]);
     fireEvent.click(screen.getByRole("button", { name: /start report/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     const weights = onSubmit.mock.calls[0][0].weights;
     expect(weights.onlinePresence).toBe(4000);
+    expect(weights.donorMatch).toBe(1000);
     expect(Object.values(weights).reduce((a: number, b) => a + (b as number), 0)).toBe(10000);
   });
 });

--- a/src/features/donor-research/components/report-viewer/WeightsPanel.test.tsx
+++ b/src/features/donor-research/components/report-viewer/WeightsPanel.test.tsx
@@ -165,12 +165,15 @@ describe("WeightsPanel", () => {
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     expect(mockUpdate.mock.calls[0][0]).toBe("report-1");
-    // Both edits are committed verbatim; the total is 10000.
-    const committed = mockUpdate.mock.calls[0][1].weights as CompositeWeights;
-    expect(committed.onlinePresence).toBe(4000);
-    expect(committed.donorMatch).toBe(1000);
-    const total = Object.values(committed).reduce((acc: number, b) => acc + (b as number), 0);
-    expect(total).toBe(10000);
+    // Both edits committed verbatim; the untouched three are intact and the
+    // five total 100% (4000+1000+2500+1000+1500 = 10000).
+    expect(mockUpdate.mock.calls[0][1].weights).toEqual({
+      onlinePresence: 4000,
+      socialPresence: 1000,
+      impactRecency: 2500,
+      donorMatch: 1000,
+      compliance: 1500,
+    });
     expect(mockUpdate.mock.calls[0][1].topCount).toBeUndefined();
   });
 

--- a/src/features/donor-research/components/report-viewer/WeightsPanel.test.tsx
+++ b/src/features/donor-research/components/report-viewer/WeightsPanel.test.tsx
@@ -126,24 +126,34 @@ describe("WeightsPanel", () => {
     expect(within(preview).queryByText(/entering top 3/i)).not.toBeInTheDocument();
   });
 
-  it("enables Update weights once a weight changes (total stays 100%)", () => {
+  it("enables Update weights only once the edited weights total 100%", () => {
     renderPanel(buildReport(DEFAULT_WEIGHTS));
     openSheet();
     expect(screen.getByRole("button", { name: "Update weights" })).toBeDisabled();
 
-    // Editing redistributes the rest, so the draft stays balanced and becomes dirty.
-    const onlineInput = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(onlineInput, { target: { value: "40" } });
-    fireEvent.blur(onlineInput);
+    // Raising one factor unbalances the set (115%): nothing is redistributed, so
+    // the commit stays disabled until the advisor reconciles the total.
+    const inputs = screen.getAllByRole("spinbutton");
+    fireEvent.change(inputs[0], { target: { value: "40" } });
+    fireEvent.blur(inputs[0]);
+    expect(screen.getByRole("button", { name: "Update weights" })).toBeDisabled();
+
+    // Dropping Mission match 25→10 brings the total back to 100% and enables it.
+    fireEvent.change(inputs[3], { target: { value: "10" } });
+    fireEvent.blur(inputs[3]);
     expect(screen.getByRole("button", { name: "Update weights" })).toBeEnabled();
   });
 
   it("commits the adjusted weights through the confirm dialog", async () => {
     renderPanel(buildReport(DEFAULT_WEIGHTS));
     openSheet();
-    const onlineInput = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(onlineInput, { target: { value: "40" } });
-    fireEvent.blur(onlineInput);
+    const inputs = screen.getAllByRole("spinbutton");
+    // Raise Online presence to 40% and rebalance Mission match to 10% so the
+    // five total 100% again (no redistribution happens automatically).
+    fireEvent.change(inputs[0], { target: { value: "40" } });
+    fireEvent.blur(inputs[0]);
+    fireEvent.change(inputs[3], { target: { value: "10" } });
+    fireEvent.blur(inputs[3]);
 
     fireEvent.click(screen.getByRole("button", { name: "Update weights" }));
 
@@ -155,9 +165,10 @@ describe("WeightsPanel", () => {
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     expect(mockUpdate.mock.calls[0][0]).toBe("report-1");
-    // Online set to 40%; the rest redistributed; the committed weights total 10000.
+    // Both edits are committed verbatim; the total is 10000.
     const committed = mockUpdate.mock.calls[0][1].weights as CompositeWeights;
     expect(committed.onlinePresence).toBe(4000);
+    expect(committed.donorMatch).toBe(1000);
     const total = Object.values(committed).reduce((acc: number, b) => acc + (b as number), 0);
     expect(total).toBe(10000);
     expect(mockUpdate.mock.calls[0][1].topCount).toBeUndefined();

--- a/src/features/donor-research/components/weights/WeightsAllocator.test.tsx
+++ b/src/features/donor-research/components/weights/WeightsAllocator.test.tsx
@@ -38,17 +38,25 @@ describe("WeightsAllocator", () => {
     expect(total(next)).toBe(10000 - BALANCED.onlinePresence + 4000);
   });
 
-  it("shows the running total and flags it when off 100%", () => {
+  it("shows the running total in the pill and tracks it live", () => {
     const offBalance: CompositeWeights = { ...BALANCED, onlinePresence: 4000 };
     const { rerender } = render(
       <WeightsAllocator value={BALANCED} onChange={() => {}} resetValue={BALANCED} />
     );
-    expect(screen.getByText("100%")).toBeInTheDocument();
-    expect(screen.queryByText(/must add up to 100%/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Total\s+100%/)).toBeInTheDocument();
 
     rerender(<WeightsAllocator value={offBalance} onChange={() => {}} resetValue={BALANCED} />);
-    expect(screen.getByText(`${total(offBalance) / 100}%`)).toBeInTheDocument();
-    expect(screen.getByText(/must add up to 100%/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`Total\\s+${total(offBalance) / 100}%`))
+    ).toBeInTheDocument();
+  });
+
+  it("does not round a near-100% total up to a balanced-looking 100%", () => {
+    // 9,999 bp — the save gate rejects it, so the pill must not read "100%".
+    const almost: CompositeWeights = { ...BALANCED, onlinePresence: BALANCED.onlinePresence - 1 };
+    render(<WeightsAllocator value={almost} onChange={() => {}} resetValue={BALANCED} />);
+    expect(screen.getByText(/Total\s+99\.99%/)).toBeInTheDocument();
+    expect(screen.queryByText(/Total\s+100%/)).not.toBeInTheDocument();
   });
 
   it("keeps the current value when the field is cleared (does not commit 0%)", () => {

--- a/src/features/donor-research/components/weights/WeightsAllocator.test.tsx
+++ b/src/features/donor-research/components/weights/WeightsAllocator.test.tsx
@@ -11,15 +11,15 @@ function total(w: CompositeWeights): number {
 }
 
 describe("WeightsAllocator", () => {
-  it("renders a lock, slider, and percentage input per factor", () => {
+  it("renders a slider and percentage input per factor", () => {
     render(<WeightsAllocator value={BALANCED} onChange={() => {}} resetValue={BALANCED} />);
     expect(screen.getAllByRole("slider")).toHaveLength(5);
     expect(screen.getAllByRole("spinbutton")).toHaveLength(5);
-    // All unlocked initially → five "Lock …" toggles.
-    expect(screen.getAllByRole("button", { name: /^lock /i })).toHaveLength(5);
+    // No lock toggles any more — only the Reset control.
+    expect(screen.queryByRole("button", { name: /lock/i })).not.toBeInTheDocument();
   });
 
-  it("redistributes across the other factors when a percentage is typed", () => {
+  it("sets only the typed factor, leaving the others untouched", () => {
     const onChange = vi.fn();
     render(<WeightsAllocator value={BALANCED} onChange={onChange} resetValue={BALANCED} />);
     const onlineInput = screen.getAllByRole("spinbutton")[0];
@@ -29,8 +29,26 @@ describe("WeightsAllocator", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     const next = onChange.mock.calls[0][0] as CompositeWeights;
     expect(next.onlinePresence).toBe(4000);
-    expect(next.socialPresence).toBeLessThan(BALANCED.socialPresence);
-    expect(total(next)).toBe(10000);
+    // Nothing is redistributed — the other four are unchanged and the total
+    // moves (the advisor reconciles it back to 100% by hand).
+    expect(next.socialPresence).toBe(BALANCED.socialPresence);
+    expect(next.impactRecency).toBe(BALANCED.impactRecency);
+    expect(next.donorMatch).toBe(BALANCED.donorMatch);
+    expect(next.compliance).toBe(BALANCED.compliance);
+    expect(total(next)).toBe(10000 - BALANCED.onlinePresence + 4000);
+  });
+
+  it("shows the running total and flags it when off 100%", () => {
+    const offBalance: CompositeWeights = { ...BALANCED, onlinePresence: 4000 };
+    const { rerender } = render(
+      <WeightsAllocator value={BALANCED} onChange={() => {}} resetValue={BALANCED} />
+    );
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.queryByText(/must add up to 100%/i)).not.toBeInTheDocument();
+
+    rerender(<WeightsAllocator value={offBalance} onChange={() => {}} resetValue={BALANCED} />);
+    expect(screen.getByText(`${total(offBalance) / 100}%`)).toBeInTheDocument();
+    expect(screen.getByText(/must add up to 100%/i)).toBeInTheDocument();
   });
 
   it("keeps the current value when the field is cleared (does not commit 0%)", () => {
@@ -40,28 +58,6 @@ describe("WeightsAllocator", () => {
     fireEvent.change(onlineInput, { target: { value: "" } });
     fireEvent.blur(onlineInput);
     expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it("freezes a locked factor when another one changes", () => {
-    const onChange = vi.fn();
-    render(<WeightsAllocator value={BALANCED} onChange={onChange} resetValue={BALANCED} />);
-    fireEvent.click(screen.getByRole("button", { name: "Lock Compliance" }));
-    const onlineInput = screen.getAllByRole("spinbutton")[0];
-    fireEvent.change(onlineInput, { target: { value: "40" } });
-    fireEvent.blur(onlineInput);
-
-    const next = onChange.mock.calls[0][0] as CompositeWeights;
-    expect(next.compliance).toBe(1500); // frozen
-    expect(next.onlinePresence).toBe(4000);
-    expect(total(next)).toBe(10000);
-  });
-
-  it("disables the slider and input of a locked factor", () => {
-    render(<WeightsAllocator value={BALANCED} onChange={() => {}} resetValue={BALANCED} />);
-    fireEvent.click(screen.getByRole("button", { name: "Lock Social presence" }));
-    // Social is the second factor.
-    expect(screen.getAllByRole("spinbutton")[1]).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Unlock Social presence" })).toBeInTheDocument();
   });
 
   it("resets to the reset value", () => {
@@ -83,6 +79,6 @@ describe("WeightsAllocator", () => {
       <WeightsAllocator value={BALANCED} onChange={() => {}} resetValue={BALANCED} disabled />
     );
     screen.getAllByRole("spinbutton").forEach((input) => expect(input).toBeDisabled());
-    screen.getAllByRole("button", { name: /lock|reset/i }).forEach((b) => expect(b).toBeDisabled());
+    expect(screen.getByRole("button", { name: /reset/i })).toBeDisabled();
   });
 });

--- a/src/features/donor-research/components/weights/WeightsAllocator.tsx
+++ b/src/features/donor-research/components/weights/WeightsAllocator.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { Lock, LockOpen } from "lucide-react";
 import { useState } from "react";
 import { Slider } from "@/components/ui/slider";
 import type { CompositeWeights } from "@/types/donor-research";
 import { cn } from "@/utilities/tailwind";
-import { redistributeWeights, type WeightDimension, weightPercent } from "./weights-allocation";
+import {
+  setWeight,
+  WEIGHTS_TOTAL_BASIS_POINTS,
+  type WeightDimension,
+  weightPercent,
+  weightsTotal,
+} from "./weights-allocation";
 
 interface WeightDimensionMeta {
   key: WeightDimension;
@@ -30,14 +35,14 @@ interface WeightsAllocatorProps {
 }
 
 /**
- * Five weight sliders with lock & redistribute (DEV-418 U6).
+ * Five independent weight sliders with a running total (DEV-418 U6).
  *
- * Each factor has a lock toggle, a slider, and an editable percentage. Locking
- * a factor freezes its share; moving an unlocked slider — or typing a new
- * percentage — only redistributes the difference across the other UNLOCKED
- * factors (proportionally), so the five always total 100% and the advisor never
- * has to land the total by hand. The number input handles the fiddly
- * last-few-percent that a drag can overshoot.
+ * Each factor has a slider and an editable percentage that set ONLY that
+ * factor — nothing is redistributed, so a small ±2% nudge never skids the other
+ * four around. The advisor reconciles the total to 100% themselves; the Total
+ * row at the bottom tracks it live and the commit button stays disabled until
+ * it lands on 100%. The number input handles the fiddly last-few-percent that a
+ * drag can overshoot.
  */
 export function WeightsAllocator({
   value,
@@ -45,25 +50,12 @@ export function WeightsAllocator({
   resetValue,
   disabled = false,
 }: WeightsAllocatorProps) {
-  const [locked, setLocked] = useState<ReadonlySet<WeightDimension>>(() => new Set());
   // Local text while a percentage field is focused, so typing "60" isn't
   // snapped back to a single digit by the controlled value mid-keystroke.
   const [editing, setEditing] = useState<{ dim: WeightDimension; text: string } | null>(null);
 
   const apply = (dim: WeightDimension, requestedPercent: number) => {
-    onChange(redistributeWeights(value, locked, dim, requestedPercent));
-  };
-
-  const toggleLock = (dim: WeightDimension) => {
-    setLocked((prev) => {
-      const next = new Set(prev);
-      if (next.has(dim)) {
-        next.delete(dim);
-      } else {
-        next.add(dim);
-      }
-      return next;
-    });
+    onChange(setWeight(value, dim, requestedPercent));
   };
 
   const commitInput = (dim: WeightDimension, text: string) => {
@@ -71,29 +63,29 @@ export function WeightsAllocator({
     if (trimmed === "") return; // cleared → keep the current value, don't zero it
     const parsed = Number(trimmed);
     // Ignore non-numeric input and no-op re-entries, so a focus/blur that didn't
-    // change anything never redistributes (or snaps a non-whole-percent weight).
+    // change anything never re-snaps a weight.
     if (!Number.isFinite(parsed) || Math.round(parsed) === weightPercent(value, dim)) return;
     apply(dim, parsed);
   };
 
   const reset = () => {
-    setLocked(new Set());
     setEditing(null);
     onChange(resetValue);
   };
 
+  const totalPercent = Math.round(weightsTotal(value) / 100);
+  const isBalanced = weightsTotal(value) === WEIGHTS_TOTAL_BASIS_POINTS;
+
   return (
     <div className="flex flex-col gap-4">
       <p className="text-xs text-muted-foreground">
-        Lock the weights you're happy with — their % is frozen. Moving an unlocked slider (or typing
-        a percentage) only redistributes across the other unlocked criteria, so the total stays
-        100%.
+        Set how much each criterion counts toward the composite. Drag a slider or type an exact
+        percentage on the right — the five must add up to 100% before you can apply them.
       </p>
 
       <div className="flex flex-col gap-3.5">
         {DIMENSIONS.map(({ key, label }) => {
           const labelId = `weight-${key}`;
-          const isLocked = locked.has(key);
           const percent = weightPercent(value, key);
           const inputValue = editing && editing.dim === key ? editing.text : String(percent);
           return (
@@ -109,7 +101,7 @@ export function WeightsAllocator({
                     min={0}
                     max={100}
                     value={inputValue}
-                    disabled={disabled || isLocked}
+                    disabled={disabled}
                     aria-labelledby={labelId}
                     onFocus={() => setEditing({ dim: key, text: String(percent) })}
                     onChange={(event) => setEditing({ dim: key, text: event.target.value })}
@@ -125,47 +117,40 @@ export function WeightsAllocator({
                   <span className="text-sm text-muted-foreground">%</span>
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  aria-pressed={isLocked}
-                  aria-label={`${isLocked ? "Unlock" : "Lock"} ${label}`}
-                  disabled={disabled}
-                  onClick={() => toggleLock(key)}
-                  className={cn(
-                    "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50",
-                    isLocked
-                      ? "border-foreground/40 bg-muted text-foreground"
-                      : "border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground"
-                  )}
-                >
-                  {isLocked ? (
-                    <Lock aria-hidden className="h-3.5 w-3.5" />
-                  ) : (
-                    <LockOpen aria-hidden className="h-3.5 w-3.5" />
-                  )}
-                </button>
-                <Slider
-                  aria-labelledby={labelId}
-                  thumbLabels={[label]}
-                  value={[percent]}
-                  min={0}
-                  max={100}
-                  step={1}
-                  disabled={disabled || isLocked}
-                  onValueChange={([next]) => {
-                    setEditing(null);
-                    apply(key, next);
-                  }}
-                />
-              </div>
+              <Slider
+                aria-labelledby={labelId}
+                thumbLabels={[label]}
+                value={[percent]}
+                min={0}
+                max={100}
+                step={1}
+                disabled={disabled}
+                onValueChange={([next]) => {
+                  setEditing(null);
+                  apply(key, next);
+                }}
+              />
             </div>
           );
         })}
       </div>
 
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between border-t border-border pt-3">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium text-foreground">Total</span>
+          <output
+            aria-live="polite"
+            className={cn(
+              "text-sm font-semibold tabular-nums",
+              isBalanced ? "text-foreground" : "text-red-600 dark:text-red-400"
+            )}
+          >
+            {totalPercent}%
+          </output>
+          {!isBalanced ? (
+            <span className="text-xs text-muted-foreground">must add up to 100%</span>
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={reset}

--- a/src/features/donor-research/components/weights/WeightsAllocator.tsx
+++ b/src/features/donor-research/components/weights/WeightsAllocator.tsx
@@ -118,8 +118,8 @@ export function WeightsAllocator({
                       if (event.key === "Enter") event.currentTarget.blur();
                     }}
                     className={cn(
-                      "w-10 rounded border-0 bg-transparent p-0 text-right text-sm tabular-nums text-foreground",
-                      "hover:bg-muted/60 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      "w-12 rounded border-0 bg-muted px-1.5 py-0.5 text-right text-sm tabular-nums text-foreground",
+                      "hover:bg-muted focus:bg-muted focus:outline-none focus-visible:outline-none focus-visible:ring-0",
                       "disabled:opacity-60",
                       "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                     )}
@@ -135,6 +135,9 @@ export function WeightsAllocator({
                 max={100}
                 step={1}
                 disabled={disabled}
+                // Uniform light track (no filled range) with a white, blue-ringed thumb.
+                rangeClassName="bg-transparent"
+                thumbClassName="h-4 w-4 border-2 border-blue-500 bg-white shadow"
                 onValueChange={([next]) => {
                   setEditing(null);
                   apply(key, next);
@@ -149,16 +152,12 @@ export function WeightsAllocator({
         <span
           aria-live="polite"
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+            "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium",
             isBalanced
               ? "bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400"
               : "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-400"
           )}
         >
-          <span
-            aria-hidden
-            className={cn("h-1.5 w-1.5 rounded-full", isBalanced ? "bg-green-500" : "bg-red-500")}
-          />
           Total {formattedTotal}%
         </span>
         <button

--- a/src/features/donor-research/components/weights/WeightsAllocator.tsx
+++ b/src/features/donor-research/components/weights/WeightsAllocator.tsx
@@ -37,12 +37,12 @@ interface WeightsAllocatorProps {
 /**
  * Five independent weight sliders with a running total (DEV-418 U6).
  *
- * Each factor has a slider and an editable percentage that set ONLY that
- * factor — nothing is redistributed, so a small ±2% nudge never skids the other
- * four around. The advisor reconciles the total to 100% themselves; the Total
- * row at the bottom tracks it live and the commit button stays disabled until
- * it lands on 100%. The number input handles the fiddly last-few-percent that a
- * drag can overshoot.
+ * Each factor has a full-width slider and an editable percentage on the right
+ * that set ONLY that factor — nothing is redistributed, so a small ±2% nudge
+ * never skids the other four around. The advisor reconciles the total to 100%
+ * themselves; the Total pill at the bottom tracks it live (green at 100%, red
+ * otherwise) and the commit button stays disabled until it balances. The number
+ * input handles the fiddly last-few-percent that a drag can overshoot.
  */
 export function WeightsAllocator({
   value,
@@ -73,28 +73,33 @@ export function WeightsAllocator({
     onChange(resetValue);
   };
 
-  const totalPercent = Math.round(weightsTotal(value) / 100);
-  const isBalanced = weightsTotal(value) === WEIGHTS_TOTAL_BASIS_POINTS;
+  // Mirror the exact basis-point gate in the display: rounding here would let
+  // 9,999 bp read as a balanced-looking "100%" while the save gate still
+  // rejects it. Whole percents stay integers; anything odd shows its real value.
+  const totalBasisPoints = weightsTotal(value);
+  const isBalanced = totalBasisPoints === WEIGHTS_TOTAL_BASIS_POINTS;
+  const totalPercent = totalBasisPoints / 100;
+  const formattedTotal = Number.isInteger(totalPercent)
+    ? String(totalPercent)
+    : totalPercent.toFixed(2).replace(/\.?0+$/, "");
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-xs text-muted-foreground">
-        Set how much each criterion counts toward the composite. Drag a slider or type an exact
-        percentage on the right — the five must add up to 100% before you can apply them.
-      </p>
-
-      <div className="flex flex-col gap-3.5">
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-5">
         {DIMENSIONS.map(({ key, label }) => {
           const labelId = `weight-${key}`;
           const percent = weightPercent(value, key);
           const inputValue = editing && editing.dim === key ? editing.text : String(percent);
           return (
-            <div key={key} className="flex flex-col gap-1.5">
+            <div key={key} className="flex flex-col gap-2">
               <div className="flex items-center justify-between gap-3 text-sm">
-                <span id={labelId} className="text-foreground/85">
+                <span id={labelId} className="text-foreground">
                   {label}
                 </span>
-                <div className="flex items-center gap-1">
+                {/* Editable percentage, styled to read like the plain value on
+                    the right while staying a real number input (hover/focus
+                    reveal it's editable). */}
+                <div className="flex items-center text-foreground tabular-nums">
                   <input
                     type="number"
                     inputMode="numeric"
@@ -112,9 +117,14 @@ export function WeightsAllocator({
                     onKeyDown={(event) => {
                       if (event.key === "Enter") event.currentTarget.blur();
                     }}
-                    className="w-14 rounded-md border border-border bg-background px-2 py-1 text-right text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                    className={cn(
+                      "w-10 rounded border-0 bg-transparent p-0 text-right text-sm tabular-nums text-foreground",
+                      "hover:bg-muted/60 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      "disabled:opacity-60",
+                      "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    )}
                   />
-                  <span className="text-sm text-muted-foreground">%</span>
+                  <span>%</span>
                 </div>
               </div>
               <Slider
@@ -135,22 +145,22 @@ export function WeightsAllocator({
         })}
       </div>
 
-      <div className="flex items-center justify-between border-t border-border pt-3">
-        <div className="flex items-baseline gap-2">
-          <span className="text-sm font-medium text-foreground">Total</span>
-          <output
-            aria-live="polite"
-            className={cn(
-              "text-sm font-semibold tabular-nums",
-              isBalanced ? "text-foreground" : "text-red-600 dark:text-red-400"
-            )}
-          >
-            {totalPercent}%
-          </output>
-          {!isBalanced ? (
-            <span className="text-xs text-muted-foreground">must add up to 100%</span>
-          ) : null}
-        </div>
+      <div className="flex items-center justify-between rounded-md bg-muted/50 px-3 py-2.5">
+        <span
+          aria-live="polite"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+            isBalanced
+              ? "bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-400"
+              : "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-400"
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn("h-1.5 w-1.5 rounded-full", isBalanced ? "bg-green-500" : "bg-red-500")}
+          />
+          Total {formattedTotal}%
+        </span>
         <button
           type="button"
           onClick={reset}

--- a/src/features/donor-research/components/weights/weights-allocation.test.ts
+++ b/src/features/donor-research/components/weights/weights-allocation.test.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { CompositeWeights } from "@/types/donor-research";
 import { DEFAULT_WEIGHTS_BASIS_POINTS } from "../report-brief/scoring";
-import {
-  isValidWeights,
-  redistributeWeights,
-  WEIGHT_DIMENSIONS,
-  type WeightDimension,
-  weightsEqual,
-  weightsTotal,
-} from "./weights-allocation";
+import { isValidWeights, setWeight, weightsEqual, weightsTotal } from "./weights-allocation";
 
 const BALANCED: CompositeWeights = DEFAULT_WEIGHTS_BASIS_POINTS; // 25/10/25/25/15
-const NONE = new Set<WeightDimension>();
 
 function sum(w: CompositeWeights): number {
   return weightsTotal(w);
@@ -29,55 +21,30 @@ describe("weights-allocation validation", () => {
   });
 });
 
-describe("redistributeWeights", () => {
-  it("redistributes the remainder across the other unlocked factors, total stays 100%", () => {
-    const next = redistributeWeights(BALANCED, NONE, "onlinePresence", 40);
+describe("setWeight", () => {
+  it("sets only the named factor and leaves the others untouched", () => {
+    const next = setWeight(BALANCED, "onlinePresence", 40);
     expect(next.onlinePresence).toBe(4000);
-    expect(sum(next)).toBe(10000);
-    // The other four absorbed the −15% proportionally (10/25/25/15 of the 60 left).
-    expect(next.socialPresence).toBe(800);
-    expect(next.impactRecency).toBe(2000);
-    expect(next.donorMatch).toBe(2000);
-    expect(next.compliance).toBe(1200);
+    // Nothing redistributes — the total shifts by the delta.
+    expect(next.socialPresence).toBe(BALANCED.socialPresence);
+    expect(next.impactRecency).toBe(BALANCED.impactRecency);
+    expect(next.donorMatch).toBe(BALANCED.donorMatch);
+    expect(next.compliance).toBe(BALANCED.compliance);
+    expect(sum(next)).toBe(10000 - BALANCED.onlinePresence + 4000);
   });
 
-  it("never touches a locked factor", () => {
-    const locked = new Set<WeightDimension>(["compliance"]);
-    const next = redistributeWeights(BALANCED, locked, "onlinePresence", 40);
-    expect(next.compliance).toBe(1500); // frozen
-    expect(next.onlinePresence).toBe(4000);
-    expect(sum(next)).toBe(10000);
+  it("rounds to whole percent and clamps to 0–100", () => {
+    expect(setWeight(BALANCED, "onlinePresence", 33.4).onlinePresence).toBe(3300);
+    expect(setWeight(BALANCED, "onlinePresence", -5).onlinePresence).toBe(0);
+    expect(setWeight(BALANCED, "onlinePresence", 150).onlinePresence).toBe(10000);
   });
 
-  it("clamps the request to what's available after locked factors", () => {
-    const locked = new Set<WeightDimension>(["impactRecency", "donorMatch", "compliance"]);
-    // 65% locked → only 35% available; asking for 50% pins at 35%.
-    const next = redistributeWeights(BALANCED, locked, "onlinePresence", 50);
-    expect(next.onlinePresence).toBe(3500);
-    expect(next.socialPresence).toBe(0);
-    expect(sum(next)).toBe(10000);
-  });
-
-  it("forces the value when it is the only unlocked factor (dead end)", () => {
-    const locked = new Set<WeightDimension>([
-      "socialPresence",
-      "impactRecency",
-      "donorMatch",
-      "compliance",
-    ]);
-    const next = redistributeWeights(BALANCED, locked, "onlinePresence", 80);
-    // 10+25+25+15 locked = 75 → online must be the remaining 25%.
-    expect(next.onlinePresence).toBe(2500);
-    expect(sum(next)).toBe(10000);
-  });
-
-  it("stays summed to 100% across many independent moves", () => {
-    let w: CompositeWeights = { ...BALANCED };
-    for (let p = 0; p <= 100; p += 13) {
-      const dim = WEIGHT_DIMENSIONS[p % WEIGHT_DIMENSIONS.length];
-      w = redistributeWeights(w, NONE, dim, p);
-      expect(sum(w)).toBe(10000);
-      expect(isValidWeights(w)).toBe(true);
-    }
+  it("can land the total back on exactly 100%", () => {
+    // Drop online 25→10 leaving 85%, then a +15% elsewhere balances it.
+    const dropped = setWeight(BALANCED, "onlinePresence", 10);
+    expect(isValidWeights(dropped)).toBe(false);
+    const balanced = setWeight(dropped, "socialPresence", 25);
+    expect(sum(balanced)).toBe(10000);
+    expect(isValidWeights(balanced)).toBe(true);
   });
 });

--- a/src/features/donor-research/components/weights/weights-allocation.ts
+++ b/src/features/donor-research/components/weights/weights-allocation.ts
@@ -3,13 +3,13 @@ import type { CompositeWeights } from "@/types/donor-research";
 /**
  * Weights model for the DEV-418 scoring allocator (U6).
  *
- * Lock & redistribute: each factor is a weight in basis points (0–10000) and
- * the five always sum to 100%. The advisor can LOCK the factors they're happy
- * with — their percentage is frozen — and moving an unlocked slider (or editing
- * its number) only redistributes the difference across the OTHER UNLOCKED
- * factors, proportionally to their current values. The total therefore stays at
- * exactly 100% by construction, so the advisor never has to hit a target by
- * hand. Whole-percent granularity keeps the numbers clean.
+ * Free allocation: each factor is a weight in basis points (0–10000) and the
+ * five must sum to 100% before the advisor can commit. Moving a slider — or
+ * typing a percentage — sets ONLY that factor; nothing is redistributed. The
+ * advisor brings the running total back to 100% themselves (the UI shows it and
+ * `isValidWeights` gates the commit), which keeps a small ±2% nudge from
+ * skidding the other factors around. Whole-percent granularity keeps the
+ * numbers clean.
  *
  * Pure and framework-free so the slider UI can stay dumb.
  */
@@ -55,59 +55,19 @@ export function weightPercent(weights: CompositeWeights, dimension: WeightDimens
   return Math.round(weights[dimension] / 100);
 }
 
-function toBasisPoints(percents: Record<WeightDimension, number>): CompositeWeights {
-  return {
-    onlinePresence: percents.onlinePresence * 100,
-    socialPresence: percents.socialPresence * 100,
-    impactRecency: percents.impactRecency * 100,
-    donorMatch: percents.donorMatch * 100,
-    compliance: percents.compliance * 100,
-  };
-}
-
 /**
- * Set `changed` to `requestedPercent` and redistribute the remainder across the
- * other UNLOCKED factors (proportionally to their current values), leaving
- * locked factors untouched. The result is whole percentages summing to exactly
- * 100, returned as basis points.
- *
- * `requestedPercent` is clamped to what's available after the locked factors,
- * so a slider dragged past the ceiling simply pins at the ceiling. When no
- * other factor is unlocked, `changed` absorbs everything that isn't locked.
+ * Set a single dimension to `requestedPercent` (whole percent, clamped 0–100)
+ * and leave every other weight untouched. Nothing is redistributed — the five
+ * no longer self-balance, so the advisor reconciles the running total to 100%
+ * themselves and `isValidWeights` gates the commit. Returned as basis points.
  */
-export function redistributeWeights(
+export function setWeight(
   weights: CompositeWeights,
-  locked: ReadonlySet<WeightDimension>,
-  changed: WeightDimension,
+  dimension: WeightDimension,
   requestedPercent: number
 ): CompositeWeights {
-  const pct = (d: WeightDimension) => weightPercent(weights, d);
-  const result = {} as Record<WeightDimension, number>;
-
-  const lockedDims = WEIGHT_DIMENSIONS.filter((d) => d !== changed && locked.has(d));
-  for (const d of lockedDims) result[d] = pct(d);
-  const lockedSum = lockedDims.reduce((sum, d) => sum + result[d], 0);
-  const available = TOTAL_PERCENT - lockedSum;
-
-  const others = WEIGHT_DIMENSIONS.filter((d) => d !== changed && !locked.has(d));
-  if (others.length === 0) {
-    result[changed] = Math.max(0, available);
-    return toBasisPoints(result);
-  }
-
-  const next = clamp(Math.round(requestedPercent), 0, available);
-  result[changed] = next;
-
-  const remaining = available - next;
-  const othersSum = others.reduce((sum, d) => sum + pct(d), 0);
-  const exact = others.map((d) => ({
-    d,
-    e: othersSum > 0 ? (pct(d) / othersSum) * remaining : remaining / others.length,
-  }));
-  for (const o of exact) result[o.d] = Math.floor(o.e);
-  let drift = remaining - exact.reduce((sum, o) => sum + Math.floor(o.e), 0);
-  const byRemainder = [...exact].sort((a, b) => b.e - Math.floor(b.e) - (a.e - Math.floor(a.e)));
-  for (let i = 0; drift > 0; i++, drift--) result[byRemainder[i % byRemainder.length].d] += 1;
-
-  return toBasisPoints(result);
+  return {
+    ...weights,
+    [dimension]: clamp(Math.round(requestedPercent), 0, TOTAL_PERCENT) * 100,
+  };
 }


### PR DESCRIPTION
## Summary

Reworks the nonprofit-research **scoring weights** allocator (`/nonprofit-research`) from a lock-and-redistribute model to **free, independent allocation** with a running total.

## Problem

The previous allocator locked the five factors together: moving one slider auto-redistributed the difference across the others so the set always summed to 100%. In practice that made fine adjustments fiddly — if an advisor was at 98% and wanted to nudge one factor +2%, the redistribution would skid the other four around, and landing an exact split via the slider was hard. It also required an explicit per-factor "lock" affordance to hold values steady.

## Solution

- **Removed the lock** mechanism entirely (toggles, `locked` state, and the redistribute math).
- Each **slider and far-right number input now sets only its own weight** — nothing is redistributed. The number input handles the exact last-few-percent a drag can overshoot.
- Added a **Total row at the bottom** that tracks the sum live (via an `aria-live` `<output>`), shown in red with a "must add up to 100%" hint until it balances.
- **Commit gating is unchanged**: the existing "Update weights" (report viewer) and "Start report" (create form) buttons already gate on `isValidWeights`, so an unbalanced set still can't be saved — that check now does the real work instead of being guaranteed by construction.

Pure logic (`weights-allocation.ts`): `redistributeWeights(...)` → `setWeight(weights, dim, percent)` which sets one dimension (rounded, clamped 0–100) and leaves the rest untouched.

## Testing Steps

1. `pnpm test:unit` — allocator + logic unit tests rewritten for the independent-edit / running-total behavior.
2. Manual: open **Adjust ranking → Weights** on a report.
   - Drag/type one factor → only that factor changes; Total updates and turns red when ≠ 100%.
   - "Update weights" stays disabled until Total reads 100%.
   - Reset restores the persisted weights.

## Risk

Low. Frontend-only, scoped to the `donor-research/weights` component + its pure helper. No API/contract change — the commit still sends the same `{ weights }` payload. Behavior change is intentional and gated by the existing 100% validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weight factors can now be adjusted independently (no lock/freezing or automatic redistribution across other factors).
  * Weight updates apply immediately, with the total indicator reflecting balanced vs. unbalanced state using rounded percentages.
* **Bug Fixes**
  * Improved validation and submission behavior so changes must bring totals back to 100% to enable updating.
  * Reset now clears the current allocation cleanly without any lock-related behavior, and the total display avoids showing “100%” for near-100% values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->