### PR TITLE
fix(browse-applications): cache application pages across filter toggles

### DIFF
--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -400,6 +400,9 @@ export function BrowseApplicationsClient({ communityId }: BrowseApplicationsClie
         return undefined;
       },
       enabled: !!selectedProgramId && !hasPrivateApplicationsSetting,
+      // Re-selecting a status chip you already viewed serves the cached page
+      // instead of re-hitting the API on every toggle.
+      staleTime: 1000 * 60 * 2, // 2 minutes
     });
 
   const applications = data?.pages.flatMap((page) => page.applications) || [];


### PR DESCRIPTION
## Problem

On the community **Browse applications** page, switching the status filter and re-selecting a chip you already viewed fires a fresh `GET /v2/funding-applications/program/:id?...` request every time, producing a burst of duplicate identical calls (e.g. eight `status=revision_requested` requests while toggling).

## Root cause

The applications `useInfiniteQuery` had no `staleTime`, so it used React Query's default of `0` — every page is considered stale immediately. Navigating away from a status filter and back marks the cached page stale and refetches, even though the data hasn't changed.

## Fix

Set `staleTime: 1000 * 60 * 2` (2 minutes) on the query, so already-fetched pages are reused when re-selecting a filter. Matches the sibling `useReviewerInbox` application-list query. Pure caching change — no behavior change to filtering, pagination, or data shape.

## Verification

- `__tests__/components/Pages/Communities/BrowseApplicationsClient.test.tsx`: 6/6 pass
- `tsc --noEmit`: 0 errors · Biome: clean (pre-existing complexity warning on the component is unchanged)

## Related

This is the companion to the backend fix that actually restores the "In review" / "Needs info" counters: show-karma/gap-indexer#2152. That PR is the root cause; this one removes the redundant refetches. The two can merge independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application list browsing by reusing recently loaded results when switching back to a previously selected status.
  * Reduced unnecessary reloads, making filter toggling feel faster and smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->