### PR TITLE
feat(donor-rewards): gamified giving prototype for DAF donors

### DIFF
--- a/__tests__/features/donor-rewards/levels.test.ts
+++ b/__tests__/features/donor-rewards/levels.test.ts
@@ -1,0 +1,30 @@
+import { LEVELS } from "@/src/features/donor-rewards/data/mock-data";
+import { levelForXp, nextLevelForXp } from "@/src/features/donor-rewards/utils/levels";
+
+describe("levelForXp", () => {
+  it("returns the lowest level at 0 XP", () => {
+    expect(levelForXp(0).name).toBe("Supporter");
+  });
+
+  it("promotes exactly at each level threshold", () => {
+    for (const level of LEVELS) {
+      expect(levelForXp(level.minXp).name).toBe(level.name);
+      expect(levelForXp(level.minXp - 1).name).not.toBe(level.minXp === 0 ? "" : level.name);
+    }
+  });
+
+  it("stays at the top level past the last threshold", () => {
+    expect(levelForXp(1_000_000).name).toBe("Luminary");
+  });
+});
+
+describe("nextLevelForXp", () => {
+  it("returns the next threshold while one exists", () => {
+    expect(nextLevelForXp(0)?.name).toBe("Contributor");
+    expect(nextLevelForXp(2140)?.name).toBe("Benefactor");
+  });
+
+  it("returns null at the top level", () => {
+    expect(nextLevelForXp(5200)).toBeNull();
+  });
+});

--- a/__tests__/features/donor-rewards/quest-logic.test.ts
+++ b/__tests__/features/donor-rewards/quest-logic.test.ts
@@ -1,0 +1,55 @@
+import {
+  questsCompletedByGrant,
+  questsCompletedByRead,
+} from "@/src/features/donor-rewards/state/quest-logic";
+import type { Quest } from "@/src/features/donor-rewards/types";
+
+const quest = (overrides: Partial<Quest>): Quest => ({
+  id: "q",
+  title: "Quest",
+  description: "",
+  xp: 100,
+  type: "grant_any",
+  goal: 1,
+  progress: 0,
+  ...overrides,
+});
+
+describe("questsCompletedByGrant", () => {
+  it("matches grant_any, matching grant_cause, and recurring quests one step from goal", () => {
+    const quests = [
+      quest({ id: "any", type: "grant_any" }),
+      quest({ id: "climate", type: "grant_cause", targetCause: "climate" }),
+      quest({ id: "arts", type: "grant_cause", targetCause: "arts" }),
+      quest({ id: "recurring", type: "recurring" }),
+      quest({ id: "reads", type: "read_updates", goal: 2 }),
+    ];
+
+    const completed = questsCompletedByGrant(quests, { cause: "climate", recurring: true });
+
+    expect(completed.map((item) => item.id)).toEqual(["any", "climate", "recurring"]);
+  });
+
+  it("skips already-completed quests and multi-step quests not at the threshold", () => {
+    const quests = [
+      quest({ id: "done", type: "grant_any", progress: 1 }),
+      quest({ id: "multi", type: "grant_any", goal: 3, progress: 1 }),
+      quest({ id: "recurring", type: "recurring" }),
+    ];
+
+    expect(questsCompletedByGrant(quests, { cause: "health", recurring: false })).toEqual([]);
+  });
+});
+
+describe("questsCompletedByRead", () => {
+  it("returns read quests that the next read pushes to their goal", () => {
+    const quests = [
+      quest({ id: "reads", type: "read_updates", goal: 2, progress: 1 }),
+      quest({ id: "reads-early", type: "read_updates", goal: 3, progress: 1 }),
+      quest({ id: "reads-done", type: "read_updates", goal: 2, progress: 2 }),
+      quest({ id: "grant", type: "grant_any" }),
+    ];
+
+    expect(questsCompletedByRead(quests).map((item) => item.id)).toEqual(["reads"]);
+  });
+});

--- a/__tests__/features/donor-rewards/rewards-context.test.tsx
+++ b/__tests__/features/donor-rewards/rewards-context.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Economy-integrity tests for the donor-rewards reducer.
+ *
+ * The core invariant: the IP the UI advertises for an action must equal the
+ * IP the reducer credits. Both sides derive quest completions from
+ * quest-logic.ts, and these tests pin the credited side.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  INITIAL_STATE,
+  XP_NEW_CAUSE_BONUS,
+  XP_PER_GRANT,
+  XP_RECURRING_BONUS,
+} from "@/src/features/donor-rewards/data/mock-data";
+import { RewardsProvider, useRewards } from "@/src/features/donor-rewards/state/rewards-context";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <RewardsProvider>{children}</RewardsProvider>
+);
+
+function renderRewards() {
+  return renderHook(() => useRewards(), { wrapper });
+}
+
+describe("rewards reducer — grants", () => {
+  it("credits grant XP plus new-cause bonus plus completed grant quests", () => {
+    const { result } = renderRewards();
+
+    // org-rainforest is climate — a new cause — and completes both the
+    // climate quest (+120) and the grant-anything quest (+80).
+    act(() => result.current.makeGrant("org-rainforest", 500, false));
+
+    const expectedXp = XP_PER_GRANT + XP_NEW_CAUSE_BONUS + 120 + 80;
+    expect(result.current.state.xp).toBe(INITIAL_STATE.xp + expectedXp);
+    expect(result.current.state.celebration?.xpEarned).toBe(expectedXp);
+    expect(result.current.state.celebration?.questsCompleted.map((quest) => quest.id)).toEqual([
+      "q-climate",
+      "q-any-grant",
+    ]);
+  });
+
+  it("credits recurring bonus and recurring quest, and unlocks the recurring badge", () => {
+    const { result } = renderRewards();
+
+    // org-tutors is education — already supported, so no new-cause bonus.
+    act(() => result.current.makeGrant("org-tutors", 150, true));
+
+    const expectedXp = XP_PER_GRANT + XP_RECURRING_BONUS + 80 + 150;
+    expect(result.current.state.celebration?.xpEarned).toBe(expectedXp);
+    expect(result.current.state.hasRecurringGrant).toBe(true);
+    expect(result.current.state.badges.find((badge) => badge.id === "b-recurring")?.unlocked).toBe(
+      true
+    );
+  });
+
+  it("extends the streak on the first grant of the month only", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.makeGrant("org-tutors", 150, false));
+    expect(result.current.state.streakMonths).toBe(INITIAL_STATE.streakMonths + 1);
+    expect(result.current.state.celebration?.newStreak).toBe(INITIAL_STATE.streakMonths + 1);
+
+    act(() => result.current.makeGrant("org-meals", 100, false));
+    expect(result.current.state.streakMonths).toBe(INITIAL_STATE.streakMonths + 1);
+    expect(result.current.state.celebration?.newStreak).toBeNull();
+  });
+
+  it("debits the balance and adds the grant record", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.makeGrant("org-meals", 250, false));
+
+    expect(result.current.state.balance).toBe(INITIAL_STATE.balance - 250);
+    expect(result.current.state.grantedThisYear).toBe(INITIAL_STATE.grantedThisYear + 250);
+    expect(result.current.state.grants).toHaveLength(1);
+    expect(result.current.state.grants[0]).toMatchObject({
+      orgId: "org-meals",
+      amount: 250,
+      recurring: false,
+    });
+  });
+
+  it("ignores a grant to an unknown org", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.makeGrant("org-nope", 250, false));
+
+    expect(result.current.state).toEqual(INITIAL_STATE);
+  });
+
+  it("clears the celebration on dismiss", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.makeGrant("org-meals", 100, false));
+    expect(result.current.state.celebration).not.toBeNull();
+
+    act(() => result.current.dismissCelebration());
+    expect(result.current.state.celebration).toBeNull();
+  });
+});
+
+describe("rewards reducer — reading updates", () => {
+  it("credits the update XP plus the quest bonus when the read completes a quest, and records it", () => {
+    const { result } = renderRewards();
+
+    // q-updates starts at 1/2 with +60 IP, so the first read completes it.
+    act(() => result.current.readUpdate("u-harvest"));
+
+    const readUpdatesQuest = result.current.state.quests.find((quest) => quest.id === "q-updates");
+    expect(readUpdatesQuest?.progress).toBe(2);
+    expect(result.current.state.xp).toBe(INITIAL_STATE.xp + 15 + 60);
+    expect(
+      result.current.state.updates.find((update) => update.id === "u-harvest")?.xpAwarded
+    ).toBe(75);
+  });
+
+  it("credits only the update XP once the read quest is already complete", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.readUpdate("u-harvest"));
+    const xpAfterFirst = result.current.state.xp;
+
+    act(() => result.current.readUpdate("u-tutors"));
+
+    expect(result.current.state.xp).toBe(xpAfterFirst + 15);
+    expect(result.current.state.updates.find((update) => update.id === "u-tutors")?.xpAwarded).toBe(
+      15
+    );
+  });
+
+  it("is a no-op for an already-read or unknown update", () => {
+    const { result } = renderRewards();
+
+    act(() => result.current.readUpdate("u-stage")); // seeded as read
+    act(() => result.current.readUpdate("u-missing"));
+
+    expect(result.current.state).toEqual(INITIAL_STATE);
+  });
+});

--- a/app/donor-rewards/error.tsx
+++ b/app/donor-rewards/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { RouteErrorBoundary as default } from "@/src/components/shared/route-error-boundary";

--- a/app/donor-rewards/loading.tsx
+++ b/app/donor-rewards/loading.tsx
@@ -1,0 +1,1 @@
+export { MarketingRouteLoading as default } from "@/src/components/shared/marketing-route-loading";

--- a/app/donor-rewards/page.tsx
+++ b/app/donor-rewards/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { DonorRewardsApp } from "@/src/features/donor-rewards/components/donor-rewards-app";
+import { customMetadata } from "@/utilities/meta";
+
+export const metadata: Metadata = customMetadata({
+  title: "Your Giving Journey: streaks, quests, and verified impact",
+  description:
+    "A rewards experience for DAF donors. Keep your giving streak alive, complete monthly quests, and watch verified impact roll in from your grantees.",
+  path: "/donor-rewards",
+});
+
+export default function DonorRewardsPage() {
+  return <DonorRewardsApp />;
+}

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -154,8 +154,8 @@
       "maxBytes": 60000
     },
     "app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx": {
-      "lines": 637,
-      "bytes": 24160,
+      "lines": 640,
+      "bytes": 24339,
       "maxLines": 600,
       "maxBytes": 40000
     },

--- a/src/features/donor-rewards/components/badges-grid.tsx
+++ b/src/features/donor-rewards/components/badges-grid.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Lock } from "lucide-react";
+import { motion } from "motion/react";
+import pluralize from "pluralize";
+import React from "react";
+import { useRewards } from "../state/rewards-context";
+import type { BadgeDef } from "../types";
+
+const BadgeTile = React.memo(function BadgeTile({ badge }: { badge: BadgeDef }) {
+  return (
+    <motion.li
+      layout
+      className={`flex flex-col items-center gap-1.5 rounded-2xl border p-4 text-center ${
+        badge.unlocked
+          ? "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30"
+          : "border-zinc-200 bg-zinc-50 opacity-70 dark:border-zinc-800 dark:bg-zinc-900"
+      }`}
+      title={badge.description}
+    >
+      <span
+        className={`relative flex h-12 w-12 items-center justify-center rounded-full text-2xl ${
+          badge.unlocked
+            ? "bg-amber-100 dark:bg-amber-500/15"
+            : "bg-zinc-200 grayscale dark:bg-zinc-800"
+        }`}
+      >
+        {badge.emoji}
+        {!badge.unlocked && (
+          <span className="absolute -bottom-1 -right-1 rounded-full bg-zinc-500 p-1 text-white dark:bg-zinc-600">
+            <Lock className="h-2.5 w-2.5" aria-hidden="true" />
+          </span>
+        )}
+      </span>
+      <span
+        className={`text-xs font-bold leading-tight ${
+          badge.unlocked ? "text-amber-800 dark:text-amber-300" : "text-zinc-500 dark:text-zinc-400"
+        }`}
+      >
+        {badge.name}
+      </span>
+      <span className="text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">
+        {badge.description}
+      </span>
+    </motion.li>
+  );
+});
+
+export function BadgesGrid() {
+  const { state } = useRewards();
+  const unlockedCount = state.badges.filter((badge) => badge.unlocked).length;
+
+  return (
+    <section
+      aria-label="Badges"
+      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Badges</h2>
+        <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400">
+          {unlockedCount} of {state.badges.length} {pluralize("badge", state.badges.length)}
+        </span>
+      </div>
+      <ul className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {state.badges.map((badge) => (
+          <BadgeTile key={badge.id} badge={badge} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/badges-grid.tsx
+++ b/src/features/donor-rewards/components/badges-grid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Lock } from "lucide-react";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import pluralize from "pluralize";
 import React from "react";
 import { useRewards } from "../state/rewards-context";
@@ -9,7 +9,7 @@ import type { BadgeDef } from "../types";
 
 const BadgeTile = React.memo(function BadgeTile({ badge }: { badge: BadgeDef }) {
   return (
-    <motion.li
+    <m.li
       layout
       className={`flex flex-col items-center gap-1.5 rounded-2xl border p-4 text-center ${
         badge.unlocked
@@ -42,7 +42,7 @@ const BadgeTile = React.memo(function BadgeTile({ badge }: { badge: BadgeDef }) 
       <span className="text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">
         {badge.description}
       </span>
-    </motion.li>
+    </m.li>
   );
 });
 
@@ -56,7 +56,7 @@ export function BadgesGrid() {
       className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Badges</h2>
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Badges</h2>
         <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400">
           {unlockedCount} of {state.badges.length} {pluralize("badge", state.badges.length)}
         </span>

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -8,24 +8,22 @@ import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
 /**
- * Clicks in the first few hundred ms after mount are ignored so the second
- * click of a double-click on the grant-confirm button (which lands where the
- * dismiss button mounts) cannot instantly close the celebration.
+ * Clicks in the first few hundred ms after the overlay appears are ignored so
+ * the second click of a double-click on the grant-confirm button (which lands
+ * where the dismiss button mounts) cannot instantly close the celebration.
+ * The gate is a wall-clock comparison, not a timer flag, so dismissal can never
+ * get stuck if a timer callback is dropped — after DISMISS_LOCK_MS any click works.
  */
 const DISMISS_LOCK_MS = 400;
 
 export function CelebrationOverlay() {
   const { state, dismissCelebration } = useRewards();
   const celebration = state.celebration;
-  const canDismissRef = useRef(false);
+  const shownAtRef = useRef(0);
 
   useEffect(() => {
     if (!celebration) return;
-    canDismissRef.current = false;
-    const unlock = setTimeout(() => {
-      canDismissRef.current = true;
-    }, DISMISS_LOCK_MS);
-    return () => clearTimeout(unlock);
+    shownAtRef.current = Date.now();
   }, [celebration]);
 
   useEffect(() => {
@@ -56,7 +54,7 @@ export function CelebrationOverlay() {
   }, [celebration]);
 
   const handleDismiss = () => {
-    if (canDismissRef.current) dismissCelebration();
+    if (Date.now() - shownAtRef.current >= DISMISS_LOCK_MS) dismissCelebration();
   };
 
   return (

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -71,7 +71,10 @@ export function CelebrationOverlay() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[60] overflow-y-auto bg-black/60 backdrop-blur-sm"
+          // above the grant sheet (z-[10000]) and the karma-assistant FAB
+          // (z-[9999]), which otherwise floats over the card and can swallow
+          // the dismiss click
+          className="fixed inset-0 z-[10010] overflow-y-auto bg-black/60 backdrop-blur-sm"
           onClick={handleDismiss}
         >
           <div className="flex min-h-full items-center justify-center p-4">

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -3,13 +3,37 @@
 import { Flame, Sparkles, TrendingUp } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import pluralize from "pluralize";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
+
+/**
+ * Clicks in the first few hundred ms after mount are ignored so the second
+ * click of a double-click on the grant-confirm button (which lands where the
+ * dismiss button mounts) cannot instantly close the celebration.
+ */
+const DISMISS_LOCK_MS = 400;
 
 export function CelebrationOverlay() {
   const { state, dismissCelebration } = useRewards();
   const celebration = state.celebration;
+  const [canDismiss, setCanDismiss] = useState(false);
+
+  useEffect(() => {
+    if (!celebration) return;
+    setCanDismiss(false);
+    const unlock = setTimeout(() => setCanDismiss(true), DISMISS_LOCK_MS);
+    return () => clearTimeout(unlock);
+  }, [celebration]);
+
+  useEffect(() => {
+    if (!celebration) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismissCelebration();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [celebration, dismissCelebration]);
 
   useEffect(() => {
     if (!celebration) return;
@@ -22,12 +46,16 @@ export function CelebrationOverlay() {
         confetti.addConfetti({ confettiNumber: 120 });
       })
       .catch(() => {
-        // Confetti is decorative. The celebration screen still renders without it.
+        // SUPPRESSED: confetti is decorative; the celebration screen renders fully without it
       });
     return () => {
       cancelled = true;
     };
   }, [celebration]);
+
+  const handleDismiss = () => {
+    if (canDismiss) dismissCelebration();
+  };
 
   return (
     <AnimatePresence>
@@ -36,129 +64,133 @@ export function CelebrationOverlay() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+          className="fixed inset-0 z-[60] overflow-y-auto bg-black/60 backdrop-blur-sm"
+          onClick={handleDismiss}
         >
-          <motion.div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Grant celebration"
-            initial={{ scale: 0.8, opacity: 0, y: 30 }}
-            animate={{ scale: 1, opacity: 1, y: 0 }}
-            exit={{ scale: 0.9, opacity: 0 }}
-            transition={{ type: "spring", stiffness: 260, damping: 20 }}
-            className="w-full max-w-md rounded-3xl bg-white p-8 text-center shadow-2xl dark:bg-zinc-900"
-          >
+          <div className="flex min-h-full items-center justify-center p-4">
             <motion.div
-              initial={{ scale: 0 }}
-              animate={{ scale: 1, rotate: [0, -10, 10, 0] }}
-              transition={{
-                delay: 0.15,
-                scale: { type: "spring", stiffness: 200, delay: 0.15 },
-                rotate: { duration: 0.6, delay: 0.15, ease: "easeInOut" },
-              }}
-              className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-5xl dark:bg-emerald-500/15"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Grant celebration"
+              initial={{ scale: 0.8, opacity: 0, y: 30 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              transition={{ type: "spring", stiffness: 260, damping: 20 }}
+              className="my-4 w-full max-w-md rounded-3xl bg-white p-8 text-center shadow-2xl dark:bg-zinc-900"
+              onClick={(event) => event.stopPropagation()}
             >
-              🎉
-            </motion.div>
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1, rotate: [0, -10, 10, 0] }}
+                transition={{
+                  delay: 0.15,
+                  scale: { type: "spring", stiffness: 200, delay: 0.15 },
+                  rotate: { duration: 0.6, delay: 0.15, ease: "easeInOut" },
+                }}
+                className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-5xl dark:bg-emerald-500/15"
+              >
+                🎉
+              </motion.div>
 
-            <h2 className="mt-4 text-2xl font-bold text-zinc-900 dark:text-white">
-              {formatUsd(celebration.grant.amount)} on its way!
-            </h2>
-            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-              Your grant to {celebration.grant.orgName}
-              {celebration.grant.recurring ? " will repeat monthly" : " is being processed"}.
-            </p>
+              <h2 className="mt-4 text-2xl font-bold text-zinc-900 dark:text-white">
+                {formatUsd(celebration.grant.amount)} on its way!
+              </h2>
+              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                Your grant to {celebration.grant.orgName}
+                {celebration.grant.recurring ? " will repeat monthly" : " is being processed"}.
+              </p>
 
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.35 }}
-              className="mt-5 flex items-center justify-center gap-2 rounded-2xl bg-violet-50 py-3 dark:bg-violet-950/40"
-            >
-              <Sparkles className="h-5 w-5 text-violet-500" aria-hidden="true" />
-              <span className="font-mono text-xl font-bold text-violet-700 dark:text-violet-300">
-                +{celebration.xpEarned} Impact Points
-              </span>
-            </motion.div>
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.35 }}
+                className="mt-5 flex items-center justify-center gap-2 rounded-2xl bg-violet-50 py-3 dark:bg-violet-950/40"
+              >
+                <Sparkles className="h-5 w-5 text-violet-500" aria-hidden="true" />
+                <span className="font-mono text-xl font-bold text-violet-700 dark:text-violet-300">
+                  +{celebration.xpEarned} Impact Points
+                </span>
+              </motion.div>
 
-            <div className="mt-3 flex flex-col gap-2">
-              {celebration.newStreak !== null && (
-                <motion.div
-                  initial={{ opacity: 0, x: -14 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.5 }}
-                  className="flex items-center gap-3 rounded-2xl bg-orange-50 px-4 py-3 text-left dark:bg-orange-950/40"
-                >
-                  <Flame
-                    className="h-6 w-6 shrink-0 text-orange-500"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  />
-                  <span className="text-sm font-semibold text-orange-800 dark:text-orange-300">
-                    Streak extended to {celebration.newStreak}{" "}
-                    {pluralize("month", celebration.newStreak)}!
-                  </span>
-                </motion.div>
-              )}
-
-              {celebration.leveledUpTo && (
-                <motion.div
-                  initial={{ opacity: 0, x: -14 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.65 }}
-                  className="flex items-center gap-3 rounded-2xl bg-emerald-50 px-4 py-3 text-left dark:bg-emerald-950/40"
-                >
-                  <TrendingUp className="h-6 w-6 shrink-0 text-emerald-500" aria-hidden="true" />
-                  <span className="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
-                    Level up! You are now a {celebration.leveledUpTo}.
-                  </span>
-                </motion.div>
-              )}
-
-              {celebration.questsCompleted.map((quest, index) => (
-                <motion.div
-                  key={quest.id}
-                  initial={{ opacity: 0, x: -14 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: 0.8 + index * 0.12 }}
-                  className="flex items-center gap-3 rounded-2xl bg-zinc-100 px-4 py-3 text-left dark:bg-zinc-800"
-                >
-                  <span className="text-lg">✅</span>
-                  <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
-                    Quest complete: {quest.title}
-                  </span>
-                </motion.div>
-              ))}
-
-              {celebration.badgesUnlocked.map((badge, index) => (
-                <motion.div
-                  key={badge.id}
-                  initial={{ opacity: 0, scale: 0.7 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: 1 + index * 0.15, type: "spring", stiffness: 220 }}
-                  className="flex items-center gap-3 rounded-2xl border-2 border-amber-300 bg-amber-50 px-4 py-3 text-left dark:border-amber-700 dark:bg-amber-950/40"
-                >
-                  <span className="text-2xl">{badge.emoji}</span>
-                  <span>
-                    <span className="block text-sm font-bold text-amber-800 dark:text-amber-300">
-                      New badge: {badge.name}
+              <div className="mt-3 flex flex-col gap-2">
+                {celebration.newStreak !== null && (
+                  <motion.div
+                    initial={{ opacity: 0, x: -14 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: 0.5 }}
+                    className="flex items-center gap-3 rounded-2xl bg-orange-50 px-4 py-3 text-left dark:bg-orange-950/40"
+                  >
+                    <Flame
+                      className="h-6 w-6 shrink-0 text-orange-500"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm font-semibold text-orange-800 dark:text-orange-300">
+                      Streak extended to {celebration.newStreak}{" "}
+                      {pluralize("month", celebration.newStreak)}!
                     </span>
-                    <span className="block text-xs text-amber-700 dark:text-amber-400">
-                      {badge.description}
-                    </span>
-                  </span>
-                </motion.div>
-              ))}
-            </div>
+                  </motion.div>
+                )}
 
-            <button
-              type="button"
-              onClick={dismissCelebration}
-              className="mt-6 w-full rounded-2xl bg-zinc-900 py-3.5 font-bold text-white transition hover:bg-zinc-700 active:scale-[0.98] dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
-            >
-              Keep going
-            </button>
-          </motion.div>
+                {celebration.leveledUpTo && (
+                  <motion.div
+                    initial={{ opacity: 0, x: -14 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: 0.65 }}
+                    className="flex items-center gap-3 rounded-2xl bg-emerald-50 px-4 py-3 text-left dark:bg-emerald-950/40"
+                  >
+                    <TrendingUp className="h-6 w-6 shrink-0 text-emerald-500" aria-hidden="true" />
+                    <span className="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
+                      Level up! You are now a {celebration.leveledUpTo}.
+                    </span>
+                  </motion.div>
+                )}
+
+                {celebration.questsCompleted.map((quest, index) => (
+                  <motion.div
+                    key={quest.id}
+                    initial={{ opacity: 0, x: -14 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: 0.8 + index * 0.12 }}
+                    className="flex items-center gap-3 rounded-2xl bg-zinc-100 px-4 py-3 text-left dark:bg-zinc-800"
+                  >
+                    <span className="text-lg">✅</span>
+                    <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                      Quest complete: {quest.title}
+                    </span>
+                  </motion.div>
+                ))}
+
+                {celebration.badgesUnlocked.map((badge, index) => (
+                  <motion.div
+                    key={badge.id}
+                    initial={{ opacity: 0, scale: 0.7 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: 1 + index * 0.15, type: "spring", stiffness: 220 }}
+                    className="flex items-center gap-3 rounded-2xl border-2 border-amber-300 bg-amber-50 px-4 py-3 text-left dark:border-amber-700 dark:bg-amber-950/40"
+                  >
+                    <span className="text-2xl">{badge.emoji}</span>
+                    <span>
+                      <span className="block text-sm font-bold text-amber-800 dark:text-amber-300">
+                        New badge: {badge.name}
+                      </span>
+                      <span className="block text-xs text-amber-700 dark:text-amber-400">
+                        {badge.description}
+                      </span>
+                    </span>
+                  </motion.div>
+                ))}
+              </div>
+
+              <button
+                type="button"
+                onClick={handleDismiss}
+                className="mt-6 w-full rounded-2xl bg-zinc-900 py-3.5 font-bold text-white transition hover:bg-zinc-700 active:scale-[0.98] dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Keep going
+              </button>
+            </motion.div>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Flame, Sparkles, TrendingUp } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, m } from "motion/react";
 import pluralize from "pluralize";
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
@@ -17,12 +17,14 @@ const DISMISS_LOCK_MS = 400;
 export function CelebrationOverlay() {
   const { state, dismissCelebration } = useRewards();
   const celebration = state.celebration;
-  const [canDismiss, setCanDismiss] = useState(false);
+  const canDismissRef = useRef(false);
 
   useEffect(() => {
     if (!celebration) return;
-    setCanDismiss(false);
-    const unlock = setTimeout(() => setCanDismiss(true), DISMISS_LOCK_MS);
+    canDismissRef.current = false;
+    const unlock = setTimeout(() => {
+      canDismissRef.current = true;
+    }, DISMISS_LOCK_MS);
     return () => clearTimeout(unlock);
   }, [celebration]);
 
@@ -54,13 +56,13 @@ export function CelebrationOverlay() {
   }, [celebration]);
 
   const handleDismiss = () => {
-    if (canDismiss) dismissCelebration();
+    if (canDismissRef.current) dismissCelebration();
   };
 
   return (
     <AnimatePresence>
       {celebration && (
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -68,7 +70,7 @@ export function CelebrationOverlay() {
           onClick={handleDismiss}
         >
           <div className="flex min-h-full items-center justify-center p-4">
-            <motion.div
+            <m.div
               role="dialog"
               aria-modal="true"
               aria-label="Grant celebration"
@@ -79,9 +81,9 @@ export function CelebrationOverlay() {
               className="my-4 w-full max-w-md rounded-3xl bg-white p-8 text-center shadow-2xl dark:bg-zinc-900"
               onClick={(event) => event.stopPropagation()}
             >
-              <motion.div
-                initial={{ scale: 0 }}
-                animate={{ scale: 1, rotate: [0, -10, 10, 0] }}
+              <m.div
+                initial={{ scale: 0.5, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1, rotate: [0, -10, 10, 0] }}
                 transition={{
                   delay: 0.15,
                   scale: { type: "spring", stiffness: 200, delay: 0.15 },
@@ -90,9 +92,9 @@ export function CelebrationOverlay() {
                 className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-5xl dark:bg-emerald-500/15"
               >
                 🎉
-              </motion.div>
+              </m.div>
 
-              <h2 className="mt-4 text-2xl font-bold text-zinc-900 dark:text-white">
+              <h2 className="mt-4 text-2xl font-semibold text-zinc-900 dark:text-white">
                 {formatUsd(celebration.grant.amount)} on its way!
               </h2>
               <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
@@ -100,7 +102,7 @@ export function CelebrationOverlay() {
                 {celebration.grant.recurring ? " will repeat monthly" : " is being processed"}.
               </p>
 
-              <motion.div
+              <m.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.35 }}
@@ -110,11 +112,11 @@ export function CelebrationOverlay() {
                 <span className="font-mono text-xl font-bold text-violet-700 dark:text-violet-300">
                   +{celebration.xpEarned} Impact Points
                 </span>
-              </motion.div>
+              </m.div>
 
               <div className="mt-3 flex flex-col gap-2">
                 {celebration.newStreak !== null && (
-                  <motion.div
+                  <m.div
                     initial={{ opacity: 0, x: -14 }}
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.5 }}
@@ -129,11 +131,11 @@ export function CelebrationOverlay() {
                       Streak extended to {celebration.newStreak}{" "}
                       {pluralize("month", celebration.newStreak)}!
                     </span>
-                  </motion.div>
+                  </m.div>
                 )}
 
                 {celebration.leveledUpTo && (
-                  <motion.div
+                  <m.div
                     initial={{ opacity: 0, x: -14 }}
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.65 }}
@@ -143,11 +145,11 @@ export function CelebrationOverlay() {
                     <span className="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
                       Level up! You are now a {celebration.leveledUpTo}.
                     </span>
-                  </motion.div>
+                  </m.div>
                 )}
 
                 {celebration.questsCompleted.map((quest, index) => (
-                  <motion.div
+                  <m.div
                     key={quest.id}
                     initial={{ opacity: 0, x: -14 }}
                     animate={{ opacity: 1, x: 0 }}
@@ -158,11 +160,11 @@ export function CelebrationOverlay() {
                     <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
                       Quest complete: {quest.title}
                     </span>
-                  </motion.div>
+                  </m.div>
                 ))}
 
                 {celebration.badgesUnlocked.map((badge, index) => (
-                  <motion.div
+                  <m.div
                     key={badge.id}
                     initial={{ opacity: 0, scale: 0.7 }}
                     animate={{ opacity: 1, scale: 1 }}
@@ -178,7 +180,7 @@ export function CelebrationOverlay() {
                         {badge.description}
                       </span>
                     </span>
-                  </motion.div>
+                  </m.div>
                 ))}
               </div>
 
@@ -189,9 +191,9 @@ export function CelebrationOverlay() {
               >
                 Keep going
               </button>
-            </motion.div>
+            </m.div>
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Flame, Sparkles, TrendingUp } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import pluralize from "pluralize";
+import { useEffect } from "react";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+export function CelebrationOverlay() {
+  const { state, dismissCelebration } = useRewards();
+  const celebration = state.celebration;
+
+  useEffect(() => {
+    if (!celebration) return;
+    let cancelled = false;
+    import("js-confetti")
+      .then(({ default: JSConfetti }) => {
+        if (cancelled) return;
+        const confetti = new JSConfetti();
+        confetti.addConfetti({ emojis: ["🎉", "💚", "✨", "🌱"], confettiNumber: 60 });
+        confetti.addConfetti({ confettiNumber: 120 });
+      })
+      .catch(() => {
+        // Confetti is decorative. The celebration screen still renders without it.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [celebration]);
+
+  return (
+    <AnimatePresence>
+      {celebration && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+        >
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Grant celebration"
+            initial={{ scale: 0.8, opacity: 0, y: 30 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            className="w-full max-w-md rounded-3xl bg-white p-8 text-center shadow-2xl dark:bg-zinc-900"
+          >
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1, rotate: [0, -10, 10, 0] }}
+              transition={{
+                delay: 0.15,
+                scale: { type: "spring", stiffness: 200, delay: 0.15 },
+                rotate: { duration: 0.6, delay: 0.15, ease: "easeInOut" },
+              }}
+              className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-5xl dark:bg-emerald-500/15"
+            >
+              🎉
+            </motion.div>
+
+            <h2 className="mt-4 text-2xl font-bold text-zinc-900 dark:text-white">
+              {formatUsd(celebration.grant.amount)} on its way!
+            </h2>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              Your grant to {celebration.grant.orgName}
+              {celebration.grant.recurring ? " will repeat monthly" : " is being processed"}.
+            </p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.35 }}
+              className="mt-5 flex items-center justify-center gap-2 rounded-2xl bg-violet-50 py-3 dark:bg-violet-950/40"
+            >
+              <Sparkles className="h-5 w-5 text-violet-500" aria-hidden="true" />
+              <span className="font-mono text-xl font-bold text-violet-700 dark:text-violet-300">
+                +{celebration.xpEarned} Impact Points
+              </span>
+            </motion.div>
+
+            <div className="mt-3 flex flex-col gap-2">
+              {celebration.newStreak !== null && (
+                <motion.div
+                  initial={{ opacity: 0, x: -14 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: 0.5 }}
+                  className="flex items-center gap-3 rounded-2xl bg-orange-50 px-4 py-3 text-left dark:bg-orange-950/40"
+                >
+                  <Flame
+                    className="h-6 w-6 shrink-0 text-orange-500"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-semibold text-orange-800 dark:text-orange-300">
+                    Streak extended to {celebration.newStreak}{" "}
+                    {pluralize("month", celebration.newStreak)}!
+                  </span>
+                </motion.div>
+              )}
+
+              {celebration.leveledUpTo && (
+                <motion.div
+                  initial={{ opacity: 0, x: -14 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: 0.65 }}
+                  className="flex items-center gap-3 rounded-2xl bg-emerald-50 px-4 py-3 text-left dark:bg-emerald-950/40"
+                >
+                  <TrendingUp className="h-6 w-6 shrink-0 text-emerald-500" aria-hidden="true" />
+                  <span className="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
+                    Level up! You are now a {celebration.leveledUpTo}.
+                  </span>
+                </motion.div>
+              )}
+
+              {celebration.questsCompleted.map((quest, index) => (
+                <motion.div
+                  key={quest.id}
+                  initial={{ opacity: 0, x: -14 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: 0.8 + index * 0.12 }}
+                  className="flex items-center gap-3 rounded-2xl bg-zinc-100 px-4 py-3 text-left dark:bg-zinc-800"
+                >
+                  <span className="text-lg">✅</span>
+                  <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                    Quest complete: {quest.title}
+                  </span>
+                </motion.div>
+              ))}
+
+              {celebration.badgesUnlocked.map((badge, index) => (
+                <motion.div
+                  key={badge.id}
+                  initial={{ opacity: 0, scale: 0.7 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: 1 + index * 0.15, type: "spring", stiffness: 220 }}
+                  className="flex items-center gap-3 rounded-2xl border-2 border-amber-300 bg-amber-50 px-4 py-3 text-left dark:border-amber-700 dark:bg-amber-950/40"
+                >
+                  <span className="text-2xl">{badge.emoji}</span>
+                  <span>
+                    <span className="block text-sm font-bold text-amber-800 dark:text-amber-300">
+                      New badge: {badge.name}
+                    </span>
+                    <span className="block text-xs text-amber-700 dark:text-amber-400">
+                      {badge.description}
+                    </span>
+                  </span>
+                </motion.div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={dismissCelebration}
+              className="mt-6 w-full rounded-2xl bg-zinc-900 py-3.5 font-bold text-white transition hover:bg-zinc-700 active:scale-[0.98] dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              Keep going
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type JSConfetti from "js-confetti";
 import { Flame, Sparkles, TrendingUp } from "lucide-react";
 import { AnimatePresence, m } from "motion/react";
 import pluralize from "pluralize";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
@@ -20,8 +21,12 @@ export function CelebrationOverlay() {
   const { state, dismissCelebration } = useRewards();
   const celebration = state.celebration;
   const shownAtRef = useRef(0);
+  const confettiRef = useRef<JSConfetti | null>(null);
 
-  useEffect(() => {
+  // Layout effect so the timestamp is set before the browser can deliver the
+  // second click of a double-click — a plain effect leaves the ref at 0 for
+  // the first paint, letting that click through the 400ms gate.
+  useLayoutEffect(() => {
     if (!celebration) return;
     shownAtRef.current = Date.now();
   }, [celebration]);
@@ -39,11 +44,13 @@ export function CelebrationOverlay() {
     if (!celebration) return;
     let cancelled = false;
     import("js-confetti")
-      .then(({ default: JSConfetti }) => {
+      .then(({ default: JSConfettiCtor }) => {
         if (cancelled) return;
-        const confetti = new JSConfetti();
-        confetti.addConfetti({ emojis: ["🎉", "💚", "✨", "🌱"], confettiNumber: 60 });
-        confetti.addConfetti({ confettiNumber: 120 });
+        // One instance for the component's lifetime — each construction
+        // appends its own canvas to document.body and never removes it.
+        confettiRef.current ??= new JSConfettiCtor();
+        confettiRef.current.addConfetti({ emojis: ["🎉", "💚", "✨", "🌱"], confettiNumber: 60 });
+        confettiRef.current.addConfetti({ confettiNumber: 120 });
       })
       .catch(() => {
         // SUPPRESSED: confetti is decorative; the celebration screen renders fully without it

--- a/src/features/donor-rewards/components/donor-rewards-app.tsx
+++ b/src/features/donor-rewards/components/donor-rewards-app.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { RewardsProvider } from "../state/rewards-context";
+import { BadgesGrid } from "./badges-grid";
+import { CelebrationOverlay } from "./celebration-overlay";
+import { GoalRing } from "./goal-ring";
+import { GrantFlow } from "./grant-flow";
+import { IdleNudge } from "./idle-nudge";
+import { ImpactFeed } from "./impact-feed";
+import { LeagueCard } from "./league-card";
+import { QuestsCard } from "./quests-card";
+import { RewardsHeader } from "./rewards-header";
+import { StreakCard } from "./streak-card";
+import { YearRecap } from "./year-recap";
+
+export function DonorRewardsApp() {
+  const [grantFlowOpen, setGrantFlowOpen] = useState(false);
+  const [recapOpen, setRecapOpen] = useState(false);
+
+  return (
+    <RewardsProvider>
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
+        <RewardsHeader
+          onOpenGrantFlow={() => setGrantFlowOpen(true)}
+          onOpenRecap={() => setRecapOpen(true)}
+        />
+
+        <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
+          <StreakCard />
+          <GoalRing />
+          <IdleNudge onOpenGrantFlow={() => setGrantFlowOpen(true)} />
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <QuestsCard />
+          </div>
+          <LeagueCard />
+        </div>
+
+        <div className="mt-6">
+          <BadgesGrid />
+        </div>
+
+        <div className="mt-6">
+          <ImpactFeed />
+        </div>
+
+        <p className="mt-8 text-center text-xs text-zinc-400 dark:text-zinc-500">
+          Prototype with sample data. No real grants are made from this page.
+        </p>
+      </main>
+
+      <GrantFlow open={grantFlowOpen} onClose={() => setGrantFlowOpen(false)} />
+      <CelebrationOverlay />
+      <YearRecap open={recapOpen} onClose={() => setRecapOpen(false)} />
+    </RewardsProvider>
+  );
+}

--- a/src/features/donor-rewards/components/donor-rewards-app.tsx
+++ b/src/features/donor-rewards/components/donor-rewards-app.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { domAnimation, LazyMotion } from "motion/react";
 import { useState } from "react";
 import { RewardsProvider } from "../state/rewards-context";
 import { BadgesGrid } from "./badges-grid";
@@ -20,41 +21,43 @@ export function DonorRewardsApp() {
 
   return (
     <RewardsProvider>
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
-        <RewardsHeader
-          onOpenGrantFlow={() => setGrantFlowOpen(true)}
-          onOpenRecap={() => setRecapOpen(true)}
-        />
+      <LazyMotion features={domAnimation} strict>
+        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
+          <RewardsHeader
+            onOpenGrantFlow={() => setGrantFlowOpen(true)}
+            onOpenRecap={() => setRecapOpen(true)}
+          />
 
-        <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
-          <StreakCard />
-          <GoalRing />
-          <IdleNudge onOpenGrantFlow={() => setGrantFlowOpen(true)} />
-        </div>
-
-        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2">
-            <QuestsCard />
+          <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
+            <StreakCard />
+            <GoalRing />
+            <IdleNudge onOpenGrantFlow={() => setGrantFlowOpen(true)} />
           </div>
-          <LeagueCard />
-        </div>
 
-        <div className="mt-6">
-          <BadgesGrid />
-        </div>
+          <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <QuestsCard />
+            </div>
+            <LeagueCard />
+          </div>
 
-        <div className="mt-6">
-          <ImpactFeed />
-        </div>
+          <div className="mt-6">
+            <BadgesGrid />
+          </div>
 
-        <p className="mt-8 text-center text-xs text-zinc-400 dark:text-zinc-500">
-          Prototype with sample data. No real grants are made from this page.
-        </p>
-      </main>
+          <div className="mt-6">
+            <ImpactFeed />
+          </div>
 
-      <GrantFlow open={grantFlowOpen} onClose={() => setGrantFlowOpen(false)} />
-      <CelebrationOverlay />
-      <YearRecap open={recapOpen} onClose={() => setRecapOpen(false)} />
+          <p className="mt-8 text-center text-xs text-zinc-400 dark:text-zinc-500">
+            Prototype with sample data. No real grants are made from this page.
+          </p>
+        </main>
+
+        <GrantFlow open={grantFlowOpen} onClose={() => setGrantFlowOpen(false)} />
+        <CelebrationOverlay />
+        <YearRecap open={recapOpen} onClose={() => setRecapOpen(false)} />
+      </LazyMotion>
     </RewardsProvider>
   );
 }

--- a/src/features/donor-rewards/components/goal-ring.tsx
+++ b/src/features/donor-rewards/components/goal-ring.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { motion } from "motion/react";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+const RADIUS = 56;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function GoalRing() {
+  const { state } = useRewards();
+  const progress = Math.min(1, state.grantedThisYear / state.annualGoal);
+  const percent = Math.round(progress * 100);
+  const remaining = Math.max(0, state.annualGoal - state.grantedThisYear);
+
+  return (
+    <section
+      aria-label="Annual giving goal"
+      className="flex flex-col rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+        2026 giving goal
+      </h2>
+
+      <div className="mt-3 flex flex-1 items-center justify-center gap-6">
+        <div className="relative h-36 w-36">
+          <svg viewBox="0 0 144 144" className="h-full w-full -rotate-90">
+            <title>Progress toward annual giving goal</title>
+            <circle
+              cx="72"
+              cy="72"
+              r={RADIUS}
+              fill="none"
+              strokeWidth="14"
+              className="stroke-zinc-100 dark:stroke-zinc-800"
+            />
+            <motion.circle
+              cx="72"
+              cy="72"
+              r={RADIUS}
+              fill="none"
+              strokeWidth="14"
+              strokeLinecap="round"
+              strokeDasharray={CIRCUMFERENCE}
+              className="stroke-emerald-500"
+              initial={false}
+              animate={{ strokeDashoffset: CIRCUMFERENCE * (1 - progress) }}
+              transition={{ type: "spring", stiffness: 50, damping: 15 }}
+            />
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="font-mono text-3xl font-bold text-zinc-900 dark:text-white">
+              {percent}%
+            </span>
+            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400">
+              of {formatUsd(state.annualGoal)}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">Granted so far</p>
+            <p className="font-mono text-xl font-bold text-emerald-600 dark:text-emerald-400">
+              {formatUsd(state.grantedThisYear)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">Left to go</p>
+            <p className="font-mono text-xl font-bold text-zinc-900 dark:text-white">
+              {formatUsd(remaining)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+        {percent >= 100
+          ? "Goal reached! Consider stretching it for the rest of the year."
+          : percent >= 50
+            ? "You are ahead of pace for July. Keep it up!"
+            : "A grant this month keeps you on pace for the year."}
+      </p>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/goal-ring.tsx
+++ b/src/features/donor-rewards/components/goal-ring.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
@@ -34,7 +34,7 @@ export function GoalRing() {
               strokeWidth="14"
               className="stroke-zinc-100 dark:stroke-zinc-800"
             />
-            <motion.circle
+            <m.circle
               cx="72"
               cy="72"
               r={RADIUS}

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -60,14 +60,21 @@ const OrgOption = React.memo(function OrgOption({
 export function GrantFlow({ open, onClose }: GrantFlowProps) {
   const { state, makeGrant } = useRewards();
   const [selectedOrg, setSelectedOrg] = useState<Nonprofit | null>(null);
-  const [amount, setAmount] = useState<number>(500);
+  const [amount, setAmount] = useState<number | null>(null);
   const [recurring, setRecurring] = useState(false);
 
   const handleClose = () => {
     onClose();
     setSelectedOrg(null);
-    setAmount(500);
+    setAmount(null);
     setRecurring(false);
+  };
+
+  // Selecting an org seeds the amount from that org's own presets, so the
+  // confirm CTA can never show a value that isn't one of the visible chips.
+  const handleSelectOrg = (org: Nonprofit) => {
+    setSelectedOrg(org);
+    setAmount(org.suggestedAmounts[org.suggestedAmounts.length - 1]);
   };
 
   useEffect(() => {
@@ -80,7 +87,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
   });
 
   const handleConfirm = () => {
-    if (!selectedOrg) return;
+    if (!selectedOrg || amount === null) return;
     makeGrant(selectedOrg.id, amount, recurring);
     handleClose();
   };
@@ -138,7 +145,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 </p>
                 <ul className="mt-4 flex flex-col gap-3">
                   {NONPROFITS.map((org) => (
-                    <OrgOption key={org.id} org={org} onSelect={setSelectedOrg} />
+                    <OrgOption key={org.id} org={org} onSelect={handleSelectOrg} />
                   ))}
                 </ul>
               </>
@@ -222,9 +229,10 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   <button
                     type="button"
                     onClick={handleConfirm}
-                    className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98]"
+                    disabled={amount === null}
+                    className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
                   >
-                    Grant {formatUsd(amount)}
+                    Grant {amount !== null ? formatUsd(amount) : ""}
                     {recurring ? " monthly" : ""} to {selectedOrg.name}
                   </button>
                   <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -105,6 +105,17 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
   const questsToComplete = selectedOrg
     ? questsCompletedByGrant(state.quests, { cause: selectedOrg.cause, recurring })
     : [];
+  const totalIp =
+    XP_PER_GRANT +
+    (isNewCause ? XP_NEW_CAUSE_BONUS : 0) +
+    (recurring ? XP_RECURRING_BONUS : 0) +
+    questsToComplete.reduce((sum, quest) => sum + quest.xp, 0);
+  const earnParts = [
+    `+${XP_PER_GRANT} grant`,
+    ...(isNewCause ? [`+${XP_NEW_CAUSE_BONUS} new cause`] : []),
+    ...(recurring ? [`+${XP_RECURRING_BONUS} recurring bonus`] : []),
+    ...questsToComplete.map((quest) => `+${quest.xp} quest: ${quest.title}`),
+  ];
 
   return (
     <AnimatePresence>
@@ -114,6 +125,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm sm:items-center sm:p-6"
+          onClick={handleClose}
         >
           <m.div
             role="dialog"
@@ -124,6 +136,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
             exit={{ opacity: 0, scale: 0.98 }}
             transition={{ duration: 0.15 }}
             className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-zinc-50 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
+            onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-center justify-between px-6 pt-6">
               {selectedOrg ? (
@@ -165,8 +178,8 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 </ul>
               </div>
             ) : (
-              <div className="mt-4 min-h-0 flex-1 overflow-y-auto px-6 pb-4">
-                <div className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+              <div className="mt-3 min-h-0 flex-1 overflow-y-auto px-6 pb-3">
+                <div className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-800">
                   <span className="text-3xl">{selectedOrg.emoji}</span>
                   <div>
                     <p className="font-bold text-zinc-900 dark:text-white">{selectedOrg.name}</p>
@@ -176,7 +189,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   </div>
                 </div>
 
-                <p className="mt-5 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                <p className="mt-4 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
                   Grant amount
                 </p>
                 <div className="mt-2 grid grid-cols-3 gap-2">
@@ -185,7 +198,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                       key={suggested}
                       type="button"
                       onClick={() => setAmount(suggested)}
-                      className={`rounded-2xl border-2 py-3 font-mono text-lg font-bold transition active:scale-95 ${
+                      className={`rounded-2xl border-2 py-2.5 font-mono text-lg font-bold transition active:scale-95 ${
                         amount === suggested
                           ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
                           : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
@@ -196,7 +209,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   ))}
                 </div>
 
-                <label className="mt-5 flex cursor-pointer items-center justify-between rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+                <label className="mt-4 flex cursor-pointer items-center justify-between rounded-2xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-800">
                   <span>
                     <span className="block font-semibold text-zinc-900 dark:text-white">
                       Make it monthly
@@ -229,32 +242,27 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
             )}
 
             {/* The earn summary lives in the fixed footer with the CTA so it is
-                readable at the moment of confirming, at any viewport height. */}
+                readable at the moment of confirming. It stays compact — one
+                total plus a single wrapped breakdown line — so the footer
+                never grows tall enough to clip the scrollable body's controls
+                on short viewports. */}
             {selectedOrg && (
-              <div className="border-t border-zinc-200 px-6 pb-5 pt-3 dark:border-zinc-800">
-                <div className="rounded-2xl bg-violet-50 p-4 text-sm dark:bg-violet-950/40">
-                  <p className="font-semibold text-violet-800 dark:text-violet-300">
-                    You will earn
+              <div className="border-t border-zinc-200 px-6 pb-4 pt-2.5 dark:border-zinc-800">
+                <div className="rounded-2xl bg-violet-50 px-4 py-3 dark:bg-violet-950/40">
+                  <p className="text-sm font-semibold text-violet-800 dark:text-violet-300">
+                    You will earn <span className="font-mono">+{totalIp} IP</span>
                   </p>
-                  <ul className="mt-1 space-y-0.5 text-violet-700 dark:text-violet-400">
-                    <li>+{XP_PER_GRANT} IP for this grant</li>
-                    {isNewCause && <li>+{XP_NEW_CAUSE_BONUS} IP for supporting a new cause</li>}
-                    {recurring && <li>+{XP_RECURRING_BONUS} IP recurring bonus</li>}
-                    {questsToComplete.map((quest) => (
-                      <li key={quest.id}>
-                        ✅ Completes quest "{quest.title}" · +{quest.xp} IP
-                      </li>
-                    ))}
-                    {!state.grantedThisMonth && (
-                      <li>🔥 Streak extends to month {state.streakMonths + 1}</li>
-                    )}
-                  </ul>
+                  <p className="mt-0.5 text-xs text-violet-700 dark:text-violet-400">
+                    {earnParts.join(" · ")}
+                    {!state.grantedThisMonth &&
+                      ` · 🔥 streak extends to month ${state.streakMonths + 1}`}
+                  </p>
                 </div>
                 <button
                   type="button"
                   onClick={handleConfirm}
                   disabled={amount === null}
-                  className="mt-3 w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                  className="mt-2.5 w-full rounded-2xl bg-emerald-600 py-3.5 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Grant {amount !== null ? formatUsd(amount) : ""}
                   {recurring ? " monthly" : ""} to {selectedOrg.name}

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { ArrowLeft, BadgeCheck, X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
-import React, { useState } from "react";
+import { AnimatePresence, m } from "motion/react";
+import React, { useEffect, useState } from "react";
 import { CAUSES, NONPROFITS } from "../data/mock-data";
 import { useRewards } from "../state/rewards-context";
 import type { Nonprofit } from "../types";
@@ -70,6 +70,15 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
     setRecurring(false);
   };
 
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
   const handleConfirm = () => {
     if (!selectedOrg) return;
     makeGrant(selectedOrg.id, amount, recurring);
@@ -81,23 +90,21 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
   return (
     <AnimatePresence>
       {open && (
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm sm:items-center sm:p-6"
-          onClick={handleClose}
         >
-          <motion.div
+          <m.div
             role="dialog"
             aria-modal="true"
             aria-label="Make a grant"
-            initial={{ y: 60, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: 60, opacity: 0 }}
-            transition={{ type: "spring", stiffness: 300, damping: 28 }}
+            initial={{ opacity: 0, scale: 0.98 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.98 }}
+            transition={{ duration: 0.15 }}
             className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-t-3xl bg-zinc-50 p-6 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
-            onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-center justify-between">
               {selectedOrg ? (
@@ -110,7 +117,9 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   Back
                 </button>
               ) : (
-                <h2 className="text-xl font-bold text-zinc-900 dark:text-white">Make a grant</h2>
+                <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">
+                  Make a grant
+                </h2>
               )}
               <button
                 type="button"
@@ -176,6 +185,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   </span>
                   <input
                     type="checkbox"
+                    aria-label="Make it monthly"
                     checked={recurring}
                     onChange={(event) => setRecurring(event.target.checked)}
                     className="peer sr-only"
@@ -208,21 +218,23 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   </ul>
                 </div>
 
-                <button
-                  type="button"
-                  onClick={handleConfirm}
-                  className="mt-5 w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98]"
-                >
-                  Grant {formatUsd(amount)}
-                  {recurring ? " monthly" : ""} to {selectedOrg.name}
-                </button>
-                <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
-                  Prototype: no real money moves.
-                </p>
+                <div className="sticky bottom-0 -mx-6 mt-5 bg-zinc-50 px-6 pb-1 pt-2 dark:bg-zinc-900">
+                  <button
+                    type="button"
+                    onClick={handleConfirm}
+                    className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98]"
+                  >
+                    Grant {formatUsd(amount)}
+                    {recurring ? " monthly" : ""} to {selectedOrg.name}
+                  </button>
+                  <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
+                    Prototype: no real money moves.
+                  </p>
+                </div>
               </div>
             )}
-          </motion.div>
-        </motion.div>
+          </m.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { ArrowLeft, BadgeCheck, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import React, { useState } from "react";
+import { CAUSES, NONPROFITS } from "../data/mock-data";
+import { useRewards } from "../state/rewards-context";
+import type { Nonprofit } from "../types";
+import { formatUsd } from "../utils/format";
+
+interface GrantFlowProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const OrgOption = React.memo(function OrgOption({
+  org,
+  onSelect,
+}: {
+  org: Nonprofit;
+  onSelect: (org: Nonprofit) => void;
+}) {
+  const cause = CAUSES[org.cause];
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(org)}
+        className="flex w-full items-start gap-3 rounded-2xl border border-zinc-200 bg-white p-4 text-left transition hover:border-emerald-400 hover:shadow-md active:scale-[0.99] dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-emerald-500"
+      >
+        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-zinc-100 text-2xl dark:bg-zinc-700">
+          {org.emoji}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-1.5">
+            <span className="font-bold text-zinc-900 dark:text-white">{org.name}</span>
+            {org.verified && (
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-bold text-sky-700 dark:bg-sky-500/15 dark:text-sky-400">
+                <BadgeCheck className="h-3 w-3" aria-hidden="true" />
+                Verified
+              </span>
+            )}
+          </span>
+          <span className="mt-0.5 block text-sm text-zinc-500 dark:text-zinc-400">
+            {org.tagline}
+          </span>
+          <span className="mt-1.5 flex items-center gap-2 text-xs">
+            <span className="rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+              {cause.emoji} {cause.label}
+            </span>
+            <span className="text-zinc-400 dark:text-zinc-500">{org.impactNote}</span>
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+});
+
+export function GrantFlow({ open, onClose }: GrantFlowProps) {
+  const { state, makeGrant } = useRewards();
+  const [selectedOrg, setSelectedOrg] = useState<Nonprofit | null>(null);
+  const [amount, setAmount] = useState<number>(500);
+  const [recurring, setRecurring] = useState(false);
+
+  const handleClose = () => {
+    onClose();
+    setSelectedOrg(null);
+    setAmount(500);
+    setRecurring(false);
+  };
+
+  const handleConfirm = () => {
+    if (!selectedOrg) return;
+    makeGrant(selectedOrg.id, amount, recurring);
+    handleClose();
+  };
+
+  const isNewCause = selectedOrg ? !state.causesSupported.includes(selectedOrg.cause) : false;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm sm:items-center sm:p-6"
+          onClick={handleClose}
+        >
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Make a grant"
+            initial={{ y: 60, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 60, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 300, damping: 28 }}
+            className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-t-3xl bg-zinc-50 p-6 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              {selectedOrg ? (
+                <button
+                  type="button"
+                  onClick={() => setSelectedOrg(null)}
+                  className="flex items-center gap-1 text-sm font-semibold text-zinc-500 transition hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+                >
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                  Back
+                </button>
+              ) : (
+                <h2 className="text-xl font-bold text-zinc-900 dark:text-white">Make a grant</h2>
+              )}
+              <button
+                type="button"
+                onClick={handleClose}
+                aria-label="Close"
+                className="rounded-full p-2 text-zinc-400 transition hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+              >
+                <X className="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            {!selectedOrg ? (
+              <>
+                <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                  Suggested for you, based on your causes and this month's quests
+                </p>
+                <ul className="mt-4 flex flex-col gap-3">
+                  {NONPROFITS.map((org) => (
+                    <OrgOption key={org.id} org={org} onSelect={setSelectedOrg} />
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <div className="mt-4">
+                <div className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+                  <span className="text-3xl">{selectedOrg.emoji}</span>
+                  <div>
+                    <p className="font-bold text-zinc-900 dark:text-white">{selectedOrg.name}</p>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {selectedOrg.impactNote}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="mt-5 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                  Grant amount
+                </p>
+                <div className="mt-2 grid grid-cols-3 gap-2">
+                  {selectedOrg.suggestedAmounts.map((suggested) => (
+                    <button
+                      key={suggested}
+                      type="button"
+                      onClick={() => setAmount(suggested)}
+                      className={`rounded-2xl border-2 py-3 font-mono text-lg font-bold transition active:scale-95 ${
+                        amount === suggested
+                          ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                          : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                      }`}
+                    >
+                      {formatUsd(suggested)}
+                    </button>
+                  ))}
+                </div>
+
+                <label className="mt-5 flex cursor-pointer items-center justify-between rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+                  <span>
+                    <span className="block font-semibold text-zinc-900 dark:text-white">
+                      Make it monthly
+                    </span>
+                    <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                      Protects your streak automatically · +100 IP bonus
+                    </span>
+                  </span>
+                  <input
+                    type="checkbox"
+                    checked={recurring}
+                    onChange={(event) => setRecurring(event.target.checked)}
+                    className="peer sr-only"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className={`relative h-7 w-12 shrink-0 rounded-full transition-colors ${
+                      recurring ? "bg-emerald-500" : "bg-zinc-300 dark:bg-zinc-600"
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-1 h-5 w-5 rounded-full bg-white shadow transition-all ${
+                        recurring ? "left-6" : "left-1"
+                      }`}
+                    />
+                  </span>
+                </label>
+
+                <div className="mt-5 rounded-2xl bg-violet-50 p-4 text-sm dark:bg-violet-950/40">
+                  <p className="font-semibold text-violet-800 dark:text-violet-300">
+                    You will earn
+                  </p>
+                  <ul className="mt-1 space-y-0.5 text-violet-700 dark:text-violet-400">
+                    <li>+150 IP for this grant</li>
+                    {isNewCause && <li>+50 IP for supporting a new cause</li>}
+                    {recurring && <li>+100 IP recurring bonus</li>}
+                    {!state.grantedThisMonth && (
+                      <li>🔥 Streak extends to month {state.streakMonths + 1}</li>
+                    )}
+                  </ul>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleConfirm}
+                  className="mt-5 w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98]"
+                >
+                  Grant {formatUsd(amount)}
+                  {recurring ? " monthly" : ""} to {selectedOrg.name}
+                </button>
+                <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
+                  Prototype: no real money moves.
+                </p>
+              </div>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -2,8 +2,15 @@
 
 import { ArrowLeft, BadgeCheck, X } from "lucide-react";
 import { AnimatePresence, m } from "motion/react";
-import React, { useEffect, useState } from "react";
-import { CAUSES, NONPROFITS } from "../data/mock-data";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  CAUSES,
+  NONPROFITS,
+  XP_NEW_CAUSE_BONUS,
+  XP_PER_GRANT,
+  XP_RECURRING_BONUS,
+} from "../data/mock-data";
+import { questsCompletedByGrant } from "../state/quest-logic";
 import { useRewards } from "../state/rewards-context";
 import type { Nonprofit } from "../types";
 import { formatUsd } from "../utils/format";
@@ -63,12 +70,12 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
   const [amount, setAmount] = useState<number | null>(null);
   const [recurring, setRecurring] = useState(false);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     onClose();
     setSelectedOrg(null);
     setAmount(null);
     setRecurring(false);
-  };
+  }, [onClose]);
 
   // Selecting an org seeds the amount from that org's own presets, so the
   // confirm CTA can never show a value that isn't one of the visible chips.
@@ -84,7 +91,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  });
+  }, [open, handleClose]);
 
   const handleConfirm = () => {
     if (!selectedOrg || amount === null) return;
@@ -93,6 +100,11 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
   };
 
   const isNewCause = selectedOrg ? !state.causesSupported.includes(selectedOrg.cause) : false;
+  // Same helper the reducer uses to credit XP, so the panel can never promise
+  // a different amount than the celebration actually awards.
+  const questsToComplete = selectedOrg
+    ? questsCompletedByGrant(state.quests, { cause: selectedOrg.cause, recurring })
+    : [];
 
   return (
     <AnimatePresence>
@@ -111,9 +123,9 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.98 }}
             transition={{ duration: 0.15 }}
-            className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-t-3xl bg-zinc-50 p-6 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
+            className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-zinc-50 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
           >
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between px-6 pt-6">
               {selectedOrg ? (
                 <button
                   type="button"
@@ -138,8 +150,11 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
               </button>
             </div>
 
+            {/* The body scrolls on its own while the confirm footer stays in
+                normal flex flow below it, so no content can ever be hidden
+                underneath the CTA. */}
             {!selectedOrg ? (
-              <>
+              <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
                 <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
                   Suggested for you, based on your causes and this month's quests
                 </p>
@@ -148,9 +163,9 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                     <OrgOption key={org.id} org={org} onSelect={handleSelectOrg} />
                   ))}
                 </ul>
-              </>
+              </div>
             ) : (
-              <div className="mt-4">
+              <div className="mt-4 min-h-0 flex-1 overflow-y-auto px-6 pb-4">
                 <div className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
                   <span className="text-3xl">{selectedOrg.emoji}</span>
                   <div>
@@ -187,7 +202,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                       Make it monthly
                     </span>
                     <span className="block text-xs text-zinc-500 dark:text-zinc-400">
-                      Protects your streak automatically · +100 IP bonus
+                      Protects your streak automatically · +{XP_RECURRING_BONUS} IP bonus
                     </span>
                   </span>
                   <input
@@ -216,29 +231,36 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                     You will earn
                   </p>
                   <ul className="mt-1 space-y-0.5 text-violet-700 dark:text-violet-400">
-                    <li>+150 IP for this grant</li>
-                    {isNewCause && <li>+50 IP for supporting a new cause</li>}
-                    {recurring && <li>+100 IP recurring bonus</li>}
+                    <li>+{XP_PER_GRANT} IP for this grant</li>
+                    {isNewCause && <li>+{XP_NEW_CAUSE_BONUS} IP for supporting a new cause</li>}
+                    {recurring && <li>+{XP_RECURRING_BONUS} IP recurring bonus</li>}
+                    {questsToComplete.map((quest) => (
+                      <li key={quest.id}>
+                        ✅ Completes quest "{quest.title}" · +{quest.xp} IP
+                      </li>
+                    ))}
                     {!state.grantedThisMonth && (
                       <li>🔥 Streak extends to month {state.streakMonths + 1}</li>
                     )}
                   </ul>
                 </div>
+              </div>
+            )}
 
-                <div className="sticky bottom-0 -mx-6 mt-5 bg-zinc-50 px-6 pb-1 pt-2 dark:bg-zinc-900">
-                  <button
-                    type="button"
-                    onClick={handleConfirm}
-                    disabled={amount === null}
-                    className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    Grant {amount !== null ? formatUsd(amount) : ""}
-                    {recurring ? " monthly" : ""} to {selectedOrg.name}
-                  </button>
-                  <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
-                    Prototype: no real money moves.
-                  </p>
-                </div>
+            {selectedOrg && (
+              <div className="border-t border-zinc-200 px-6 pb-5 pt-3 dark:border-zinc-800">
+                <button
+                  type="button"
+                  onClick={handleConfirm}
+                  disabled={amount === null}
+                  className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Grant {amount !== null ? formatUsd(amount) : ""}
+                  {recurring ? " monthly" : ""} to {selectedOrg.name}
+                </button>
+                <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
+                  Prototype: no real money moves.
+                </p>
               </div>
             )}
           </m.div>

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -225,8 +225,14 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                     />
                   </span>
                 </label>
+              </div>
+            )}
 
-                <div className="mt-5 rounded-2xl bg-violet-50 p-4 text-sm dark:bg-violet-950/40">
+            {/* The earn summary lives in the fixed footer with the CTA so it is
+                readable at the moment of confirming, at any viewport height. */}
+            {selectedOrg && (
+              <div className="border-t border-zinc-200 px-6 pb-5 pt-3 dark:border-zinc-800">
+                <div className="rounded-2xl bg-violet-50 p-4 text-sm dark:bg-violet-950/40">
                   <p className="font-semibold text-violet-800 dark:text-violet-300">
                     You will earn
                   </p>
@@ -244,16 +250,11 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                     )}
                   </ul>
                 </div>
-              </div>
-            )}
-
-            {selectedOrg && (
-              <div className="border-t border-zinc-200 px-6 pb-5 pt-3 dark:border-zinc-800">
                 <button
                   type="button"
                   onClick={handleConfirm}
                   disabled={amount === null}
-                  className="w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                  className="mt-3 w-full rounded-2xl bg-emerald-600 py-4 text-base font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Grant {amount !== null ? formatUsd(amount) : ""}
                   {recurring ? " monthly" : ""} to {selectedOrg.name}

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -124,7 +124,9 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm sm:items-center sm:p-6"
+          // above the karma-assistant FAB (z-[9999]); the FAB otherwise floats
+          // over the sheet and swallows clicks near the bottom-right corner
+          className="fixed inset-0 z-[10000] flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm sm:items-center sm:p-6"
           onClick={handleClose}
         >
           <m.div

--- a/src/features/donor-rewards/components/idle-nudge.tsx
+++ b/src/features/donor-rewards/components/idle-nudge.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Zap } from "lucide-react";
+import { motion } from "motion/react";
+import pluralize from "pluralize";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+interface IdleNudgeProps {
+  onOpenGrantFlow: () => void;
+}
+
+export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
+  const { state } = useRewards();
+
+  if (state.idleDays === 0) {
+    return (
+      <section
+        aria-label="Funds at work"
+        className="flex flex-col justify-between rounded-3xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm dark:border-emerald-900 dark:bg-emerald-950/40"
+      >
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+            Funds at work
+          </h2>
+          <p className="mt-3 text-2xl font-bold text-emerald-800 dark:text-emerald-200">
+            Nice work! 🎉
+          </p>
+          <p className="mt-2 text-sm text-emerald-700 dark:text-emerald-300">
+            Your latest grant put your dollars back to work. Nonprofits will report verified
+            milestones as your funding lands.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenGrantFlow}
+          className="mt-4 w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-emerald-700 active:scale-95"
+        >
+          Grant again
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Idle funds nudge"
+      className="flex flex-col justify-between rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm dark:border-amber-900 dark:bg-amber-950/40"
+    >
+      <div>
+        <div className="flex items-center gap-2">
+          <motion.div
+            animate={{ y: [0, -3, 0] }}
+            transition={{ repeat: Number.POSITIVE_INFINITY, duration: 2 }}
+            className="rounded-xl bg-amber-100 p-2 text-amber-600 dark:bg-amber-500/15 dark:text-amber-400"
+          >
+            <Zap className="h-5 w-5" fill="currentColor" aria-hidden="true" />
+          </motion.div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
+            Money resting
+          </h2>
+        </div>
+        <p className="mt-3 text-2xl font-bold text-amber-900 dark:text-amber-100">
+          {formatUsd(state.balance)} has been idle for {state.idleDays}{" "}
+          {pluralize("day", state.idleDays)}
+        </p>
+        <p className="mt-2 text-sm text-amber-800 dark:text-amber-200">
+          Even {formatUsd(500)} could fund a month of verified impact. Put a piece of it to work
+          today.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onOpenGrantFlow}
+        className="mt-4 w-full rounded-2xl bg-amber-500 px-4 py-3 text-sm font-bold text-white transition hover:bg-amber-600 active:scale-95"
+      >
+        Put {formatUsd(500)} to work
+      </button>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/idle-nudge.tsx
+++ b/src/features/donor-rewards/components/idle-nudge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Zap } from "lucide-react";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import pluralize from "pluralize";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
@@ -49,13 +49,13 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
     >
       <div>
         <div className="flex items-center gap-2">
-          <motion.div
+          <m.div
             animate={{ y: [0, -3, 0] }}
             transition={{ repeat: Number.POSITIVE_INFINITY, duration: 2 }}
             className="rounded-xl bg-amber-100 p-2 text-amber-600 dark:bg-amber-500/15 dark:text-amber-400"
           >
             <Zap className="h-5 w-5" fill="currentColor" aria-hidden="true" />
-          </motion.div>
+          </m.div>
           <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
             Money resting
           </h2>

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { BadgeCheck, BookOpenCheck } from "lucide-react";
-import React from "react";
+import React, { useMemo } from "react";
+import { questsCompletedByRead } from "../state/quest-logic";
 import { useRewards } from "../state/rewards-context";
-import type { ImpactUpdate } from "../types";
+import type { ImpactUpdate, Quest } from "../types";
 
 const UpdateCard = React.memo(function UpdateCard({
   update,
   onRead,
+  pendingQuests,
 }: {
   update: ImpactUpdate;
   onRead: (id: string) => void;
+  /** Quests the next read completes — their XP is credited on top of the update's own */
+  pendingQuests: Quest[];
 }) {
+  const pendingBonus = pendingQuests.reduce((sum, quest) => sum + quest.xp, 0);
   return (
     <li className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
       <div className="flex items-start gap-3">
@@ -39,16 +44,26 @@ const UpdateCard = React.memo(function UpdateCard({
             {update.read ? (
               <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
                 <BookOpenCheck className="h-4 w-4" aria-hidden="true" />
-                Read · +{update.xp} IP earned
+                Read · +{update.xpAwarded ?? update.xp} IP earned
               </span>
             ) : (
-              <button
-                type="button"
-                onClick={() => onRead(update.id)}
-                className="rounded-xl bg-zinc-900 px-3 py-1.5 text-xs font-bold text-white transition hover:bg-zinc-700 active:scale-95 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
-              >
-                Mark as read · +{update.xp} IP
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={() => onRead(update.id)}
+                  className="rounded-xl bg-zinc-900 px-3 py-1.5 text-xs font-bold text-white transition hover:bg-zinc-700 active:scale-95 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  Mark as read · +{update.xp + pendingBonus} IP
+                </button>
+                {pendingQuests.map((quest) => (
+                  <p
+                    key={quest.id}
+                    className="mt-1.5 text-xs font-medium text-violet-600 dark:text-violet-400"
+                  >
+                    Completes quest "{quest.title}" · +{quest.xp} IP included
+                  </p>
+                ))}
+              </>
             )}
           </div>
         </div>
@@ -59,6 +74,7 @@ const UpdateCard = React.memo(function UpdateCard({
 
 export function ImpactFeed() {
   const { state, readUpdate } = useRewards();
+  const pendingQuests = useMemo(() => questsCompletedByRead(state.quests), [state.quests]);
 
   return (
     <section
@@ -71,7 +87,12 @@ export function ImpactFeed() {
       </p>
       <ul className="mt-4 flex flex-col gap-3">
         {state.updates.map((update) => (
-          <UpdateCard key={update.id} update={update} onRead={readUpdate} />
+          <UpdateCard
+            key={update.id}
+            update={update}
+            onRead={readUpdate}
+            pendingQuests={pendingQuests}
+          />
         ))}
       </ul>
     </section>

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { BadgeCheck, BookOpenCheck } from "lucide-react";
+import React from "react";
+import { useRewards } from "../state/rewards-context";
+import type { ImpactUpdate } from "../types";
+
+const UpdateCard = React.memo(function UpdateCard({
+  update,
+  onRead,
+}: {
+  update: ImpactUpdate;
+  onRead: (id: string) => void;
+}) {
+  return (
+    <li className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-zinc-100 text-xl dark:bg-zinc-800">
+          {update.orgEmoji}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-sm font-bold text-zinc-900 dark:text-white">
+              {update.orgName}
+            </span>
+            {update.verified && (
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-bold text-sky-700 dark:bg-sky-500/15 dark:text-sky-400">
+                <BadgeCheck className="h-3 w-3" aria-hidden="true" />
+                Verified on Karma
+              </span>
+            )}
+            <span className="text-xs text-zinc-400 dark:text-zinc-500">{update.postedAgo}</span>
+          </div>
+          <p className="mt-1 text-sm font-semibold text-zinc-800 dark:text-zinc-200">
+            {update.title}
+          </p>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{update.detail}</p>
+          <div className="mt-3">
+            {update.read ? (
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+                <BookOpenCheck className="h-4 w-4" aria-hidden="true" />
+                Read · +{update.xp} IP earned
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onRead(update.id)}
+                className="rounded-xl bg-zinc-900 px-3 py-1.5 text-xs font-bold text-white transition hover:bg-zinc-700 active:scale-95 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Mark as read · +{update.xp} IP
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+});
+
+export function ImpactFeed() {
+  const { state, readUpdate } = useRewards();
+
+  return (
+    <section
+      aria-label="Impact feed"
+      className="rounded-3xl border border-zinc-200 bg-zinc-50 p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Your impact feed</h2>
+      <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        Milestone updates from your grantees, verified through Karma's accountability protocol.
+      </p>
+      <ul className="mt-4 flex flex-col gap-3">
+        {state.updates.map((update) => (
+          <UpdateCard key={update.id} update={update} onRead={readUpdate} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -85,16 +85,25 @@ export function ImpactFeed() {
       <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
         Milestone updates from your grantees, verified through Karma's accountability protocol.
       </p>
-      <ul className="mt-4 flex flex-col gap-3">
-        {state.updates.map((update) => (
-          <UpdateCard
-            key={update.id}
-            update={update}
-            onRead={readUpdate}
-            pendingQuests={pendingQuests}
-          />
-        ))}
-      </ul>
+      {state.updates.length === 0 ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-zinc-300 bg-white p-6 text-center dark:border-zinc-700 dark:bg-zinc-900">
+          <p className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">No updates yet</p>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Make a grant and your grantees' verified milestones will show up here.
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-4 flex flex-col gap-3">
+          {state.updates.map((update) => (
+            <UpdateCard
+              key={update.id}
+              update={update}
+              onRead={readUpdate}
+              pendingQuests={pendingQuests}
+            />
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -65,7 +65,7 @@ export function ImpactFeed() {
       aria-label="Impact feed"
       className="rounded-3xl border border-zinc-200 bg-zinc-50 p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
     >
-      <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Your impact feed</h2>
+      <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Your impact feed</h2>
       <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
         Milestone updates from your grantees, verified through Karma's accountability protocol.
       </p>

--- a/src/features/donor-rewards/components/league-card.tsx
+++ b/src/features/donor-rewards/components/league-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Shield } from "lucide-react";
+import React, { useMemo } from "react";
+import { LEAGUE_PEERS } from "../data/mock-data";
+import { useRewards } from "../state/rewards-context";
+import type { LeaguePeer } from "../types";
+import { formatNumber } from "../utils/format";
+
+const PEER_POINTS = [2890, 2610, 2380, 2050, 1740, 1420, 980];
+
+const LeagueRow = React.memo(function LeagueRow({
+  peer,
+  rank,
+}: {
+  peer: LeaguePeer;
+  rank: number;
+}) {
+  return (
+    <li
+      className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ${
+        peer.isUser
+          ? "bg-emerald-50 ring-2 ring-emerald-400 dark:bg-emerald-950/40 dark:ring-emerald-600"
+          : ""
+      }`}
+    >
+      <span
+        className={`w-6 text-center font-mono text-sm font-bold ${
+          rank <= 3 ? "text-amber-500" : "text-zinc-400 dark:text-zinc-500"
+        }`}
+      >
+        {rank}
+      </span>
+      <span className="text-xl">{peer.emoji}</span>
+      <span
+        className={`flex-1 truncate text-sm ${
+          peer.isUser
+            ? "font-bold text-emerald-800 dark:text-emerald-300"
+            : "font-medium text-zinc-700 dark:text-zinc-300"
+        }`}
+      >
+        {peer.isUser ? "You" : peer.alias}
+      </span>
+      <span className="font-mono text-sm font-semibold text-zinc-500 dark:text-zinc-400">
+        {formatNumber(peer.points)}
+      </span>
+    </li>
+  );
+});
+
+export function LeagueCard() {
+  const { state } = useRewards();
+
+  const standings = useMemo(() => {
+    const peers: LeaguePeer[] = LEAGUE_PEERS.map((peer, index) => ({
+      ...peer,
+      points: PEER_POINTS[index],
+      isUser: false,
+    }));
+    peers.push({ id: "you", alias: "You", emoji: "🦉", points: state.xp, isUser: true });
+    return peers.sort((a, b) => b.points - a.points);
+  }, [state.xp]);
+
+  const userRank = standings.findIndex((peer) => peer.isUser) + 1;
+  const percentile = Math.max(1, Math.round((userRank / standings.length) * 100));
+
+  return (
+    <section
+      aria-label="Giving league"
+      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-center gap-3">
+        <div className="rounded-2xl bg-emerald-100 p-2.5 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400">
+          <Shield className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div>
+          <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Emerald League</h2>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            Top {percentile}% most consistent givers among accounts your size
+          </p>
+        </div>
+      </div>
+
+      <ol className="mt-4 flex flex-col gap-1">
+        {standings.map((peer, index) => (
+          <LeagueRow key={peer.id} peer={peer} rank={index + 1} />
+        ))}
+      </ol>
+
+      <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
+        Rankings are based on giving consistency, never dollar amounts. Aliases keep everyone
+        anonymous.
+      </p>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/league-card.tsx
+++ b/src/features/donor-rewards/components/league-card.tsx
@@ -74,7 +74,7 @@ export function LeagueCard() {
           <Shield className="h-6 w-6" aria-hidden="true" />
         </div>
         <div>
-          <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Emerald League</h2>
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Emerald League</h2>
           <p className="text-xs text-zinc-500 dark:text-zinc-400">
             Top {percentile}% most consistent givers among accounts your size
           </p>

--- a/src/features/donor-rewards/components/quests-card.tsx
+++ b/src/features/donor-rewards/components/quests-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckCircle2, Circle } from "lucide-react";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import pluralize from "pluralize";
 import React from "react";
 import { useRewards } from "../state/rewards-context";
@@ -19,14 +19,14 @@ const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
       }`}
     >
       {done ? (
-        <motion.span
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
+        <m.span
+          initial={{ scale: 0.5, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
           transition={{ type: "spring", stiffness: 300, damping: 15 }}
           className="text-emerald-500"
         >
           <CheckCircle2 className="h-7 w-7" aria-hidden="true" />
-        </motion.span>
+        </m.span>
       ) : (
         <span className="text-zinc-300 dark:text-zinc-600">
           <Circle className="h-7 w-7" aria-hidden="true" />
@@ -82,7 +82,7 @@ export function QuestsCard() {
       className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold text-zinc-900 dark:text-white">July quests</h2>
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">July quests</h2>
         {remaining > 0 ? (
           <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-bold text-violet-700 dark:bg-violet-500/15 dark:text-violet-400">
             {remaining} {pluralize("quest", remaining)} left

--- a/src/features/donor-rewards/components/quests-card.tsx
+++ b/src/features/donor-rewards/components/quests-card.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { CheckCircle2, Circle } from "lucide-react";
+import { motion } from "motion/react";
+import pluralize from "pluralize";
+import React from "react";
+import { useRewards } from "../state/rewards-context";
+import type { Quest } from "../types";
+
+const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
+  const done = quest.progress >= quest.goal;
+
+  return (
+    <li
+      className={`flex items-center gap-4 rounded-2xl border p-4 transition-colors ${
+        done
+          ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/40"
+          : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+      }`}
+    >
+      {done ? (
+        <motion.span
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", stiffness: 300, damping: 15 }}
+          className="text-emerald-500"
+        >
+          <CheckCircle2 className="h-7 w-7" aria-hidden="true" />
+        </motion.span>
+      ) : (
+        <span className="text-zinc-300 dark:text-zinc-600">
+          <Circle className="h-7 w-7" aria-hidden="true" />
+        </span>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p
+          className={`font-semibold ${
+            done
+              ? "text-emerald-800 line-through decoration-emerald-400 dark:text-emerald-300"
+              : "text-zinc-900 dark:text-white"
+          }`}
+        >
+          {quest.title}
+        </p>
+        <p className="truncate text-sm text-zinc-500 dark:text-zinc-400">{quest.description}</p>
+        {quest.goal > 1 && (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="h-1.5 w-32 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all"
+                style={{ width: `${(quest.progress / quest.goal) * 100}%` }}
+              />
+            </div>
+            <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+              {quest.progress}/{quest.goal}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <span
+        className={`shrink-0 rounded-full px-3 py-1 font-mono text-xs font-bold ${
+          done
+            ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+            : "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400"
+        }`}
+      >
+        +{quest.xp} IP
+      </span>
+    </li>
+  );
+});
+
+export function QuestsCard() {
+  const { state } = useRewards();
+  const remaining = state.quests.filter((quest) => quest.progress < quest.goal).length;
+
+  return (
+    <section
+      aria-label="Monthly quests"
+      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-zinc-900 dark:text-white">July quests</h2>
+        {remaining > 0 ? (
+          <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-bold text-violet-700 dark:bg-violet-500/15 dark:text-violet-400">
+            {remaining} {pluralize("quest", remaining)} left
+          </span>
+        ) : (
+          <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400">
+            All complete! 🎉
+          </span>
+        )}
+      </div>
+      <ul className="mt-4 flex flex-col gap-3">
+        {state.quests.map((quest) => (
+          <QuestRow key={quest.id} quest={quest} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/rewards-header.tsx
+++ b/src/features/donor-rewards/components/rewards-header.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Sparkles, Wallet } from "lucide-react";
+import { motion } from "motion/react";
+import { levelForXp, nextLevelForXp, useRewards } from "../state/rewards-context";
+import { formatNumber, formatUsd } from "../utils/format";
+
+interface RewardsHeaderProps {
+  onOpenGrantFlow: () => void;
+  onOpenRecap: () => void;
+}
+
+export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderProps) {
+  const { state } = useRewards();
+  const level = levelForXp(state.xp);
+  const nextLevel = nextLevelForXp(state.xp);
+  const progressToNext = nextLevel
+    ? Math.min(100, ((state.xp - level.minXp) / (nextLevel.minXp - level.minXp)) * 100)
+    : 100;
+
+  return (
+    <header className="w-full rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-700 to-teal-800 p-6 text-white shadow-lg sm:p-8">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/15 text-3xl backdrop-blur-sm">
+            🦉
+          </div>
+          <div>
+            <p className="text-sm font-medium text-emerald-100">Good morning, Maya</p>
+            <h1 className="text-2xl font-bold sm:text-3xl">Your Giving Journey</h1>
+            <div className="mt-1 flex items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide">
+                <Sparkles className="h-3 w-3" aria-hidden="true" />
+                {level.name}
+              </span>
+              <span className="text-sm text-emerald-100">
+                {formatNumber(state.xp)} Impact Points
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-2 rounded-2xl bg-white/10 px-4 py-3 backdrop-blur-sm">
+            <Wallet className="h-5 w-5 text-emerald-200" aria-hidden="true" />
+            <div>
+              <p className="text-xs text-emerald-100">DAF balance</p>
+              <p className="font-mono text-lg font-bold">{formatUsd(state.balance)}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onOpenGrantFlow}
+            className="rounded-2xl bg-white px-6 py-3 text-sm font-bold text-emerald-800 shadow-md transition hover:bg-emerald-50 active:scale-95"
+          >
+            Make a grant
+          </button>
+          <button
+            type="button"
+            onClick={onOpenRecap}
+            className="rounded-2xl border border-white/40 px-6 py-3 text-sm font-bold text-white transition hover:bg-white/10 active:scale-95"
+          >
+            Year in Giving
+          </button>
+        </div>
+      </div>
+
+      {nextLevel ? (
+        <div className="mt-6">
+          <div className="mb-1.5 flex items-center justify-between text-xs font-medium text-emerald-100">
+            <span>
+              {level.name} · {formatNumber(state.xp)} IP
+            </span>
+            <span>
+              {formatNumber(nextLevel.minXp - state.xp)} IP to {nextLevel.name}
+            </span>
+          </div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-white/20">
+            <motion.div
+              className="h-full rounded-full bg-gradient-to-r from-amber-300 to-yellow-400"
+              initial={false}
+              animate={{ width: `${progressToNext}%` }}
+              transition={{ type: "spring", stiffness: 60, damping: 15 }}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="mt-6 text-sm font-medium text-emerald-100">
+          You have reached the highest level. Thank you for your extraordinary generosity.
+        </p>
+      )}
+    </header>
+  );
+}

--- a/src/features/donor-rewards/components/rewards-header.tsx
+++ b/src/features/donor-rewards/components/rewards-header.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Sparkles, Wallet } from "lucide-react";
-import { motion } from "motion/react";
-import { levelForXp, nextLevelForXp, useRewards } from "../state/rewards-context";
+import { m } from "motion/react";
+import { useRewards } from "../state/rewards-context";
 import { formatNumber, formatUsd } from "../utils/format";
+import { levelForXp, nextLevelForXp } from "../utils/levels";
 
 interface RewardsHeaderProps {
   onOpenGrantFlow: () => void;
@@ -27,7 +28,7 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
           </div>
           <div>
             <p className="text-sm font-medium text-emerald-100">Good morning, Maya</p>
-            <h1 className="text-2xl font-bold sm:text-3xl">Your Giving Journey</h1>
+            <h1 className="text-2xl font-semibold sm:text-3xl">Your Giving Journey</h1>
             <div className="mt-1 flex items-center gap-2">
               <span className="inline-flex items-center gap-1 rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide">
                 <Sparkles className="h-3 w-3" aria-hidden="true" />
@@ -76,7 +77,7 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
             </span>
           </div>
           <div className="h-3 w-full overflow-hidden rounded-full bg-white/20">
-            <motion.div
+            <m.div
               className="h-full rounded-full bg-gradient-to-r from-amber-300 to-yellow-400"
               initial={false}
               animate={{ width: `${progressToNext}%` }}

--- a/src/features/donor-rewards/components/streak-card.tsx
+++ b/src/features/donor-rewards/components/streak-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Flame } from "lucide-react";
+import { motion } from "motion/react";
+import pluralize from "pluralize";
+import { useRewards } from "../state/rewards-context";
+
+const PREVIOUS_MONTHS = ["Feb", "Mar", "Apr", "May", "Jun"];
+
+export function StreakCard() {
+  const { state } = useRewards();
+  const previousStreak = state.grantedThisMonth ? state.streakMonths - 1 : state.streakMonths;
+
+  const dots = [
+    ...PREVIOUS_MONTHS.map((label, index) => ({
+      label,
+      lit: index >= PREVIOUS_MONTHS.length - Math.min(previousStreak, PREVIOUS_MONTHS.length),
+      current: false,
+    })),
+    { label: "Jul", lit: state.grantedThisMonth, current: true },
+  ];
+
+  return (
+    <section
+      aria-label="Giving streak"
+      className="flex flex-col justify-between rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            Giving streak
+          </h2>
+          <div className="mt-2 flex items-baseline gap-2">
+            <motion.span
+              key={state.streakMonths}
+              initial={{ scale: 1.4 }}
+              animate={{ scale: 1 }}
+              transition={{ type: "spring", stiffness: 300, damping: 12 }}
+              className="font-mono text-5xl font-bold text-zinc-900 dark:text-white"
+            >
+              {state.streakMonths}
+            </motion.span>
+            <span className="text-lg text-zinc-500 dark:text-zinc-400">
+              {pluralize("month", state.streakMonths)}
+            </span>
+          </div>
+        </div>
+        <motion.div
+          animate={
+            state.grantedThisMonth
+              ? { scale: [1, 1.25, 1], rotate: [0, -8, 8, 0] }
+              : { scale: 1, rotate: 0 }
+          }
+          transition={{ duration: 0.7 }}
+          className={
+            state.grantedThisMonth
+              ? "rounded-2xl bg-orange-100 p-3 text-orange-500 dark:bg-orange-500/15"
+              : "rounded-2xl bg-zinc-100 p-3 text-zinc-400 dark:bg-zinc-800"
+          }
+        >
+          <Flame className="h-8 w-8" fill="currentColor" aria-hidden="true" />
+        </motion.div>
+      </div>
+
+      <div className="mt-5 flex items-end justify-between gap-1.5">
+        {dots.map((dot) => (
+          <div key={dot.label} className="flex flex-1 flex-col items-center gap-1.5">
+            <div
+              className={`h-3.5 w-full max-w-8 rounded-full transition-colors ${
+                dot.lit
+                  ? "bg-orange-400"
+                  : dot.current
+                    ? "border-2 border-dashed border-orange-300 bg-transparent dark:border-orange-500/50"
+                    : "bg-zinc-200 dark:bg-zinc-700"
+              }`}
+            />
+            <span
+              className={`text-[10px] font-medium ${
+                dot.current ? "text-orange-500" : "text-zinc-400 dark:text-zinc-500"
+              }`}
+            >
+              {dot.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">
+        {state.grantedThisMonth
+          ? `July is locked in. Longest streak: ${state.longestStreak} ${pluralize("month", state.longestStreak)}.`
+          : "Make a grant this month to keep your streak alive. A recurring grant protects it automatically."}
+      </p>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/streak-card.tsx
+++ b/src/features/donor-rewards/components/streak-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flame } from "lucide-react";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import pluralize from "pluralize";
 import { useRewards } from "../state/rewards-context";
 
@@ -31,7 +31,7 @@ export function StreakCard() {
             Giving streak
           </h2>
           <div className="mt-2 flex items-baseline gap-2">
-            <motion.span
+            <m.span
               key={state.streakMonths}
               initial={{ scale: 1.4 }}
               animate={{ scale: 1 }}
@@ -39,13 +39,13 @@ export function StreakCard() {
               className="font-mono text-5xl font-bold text-zinc-900 dark:text-white"
             >
               {state.streakMonths}
-            </motion.span>
+            </m.span>
             <span className="text-lg text-zinc-500 dark:text-zinc-400">
               {pluralize("month", state.streakMonths)}
             </span>
           </div>
         </div>
-        <motion.div
+        <m.div
           animate={
             state.grantedThisMonth
               ? { scale: [1, 1.25, 1], rotate: [0, -8, 8, 0] }
@@ -59,7 +59,7 @@ export function StreakCard() {
           }
         >
           <Flame className="h-8 w-8" fill="currentColor" aria-hidden="true" />
-        </motion.div>
+        </m.div>
       </div>
 
       <div className="mt-5 flex items-end justify-between gap-1.5">

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -22,6 +22,27 @@ interface Slide {
 }
 
 export function YearRecap({ open, onClose }: YearRecapProps) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
+        >
+          <RecapStories onClose={onClose} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * Mounted only while the recap is open, so slide state starts fresh on every
+ * open without effect-based resets.
+ */
+function RecapStories({ onClose }: { onClose: () => void }) {
   const { state } = useRewards();
   const [slideIndex, setSlideIndex] = useState(0);
   const level = levelForXp(state.xp);
@@ -204,84 +225,69 @@ export function YearRecap({ open, onClose }: YearRecapProps) {
   }, [state, level.name]);
 
   useEffect(() => {
-    if (!open) {
-      setSlideIndex(0);
-      return;
-    }
     if (slideIndex >= slides.length - 1) return;
     const timer = setTimeout(() => setSlideIndex((index) => index + 1), SLIDE_DURATION_MS);
     return () => clearTimeout(timer);
-  }, [open, slideIndex, slides.length]);
+  }, [slideIndex, slides.length]);
 
   const goNext = () => {
-    if (slideIndex < slides.length - 1) {
-      setSlideIndex(slideIndex + 1);
-    } else {
+    if (slideIndex >= slides.length - 1) {
       onClose();
+      return;
     }
+    setSlideIndex((index) => Math.min(index + 1, slides.length - 1));
   };
 
   const slide = slides[slideIndex];
 
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Year in giving recap"
-            className="relative h-[640px] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl"
-          >
-            <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
-              {slides.map((item, index) => (
-                <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">
-                  <motion.div
-                    className="h-full bg-white"
-                    initial={{ width: index < slideIndex ? "100%" : "0%" }}
-                    animate={{ width: index <= slideIndex ? "100%" : "0%" }}
-                    transition={
-                      index === slideIndex
-                        ? { duration: SLIDE_DURATION_MS / 1000, ease: "linear" }
-                        : { duration: 0 }
-                    }
-                  />
-                </div>
-              ))}
-            </div>
-
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close recap"
-              className="absolute right-3 top-7 z-10 rounded-full bg-white/20 p-2 text-white backdrop-blur-sm transition hover:bg-white/30"
-            >
-              <X className="h-5 w-5" aria-hidden="true" />
-            </button>
-
-            <AnimatePresence mode="wait">
-              <motion.button
-                key={slide.id}
-                type="button"
-                onClick={goNext}
-                initial={{ opacity: 0, x: 40 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -40 }}
-                transition={{ duration: 0.3 }}
-                className={`flex h-full w-full cursor-pointer flex-col items-center justify-center p-8 text-center text-white ${slide.background}`}
-              >
-                {slide.content}
-                <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
-              </motion.button>
-            </AnimatePresence>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Year in giving recap"
+      className="relative h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl"
+    >
+      <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
+        {slides.map((item, index) => (
+          <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">
+            <motion.div
+              className="h-full bg-white"
+              initial={{ width: index < slideIndex ? "100%" : "0%" }}
+              animate={{ width: index <= slideIndex ? "100%" : "0%" }}
+              transition={
+                index === slideIndex
+                  ? { duration: SLIDE_DURATION_MS / 1000, ease: "linear" }
+                  : { duration: 0 }
+              }
+            />
           </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close recap"
+        className="absolute right-3 top-7 z-10 rounded-full bg-white/20 p-2 text-white backdrop-blur-sm transition hover:bg-white/30"
+      >
+        <X className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      <AnimatePresence mode="wait">
+        <motion.button
+          key={slide.id}
+          type="button"
+          onClick={goNext}
+          initial={{ opacity: 0, x: 40 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -40 }}
+          transition={{ duration: 0.3 }}
+          className={`flex h-full w-full cursor-pointer flex-col items-center justify-center p-8 text-center text-white ${slide.background}`}
+        >
+          {slide.content}
+          <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
+        </motion.button>
+      </AnimatePresence>
+    </div>
   );
 }

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -31,6 +31,15 @@ const openAsModal = (node: HTMLDialogElement | null) => {
   if (node && !node.open) node.showModal();
 };
 
+// When a slide remounts, focus has fallen back to the body/dialog; claim it
+// for the new slide button so Enter/Space keeps advancing the deck.
+const refocusSlide = (node: HTMLButtonElement | null) => {
+  const active = document.activeElement;
+  if (node && (!active || active === document.body || active.tagName === "DIALOG")) {
+    node.focus();
+  }
+};
+
 export function YearRecap({ open, onClose }: YearRecapProps) {
   if (!open) return null;
 
@@ -283,9 +292,13 @@ function RecapStories({ onClose }: { onClose: () => void }) {
 
       {/* Enter-only animation: the outgoing slide unmounts instantly when the
           key changes, so rapid taps can never race an exit transition into a
-          blank card (an AnimatePresence mode="wait" exit did exactly that). */}
+          blank card (an AnimatePresence mode="wait" exit did exactly that).
+          The remount drops keyboard focus, so refocus the new slide button
+          unless the user has deliberately moved focus elsewhere (e.g. the
+          close button). */}
       <m.button
         key={slide.id}
+        ref={refocusSlide}
         type="button"
         onClick={goNext}
         initial={{ opacity: 0, x: 40 }}

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, m } from "motion/react";
 import pluralize from "pluralize";
 import { useEffect, useMemo, useState } from "react";
 import { CAUSES, RECAP_YEAR } from "../data/mock-data";
-import { levelForXp, useRewards } from "../state/rewards-context";
+import { useRewards } from "../state/rewards-context";
 import { formatNumber, formatUsd } from "../utils/format";
+import { levelForXp } from "../utils/levels";
 
 interface YearRecapProps {
   open: boolean;
@@ -25,14 +26,14 @@ export function YearRecap({ open, onClose }: YearRecapProps) {
   return (
     <AnimatePresence>
       {open && (
-        <motion.div
+        <m.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
         >
           <RecapStories onClose={onClose} />
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );
@@ -58,9 +59,9 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         background: "bg-gradient-to-br from-emerald-600 to-teal-900",
         content: (
           <>
-            <motion.span
-              initial={{ scale: 0 }}
-              animate={{ scale: 1, rotate: [0, 10, -10, 0] }}
+            <m.span
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1, rotate: [0, 10, -10, 0] }}
               transition={{
                 scale: { type: "spring", stiffness: 180 },
                 rotate: { duration: 0.6, ease: "easeInOut" },
@@ -68,8 +69,8 @@ function RecapStories({ onClose }: { onClose: () => void }) {
               className="text-7xl"
             >
               💚
-            </motion.span>
-            <h3 className="mt-6 text-3xl font-bold">Your {RECAP_YEAR} in giving</h3>
+            </m.span>
+            <h3 className="mt-6 text-3xl font-semibold">Your {RECAP_YEAR} in giving</h3>
             <p className="mt-3 text-lg text-white/80">
               Six months in, and you have already made it count. Let's look back.
             </p>
@@ -82,14 +83,14 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         content: (
           <>
             <p className="text-lg font-medium text-white/80">You granted</p>
-            <motion.p
+            <m.p
               initial={{ scale: 0.6, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ type: "spring", stiffness: 160, delay: 0.2 }}
               className="mt-2 font-mono text-6xl font-bold"
             >
               {formatUsd(totalGranted)}
-            </motion.p>
+            </m.p>
             <p className="mt-4 text-lg text-white/80">
               across {totalGrants} {pluralize("grant", totalGrants)}. That puts your money to work,
               not to rest.
@@ -103,20 +104,20 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         content: (
           <>
             <p className="text-lg font-medium text-white/80">You showed up for</p>
-            <motion.p
+            <m.p
               initial={{ scale: 0.6, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ type: "spring", stiffness: 160, delay: 0.2 }}
               className="mt-2 font-mono text-6xl font-bold"
             >
               {state.causesSupported.length}
-            </motion.p>
+            </m.p>
             <p className="text-lg text-white/80">
               {pluralize("cause", state.causesSupported.length)}
             </p>
             <div className="mt-5 flex flex-wrap justify-center gap-2">
               {causeChips.map((cause, index) => (
-                <motion.span
+                <m.span
                   key={cause.id}
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -124,7 +125,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
                   className="rounded-full bg-white/20 px-4 py-1.5 text-sm font-semibold backdrop-blur-sm"
                 >
                   {cause.emoji} {cause.label}
-                </motion.span>
+                </m.span>
               ))}
             </div>
           </>
@@ -135,14 +136,14 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         background: "bg-gradient-to-br from-orange-500 to-rose-800",
         content: (
           <>
-            <motion.span
-              initial={{ scale: 0 }}
-              animate={{ scale: [0, 1.3, 1] }}
-              transition={{ delay: 0.2, duration: 0.6 }}
+            <m.span
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.2, type: "spring", stiffness: 260, damping: 12 }}
               className="text-7xl"
             >
               🔥
-            </motion.span>
+            </m.span>
             <p className="mt-4 text-lg font-medium text-white/80">Longest giving streak</p>
             <p className="mt-1 font-mono text-6xl font-bold">{state.longestStreak}</p>
             <p className="text-lg text-white/80">
@@ -157,14 +158,14 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         background: "bg-gradient-to-br from-sky-600 to-blue-900",
         content: (
           <>
-            <motion.span
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
+            <m.span
+              initial={{ scale: 0.5, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
               transition={{ type: "spring", stiffness: 200, delay: 0.2 }}
               className="text-7xl"
             >
               ✅
-            </motion.span>
+            </m.span>
             <p className="mt-4 text-lg font-medium text-white/80">Your grants touched</p>
             <p className="mt-1 font-mono text-6xl font-bold">{state.verifiedMilestones}</p>
             <p className="text-lg text-white/80">
@@ -183,7 +184,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         content: (
           <>
             <p className="text-lg font-medium text-white/80">Your giving card</p>
-            <motion.div
+            <m.div
               initial={{ rotateY: 90, opacity: 0 }}
               animate={{ rotateY: 0, opacity: 1 }}
               transition={{ delay: 0.3, type: "spring", stiffness: 120 }}
@@ -216,7 +217,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
                   <p className="font-mono text-lg font-bold">{state.verifiedMilestones}</p>
                 </div>
               </div>
-            </motion.div>
+            </m.div>
             <p className="mt-4 text-sm text-white/60">Share it. Generosity is contagious.</p>
           </>
         ),
@@ -241,16 +242,15 @@ function RecapStories({ onClose }: { onClose: () => void }) {
   const slide = slides[slideIndex];
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      open
       aria-label="Year in giving recap"
-      className="relative h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl"
+      className="relative m-0 h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl border-0 bg-transparent p-0 shadow-2xl"
     >
       <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
         {slides.map((item, index) => (
           <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">
-            <motion.div
+            <m.div
               className="h-full bg-white"
               initial={{ width: index < slideIndex ? "100%" : "0%" }}
               animate={{ width: index <= slideIndex ? "100%" : "0%" }}
@@ -274,7 +274,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
       </button>
 
       <AnimatePresence mode="wait">
-        <motion.button
+        <m.button
           key={slide.id}
           type="button"
           onClick={goNext}
@@ -286,8 +286,8 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         >
           {slide.content}
           <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
-        </motion.button>
+        </m.button>
       </AnimatePresence>
-    </div>
+    </dialog>
   );
 }

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -48,6 +48,17 @@ function RecapStories({ onClose }: { onClose: () => void }) {
   const [slideIndex, setSlideIndex] = useState(0);
   const level = levelForXp(state.xp);
 
+  // A non-modal <dialog open> does not close on Escape on its own, so wire it
+  // up explicitly. onClose unmounts this component, which resets slideIndex —
+  // reopening always restarts at slide 1 regardless of how it was closed.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   const slides = useMemo<Slide[]>(() => {
     const causeChips = state.causesSupported.map((causeId) => CAUSES[causeId]);
     const totalGrants = 14 + state.grants.length;

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -22,20 +22,32 @@ interface Slide {
   content: React.ReactNode;
 }
 
+// A ref callback opens the native dialog with showModal() the moment it mounts,
+// so it renders in the top layer — always viewport-centered and immune to page
+// scroll — with Escape-to-close and focus trapping for free. Unmounting on close
+// removes it from the top layer. A plain <dialog open> renders in normal flow
+// and opens off-screen once the page has been scrolled.
+const openAsModal = (node: HTMLDialogElement | null) => {
+  if (node && !node.open) node.showModal();
+};
+
 export function YearRecap({ open, onClose }: YearRecapProps) {
+  if (!open) return null;
+
   return (
-    <AnimatePresence>
-      {open && (
-        <m.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
-        >
-          <RecapStories onClose={onClose} />
-        </m.div>
-      )}
-    </AnimatePresence>
+    <dialog
+      ref={openAsModal}
+      aria-label="Year in giving recap"
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      className="m-0 max-h-none max-w-none bg-transparent p-0 backdrop:bg-black/80 backdrop:backdrop-blur-sm"
+    >
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <RecapStories onClose={onClose} />
+      </div>
+    </dialog>
   );
 }
 
@@ -47,17 +59,6 @@ function RecapStories({ onClose }: { onClose: () => void }) {
   const { state } = useRewards();
   const [slideIndex, setSlideIndex] = useState(0);
   const level = levelForXp(state.xp);
-
-  // A non-modal <dialog open> does not close on Escape on its own, so wire it
-  // up explicitly. onClose unmounts this component, which resets slideIndex —
-  // reopening always restarts at slide 1 regardless of how it was closed.
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
 
   const slides = useMemo<Slide[]>(() => {
     const causeChips = state.causesSupported.map((causeId) => CAUSES[causeId]);
@@ -253,11 +254,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
   const slide = slides[slideIndex];
 
   return (
-    <dialog
-      open
-      aria-label="Year in giving recap"
-      className="relative m-0 h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl border-0 bg-transparent p-0 shadow-2xl"
-    >
+    <div className="relative h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl">
       <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
         {slides.map((item, index) => (
           <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">
@@ -299,6 +296,6 @@ function RecapStories({ onClose }: { onClose: () => void }) {
           <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
         </m.button>
       </AnimatePresence>
-    </dialog>
+    </div>
   );
 }

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
-import { AnimatePresence, m } from "motion/react";
+import { m } from "motion/react";
 import pluralize from "pluralize";
 import { useEffect, useMemo, useState } from "react";
 import { CAUSES, RECAP_YEAR } from "../data/mock-data";
@@ -221,7 +221,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
                 <div>
                   <p className="text-white/70">Longest streak</p>
                   <p className="font-mono text-lg font-bold">
-                    {state.longestStreak} {pluralize("mo", state.longestStreak)}
+                    {state.longestStreak} {pluralize("month", state.longestStreak)}
                   </p>
                 </div>
                 <div>
@@ -281,21 +281,21 @@ function RecapStories({ onClose }: { onClose: () => void }) {
         <X className="h-5 w-5" aria-hidden="true" />
       </button>
 
-      <AnimatePresence mode="wait">
-        <m.button
-          key={slide.id}
-          type="button"
-          onClick={goNext}
-          initial={{ opacity: 0, x: 40 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -40 }}
-          transition={{ duration: 0.3 }}
-          className={`flex h-full w-full cursor-pointer flex-col items-center justify-center p-8 text-center text-white ${slide.background}`}
-        >
-          {slide.content}
-          <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
-        </m.button>
-      </AnimatePresence>
+      {/* Enter-only animation: the outgoing slide unmounts instantly when the
+          key changes, so rapid taps can never race an exit transition into a
+          blank card (an AnimatePresence mode="wait" exit did exactly that). */}
+      <m.button
+        key={slide.id}
+        type="button"
+        onClick={goNext}
+        initial={{ opacity: 0, x: 40 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.25 }}
+        className={`flex h-full w-full cursor-pointer flex-col items-center justify-center p-8 text-center text-white ${slide.background}`}
+      >
+        {slide.content}
+        <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
+      </m.button>
     </div>
   );
 }

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -28,7 +28,13 @@ interface Slide {
 // removes it from the top layer. A plain <dialog open> renders in normal flow
 // and opens off-screen once the page has been scrolled.
 const openAsModal = (node: HTMLDialogElement | null) => {
-  if (node && !node.open) node.showModal();
+  if (node && !node.open) {
+    node.showModal();
+    // showModal moves focus to the dialog's first focusable control — the
+    // close button — where Enter would immediately close the deck. Hand it
+    // to the slide advance button so keyboard users can walk the slides.
+    node.querySelector<HTMLButtonElement>("[data-slide-advance]")?.focus();
+  }
 };
 
 // When a slide remounts, focus has fallen back to the body/dialog; claim it
@@ -299,6 +305,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
       <m.button
         key={slide.id}
         ref={refocusSlide}
+        data-slide-advance
         type="button"
         onClick={goNext}
         initial={{ opacity: 0, x: 40 }}

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import pluralize from "pluralize";
+import { useEffect, useMemo, useState } from "react";
+import { CAUSES, RECAP_YEAR } from "../data/mock-data";
+import { levelForXp, useRewards } from "../state/rewards-context";
+import { formatNumber, formatUsd } from "../utils/format";
+
+interface YearRecapProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SLIDE_DURATION_MS = 4500;
+
+interface Slide {
+  id: string;
+  background: string;
+  content: React.ReactNode;
+}
+
+export function YearRecap({ open, onClose }: YearRecapProps) {
+  const { state } = useRewards();
+  const [slideIndex, setSlideIndex] = useState(0);
+  const level = levelForXp(state.xp);
+
+  const slides = useMemo<Slide[]>(() => {
+    const causeChips = state.causesSupported.map((causeId) => CAUSES[causeId]);
+    const totalGrants = 14 + state.grants.length;
+    const totalGranted = state.grantedThisYear;
+
+    return [
+      {
+        id: "intro",
+        background: "bg-gradient-to-br from-emerald-600 to-teal-900",
+        content: (
+          <>
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: 1, rotate: [0, 10, -10, 0] }}
+              transition={{
+                scale: { type: "spring", stiffness: 180 },
+                rotate: { duration: 0.6, ease: "easeInOut" },
+              }}
+              className="text-7xl"
+            >
+              💚
+            </motion.span>
+            <h3 className="mt-6 text-3xl font-bold">Your {RECAP_YEAR} in giving</h3>
+            <p className="mt-3 text-lg text-white/80">
+              Six months in, and you have already made it count. Let's look back.
+            </p>
+          </>
+        ),
+      },
+      {
+        id: "total",
+        background: "bg-gradient-to-br from-violet-600 to-indigo-900",
+        content: (
+          <>
+            <p className="text-lg font-medium text-white/80">You granted</p>
+            <motion.p
+              initial={{ scale: 0.6, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: "spring", stiffness: 160, delay: 0.2 }}
+              className="mt-2 font-mono text-6xl font-bold"
+            >
+              {formatUsd(totalGranted)}
+            </motion.p>
+            <p className="mt-4 text-lg text-white/80">
+              across {totalGrants} {pluralize("grant", totalGrants)}. That puts your money to work,
+              not to rest.
+            </p>
+          </>
+        ),
+      },
+      {
+        id: "causes",
+        background: "bg-gradient-to-br from-amber-500 to-orange-800",
+        content: (
+          <>
+            <p className="text-lg font-medium text-white/80">You showed up for</p>
+            <motion.p
+              initial={{ scale: 0.6, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: "spring", stiffness: 160, delay: 0.2 }}
+              className="mt-2 font-mono text-6xl font-bold"
+            >
+              {state.causesSupported.length}
+            </motion.p>
+            <p className="text-lg text-white/80">
+              {pluralize("cause", state.causesSupported.length)}
+            </p>
+            <div className="mt-5 flex flex-wrap justify-center gap-2">
+              {causeChips.map((cause, index) => (
+                <motion.span
+                  key={cause.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.4 + index * 0.1 }}
+                  className="rounded-full bg-white/20 px-4 py-1.5 text-sm font-semibold backdrop-blur-sm"
+                >
+                  {cause.emoji} {cause.label}
+                </motion.span>
+              ))}
+            </div>
+          </>
+        ),
+      },
+      {
+        id: "streak",
+        background: "bg-gradient-to-br from-orange-500 to-rose-800",
+        content: (
+          <>
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: [0, 1.3, 1] }}
+              transition={{ delay: 0.2, duration: 0.6 }}
+              className="text-7xl"
+            >
+              🔥
+            </motion.span>
+            <p className="mt-4 text-lg font-medium text-white/80">Longest giving streak</p>
+            <p className="mt-1 font-mono text-6xl font-bold">{state.longestStreak}</p>
+            <p className="text-lg text-white/80">
+              {pluralize("month", state.longestStreak)} in a row
+            </p>
+            <p className="mt-4 text-white/70">Consistency is the rarest kind of generosity.</p>
+          </>
+        ),
+      },
+      {
+        id: "verified",
+        background: "bg-gradient-to-br from-sky-600 to-blue-900",
+        content: (
+          <>
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ type: "spring", stiffness: 200, delay: 0.2 }}
+              className="text-7xl"
+            >
+              ✅
+            </motion.span>
+            <p className="mt-4 text-lg font-medium text-white/80">Your grants touched</p>
+            <p className="mt-1 font-mono text-6xl font-bold">{state.verifiedMilestones}</p>
+            <p className="text-lg text-white/80">
+              verified {pluralize("milestone", state.verifiedMilestones)}
+            </p>
+            <p className="mt-4 text-white/70">
+              Every one independently verified through Karma's accountability protocol. Receipts,
+              not vibes.
+            </p>
+          </>
+        ),
+      },
+      {
+        id: "card",
+        background: "bg-gradient-to-br from-zinc-800 to-zinc-950",
+        content: (
+          <>
+            <p className="text-lg font-medium text-white/80">Your giving card</p>
+            <motion.div
+              initial={{ rotateY: 90, opacity: 0 }}
+              animate={{ rotateY: 0, opacity: 1 }}
+              transition={{ delay: 0.3, type: "spring", stiffness: 120 }}
+              className="mt-4 w-full rounded-3xl bg-gradient-to-br from-emerald-500 to-teal-700 p-6 text-left shadow-2xl"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-3xl">🦉</span>
+                <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-bold uppercase tracking-wide">
+                  {level.name}
+                </span>
+              </div>
+              <p className="mt-4 text-2xl font-bold">Maya's {RECAP_YEAR}</p>
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <p className="text-white/70">Granted</p>
+                  <p className="font-mono text-lg font-bold">{formatUsd(totalGranted)}</p>
+                </div>
+                <div>
+                  <p className="text-white/70">Impact Points</p>
+                  <p className="font-mono text-lg font-bold">{formatNumber(state.xp)}</p>
+                </div>
+                <div>
+                  <p className="text-white/70">Streak</p>
+                  <p className="font-mono text-lg font-bold">
+                    {state.longestStreak} {pluralize("mo", state.longestStreak)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-white/70">Verified milestones</p>
+                  <p className="font-mono text-lg font-bold">{state.verifiedMilestones}</p>
+                </div>
+              </div>
+            </motion.div>
+            <p className="mt-4 text-sm text-white/60">Share it. Generosity is contagious.</p>
+          </>
+        ),
+      },
+    ];
+  }, [state, level.name]);
+
+  useEffect(() => {
+    if (!open) {
+      setSlideIndex(0);
+      return;
+    }
+    if (slideIndex >= slides.length - 1) return;
+    const timer = setTimeout(() => setSlideIndex((index) => index + 1), SLIDE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [open, slideIndex, slides.length]);
+
+  const goNext = () => {
+    if (slideIndex < slides.length - 1) {
+      setSlideIndex(slideIndex + 1);
+    } else {
+      onClose();
+    }
+  };
+
+  const slide = slides[slideIndex];
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Year in giving recap"
+            className="relative h-[640px] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl"
+          >
+            <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
+              {slides.map((item, index) => (
+                <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">
+                  <motion.div
+                    className="h-full bg-white"
+                    initial={{ width: index < slideIndex ? "100%" : "0%" }}
+                    animate={{ width: index <= slideIndex ? "100%" : "0%" }}
+                    transition={
+                      index === slideIndex
+                        ? { duration: SLIDE_DURATION_MS / 1000, ease: "linear" }
+                        : { duration: 0 }
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close recap"
+              className="absolute right-3 top-7 z-10 rounded-full bg-white/20 p-2 text-white backdrop-blur-sm transition hover:bg-white/30"
+            >
+              <X className="h-5 w-5" aria-hidden="true" />
+            </button>
+
+            <AnimatePresence mode="wait">
+              <motion.button
+                key={slide.id}
+                type="button"
+                onClick={goNext}
+                initial={{ opacity: 0, x: 40 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -40 }}
+                transition={{ duration: 0.3 }}
+                className={`flex h-full w-full cursor-pointer flex-col items-center justify-center p-8 text-center text-white ${slide.background}`}
+              >
+                {slide.content}
+                <span className="absolute bottom-5 text-xs text-white/50">Tap to continue</span>
+              </motion.button>
+            </AnimatePresence>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -218,7 +218,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
                   <p className="font-mono text-lg font-bold">{formatNumber(state.xp)}</p>
                 </div>
                 <div>
-                  <p className="text-white/70">Streak</p>
+                  <p className="text-white/70">Longest streak</p>
                   <p className="font-mono text-lg font-bold">
                     {state.longestStreak} {pluralize("mo", state.longestStreak)}
                   </p>

--- a/src/features/donor-rewards/data/mock-data.ts
+++ b/src/features/donor-rewards/data/mock-data.ts
@@ -277,7 +277,10 @@ export const INITIAL_STATE: RewardsState = {
   longestStreak: 7,
   grantedThisMonth: false,
   idleDays: 47,
-  causesSupported: ["education", "health", "food", "arts"],
+  // Three causes to date. The Cause Explorer badge needs five, so it stays
+  // locked until the donor branches into genuinely new areas over several
+  // grants — a single grant can never trip it.
+  causesSupported: ["education", "health", "food"],
   quests: INITIAL_QUESTS,
   badges: INITIAL_BADGES,
   updates: INITIAL_UPDATES,

--- a/src/features/donor-rewards/data/mock-data.ts
+++ b/src/features/donor-rewards/data/mock-data.ts
@@ -1,0 +1,290 @@
+import type {
+  BadgeDef,
+  CauseId,
+  CauseInfo,
+  ImpactUpdate,
+  LeaguePeer,
+  LevelDef,
+  Nonprofit,
+  Quest,
+  RewardsState,
+} from "../types";
+
+export const CAUSES: Record<CauseId, CauseInfo> = {
+  climate: { id: "climate", label: "Climate", emoji: "🌍" },
+  education: { id: "education", label: "Education", emoji: "📚" },
+  health: { id: "health", label: "Health", emoji: "🩺" },
+  food: { id: "food", label: "Food Security", emoji: "🥕" },
+  housing: { id: "housing", label: "Housing", emoji: "🏠" },
+  arts: { id: "arts", label: "Arts & Culture", emoji: "🎭" },
+};
+
+export const LEVELS: LevelDef[] = [
+  { name: "Supporter", minXp: 0 },
+  { name: "Contributor", minXp: 500 },
+  { name: "Champion", minXp: 1200 },
+  { name: "Benefactor", minXp: 2200 },
+  { name: "Philanthropist", minXp: 3500 },
+  { name: "Luminary", minXp: 5200 },
+];
+
+export const XP_PER_GRANT = 150;
+export const XP_NEW_CAUSE_BONUS = 50;
+export const XP_RECURRING_BONUS = 100;
+
+export const NONPROFITS: Nonprofit[] = [
+  {
+    id: "org-rainforest",
+    name: "Rainforest Guardians",
+    tagline: "Protecting 40,000 acres of primary forest in the Amazon basin",
+    cause: "climate",
+    emoji: "🌳",
+    verified: true,
+    impactNote: "14 milestones verified this year",
+    suggestedAmounts: [100, 250, 500],
+  },
+  {
+    id: "org-solar",
+    name: "SunUp Communities",
+    tagline: "Solar microgrids for off-grid clinics and schools",
+    cause: "climate",
+    emoji: "☀️",
+    verified: true,
+    impactNote: "9 milestones verified this year",
+    suggestedAmounts: [100, 250, 500],
+  },
+  {
+    id: "org-tutors",
+    name: "Open Door Tutors",
+    tagline: "Free 1:1 tutoring for first-generation students",
+    cause: "education",
+    emoji: "✏️",
+    verified: true,
+    impactNote: "11 milestones verified this year",
+    suggestedAmounts: [50, 150, 300],
+  },
+  {
+    id: "org-meals",
+    name: "Harvest Table",
+    tagline: "Rescuing surplus produce for 120 neighborhood pantries",
+    cause: "food",
+    emoji: "🍎",
+    verified: true,
+    impactNote: "17 milestones verified this year",
+    suggestedAmounts: [100, 250, 500],
+  },
+  {
+    id: "org-clinic",
+    name: "Mobile Health Collective",
+    tagline: "Pop-up clinics reaching rural patients without coverage",
+    cause: "health",
+    emoji: "🚐",
+    verified: false,
+    impactNote: "Reporting onboarding in progress",
+    suggestedAmounts: [100, 250, 500],
+  },
+  {
+    id: "org-stage",
+    name: "Neighborhood Stage",
+    tagline: "Youth theater programs in under-resourced schools",
+    cause: "arts",
+    emoji: "🎭",
+    verified: true,
+    impactNote: "6 milestones verified this year",
+    suggestedAmounts: [50, 150, 300],
+  },
+];
+
+const INITIAL_QUESTS: Quest[] = [
+  {
+    id: "q-climate",
+    title: "Fund a climate project",
+    description: "Make a grant to any climate organization this month",
+    xp: 120,
+    type: "grant_cause",
+    targetCause: "climate",
+    goal: 1,
+    progress: 0,
+  },
+  {
+    id: "q-any-grant",
+    title: "Keep your streak alive",
+    description: "Make at least one grant in July",
+    xp: 80,
+    type: "grant_any",
+    goal: 1,
+    progress: 0,
+  },
+  {
+    id: "q-recurring",
+    title: "Put giving on autopilot",
+    description: "Set up one recurring monthly grant",
+    xp: 150,
+    type: "recurring",
+    goal: 1,
+    progress: 0,
+  },
+  {
+    id: "q-updates",
+    title: "See your impact",
+    description: "Read 2 verified updates from your grantees",
+    xp: 60,
+    type: "read_updates",
+    goal: 2,
+    progress: 1,
+  },
+];
+
+const INITIAL_BADGES: BadgeDef[] = [
+  {
+    id: "b-first-grant",
+    name: "First Grant",
+    description: "Made your very first grant",
+    emoji: "🌱",
+    unlocked: true,
+  },
+  {
+    id: "b-streak-3",
+    name: "3-Month Streak",
+    description: "Granted 3 months in a row",
+    emoji: "🔥",
+    unlocked: true,
+  },
+  {
+    id: "b-early-bird",
+    name: "Early Bird",
+    description: "Gave before Giving Tuesday",
+    emoji: "🐦",
+    unlocked: true,
+  },
+  {
+    id: "b-big-heart",
+    name: "Big Heart",
+    description: "Granted $10,000 in a single year",
+    emoji: "💗",
+    unlocked: true,
+  },
+  {
+    id: "b-local-hero",
+    name: "Local Hero",
+    description: "Supported a nonprofit in your own city",
+    emoji: "🏙️",
+    unlocked: true,
+  },
+  {
+    id: "b-cause-explorer",
+    name: "Cause Explorer",
+    description: "Supported 5 different cause areas",
+    emoji: "🧭",
+    unlocked: false,
+  },
+  {
+    id: "b-recurring",
+    name: "Recurring Giver",
+    description: "Set up a recurring monthly grant",
+    emoji: "🔁",
+    unlocked: false,
+  },
+  {
+    id: "b-streak-12",
+    name: "12-Month Streak",
+    description: "A full year of monthly giving",
+    emoji: "🏆",
+    unlocked: false,
+  },
+  {
+    id: "b-matcher",
+    name: "Matcher",
+    description: "Joined a matching campaign",
+    emoji: "🤝",
+    unlocked: false,
+  },
+  {
+    id: "b-luminary",
+    name: "Luminary",
+    description: "Reached the highest giving level",
+    emoji: "✨",
+    unlocked: false,
+  },
+];
+
+const INITIAL_UPDATES: ImpactUpdate[] = [
+  {
+    id: "u-harvest",
+    orgName: "Harvest Table",
+    orgEmoji: "🍎",
+    title: "Milestone complete: 500,000 lbs of produce rescued",
+    detail:
+      "Six months ahead of schedule. Your March grant helped fund the two refrigerated vans that made the new routes possible.",
+    postedAgo: "2 days ago",
+    verified: true,
+    read: false,
+    xp: 15,
+  },
+  {
+    id: "u-tutors",
+    orgName: "Open Door Tutors",
+    orgEmoji: "✏️",
+    title: "Spring cohort results are in",
+    detail:
+      "94% of tutored students passed algebra, up from 61% last year. 38 new volunteer tutors onboarded.",
+    postedAgo: "5 days ago",
+    verified: true,
+    read: false,
+    xp: 15,
+  },
+  {
+    id: "u-stage",
+    orgName: "Neighborhood Stage",
+    orgEmoji: "🎭",
+    title: "Summer production funded and cast",
+    detail:
+      "62 students from 4 schools are staging The Tempest in August. Costume shop is run entirely by students.",
+    postedAgo: "1 week ago",
+    verified: true,
+    read: true,
+    xp: 15,
+  },
+  {
+    id: "u-clinic",
+    orgName: "Mobile Health Collective",
+    orgEmoji: "🚐",
+    title: "Q2 report: 1,840 patients seen",
+    detail: "Three new county partnerships signed. Dental van pilot starts in September.",
+    postedAgo: "2 weeks ago",
+    verified: false,
+    read: false,
+    xp: 15,
+  },
+];
+
+export const LEAGUE_PEERS: Omit<LeaguePeer, "points" | "isUser">[] = [
+  { id: "p1", alias: "Quiet Redwood", emoji: "🌲" },
+  { id: "p2", alias: "Golden Finch", emoji: "🐤" },
+  { id: "p3", alias: "Steady Lantern", emoji: "🏮" },
+  { id: "p4", alias: "Blue Harbor", emoji: "⚓" },
+  { id: "p5", alias: "Kind Comet", emoji: "☄️" },
+  { id: "p6", alias: "Bright Acorn", emoji: "🌰" },
+  { id: "p7", alias: "Silver Brook", emoji: "🌊" },
+];
+
+export const INITIAL_STATE: RewardsState = {
+  balance: 48200,
+  grantedThisYear: 16750,
+  annualGoal: 25000,
+  xp: 2140,
+  streakMonths: 4,
+  longestStreak: 7,
+  grantedThisMonth: false,
+  idleDays: 47,
+  causesSupported: ["education", "health", "food", "arts"],
+  quests: INITIAL_QUESTS,
+  badges: INITIAL_BADGES,
+  updates: INITIAL_UPDATES,
+  grants: [],
+  hasRecurringGrant: false,
+  celebration: null,
+  verifiedMilestones: 23,
+};
+
+export const RECAP_YEAR = 2026;

--- a/src/features/donor-rewards/state/quest-logic.ts
+++ b/src/features/donor-rewards/state/quest-logic.ts
@@ -1,0 +1,39 @@
+import type { CauseId, Quest } from "../types";
+
+export interface GrantQuestInput {
+  cause: CauseId;
+  recurring: boolean;
+}
+
+function questCompletesOnGrant(quest: Quest, grant: GrantQuestInput): boolean {
+  if (quest.progress >= quest.goal) return false;
+  const matches =
+    quest.type === "grant_any" ||
+    (quest.type === "grant_cause" && quest.targetCause === grant.cause) ||
+    (quest.type === "recurring" && grant.recurring);
+  return matches && quest.progress + 1 >= quest.goal;
+}
+
+/**
+ * Quests a grant with these attributes would complete. Shared between the
+ * reducer (to credit the XP) and the grant flow's "You will earn" panel (to
+ * advertise it), so the promised and credited amounts can never drift apart.
+ */
+export function questsCompletedByGrant(quests: Quest[], grant: GrantQuestInput): Quest[] {
+  return quests.filter((quest) => questCompletesOnGrant(quest, grant));
+}
+
+function questCompletesOnRead(quest: Quest): boolean {
+  return (
+    quest.type === "read_updates" && quest.progress < quest.goal && quest.progress + 1 >= quest.goal
+  );
+}
+
+/**
+ * Quests that reading one more update would complete. Shared between the
+ * reducer and the impact feed's "Mark as read" buttons for the same reason
+ * as {@link questsCompletedByGrant}.
+ */
+export function questsCompletedByRead(quests: Quest[]): Quest[] {
+  return quests.filter(questCompletesOnRead);
+}

--- a/src/features/donor-rewards/state/quest-logic.ts
+++ b/src/features/donor-rewards/state/quest-logic.ts
@@ -1,6 +1,6 @@
 import type { CauseId, Quest } from "../types";
 
-export interface GrantQuestInput {
+interface GrantQuestInput {
   cause: CauseId;
   recurring: boolean;
 }

--- a/src/features/donor-rewards/state/rewards-context.tsx
+++ b/src/features/donor-rewards/state/rewards-context.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { createContext, useContext, useMemo, useReducer } from "react";
+import {
+  INITIAL_STATE,
+  LEVELS,
+  NONPROFITS,
+  XP_NEW_CAUSE_BONUS,
+  XP_PER_GRANT,
+  XP_RECURRING_BONUS,
+} from "../data/mock-data";
+import type { BadgeDef, CelebrationPayload, LevelDef, Quest, RewardsState } from "../types";
+
+type RewardsAction =
+  | { type: "MAKE_GRANT"; orgId: string; amount: number; recurring: boolean }
+  | { type: "READ_UPDATE"; updateId: string }
+  | { type: "DISMISS_CELEBRATION" };
+
+export function levelForXp(xp: number): LevelDef {
+  let current = LEVELS[0];
+  for (const level of LEVELS) {
+    if (xp >= level.minXp) current = level;
+  }
+  return current;
+}
+
+export function nextLevelForXp(xp: number): LevelDef | null {
+  return LEVELS.find((level) => level.minXp > xp) ?? null;
+}
+
+function unlockBadge(badges: BadgeDef[], id: string, unlockedList: BadgeDef[]): BadgeDef[] {
+  return badges.map((badge) => {
+    if (badge.id === id && !badge.unlocked) {
+      const unlockedBadge = { ...badge, unlocked: true };
+      unlockedList.push(unlockedBadge);
+      return unlockedBadge;
+    }
+    return badge;
+  });
+}
+
+function applyGrant(
+  state: RewardsState,
+  action: { orgId: string; amount: number; recurring: boolean }
+): RewardsState {
+  const org = NONPROFITS.find((nonprofit) => nonprofit.id === action.orgId);
+  if (!org) return state;
+
+  const grant = {
+    id: `grant-${state.grants.length + 1}`,
+    orgId: org.id,
+    orgName: org.name,
+    amount: action.amount,
+    cause: org.cause,
+    recurring: action.recurring,
+  };
+
+  const isNewCause = !state.causesSupported.includes(org.cause);
+  const causesSupported = isNewCause
+    ? [...state.causesSupported, org.cause]
+    : state.causesSupported;
+
+  let xpEarned = XP_PER_GRANT;
+  if (isNewCause) xpEarned += XP_NEW_CAUSE_BONUS;
+  if (action.recurring) xpEarned += XP_RECURRING_BONUS;
+
+  const questsCompleted: Quest[] = [];
+  const quests = state.quests.map((quest) => {
+    if (quest.progress >= quest.goal) return quest;
+    const matchesGrantQuest =
+      (quest.type === "grant_any" ||
+        (quest.type === "grant_cause" && quest.targetCause === org.cause) ||
+        (quest.type === "recurring" && action.recurring)) &&
+      quest.progress + 1 >= quest.goal;
+    if (matchesGrantQuest) {
+      const completed = { ...quest, progress: quest.goal };
+      questsCompleted.push(completed);
+      return completed;
+    }
+    return quest;
+  });
+  xpEarned += questsCompleted.reduce((sum, quest) => sum + quest.xp, 0);
+
+  const badgesUnlocked: BadgeDef[] = [];
+  let badges = state.badges;
+  if (causesSupported.length >= 5) {
+    badges = unlockBadge(badges, "b-cause-explorer", badgesUnlocked);
+  }
+  if (action.recurring) {
+    badges = unlockBadge(badges, "b-recurring", badgesUnlocked);
+  }
+
+  const previousLevel = levelForXp(state.xp);
+  const newXp = state.xp + xpEarned;
+  const newLevel = levelForXp(newXp);
+  const leveledUpTo = newLevel.minXp > previousLevel.minXp ? newLevel.name : null;
+  if (newLevel.name === "Luminary") {
+    badges = unlockBadge(badges, "b-luminary", badgesUnlocked);
+  }
+
+  const extendsStreak = !state.grantedThisMonth;
+  const streakMonths = extendsStreak ? state.streakMonths + 1 : state.streakMonths;
+
+  const celebration: CelebrationPayload = {
+    grant,
+    xpEarned,
+    questsCompleted,
+    badgesUnlocked,
+    leveledUpTo,
+    newStreak: extendsStreak ? streakMonths : null,
+  };
+
+  return {
+    ...state,
+    balance: state.balance - action.amount,
+    grantedThisYear: state.grantedThisYear + action.amount,
+    xp: newXp,
+    streakMonths,
+    longestStreak: Math.max(state.longestStreak, streakMonths),
+    grantedThisMonth: true,
+    idleDays: 0,
+    causesSupported,
+    quests,
+    badges,
+    grants: [...state.grants, grant],
+    hasRecurringGrant: state.hasRecurringGrant || action.recurring,
+    celebration,
+  };
+}
+
+function applyReadUpdate(state: RewardsState, updateId: string): RewardsState {
+  const update = state.updates.find((item) => item.id === updateId);
+  if (!update || update.read) return state;
+
+  const updates = state.updates.map((item) =>
+    item.id === updateId ? { ...item, read: true } : item
+  );
+
+  let xpEarned = update.xp;
+  const quests = state.quests.map((quest) => {
+    if (quest.type !== "read_updates" || quest.progress >= quest.goal) return quest;
+    const progress = quest.progress + 1;
+    if (progress >= quest.goal) xpEarned += quest.xp;
+    return { ...quest, progress };
+  });
+
+  return { ...state, updates, quests, xp: state.xp + xpEarned };
+}
+
+function rewardsReducer(state: RewardsState, action: RewardsAction): RewardsState {
+  switch (action.type) {
+    case "MAKE_GRANT":
+      return applyGrant(state, action);
+    case "READ_UPDATE":
+      return applyReadUpdate(state, action.updateId);
+    case "DISMISS_CELEBRATION":
+      return { ...state, celebration: null };
+    default:
+      return state;
+  }
+}
+
+interface RewardsContextValue {
+  state: RewardsState;
+  makeGrant: (orgId: string, amount: number, recurring: boolean) => void;
+  readUpdate: (updateId: string) => void;
+  dismissCelebration: () => void;
+}
+
+const RewardsContext = createContext<RewardsContextValue | null>(null);
+
+export function RewardsProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(rewardsReducer, INITIAL_STATE);
+
+  const value = useMemo<RewardsContextValue>(
+    () => ({
+      state,
+      makeGrant: (orgId, amount, recurring) =>
+        dispatch({ type: "MAKE_GRANT", orgId, amount, recurring }),
+      readUpdate: (updateId) => dispatch({ type: "READ_UPDATE", updateId }),
+      dismissCelebration: () => dispatch({ type: "DISMISS_CELEBRATION" }),
+    }),
+    [state]
+  );
+
+  return <RewardsContext.Provider value={value}>{children}</RewardsContext.Provider>;
+}
+
+export function useRewards(): RewardsContextValue {
+  const context = useContext(RewardsContext);
+  if (!context) {
+    throw new Error("useRewards must be used within a RewardsProvider");
+  }
+  return context;
+}

--- a/src/features/donor-rewards/state/rewards-context.tsx
+++ b/src/features/donor-rewards/state/rewards-context.tsx
@@ -1,32 +1,20 @@
 "use client";
 
-import { createContext, useContext, useMemo, useReducer } from "react";
+import { createContext, use, useMemo, useReducer } from "react";
 import {
   INITIAL_STATE,
-  LEVELS,
   NONPROFITS,
   XP_NEW_CAUSE_BONUS,
   XP_PER_GRANT,
   XP_RECURRING_BONUS,
 } from "../data/mock-data";
-import type { BadgeDef, CelebrationPayload, LevelDef, Quest, RewardsState } from "../types";
+import type { BadgeDef, CelebrationPayload, Quest, RewardsState } from "../types";
+import { levelForXp } from "../utils/levels";
 
 type RewardsAction =
   | { type: "MAKE_GRANT"; orgId: string; amount: number; recurring: boolean }
   | { type: "READ_UPDATE"; updateId: string }
   | { type: "DISMISS_CELEBRATION" };
-
-export function levelForXp(xp: number): LevelDef {
-  let current = LEVELS[0];
-  for (const level of LEVELS) {
-    if (xp >= level.minXp) current = level;
-  }
-  return current;
-}
-
-export function nextLevelForXp(xp: number): LevelDef | null {
-  return LEVELS.find((level) => level.minXp > xp) ?? null;
-}
 
 function unlockBadge(badges: BadgeDef[], id: string, unlockedList: BadgeDef[]): BadgeDef[] {
   return badges.map((badge) => {
@@ -187,7 +175,7 @@ export function RewardsProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useRewards(): RewardsContextValue {
-  const context = useContext(RewardsContext);
+  const context = use(RewardsContext);
   if (!context) {
     throw new Error("useRewards must be used within a RewardsProvider");
   }

--- a/src/features/donor-rewards/state/rewards-context.tsx
+++ b/src/features/donor-rewards/state/rewards-context.tsx
@@ -10,6 +10,7 @@ import {
 } from "../data/mock-data";
 import type { BadgeDef, CelebrationPayload, Quest, RewardsState } from "../types";
 import { levelForXp } from "../utils/levels";
+import { questsCompletedByGrant, questsCompletedByRead } from "./quest-logic";
 
 type RewardsAction =
   | { type: "MAKE_GRANT"; orgId: string; amount: number; recurring: boolean }
@@ -52,20 +53,17 @@ function applyGrant(
   if (isNewCause) xpEarned += XP_NEW_CAUSE_BONUS;
   if (action.recurring) xpEarned += XP_RECURRING_BONUS;
 
+  const completedIds = new Set(
+    questsCompletedByGrant(state.quests, { cause: org.cause, recurring: action.recurring }).map(
+      (quest) => quest.id
+    )
+  );
   const questsCompleted: Quest[] = [];
   const quests = state.quests.map((quest) => {
-    if (quest.progress >= quest.goal) return quest;
-    const matchesGrantQuest =
-      (quest.type === "grant_any" ||
-        (quest.type === "grant_cause" && quest.targetCause === org.cause) ||
-        (quest.type === "recurring" && action.recurring)) &&
-      quest.progress + 1 >= quest.goal;
-    if (matchesGrantQuest) {
-      const completed = { ...quest, progress: quest.goal };
-      questsCompleted.push(completed);
-      return completed;
-    }
-    return quest;
+    if (!completedIds.has(quest.id)) return quest;
+    const completed = { ...quest, progress: quest.goal };
+    questsCompleted.push(completed);
+    return completed;
   });
   xpEarned += questsCompleted.reduce((sum, quest) => sum + quest.xp, 0);
 
@@ -120,16 +118,18 @@ function applyReadUpdate(state: RewardsState, updateId: string): RewardsState {
   const update = state.updates.find((item) => item.id === updateId);
   if (!update || update.read) return state;
 
+  const questBonus = questsCompletedByRead(state.quests).reduce((sum, quest) => sum + quest.xp, 0);
+  const xpEarned = update.xp + questBonus;
+
+  // xpAwarded records the full credit (update + quest bonus) so the feed can
+  // report exactly what this read actually earned.
   const updates = state.updates.map((item) =>
-    item.id === updateId ? { ...item, read: true } : item
+    item.id === updateId ? { ...item, read: true, xpAwarded: xpEarned } : item
   );
 
-  let xpEarned = update.xp;
   const quests = state.quests.map((quest) => {
     if (quest.type !== "read_updates" || quest.progress >= quest.goal) return quest;
-    const progress = quest.progress + 1;
-    if (progress >= quest.goal) xpEarned += quest.xp;
-    return { ...quest, progress };
+    return { ...quest, progress: quest.progress + 1 };
   });
 
   return { ...state, updates, quests, xp: state.xp + xpEarned };

--- a/src/features/donor-rewards/types.ts
+++ b/src/features/donor-rewards/types.ts
@@ -50,6 +50,8 @@ export interface ImpactUpdate {
   verified: boolean;
   read: boolean;
   xp: number;
+  /** Total IP actually credited when read, including quest-completion bonuses */
+  xpAwarded?: number;
 }
 
 export interface GrantRecord {

--- a/src/features/donor-rewards/types.ts
+++ b/src/features/donor-rewards/types.ts
@@ -1,0 +1,103 @@
+export type CauseId = "climate" | "education" | "health" | "food" | "housing" | "arts";
+
+export interface CauseInfo {
+  id: CauseId;
+  label: string;
+  emoji: string;
+}
+
+export interface Nonprofit {
+  id: string;
+  name: string;
+  tagline: string;
+  cause: CauseId;
+  emoji: string;
+  /** Karma GAP verified impact reporting */
+  verified: boolean;
+  impactNote: string;
+  suggestedAmounts: number[];
+}
+
+export type QuestType = "grant_cause" | "grant_any" | "recurring" | "read_updates";
+
+export interface Quest {
+  id: string;
+  title: string;
+  description: string;
+  xp: number;
+  type: QuestType;
+  targetCause?: CauseId;
+  /** for progress-based quests such as reading updates */
+  goal: number;
+  progress: number;
+}
+
+export interface BadgeDef {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  unlocked: boolean;
+}
+
+export interface ImpactUpdate {
+  id: string;
+  orgName: string;
+  orgEmoji: string;
+  title: string;
+  detail: string;
+  postedAgo: string;
+  verified: boolean;
+  read: boolean;
+  xp: number;
+}
+
+export interface GrantRecord {
+  id: string;
+  orgId: string;
+  orgName: string;
+  amount: number;
+  cause: CauseId;
+  recurring: boolean;
+}
+
+export interface LeaguePeer {
+  id: string;
+  alias: string;
+  emoji: string;
+  points: number;
+  isUser: boolean;
+}
+
+export interface LevelDef {
+  name: string;
+  minXp: number;
+}
+
+export interface CelebrationPayload {
+  grant: GrantRecord;
+  xpEarned: number;
+  questsCompleted: Quest[];
+  badgesUnlocked: BadgeDef[];
+  leveledUpTo: string | null;
+  newStreak: number | null;
+}
+
+export interface RewardsState {
+  balance: number;
+  grantedThisYear: number;
+  annualGoal: number;
+  xp: number;
+  streakMonths: number;
+  longestStreak: number;
+  grantedThisMonth: boolean;
+  idleDays: number;
+  causesSupported: CauseId[];
+  quests: Quest[];
+  badges: BadgeDef[];
+  updates: ImpactUpdate[];
+  grants: GrantRecord[];
+  hasRecurringGrant: boolean;
+  celebration: CelebrationPayload | null;
+  verifiedMilestones: number;
+}

--- a/src/features/donor-rewards/utils/format.ts
+++ b/src/features/donor-rewards/utils/format.ts
@@ -1,0 +1,15 @@
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+export function formatUsd(amount: number): string {
+  return usdFormatter.format(amount);
+}
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+export function formatNumber(value: number): string {
+  return numberFormatter.format(value);
+}

--- a/src/features/donor-rewards/utils/levels.ts
+++ b/src/features/donor-rewards/utils/levels.ts
@@ -1,0 +1,14 @@
+import { LEVELS } from "../data/mock-data";
+import type { LevelDef } from "../types";
+
+export function levelForXp(xp: number): LevelDef {
+  let current = LEVELS[0];
+  for (const level of LEVELS) {
+    if (xp >= level.minXp) current = level;
+  }
+  return current;
+}
+
+export function nextLevelForXp(xp: number): LevelDef | null {
+  return LEVELS.find((level) => level.minXp > xp) ?? null;
+}

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -176,6 +176,7 @@ export const PAGES = {
   FOR_AGENTS: `/for-agents`,
   NONPROFITS: `/nonprofits`,
   DONOR_ADVISORS: `/donor-advisors`,
+  DONOR_REWARDS: `/donor-rewards`,
   CREATE_PROJECT_PROFILE: `/create-project-profile`,
   MCP_CONNECT: `/mcp/connect`,
   SEEDS: `/seeds`,


### PR DESCRIPTION
## Summary

Customer-demo prototype that applies Duolingo-style gamification to DAF donor behavior, aimed at the core problem of idle DAF balances. Everything runs on mocked client-side state: no backend calls, no real money movement, clearly labeled as a prototype on the page.

New route: `/donor-rewards`

## What it includes

- **Hero header**: donor level, Impact Points, animated XP bar, DAF balance
- **Giving streak**: month dots plus flame, extends when a grant is made in the current month
- **Annual goal ring**: animated SVG progress toward a yearly granting goal
- **Idle funds nudge**: "$48,200 has been idle for 47 days" CTA that flips to a congratulations card after granting
- **Monthly quests**: four quests that complete live from user actions
- **Emerald League**: anonymized consistency ranking; the user's row climbs as they earn points
- **Badges**: unlocked and locked-with-lock-icon grid
- **Impact feed**: verified grantee milestone updates that award points when read (ties gamification to Karma's accountability data)
- **Grant flow**: suggested verified nonprofits, amount chips, recurring toggle with earn preview, confirmation
- **Celebration overlay**: confetti plus staggered reveal of XP, streak, level-up, quests, and badge unlocks
- **Year in Giving**: story-style auto-advancing recap ending in a shareable giving card

## Implementation notes

- All game logic lives in one reducer (`src/features/donor-rewards/state/rewards-context.tsx`); components are presentational
- Mock data isolated in `data/mock-data.ts`
- `js-confetti` is lazy-imported only when a celebration mounts
- Route registered in `PAGES` constants; page ships `loading.tsx` and `error.tsx`
- Light and dark mode styled throughout

## Testing

- Walked end to end in the browser: grant flow triggers XP gain, streak extension, level-up, quest completion, badge unlocks, league rank change, and goal ring update in one pass; impact-feed reads complete the reading quest; recap reflects live state
- Biome and typecheck clean
- No unit tests: throwaway demo prototype; if any piece is productionized the reducer is the testable surface

## Screenshots

Light and dark full-page captures plus the celebration and recap screens were taken during verification (available on request).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the donor rewards page at `/donor-rewards`, including a giving journey header, annual goal ring, streak and badges, quests list, impact feed, giving league, and interactive grant + year recap dialogs with milestone celebrations and gated overlays.
  * Added supporting UI modules such as the idle funds nudge.
* **Bug Fixes**
  * Improved route-level loading and error handling for the donor rewards experience.
* **Tests**
  * Added unit tests covering XP level logic, quest completion rules, and rewards state actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->