### PR TITLE
fix(donor-research): honest outreach status while queued or blocked

### DIFF
--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -26,6 +26,7 @@ import { DILIGENCE_TEMPLATE_LIMITS } from "@/types/diligence";
 import { PAGES } from "@/utilities/pages";
 import { OutreachEmailPreview } from "./OutreachEmailPreview";
 import { getOutreachBodyIssue } from "./outreach-body";
+import { NO_CONTACT_FOUND_MESSAGE } from "./outreach-messages";
 import { makeQuestionId } from "./question-id";
 
 interface AskQuestionsDialogProps {
@@ -138,7 +139,7 @@ function AskQuestionsBody({
           // toast would contradict the "Couldn't reach" badge the card is
           // about to show.
           if (result.coarseStatus === "blocked") {
-            toast.error("We couldn't find a contact for this nonprofit, so nothing was sent.");
+            toast.error(NO_CONTACT_FOUND_MESSAGE);
           } else {
             toast.success("Questions sent");
           }

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -132,8 +132,16 @@ function AskQuestionsBody({
     askQuestions.mutate(
       { reportId, candidateId, ...(isEdited ? { body: body.trim() } : {}) },
       {
-        onSuccess: () => {
-          toast.success("Questions sent");
+        onSuccess: (result) => {
+          // A 202 can still end `blocked` (no contact could be resolved for
+          // the nonprofit) — nothing was or will be emailed, so a success
+          // toast would contradict the "Couldn't reach" badge the card is
+          // about to show.
+          if (result.coarseStatus === "blocked") {
+            toast.error("We couldn't find a contact for this nonprofit, so nothing was sent.");
+          } else {
+            toast.success("Questions sent");
+          }
           onClose();
         },
         onError: () => {

--- a/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
+++ b/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
@@ -64,13 +64,18 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
 
   const view = diligenceQuery.data;
   const { actions, coarseStatus, request, latestAnswers, intro } = view;
-  const introLabel = intro ? introStateLabel(intro.sentAt) : null;
+  const introQueued = intro !== null && intro.sentAt === null;
+  // Only the delivered state gets a detail line (it carries the relative
+  // time); the queued state is fully expressed by the badge.
+  const introLabel = intro?.sentAt ? introSentLabel(intro.sentAt) : null;
 
   return (
     <div className="mt-6 flex flex-col gap-4 border-t border-border/60 pt-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          {coarseStatus === "not_requested" ? null : <DiligenceStatusBadge status={coarseStatus} />}
+          {coarseStatus === "not_requested" ? null : (
+            <DiligenceStatusBadge status={coarseStatus} introQueued={introQueued} />
+          )}
           {introLabel ? <span className="text-xs text-muted-foreground">{introLabel}</span> : null}
         </div>
 
@@ -119,10 +124,7 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
   );
 });
 
-function introStateLabel(sentAt: string | null): string {
-  if (!sentAt) {
-    return "Intro queued";
-  }
+function introSentLabel(sentAt: string): string {
   const ms = Date.parse(sentAt);
   if (Number.isNaN(ms)) {
     return "Intro sent";

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label";
 import { useOutreachPreview, useRequestIntro, useUpdateAdvisorEmail } from "@/hooks/useDiligence";
 import { OutreachEmailPreview } from "./OutreachEmailPreview";
 import { getOutreachBodyIssue } from "./outreach-body";
+import { NO_CONTACT_FOUND_MESSAGE } from "./outreach-messages";
 
 interface ConnectDialogProps {
   reportId: string;
@@ -140,7 +141,7 @@ function ConnectBody({
             if (result.data.coarseStatus === "intro_sent") {
               toast.success("Intro sent");
             } else {
-              toast.error("We couldn't find a contact for this nonprofit, so nothing was sent.");
+              toast.error(NO_CONTACT_FOUND_MESSAGE);
             }
             onClose();
           } else {

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -133,7 +133,15 @@ function ConnectBody({
       {
         onSuccess: (result) => {
           if (result.kind === "queued") {
-            toast.success("Intro sent");
+            // A queued intro always reports `intro_sent` (an active intro
+            // outranks everything in the coarse status); anything else on a
+            // 202 means the intro was immediately blocked — e.g. no contact
+            // could be resolved — and no email will go out.
+            if (result.data.coarseStatus === "intro_sent") {
+              toast.success("Intro sent");
+            } else {
+              toast.error("We couldn't find a contact for this nonprofit, so nothing was sent.");
+            }
             onClose();
           } else {
             onEmailRequired(result.message);

--- a/src/features/donor-research/components/diligence/DiligenceStatusBadge.tsx
+++ b/src/features/donor-research/components/diligence/DiligenceStatusBadge.tsx
@@ -3,6 +3,14 @@ import type { DiligenceCoarseStatus } from "@/types/diligence";
 
 interface DiligenceStatusBadgeProps {
   status: DiligenceCoarseStatus;
+  /**
+   * True while an active intro is queued but not yet delivered (`intro.sentAt`
+   * is null). The backend deliberately collapses queued+sent intros into the
+   * one `intro_sent` coarse status, so the split lives here, where `sentAt`
+   * is available — otherwise the badge claims "Intro sent" while the intro
+   * line right next to it says "Intro queued".
+   */
+  introQueued?: boolean;
 }
 
 /**
@@ -35,11 +43,17 @@ const STATUS_CONFIG: Record<
   },
 };
 
-export function DiligenceStatusBadge({ status }: DiligenceStatusBadgeProps) {
+const INTRO_QUEUED_CONFIG = {
+  label: "Intro queued",
+  className: "border-border bg-muted text-muted-foreground",
+};
+
+export function DiligenceStatusBadge({ status, introQueued }: DiligenceStatusBadgeProps) {
   if (status === "not_requested") {
     return null;
   }
-  const config = STATUS_CONFIG[status];
+  const config =
+    status === "intro_sent" && introQueued ? INTRO_QUEUED_CONFIG : STATUS_CONFIG[status];
   return (
     <Badge variant="outline" className={config.className}>
       {config.label}

--- a/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
@@ -168,7 +168,9 @@ describe("AskQuestionsDialog", () => {
   it("POSTs WITHOUT a body when the advisor didn't edit", () => {
     mockTemplateWithQuestions();
     mockPreviewLoaded();
-    mockAskMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
+    mockAskMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess?.({ requestId: "req-1", coarseStatus: "in_progress" })
+    );
     const onOpenChange = vi.fn();
 
     render(
@@ -192,10 +194,40 @@ describe("AskQuestionsDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("shows a couldn't-reach toast (not success) when the 202 reports blocked", () => {
+    mockTemplateWithQuestions();
+    mockPreviewLoaded();
+    mockAskMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess?.({ requestId: "req-1", coarseStatus: "blocked" })
+    );
+    const onOpenChange = vi.fn();
+
+    render(
+      <AskQuestionsDialog
+        reportId="report-1"
+        candidateId="candidate-1"
+        open
+        onOpenChange={onOpenChange}
+        view={buildView()}
+        candidateName="Hope Shelter"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Send questions" }));
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "We couldn't find a contact for this nonprofit, so nothing was sent."
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("POSTs WITH the edited body when the advisor changed the text", () => {
     mockTemplateWithQuestions();
     mockPreviewLoaded();
-    mockAskMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
+    mockAskMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess?.({ requestId: "req-1", coarseStatus: "in_progress" })
+    );
 
     renderDialog();
 

--- a/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
@@ -111,6 +111,42 @@ describe("CandidateDiligenceActions", () => {
     expect(screen.getByText("Intro sent")).toBeInTheDocument();
   });
 
+  it("labels a queued intro 'Intro queued', never 'Intro sent'", () => {
+    mockUseCandidateDiligence.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: buildView({
+        coarseStatus: "intro_sent",
+        intro: { introRequestId: "i1", requestedAt: "2026-07-07T00:00:00Z", sentAt: null },
+      }),
+    });
+
+    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+
+    expect(screen.getByText("Intro queued")).toBeInTheDocument();
+    expect(screen.queryByText(/Intro sent/)).not.toBeInTheDocument();
+  });
+
+  it("labels a delivered intro 'Intro sent' with the relative time detail", () => {
+    mockUseCandidateDiligence.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: buildView({
+        coarseStatus: "intro_sent",
+        intro: {
+          introRequestId: "i1",
+          requestedAt: "2026-07-01T00:00:00Z",
+          sentAt: "2026-07-06T00:00:00Z",
+        },
+      }),
+    });
+
+    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+
+    expect(screen.getAllByText(/Intro sent/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("Intro queued")).not.toBeInTheDocument();
+  });
+
   it("renders no badge for not_requested", () => {
     mockUseCandidateDiligence.mockReturnValue({
       isLoading: false,

--- a/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
@@ -108,6 +108,27 @@ describe("ConnectDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("shows a couldn't-reach toast (not success) when the queued 202 reports blocked", () => {
+    mockPreviewLoaded();
+    mockIntroMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess?.({
+        kind: "queued",
+        data: { introRequestId: "i1", coarseStatus: "blocked" },
+      })
+    );
+    const onOpenChange = vi.fn();
+
+    renderDialog({ onOpenChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "We couldn't find a contact for this nonprofit, so nothing was sent."
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("sends the edited body when the advisor changed the text", () => {
     mockPreviewLoaded();
     mockIntroMutate.mockImplementation((_vars, opts) =>

--- a/src/features/donor-research/components/diligence/outreach-messages.ts
+++ b/src/features/donor-research/components/diligence/outreach-messages.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared user-facing copy for the two outreach dialogs, so the wording can't
+ * drift between Ask Questions and Connect.
+ */
+export const NO_CONTACT_FOUND_MESSAGE =
+  "We couldn't find a contact for this nonprofit, so nothing was sent.";


### PR DESCRIPTION
## Overview

Two status-feedback fixes for the outreach flows shipped in #1761, both found in live QA against the backend on show-karma/gap-indexer#2158.

## Problem

1. **Contradictory intro status.** While an intro sits in the outbox (`email_queued`), the candidate card showed the **"Intro sent"** badge next to an **"Intro queued"** detail line. The backend deliberately collapses queued+sent intros into the single `intro_sent` coarse status (it doesn't leak dispatch internals), so the disambiguation has to happen client-side — and the view already carries `intro.sentAt`.
2. **False success toast when outreach is blocked.** A POST to `diligence-requests` / `intro-requests` returns **202 with `coarseStatus: "blocked"`** when no contact could be resolved for the nonprofit — nothing was or will be emailed. Both dialogs toasted success ("Questions sent" / "Intro sent") and closed, right before the card flipped to "Couldn't reach".

## Solution

- `DiligenceStatusBadge` takes an `introQueued` flag: `intro_sent` + queued renders a muted **"Intro queued"** pill; the delivered state keeps the brand **"Intro sent"** pill. The redundant queued detail line is dropped — the relative-time line now renders only once delivered ("Intro sent today").
- `AskQuestionsDialog` and `ConnectDialog` branch on the 202 response's `coarseStatus`: blocked shows *"We couldn't find a contact for this nonprofit, so nothing was sent."* instead of the success toast.

## Testing

- 5 new unit tests (queued vs delivered badge, blocked toast in both dialogs); existing mutation mocks updated to pass realistic 202 payloads. Full donor-research + hooks suites: 147 files / 1,418 tests green; typecheck and Biome clean.
- Live-verified against a local indexer running show-karma/gap-indexer#2158: a blocked send now shows the couldn't-reach toast and the card badge stays consistent; a delivered intro shows "Intro sent / Intro sent today" with no queued contradiction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when an intro or question can’t be sent because no contact was found.
  * “Intro queued” and “Intro sent” statuses now display more accurately in diligence badges and related screens.
  * Dialogs now close correctly after blocked send attempts, while successful sends still show the usual success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->