### PR TITLE
feat(seo): project page h1 + JSON-LD structured data

### DIFF
--- a/__tests__/app/project-layout-h1.test.tsx
+++ b/__tests__/app/project-layout-h1.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/utilities/metadata/projectMetadata", () => ({
 
 vi.mock("next/navigation", () => ({
   notFound: vi.fn(),
+  unstable_rethrow: vi.fn(),
   redirect: vi.fn(),
   usePathname: vi.fn(() => "/"),
   useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),

--- a/__tests__/app/project-layout-h1.test.tsx
+++ b/__tests__/app/project-layout-h1.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from "@testing-library/react";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    dehydrate: vi.fn(() => ({ queries: [] })),
+    HydrationBoundary: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="hydration-boundary">{children}</div>
+    ),
+  };
+});
+
+vi.mock("@/components/Pages/Project/ProjectShareDialogMount", () => ({
+  ProjectShareDialogMount: () => null,
+}));
+
+vi.mock("@/components/Utilities/E2EStoreExposer", () => ({
+  E2EStoreExposer: () => null,
+}));
+
+// The JSON-LD components render inert <script> tags; stub them so this test
+// focuses on the single <h1> heading signal.
+vi.mock("@/components/Seo/ProjectJsonLd", () => ({ ProjectJsonLd: () => null }));
+vi.mock("@/components/Seo/BreadcrumbJsonLd", () => ({ BreadcrumbJsonLd: () => null }));
+
+vi.mock("@/utilities/queries/getProjectCachedData", () => ({
+  getProjectCachedData: vi.fn(),
+}));
+
+vi.mock("@/utilities/queries/prefetchProjectProfile", () => ({
+  prefetchProjectProfileData: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/utilities/metadata/projectMetadata", () => ({
+  generateProjectOverviewMetadata: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  redirect: vi.fn(),
+  usePathname: vi.fn(() => "/"),
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+  useSearchParams: vi.fn(() => ({ get: vi.fn() })),
+  useParams: vi.fn(() => ({})),
+}));
+
+import type { Project } from "@/types/v2/project";
+import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
+
+const mockGetProjectCachedData = getProjectCachedData as vi.MockedFunction<
+  typeof getProjectCachedData
+>;
+
+function createMockProject(overrides: Partial<Project["details"]> = {}): Project {
+  return {
+    uid: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
+    chainID: 10,
+    owner: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as `0x${string}`,
+    details: {
+      title: "Test Project Title",
+      slug: "test-project",
+      ...overrides,
+    },
+    members: [],
+    pointers: [],
+    createdAt: "2024-01-01",
+  } as Project;
+}
+
+describe("Project Layout - server-rendered single h1", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS = "false";
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS;
+  });
+
+  async function renderLayout(projectId = "test-project") {
+    const { default: RootLayout } = await import("@/app/project/[projectId]/layout");
+    const element = await RootLayout({
+      children: <div data-testid="children">Children</div>,
+      params: Promise.resolve({ projectId }),
+    });
+    return render(element as React.ReactElement);
+  }
+
+  it("renders exactly one sr-only h1 with the project title", async () => {
+    mockGetProjectCachedData.mockResolvedValue(createMockProject());
+    const { container } = await renderLayout();
+
+    const h1s = container.querySelectorAll("h1");
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent("Test Project Title");
+    expect(h1s[0]).toHaveClass("sr-only");
+  });
+
+  it("omits the h1 when the project has no title", async () => {
+    mockGetProjectCachedData.mockResolvedValue(createMockProject({ title: "" }));
+    const { container } = await renderLayout();
+
+    expect(container.querySelectorAll("h1")).toHaveLength(0);
+  });
+
+  it("omits the h1 when project data fails to load", async () => {
+    mockGetProjectCachedData.mockRejectedValue(new Error("Not found"));
+    const { container } = await renderLayout();
+
+    expect(container.querySelectorAll("h1")).toHaveLength(0);
+  });
+});

--- a/__tests__/app/project-layout-ssr-shell.test.tsx
+++ b/__tests__/app/project-layout-ssr-shell.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/utilities/metadata/projectMetadata", () => ({
 
 vi.mock("next/navigation", () => ({
   notFound: vi.fn(),
+  unstable_rethrow: vi.fn(),
   redirect: vi.fn(),
   usePathname: vi.fn(() => "/"),
   useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),

--- a/__tests__/components/Seo/ProjectJsonLd.test.tsx
+++ b/__tests__/components/Seo/ProjectJsonLd.test.tsx
@@ -1,0 +1,119 @@
+import { render } from "@testing-library/react";
+import { ProjectJsonLd } from "@/components/Seo/ProjectJsonLd";
+import type { Project } from "@/types/v2/project";
+import { SITE_URL } from "@/utilities/meta";
+import "@testing-library/jest-dom";
+
+function buildProject(
+  overrides: Partial<Project["details"]> = {},
+  top: Partial<Project> = {}
+): Project {
+  return {
+    uid: "0x1234",
+    chainID: 10,
+    owner: "0xowner",
+    members: [],
+    createdAt: "2024-01-15T00:00:00.000Z",
+    details: {
+      title: "Acme Protocol",
+      slug: "acme-protocol",
+      description: "A **decentralized** protocol for public goods funding.",
+      logoUrl: "https://cdn.example.com/acme.png",
+      tags: ["defi", "public-goods"],
+      links: [
+        { url: "https://acme.xyz", type: "website" },
+        { url: "https://github.com/acme", type: "github" },
+      ],
+      ...overrides,
+    },
+    ...top,
+  } as Project;
+}
+
+describe("ProjectJsonLd", () => {
+  function getSchema(container: HTMLElement) {
+    const script = container.querySelector('script[type="application/ld+json"]');
+    return JSON.parse(script?.innerHTML || "{}");
+  }
+
+  it("renders a single JSON-LD script tag", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    expect(container.querySelectorAll('script[type="application/ld+json"]')).toHaveLength(1);
+  });
+
+  it("has schema.org context and Project type", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("Project");
+  });
+
+  it("uses the project title as name and the canonical URL", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.name).toBe("Acme Protocol");
+    expect(schema.url).toBe(`${SITE_URL}/project/acme-protocol`);
+  });
+
+  it("strips markdown from the description", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.description).not.toContain("**");
+    expect(schema.description).toContain("decentralized");
+  });
+
+  it("maps logoUrl to both logo and image", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.logo).toBe("https://cdn.example.com/acme.png");
+    expect(schema.image).toBe("https://cdn.example.com/acme.png");
+  });
+
+  it("maps http(s) links to sameAs and drops non-http links", () => {
+    const project = buildProject({
+      links: [
+        { url: "https://acme.xyz", type: "website" },
+        { url: "not-a-url", type: "other" },
+        { url: "", type: "empty" },
+      ],
+    });
+    const { container } = render(<ProjectJsonLd project={project} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.sameAs).toEqual(["https://acme.xyz"]);
+  });
+
+  it("joins tags into a keywords string", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.keywords).toBe("defi, public-goods");
+  });
+
+  it("exposes foundingDate from createdAt", () => {
+    const { container } = render(<ProjectJsonLd project={buildProject()} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema.foundingDate).toBe("2024-01-15T00:00:00.000Z");
+  });
+
+  it("omits optional fields when data is absent", () => {
+    const project = buildProject(
+      { description: undefined, logoUrl: undefined, tags: [], links: [] },
+      { createdAt: undefined }
+    );
+    const { container } = render(<ProjectJsonLd project={project} slug="acme-protocol" />);
+    const schema = getSchema(container);
+    expect(schema).not.toHaveProperty("description");
+    expect(schema).not.toHaveProperty("logo");
+    expect(schema).not.toHaveProperty("image");
+    expect(schema).not.toHaveProperty("sameAs");
+    expect(schema).not.toHaveProperty("keywords");
+    expect(schema).not.toHaveProperty("foundingDate");
+  });
+
+  it("escapes </script> sequences to prevent XSS", () => {
+    const project = buildProject({ description: "</script><script>alert(1)</script>" });
+    const { container } = render(<ProjectJsonLd project={project} slug="acme-protocol" />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script?.innerHTML).not.toContain("</script><script>");
+    expect(() => JSON.parse(script?.innerHTML || "{}")).not.toThrow();
+  });
+});

--- a/__tests__/utilities/markdown.server.test.ts
+++ b/__tests__/utilities/markdown.server.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdownToHtml } from "@/utilities/markdown.server";
+
+describe("renderMarkdownToHtml", () => {
+  it("returns an empty string for empty input", () => {
+    expect(renderMarkdownToHtml("")).toBe("");
+    expect(renderMarkdownToHtml(undefined)).toBe("");
+    expect(renderMarkdownToHtml(null)).toBe("");
+  });
+
+  it("renders a leading `# ` as <h1> by default (no offset)", () => {
+    expect(renderMarkdownToHtml("# Brief")).toContain("<h1>Brief</h1>");
+  });
+
+  it("demotes headings by the given offset so content never emits an <h1>", () => {
+    const html = renderMarkdownToHtml("# Brief\n\n## Detail", { headingOffset: 1 });
+    expect(html).toContain("<h2>Brief</h2>");
+    expect(html).toContain("<h3>Detail</h3>");
+    expect(html).not.toContain("<h1>");
+  });
+
+  it("clamps demoted headings at <h6>", () => {
+    const html = renderMarkdownToHtml("###### Deep", { headingOffset: 1 });
+    expect(html).toContain("<h6>Deep</h6>");
+    expect(html).not.toContain("<h7>");
+  });
+
+  it("leaves headings untouched when offset is 0", () => {
+    expect(renderMarkdownToHtml("## Section", { headingOffset: 0 })).toContain("<h2>Section</h2>");
+  });
+
+  it("still opens links in a new tab with nofollow when demoting", () => {
+    const html = renderMarkdownToHtml("# [x](https://example.com)", { headingOffset: 1 });
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="nofollow noopener noreferrer"');
+  });
+});

--- a/app/project/[projectId]/(profile)/about/error.tsx
+++ b/app/project/[projectId]/(profile)/about/error.tsx
@@ -8,7 +8,8 @@ export default function AboutErrorBoundary({
 }) {
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
-      <h1 className="text-2xl font-bold text-black dark:text-white">Something went wrong</h1>
+      {/* h2, not h1: the shared project layout renders the single page <h1>. */}
+      <h2 className="text-2xl font-bold text-black dark:text-white">Something went wrong</h2>
       <p className="mt-4 text-base text-zinc-700 dark:text-zinc-300">
         The About section failed to load. This is usually temporary.
       </p>

--- a/app/project/[projectId]/layout.tsx
+++ b/app/project/[projectId]/layout.tsx
@@ -3,6 +3,7 @@ export const revalidate = 60;
 
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
+import { unstable_rethrow } from "next/navigation";
 import { ProjectShareDialogMount } from "@/components/Pages/Project/ProjectShareDialogMount";
 import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
 import { ProjectJsonLd } from "@/components/Seo/ProjectJsonLd";
@@ -123,7 +124,11 @@ export default async function RootLayout(props: {
   if (!isE2E) {
     try {
       projectInfo = await getProjectCachedData(projectId);
-    } catch {
+    } catch (error) {
+      // Re-throw Next.js control-flow errors (notFound()/redirect(), which work
+      // by throwing) so a bare catch can't swallow them; only a genuine
+      // transient fetch failure falls through to render the shell.
+      unstable_rethrow(error);
       // SUPPRESSED: transient project fetch failure — client hooks refetch.
     }
   }

--- a/app/project/[projectId]/layout.tsx
+++ b/app/project/[projectId]/layout.tsx
@@ -4,9 +4,12 @@ export const revalidate = 60;
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { ProjectShareDialogMount } from "@/components/Pages/Project/ProjectShareDialogMount";
+import { BreadcrumbJsonLd } from "@/components/Seo/BreadcrumbJsonLd";
+import { ProjectJsonLd } from "@/components/Seo/ProjectJsonLd";
 import { E2EStoreExposer } from "@/components/Utilities/E2EStoreExposer";
 import { layoutTheme } from "@/src/helper/theme";
 import { generateProjectOverviewMetadata } from "@/utilities/metadata/projectMetadata";
+import { PAGES } from "@/utilities/pages";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 import { getProjectCachedData } from "@/utilities/queries/getProjectCachedData";
 import { prefetchProjectProfileData } from "@/utilities/queries/prefetchProjectProfile";
@@ -105,15 +108,57 @@ export default async function RootLayout(props: {
   // Skip prefetch during E2E tests — the staging API may be behind Cloudflare,
   // and a server-side prefetch failure gets cached by React Query, preventing
   // client-side refetch (which Cypress CAN intercept).
-  if (process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS !== "true") {
+  const isE2E = process.env.NEXT_PUBLIC_E2E_AUTH_BYPASS === "true";
+  if (!isE2E) {
     await safePrefetchProjectData(queryClient, projectId);
   }
 
+  // Structured data for crawlers. `getProjectCachedData` is memoized (react
+  // `cache`) and already resolved during `generateMetadata`, so this reuses the
+  // same result with no extra request. Skipped under E2E for the same reason as
+  // the prefetch above. Wrapped defensively: notFound()/redirect() are already
+  // enforced by generateMetadata, so a throw here is a transient fetch error —
+  // render the shell rather than failing the whole page.
+  let projectInfo: Awaited<ReturnType<typeof getProjectCachedData>> | null = null;
+  if (!isE2E) {
+    try {
+      projectInfo = await getProjectCachedData(projectId);
+    } catch {
+      // SUPPRESSED: transient project fetch failure — client hooks refetch.
+    }
+  }
+  const canonicalSlug = projectInfo?.details?.slug || projectId;
+
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
+      {projectInfo?.details?.title ? (
+        <>
+          <ProjectJsonLd project={projectInfo} slug={canonicalSlug} />
+          <BreadcrumbJsonLd
+            items={[
+              { name: "Home", url: PAGES.HOME },
+              { name: "Projects", url: PAGES.PROJECTS_EXPLORER },
+              { name: projectInfo.details.title, url: PAGES.PROJECT.OVERVIEW(canonicalSlug) },
+            ]}
+          />
+        </>
+      ) : null}
       <E2EStoreExposer />
       <ProjectShareDialogMount />
-      <div className={layoutTheme.padding}>{children}</div>
+      <div className={layoutTheme.padding}>
+        {/*
+          Server-render exactly one <h1> per project page for SEO. The visible
+          project title lives in the sidebar profile card as an <h2>, and that
+          card renders twice (mobile + desktop, toggled by CSS) — promoting it
+          to <h1> would emit two h1s. A single screen-reader-only <h1> at this
+          shared layout level is the one authoritative, viewport-independent
+          page heading crawlers see, and it covers every project sub-route.
+        */}
+        {projectInfo?.details?.title ? (
+          <h1 className="sr-only">{projectInfo.details.title}</h1>
+        ) : null}
+        {children}
+      </div>
     </HydrationBoundary>
   );
 }

--- a/components/Pages/Project/v2/MainContent/AboutContentServer.tsx
+++ b/components/Pages/Project/v2/MainContent/AboutContentServer.tsx
@@ -44,8 +44,10 @@ function AboutSection({ icon, title, content, testId }: AboutSectionProps) {
         )}
         // Server-rendered markdown. Source is sanitized by markdown-it (html:false
         // escapes raw HTML, link protocols validated) before reaching the DOM.
+        // headingOffset:1 keeps authored headings below the page <h1> and this
+        // section's <h2> — a leading `# ` must not emit a competing <h1>.
         // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized server markdown
-        dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(content) }}
+        dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(content, { headingOffset: 1 }) }}
       />
     </div>
   );

--- a/components/Pages/Project/v2/MainContent/AboutContentServer.tsx
+++ b/components/Pages/Project/v2/MainContent/AboutContentServer.tsx
@@ -44,10 +44,11 @@ function AboutSection({ icon, title, content, testId }: AboutSectionProps) {
         )}
         // Server-rendered markdown. Source is sanitized by markdown-it (html:false
         // escapes raw HTML, link protocols validated) before reaching the DOM.
-        // headingOffset:1 keeps authored headings below the page <h1> and this
-        // section's <h2> — a leading `# ` must not emit a competing <h1>.
+        // headingOffset:2 nests authored headings below the page <h1> AND this
+        // section's <h2> title — a leading `# ` becomes <h3>, never a competing
+        // <h1> and never outranking the section heading it sits under.
         // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized server markdown
-        dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(content, { headingOffset: 1 }) }}
+        dangerouslySetInnerHTML={{ __html: renderMarkdownToHtml(content, { headingOffset: 2 }) }}
       />
     </div>
   );

--- a/components/Seo/ProjectJsonLd.tsx
+++ b/components/Seo/ProjectJsonLd.tsx
@@ -1,0 +1,60 @@
+import type { Project } from "@/types/v2/project";
+import { safeJsonLdStringify } from "@/utilities/jsonLd";
+import { cleanMarkdownForPlainText } from "@/utilities/markdown";
+import { SITE_URL } from "@/utilities/meta";
+import { PAGES } from "@/utilities/pages";
+
+interface ProjectJsonLdProps {
+  project: Project;
+  /** Canonical slug (or uid) used to build the project URL. */
+  slug: string;
+}
+
+const isHttpUrl = (url: string): boolean => /^https?:\/\//i.test(url);
+
+/**
+ * Emits schema.org structured data for a single project profile.
+ *
+ * Modeled as a `Project` (a subtype of `Organization`) — "An enterprise
+ * (potentially individual but typically collaborative), planned to achieve a
+ * particular aim." — which is exactly what a Karma project represents, so it
+ * inherits Organization properties like `logo`, `sameAs`, and `foundingDate`.
+ */
+export function ProjectJsonLd({ project, slug }: ProjectJsonLdProps) {
+  const details = project?.details;
+  const name = details?.title || "";
+  const description = cleanMarkdownForPlainText(details?.description || "", 300);
+  const url = `${SITE_URL}${PAGES.PROJECT.OVERVIEW(slug)}`;
+
+  // External links (website, twitter, github, …) become `sameAs` entries so
+  // crawlers can reconcile this project with its off-platform presence.
+  const sameAs = (details?.links || [])
+    .map((link) => link?.url)
+    .filter((linkUrl): linkUrl is string => Boolean(linkUrl) && isHttpUrl(linkUrl));
+
+  const projectSchema = {
+    "@context": "https://schema.org",
+    "@type": "Project",
+    name,
+    url,
+    ...(description && { description }),
+    ...(details?.logoUrl && { logo: details.logoUrl, image: details.logoUrl }),
+    ...(sameAs.length > 0 && { sameAs }),
+    ...(details?.tags?.length && { keywords: details.tags.join(", ") }),
+    ...(project?.createdAt && { foundingDate: project.createdAt }),
+    subjectOf: {
+      "@type": "WebPage",
+      url,
+      name,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: safeJsonLdStringify(projectSchema),
+      }}
+    />
+  );
+}

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -463,11 +463,11 @@
   "reactDoctor": {
     "score": 0,
     "errors": 63,
-    "warnings": 3294,
+    "warnings": 3295,
     "byCategory": {
       "Architecture": 1172,
       "Accessibility": 287,
-      "Correctness": 392,
+      "Correctness": 393,
       "Next.js": 142,
       "TanStack Query": 38,
       "State & Effects": 684,

--- a/utilities/markdown.server.ts
+++ b/utilities/markdown.server.ts
@@ -22,11 +22,34 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
   return defaultLinkOpen(tokens, idx, options, env, self);
 };
 
+// Optional heading demotion. When a caller renders user markdown *underneath* a
+// page/section heading (e.g. the project About sections, which sit below the
+// page <h1> and an <h2> section title), a leading `# ` in the content would emit
+// a rogue <h1> and break the single-<h1> page outline. Passing `headingOffset`
+// shifts every heading down by N levels (clamped to h6) so authored content can
+// never introduce a heading above the level the caller reserves for it.
+md.core.ruler.push("heading_offset", (state) => {
+  const offset = (state.env as { headingOffset?: number })?.headingOffset ?? 0;
+  if (!offset) return;
+  for (const token of state.tokens) {
+    if (token.type === "heading_open" || token.type === "heading_close") {
+      const level = Number.parseInt(token.tag.slice(1), 10);
+      token.tag = `h${Math.min(6, Math.max(1, level + offset))}`;
+    }
+  }
+});
+
 /**
  * Renders a markdown string to sanitized HTML on the server. Returns an empty
  * string for empty input so callers can skip rendering empty sections.
+ *
+ * @param options.headingOffset shift every heading down N levels (clamped to h6)
+ *   so content rendered under a section heading cannot emit an <h1>/outrank it.
  */
-export function renderMarkdownToHtml(source: string | undefined | null): string {
+export function renderMarkdownToHtml(
+  source: string | undefined | null,
+  options?: { headingOffset?: number }
+): string {
   if (!source) return "";
-  return md.render(source);
+  return md.render(source, { headingOffset: options?.headingOffset ?? 0 });
 }


### PR DESCRIPTION
## Overview

Project profile pages are the largest bucket in GSC **Crawled – currently not indexed (~24k URLs)**. Two root causes make each page look thin/low-value to crawlers:

1. **No structured data** — nothing tells crawlers what entity a project page represents.
2. **No server-rendered `<h1>`** — the visible title is an `<h2>` inside a sidebar card that renders twice (mobile + desktop), so there was no single authoritative page heading.

This PR ships both signals together (two commits) because both edit the same region of `app/project/[projectId]/layout.tsx` and would otherwise conflict.

## Commit 1 — `feat(seo): emit Project + Breadcrumb JSON-LD on project pages`

- New `components/Seo/ProjectJsonLd.tsx`, reusing the existing `components/Seo` pattern + `safeJsonLdStringify`. Emits a schema.org **`Project`** entity: `name`, canonical `url`, markdown-cleaned `description`, `logo`/`image`, `sameAs` (external project links), `keywords` (tags), `foundingDate`. All optional fields are conditionally spread — absent data produces no empty keys.
- Reuses the existing **`BreadcrumbJsonLd`** for `Home › Projects › <title>`.
- Rendered from the shared `[projectId]/layout.tsx` using the already-memoized `getProjectCachedData` (React `cache`), so **no extra request** is made. The fetch is wrapped defensively so a transient failure renders the shell instead of erroring the page.

## Commit 2 — `feat(seo): server-render a single sr-only h1 on project pages`

- Adds one **screen-reader-only `<h1>`** with the project title at the shared layout level, derived from the same project record — covering every project sub-route (profile tabs, updates, funding).
- Demotes the two competing `<h1>`s (About error boundary, "Project Not Found" state) to `<h2>` so each project page has exactly one authoritative heading.

## Testing

- `__tests__/components/Seo/ProjectJsonLd.test.tsx` — 10 tests: schema shape, field mapping, link filtering, optional-field omission, `</script>` XSS escaping.
- `__tests__/app/project-layout-h1.test.tsx` — 3 tests: exactly one `sr-only` h1 with the title; absent when title missing; absent when the fetch fails.
- Existing `__tests__/app/project-layout-ssr-shell.test.tsx` still green (including the fetch-rejection resilience path).
- `biome check` clean on all changed files; `tsc --noEmit` introduces **zero** new type errors (the 12 pre-existing errors live in an unrelated `rotating-word.test.tsx` on `main`).

## Notes

- No new env vars, routes, colors, or hardcoded URLs. Uses `SITE_URL` and existing helpers.
- Verify via **View Source** on a deployed preview of any `/project/<slug>`: two `application/ld+json` blocks (`Project` + `BreadcrumbList`) and a single `<h1 class="sr-only">`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project pages now include richer SEO metadata for search engines and social previews.
  * Project pages now show a crawler-friendly hidden page heading when a project title is available.

* **Bug Fixes**
  * Improved page heading rendering so section content no longer competes with the main page heading.
  * Project pages continue loading even if project data lookup temporarily fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->