### PR TITLE
fix(applications): restrict status-change reasons to authorized viewers [DEV-517]

### DIFF
--- a/__tests__/features/applications/status-history.service.test.ts
+++ b/__tests__/features/applications/status-history.service.test.ts
@@ -32,9 +32,15 @@ describe("getApplicationStatusHistory", () => {
     expect(mockFetchData).toHaveBeenCalledWith("/v2/funding-applications/REF-123", "GET");
   });
 
-  it("should return an empty array when the application is missing", async () => {
-    mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+  it("should return an empty array when the application has no status history", async () => {
+    mockFetchData.mockResolvedValue([{ referenceNumber: "REF-123" }, null, null, 200]);
 
     expect(await getApplicationStatusHistory("REF-123")).toEqual([]);
+  });
+
+  it("should throw on fetch failure so the SSR fallback is preserved", async () => {
+    mockFetchData.mockResolvedValue([null, "Request failed", null, 500]);
+
+    await expect(getApplicationStatusHistory("REF-123")).rejects.toThrow("Request failed");
   });
 });

--- a/__tests__/features/applications/status-history.service.test.ts
+++ b/__tests__/features/applications/status-history.service.test.ts
@@ -1,0 +1,40 @@
+/**
+ * DEV-517: the service re-requests the application with the caller's token so
+ * the backend can return the private status-change reasons to authorized
+ * viewers. The service itself makes no access decision.
+ */
+
+import { getApplicationStatusHistory } from "@/src/features/applications/services/status-history.service";
+import fetchData from "@/utilities/fetchData";
+
+vi.mock("@/utilities/fetchData", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+const mockFetchData = fetchData as unknown as vi.Mock;
+
+const statusHistory = [
+  { status: "rejected", timestamp: "2026-02-25T00:00:00.000Z", reason: "why" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getApplicationStatusHistory", () => {
+  it("should return the application's status history from the authenticated endpoint", async () => {
+    mockFetchData.mockResolvedValue([{ statusHistory }, null, null, 200]);
+
+    const result = await getApplicationStatusHistory("REF-123");
+
+    expect(result).toEqual(statusHistory);
+    expect(mockFetchData).toHaveBeenCalledWith("/v2/funding-applications/REF-123", "GET");
+  });
+
+  it("should return an empty array when the application is missing", async () => {
+    mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+    expect(await getApplicationStatusHistory("REF-123")).toEqual([]);
+  });
+});

--- a/__tests__/features/applications/use-application-status-history.test.tsx
+++ b/__tests__/features/applications/use-application-status-history.test.tsx
@@ -62,4 +62,16 @@ describe("useApplicationStatusHistory", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(mockGetStatusHistory).not.toHaveBeenCalled();
   });
+
+  it("should leave statusHistory undefined when the fetch fails (so callers fall back to SSR)", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: true, ready: true });
+    mockGetStatusHistory.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useApplicationStatusHistory("REF-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.statusHistory).toBeUndefined();
+  });
 });

--- a/__tests__/features/applications/use-application-status-history.test.tsx
+++ b/__tests__/features/applications/use-application-status-history.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * DEV-517: authenticated viewers re-fetch the application (via the service) so
+ * the backend can return the private status-change reasons. Guests are
+ * unauthenticated, so the query must never run.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useApplicationStatusHistory } from "@/src/features/applications/hooks/use-application-status-history";
+import { getApplicationStatusHistory } from "@/src/features/applications/services/status-history.service";
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/src/features/applications/services/status-history.service", () => ({
+  getApplicationStatusHistory: vi.fn(),
+}));
+
+const mockUseAuth = useAuth as unknown as vi.Mock;
+const mockGetStatusHistory = getApplicationStatusHistory as unknown as vi.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const statusHistory = [
+  { status: "rejected", timestamp: "2026-02-25T00:00:00.000Z", reason: "why" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetStatusHistory.mockResolvedValue(statusHistory);
+});
+
+describe("useApplicationStatusHistory", () => {
+  it("should fetch status history through the service when authenticated", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: true, ready: true });
+
+    const { result } = renderHook(() => useApplicationStatusHistory("REF-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.statusHistory).toEqual(statusHistory));
+    expect(mockGetStatusHistory).toHaveBeenCalledWith("REF-123");
+  });
+
+  it("should not fetch when the viewer is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ authenticated: false, ready: true });
+
+    const { result } = renderHook(() => useApplicationStatusHistory("REF-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetStatusHistory).not.toHaveBeenCalled();
+  });
+});

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -14,6 +14,7 @@ import { CommentTimeline } from "@/src/features/application-comments/components/
 import { PublicComments } from "@/src/features/application-comments/components/PublicComments";
 import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
 import { useApplicationAccess } from "@/src/features/applications/hooks/use-application-access";
+import { useApplicationStatusHistory } from "@/src/features/applications/hooks/use-application-status-history";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
 import type { Application, ApplicationStatus, FundingProgram } from "@/types/whitelabel-entities";
 import { formatDate } from "@/utilities/formatDate";
@@ -115,6 +116,16 @@ export function ApplicationPageClient({
       ? "reviewer"
       : "guest";
 
+  // The whitelabel page is fetched server-side without a Privy token, so the
+  // backend serves it anonymously and strips the private status-change reasons
+  // (rejection/revision messages) — the backend is the guard. Authenticated
+  // viewers re-fetch with their token; the backend returns the reasons only to
+  // the applicant, reviewers, and admins. Guests keep the sanitized SSR payload.
+  const { statusHistory: authedStatusHistory } = useApplicationStatusHistory(
+    application.referenceNumber
+  );
+  const statusHistory = authedStatusHistory ?? application.statusHistory ?? [];
+
   const editHref = PAGES.COMMUNITY.APPLICATION_EDIT(communityId, application.referenceNumber);
   const reviewHref = PAGES.REVIEWER.APPLICATION_DETAIL(
     communityId,
@@ -172,7 +183,7 @@ export function ApplicationPageClient({
   const commentsSection = canUseComments ? (
     <CommentTimeline
       applicationId={application.referenceNumber}
-      statusHistory={application.statusHistory || []}
+      statusHistory={statusHistory}
       communityId={communityId}
     />
   ) : showPublicComments ? (
@@ -264,6 +275,7 @@ export function ApplicationPageClient({
             postApprovalPending={postApprovalPending}
             editHref={editHref}
             reviewHref={reviewHref}
+            statusHistory={statusHistory}
             onGoToMilestones={() => setActiveTab("milestones")}
             onGoToPostApproval={() => setActiveTab("post-approval")}
             onViewActivity={hasCommentsSurface ? handleViewActivity : undefined}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
@@ -14,6 +14,12 @@ interface ApplicationSidebarProps {
   postApprovalPending: boolean;
   editHref: string;
   reviewHref: string;
+  /**
+   * Status history with `reason` bodies already gated for the current viewer.
+   * Passed in (rather than read from `application`) so the rejection/revision
+   * communications are only shown to the applicant, reviewers, and admins.
+   */
+  statusHistory: Application["statusHistory"];
   onGoToMilestones?: () => void;
   onGoToPostApproval?: () => void;
   onViewActivity?: () => void;
@@ -28,6 +34,7 @@ export function ApplicationSidebar({
   postApprovalPending,
   editHref,
   reviewHref,
+  statusHistory,
   onGoToMilestones,
   onGoToPostApproval,
   onViewActivity,
@@ -46,10 +53,7 @@ export function ApplicationSidebar({
         onViewActivity={onViewActivity}
       />
 
-      <ApplicationStatusStepper
-        status={application.status}
-        statusHistory={application.statusHistory || []}
-      />
+      <ApplicationStatusStepper status={application.status} statusHistory={statusHistory || []} />
 
       <ApplicationInfoCard
         referenceNumber={application.referenceNumber}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/ApplicationEditClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/ApplicationEditClient.tsx
@@ -33,9 +33,11 @@ export function ApplicationEditClient({ communityId, application }: ApplicationE
   const { statusHistory: authedStatusHistory } = useApplicationStatusHistory(
     application.referenceNumber
   );
-  const revisionReason = (authedStatusHistory ?? application.statusHistory ?? []).find(
-    (entry) => entry.status === "revision_requested"
-  )?.reason;
+  // Latest revision request wins — after multiple revision cycles there can be
+  // several `revision_requested` entries and the applicant needs the newest.
+  const revisionReason = (authedStatusHistory ?? application.statusHistory ?? [])
+    .filter((entry) => entry.status === "revision_requested")
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0]?.reason;
 
   // Fetch program details
   const {

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/ApplicationEditClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/edit/ApplicationEditClient.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { Link } from "@/src/components/navigation/Link";
 import { useIsFundingPlatformAdmin } from "@/src/core/rbac";
 import { ApplicationForm } from "@/src/features/applications/components/ApplicationForm";
+import { useApplicationStatusHistory } from "@/src/features/applications/hooks/use-application-status-history";
 import {
   transformDataForDisplay,
   transformDataForSubmission,
@@ -25,6 +26,16 @@ export function ApplicationEditClient({ communityId, application }: ApplicationE
   const router = useRouter();
   const queryClient = useQueryClient();
   const isAdmin = useIsFundingPlatformAdmin();
+
+  // The SSR fetch is tokenless, so the backend strips the private revision
+  // reason. Re-fetch with the viewer's token; the backend returns it only to
+  // the applicant and admins — the backend is the guard.
+  const { statusHistory: authedStatusHistory } = useApplicationStatusHistory(
+    application.referenceNumber
+  );
+  const revisionReason = (authedStatusHistory ?? application.statusHistory ?? []).find(
+    (entry) => entry.status === "revision_requested"
+  )?.reason;
 
   // Fetch program details
   const {
@@ -184,12 +195,10 @@ export function ApplicationEditClient({ communityId, application }: ApplicationE
           <p className="mb-1 font-semibold text-orange-700 dark:text-orange-400">
             Revision Required
           </p>
-          {application.statusHistory?.find((s) => s.status === "revision_requested")?.reason && (
+          {revisionReason && (
             <div className="space-y-1 text-sm text-orange-600 dark:text-orange-500">
               <p className="font-medium">Reason for revision:</p>
-              <p>
-                {application.statusHistory.find((s) => s.status === "revision_requested")?.reason}
-              </p>
+              <p>{revisionReason}</p>
             </div>
           )}
         </div>

--- a/src/features/applications/hooks/use-application-status-history.ts
+++ b/src/features/applications/hooks/use-application-status-history.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/hooks/useAuth";
+import { getApplicationStatusHistory } from "@/src/features/applications/services/status-history.service";
+import type { Application } from "@/types/whitelabel-entities";
+
+type StatusHistory = Application["statusHistory"];
+
+/**
+ * Re-fetches an application's status history with the viewer's token.
+ *
+ * The whitelabel page is server-rendered anonymously (no Privy token exists
+ * server-side), so the backend strips the private status-change reasons from
+ * that payload — the backend is the access guard. Authenticated viewers call
+ * this so the backend can return the reasons to the applicant, reviewers, and
+ * admins. Guests are unauthenticated, so the query never runs and they keep the
+ * sanitized SSR payload. No authorization happens here.
+ */
+export function useApplicationStatusHistory(referenceNumber: string | undefined): {
+  statusHistory: StatusHistory | undefined;
+  isLoading: boolean;
+} {
+  const { authenticated, ready } = useAuth();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["application-status-history", referenceNumber, authenticated],
+    queryFn: () => getApplicationStatusHistory(referenceNumber as string),
+    enabled: !!referenceNumber && ready && authenticated,
+    staleTime: 1000 * 30,
+    gcTime: 1000 * 60 * 5,
+  });
+
+  return { statusHistory: data, isLoading };
+}

--- a/src/features/applications/services/status-history.service.ts
+++ b/src/features/applications/services/status-history.service.ts
@@ -16,9 +16,18 @@ import { INDEXER } from "@/utilities/indexer";
 export async function getApplicationStatusHistory(
   referenceNumber: string
 ): Promise<Application["statusHistory"]> {
-  const [application] = await fetchData<Application>(
+  const [application, error] = await fetchData<Application>(
     INDEXER.V2.FUNDING_APPLICATIONS.GET(referenceNumber),
     "GET"
   );
+  // Throw on failure (network, timeout, 4xx/5xx) so React Query keeps `data`
+  // undefined and callers fall back to the sanitized SSR `application.statusHistory`.
+  // Resolving to `[]` here would win the `?? ` fallback and blank the timeline
+  // for authorized viewers on a transient re-fetch failure.
+  if (error) {
+    throw new Error(
+      typeof error === "string" ? error : "Failed to load application status history"
+    );
+  }
   return application?.statusHistory ?? [];
 }

--- a/src/features/applications/services/status-history.service.ts
+++ b/src/features/applications/services/status-history.service.ts
@@ -1,0 +1,24 @@
+import type { Application } from "@/types/whitelabel-entities";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+/**
+ * Fetches an application's status history with the caller's auth token.
+ *
+ * The whitelabel application page is server-rendered without a Privy token, so
+ * the backend serves that request anonymously and strips the private
+ * status-change reasons (rejection/revision messages). Calling this from the
+ * client with the viewer's token lets the backend — which is the access guard —
+ * return the reasons to the applicant, reviewers, and admins, and to no one
+ * else. This only re-requests the authenticated view; it makes no access
+ * decision of its own.
+ */
+export async function getApplicationStatusHistory(
+  referenceNumber: string
+): Promise<Application["statusHistory"]> {
+  const [application] = await fetchData<Application>(
+    INDEXER.V2.FUNDING_APPLICATIONS.GET(referenceNumber),
+    "GET"
+  );
+  return application?.statusHistory ?? [];
+}


### PR DESCRIPTION
## Overview

Fixes **DEV-517** (Filecoin / filpgf.io, High): logged-out visitors could read the reviewer's **rejection / revision communications** on a funding application. This is the **frontend half**. Pairs with the gap-indexer PR (see below).

## The guard is on the backend

The access control lives entirely in **show-karma/gap-indexer#2157**: the read endpoint refuses to return `statusHistory[].reason` to anyone who is not the applicant, a reviewer, or a program/community admin. Client-side hiding is **not** a guard — a logged-out visitor can read the raw JSON in the network tab regardless of what React renders — so this PR does **no authorization of its own**.

## Root cause (frontend side)

The reviewer's message lives in `application.statusHistory[].reason`. On the whitelabel page it surfaced in `ApplicationStatusStepper` (sidebar) with no viewer check, and the page is fetched **server-side without a Privy token**, so before the backend fix the reason was in the anonymous SSR payload too. The edit page's "Revision Required" banner had the same unguarded render.

## Why the frontend needs any change at all

Privy tokens live in client storage, so the **server-side fetch has no token** — the backend serves that request anonymously and (after the paired fix) strips the reasons. That means the *authorized* applicant/reviewer/admin also gets a reason-less SSR payload. To let them see the comms they're entitled to, authenticated viewers **re-fetch the application with their token**; the backend returns the reasons only to authorized users. This mirrors the existing `useApplicationAccess` pattern (SSR is sanitized; the client re-fetches authenticated for sensitive fields).

- **`useApplicationStatusHistory`** (new hook) — re-fetches the application with the viewer's token, enabled only when `authenticated`. Guests never fire it and keep the sanitized SSR payload. It applies no role logic — the backend decides what to return.
- Feed the resulting status history (`authedStatusHistory ?? application.statusHistory`) to the sidebar stepper, the activity timeline, and the edit-page revision banner.

Net behavior (all enforced by the backend):

| Viewer | Sees reason? |
|--------|--------------|
| Logged out / general public | No — SSR payload is sanitized, no client fetch |
| Other authenticated applicant | No — backend strips it from the re-fetch |
| Applicant (owner) | Yes — backend returns it to the re-fetch |
| Reviewer / program / community admin | Yes — backend returns it to the re-fetch |

## Wire contract (FE ↔ BE seam)

| FE request | Transport | BE reader |
|------------|-----------|-----------|
| SSR fetch | tokenless | `optionalAuthentication()` → guest → reason stripped |
| Client re-fetch (`useApplicationStatusHistory`) | `Authorization: Bearer` (attached by `fetchData`) | `optionalAuthentication()` → `session.linkedAddresses` → owner/reviewer/admin branch returns reasons |

## User flows

1. Guest views a rejected application → status timeline shows Pending → Rejected, **no message body**, no Comments tab.
2. Applicant views their rejected application → sidebar + activity show the rejection message.
3. Applicant on the **edit** page of a `revision_requested` application → revision reason shown.
4. Reviewer / community admin views on the whitelabel page → message shown.
5. A different logged-in applicant views someone else's rejected application → no message body.

## Tests

`__tests__/features/applications/use-application-status-history.test.tsx` — fetches with the token when authenticated; does **not** fetch when the viewer is unauthenticated (guests keep the sanitized SSR payload).

`pnpm test` (applications + application-comments + whitelabel components) → green · `tsc --noEmit` clean · `biome check` clean · `pnpm run build` passes.

## Smoke plan (cross-service E2E gate — DEV-517 §4)

Deploy this + the gap-indexer branch to the same preview and walk flows 1–5 above, including two negative paths (logged-out guest; different-applicant). Verify a logged-out visitor gets `reason` absent **in the network response**, not just hidden in the UI. Attach screenshots before merge.

Linear: DEV-517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application pages now load status history using the signed-in viewer’s access level, including gated reason text when available.
  * The edit view now surfaces the “Reason for revision” derived from the latest accessible status-history entry.
* **Bug Fixes**
  * Improved consistency across the sidebar and timeline by sourcing status history from the same viewer-aware data, with safe fallbacks when data can’t be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->