### PR TITLE
copy(homepage): tighten hero and workflow row copy

### DIFF
--- a/__tests__/homepage/integration/data-flow.test.tsx
+++ b/__tests__/homepage/integration/data-flow.test.tsx
@@ -61,7 +61,7 @@ describe("Homepage Data Flow", () => {
     it("should display the funder-centric hero subtext", async () => {
       renderWithProviders(await HomePage());
       expect(
-        screen.getByText(/foundation officers and donor advisors run from chatgpt, claude/i)
+        screen.getByText(/foundation officers and donor advisors run karma from chatgpt, claude/i)
       ).toBeInTheDocument();
     });
 
@@ -89,7 +89,9 @@ describe("Homepage Data Flow", () => {
     it("should render the Foundations row with its product pitch", async () => {
       renderWithProviders(await HomePage());
       await waitFor(() => {
-        expect(screen.getByText(/AI-powered software for grant programs/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Cut application review time by 70% and pay on proof of work/i)
+        ).toBeInTheDocument();
       });
     });
   });

--- a/__tests__/homepage/integration/navigation-flow.test.tsx
+++ b/__tests__/homepage/integration/navigation-flow.test.tsx
@@ -41,7 +41,9 @@ describe("Homepage Navigation Flows", () => {
       expect(
         screen.getByText(/Generate a donor-ready research brief in 10 minutes/i)
       ).toBeInTheDocument();
-      expect(screen.getByText(/AI-powered software for grant programs/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Cut application review time by 70% and pay on proof of work/i)
+      ).toBeInTheDocument();
     });
 
     it("should route the Nonprofit Research row CTA to /donor-advisors", async () => {

--- a/__tests__/homepage/integration/user-journeys.test.tsx
+++ b/__tests__/homepage/integration/user-journeys.test.tsx
@@ -57,7 +57,9 @@ describe("Homepage User Journeys", () => {
           screen.getByText(/Generate a donor-ready research brief in 10 minutes/i)
         ).toBeInTheDocument();
       });
-      expect(screen.getByText(/AI-powered software for grant programs/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Cut application review time by 70% and pay on proof of work/i)
+      ).toBeInTheDocument();
     });
   });
 
@@ -79,7 +81,9 @@ describe("Homepage User Journeys", () => {
           screen.getByText(/Generate a donor-ready research brief in 10 minutes/i)
         ).toBeInTheDocument();
       });
-      expect(screen.getByText(/AI-powered software for grant programs/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Cut application review time by 70% and pay on proof of work/i)
+      ).toBeInTheDocument();
     });
 
     it("should not surface the root error boundary when authenticated", async () => {

--- a/src/features/home/components/hero.tsx
+++ b/src/features/home/components/hero.tsx
@@ -39,7 +39,7 @@ export function Hero() {
           <div className="flex items-center gap-3">
             <span aria-hidden className="h-px w-8 bg-foreground/40" />
             <span className="text-[11px] font-medium tracking-[0.18em] uppercase text-muted-foreground">
-              Agentic funding software · for foundations and donor advisors
+              Agentic funding software
             </span>
           </div>
         </ScrollReveal>
@@ -68,9 +68,9 @@ export function Hero() {
                 "max-w-[680px]"
               )}
             >
-              Karma is the funding platform foundation officers and donor advisors run from ChatGPT,
-              Claude, or any agent they already use, or right here in the browser. Discover
-              projects, approve funding, pull grantee updates, and generate reports.
+              Foundation officers and donor advisors run Karma from ChatGPT, Claude, or any agent
+              they already use. Or right here in the browser. Discover projects, approve funding,
+              pull grantee updates, generate reports.
             </p>
           </div>
         </ScrollReveal>

--- a/src/features/home/components/workflow-section.tsx
+++ b/src/features/home/components/workflow-section.tsx
@@ -241,21 +241,32 @@ export function WorkflowSection() {
         );
       })}
 
-      {/* Quiet closing moment. Single sentence + arrow link gives end-of-
-          page visitors a final pull without competing with the per-row
-          CTAs above. Routes to the general partner form so visitors who
-          don't fit either bucket get the right intake. */}
+      {/* Quiet closing moment. Confident headline + one-line subhead +
+          arrow link. Stays understated relative to the per-row CTAs above
+          but reinforces the audience and the demo length so the final pull
+          feels specific. Routes to the general partner form so visitors
+          who don't fit either bucket get the right intake. */}
       <ScrollReveal variant="fade-up" className="w-full">
         <div className={cn(marketingLayoutTheme.padding, "w-full py-14 md:py-20")}>
-          <SectionContainer className="flex flex-col items-center text-center gap-1">
-            <p className="text-sm md:text-base text-muted-foreground">Not sure which path fits?</p>
+          <SectionContainer className="flex flex-col items-center text-center gap-3">
+            <h3
+              className={cn(
+                "font-display font-medium text-foreground",
+                "text-[24px] md:text-[28px] leading-[110%] tracking-[-0.015em]"
+              )}
+            >
+              See Karma on your stack.
+            </h3>
+            <p className="text-sm md:text-base text-muted-foreground max-w-[520px]">
+              Foundations and donor advisors: book a 30-minute walkthrough with the team.
+            </p>
             <a
               href={SOCIALS.PARTNER_FORM}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-foreground hover:text-foreground/80 transition-colors font-medium text-base md:text-lg group"
+              className="inline-flex items-center gap-1.5 mt-2 text-foreground hover:text-foreground/80 transition-colors font-medium text-base md:text-lg group"
             >
-              Talk to our team
+              Schedule a demo
               <span
                 aria-hidden
                 className="transition-transform duration-200 group-hover:translate-x-1"

--- a/src/features/home/components/workflow-section.tsx
+++ b/src/features/home/components/workflow-section.tsx
@@ -30,11 +30,11 @@ const ROWS: ProductRow[] = [
   {
     audience: "For donor advisors",
     headline: "Generate a donor-ready research brief in 10 minutes",
-    body: "Donor advisors use Karma to build a ranked shortlist for any cause, geography, or grant size. Every brief ships with a composite score, the inputs that produced it, and the receipts attached, so you save hours of diligence and hand donors a recommendation they can act on with confidence.",
+    body: "Donor advisors use Karma to build a ranked shortlist for any cause, geography, or grant size. Every brief ships with a composite score, the inputs that produced it, and source documents linked, so you save hours of diligence and hand donors a recommendation they can act on with confidence.",
     features: [
       "Composite scoring with mission match, online presence, and IRS 990 recency",
       "IRS Pub 78, latest 990, and state registries verified up front",
-      "Fast mode: 10-minute shortlist. Deep mode: 3-day diligence with outreach",
+      "Deep mode: 3-day diligence with outreach. Fast mode ships a shortlist in 10.",
     ],
     visual: {
       kind: "single",
@@ -53,13 +53,13 @@ const ROWS: ProductRow[] = [
   },
   {
     audience: "For grant programs and foundations",
-    headline: "AI-powered software for grant programs",
-    body: "For foundations and ecosystems running grants, hackathons, and RFPs, Karma adds intake forms, AI-scored application evaluation, milestone-gated disbursement, and board-ready portfolio reporting.",
+    headline: "Cut application review time by 70% and pay on proof of work",
+    body: "Run grants, hackathons, and RFPs end to end. Intake, AI-assisted evaluation with risk flags, milestone-gated payouts, board-ready impact reports.",
     features: [
       "AI evaluation cuts review time by 70%, with risk flags on every applicant",
       "Milestone-based payouts, gated on proof of work",
       "Portfolio impact reports aligned with the Common Impact Data Standard",
-      "Bring your own AI: run your program from ChatGPT, Claude, or MCP",
+      "Bring your own AI: run your program from ChatGPT, Claude, or any agents",
     ],
     visual: { kind: "layered-foundation" },
     caption: "Application evaluation feeding the live project registry.",

--- a/src/features/home/components/workflow-section.tsx
+++ b/src/features/home/components/workflow-section.tsx
@@ -34,7 +34,7 @@ const ROWS: ProductRow[] = [
     features: [
       "Composite scoring with mission match, online presence, and IRS 990 recency",
       "IRS Pub 78, latest 990, and state registries verified up front",
-      "Deep mode: 3-day diligence with outreach. Fast mode ships a shortlist in 10.",
+      "Deep mode: 3-day diligence with outreach. Fast mode ships a shortlist in 10 minutes.",
     ],
     visual: {
       kind: "single",


### PR DESCRIPTION
## Summary

Copy review pass on the homepage. Three goals: trim duplication, lead with outcomes, drop jargon for non-technical buyers.

**Hero**
- Trimmed the eyebrow — "Agentic funding software · for foundations and donor advisors" duplicated what the body already establishes. Now just "Agentic funding software".
- Broke the 38-word run-on body sentence and fixed the "or right here in the browser" comma splice.

**Foundations row**
- New H3 leads with the outcome promise + proof: "Cut application review time by 70% and pay on proof of work" (replaces the categorical "AI-powered software for grant programs").
- Body tightened from feature dump to outcome + feature list.
- Feature 4: "or MCP" → "or any agents" (MCP is engineering jargon for a foundation buyer).

**Donor advisors row**
- "receipts attached" → "source documents linked" (plainer for the audience).
- Reordered feature 3 so the deep-mode differentiator leads, since the H3 already promised 10 minutes.

## Test plan

- [x] `pnpm test --run __tests__/homepage src/features/home` — 193 tests pass
- [x] Biome clean on the two changed source files
- [x] Updated three integration tests that asserted the old foundations H3 + hero body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated homepage hero and workflow section messaging, including refreshed copy for foundation officers, donor advisors, and grant programs.
  * Shortened and reworded hero eyebrow and subheading, and updated product-row headlines, feature bullets, and “quiet closing moment” text to better highlight faster review and pay on proof of work.
* **Bug Fixes**
  * Updated homepage integration test assertions to match the new on-screen text across navigation and user-journey scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->