### PR TITLE
fix(funding-platform): preserve admin/finance emails on program edit

### DIFF
--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -31,9 +31,27 @@ vi.mock("@/src/features/program-registry/services/program-registry.service", () 
       title: formData.name,
       description: formData.description,
       shortDescription: formData.shortDescription,
+      adminEmails: formData.adminEmails,
+      financeEmails: formData.financeEmails,
     })),
   },
 }));
+
+// The form pulls admin/finance emails from the admin-aware single-config
+// endpoint via useProgramConfig -> getProgramConfiguration. Mock the service
+// method (not the hook) so the real React Query timing is preserved.
+vi.mock("@/services/fundingPlatformService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/fundingPlatformService")>();
+  const getProgramConfiguration = vi.fn().mockResolvedValue(null);
+  return {
+    ...actual,
+    fundingProgramsAPI: { ...actual.fundingProgramsAPI, getProgramConfiguration },
+    fundingPlatformService: {
+      ...actual.fundingPlatformService,
+      programs: { ...actual.fundingPlatformService.programs, getProgramConfiguration },
+    },
+  };
+});
 
 vi.mock("@/utilities/fetchData", () => ({
   __esModule: true,
@@ -201,6 +219,7 @@ vi.mock("@/components/Utilities/DateTimePicker", () => ({
 import toast from "react-hot-toast";
 import { useAccount } from "wagmi";
 import { useAuth } from "@/hooks/useAuth";
+import { fundingPlatformService } from "@/services/fundingPlatformService";
 import fetchData from "@/utilities/fetchData";
 
 // Test data
@@ -293,6 +312,9 @@ describe("ProgramDetailsTab", () => {
 
     vi.mocked(ProgramRegistryService.extractProgramId).mockReturnValue(mockProgramDbId);
     vi.mocked(ProgramRegistryService.updateProgram).mockResolvedValue(undefined);
+
+    // Default: no separate config data — form sources emails from `program`.
+    vi.mocked(fundingPlatformService.programs.getProgramConfiguration).mockResolvedValue(null);
 
     vi.mocked(fetchData).mockImplementation(async (url: string) => {
       if (url.includes("find")) {
@@ -866,6 +888,107 @@ describe("ProgramDetailsTab", () => {
         },
         { timeout: 3000 }
       );
+    });
+  });
+
+  describe("Admin/Finance emails from admin-aware config (DEV-499)", () => {
+    // The community-list endpoint that hydrates `program` strips admin/finance
+    // email PII, so the form base arrives without them.
+    const strippedProgram: GrantProgram = {
+      ...mockProgram,
+      metadata: {
+        ...mockProgram.metadata!,
+        adminEmails: undefined,
+        financeEmails: undefined,
+      },
+    };
+
+    // The single-config endpoint (useProgramConfig) returns them to staff/admins.
+    const adminEmails = ["sejal@protocol.ai", "brynn@fil.org"];
+    const financeEmails = ["andreas@autonomousprojects.co", "brynn@fil.org"];
+    const configWithEmails = {
+      ...mockProgram,
+      metadata: {
+        ...mockProgram.metadata!,
+        adminEmails,
+        financeEmails,
+      },
+    };
+
+    beforeEach(() => {
+      vi.mocked(fetchData).mockImplementation(async (url: string) => {
+        if (url.includes("find")) {
+          return [strippedProgram, null];
+        }
+        return [null, null];
+      });
+      vi.mocked(fundingPlatformService.programs.getProgramConfiguration).mockResolvedValue(
+        configWithEmails as Awaited<
+          ReturnType<typeof fundingPlatformService.programs.getProgramConfiguration>
+        >
+      );
+    });
+
+    it("should populate email inputs from the config when the list-sourced program has them stripped", async () => {
+      renderWithProviders(<ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/program name/i)).toBeInTheDocument();
+      });
+
+      const adminTags = screen.getAllByTestId("email-tag-admin").map((el) => el.textContent);
+      expect(adminTags).toEqual(expect.arrayContaining(adminEmails));
+
+      const financeTags = screen.getAllByTestId("email-tag-finance").map((el) => el.textContent);
+      expect(financeTags).toEqual(expect.arrayContaining(financeEmails));
+    });
+
+    it("should preserve existing emails on save instead of overwriting them with an empty array", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/program name/i)).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/program name/i);
+      await user.type(nameInput, " Updated");
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(ProgramRegistryService.updateProgram).toHaveBeenCalledWith(
+          mockProgramId,
+          expect.objectContaining({ adminEmails, financeEmails })
+        );
+      });
+    });
+
+    it("should keep showing the loading spinner while the config is still loading", async () => {
+      // Never-resolving config keeps useProgramConfig in its loading state.
+      vi.mocked(fundingPlatformService.programs.getProgramConfiguration).mockReturnValue(
+        new Promise(() => {})
+      );
+
+      renderWithProviders(<ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} />);
+
+      expect(await screen.findByRole("status")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/program name/i)).not.toBeInTheDocument();
+    });
+
+    it("should block the form with a retry when the config fails to load", async () => {
+      vi.mocked(fundingPlatformService.programs.getProgramConfiguration).mockRejectedValue(
+        new Error("boom")
+      );
+
+      renderWithProviders(<ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load program configuration/i)).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+      // Form must not be editable when we can't confirm the stored emails.
+      expect(screen.queryByLabelText(/program name/i)).not.toBeInTheDocument();
     });
   });
 

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { DocumentTextIcon } from "@heroicons/react/24/solid";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GrantProgram } from "@/components/Pages/ProgramRegistry/ProgramList";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { Button } from "@/components/ui/button";
@@ -28,7 +28,12 @@ export function ProgramDetailsTab({
   readOnly = false,
   initialProgram,
 }: ProgramDetailsTabProps) {
-  const { data: programConfig } = useProgramConfig(programId);
+  const {
+    data: programConfig,
+    isLoading: isLoadingConfig,
+    error: configError,
+    refetch: refetchConfig,
+  } = useProgramConfig(programId);
   const effectiveChainId = chainId ?? programConfig?.chainID;
 
   const [isLoadingProgram, setIsLoadingProgram] = useState(!initialProgram);
@@ -99,6 +104,25 @@ export function ProgramDetailsTab({
     }
   }, [programId, effectiveChainId]);
 
+  // `program`/`initialProgram` is hydrated from the community-list endpoint,
+  // which strips admin/finance email PII for every caller. `useProgramConfig`
+  // hits the single-program endpoint that returns those fields to authenticated
+  // admins/staff — overlay them so the inputs populate and a Save can't
+  // overwrite the stored emails with an empty array.
+  const formProgram = useMemo<GrantProgram | null>(() => {
+    if (!program) return null;
+    const configMetadata = programConfig?.metadata;
+    if (!configMetadata || !program.metadata) return program;
+    return {
+      ...program,
+      metadata: {
+        ...program.metadata,
+        adminEmails: configMetadata.adminEmails ?? program.metadata.adminEmails,
+        financeEmails: configMetadata.financeEmails ?? program.metadata.financeEmails,
+      },
+    };
+  }, [program, programConfig]);
+
   const programIdToUpdate = programId || ProgramRegistryService.extractProgramId(program!);
 
   const {
@@ -113,7 +137,7 @@ export function ProgramDetailsTab({
   } = useAdminProgramForm({
     mode: "update",
     programId: programIdToUpdate || programId,
-    existingProgram: program,
+    existingProgram: formProgram,
     readOnly,
     onSuccess: () => {
       refetchProgramData();
@@ -129,7 +153,9 @@ export function ProgramDetailsTab({
     formState: { errors },
   } = form;
 
-  if (isLoadingProgram) {
+  // Wait for the admin-aware config too, so the form never renders (and can't
+  // be saved) with the email fields still missing from the stripped list data.
+  if (isLoadingProgram || isLoadingConfig) {
     return (
       <div className="flex items-center justify-center py-8">
         <Spinner />
@@ -137,11 +163,21 @@ export function ProgramDetailsTab({
     );
   }
 
-  if (programError) {
+  // A failed config load means the admin/finance emails never arrived, so block
+  // editing rather than let a Save wipe them — surface a retry instead.
+  if (programError || configError) {
     return (
       <div className="flex flex-col items-center justify-center py-8">
-        <p className="text-sm text-destructive mb-4">{programError}</p>
-        <Button variant="secondary" onClick={fetchProgram}>
+        <p className="text-sm text-destructive mb-4">
+          {programError ?? "Failed to load program configuration"}
+        </p>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            if (programError) fetchProgram();
+            if (configError) refetchConfig();
+          }}
+        >
           Retry
         </Button>
       </div>


### PR DESCRIPTION
## Summary

The program-details edit form (`/manage/funding-platform/[programId]/question-builder?tab=program-details`) rendered the **Admin Emails** and **Finance Emails** fields empty even for staff/admins who had emails configured, and saving the form would have wiped the stored emails.

## Problem

`ProgramDetailsTab` hydrates its form from the program passed down by `useFundingPrograms(...)`, which comes from the **community-list** endpoint `GET /v2/funding-program-configs/community/:id`. That endpoint's read service (`getByCommunity`) unconditionally strips `adminEmails`/`financeEmails` as PII for every caller — there is no admin/staff bypass on the list path.

The single-program endpoint `GET /v2/funding-program-configs/:programId` **does** return those fields to authenticated admins/staff (`getByProgramIdForUser` → `hasFundingProgramAdminAccess`), which is why they were visible at the raw API/JSON but not in the form.

Two bugs resulted:
1. **Display** — the email inputs were always empty in the editor, even for staff.
2. **Data loss** — because the form loaded empty emails and `buildUpdateMetadata` submits the current form values, clicking **Save Changes** posted `adminEmails: []` / `financeEmails: []`, overwriting the stored contacts.

The backend stripping is correct (PII shouldn't ride along in a broad community list), so this is a frontend-only fix: the editor must source its data from the admin-aware single-program config.

## Solution

- Overlay `adminEmails`/`financeEmails` from the admin-aware config (`useProgramConfig`, already fetched in the component) onto the form source, falling back to the existing value when the config doesn't carry them.
- Gate the form render on the config finishing loading (`isLoadingConfig`) so it can never be saved with the emails still missing from the stripped list data.
- Surface the existing error/retry state when the config fails to load, rather than letting an edit proceed against unknown email values.

## Testing Steps

1. As a staff/admin, open a program's **Program Details** tab where admin/finance emails are set (e.g. Filecoin program `1039`).
2. Confirm the **Admin Emails** and **Finance Emails** fields are pre-populated.
3. Remove one address, click **Save Changes**, reload — only that address is gone; the others are preserved.

Automated: `__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx` adds coverage for populate-from-config, preserve-on-save, spinner-while-loading, and config-load failure. Full file 34/34, related suites 69/69, `pnpm run build` green (95/95).

## Risk

Low. Frontend-only; no backend/API contract change. Adds a brief spinner while the single-program config resolves. Refs DEV-499 (unblocks the "remove brynn from email copy" request).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin and finance email fields now populate correctly from program configuration, even when the main program list omits those values.
  * Saving a program now preserves existing email entries instead of clearing them.
  * The details form now stays in a loading state until all required data is ready.
  * If configuration loading fails, the screen now shows an error with a retry option and prevents editing until the issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->