### PR TITLE
chore: pin pnpm version via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gap-app-v2",
   "version": "2.0.1",
   "private": true,
+  "packageManager": "pnpm@10.34.3",
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:wl": "next dev --turbopack --experimental-https --experimental-https-key ./test-wl.local+2-key.pem --experimental-https-cert ./test-wl.local+2.pem",


### PR DESCRIPTION
## Problem

The repo has no `packageManager` field, so the pnpm version used locally is whatever each developer happens to have installed. CI, however, pins **pnpm 10** (`pnpm/action-setup@v5` with `version: 10` across all workflows).

When a developer on a newer pnpm (e.g. 11.x) runs `pnpm install`, pnpm re-resolves peer-dependency hashes and rewrites the lockfile differently from pnpm 10 — including **dropping the `overrides:` block** from `pnpm-lock.yaml` (which pins security-patched versions of `undici`, `qs`, `ws`, etc.). This shows up as large, spurious lockfile diffs that have nothing to do with the actual change.

## Solution

Pin `"packageManager": "pnpm@10.34.3"` (latest 10.x, matching CI's `version: 10`).

With Corepack enabled, local pnpm now auto-aligns to the same major as CI, eliminating the lockfile drift. Developers without Corepack get a clear version-mismatch warning instead of silent divergence.

## Testing

- ✅ `package.json` still parses; `packageManager` resolves to `pnpm@10.34.3`
- ✅ No dependency or lockfile changes — this only records the intended pnpm version

## Notes

- Complements #1720 (the `allowBuilds` allowlist fix). Independent and can merge in any order.
- `10.34.3` is the current `latest-10` dist-tag; bump as desired if the team prefers a different 10.x.
