### PR TITLE
fix(seo): canonicalize project About tab to the project root

### DIFF
--- a/__tests__/utilities/metadata/projectMetadata.test.ts
+++ b/__tests__/utilities/metadata/projectMetadata.test.ts
@@ -42,7 +42,12 @@ describe("generateProjectAboutMetadata", () => {
     const meta = generateProjectAboutMetadata(project, "acme");
 
     expect(meta.robots).toBeUndefined();
-    expect(meta.alternates?.canonical).toBe("/project/acme/about");
+  });
+
+  it("canonicalizes the about tab to the project root to consolidate ranking signals", () => {
+    const meta = generateProjectAboutMetadata(project, "acme");
+
+    expect(meta.alternates?.canonical).toBe("/project/acme");
   });
 });
 

--- a/utilities/metadata/projectMetadata.ts
+++ b/utilities/metadata/projectMetadata.ts
@@ -101,7 +101,10 @@ export const generateProjectAboutMetadata = (
     description:
       getRealDescriptionExcerpt(project) ||
       `Learn about ${projectTitle}: mission, problem statement, solution, and project details.`,
-    canonicalPath: `/project/${projectId}/about`,
+    // The About tab shares its mission/description content with the project root
+    // (overview), so it reads as a near-duplicate to search engines. Canonicalize
+    // to the project root to consolidate ranking signals onto the primary URL.
+    canonicalPath: `/project/${projectId}`,
   });
 };
 


### PR DESCRIPTION
## Problem

Google Search Console reports two large duplicate-content buckets for project pages:

- **Duplicate without user-selected canonical** — 2,928 URLs
- **Alternate page with proper canonical tag** — 5,589 URLs

A significant driver is the project **About tab** (`/project/[projectId]/about`). It self-canonicalized to its own URL while sharing its mission/description content with the project **root/overview** (`/project/[projectId]`). To crawlers the two URLs read as near-duplicates competing for the same ranking signals, and neither declared the other as canonical.

## Solution

Point the About tab's canonical at the **project root** instead of self-canonicalizing:

```diff
- canonicalPath: `/project/${projectId}/about`
+ canonicalPath: `/project/${projectId}`
```

This emits `<link rel="canonical" href=".../project/[projectId]">` on the About tab, consolidating ranking signals onto the primary project URL. `openGraph.url` follows `canonicalPath`, so it resolves to the root too — consistent. The tab stays crawlable/followable (no `noindex`); canonicalization is the consolidation mechanism, matching how the codebase already treats the overview/team/updates tabs.

Complements **gap-indexer#2125**, which drops `/about` from the project sitemap so the non-canonical URL is no longer advertised for crawling.

## Testing steps

- `pnpm exec vitest run __tests__/utilities/metadata/projectMetadata.test.ts` — 9/9 pass (added a dedicated test asserting the About canonical resolves to `/project/[projectId]`).
- `pnpm exec vitest run __tests__/integration/pages/smoke/project-pages.test.tsx` — 14/14 pass.
- Manual: load a project's About tab and confirm `<link rel="canonical">` in the `<head>` points to `/project/[slug]` (the root), not `/project/[slug]/about`.

## Notes

- Scope is exactly two files: `utilities/metadata/projectMetadata.ts` and its test.
- The About tab keeps its unique server-rendered content and remains indexable; only the canonical target changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the project About page to use the project root as its canonical URL.
  * This helps consolidate search and ranking signals for the project overview and About content.
  * Adjusted related tests to match the new canonical URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->