### PR TITLE
feat(donor-research): outreach email preview & edit before Ask Questions / Connect (DEV-500)

### DIFF
--- a/hooks/useDiligence.ts
+++ b/hooks/useDiligence.ts
@@ -4,6 +4,7 @@ import {
   fetchDiligenceResponseContext,
   getCandidateDiligence,
   getDiligenceTemplate,
+  getOutreachPreview,
   requestIntro,
   saveDiligenceTemplate,
   submitDiligenceResponse,
@@ -14,6 +15,8 @@ import type {
   CandidateDiligenceView,
   DiligenceResponseContext,
   DiligenceTemplate,
+  OutreachAction,
+  OutreachPreview,
   RequestIntroResult,
   SaveDiligenceTemplateRequest,
   SubmitDiligenceResponseRequest,
@@ -29,6 +32,12 @@ export const candidateDiligenceQueryKey = (reportId: string, candidateId: string
 
 export const diligenceResponseContextQueryKey = (token: string) =>
   ["donor-research", "diligence", "response-context", token] as const;
+
+export const outreachPreviewQueryKey = (
+  reportId: string,
+  candidateId: string,
+  action: OutreachAction
+) => ["donor-research", "diligence", "outreach-preview", reportId, candidateId, action] as const;
 
 // -- Advisor: template -------------------------------------------------------
 
@@ -74,13 +83,39 @@ export function useCandidateDiligence(
 }
 
 /**
+ * Loads the exact outreach email a send action would dispatch, for the
+ * preview-and-edit step. `staleTime: 0` + refetch on mount so every dialog
+ * open shows the current composition (the intro body embeds live Q&A context).
+ */
+export function useOutreachPreview(
+  reportId: string,
+  candidateId: string,
+  action: OutreachAction,
+  enabled = true
+) {
+  return useQuery<OutreachPreview>({
+    queryKey: outreachPreviewQueryKey(reportId, candidateId, action),
+    queryFn: () => getOutreachPreview(reportId, candidateId, action),
+    enabled: enabled && !!reportId && !!candidateId,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
  * Ask Questions (202, async). Invalidates the candidate view so the new
  * `in_progress` / `blocked` state is reflected after the outbox dispatches.
+ * `body` carries the advisor-edited email body — pass it ONLY when edited so
+ * an untouched preview lets the backend compose its own default.
  */
 export function useAskQuestions() {
   const queryClient = useQueryClient();
-  return useMutation<AskQuestionsResponse, Error, { reportId: string; candidateId: string }>({
-    mutationFn: ({ reportId, candidateId }) => askQuestions(reportId, candidateId),
+  return useMutation<
+    AskQuestionsResponse,
+    Error,
+    { reportId: string; candidateId: string; body?: string }
+  >({
+    mutationFn: ({ reportId, candidateId, body }) => askQuestions(reportId, candidateId, body),
     onSuccess: (_data, { reportId, candidateId }) => {
       queryClient.invalidateQueries({
         queryKey: candidateDiligenceQueryKey(reportId, candidateId),
@@ -92,12 +127,17 @@ export function useAskQuestions() {
 /**
  * Connect / named intro (202 | 422-email). On a queued result invalidates the
  * candidate view. The `email_required` branch is surfaced to the caller (it
- * resolves, not rejects) so the UI can run the email-capture flow.
+ * resolves, not rejects) so the UI can run the email-capture flow. `body`
+ * follows the same only-when-edited contract as {@link useAskQuestions}.
  */
 export function useRequestIntro() {
   const queryClient = useQueryClient();
-  return useMutation<RequestIntroResult, Error, { reportId: string; candidateId: string }>({
-    mutationFn: ({ reportId, candidateId }) => requestIntro(reportId, candidateId),
+  return useMutation<
+    RequestIntroResult,
+    Error,
+    { reportId: string; candidateId: string; body?: string }
+  >({
+    mutationFn: ({ reportId, candidateId, body }) => requestIntro(reportId, candidateId, body),
     onSuccess: (result, { reportId, candidateId }) => {
       if (result.kind === "queued") {
         queryClient.invalidateQueries({

--- a/services/diligence.service.ts
+++ b/services/diligence.service.ts
@@ -4,6 +4,8 @@ import type {
   DiligenceResponseContext,
   DiligenceTemplate,
   IntroQueuedResponse,
+  OutreachAction,
+  OutreachPreview,
   RequestIntroResult,
   SaveDiligenceTemplateRequest,
   SubmitDiligenceResponseRequest,
@@ -83,18 +85,45 @@ export const getCandidateDiligence = async (
 };
 
 /**
+ * Loads the exact email a send action would dispatch (DEV-500) so the advisor
+ * can review/edit the body first. The backend composes it with the same
+ * builders as delivery, so preview and sent content cannot drift. A 404 means
+ * the candidate is unknown / cross-advisor (same semantics as the diligence
+ * view).
+ */
+export const getOutreachPreview = async (
+  reportId: string,
+  candidateId: string,
+  action: OutreachAction
+): Promise<OutreachPreview> => {
+  const [data, error] = await fetchData<OutreachPreview>(
+    DILIGENCE_ENDPOINTS.OUTREACH_PREVIEW(reportId, candidateId, action)
+  );
+  if (error || !data) {
+    throw new Error(error || "Failed to load the email preview");
+  }
+  return data;
+};
+
+/**
  * Ask Questions — sends an anonymous diligence request (202, async). The email
  * is dispatched via the outbox, not synchronously, so callers should re-fetch
  * the candidate view shortly after. Idempotent per candidate, so retries are
  * safe.
+ *
+ * `body` is the advisor-edited email body. Pass it ONLY when the advisor
+ * actually edited the preview — omitted, the backend composes its own default,
+ * which is the contract for an untouched textarea.
  */
 export const askQuestions = async (
   reportId: string,
-  candidateId: string
+  candidateId: string,
+  body?: string
 ): Promise<AskQuestionsResponse> => {
   const [data, error] = await fetchData<AskQuestionsResponse>(
     DILIGENCE_ENDPOINTS.REQUESTS(reportId, candidateId),
-    "POST"
+    "POST",
+    body === undefined ? {} : { body }
   );
   if (error || !data) {
     throw new Error(error || "Failed to send diligence request");
@@ -118,11 +147,13 @@ export const askQuestions = async (
  */
 export const requestIntro = async (
   reportId: string,
-  candidateId: string
+  candidateId: string,
+  body?: string
 ): Promise<RequestIntroResult> => {
   const [data, error, , status] = await fetchData<IntroQueuedResponse>(
     DILIGENCE_ENDPOINTS.INTRO_REQUESTS(reportId, candidateId),
-    "POST"
+    "POST",
+    body === undefined ? {} : { body }
   );
   if (status === 422) {
     return {

--- a/src/features/donor-research/components/diligence-template/DiligenceTemplateEditor.tsx
+++ b/src/features/donor-research/components/diligence-template/DiligenceTemplateEditor.tsx
@@ -37,23 +37,9 @@ import { Link } from "@/src/components/navigation/Link";
 import { DonorResearchLoading } from "@/src/features/donor-research/components/common/DonorResearchLoading";
 import { DILIGENCE_TEMPLATE_LIMITS, type DiligenceQuestion } from "@/types/diligence";
 import { PAGES } from "@/utilities/pages";
+import { makeQuestionId } from "../diligence/question-id";
 
 const { MAX_QUESTIONS, QUESTION_TEXT_MAX } = DILIGENCE_TEMPLATE_LIMITS;
-
-/**
- * Collision-free stable id for a *newly added* row only. Existing rows keep the
- * server-issued id untouched, so collected answers stay keyed correctly across
- * edits. We never use the array index as the id, and avoid Math.random/Date.now
- * patterns flagged by the anti-pattern rules.
- */
-let fallbackIdCounter = 0;
-function makeQuestionId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  fallbackIdCounter += 1;
-  return `dq-${fallbackIdCounter.toString(36)}`;
-}
 
 interface RowError {
   message: string;

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import pluralize from "pluralize";
+import { useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,9 +13,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useAskQuestions, useDiligenceTemplate } from "@/hooks/useDiligence";
-import type { CandidateDiligenceView, DiligenceQuestion } from "@/types/diligence";
+import { useAskQuestions, useDiligenceTemplate, useOutreachPreview } from "@/hooks/useDiligence";
+import type { CandidateDiligenceView } from "@/types/diligence";
 import { PAGES } from "@/utilities/pages";
+import { getOutreachBodyIssue, OutreachEmailPreview } from "./OutreachEmailPreview";
 
 interface AskQuestionsDialogProps {
   reportId: string;
@@ -23,14 +24,18 @@ interface AskQuestionsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   view: CandidateDiligenceView;
+  /** Nonprofit display name for the preview's To row (null → row hidden). */
+  candidateName?: string | null;
 }
 
 /**
  * Confirms an ANONYMOUS diligence request. Karma emails the nonprofit the
  * org-facing questions only — never the advisor's identity.
  *
- * The questions previewed are the FROZEN snapshot when a request already
- * exists (`view.request.questions`), otherwise the advisor's current template.
+ * Before sending, the advisor sees the ENTIRE email (DEV-500): the backend
+ * composes the exact default body (template questions embedded as numbered
+ * lines) and the advisor may edit it. An untouched body POSTs without `body`
+ * so the backend renders its own default.
  */
 export function AskQuestionsDialog({
   reportId,
@@ -38,17 +43,20 @@ export function AskQuestionsDialog({
   open,
   onOpenChange,
   view,
+  candidateName,
 }: AskQuestionsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        {/* The portal only mounts children when open, so the template fetch in
-            AskQuestionsBody runs lazily — never for closed/unopened dialogs. */}
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+        {/* The portal only mounts children when open, so the template/preview
+            fetches in AskQuestionsBody run lazily — never for closed dialogs —
+            and the edited-body draft resets on close via unmount. */}
         {open ? (
           <AskQuestionsBody
             reportId={reportId}
             candidateId={candidateId}
             view={view}
+            candidateName={candidateName ?? null}
             onClose={() => onOpenChange(false)}
           />
         ) : null}
@@ -61,23 +69,50 @@ interface AskQuestionsBodyProps {
   reportId: string;
   candidateId: string;
   view: CandidateDiligenceView;
+  candidateName: string | null;
   onClose: () => void;
 }
 
-function AskQuestionsBody({ reportId, candidateId, view, onClose }: AskQuestionsBodyProps) {
-  const frozen = view.request?.questions ?? null;
+function AskQuestionsBody({
+  reportId,
+  candidateId,
+  view,
+  candidateName,
+  onClose,
+}: AskQuestionsBodyProps) {
+  // The template is only consulted for the empty guard — the email content
+  // itself always comes from the backend preview, which composes from the
+  // live template exactly as delivery would.
   const templateQuery = useDiligenceTemplate();
   const askQuestions = useAskQuestions();
 
-  const questions: DiligenceQuestion[] = frozen ?? templateQuery.data?.questions ?? [];
-  const isLoadingTemplate = !frozen && templateQuery.isLoading;
-  const isTemplateError = !frozen && templateQuery.isError;
-  const isEmpty = !isLoadingTemplate && !isTemplateError && questions.length === 0;
-  const canSend = view.actions.canAskQuestions && questions.length > 0;
+  const hasFrozenRequest = (view.request?.questions.length ?? 0) > 0;
+  const isTemplateLoading = !hasFrozenRequest && templateQuery.isLoading;
+  const isTemplateError = !hasFrozenRequest && templateQuery.isError;
+  const isTemplateEmpty =
+    !hasFrozenRequest &&
+    !isTemplateLoading &&
+    !isTemplateError &&
+    (templateQuery.data?.questions.length ?? 0) === 0;
+
+  const previewQuery = useOutreachPreview(reportId, candidateId, "diligence", !isTemplateEmpty);
+  const preview = previewQuery.data;
+
+  // null = untouched; the textarea always shows the draft once one exists so
+  // edits survive a background preview refetch.
+  const [draft, setDraft] = useState<string | null>(null);
+  const body = draft ?? preview?.bodyText ?? "";
+  const isEdited = draft !== null && preview !== undefined && draft !== preview.bodyText;
+
+  const canSend =
+    view.actions.canAskQuestions &&
+    !isTemplateEmpty &&
+    preview !== undefined &&
+    getOutreachBodyIssue(body) === null;
 
   const handleSend = () => {
     askQuestions.mutate(
-      { reportId, candidateId },
+      { reportId, candidateId, ...(isEdited ? { body: body.trim() } : {}) },
       {
         onSuccess: () => {
           toast.success("Questions sent");
@@ -95,13 +130,13 @@ function AskQuestionsBody({ reportId, candidateId, view, onClose }: AskQuestions
       <DialogHeader>
         <DialogTitle>Ask questions anonymously</DialogTitle>
         <DialogDescription>
-          Karma emails this nonprofit your questions. Your identity is never shared — they only see
-          that a funder is interested.
+          Karma emails this nonprofit the message below. Your identity is never shared — they only
+          see that a funder is interested. Review the email and edit it if needed before sending.
         </DialogDescription>
       </DialogHeader>
 
       <div className="py-1">
-        {isLoadingTemplate ? (
+        {isTemplateLoading ? (
           <div className="flex flex-col gap-2" aria-busy="true">
             <Skeleton className="h-4 w-3/4" />
             <Skeleton className="h-4 w-2/3" />
@@ -119,7 +154,7 @@ function AskQuestionsBody({ reportId, candidateId, view, onClose }: AskQuestions
               Retry
             </Button>
           </div>
-        ) : isEmpty ? (
+        ) : isTemplateEmpty ? (
           <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 p-3">
             <p className="text-sm text-muted-foreground">
               You haven't added any diligence questions yet. Add questions to your template before
@@ -133,19 +168,17 @@ function AskQuestionsBody({ reportId, candidateId, view, onClose }: AskQuestions
             </Link>
           </div>
         ) : (
-          <>
-            <p className="mb-2 text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-              {questions.length} {pluralize("question", questions.length)} will be sent
-            </p>
-            <ol className="flex flex-col gap-2">
-              {questions.map((question, index) => (
-                <li key={question.id} className="flex gap-2 text-sm text-foreground">
-                  <span className="tabular-nums text-muted-foreground">{index + 1}.</span>
-                  <span className="flex-1">{question.text}</span>
-                </li>
-              ))}
-            </ol>
-          </>
+          <OutreachEmailPreview
+            preview={preview}
+            isLoading={previewQuery.isLoading}
+            isError={previewQuery.isError}
+            onRetry={() => previewQuery.refetch()}
+            toName={candidateName}
+            body={body}
+            onBodyChange={setDraft}
+            idPrefix="ask-questions"
+            hint="Editing the questions here changes the email text only — the answer form uses your saved question template."
+          />
         )}
       </div>
 

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -24,7 +24,8 @@ import {
 import type { CandidateDiligenceView, DiligenceQuestion } from "@/types/diligence";
 import { DILIGENCE_TEMPLATE_LIMITS } from "@/types/diligence";
 import { PAGES } from "@/utilities/pages";
-import { getOutreachBodyIssue, OutreachEmailPreview } from "./OutreachEmailPreview";
+import { OutreachEmailPreview } from "./OutreachEmailPreview";
+import { getOutreachBodyIssue } from "./outreach-body";
 import { makeQuestionId } from "./question-id";
 
 interface AskQuestionsDialogProps {

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -105,14 +105,22 @@ function AskQuestionsBody({
     !isTemplateError &&
     (templateQuery.data?.questions.length ?? 0) === 0;
 
-  const previewQuery = useOutreachPreview(reportId, candidateId, "diligence", !isTemplateEmpty);
+  // Enable the preview only once we KNOW questions exist (frozen request or
+  // loaded template) — never speculatively while the template is loading, so
+  // first-run empty-template users don't fire a preview they'll never see.
+  const shouldLoadPreview =
+    hasFrozenRequest ||
+    (!isTemplateLoading && !isTemplateError && (templateQuery.data?.questions.length ?? 0) > 0);
+  const previewQuery = useOutreachPreview(reportId, candidateId, "diligence", shouldLoadPreview);
   const preview = previewQuery.data;
 
   // null = untouched; the textarea always shows the draft once one exists so
-  // edits survive a background preview refetch.
+  // edits survive a background preview refetch. Edited-ness compares TRIMMED
+  // text — a whitespace-only tweak still sends the backend default.
   const [draft, setDraft] = useState<string | null>(null);
   const body = draft ?? preview?.bodyText ?? "";
-  const isEdited = draft !== null && preview !== undefined && draft !== preview.bodyText;
+  const isEdited =
+    draft !== null && preview !== undefined && body.trim() !== preview.bodyText.trim();
 
   const canSend =
     view.actions.canAskQuestions &&

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Plus, X } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -13,10 +14,18 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useAskQuestions, useDiligenceTemplate, useOutreachPreview } from "@/hooks/useDiligence";
-import type { CandidateDiligenceView } from "@/types/diligence";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  useAskQuestions,
+  useDiligenceTemplate,
+  useOutreachPreview,
+  useSaveDiligenceTemplate,
+} from "@/hooks/useDiligence";
+import type { CandidateDiligenceView, DiligenceQuestion } from "@/types/diligence";
+import { DILIGENCE_TEMPLATE_LIMITS } from "@/types/diligence";
 import { PAGES } from "@/utilities/pages";
 import { getOutreachBodyIssue, OutreachEmailPreview } from "./OutreachEmailPreview";
+import { makeQuestionId } from "./question-id";
 
 interface AskQuestionsDialogProps {
   reportId: string;
@@ -155,18 +164,7 @@ function AskQuestionsBody({
             </Button>
           </div>
         ) : isTemplateEmpty ? (
-          <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 p-3">
-            <p className="text-sm text-muted-foreground">
-              You haven't added any diligence questions yet. Add questions to your template before
-              you can send them.
-            </p>
-            <Link
-              href={PAGES.DONOR_RESEARCH.DILIGENCE_TEMPLATE}
-              className="text-sm font-medium text-brand-emphasis underline-offset-2 hover:underline dark:text-brand-subtle"
-            >
-              Edit your question template
-            </Link>
-          </div>
+          <InlineQuestionSetup />
         ) : (
           <OutreachEmailPreview
             preview={preview}
@@ -196,5 +194,127 @@ function AskQuestionsBody({
         </Button>
       </DialogFooter>
     </>
+  );
+}
+
+const { MAX_QUESTIONS, QUESTION_TEXT_MAX } = DILIGENCE_TEMPLATE_LIMITS;
+
+/**
+ * First-run question capture inside the dialog: lets the advisor write their
+ * diligence questions right here instead of detouring to the template page
+ * (which stays available via the link below). Saving goes through the normal
+ * template save, and the seeded cache flips the dialog straight into the email
+ * preview — blank rows are dropped, so only real questions persist.
+ */
+function InlineQuestionSetup() {
+  const save = useSaveDiligenceTemplate();
+  const [rows, setRows] = useState<DiligenceQuestion[]>(() => [{ id: makeQuestionId(), text: "" }]);
+
+  const filled = rows.filter((row) => row.text.trim().length > 0);
+  const hasTooLong = rows.some((row) => row.text.trim().length > QUESTION_TEXT_MAX);
+  const canSave = filled.length > 0 && !hasTooLong && !save.isPending;
+
+  const updateRow = (id: string, text: string) => {
+    setRows((prev) => prev.map((row) => (row.id === id ? { ...row, text } : row)));
+  };
+
+  const removeRow = (id: string) => {
+    setRows((prev) => prev.filter((row) => row.id !== id));
+  };
+
+  const addRow = () => {
+    setRows((prev) =>
+      prev.length >= MAX_QUESTIONS ? prev : [...prev, { id: makeQuestionId(), text: "" }]
+    );
+  };
+
+  const handleSave = () => {
+    save.mutate(
+      { questions: filled.map((row) => ({ id: row.id, text: row.text.trim() })) },
+      {
+        onSuccess: () => {
+          toast.success("Questions saved to your template");
+        },
+        onError: () => {
+          toast.error("Couldn't save your questions. Please try again.");
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/30 p-3">
+      <p className="text-sm text-muted-foreground">
+        You haven't added any diligence questions yet. Write them here — they're saved to your
+        question template and dropped into the email.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {rows.map((row, index) => {
+          const tooLong = row.text.trim().length > QUESTION_TEXT_MAX;
+          return (
+            <div key={row.id} className="flex flex-col gap-1">
+              <div className="flex items-start gap-2">
+                <Textarea
+                  aria-label={`Question ${index + 1}`}
+                  placeholder="e.g. What is your annual operating budget?"
+                  value={row.text}
+                  onChange={(event) => updateRow(row.id, event.target.value)}
+                  disabled={save.isPending}
+                  className="min-h-[40px]"
+                  rows={1}
+                />
+                {rows.length > 1 ? (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    aria-label={`Remove question ${index + 1}`}
+                    onClick={() => removeRow(row.id)}
+                    disabled={save.isPending}
+                  >
+                    <X className="size-4" aria-hidden />
+                  </Button>
+                ) : null}
+              </div>
+              {tooLong ? (
+                <p className="text-sm text-destructive">
+                  Use {QUESTION_TEXT_MAX.toLocaleString("en-US")} characters or fewer.
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={addRow}
+          disabled={save.isPending || rows.length >= MAX_QUESTIONS}
+        >
+          <Plus className="size-4" aria-hidden />
+          Add another question
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          disabled={!canSave}
+          isLoading={save.isPending}
+        >
+          Save questions
+        </Button>
+      </div>
+
+      <Link
+        href={PAGES.DONOR_RESEARCH.DILIGENCE_TEMPLATE}
+        className="text-sm font-medium text-brand-emphasis underline-offset-2 hover:underline dark:text-brand-subtle"
+      >
+        Edit your question template
+      </Link>
+    </div>
   );
 }

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -2,7 +2,7 @@
 
 import { Plus, X } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { memo, useCallback, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -214,13 +214,13 @@ function InlineQuestionSetup() {
   const hasTooLong = rows.some((row) => row.text.trim().length > QUESTION_TEXT_MAX);
   const canSave = filled.length > 0 && !hasTooLong && !save.isPending;
 
-  const updateRow = (id: string, text: string) => {
+  const updateRow = useCallback((id: string, text: string) => {
     setRows((prev) => prev.map((row) => (row.id === id ? { ...row, text } : row)));
-  };
+  }, []);
 
-  const removeRow = (id: string) => {
+  const removeRow = useCallback((id: string) => {
     setRows((prev) => prev.filter((row) => row.id !== id));
-  };
+  }, []);
 
   const addRow = () => {
     setRows((prev) =>
@@ -250,41 +250,17 @@ function InlineQuestionSetup() {
       </p>
 
       <div className="flex flex-col gap-2">
-        {rows.map((row, index) => {
-          const tooLong = row.text.trim().length > QUESTION_TEXT_MAX;
-          return (
-            <div key={row.id} className="flex flex-col gap-1">
-              <div className="flex items-start gap-2">
-                <Textarea
-                  aria-label={`Question ${index + 1}`}
-                  placeholder="e.g. What is your annual operating budget?"
-                  value={row.text}
-                  onChange={(event) => updateRow(row.id, event.target.value)}
-                  disabled={save.isPending}
-                  className="min-h-[40px]"
-                  rows={1}
-                />
-                {rows.length > 1 ? (
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={`Remove question ${index + 1}`}
-                    onClick={() => removeRow(row.id)}
-                    disabled={save.isPending}
-                  >
-                    <X className="size-4" aria-hidden />
-                  </Button>
-                ) : null}
-              </div>
-              {tooLong ? (
-                <p className="text-sm text-destructive">
-                  Use {QUESTION_TEXT_MAX.toLocaleString("en-US")} characters or fewer.
-                </p>
-              ) : null}
-            </div>
-          );
-        })}
+        {rows.map((row, index) => (
+          <InlineQuestionRow
+            key={row.id}
+            row={row}
+            index={index}
+            removable={rows.length > 1}
+            disabled={save.isPending}
+            onChangeText={updateRow}
+            onRemove={removeRow}
+          />
+        ))}
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -318,3 +294,56 @@ function InlineQuestionSetup() {
     </div>
   );
 }
+
+interface InlineQuestionRowProps {
+  row: DiligenceQuestion;
+  index: number;
+  removable: boolean;
+  disabled: boolean;
+  onChangeText: (id: string, text: string) => void;
+  onRemove: (id: string) => void;
+}
+
+/** One editable question row; memoized since it renders inside a map. */
+const InlineQuestionRow = memo(function InlineQuestionRow({
+  row,
+  index,
+  removable,
+  disabled,
+  onChangeText,
+  onRemove,
+}: InlineQuestionRowProps) {
+  const tooLong = row.text.trim().length > QUESTION_TEXT_MAX;
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-start gap-2">
+        <Textarea
+          aria-label={`Question ${index + 1}`}
+          placeholder="e.g. What is your annual operating budget?"
+          value={row.text}
+          onChange={(event) => onChangeText(row.id, event.target.value)}
+          disabled={disabled}
+          className="min-h-[40px]"
+          rows={1}
+        />
+        {removable ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label={`Remove question ${index + 1}`}
+            onClick={() => onRemove(row.id)}
+            disabled={disabled}
+          >
+            <X className="size-4" aria-hidden />
+          </Button>
+        ) : null}
+      </div>
+      {tooLong ? (
+        <p className="text-sm text-destructive">
+          Use {QUESTION_TEXT_MAX.toLocaleString("en-US")} characters or fewer.
+        </p>
+      ) : null}
+    </div>
+  );
+});

--- a/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
+++ b/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
@@ -13,6 +13,8 @@ import { DiligenceStatusBadge } from "./DiligenceStatusBadge";
 interface CandidateDiligenceActionsProps {
   reportId: string;
   candidateId: string;
+  /** Nonprofit display name for the outreach previews' To row. */
+  candidateName?: string | null;
 }
 
 /**
@@ -28,6 +30,7 @@ interface CandidateDiligenceActionsProps {
 export const CandidateDiligenceActions = memo(function CandidateDiligenceActions({
   reportId,
   candidateId,
+  candidateName,
 }: CandidateDiligenceActionsProps) {
   const [askOpen, setAskOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
@@ -102,6 +105,7 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
         open={askOpen}
         onOpenChange={setAskOpen}
         view={view}
+        candidateName={candidateName}
       />
       <ConnectDialog
         reportId={reportId}
@@ -109,6 +113,7 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
         open={connectOpen}
         onOpenChange={setConnectOpen}
         canConnect={actions.canConnect}
+        candidateName={candidateName}
       />
     </div>
   );

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -106,9 +106,12 @@ function ConnectBody({
 
   // null = untouched. Lives here (not in the preview block) so an edited body
   // survives the switch to the email-capture step and the automatic retry.
+  // Edited-ness compares TRIMMED text — a whitespace-only tweak still sends
+  // the backend default.
   const [draft, setDraft] = useState<string | null>(null);
   const body = draft ?? preview?.bodyText ?? "";
-  const isEdited = draft !== null && preview !== undefined && draft !== preview.bodyText;
+  const isEdited =
+    draft !== null && preview !== undefined && body.trim() !== preview.bodyText.trim();
 
   const canSend = canConnect && preview !== undefined && getOutreachBodyIssue(body) === null;
 

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -16,7 +16,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useRequestIntro, useUpdateAdvisorEmail } from "@/hooks/useDiligence";
+import { useOutreachPreview, useRequestIntro, useUpdateAdvisorEmail } from "@/hooks/useDiligence";
+import { getOutreachBodyIssue, OutreachEmailPreview } from "./OutreachEmailPreview";
 
 interface ConnectDialogProps {
   reportId: string;
@@ -25,6 +26,8 @@ interface ConnectDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Drives the confirm button (from `view.actions.canConnect`). */
   canConnect: boolean;
+  /** Nonprofit display name for the preview's To row (null → row hidden). */
+  candidateName?: string | null;
 }
 
 const emailSchema = z.object({
@@ -39,9 +42,14 @@ type Step = "confirm" | "email";
  * Confirms a NAMED intro that reveals the advisor's identity (and any prior
  * Q&A) to the nonprofit.
  *
+ * Before sending, the advisor sees the ENTIRE intro email (DEV-500) and may
+ * edit the body; an untouched body POSTs without `body` so the backend
+ * composes its own default.
+ *
  * If the advisor has no resolvable reply-to email the backend answers
  * `email_required` instead of queuing — we switch to an email-capture step,
- * persist the address, then re-attempt the original intro automatically.
+ * persist the address, then re-attempt the original intro automatically,
+ * preserving any edited body across the capture step.
  */
 export function ConnectDialog({
   reportId,
@@ -49,17 +57,63 @@ export function ConnectDialog({
   open,
   onOpenChange,
   canConnect,
+  candidateName,
 }: ConnectDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+        {/* The portal only mounts children when open, so the preview fetch in
+            ConnectBody runs lazily, and closing resets the step, the email
+            form, and the edited-body draft via unmount. */}
+        {open ? (
+          <ConnectBody
+            reportId={reportId}
+            candidateId={candidateId}
+            canConnect={canConnect}
+            candidateName={candidateName ?? null}
+            onClose={() => onOpenChange(false)}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ConnectBodyProps {
+  reportId: string;
+  candidateId: string;
+  canConnect: boolean;
+  candidateName: string | null;
+  onClose: () => void;
+}
+
+function ConnectBody({
+  reportId,
+  candidateId,
+  canConnect,
+  candidateName,
+  onClose,
+}: ConnectBodyProps) {
   const [step, setStep] = useState<Step>("confirm");
   const [emailPrompt, setEmailPrompt] = useState<string | null>(null);
 
   const requestIntro = useRequestIntro();
   const updateAdvisorEmail = useUpdateAdvisorEmail();
 
+  const previewQuery = useOutreachPreview(reportId, candidateId, "intro");
+  const preview = previewQuery.data;
+
+  // null = untouched. Lives here (not in the preview block) so an edited body
+  // survives the switch to the email-capture step and the automatic retry.
+  const [draft, setDraft] = useState<string | null>(null);
+  const body = draft ?? preview?.bodyText ?? "";
+  const isEdited = draft !== null && preview !== undefined && draft !== preview.bodyText;
+
+  const canSend = canConnect && preview !== undefined && getOutreachBodyIssue(body) === null;
+
   const {
     register,
     handleSubmit,
-    reset,
     formState: { errors },
   } = useForm<EmailFormValues>({
     resolver: zodResolver(emailSchema),
@@ -69,27 +123,14 @@ export function ConnectDialog({
     defaultValues: { email: "" },
   });
 
-  // Reset back to the first step on close, so the next open starts fresh
-  // (handled in the close path rather than a state-syncing effect).
-  const handleOpenChange = (next: boolean) => {
-    if (!next) {
-      setStep("confirm");
-      setEmailPrompt(null);
-      reset({ email: "" });
-    }
-    onOpenChange(next);
-  };
-
-  const close = () => handleOpenChange(false);
-
   const sendIntro = (onEmailRequired: (message: string) => void) => {
     requestIntro.mutate(
-      { reportId, candidateId },
+      { reportId, candidateId, ...(isEdited ? { body: body.trim() } : {}) },
       {
         onSuccess: (result) => {
           if (result.kind === "queued") {
             toast.success("Intro sent");
-            close();
+            onClose();
           } else {
             onEmailRequired(result.message);
           }
@@ -114,7 +155,8 @@ export function ConnectDialog({
       { email: values.email },
       {
         onSuccess: () => {
-          // Re-attempt the original intro now that a reply-to exists.
+          // Re-attempt the original intro (edited body included) now that a
+          // reply-to exists.
           sendIntro((message) => {
             setEmailPrompt(message);
             toast.error(message);
@@ -129,69 +171,79 @@ export function ConnectDialog({
 
   const isSubmittingEmail = updateAdvisorEmail.isPending || requestIntro.isPending;
 
+  if (step === "confirm") {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>Send a named intro</DialogTitle>
+          <DialogDescription>
+            Connecting reveals your identity to this nonprofit, along with any answers they've
+            already shared. Karma sends them the email below on your behalf — review it and edit if
+            needed before sending.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-1">
+          <OutreachEmailPreview
+            preview={preview}
+            isLoading={previewQuery.isLoading}
+            isError={previewQuery.isError}
+            onRetry={() => previewQuery.refetch()}
+            toName={candidateName}
+            body={body}
+            onBodyChange={setDraft}
+            idPrefix="connect"
+          />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canSend || requestIntro.isPending}
+            isLoading={requestIntro.isPending}
+          >
+            Send intro
+          </Button>
+        </DialogFooter>
+      </>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
-        {step === "confirm" ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>Send a named intro</DialogTitle>
-              <DialogDescription>
-                Connecting reveals your identity to this nonprofit, along with any answers they've
-                already shared. Karma sends them a warm intro on your behalf.
-              </DialogDescription>
-            </DialogHeader>
+    <form onSubmit={handleEmailSubmit}>
+      <DialogHeader>
+        <DialogTitle>Add your email</DialogTitle>
+        <DialogDescription>
+          {emailPrompt ?? "Add an email so we can send the named intro."} We use your email as the
+          reply-to for the intro.
+        </DialogDescription>
+      </DialogHeader>
 
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={close}>
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                onClick={handleConfirm}
-                disabled={!canConnect || requestIntro.isPending}
-                isLoading={requestIntro.isPending}
-              >
-                Send intro
-              </Button>
-            </DialogFooter>
-          </>
-        ) : (
-          <form onSubmit={handleEmailSubmit}>
-            <DialogHeader>
-              <DialogTitle>Add your email</DialogTitle>
-              <DialogDescription>
-                {emailPrompt ?? "Add an email so we can send the named intro."} We use your email as
-                the reply-to for the intro.
-              </DialogDescription>
-            </DialogHeader>
+      <div className="flex flex-col gap-2 py-2">
+        <Label htmlFor="advisor-email">Email address</Label>
+        <Input
+          id="advisor-email"
+          type="email"
+          autoComplete="email"
+          placeholder="you@example.org"
+          aria-invalid={errors.email ? "true" : undefined}
+          {...register("email")}
+        />
+        {errors.email ? <p className="text-sm text-destructive">{errors.email.message}</p> : null}
+      </div>
 
-            <div className="flex flex-col gap-2 py-2">
-              <Label htmlFor="advisor-email">Email address</Label>
-              <Input
-                id="advisor-email"
-                type="email"
-                autoComplete="email"
-                placeholder="you@example.org"
-                aria-invalid={errors.email ? "true" : undefined}
-                {...register("email")}
-              />
-              {errors.email ? (
-                <p className="text-sm text-destructive">{errors.email.message}</p>
-              ) : null}
-            </div>
-
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={close}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSubmittingEmail} isLoading={isSubmittingEmail}>
-                Save and send intro
-              </Button>
-            </DialogFooter>
-          </form>
-        )}
-      </DialogContent>
-    </Dialog>
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isSubmittingEmail} isLoading={isSubmittingEmail}>
+          Save and send intro
+        </Button>
+      </DialogFooter>
+    </form>
   );
 }

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -17,7 +17,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useOutreachPreview, useRequestIntro, useUpdateAdvisorEmail } from "@/hooks/useDiligence";
-import { getOutreachBodyIssue, OutreachEmailPreview } from "./OutreachEmailPreview";
+import { OutreachEmailPreview } from "./OutreachEmailPreview";
+import { getOutreachBodyIssue } from "./outreach-body";
 
 interface ConnectDialogProps {
   reportId: string;

--- a/src/features/donor-research/components/diligence/OutreachEmailPreview.tsx
+++ b/src/features/donor-research/components/diligence/OutreachEmailPreview.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Info, Lock } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import type { OutreachPreview } from "@/types/diligence";
+import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
+
+/**
+ * Why the edited body is invalid for sending, mirroring the backend's
+ * `OutreachActionBodySchema` (trimmed, 1..10,000 chars). `null` means the body
+ * is sendable.
+ */
+export type OutreachBodyIssue = "empty" | "over_limit" | null;
+
+export function getOutreachBodyIssue(body: string): OutreachBodyIssue {
+  const trimmedLength = body.trim().length;
+  if (trimmedLength === 0) return "empty";
+  if (trimmedLength > OUTREACH_BODY_LIMITS.MAX_CHARS) return "over_limit";
+  return null;
+}
+
+interface OutreachEmailPreviewProps {
+  preview: OutreachPreview | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  /** Nonprofit display name for the To row; the row is hidden when unknown. */
+  toName: string | null;
+  /** Current body value — the caller resolves draft ?? preview.bodyText. */
+  body: string;
+  onBodyChange: (value: string) => void;
+  /** Unique per host dialog so the textarea label ids never collide. */
+  idPrefix: string;
+  /** Optional extra note under the body (e.g. the questions-snapshot hint). */
+  hint?: ReactNode;
+}
+
+/**
+ * The email-shaped preview-and-edit block shared by the Ask Questions and
+ * Connect dialogs (DEV-500): read-only To/Subject rows, an editable plain-text
+ * body, and the non-editable footer the system appends at send time. Never
+ * renders null — loading and error both have explicit states, and sending is
+ * impossible until a preview has loaded (callers gate on `preview`).
+ */
+export function OutreachEmailPreview({
+  preview,
+  isLoading,
+  isError,
+  onRetry,
+  toName,
+  body,
+  onBodyChange,
+  idPrefix,
+  hint,
+}: OutreachEmailPreviewProps) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3" aria-busy="true">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (isError || !preview) {
+    return (
+      <div className="flex flex-col items-start gap-2 rounded-md border border-border bg-muted/30 p-3">
+        <p className="text-sm text-muted-foreground">Couldn't load the email preview.</p>
+        <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const bodyId = `${idPrefix}-outreach-body`;
+  const issue = getOutreachBodyIssue(body);
+  const trimmedLength = body.trim().length;
+  const showCounter = trimmedLength > OUTREACH_BODY_LIMITS.COUNTER_THRESHOLD;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {toName ? <ReadOnlyRow label="To" value={toName} /> : null}
+      <ReadOnlyRow label="Subject" value={preview.subject} locked />
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor={bodyId}>Email body</Label>
+        <Textarea
+          id={bodyId}
+          value={body}
+          onChange={(event) => onBodyChange(event.target.value)}
+          className="min-h-[220px] max-h-[45vh] whitespace-pre-wrap leading-relaxed"
+          aria-invalid={issue !== null ? "true" : undefined}
+        />
+        {issue === "over_limit" ? (
+          <p className="text-sm text-destructive">
+            The email body can't exceed {OUTREACH_BODY_LIMITS.MAX_CHARS.toLocaleString("en-US")}{" "}
+            characters.
+          </p>
+        ) : issue === "empty" ? (
+          <p className="text-sm text-destructive">The email body can't be empty.</p>
+        ) : null}
+        {showCounter ? (
+          <p
+            className={`text-right text-xs tabular-nums ${
+              issue === "over_limit" ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {trimmedLength.toLocaleString("en-US")} /{" "}
+            {OUTREACH_BODY_LIMITS.MAX_CHARS.toLocaleString("en-US")}
+          </p>
+        ) : null}
+      </div>
+
+      {preview.fixedFooter ? (
+        <p className="flex items-start gap-2 rounded-md border border-border bg-muted/30 p-2.5 text-xs italic text-muted-foreground">
+          <Lock className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          <span>{preview.fixedFooter}</span>
+        </p>
+      ) : null}
+
+      {hint ? (
+        <p className="flex items-start gap-2 text-xs text-muted-foreground">
+          <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+          <span>{hint}</span>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface ReadOnlyRowProps {
+  label: string;
+  value: string;
+  locked?: boolean;
+}
+
+/** A muted, visibly non-editable header row (To / Subject). */
+function ReadOnlyRow({ label, value, locked = false }: ReadOnlyRowProps) {
+  return (
+    <div className="flex items-baseline gap-2 rounded-md bg-muted/40 px-3 py-2">
+      <span className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </span>
+      <span className="flex-1 text-sm text-foreground">{value}</span>
+      {locked ? <Lock className="size-3.5 shrink-0 text-muted-foreground" aria-hidden /> : null}
+    </div>
+  );
+}

--- a/src/features/donor-research/components/diligence/OutreachEmailPreview.tsx
+++ b/src/features/donor-research/components/diligence/OutreachEmailPreview.tsx
@@ -8,20 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import type { OutreachPreview } from "@/types/diligence";
 import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
-
-/**
- * Why the edited body is invalid for sending, mirroring the backend's
- * `OutreachActionBodySchema` (trimmed, 1..10,000 chars). `null` means the body
- * is sendable.
- */
-export type OutreachBodyIssue = "empty" | "over_limit" | null;
-
-export function getOutreachBodyIssue(body: string): OutreachBodyIssue {
-  const trimmedLength = body.trim().length;
-  if (trimmedLength === 0) return "empty";
-  if (trimmedLength > OUTREACH_BODY_LIMITS.MAX_CHARS) return "over_limit";
-  return null;
-}
+import { getOutreachBodyIssue } from "./outreach-body";
 
 interface OutreachEmailPreviewProps {
   preview: OutreachPreview | undefined;

--- a/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
@@ -214,6 +214,23 @@ describe("AskQuestionsDialog", () => {
     );
   });
 
+  it("treats a whitespace-only tweak as unedited (trimmed comparison)", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Email body"), {
+      target: { value: `${DEFAULT_BODY}\n\n   ` },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send questions" }));
+
+    expect(mockAskMutate).toHaveBeenCalledWith(
+      { reportId: "report-1", candidateId: "candidate-1" },
+      expect.any(Object)
+    );
+  });
+
   it("treats a body edited back to the default as unedited", () => {
     mockTemplateWithQuestions();
     mockPreviewLoaded();

--- a/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
@@ -2,10 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom";
-import type { CandidateDiligenceView, DiligenceTemplate } from "@/types/diligence";
+import type { CandidateDiligenceView, DiligenceTemplate, OutreachPreview } from "@/types/diligence";
+import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
 
 const mockAskMutate = vi.fn();
 const mockUseDiligenceTemplate = vi.fn();
+const mockUseOutreachPreview = vi.fn();
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
@@ -26,10 +28,43 @@ vi.mock("next/link", () => ({
 
 vi.mock("@/hooks/useDiligence", () => ({
   useDiligenceTemplate: () => mockUseDiligenceTemplate(),
+  useOutreachPreview: (...args: unknown[]) => mockUseOutreachPreview(...args),
   useAskQuestions: () => ({ mutate: mockAskMutate, isPending: false }),
 }));
 
 import { AskQuestionsDialog } from "../AskQuestionsDialog";
+
+const DEFAULT_BODY =
+  "Hello,\n\nA philanthropic funder researching organizations like Hope Shelter would like to learn more about your work.\n\n1. What is your budget?";
+
+function buildPreview(overrides: Partial<OutreachPreview> = {}): OutreachPreview {
+  return {
+    action: "diligence",
+    subject: "A funder is interested in learning more about Hope Shelter",
+    bodyText: DEFAULT_BODY,
+    fixedFooter:
+      'A secure "Answer securely" link is added to the end of this email automatically when it is sent.',
+    editable: { subject: false, body: true },
+    ...overrides,
+  };
+}
+
+function mockPreviewLoaded(preview = buildPreview()) {
+  mockUseOutreachPreview.mockReturnValue({
+    data: preview,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+}
+
+function mockTemplateWithQuestions() {
+  const template: DiligenceTemplate = {
+    questions: [{ id: "q1", text: "What is your budget?" }],
+    updatedAt: "2026-06-01T00:00:00Z",
+  };
+  mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+}
 
 function buildView(overrides: Partial<CandidateDiligenceView> = {}): CandidateDiligenceView {
   return {
@@ -44,6 +79,19 @@ function buildView(overrides: Partial<CandidateDiligenceView> = {}): CandidateDi
   };
 }
 
+function renderDialog(view = buildView()) {
+  return render(
+    <AskQuestionsDialog
+      reportId="report-1"
+      candidateId="candidate-1"
+      open
+      onOpenChange={vi.fn()}
+      view={view}
+      candidateName="Hope Shelter"
+    />
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -52,27 +100,38 @@ describe("AskQuestionsDialog", () => {
   it("guards on an empty template, links to the editor, and disables send", () => {
     const template: DiligenceTemplate = { questions: [], updatedAt: null };
     mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+    mockPreviewLoaded();
 
-    render(
-      <AskQuestionsDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={vi.fn()}
-        view={buildView()}
-      />
-    );
+    renderDialog();
 
     expect(screen.getByRole("link", { name: "Edit your question template" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send questions" })).toBeDisabled();
+    // The preview fetch is disabled while the template is empty.
+    expect(mockUseOutreachPreview).toHaveBeenCalledWith(
+      "report-1",
+      "candidate-1",
+      "diligence",
+      false
+    );
   });
 
-  it("sends the questions and closes on success", () => {
-    const template: DiligenceTemplate = {
-      questions: [{ id: "q1", text: "What is your budget?" }],
-      updatedAt: "2026-06-01T00:00:00Z",
-    };
-    mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+  it("shows the full email (To, locked subject, editable body, fixed footer)", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    expect(screen.getByText("Hope Shelter")).toBeInTheDocument();
+    expect(
+      screen.getByText("A funder is interested in learning more about Hope Shelter")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email body")).toHaveValue(DEFAULT_BODY);
+    expect(screen.getByText(/Answer securely.*link is added/)).toBeInTheDocument();
+  });
+
+  it("POSTs WITHOUT a body when the advisor didn't edit", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
     mockAskMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
     const onOpenChange = vi.fn();
 
@@ -83,10 +142,9 @@ describe("AskQuestionsDialog", () => {
         open
         onOpenChange={onOpenChange}
         view={buildView()}
+        candidateName="Hope Shelter"
       />
     );
-
-    expect(screen.getByText("What is your budget?")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Send questions" }));
 
@@ -98,33 +156,89 @@ describe("AskQuestionsDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("previews the frozen snapshot when a request already exists", () => {
-    mockUseDiligenceTemplate.mockReturnValue({
-      data: { questions: [{ id: "live", text: "Live template question" }], updatedAt: null },
-      isLoading: false,
-      isError: false,
+  it("POSTs WITH the edited body when the advisor changed the text", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+    mockAskMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Email body"), {
+      target: { value: "Hello,\n\nMy own words.\n\n1. What is your budget?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send questions" }));
+
+    expect(mockAskMutate).toHaveBeenCalledWith(
+      {
+        reportId: "report-1",
+        candidateId: "candidate-1",
+        body: "Hello,\n\nMy own words.\n\n1. What is your budget?",
+      },
+      expect.any(Object)
+    );
+  });
+
+  it("treats a body edited back to the default as unedited", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    const textarea = screen.getByLabelText("Email body");
+    fireEvent.change(textarea, { target: { value: "changed" } });
+    fireEvent.change(textarea, { target: { value: DEFAULT_BODY } });
+    fireEvent.click(screen.getByRole("button", { name: "Send questions" }));
+
+    expect(mockAskMutate).toHaveBeenCalledWith(
+      { reportId: "report-1", candidateId: "candidate-1" },
+      expect.any(Object)
+    );
+  });
+
+  it("disables send and explains when the body is cleared", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Email body"), { target: { value: "   " } });
+
+    expect(screen.getByText("The email body can't be empty.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send questions" })).toBeDisabled();
+    expect(mockAskMutate).not.toHaveBeenCalled();
+  });
+
+  it("blocks send above the character limit and shows the counter", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Email body"), {
+      target: { value: "x".repeat(OUTREACH_BODY_LIMITS.MAX_CHARS + 1) },
     });
 
-    render(
-      <AskQuestionsDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={vi.fn()}
-        view={buildView({
-          coarseStatus: "in_progress",
-          request: {
-            requestId: "req-1",
-            requestedAt: "2026-06-01T00:00:00Z",
-            answeredAt: null,
-            questions: [{ id: "frozen", text: "Frozen snapshot question" }],
-          },
-        })}
-      />
-    );
+    expect(screen.getByText(/can't exceed 10,000 characters/)).toBeInTheDocument();
+    expect(screen.getByText("10,001 / 10,000")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send questions" })).toBeDisabled();
+  });
 
-    // Renders the frozen snapshot, NOT the diverged live template.
-    expect(screen.getByText("Frozen snapshot question")).toBeInTheDocument();
-    expect(screen.queryByText("Live template question")).not.toBeInTheDocument();
+  it("shows an in-modal error with retry and blocks sending when the preview fails", () => {
+    mockTemplateWithQuestions();
+    const refetch = vi.fn();
+    mockUseOutreachPreview.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    });
+
+    renderDialog();
+
+    expect(screen.getByText("Couldn't load the email preview.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send questions" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalled();
   });
 });

--- a/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
@@ -6,6 +6,7 @@ import type { CandidateDiligenceView, DiligenceTemplate, OutreachPreview } from 
 import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
 
 const mockAskMutate = vi.fn();
+const mockSaveTemplateMutate = vi.fn();
 const mockUseDiligenceTemplate = vi.fn();
 const mockUseOutreachPreview = vi.fn();
 const toastSuccess = vi.fn();
@@ -30,6 +31,7 @@ vi.mock("@/hooks/useDiligence", () => ({
   useDiligenceTemplate: () => mockUseDiligenceTemplate(),
   useOutreachPreview: (...args: unknown[]) => mockUseOutreachPreview(...args),
   useAskQuestions: () => ({ mutate: mockAskMutate, isPending: false }),
+  useSaveDiligenceTemplate: () => ({ mutate: mockSaveTemplateMutate, isPending: false }),
 }));
 
 import { AskQuestionsDialog } from "../AskQuestionsDialog";
@@ -97,15 +99,18 @@ afterEach(() => {
 });
 
 describe("AskQuestionsDialog", () => {
-  it("guards on an empty template, links to the editor, and disables send", () => {
+  it("guards on an empty template with the inline editor, keeps the page link, and disables send", () => {
     const template: DiligenceTemplate = { questions: [], updatedAt: null };
     mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
     mockPreviewLoaded();
 
     renderDialog();
 
+    expect(screen.getByLabelText("Question 1")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Edit your question template" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send questions" })).toBeDisabled();
+    // No question typed yet → nothing to save.
+    expect(screen.getByRole("button", { name: "Save questions" })).toBeDisabled();
     // The preview fetch is disabled while the template is empty.
     expect(mockUseOutreachPreview).toHaveBeenCalledWith(
       "report-1",
@@ -113,6 +118,37 @@ describe("AskQuestionsDialog", () => {
       "diligence",
       false
     );
+  });
+
+  it("saves inline questions to the template, dropping blank rows", () => {
+    const template: DiligenceTemplate = { questions: [], updatedAt: null };
+    mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+    mockPreviewLoaded();
+    mockSaveTemplateMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Question 1"), {
+      target: { value: "  What is your annual operating budget?  " },
+    });
+    // A second, blank row must not be saved.
+    fireEvent.click(screen.getByRole("button", { name: "Add another question" }));
+    expect(screen.getByLabelText("Question 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save questions" }));
+
+    expect(mockSaveTemplateMutate).toHaveBeenCalledWith(
+      {
+        questions: [
+          expect.objectContaining({
+            id: expect.any(String),
+            text: "What is your annual operating budget?",
+          }),
+        ],
+      },
+      expect.any(Object)
+    );
+    expect(toastSuccess).toHaveBeenCalledWith("Questions saved to your template");
   });
 
   it("shows the full email (To, locked subject, editable body, fixed footer)", () => {

--- a/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/hooks/useDiligence", () => ({
     refetch: vi.fn(),
   }),
   useAskQuestions: () => ({ mutate: vi.fn(), isPending: false }),
+  useSaveDiligenceTemplate: () => ({ mutate: vi.fn(), isPending: false }),
   useRequestIntro: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateAdvisorEmail: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
@@ -28,6 +28,12 @@ const emptyTemplate: DiligenceTemplate = { questions: [], updatedAt: null };
 vi.mock("@/hooks/useDiligence", () => ({
   useCandidateDiligence: (...args: unknown[]) => mockUseCandidateDiligence(...args),
   useDiligenceTemplate: () => ({ data: emptyTemplate, isLoading: false, isError: false }),
+  useOutreachPreview: () => ({
+    data: undefined,
+    isLoading: true,
+    isError: false,
+    refetch: vi.fn(),
+  }),
   useAskQuestions: () => ({ mutate: vi.fn(), isPending: false }),
   useRequestIntro: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateAdvisorEmail: () => ({ mutate: vi.fn(), isPending: false }),

--- a/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom";
+import type { OutreachPreview } from "@/types/diligence";
 
 const mockIntroMutate = vi.fn();
 const mockEmailMutate = vi.fn();
+const mockUseOutreachPreview = vi.fn();
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
@@ -16,18 +18,76 @@ vi.mock("react-hot-toast", () => ({
 }));
 
 vi.mock("@/hooks/useDiligence", () => ({
+  useOutreachPreview: (...args: unknown[]) => mockUseOutreachPreview(...args),
   useRequestIntro: () => ({ mutate: mockIntroMutate, isPending: false }),
   useUpdateAdvisorEmail: () => ({ mutate: mockEmailMutate, isPending: false }),
 }));
 
 import { ConnectDialog } from "../ConnectDialog";
 
+const DEFAULT_BODY =
+  "Hello,\n\nJane Advisor from Bright Giving would like to connect with Hope Shelter about your work.";
+
+function buildPreview(overrides: Partial<OutreachPreview> = {}): OutreachPreview {
+  return {
+    action: "intro",
+    subject: "Jane Advisor would like to connect with Hope Shelter",
+    bodyText: DEFAULT_BODY,
+    fixedFooter: null,
+    editable: { subject: false, body: true },
+    ...overrides,
+  };
+}
+
+function mockPreviewLoaded(preview = buildPreview()) {
+  mockUseOutreachPreview.mockReturnValue({
+    data: preview,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+}
+
+function renderDialog({
+  canConnect = true,
+  onOpenChange = vi.fn(),
+}: {
+  canConnect?: boolean;
+  onOpenChange?: (open: boolean) => void;
+} = {}) {
+  return render(
+    <ConnectDialog
+      reportId="report-1"
+      candidateId="candidate-1"
+      open
+      onOpenChange={onOpenChange}
+      canConnect={canConnect}
+      candidateName="Hope Shelter"
+    />
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
 
 describe("ConnectDialog", () => {
-  it("sends a queued intro and closes on success", () => {
+  it("shows the full intro email before sending (no fixed footer for intros)", () => {
+    mockPreviewLoaded();
+
+    renderDialog();
+
+    expect(mockUseOutreachPreview).toHaveBeenCalledWith("report-1", "candidate-1", "intro");
+    expect(screen.getByText("Hope Shelter")).toBeInTheDocument();
+    expect(
+      screen.getByText("Jane Advisor would like to connect with Hope Shelter")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email body")).toHaveValue(DEFAULT_BODY);
+    expect(screen.queryByText(/Answer securely/)).not.toBeInTheDocument();
+  });
+
+  it("sends a queued intro WITHOUT a body when untouched and closes on success", () => {
+    mockPreviewLoaded();
     mockIntroMutate.mockImplementation((_vars, opts) =>
       opts.onSuccess?.({
         kind: "queued",
@@ -36,15 +96,7 @@ describe("ConnectDialog", () => {
     );
     const onOpenChange = vi.fn();
 
-    render(
-      <ConnectDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={onOpenChange}
-        canConnect
-      />
-    );
+    renderDialog({ onOpenChange });
 
     fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
 
@@ -56,21 +108,60 @@ describe("ConnectDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("disables the confirm button when canConnect is false", () => {
-    render(
-      <ConnectDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={vi.fn()}
-        canConnect={false}
-      />
+  it("sends the edited body when the advisor changed the text", () => {
+    mockPreviewLoaded();
+    mockIntroMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess?.({
+        kind: "queued",
+        data: { introRequestId: "i1", coarseStatus: "intro_sent" },
+      })
     );
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Email body"), {
+      target: { value: "Hello,\n\nA personal note from Jane." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
+
+    expect(mockIntroMutate).toHaveBeenCalledWith(
+      {
+        reportId: "report-1",
+        candidateId: "candidate-1",
+        body: "Hello,\n\nA personal note from Jane.",
+      },
+      expect.any(Object)
+    );
+  });
+
+  it("disables the confirm button when canConnect is false", () => {
+    mockPreviewLoaded();
+
+    renderDialog({ canConnect: false });
 
     expect(screen.getByRole("button", { name: "Send intro" })).toBeDisabled();
   });
 
-  it("captures email on email_required, then re-attempts the intro", async () => {
+  it("disables sending and offers retry while the preview is failed", () => {
+    const refetch = vi.fn();
+    mockUseOutreachPreview.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    });
+
+    renderDialog();
+
+    expect(screen.getByText("Couldn't load the email preview.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send intro" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("captures email on email_required, then re-attempts with the edited body preserved", async () => {
+    mockPreviewLoaded();
     let introCall = 0;
     mockIntroMutate.mockImplementation((_vars, opts) => {
       introCall += 1;
@@ -90,15 +181,12 @@ describe("ConnectDialog", () => {
     mockEmailMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
     const onOpenChange = vi.fn();
 
-    render(
-      <ConnectDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={onOpenChange}
-        canConnect
-      />
-    );
+    renderDialog({ onOpenChange });
+
+    // The advisor edits the body BEFORE the email-capture detour.
+    fireEvent.change(screen.getByLabelText("Email body"), {
+      target: { value: "Hello,\n\nEdited before capture." },
+    });
 
     // Step 1: confirm → backend says email required → switch to email step.
     fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
@@ -117,13 +205,32 @@ describe("ConnectDialog", () => {
       );
     });
 
-    // The original intro is re-attempted and now queues successfully.
+    // Both attempts carried the edited body through the capture flow.
     expect(mockIntroMutate).toHaveBeenCalledTimes(2);
+    expect(mockIntroMutate).toHaveBeenNthCalledWith(
+      1,
+      {
+        reportId: "report-1",
+        candidateId: "candidate-1",
+        body: "Hello,\n\nEdited before capture.",
+      },
+      expect.any(Object)
+    );
+    expect(mockIntroMutate).toHaveBeenNthCalledWith(
+      2,
+      {
+        reportId: "report-1",
+        candidateId: "candidate-1",
+        body: "Hello,\n\nEdited before capture.",
+      },
+      expect.any(Object)
+    );
     expect(toastSuccess).toHaveBeenCalledWith("Intro sent");
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("rejects an invalid email without calling the email endpoint", async () => {
+    mockPreviewLoaded();
     mockIntroMutate.mockImplementation((_vars, opts) =>
       opts.onSuccess?.({
         kind: "email_required",
@@ -131,17 +238,8 @@ describe("ConnectDialog", () => {
         requiredFields: ["email"],
       })
     );
-    const onOpenChange = vi.fn();
 
-    render(
-      <ConnectDialog
-        reportId="report-1"
-        candidateId="candidate-1"
-        open
-        onOpenChange={onOpenChange}
-        canConnect
-      />
-    );
+    renderDialog();
 
     fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
     fireEvent.change(screen.getByLabelText("Email address"), {

--- a/src/features/donor-research/components/diligence/outreach-body.ts
+++ b/src/features/donor-research/components/diligence/outreach-body.ts
@@ -1,0 +1,13 @@
+import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
+
+/**
+ * Why an edited outreach body is invalid for sending, mirroring the backend's
+ * `OutreachActionBodySchema` (trimmed, 1..10,000 chars). `null` means the body
+ * is sendable.
+ */
+export function getOutreachBodyIssue(body: string): "empty" | "over_limit" | null {
+  const trimmedLength = body.trim().length;
+  if (trimmedLength === 0) return "empty";
+  if (trimmedLength > OUTREACH_BODY_LIMITS.MAX_CHARS) return "over_limit";
+  return null;
+}

--- a/src/features/donor-research/components/diligence/question-id.ts
+++ b/src/features/donor-research/components/diligence/question-id.ts
@@ -1,0 +1,15 @@
+/**
+ * Collision-free stable id for a *newly added* diligence question. Existing
+ * questions keep their server-issued id untouched, so collected answers stay
+ * keyed correctly across edits. Never index-based, and avoids the
+ * Math.random/Date.now patterns flagged by the anti-pattern rules.
+ */
+let fallbackIdCounter = 0;
+
+export function makeQuestionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  fallbackIdCounter += 1;
+  return `dq-${fallbackIdCounter.toString(36)}`;
+}

--- a/src/features/donor-research/components/report-brief/LeadCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/LeadCandidate.tsx
@@ -155,7 +155,11 @@ export function LeadCandidate({
       <LeadJustification candidate={candidate} hasMore={hasMore} />
 
       {showDiligenceActions && reportId ? (
-        <CandidateDiligenceActions reportId={reportId} candidateId={candidate.id} />
+        <CandidateDiligenceActions
+          reportId={reportId}
+          candidateId={candidate.id}
+          candidateName={candidate.organizationName}
+        />
       ) : null}
     </section>
   );

--- a/src/features/donor-research/components/report-brief/LeadCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/LeadCandidate.tsx
@@ -158,7 +158,7 @@ export function LeadCandidate({
         <CandidateDiligenceActions
           reportId={reportId}
           candidateId={candidate.id}
-          candidateName={candidate.organizationName}
+          candidateName={name}
         />
       ) : null}
     </section>

--- a/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
@@ -165,7 +165,11 @@ export function RunnerUpCandidate({
       </div>
 
       {showDiligenceActions && reportId ? (
-        <CandidateDiligenceActions reportId={reportId} candidateId={candidate.id} />
+        <CandidateDiligenceActions
+          reportId={reportId}
+          candidateId={candidate.id}
+          candidateName={candidate.organizationName}
+        />
       ) : null}
     </section>
   );

--- a/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
@@ -168,7 +168,7 @@ export function RunnerUpCandidate({
         <CandidateDiligenceActions
           reportId={reportId}
           candidateId={candidate.id}
-          candidateName={candidate.organizationName}
+          candidateName={name}
         />
       ) : null}
     </section>

--- a/src/features/donor-research/components/report-viewer/CandidateCard.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.tsx
@@ -159,6 +159,7 @@ export function CandidateCard({
         <CandidateDiligenceFooter
           reportId={reportId}
           candidateId={candidate.id}
+          candidateName={candidate.organizationName}
           show={showDiligenceActions}
         />
       </div>
@@ -169,6 +170,7 @@ export function CandidateCard({
 interface CandidateDiligenceFooterProps {
   reportId: string | undefined;
   candidateId: string;
+  candidateName: string | null;
   show: boolean;
 }
 
@@ -177,9 +179,18 @@ interface CandidateDiligenceFooterProps {
  * already-dense {@link CandidateCard} body. Renders nothing on the donor shared
  * view (where `show` is false / `reportId` is absent).
  */
-function CandidateDiligenceFooter({ reportId, candidateId, show }: CandidateDiligenceFooterProps) {
+function CandidateDiligenceFooter({
+  reportId,
+  candidateId,
+  candidateName,
+  show,
+}: CandidateDiligenceFooterProps) {
   return show && reportId ? (
-    <CandidateDiligenceActions reportId={reportId} candidateId={candidateId} />
+    <CandidateDiligenceActions
+      reportId={reportId}
+      candidateId={candidateId}
+      candidateName={candidateName}
+    />
   ) : null;
 }
 

--- a/src/features/donor-research/components/report-viewer/CandidateCard.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.tsx
@@ -159,7 +159,7 @@ export function CandidateCard({
         <CandidateDiligenceFooter
           reportId={reportId}
           candidateId={candidate.id}
-          candidateName={candidate.organizationName}
+          candidateName={name}
           show={showDiligenceActions}
         />
       </div>

--- a/src/features/donor-research/components/report-viewer/GeographyWarning.tsx
+++ b/src/features/donor-research/components/report-viewer/GeographyWarning.tsx
@@ -47,7 +47,7 @@ export function GeographyWarning({ diagnostic }: GeographyWarningProps) {
         </p>
         <p className="mt-0.5 text-amber-800 dark:text-amber-200">
           {emptyStates || unknownRadius
-            ? "Results aren't filtered by state — try a US city, state, or region (e.g., \"San Francisco\", \"Texas\", \"Pacific Northwest\")."
+            ? 'Results aren\'t filtered by state — try a US city, state, or region (e.g., "San Francisco", "Texas", "Pacific Northwest").'
             : `We mapped this to ${describeResolution(diagnostic)}. If that's wrong, try a more specific input.`}
         </p>
       </div>

--- a/src/features/donor-research/components/report-viewer/RecentActivity.tsx
+++ b/src/features/donor-research/components/report-viewer/RecentActivity.tsx
@@ -7,20 +7,7 @@ interface RecentActivityProps {
   mentions: readonly RecentMention[];
 }
 
-const MONTHS = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 /**
  * Lists the validated mentions that established this candidate's

--- a/types/diligence.ts
+++ b/types/diligence.ts
@@ -104,6 +104,23 @@ export interface CandidateDiligenceView {
   actions: CandidateDiligenceActions;
 }
 
+/** Which outreach email a preview describes (maps to the two send actions). */
+export type OutreachAction = "diligence" | "intro";
+
+/**
+ * GET .../outreach-preview?action=… — the exact email the matching send action
+ * would dispatch. `bodyText` is the editable default composition; `subject` is
+ * system-owned. `fixedFooter` is non-editable content appended at send time
+ * (the secure-link note for `diligence`, null for `intro`).
+ */
+export interface OutreachPreview {
+  action: OutreachAction;
+  subject: string;
+  bodyText: string;
+  fixedFooter: string | null;
+  editable: { subject: boolean; body: boolean };
+}
+
 /** 202 response from POST .../diligence-requests. */
 export interface AskQuestionsResponse {
   requestId: string;
@@ -186,4 +203,11 @@ export const DILIGENCE_RESPONSE_LIMITS = {
   MAX_ANSWERS: 50,
   ANSWER_TEXT_MAX: 5000,
   QUESTION_ID_MAX: 128,
+} as const;
+
+export const OUTREACH_BODY_LIMITS = {
+  /** Backend rejects trimmed bodies above this (OutreachActionBodySchema). */
+  MAX_CHARS: 10_000,
+  /** Show the live character counter once the body passes this. */
+  COUNTER_THRESHOLD: 9_000,
 } as const;

--- a/utilities/diligenceEndpoints.ts
+++ b/utilities/diligenceEndpoints.ts
@@ -12,6 +12,8 @@ export const DILIGENCE_ENDPOINTS = {
     `/v2/donor-research/reports/${reportId}/candidates/${candidateId}/diligence`,
   REQUESTS: (reportId: string, candidateId: string) =>
     `/v2/donor-research/reports/${reportId}/candidates/${candidateId}/diligence-requests`,
+  OUTREACH_PREVIEW: (reportId: string, candidateId: string, action: "diligence" | "intro") =>
+    `/v2/donor-research/reports/${reportId}/candidates/${candidateId}/outreach-preview?action=${action}`,
   INTRO_REQUESTS: (reportId: string, candidateId: string) =>
     `/v2/donor-research/reports/${reportId}/candidates/${candidateId}/intro-requests`,
   // Public (token = capability, no auth):


### PR DESCRIPTION
## Overview

Before either donor-research contact action sends, the advisor now sees the **entire email** in a modal — editable body, locked subject — and only then hits Send. Implements the outreach preview & edit PRD (DEV-500). FE half of a cross-service feature; BE half is show-karma/gap-indexer#2156.

> ⚠️ **Deploy order:** this PR must not reach production before gap-indexer#2156. Without the preview endpoint the modal error state blocks sending entirely (fails safe, but advisors would lose the Ask Questions / Connect actions). Draft until the BE PR merges + deploys.

## What changed

- **`OutreachEmailPreview`** (new, shared): email-shaped block — To row (org name), read-only Subject row with lock, plain-text body textarea, non-editable fixed-footer note (secure-link hint on Ask Questions), loading skeleton, in-modal error + Retry, empty/over-limit validation with live counter past 9,000 chars.
- **`AskQuestionsDialog` / `ConnectDialog`**: preview-first. Untouched body → POST **without** `body` (backend composes its default); edited → POST `{ body }`. Editing back to the default counts as untouched. Empty-template guard for Ask Questions kept.
- **Inline question setup**: when the template is empty, the Ask Questions dialog now embeds a mini editor (add/remove rows, per-row 1,000-char limit, blank rows dropped) that saves through the normal template save and flips straight into the email preview — no detour to the template page, which stays linked for full management.
- **Connect 422 email-capture**: edited body survives the capture step and is included in the automatic re-attempt.
- API layer: `OUTREACH_PREVIEW` endpoint constant, `OutreachPreview` types + `OUTREACH_BODY_LIMITS`, `getOutreachPreview` service, `useOutreachPreview` hook, optional `body` through both send mutations.
- `candidateName` threaded from CandidateCard / LeadCandidate / RunnerUpCandidate for the To row.

## User flows

1. Ask Questions → preview loads → send unedited → POST `{}` ✅
2. Ask Questions → edit body → send → POST `{ body }` (newlines preserved) ✅
3. Ask Questions → clear body → send disabled + inline message ✅
4. Ask Questions → paste >10,000 chars → counter `10,001 / 10,000`, send blocked ✅
5. Connect → preview fails (real BE 500) → in-modal error + Retry, send disabled ✅
6. Connect → edit → send → POST `{ body }` ✅
7. Connect → 422 `requiredFields:["email"]` → email step → save → re-attempt carries the edited body on both POSTs ✅
8. Empty template → write question inline → Save → dialog flips into the email preview with the new question embedded (live QA vs real BE) ✅

## Wire contract

| FE | transformation | BE reader |
|---|---|---|
| `GET …/outreach-preview?action=diligence\|intro` (Privy Bearer via `fetchData`) | direct | `OutreachPreviewReadController` (`action` query enum) |
| `POST …/diligence-requests` / `…/intro-requests` body `{}` (unedited) | `sanitizeObject` trims strings only — newlines intact | `request.body?.body ?? null` → default composition |
| same, body `{ body }` (edited) | trimmed client-side; 1..10,000 enforced both sides | `OutreachActionBodySchema` (`trim().min(1).max(10000).optional()`) |

## Production reality

- Contract verified by reading `pull/2156/head` in gap-indexer (controller, read service, DTOs, route registration, composers) — not assumed from the PRD.
- Empty template still previews on the BE ("The funder has not listed specific questions.") — FE keeps its existing empty-template guard regardless.
- Preview composes from the **live** template (matches delivery); the old frozen-snapshot question list rendering was removed, with an in-modal hint that the answer form uses the saved template snapshot.
- `fetchData`'s `sanitizeObject` only trims strings — multi-line bodies pass through unmangled.

## Smoke results

Live run against a local gap-indexer on the #2156 branch (real `outreach-preview` responses; send POSTs intercepted in-page so no outreach email could actually queue). All 7 flows above exercised in-browser, including two failure paths (preview 500 → error+retry; 422 → email capture). Payload assertions taken from the captured XHR bodies.

Found while smoking (backend, pre-existing on the #2156 branch env): `GET …/candidates/:id/diligence` and `outreach-preview?action=intro` return 500 on a DB without the #2156 migration applied — worth a note in the BE PR's deploy steps.

## Testing

- 122 donor-research vitest tests green, incl. 14 new/updated dialog cases mirroring the flows above
- `tsc --noEmit` clean, Biome clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email preview and editing for outreach flows, with live validation and character limits.
  * Added candidate names to diligence and intro dialogs for clearer messaging.
  * Added inline question entry when starting an outreach request.

* **Bug Fixes**
  * Improved sending behavior so edited email content is preserved when submitted.
  * Prevented sending when the email body is empty or too long.
  * Added retry handling for preview loading errors.

* **Style**
  * Standardized question ID generation for newly added items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->