### PR TITLE
chore(quality): refresh baseline for ProgramDetailsTab test drift

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -52,8 +52,8 @@
       "maxBytes": 60000
     },
     "__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx": {
-      "lines": 921,
-      "bytes": 31385,
+      "lines": 1060,
+      "bytes": 37111,
       "maxLines": 800,
       "maxBytes": 60000
     },


### PR DESCRIPTION
## Problem

`main`'s quality baseline is red: #1747/#1748 grew `__tests__/components/FundingPlatform/QuestionBuilder/ProgramDetailsTab.test.tsx` from **921 → 1060 lines** (31385 → 37111 bytes) without updating `quality-baseline.json`. The file was already over the 800-line limit, so the quality gate flags it as a regression on **every PR branched off main**, even PRs that never touch it.

## Fix

Record the file's current line/byte counts in `quality-baseline.json` (the only drifted entry) so the gate reflects reality. Carries the `quality-baseline` label per repo policy.

## Scope

Baseline-only, 2-line change. No source changes.