### PR TITLE
fix(funding-platform): keep read-only program details visible on config error

### DIFF
--- a/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
+++ b/__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx
@@ -990,6 +990,22 @@ describe("ProgramDetailsTab", () => {
       // Form must not be editable when we can't confirm the stored emails.
       expect(screen.queryByLabelText(/program name/i)).not.toBeInTheDocument();
     });
+
+    it("should still show read-only details when the config fails to load for a read-only viewer", async () => {
+      vi.mocked(fundingPlatformService.programs.getProgramConfiguration).mockRejectedValue(
+        new Error("boom")
+      );
+
+      renderWithProviders(
+        <ProgramDetailsTab programId={mockProgramId} chainId={mockChainId} readOnly />
+      );
+
+      // Read-only viewers can't save, so a config failure must not hide the view.
+      await waitFor(() => {
+        expect(screen.getByLabelText(/program name/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+    });
   });
 
   describe("Date Handling", () => {

--- a/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
+++ b/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.tsx
@@ -100,7 +100,8 @@ export function ProgramDetailsTab({
         setProgram(programData as GrantProgram | null);
       }
     } catch {
-      // Non-critical: silently ignore refetch failures
+      // SUPPRESSED: best-effort refetch after a successful save; the stored data
+      // is already updated and the stale view self-heals on the next load.
     }
   }, [programId, effectiveChainId]);
 
@@ -153,9 +154,10 @@ export function ProgramDetailsTab({
     formState: { errors },
   } = form;
 
-  // Wait for the admin-aware config too, so the form never renders (and can't
-  // be saved) with the email fields still missing from the stripped list data.
-  if (isLoadingProgram || isLoadingConfig) {
+  // Editors must wait for the admin-aware config so the form never renders (and
+  // can't be saved) with the email fields still missing from the stripped list
+  // data. Read-only viewers can't save, so don't gate their view on it.
+  if (isLoadingProgram || (isLoadingConfig && !readOnly)) {
     return (
       <div className="flex items-center justify-center py-8">
         <Spinner />
@@ -163,9 +165,10 @@ export function ProgramDetailsTab({
     );
   }
 
-  // A failed config load means the admin/finance emails never arrived, so block
-  // editing rather than let a Save wipe them — surface a retry instead.
-  if (programError || configError) {
+  // A failed config load means the admin/finance emails never arrived. For
+  // editors, block editing behind a retry rather than let a Save wipe them;
+  // read-only viewers still get the program details from the list data.
+  if (programError || (configError && !readOnly)) {
     return (
       <div className="flex flex-col items-center justify-center py-8">
         <p className="text-sm text-destructive mb-4">


### PR DESCRIPTION
## Summary

Follow-up to #1747 (admin/finance emails in the Program Details form). Refines the config-load gating so a config-lookup failure no longer hides the whole tab from read-only viewers, and clears the empty-catch anti-pattern flagged on the original PR.

## Problem

#1747 added two gates to `ProgramDetailsTab` that block the view until the admin-aware `useProgramConfig` resolves — a loading spinner and a config-error retry screen. Both applied to **everyone**, including read-only viewers (reviewers). A reviewer can reach this tab but can't save, so replacing the entire program-details view with a retry screen on a config error hides information they're entitled to see, for no safety benefit. (Raised by CodeRabbit on #1747.)

## Solution

- Scope both the config **loading** gate and the config **error** gate to editors (`!readOnly`):
  - Editors still wait for the admin-aware config and are blocked behind a retry on failure — this is what prevents a Save from overwriting the stored emails with `[]`.
  - Read-only viewers always see the program details (sourced from the list data); they can't save, so there's nothing to protect.
- Mark the pre-existing best-effort post-save refetch `catch` as `// SUPPRESSED:` with a reason, satisfying the empty-catch anti-pattern gate.

## Testing Steps

1. As a **reviewer** (read-only), open a program's Program Details tab while the config endpoint is failing → the read-only details still render (no full-screen retry).
2. As an **admin/editor**, with the config endpoint failing → a retry screen is shown (editing is blocked so emails can't be wiped).
3. Recover the config and retry → the form loads with the emails populated.

Automated: `ProgramDetailsTab.test.tsx` adds a read-only + config-error case; full file 35/35, `pnpm run build` green (95/95).

## Risk

Low. Frontend-only, no API contract change. Narrows when the config gates apply; the data-loss protection for editors is unchanged. Refs DEV-499.
