### PR TITLE
feat(donor-rewards): fund horizon, gains granting, personal goals, and ledger design pass

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -50,18 +50,24 @@ concurrency:
 # previous "changed" mode (vitest --changed) was dropped: the transitive
 # import graph pulled in most of the suite anyway (~8 min on one runner),
 # so a sharded full run is both faster wall-clock and a stronger signal.
+#
+# Shard count is 6 rather than 4: the jsdom + axe accessibility suites are
+# memory-heavy, and with only four shards a single shard could accumulate
+# enough of them to push a runner past its RSS limit and get OOM-killed
+# (crash with no test failures). More, thinner shards keep per-shard peak
+# memory down while also improving wall-clock through extra parallelism.
 env:
-  SHARD_COUNT: 4
+  SHARD_COUNT: 6
 
 jobs:
-  # ── Step 1: run tests (4 shards) ────────────────────────────────────────────
+  # ── Step 1: run tests (6 shards) ────────────────────────────────────────────
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
 
     steps:
       - name: Checkout code

--- a/src/features/donor-rewards/components/__tests__/impact-feed.test.tsx
+++ b/src/features/donor-rewards/components/__tests__/impact-feed.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for donor-rewards/components/impact-feed.tsx.
+ *
+ * A read quest pays out once, on whichever update is read next. The feed must
+ * advertise that one-time bonus on a single card, not on every unread card, or
+ * the promised rewards overstate what reading them all actually earns.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RewardsProvider } from "../../state/rewards-context";
+import { ImpactFeed } from "../impact-feed";
+
+function renderFeed() {
+  return render(
+    <RewardsProvider>
+      <ImpactFeed />
+    </RewardsProvider>
+  );
+}
+
+describe("ImpactFeed quest-bonus display", () => {
+  it("advertises the one-time read-quest bonus on only the first unread card", () => {
+    renderFeed();
+
+    // The initial fixture has one read quest one read away from completion, so
+    // the +60 bonus must be promised exactly once, not on every unread card.
+    expect(screen.getAllByText(/Completes quest/i)).toHaveLength(1);
+
+    // First unread card carries the bonus (15 base + 60 quest); the other
+    // unread cards show only their base reward.
+    expect(screen.getByRole("button", { name: /Mark as read · \+75 IP/ })).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: /Mark as read · \+15 IP/ }).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/features/donor-rewards/components/badges-grid.tsx
+++ b/src/features/donor-rewards/components/badges-grid.tsx
@@ -11,35 +11,33 @@ const BadgeTile = React.memo(function BadgeTile({ badge }: { badge: BadgeDef }) 
   return (
     <m.li
       layout
-      className={`flex flex-col items-center gap-1.5 rounded-2xl border p-4 text-center ${
-        badge.unlocked
-          ? "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30"
-          : "border-zinc-200 bg-zinc-50 opacity-70 dark:border-zinc-800 dark:bg-zinc-900"
+      className={`flex flex-col items-center gap-2 px-2 py-4 text-center ${
+        badge.unlocked ? "" : "opacity-50"
       }`}
       title={badge.description}
     >
       <span
-        className={`relative flex h-12 w-12 items-center justify-center rounded-full text-2xl ${
+        className={`relative flex h-16 w-16 items-center justify-center rounded-full text-3xl ${
           badge.unlocked
-            ? "bg-amber-100 dark:bg-amber-500/15"
-            : "bg-zinc-200 grayscale dark:bg-zinc-800"
+            ? "bg-amber-50 ring-2 ring-amber-400/70 dark:bg-amber-500/10 dark:ring-amber-500/50"
+            : "bg-stone-100 grayscale ring-1 ring-stone-200 dark:bg-stone-800 dark:ring-stone-700"
         }`}
       >
         {badge.emoji}
         {!badge.unlocked && (
-          <span className="absolute -bottom-1 -right-1 rounded-full bg-zinc-500 p-1 text-white dark:bg-zinc-600">
+          <span className="absolute -bottom-0.5 -right-0.5 rounded-full bg-stone-400 p-1 text-white dark:bg-stone-600">
             <Lock className="h-2.5 w-2.5" aria-hidden="true" />
           </span>
         )}
       </span>
       <span
-        className={`text-xs font-bold leading-tight ${
-          badge.unlocked ? "text-amber-800 dark:text-amber-300" : "text-zinc-500 dark:text-zinc-400"
+        className={`text-xs font-semibold leading-tight ${
+          badge.unlocked ? "text-stone-900 dark:text-white" : "text-stone-500 dark:text-stone-400"
         }`}
       >
         {badge.name}
       </span>
-      <span className="text-[10px] leading-tight text-zinc-500 dark:text-zinc-400">
+      <span className="text-[10px] leading-tight text-stone-400 dark:text-stone-500">
         {badge.description}
       </span>
     </m.li>
@@ -53,10 +51,12 @@ export function BadgesGrid() {
   return (
     <section
       aria-label="Badges"
-      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Badges</h2>
+        <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+          Badges
+        </h2>
         <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400">
           {unlockedCount} of {state.badges.length} {pluralize("badge", state.badges.length)}
         </span>

--- a/src/features/donor-rewards/components/celebration-overlay.tsx
+++ b/src/features/donor-rewards/components/celebration-overlay.tsx
@@ -86,7 +86,7 @@ export function CelebrationOverlay() {
               animate={{ scale: 1, opacity: 1, y: 0 }}
               exit={{ scale: 0.9, opacity: 0 }}
               transition={{ type: "spring", stiffness: 260, damping: 20 }}
-              className="my-4 w-full max-w-md rounded-3xl bg-white p-8 text-center shadow-2xl dark:bg-zinc-900"
+              className="my-4 w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-2xl dark:bg-stone-900"
               onClick={(event) => event.stopPropagation()}
             >
               <m.div
@@ -102,10 +102,10 @@ export function CelebrationOverlay() {
                 🎉
               </m.div>
 
-              <h2 className="mt-4 text-2xl font-semibold text-zinc-900 dark:text-white">
+              <h2 className="mt-4 text-2xl font-semibold text-stone-900 dark:text-white">
                 {formatUsd(celebration.grant.amount)} on its way!
               </h2>
-              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
                 Your grant to {celebration.grant.orgName}
                 {celebration.grant.recurring ? " will repeat monthly" : " is being processed"}.
               </p>
@@ -114,10 +114,10 @@ export function CelebrationOverlay() {
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.35 }}
-                className="mt-5 flex items-center justify-center gap-2 rounded-2xl bg-violet-50 py-3 dark:bg-violet-950/40"
+                className="mt-5 flex items-center justify-center gap-2 rounded-2xl bg-amber-50 py-3 dark:bg-amber-950/40"
               >
-                <Sparkles className="h-5 w-5 text-violet-500" aria-hidden="true" />
-                <span className="font-mono text-xl font-bold text-violet-700 dark:text-violet-300">
+                <Sparkles className="h-5 w-5 text-amber-500" aria-hidden="true" />
+                <span className="font-mono text-xl font-bold text-amber-700 dark:text-amber-300">
                   +{celebration.xpEarned} Impact Points
                 </span>
               </m.div>
@@ -128,14 +128,14 @@ export function CelebrationOverlay() {
                     initial={{ opacity: 0, x: -14 }}
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.5 }}
-                    className="flex items-center gap-3 rounded-2xl bg-orange-50 px-4 py-3 text-left dark:bg-orange-950/40"
+                    className="flex items-center gap-3 rounded-2xl bg-amber-50 px-4 py-3 text-left dark:bg-amber-950/40"
                   >
                     <Flame
-                      className="h-6 w-6 shrink-0 text-orange-500"
+                      className="h-6 w-6 shrink-0 text-amber-500"
                       fill="currentColor"
                       aria-hidden="true"
                     />
-                    <span className="text-sm font-semibold text-orange-800 dark:text-orange-300">
+                    <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
                       Streak extended to {celebration.newStreak}{" "}
                       {pluralize("month", celebration.newStreak)}!
                     </span>
@@ -162,10 +162,10 @@ export function CelebrationOverlay() {
                     initial={{ opacity: 0, x: -14 }}
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.8 + index * 0.12 }}
-                    className="flex items-center gap-3 rounded-2xl bg-zinc-100 px-4 py-3 text-left dark:bg-zinc-800"
+                    className="flex items-center gap-3 rounded-2xl bg-stone-100 px-4 py-3 text-left dark:bg-stone-800"
                   >
                     <span className="text-lg">✅</span>
-                    <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                    <span className="text-sm font-semibold text-stone-700 dark:text-stone-300">
                       Quest complete: {quest.title}
                     </span>
                   </m.div>
@@ -195,7 +195,7 @@ export function CelebrationOverlay() {
               <button
                 type="button"
                 onClick={handleDismiss}
-                className="mt-6 w-full rounded-2xl bg-zinc-900 py-3.5 font-bold text-white transition hover:bg-zinc-700 active:scale-[0.98] dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                className="mt-6 w-full rounded-2xl bg-stone-900 py-3.5 font-bold text-white transition hover:bg-stone-700 active:scale-[0.98] dark:bg-white dark:text-stone-900 dark:hover:bg-stone-200"
               >
                 Keep going
               </button>

--- a/src/features/donor-rewards/components/donor-rewards-app.tsx
+++ b/src/features/donor-rewards/components/donor-rewards-app.tsx
@@ -5,40 +5,59 @@ import { useState } from "react";
 import { RewardsProvider } from "../state/rewards-context";
 import { BadgesGrid } from "./badges-grid";
 import { CelebrationOverlay } from "./celebration-overlay";
+import { FundHorizon } from "./fund-horizon";
+import { GainsCard } from "./gains-card";
 import { GoalRing } from "./goal-ring";
 import { GrantFlow } from "./grant-flow";
 import { IdleNudge } from "./idle-nudge";
 import { ImpactFeed } from "./impact-feed";
 import { LeagueCard } from "./league-card";
+import { PersonalGoals } from "./personal-goals";
 import { QuestsCard } from "./quests-card";
 import { RewardsHeader } from "./rewards-header";
 import { StreakCard } from "./streak-card";
 import { YearRecap } from "./year-recap";
 
+interface GrantRequest {
+  open: boolean;
+  amount: number | null;
+}
+
 export function DonorRewardsApp() {
-  const [grantFlowOpen, setGrantFlowOpen] = useState(false);
+  const [grantRequest, setGrantRequest] = useState<GrantRequest>({ open: false, amount: null });
   const [recapOpen, setRecapOpen] = useState(false);
+
+  const openGrantFlow = () => setGrantRequest({ open: true, amount: null });
+  const openGrantFlowWithAmount = (amount: number) => setGrantRequest({ open: true, amount });
+  const closeGrantFlow = () => setGrantRequest({ open: false, amount: null });
 
   return (
     <RewardsProvider>
       <LazyMotion features={domAnimation} strict>
         <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
-          <RewardsHeader
-            onOpenGrantFlow={() => setGrantFlowOpen(true)}
-            onOpenRecap={() => setRecapOpen(true)}
-          />
+          <RewardsHeader onOpenGrantFlow={openGrantFlow} onOpenRecap={() => setRecapOpen(true)} />
+
+          <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <FundHorizon />
+            </div>
+            <GainsCard onGrantGains={openGrantFlowWithAmount} />
+          </div>
 
           <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
             <StreakCard />
             <GoalRing />
-            <IdleNudge onOpenGrantFlow={() => setGrantFlowOpen(true)} />
+            <IdleNudge onOpenGrantFlow={openGrantFlow} />
           </div>
 
           <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
             <div className="lg:col-span-2">
               <QuestsCard />
             </div>
-            <LeagueCard />
+            <div className="flex flex-col gap-6">
+              <PersonalGoals />
+              <LeagueCard />
+            </div>
           </div>
 
           <div className="mt-6">
@@ -49,12 +68,16 @@ export function DonorRewardsApp() {
             <ImpactFeed />
           </div>
 
-          <p className="mt-8 text-center text-xs text-zinc-400 dark:text-zinc-500">
+          <p className="mt-8 text-center text-xs text-stone-400 dark:text-stone-500">
             Prototype with sample data. No real grants are made from this page.
           </p>
         </main>
 
-        <GrantFlow open={grantFlowOpen} onClose={() => setGrantFlowOpen(false)} />
+        <GrantFlow
+          open={grantRequest.open}
+          requestedAmount={grantRequest.amount}
+          onClose={closeGrantFlow}
+        />
         <CelebrationOverlay />
         <YearRecap open={recapOpen} onClose={() => setRecapOpen(false)} />
       </LazyMotion>

--- a/src/features/donor-rewards/components/fund-horizon.tsx
+++ b/src/features/donor-rewards/components/fund-horizon.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Hourglass } from "lucide-react";
+import pluralize from "pluralize";
+import { useState } from "react";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+/** Rough demo heuristic: every $750 granted touches about one verified milestone. */
+const DOLLARS_PER_MILESTONE = 750;
+const PEER_PAYOUT_RATE = 10;
+
+export function FundHorizon() {
+  const { state } = useRewards();
+  const [payoutRate, setPayoutRate] = useState(5);
+
+  const yearsToDeploy = Math.max(1, Math.round(100 / payoutRate));
+  const annualDollars = Math.round((state.balance * payoutRate) / 100);
+  const milestonesPerYear = Math.max(1, Math.round(annualDollars / DOLLARS_PER_MILESTONE));
+
+  return (
+    <section
+      aria-label="Fund horizon"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-start gap-3">
+          <Hourglass
+            className="mt-0.5 h-5 w-5 text-emerald-700 dark:text-emerald-500"
+            aria-hidden="true"
+          />
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-stone-500 dark:text-stone-400">
+              Fund horizon
+            </h2>
+            <p className="mt-1 max-w-md text-sm text-stone-700 dark:text-stone-300">
+              At a <span className="font-mono font-bold">{payoutRate}%</span> annual payout, your{" "}
+              {formatUsd(state.balance)} deploys in about{" "}
+              <span className="font-mono font-bold text-emerald-600 dark:text-emerald-400">
+                {yearsToDeploy} {pluralize("year", yearsToDeploy)}
+              </span>{" "}
+              and funds an estimated{" "}
+              <span className="font-mono font-bold text-emerald-600 dark:text-emerald-400">
+                {milestonesPerYear}
+              </span>{" "}
+              verified {pluralize("milestone", milestonesPerYear)} per year.
+            </p>
+          </div>
+        </div>
+
+        <div className="w-full max-w-xs">
+          <label
+            htmlFor="payout-rate"
+            className="mb-1 flex items-center justify-between text-xs font-medium text-stone-500 dark:text-stone-400"
+          >
+            <span>Annual payout rate</span>
+            <span className="font-mono font-bold text-stone-800 dark:text-stone-200">
+              {payoutRate}% · {formatUsd(annualDollars)}/yr
+            </span>
+          </label>
+          <input
+            id="payout-rate"
+            aria-label="Annual payout rate"
+            type="range"
+            min={2}
+            max={25}
+            step={1}
+            value={payoutRate}
+            onChange={(event) => setPayoutRate(Number(event.target.value))}
+            className="w-full accent-emerald-600"
+          />
+          <p className="mt-1 text-[11px] text-stone-400 dark:text-stone-500">
+            {payoutRate < PEER_PAYOUT_RATE
+              ? `Donors like you target ${PEER_PAYOUT_RATE}%+ per year. Money that moves creates impact now.`
+              : "Nice pace. Your dollars are working, not resting."}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/gains-card.tsx
+++ b/src/features/donor-rewards/components/gains-card.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+interface GainsCardProps {
+  onGrantGains: (amount: number) => void;
+}
+
+/**
+ * Windfall framing (NCFP Barrier 9): people part with windfalls far more
+ * easily than with earned or saved money. Investment returns inside the fund
+ * are the purest windfall there is, so we surface them with a one-tap path
+ * to grant them out while the original balance "stays whole."
+ */
+export function GainsCard({ onGrantGains }: GainsCardProps) {
+  const { state } = useRewards();
+
+  if (state.investmentGains === 0) {
+    return (
+      <section
+        aria-label="Investment gains"
+        className="flex flex-col justify-center rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
+      >
+        <div className="flex items-center gap-2">
+          <TrendingUp
+            className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
+            aria-hidden="true"
+          />
+          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-stone-500 dark:text-stone-400">
+            Investment gains
+          </h2>
+        </div>
+        <p className="mt-3 [font-family:var(--font-display)] text-2xl font-medium text-stone-900 dark:text-white">
+          All gains deployed 🎉
+        </p>
+        <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">
+          Every dollar your investments earned this year is now out working. New gains will show up
+          here as your fund grows.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Investment gains"
+      className="flex flex-col justify-between rounded-2xl border border-amber-200 bg-amber-50 p-6 shadow-sm dark:border-amber-900 dark:bg-amber-950/40"
+    >
+      <div>
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-5 w-5 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-amber-700 dark:text-amber-400">
+            Investment gains
+          </h2>
+        </div>
+        <p className="mt-3 font-mono text-3xl font-bold tracking-tight text-amber-900 dark:text-amber-100">
+          +{formatUsd(state.investmentGains)}
+        </p>
+        <p className="mt-2 text-sm text-amber-800/90 dark:text-amber-300">
+          Your fund grew this year while you slept. Grant the gains and your original balance stays
+          whole.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => onGrantGains(state.investmentGains)}
+        className="mt-4 w-full rounded-xl bg-amber-500 px-4 py-3 text-sm font-bold text-amber-950 transition hover:bg-amber-400 active:scale-95"
+      >
+        Grant it out
+      </button>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/goal-ring.tsx
+++ b/src/features/donor-rewards/components/goal-ring.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { m } from "motion/react";
-import { useState } from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
@@ -19,7 +18,6 @@ function goalAmountForRate(balance: number, granted: number, rate: number): numb
 
 export function GoalRing() {
   const { state, setAnnualGoal } = useRewards();
-  const [editing, setEditing] = useState(false);
   const progress = Math.min(1, state.grantedThisYear / state.annualGoal);
   const percent = Math.round(progress * 100);
   const remaining = Math.max(0, state.annualGoal - state.grantedThisYear);
@@ -29,53 +27,45 @@ export function GoalRing() {
       aria-label="Annual giving goal"
       className="flex flex-col rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
-          2026 giving goal
-        </h2>
-        <button
-          type="button"
-          onClick={() => setEditing((open) => !open)}
-          className="rounded-full px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
-        >
-          {editing ? "Done" : "Adjust"}
-        </button>
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
+        2026 giving goal
+      </h2>
+
+      {/* Plan-to-give control is always visible: donors set the goal as a share
+          of the fund with a single tap, anchored on the peer-norm range. */}
+      <div className="mt-3">
+        <p className="text-xs text-stone-500 dark:text-stone-400">
+          Set your goal as a share of your fund. Donors like you target 8-15% per year.
+        </p>
+        <div className="mt-2 grid grid-cols-3 gap-2">
+          {GOAL_RATE_PRESETS.map((rate) => {
+            const amount = goalAmountForRate(state.balance, state.grantedThisYear, rate);
+            const selected = state.annualGoal === amount;
+            return (
+              <button
+                key={rate}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => setAnnualGoal(amount)}
+                className={`rounded-xl border-2 px-2 py-2 text-center transition active:scale-95 ${
+                  selected
+                    ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950/50"
+                    : "border-stone-200 bg-white hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800"
+                }`}
+              >
+                <span className="block font-mono text-sm font-bold text-stone-900 dark:text-white">
+                  {rate}%
+                </span>
+                <span className="block text-[10px] text-stone-500 dark:text-stone-400">
+                  {formatUsd(amount)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {editing && (
-        <div className="mt-3 rounded-2xl bg-stone-50 p-3 dark:bg-stone-800/60">
-          <p className="text-xs text-stone-500 dark:text-stone-400">
-            Set your goal as a share of your fund. Donors like you target 8-15% per year.
-          </p>
-          <div className="mt-2 grid grid-cols-3 gap-2">
-            {GOAL_RATE_PRESETS.map((rate) => {
-              const amount = goalAmountForRate(state.balance, state.grantedThisYear, rate);
-              const selected = state.annualGoal === amount;
-              return (
-                <button
-                  key={rate}
-                  type="button"
-                  onClick={() => setAnnualGoal(amount)}
-                  className={`rounded-xl border-2 px-2 py-2 text-center transition active:scale-95 ${
-                    selected
-                      ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950/50"
-                      : "border-stone-200 bg-white hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800"
-                  }`}
-                >
-                  <span className="block font-mono text-sm font-bold text-stone-900 dark:text-white">
-                    {rate}%
-                  </span>
-                  <span className="block text-[10px] text-stone-500 dark:text-stone-400">
-                    {formatUsd(amount)}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      <div className="mt-3 flex flex-1 items-center justify-center gap-6">
+      <div className="mt-4 flex flex-1 items-center justify-center gap-6">
         <div className="relative h-36 w-36">
           <svg viewBox="0 0 144 144" className="h-full w-full -rotate-90">
             <title>Progress toward annual giving goal</title>

--- a/src/features/donor-rewards/components/goal-ring.tsx
+++ b/src/features/donor-rewards/components/goal-ring.tsx
@@ -1,14 +1,25 @@
 "use client";
 
 import { m } from "motion/react";
+import { useState } from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
 const RADIUS = 56;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
+/** Payout-rate presets for the plan-to-give goal editor, anchored on peer norms. */
+const GOAL_RATE_PRESETS = [8, 10, 15];
+
+function goalAmountForRate(balance: number, granted: number, rate: number): number {
+  // Goals are set against total fund capital for the year (already granted +
+  // remaining balance), rounded to a clean number.
+  return Math.round(((balance + granted) * rate) / 100 / 500) * 500;
+}
+
 export function GoalRing() {
-  const { state } = useRewards();
+  const { state, setAnnualGoal } = useRewards();
+  const [editing, setEditing] = useState(false);
   const progress = Math.min(1, state.grantedThisYear / state.annualGoal);
   const percent = Math.round(progress * 100);
   const remaining = Math.max(0, state.annualGoal - state.grantedThisYear);
@@ -16,11 +27,53 @@ export function GoalRing() {
   return (
     <section
       aria-label="Annual giving goal"
-      className="flex flex-col rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+      className="flex flex-col rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-        2026 giving goal
-      </h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
+          2026 giving goal
+        </h2>
+        <button
+          type="button"
+          onClick={() => setEditing((open) => !open)}
+          className="rounded-full px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
+        >
+          {editing ? "Done" : "Adjust"}
+        </button>
+      </div>
+
+      {editing && (
+        <div className="mt-3 rounded-2xl bg-stone-50 p-3 dark:bg-stone-800/60">
+          <p className="text-xs text-stone-500 dark:text-stone-400">
+            Set your goal as a share of your fund. Donors like you target 8-15% per year.
+          </p>
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            {GOAL_RATE_PRESETS.map((rate) => {
+              const amount = goalAmountForRate(state.balance, state.grantedThisYear, rate);
+              const selected = state.annualGoal === amount;
+              return (
+                <button
+                  key={rate}
+                  type="button"
+                  onClick={() => setAnnualGoal(amount)}
+                  className={`rounded-xl border-2 px-2 py-2 text-center transition active:scale-95 ${
+                    selected
+                      ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-950/50"
+                      : "border-stone-200 bg-white hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800"
+                  }`}
+                >
+                  <span className="block font-mono text-sm font-bold text-stone-900 dark:text-white">
+                    {rate}%
+                  </span>
+                  <span className="block text-[10px] text-stone-500 dark:text-stone-400">
+                    {formatUsd(amount)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="mt-3 flex flex-1 items-center justify-center gap-6">
         <div className="relative h-36 w-36">
@@ -32,7 +85,7 @@ export function GoalRing() {
               r={RADIUS}
               fill="none"
               strokeWidth="14"
-              className="stroke-zinc-100 dark:stroke-zinc-800"
+              className="stroke-stone-100 dark:stroke-stone-800"
             />
             <m.circle
               cx="72"
@@ -49,10 +102,10 @@ export function GoalRing() {
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <span className="font-mono text-3xl font-bold text-zinc-900 dark:text-white">
+            <span className="font-mono text-3xl font-bold text-stone-900 dark:text-white">
               {percent}%
             </span>
-            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400">
+            <span className="text-[11px] font-medium text-stone-500 dark:text-stone-400">
               of {formatUsd(state.annualGoal)}
             </span>
           </div>
@@ -60,21 +113,21 @@ export function GoalRing() {
 
         <div className="flex flex-col gap-3">
           <div>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">Granted so far</p>
+            <p className="text-xs text-stone-500 dark:text-stone-400">Granted so far</p>
             <p className="font-mono text-xl font-bold text-emerald-600 dark:text-emerald-400">
               {formatUsd(state.grantedThisYear)}
             </p>
           </div>
           <div>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">Left to go</p>
-            <p className="font-mono text-xl font-bold text-zinc-900 dark:text-white">
+            <p className="text-xs text-stone-500 dark:text-stone-400">Left to go</p>
+            <p className="font-mono text-xl font-bold text-stone-900 dark:text-white">
               {formatUsd(remaining)}
             </p>
           </div>
         </div>
       </div>
 
-      <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+      <p className="mt-3 text-xs text-stone-500 dark:text-stone-400">
         {percent >= 100
           ? "Goal reached! Consider stretching it for the rest of the year."
           : percent >= 50

--- a/src/features/donor-rewards/components/grant-flow.tsx
+++ b/src/features/donor-rewards/components/grant-flow.tsx
@@ -17,6 +17,8 @@ import { formatUsd } from "../utils/format";
 
 interface GrantFlowProps {
   open: boolean;
+  /** pre-seeded amount, e.g. "grant your investment gains" */
+  requestedAmount?: number | null;
   onClose: () => void;
 }
 
@@ -34,29 +36,29 @@ const OrgOption = React.memo(function OrgOption({
       <button
         type="button"
         onClick={() => onSelect(org)}
-        className="flex w-full items-start gap-3 rounded-2xl border border-zinc-200 bg-white p-4 text-left transition hover:border-emerald-400 hover:shadow-md active:scale-[0.99] dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-emerald-500"
+        className="flex w-full items-start gap-3 rounded-2xl border border-stone-200 bg-white p-4 text-left transition hover:border-emerald-400 hover:shadow-md active:scale-[0.99] dark:border-stone-700 dark:bg-stone-800 dark:hover:border-emerald-500"
       >
-        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-zinc-100 text-2xl dark:bg-zinc-700">
+        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-stone-100 text-2xl dark:bg-stone-700">
           {org.emoji}
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex flex-wrap items-center gap-1.5">
-            <span className="font-bold text-zinc-900 dark:text-white">{org.name}</span>
+            <span className="font-bold text-stone-900 dark:text-white">{org.name}</span>
             {org.verified && (
-              <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-bold text-sky-700 dark:bg-sky-500/15 dark:text-sky-400">
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400">
                 <BadgeCheck className="h-3 w-3" aria-hidden="true" />
                 Verified
               </span>
             )}
           </span>
-          <span className="mt-0.5 block text-sm text-zinc-500 dark:text-zinc-400">
+          <span className="mt-0.5 block text-sm text-stone-500 dark:text-stone-400">
             {org.tagline}
           </span>
           <span className="mt-1.5 flex items-center gap-2 text-xs">
-            <span className="rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+            <span className="rounded-full bg-stone-100 px-2 py-0.5 font-medium text-stone-600 dark:bg-stone-700 dark:text-stone-300">
               {cause.emoji} {cause.label}
             </span>
-            <span className="text-zinc-400 dark:text-zinc-500">{org.impactNote}</span>
+            <span className="text-stone-400 dark:text-stone-500">{org.impactNote}</span>
           </span>
         </span>
       </button>
@@ -64,7 +66,7 @@ const OrgOption = React.memo(function OrgOption({
   );
 });
 
-export function GrantFlow({ open, onClose }: GrantFlowProps) {
+export function GrantFlow({ open, requestedAmount = null, onClose }: GrantFlowProps) {
   const { state, makeGrant } = useRewards();
   const [selectedOrg, setSelectedOrg] = useState<Nonprofit | null>(null);
   const [amount, setAmount] = useState<number | null>(null);
@@ -77,11 +79,12 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
     setRecurring(false);
   }, [onClose]);
 
-  // Selecting an org seeds the amount from that org's own presets, so the
-  // confirm CTA can never show a value that isn't one of the visible chips.
+  // Selecting an org seeds the amount from the caller's request (e.g. "grant
+  // your gains") or from that org's own presets, so the confirm CTA always
+  // shows a value that appears as a visible, selected chip.
   const handleSelectOrg = (org: Nonprofit) => {
     setSelectedOrg(org);
-    setAmount(org.suggestedAmounts[org.suggestedAmounts.length - 1]);
+    setAmount(requestedAmount ?? org.suggestedAmounts[org.suggestedAmounts.length - 1]);
   };
 
   useEffect(() => {
@@ -137,7 +140,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.98 }}
             transition={{ duration: 0.15 }}
-            className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-zinc-50 shadow-2xl sm:rounded-3xl dark:bg-zinc-900"
+            className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-2xl bg-stone-50 shadow-2xl sm:rounded-2xl dark:bg-stone-900"
             onClick={(event) => event.stopPropagation()}
           >
             <div className="flex items-center justify-between px-6 pt-6">
@@ -145,13 +148,13 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 <button
                   type="button"
                   onClick={() => setSelectedOrg(null)}
-                  className="flex items-center gap-1 text-sm font-semibold text-zinc-500 transition hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+                  className="flex items-center gap-1 text-sm font-semibold text-stone-500 transition hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200"
                 >
                   <ArrowLeft className="h-4 w-4" aria-hidden="true" />
                   Back
                 </button>
               ) : (
-                <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">
+                <h2 className="text-xl font-semibold text-stone-900 dark:text-white">
                   Make a grant
                 </h2>
               )}
@@ -159,7 +162,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 type="button"
                 onClick={handleClose}
                 aria-label="Close"
-                className="rounded-full p-2 text-zinc-400 transition hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                className="rounded-full p-2 text-stone-400 transition hover:bg-stone-200 hover:text-stone-700 dark:hover:bg-stone-800 dark:hover:text-stone-200"
               >
                 <X className="h-5 w-5" aria-hidden="true" />
               </button>
@@ -170,7 +173,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 underneath the CTA. */}
             {!selectedOrg ? (
               <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
-                <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
                   Suggested for you, based on your causes and this month's quests
                 </p>
                 <ul className="mt-4 flex flex-col gap-3">
@@ -181,17 +184,17 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
               </div>
             ) : (
               <div className="mt-3 min-h-0 flex-1 overflow-y-auto px-6 pb-3">
-                <div className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-800">
+                <div className="flex items-center gap-3 rounded-2xl border border-stone-200 bg-white p-3 dark:border-stone-700 dark:bg-stone-800">
                   <span className="text-3xl">{selectedOrg.emoji}</span>
                   <div>
-                    <p className="font-bold text-zinc-900 dark:text-white">{selectedOrg.name}</p>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    <p className="font-bold text-stone-900 dark:text-white">{selectedOrg.name}</p>
+                    <p className="text-xs text-stone-500 dark:text-stone-400">
                       {selectedOrg.impactNote}
                     </p>
                   </div>
                 </div>
 
-                <p className="mt-4 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+                <p className="mt-4 text-sm font-semibold text-stone-700 dark:text-stone-300">
                   Grant amount
                 </p>
                 <div className="mt-2 grid grid-cols-3 gap-2">
@@ -203,20 +206,37 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                       className={`rounded-2xl border-2 py-2.5 font-mono text-lg font-bold transition active:scale-95 ${
                         amount === suggested
                           ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
-                          : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                          : "border-stone-200 bg-white text-stone-700 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
                       }`}
                     >
                       {formatUsd(suggested)}
                     </button>
                   ))}
+                  {requestedAmount !== null &&
+                    !selectedOrg.suggestedAmounts.includes(requestedAmount) && (
+                      <button
+                        type="button"
+                        onClick={() => setAmount(requestedAmount)}
+                        className={`col-span-3 rounded-2xl border-2 py-2.5 font-mono text-lg font-bold transition active:scale-95 ${
+                          amount === requestedAmount
+                            ? "border-amber-500 bg-amber-50 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300"
+                            : "border-stone-200 bg-white text-stone-700 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                        }`}
+                      >
+                        {formatUsd(requestedAmount)}
+                        <span className="ml-2 text-xs font-semibold uppercase tracking-wide">
+                          your gains ✨
+                        </span>
+                      </button>
+                    )}
                 </div>
 
-                <label className="mt-4 flex cursor-pointer items-center justify-between rounded-2xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-800">
+                <label className="mt-4 flex cursor-pointer items-center justify-between rounded-2xl border border-stone-200 bg-white p-3 dark:border-stone-700 dark:bg-stone-800">
                   <span>
-                    <span className="block font-semibold text-zinc-900 dark:text-white">
+                    <span className="block font-semibold text-stone-900 dark:text-white">
                       Make it monthly
                     </span>
-                    <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                    <span className="block text-xs text-stone-500 dark:text-stone-400">
                       Protects your streak automatically · +{XP_RECURRING_BONUS} IP bonus
                     </span>
                   </span>
@@ -230,7 +250,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   <span
                     aria-hidden="true"
                     className={`relative h-7 w-12 shrink-0 rounded-full transition-colors ${
-                      recurring ? "bg-emerald-500" : "bg-zinc-300 dark:bg-zinc-600"
+                      recurring ? "bg-emerald-500" : "bg-stone-300 dark:bg-stone-600"
                     }`}
                   >
                     <span
@@ -249,12 +269,12 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                 never grows tall enough to clip the scrollable body's controls
                 on short viewports. */}
             {selectedOrg && (
-              <div className="border-t border-zinc-200 px-6 pb-4 pt-2.5 dark:border-zinc-800">
-                <div className="rounded-2xl bg-violet-50 px-4 py-3 dark:bg-violet-950/40">
-                  <p className="text-sm font-semibold text-violet-800 dark:text-violet-300">
+              <div className="border-t border-stone-200 px-6 pb-4 pt-2.5 dark:border-stone-800">
+                <div className="rounded-2xl bg-amber-50 px-4 py-3 dark:bg-amber-950/40">
+                  <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
                     You will earn <span className="font-mono">+{totalIp} IP</span>
                   </p>
-                  <p className="mt-0.5 text-xs text-violet-700 dark:text-violet-400">
+                  <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-400">
                     {earnParts.join(" · ")}
                     {!state.grantedThisMonth &&
                       ` · 🔥 streak extends to month ${state.streakMonths + 1}`}
@@ -269,7 +289,7 @@ export function GrantFlow({ open, onClose }: GrantFlowProps) {
                   Grant {amount !== null ? formatUsd(amount) : ""}
                   {recurring ? " monthly" : ""} to {selectedOrg.name}
                 </button>
-                <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
+                <p className="mt-2 text-center text-xs text-stone-400 dark:text-stone-500">
                   Prototype: no real money moves.
                 </p>
               </div>

--- a/src/features/donor-rewards/components/idle-nudge.tsx
+++ b/src/features/donor-rewards/components/idle-nudge.tsx
@@ -17,16 +17,16 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
     return (
       <section
         aria-label="Funds at work"
-        className="flex flex-col justify-between rounded-3xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm dark:border-emerald-900 dark:bg-emerald-950/40"
+        className="flex flex-col justify-between rounded-2xl bg-emerald-950 p-6 text-white shadow-sm dark:bg-emerald-950"
       >
         <div>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-emerald-300/80">
             Funds at work
           </h2>
-          <p className="mt-3 text-2xl font-bold text-emerald-800 dark:text-emerald-200">
+          <p className="mt-3 [font-family:var(--font-display)] text-2xl font-medium leading-snug">
             Nice work! 🎉
           </p>
-          <p className="mt-2 text-sm text-emerald-700 dark:text-emerald-300">
+          <p className="mt-2 text-sm text-emerald-200/80">
             Your latest grant put your dollars back to work. Nonprofits will report verified
             milestones as your funding lands.
           </p>
@@ -34,7 +34,7 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
         <button
           type="button"
           onClick={onOpenGrantFlow}
-          className="mt-4 w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-bold text-white transition hover:bg-emerald-700 active:scale-95"
+          className="mt-4 w-full rounded-xl bg-white px-4 py-3 text-sm font-bold text-emerald-900 transition hover:bg-emerald-50 active:scale-95"
         >
           Grant again
         </button>
@@ -45,34 +45,33 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
   return (
     <section
       aria-label="Idle funds nudge"
-      className="flex flex-col justify-between rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm dark:border-amber-900 dark:bg-amber-950/40"
+      className="flex flex-col justify-between rounded-2xl bg-emerald-950 p-6 text-white shadow-sm dark:bg-emerald-950"
     >
       <div>
         <div className="flex items-center gap-2">
-          <m.div
+          <m.span
             animate={{ y: [0, -3, 0] }}
             transition={{ repeat: Number.POSITIVE_INFINITY, duration: 2 }}
-            className="rounded-xl bg-amber-100 p-2 text-amber-600 dark:bg-amber-500/15 dark:text-amber-400"
+            className="text-amber-400"
           >
-            <Zap className="h-5 w-5" fill="currentColor" aria-hidden="true" />
-          </m.div>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400">
+            <Zap className="h-4 w-4" fill="currentColor" aria-hidden="true" />
+          </m.span>
+          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-emerald-300/80">
             Money resting
           </h2>
         </div>
-        <p className="mt-3 text-2xl font-bold text-amber-900 dark:text-amber-100">
+        <p className="mt-3 [font-family:var(--font-display)] text-2xl font-medium leading-snug">
           {formatUsd(state.balance)} has been idle for {state.idleDays}{" "}
-          {pluralize("day", state.idleDays)}
+          {pluralize("day", state.idleDays)}.
         </p>
-        <p className="mt-2 text-sm text-amber-800 dark:text-amber-200">
-          Even {formatUsd(500)} could fund a month of verified impact. Put a piece of it to work
-          today.
+        <p className="mt-2 text-sm text-emerald-200/80">
+          Even {formatUsd(500)} could fund a month of verified impact.
         </p>
       </div>
       <button
         type="button"
         onClick={onOpenGrantFlow}
-        className="mt-4 w-full rounded-2xl bg-amber-500 px-4 py-3 text-sm font-bold text-white transition hover:bg-amber-600 active:scale-95"
+        className="mt-4 w-full rounded-xl bg-white px-4 py-3 text-sm font-bold text-emerald-900 transition hover:bg-emerald-50 active:scale-95"
       >
         Put {formatUsd(500)} to work
       </button>

--- a/src/features/donor-rewards/components/idle-nudge.tsx
+++ b/src/features/donor-rewards/components/idle-nudge.tsx
@@ -45,7 +45,7 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
   return (
     <section
       aria-label="Idle funds nudge"
-      className="flex flex-col justify-between rounded-2xl bg-emerald-950 p-6 text-white shadow-sm dark:bg-emerald-950"
+      className="flex flex-col justify-between rounded-2xl bg-amber-950 p-6 text-white shadow-sm dark:bg-amber-950"
     >
       <div>
         <div className="flex items-center gap-2">
@@ -56,7 +56,7 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
           >
             <Zap className="h-4 w-4" fill="currentColor" aria-hidden="true" />
           </m.span>
-          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-emerald-300/80">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-amber-300/80">
             Money resting
           </h2>
         </div>
@@ -64,14 +64,14 @@ export function IdleNudge({ onOpenGrantFlow }: IdleNudgeProps) {
           {formatUsd(state.balance)} has been idle for {state.idleDays}{" "}
           {pluralize("day", state.idleDays)}.
         </p>
-        <p className="mt-2 text-sm text-emerald-200/80">
+        <p className="mt-2 text-sm text-amber-200/80">
           Even {formatUsd(500)} could fund a month of verified impact.
         </p>
       </div>
       <button
         type="button"
         onClick={onOpenGrantFlow}
-        className="mt-4 w-full rounded-xl bg-white px-4 py-3 text-sm font-bold text-emerald-900 transition hover:bg-emerald-50 active:scale-95"
+        className="mt-4 w-full rounded-xl bg-amber-400 px-4 py-3 text-sm font-bold text-amber-950 transition hover:bg-amber-300 active:scale-95"
       >
         Put {formatUsd(500)} to work
       </button>

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -18,28 +18,28 @@ const UpdateCard = React.memo(function UpdateCard({
 }) {
   const pendingBonus = pendingQuests.reduce((sum, quest) => sum + quest.xp, 0);
   return (
-    <li className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="flex items-start gap-3">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-zinc-100 text-xl dark:bg-zinc-800">
+    <li className="py-5 first:pt-4 last:pb-0">
+      <div className="flex items-start gap-3.5">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-stone-100 text-xl dark:bg-stone-800">
           {update.orgEmoji}
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-sm font-bold text-zinc-900 dark:text-white">
+            <span className="text-sm font-bold text-stone-900 dark:text-white">
               {update.orgName}
             </span>
             {update.verified && (
-              <span className="inline-flex items-center gap-0.5 rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-bold text-sky-700 dark:bg-sky-500/15 dark:text-sky-400">
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400">
                 <BadgeCheck className="h-3 w-3" aria-hidden="true" />
                 Verified on Karma
               </span>
             )}
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">{update.postedAgo}</span>
+            <span className="text-xs text-stone-400 dark:text-stone-500">{update.postedAgo}</span>
           </div>
-          <p className="mt-1 text-sm font-semibold text-zinc-800 dark:text-zinc-200">
+          <p className="mt-1 text-sm font-semibold text-stone-800 dark:text-stone-200">
             {update.title}
           </p>
-          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{update.detail}</p>
+          <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">{update.detail}</p>
           <div className="mt-3">
             {update.read ? (
               <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
@@ -51,14 +51,14 @@ const UpdateCard = React.memo(function UpdateCard({
                 <button
                   type="button"
                   onClick={() => onRead(update.id)}
-                  className="rounded-xl bg-zinc-900 px-3 py-1.5 text-xs font-bold text-white transition hover:bg-zinc-700 active:scale-95 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  className="rounded-xl bg-stone-900 px-3 py-1.5 text-xs font-bold text-white transition hover:bg-stone-700 active:scale-95 dark:bg-white dark:text-stone-900 dark:hover:bg-stone-200"
                 >
                   Mark as read · +{update.xp + pendingBonus} IP
                 </button>
                 {pendingQuests.map((quest) => (
                   <p
                     key={quest.id}
-                    className="mt-1.5 text-xs font-medium text-violet-600 dark:text-violet-400"
+                    className="mt-1.5 text-xs font-medium text-amber-600 dark:text-amber-400"
                   >
                     Completes quest "{quest.title}" · +{quest.xp} IP included
                   </p>
@@ -79,21 +79,23 @@ export function ImpactFeed() {
   return (
     <section
       aria-label="Impact feed"
-      className="rounded-3xl border border-zinc-200 bg-zinc-50 p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
-      <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Your impact feed</h2>
-      <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+      <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+        Your impact feed
+      </h2>
+      <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
         Milestone updates from your grantees, verified through Karma's accountability protocol.
       </p>
       {state.updates.length === 0 ? (
-        <div className="mt-4 rounded-2xl border border-dashed border-zinc-300 bg-white p-6 text-center dark:border-zinc-700 dark:bg-zinc-900">
-          <p className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">No updates yet</p>
-          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        <div className="mt-4 rounded-2xl border border-dashed border-stone-300 bg-white p-6 text-center dark:border-stone-700 dark:bg-stone-900">
+          <p className="text-sm font-semibold text-stone-700 dark:text-stone-300">No updates yet</p>
+          <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
             Make a grant and your grantees' verified milestones will show up here.
           </p>
         </div>
       ) : (
-        <ul className="mt-4 flex flex-col gap-3">
+        <ul className="mt-2 divide-y divide-stone-100 dark:divide-stone-800">
           {state.updates.map((update) => (
             <UpdateCard
               key={update.id}

--- a/src/features/donor-rewards/components/impact-feed.tsx
+++ b/src/features/donor-rewards/components/impact-feed.tsx
@@ -6,6 +6,10 @@ import { questsCompletedByRead } from "../state/quest-logic";
 import { useRewards } from "../state/rewards-context";
 import type { ImpactUpdate, Quest } from "../types";
 
+// Stable empty reference so memoized cards that get no pending bonus don't
+// re-render on every parent render.
+const NO_PENDING_QUESTS: Quest[] = [];
+
 const UpdateCard = React.memo(function UpdateCard({
   update,
   onRead,
@@ -75,6 +79,14 @@ const UpdateCard = React.memo(function UpdateCard({
 export function ImpactFeed() {
   const { state, readUpdate } = useRewards();
   const pendingQuests = useMemo(() => questsCompletedByRead(state.quests), [state.quests]);
+  // A read quest completes on the *next* read, whichever update that is, and it
+  // pays out only once. Advertise the bonus on just the first unread card so
+  // the feed never promises the same one-time quest reward on several cards at
+  // once (which would over-count what reading them all actually earns).
+  const firstUnreadId = useMemo(
+    () => state.updates.find((update) => !update.read)?.id,
+    [state.updates]
+  );
 
   return (
     <section
@@ -101,7 +113,7 @@ export function ImpactFeed() {
               key={update.id}
               update={update}
               onRead={readUpdate}
-              pendingQuests={pendingQuests}
+              pendingQuests={update.id === firstUnreadId ? pendingQuests : NO_PENDING_QUESTS}
             />
           ))}
         </ul>

--- a/src/features/donor-rewards/components/league-card.tsx
+++ b/src/features/donor-rewards/components/league-card.tsx
@@ -26,7 +26,7 @@ const LeagueRow = React.memo(function LeagueRow({
     >
       <span
         className={`w-6 text-center font-mono text-sm font-bold ${
-          rank <= 3 ? "text-amber-500" : "text-zinc-400 dark:text-zinc-500"
+          rank <= 3 ? "text-amber-500" : "text-stone-400 dark:text-stone-500"
         }`}
       >
         {rank}
@@ -36,12 +36,12 @@ const LeagueRow = React.memo(function LeagueRow({
         className={`flex-1 truncate text-sm ${
           peer.isUser
             ? "font-bold text-emerald-800 dark:text-emerald-300"
-            : "font-medium text-zinc-700 dark:text-zinc-300"
+            : "font-medium text-stone-700 dark:text-stone-300"
         }`}
       >
         {peer.isUser ? "You" : peer.alias}
       </span>
-      <span className="font-mono text-sm font-semibold text-zinc-500 dark:text-zinc-400">
+      <span className="font-mono text-sm font-semibold text-stone-500 dark:text-stone-400">
         {formatNumber(peer.points)}
       </span>
     </li>
@@ -67,15 +67,15 @@ export function LeagueCard() {
   return (
     <section
       aria-label="Giving league"
-      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
       <div className="flex items-center gap-3">
-        <div className="rounded-2xl bg-emerald-100 p-2.5 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-400">
-          <Shield className="h-6 w-6" aria-hidden="true" />
-        </div>
+        <Shield className="h-5 w-5 text-emerald-700 dark:text-emerald-500" aria-hidden="true" />
         <div>
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">Emerald League</h2>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+          <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+            Emerald League
+          </h2>
+          <p className="text-xs text-stone-500 dark:text-stone-400">
             Top {percentile}% most consistent givers among accounts your size
           </p>
         </div>
@@ -87,7 +87,7 @@ export function LeagueCard() {
         ))}
       </ol>
 
-      <p className="mt-4 text-xs text-zinc-400 dark:text-zinc-500">
+      <p className="mt-4 text-xs text-stone-400 dark:text-stone-500">
         Rankings are based on giving consistency, never dollar amounts. Aliases keep everyone
         anonymous.
       </p>

--- a/src/features/donor-rewards/components/personal-goals.tsx
+++ b/src/features/donor-rewards/components/personal-goals.tsx
@@ -2,7 +2,7 @@
 
 import { Target } from "lucide-react";
 import pluralize from "pluralize";
-import React, { useState } from "react";
+import React from "react";
 import { useRewards } from "../state/rewards-context";
 import { formatUsd } from "../utils/format";
 
@@ -34,9 +34,7 @@ const GoalRow = React.memo(function GoalRow({ goal }: { goal: GoalRowData }) {
       </div>
       <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-stone-100 dark:bg-stone-700">
         <div
-          className={`h-full rounded-full transition-all ${
-            goal.done ? "bg-emerald-500" : "bg-emerald-500"
-          }`}
+          className="h-full rounded-full bg-emerald-500 transition-all"
           style={{ width: `${percent}%` }}
         />
       </div>
@@ -49,7 +47,6 @@ const MONTH_TARGET_OPTIONS = [6, 9, 12];
 
 export function PersonalGoals() {
   const { state, setPersonalGoals } = useRewards();
-  const [editing, setEditing] = useState(false);
   const { causesTarget, monthsTarget } = state.personalGoals;
 
   const goals: GoalRowData[] = [
@@ -84,77 +81,65 @@ export function PersonalGoals() {
       aria-label="Personal goals"
       className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
-          <Target className="h-5 w-5 text-emerald-700 dark:text-emerald-500" aria-hidden="true" />
-          <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
-            My goals
-          </h2>
-        </div>
-        <button
-          type="button"
-          onClick={() => setEditing((open) => !open)}
-          className="rounded-full px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
-        >
-          {editing ? "Done" : "Edit goals"}
-        </button>
+      <div className="flex items-center gap-2.5">
+        <Target className="h-5 w-5 text-emerald-700 dark:text-emerald-500" aria-hidden="true" />
+        <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+          My goals
+        </h2>
       </div>
-
-      {editing && (
-        <div className="mt-3 flex flex-col gap-3 rounded-2xl bg-stone-50 p-3 dark:bg-stone-800/60">
-          <div>
-            <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
-              Causes to support
-            </p>
-            <div className="mt-1.5 flex gap-2">
-              {CAUSE_TARGET_OPTIONS.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() => setPersonalGoals({ causesTarget: option })}
-                  className={`flex-1 rounded-xl border-2 py-1.5 font-mono text-sm font-bold transition active:scale-95 ${
-                    causesTarget === option
-                      ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
-                      : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
-                  }`}
-                >
-                  {option}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div>
-            <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
-              Giving streak target
-            </p>
-            <div className="mt-1.5 flex gap-2">
-              {MONTH_TARGET_OPTIONS.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() => setPersonalGoals({ monthsTarget: option })}
-                  className={`flex-1 rounded-xl border-2 py-1.5 font-mono text-sm font-bold transition active:scale-95 ${
-                    monthsTarget === option
-                      ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
-                      : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
-                  }`}
-                >
-                  {option} mo
-                </button>
-              ))}
-            </div>
-          </div>
-          <p className="text-[11px] text-stone-400 dark:text-stone-500">
-            The dollar goal is set from the giving goal card above.
-          </p>
-        </div>
-      )}
 
       <ul className="mt-4 flex flex-col gap-2.5">
         {goals.map((goal) => (
           <GoalRow key={goal.id} goal={goal} />
         ))}
       </ul>
+
+      {/* Target controls stay inline and always visible, so setting a goal is a
+          single tap with no hidden panel to expand. */}
+      <div className="mt-4 flex flex-col gap-3 border-t border-stone-100 pt-4 dark:border-stone-800">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
+            Causes to support
+          </p>
+          <div className="flex gap-1.5">
+            {CAUSE_TARGET_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={causesTarget === option}
+                onClick={() => setPersonalGoals({ causesTarget: option })}
+                className={`w-10 rounded-lg border-2 py-1 font-mono text-sm font-bold transition active:scale-95 ${
+                  causesTarget === option
+                    ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                    : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-medium text-stone-500 dark:text-stone-400">Streak target</p>
+          <div className="flex gap-1.5">
+            {MONTH_TARGET_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={monthsTarget === option}
+                onClick={() => setPersonalGoals({ monthsTarget: option })}
+                className={`w-12 rounded-lg border-2 py-1 font-mono text-sm font-bold transition active:scale-95 ${
+                  monthsTarget === option
+                    ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                    : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                }`}
+              >
+                {option}mo
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/features/donor-rewards/components/personal-goals.tsx
+++ b/src/features/donor-rewards/components/personal-goals.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Target } from "lucide-react";
+import pluralize from "pluralize";
+import React, { useState } from "react";
+import { useRewards } from "../state/rewards-context";
+import { formatUsd } from "../utils/format";
+
+interface GoalRowData {
+  id: string;
+  label: string;
+  progress: number;
+  target: number;
+  progressLabel: string;
+  done: boolean;
+}
+
+const GoalRow = React.memo(function GoalRow({ goal }: { goal: GoalRowData }) {
+  const percent = Math.min(100, Math.round((goal.progress / goal.target) * 100));
+
+  return (
+    <li className="rounded-2xl border border-stone-200 bg-white p-3.5 dark:border-stone-700 dark:bg-stone-800">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm font-semibold text-stone-800 dark:text-stone-200">{goal.label}</p>
+        <span
+          className={`shrink-0 font-mono text-xs font-bold ${
+            goal.done
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-stone-500 dark:text-stone-400"
+          }`}
+        >
+          {goal.done ? "Done! 🎉" : goal.progressLabel}
+        </span>
+      </div>
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-stone-100 dark:bg-stone-700">
+        <div
+          className={`h-full rounded-full transition-all ${
+            goal.done ? "bg-emerald-500" : "bg-emerald-500"
+          }`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </li>
+  );
+});
+
+const CAUSE_TARGET_OPTIONS = [4, 6, 8];
+const MONTH_TARGET_OPTIONS = [6, 9, 12];
+
+export function PersonalGoals() {
+  const { state, setPersonalGoals } = useRewards();
+  const [editing, setEditing] = useState(false);
+  const { causesTarget, monthsTarget } = state.personalGoals;
+
+  const goals: GoalRowData[] = [
+    {
+      id: "dollars",
+      label: `Give ${formatUsd(state.annualGoal)} this year`,
+      progress: state.grantedThisYear,
+      target: state.annualGoal,
+      progressLabel: `${formatUsd(state.grantedThisYear)} of ${formatUsd(state.annualGoal)}`,
+      done: state.grantedThisYear >= state.annualGoal,
+    },
+    {
+      id: "causes",
+      label: `Support ${causesTarget} ${pluralize("cause", causesTarget)}`,
+      progress: state.causesSupported.length,
+      target: causesTarget,
+      progressLabel: `${state.causesSupported.length}/${causesTarget}`,
+      done: state.causesSupported.length >= causesTarget,
+    },
+    {
+      id: "months",
+      label: `Give ${monthsTarget} ${pluralize("month", monthsTarget)} in a row`,
+      progress: state.streakMonths,
+      target: monthsTarget,
+      progressLabel: `${state.streakMonths}/${monthsTarget}`,
+      done: state.streakMonths >= monthsTarget,
+    },
+  ];
+
+  return (
+    <section
+      aria-label="Personal goals"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <Target className="h-5 w-5 text-emerald-700 dark:text-emerald-500" aria-hidden="true" />
+          <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+            My goals
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEditing((open) => !open)}
+          className="rounded-full px-2.5 py-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
+        >
+          {editing ? "Done" : "Edit goals"}
+        </button>
+      </div>
+
+      {editing && (
+        <div className="mt-3 flex flex-col gap-3 rounded-2xl bg-stone-50 p-3 dark:bg-stone-800/60">
+          <div>
+            <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
+              Causes to support
+            </p>
+            <div className="mt-1.5 flex gap-2">
+              {CAUSE_TARGET_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setPersonalGoals({ causesTarget: option })}
+                  className={`flex-1 rounded-xl border-2 py-1.5 font-mono text-sm font-bold transition active:scale-95 ${
+                    causesTarget === option
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                      : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                  }`}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-stone-500 dark:text-stone-400">
+              Giving streak target
+            </p>
+            <div className="mt-1.5 flex gap-2">
+              {MONTH_TARGET_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => setPersonalGoals({ monthsTarget: option })}
+                  className={`flex-1 rounded-xl border-2 py-1.5 font-mono text-sm font-bold transition active:scale-95 ${
+                    monthsTarget === option
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                      : "border-stone-200 bg-white text-stone-600 hover:border-stone-300 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-300"
+                  }`}
+                >
+                  {option} mo
+                </button>
+              ))}
+            </div>
+          </div>
+          <p className="text-[11px] text-stone-400 dark:text-stone-500">
+            The dollar goal is set from the giving goal card above.
+          </p>
+        </div>
+      )}
+
+      <ul className="mt-4 flex flex-col gap-2.5">
+        {goals.map((goal) => (
+          <GoalRow key={goal.id} goal={goal} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/donor-rewards/components/quests-card.tsx
+++ b/src/features/donor-rewards/components/quests-card.tsx
@@ -15,7 +15,7 @@ const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
       className={`flex items-center gap-4 rounded-2xl border p-4 transition-colors ${
         done
           ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/40"
-          : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+          : "border-stone-200 bg-white dark:border-stone-800 dark:bg-stone-900"
       }`}
     >
       {done ? (
@@ -28,7 +28,7 @@ const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
           <CheckCircle2 className="h-7 w-7" aria-hidden="true" />
         </m.span>
       ) : (
-        <span className="text-zinc-300 dark:text-zinc-600">
+        <span className="text-stone-300 dark:text-stone-600">
           <Circle className="h-7 w-7" aria-hidden="true" />
         </span>
       )}
@@ -38,21 +38,21 @@ const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
           className={`font-semibold ${
             done
               ? "text-emerald-800 line-through decoration-emerald-400 dark:text-emerald-300"
-              : "text-zinc-900 dark:text-white"
+              : "text-stone-900 dark:text-white"
           }`}
         >
           {quest.title}
         </p>
-        <p className="truncate text-sm text-zinc-500 dark:text-zinc-400">{quest.description}</p>
+        <p className="truncate text-sm text-stone-500 dark:text-stone-400">{quest.description}</p>
         {quest.goal > 1 && (
           <div className="mt-2 flex items-center gap-2">
-            <div className="h-1.5 w-32 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+            <div className="h-1.5 w-32 overflow-hidden rounded-full bg-stone-200 dark:bg-stone-700">
               <div
                 className="h-full rounded-full bg-emerald-500 transition-all"
                 style={{ width: `${(quest.progress / quest.goal) * 100}%` }}
               />
             </div>
-            <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+            <span className="text-xs font-medium text-stone-500 dark:text-stone-400">
               {quest.progress}/{quest.goal}
             </span>
           </div>
@@ -63,7 +63,7 @@ const QuestRow = React.memo(function QuestRow({ quest }: { quest: Quest }) {
         className={`shrink-0 rounded-full px-3 py-1 font-mono text-xs font-bold ${
           done
             ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
-            : "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400"
+            : "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400"
         }`}
       >
         +{quest.xp} IP
@@ -79,12 +79,14 @@ export function QuestsCard() {
   return (
     <section
       aria-label="Monthly quests"
-      className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+      className="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">July quests</h2>
+        <h2 className="[font-family:var(--font-display)] text-xl font-medium text-stone-900 dark:text-white">
+          July quests
+        </h2>
         {remaining > 0 ? (
-          <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-bold text-violet-700 dark:bg-violet-500/15 dark:text-violet-400">
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400">
             {remaining} {pluralize("quest", remaining)} left
           </span>
         ) : (

--- a/src/features/donor-rewards/components/rewards-header.tsx
+++ b/src/features/donor-rewards/components/rewards-header.tsx
@@ -20,21 +20,25 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
     : 100;
 
   return (
-    <header className="w-full rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-700 to-teal-800 p-6 text-white shadow-lg sm:p-8">
+    <header className="w-full rounded-2xl bg-gradient-to-br from-emerald-950 via-teal-950 to-emerald-950 p-6 text-white shadow-lg sm:p-8">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         <div className="flex items-center gap-4">
-          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/15 text-3xl backdrop-blur-sm">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/10 text-3xl">
             🦉
           </div>
           <div>
-            <p className="text-sm font-medium text-emerald-100">Good morning, Maya</p>
-            <h1 className="text-2xl font-semibold sm:text-3xl">Your Giving Journey</h1>
-            <div className="mt-1 flex items-center gap-2">
-              <span className="inline-flex items-center gap-1 rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-emerald-300/80">
+              Good morning, Maya
+            </p>
+            <h1 className="[font-family:var(--font-display)] text-3xl font-medium italic tracking-tight sm:text-4xl">
+              Your giving, at work
+            </h1>
+            <div className="mt-1.5 flex items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-400/15 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-300">
                 <Sparkles className="h-3 w-3" aria-hidden="true" />
                 {level.name}
               </span>
-              <span className="text-sm text-emerald-100">
+              <span className="font-mono text-sm text-emerald-200/90">
                 {formatNumber(state.xp)} Impact Points
               </span>
             </div>
@@ -42,11 +46,21 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <div className="flex items-center gap-2 rounded-2xl bg-white/10 px-4 py-3 backdrop-blur-sm">
-            <Wallet className="h-5 w-5 text-emerald-200" aria-hidden="true" />
+          {/* Impact deployed leads; the balance is secondary. Framing activity as
+              cumulative impact generated, not a shrinking balance (ideas42). */}
+          <div className="flex items-center gap-3 rounded-2xl bg-white/5 px-4 py-3">
+            <Wallet className="h-5 w-5 text-emerald-300/80" aria-hidden="true" />
             <div>
-              <p className="text-xs text-emerald-100">DAF balance</p>
-              <p className="font-mono text-lg font-bold">{formatUsd(state.balance)}</p>
+              <p className="text-[11px] uppercase tracking-wide text-emerald-300/80">
+                Impact deployed
+              </p>
+              <p className="font-mono text-xl font-bold tracking-tight">
+                {formatUsd(state.lifetimeGranted)}
+              </p>
+              <p className="text-[10px] text-emerald-200/70">
+                {state.verifiedMilestones} verified milestones · {formatUsd(state.balance)} ready to
+                deploy
+              </p>
             </div>
           </div>
           <button
@@ -76,9 +90,9 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
               {formatNumber(nextLevel.minXp - state.xp)} IP to {nextLevel.name}
             </span>
           </div>
-          <div className="h-3 w-full overflow-hidden rounded-full bg-white/20">
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-white/10">
             <m.div
-              className="h-full rounded-full bg-gradient-to-r from-amber-300 to-yellow-400"
+              className="h-full rounded-full bg-amber-400"
               initial={false}
               animate={{ width: `${progressToNext}%` }}
               transition={{ type: "spring", stiffness: 60, damping: 15 }}

--- a/src/features/donor-rewards/components/rewards-header.tsx
+++ b/src/features/donor-rewards/components/rewards-header.tsx
@@ -2,6 +2,7 @@
 
 import { Sparkles, Wallet } from "lucide-react";
 import { m } from "motion/react";
+import pluralize from "pluralize";
 import { useRewards } from "../state/rewards-context";
 import { formatNumber, formatUsd } from "../utils/format";
 import { levelForXp, nextLevelForXp } from "../utils/levels";
@@ -58,8 +59,9 @@ export function RewardsHeader({ onOpenGrantFlow, onOpenRecap }: RewardsHeaderPro
                 {formatUsd(state.lifetimeGranted)}
               </p>
               <p className="text-[10px] text-emerald-200/70">
-                {state.verifiedMilestones} verified milestones · {formatUsd(state.balance)} ready to
-                deploy
+                {state.verifiedMilestones} verified{" "}
+                {pluralize("milestone", state.verifiedMilestones)} · {formatUsd(state.balance)}{" "}
+                ready to deploy
               </p>
             </div>
           </div>

--- a/src/features/donor-rewards/components/streak-card.tsx
+++ b/src/features/donor-rewards/components/streak-card.tsx
@@ -23,11 +23,11 @@ export function StreakCard() {
   return (
     <section
       aria-label="Giving streak"
-      className="flex flex-col justify-between rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+      className="flex flex-col justify-between rounded-2xl border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900"
     >
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
             Giving streak
           </h2>
           <div className="mt-2 flex items-baseline gap-2">
@@ -36,11 +36,11 @@ export function StreakCard() {
               initial={{ scale: 1.4 }}
               animate={{ scale: 1 }}
               transition={{ type: "spring", stiffness: 300, damping: 12 }}
-              className="font-mono text-5xl font-bold text-zinc-900 dark:text-white"
+              className="font-mono text-5xl font-bold text-stone-900 dark:text-white"
             >
               {state.streakMonths}
             </m.span>
-            <span className="text-lg text-zinc-500 dark:text-zinc-400">
+            <span className="text-lg text-stone-500 dark:text-stone-400">
               {pluralize("month", state.streakMonths)}
             </span>
           </div>
@@ -54,8 +54,8 @@ export function StreakCard() {
           transition={{ duration: 0.7 }}
           className={
             state.grantedThisMonth
-              ? "rounded-2xl bg-orange-100 p-3 text-orange-500 dark:bg-orange-500/15"
-              : "rounded-2xl bg-zinc-100 p-3 text-zinc-400 dark:bg-zinc-800"
+              ? "rounded-2xl bg-amber-100 p-3 text-amber-500 dark:bg-amber-500/15"
+              : "rounded-2xl bg-stone-100 p-3 text-stone-400 dark:bg-stone-800"
           }
         >
           <Flame className="h-8 w-8" fill="currentColor" aria-hidden="true" />
@@ -68,15 +68,15 @@ export function StreakCard() {
             <div
               className={`h-3.5 w-full max-w-8 rounded-full transition-colors ${
                 dot.lit
-                  ? "bg-orange-400"
+                  ? "bg-amber-400"
                   : dot.current
-                    ? "border-2 border-dashed border-orange-300 bg-transparent dark:border-orange-500/50"
-                    : "bg-zinc-200 dark:bg-zinc-700"
+                    ? "border-2 border-dashed border-amber-300 bg-transparent dark:border-amber-500/50"
+                    : "bg-stone-200 dark:bg-stone-700"
               }`}
             />
             <span
               className={`text-[10px] font-medium ${
-                dot.current ? "text-orange-500" : "text-zinc-400 dark:text-zinc-500"
+                dot.current ? "text-amber-500" : "text-stone-400 dark:text-stone-500"
               }`}
             >
               {dot.label}
@@ -85,7 +85,7 @@ export function StreakCard() {
         ))}
       </div>
 
-      <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">
+      <p className="mt-4 text-xs text-stone-500 dark:text-stone-400">
         {state.grantedThisMonth
           ? `July is locked in. Longest streak: ${state.longestStreak} ${pluralize("month", state.longestStreak)}.`
           : "Make a grant this month to keep your streak alive. A recurring grant protects it automatically."}

--- a/src/features/donor-rewards/components/year-recap.tsx
+++ b/src/features/donor-rewards/components/year-recap.tsx
@@ -207,7 +207,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
       },
       {
         id: "card",
-        background: "bg-gradient-to-br from-zinc-800 to-zinc-950",
+        background: "bg-gradient-to-br from-stone-800 to-stone-950",
         content: (
           <>
             <p className="text-lg font-medium text-white/80">Your giving card</p>
@@ -215,7 +215,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
               initial={{ rotateY: 90, opacity: 0 }}
               animate={{ rotateY: 0, opacity: 1 }}
               transition={{ delay: 0.3, type: "spring", stiffness: 120 }}
-              className="mt-4 w-full rounded-3xl bg-gradient-to-br from-emerald-500 to-teal-700 p-6 text-left shadow-2xl"
+              className="mt-4 w-full rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-700 p-6 text-left shadow-2xl"
             >
               <div className="flex items-center justify-between">
                 <span className="text-3xl">🦉</span>
@@ -269,7 +269,7 @@ function RecapStories({ onClose }: { onClose: () => void }) {
   const slide = slides[slideIndex];
 
   return (
-    <div className="relative h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-3xl shadow-2xl">
+    <div className="relative h-[640px] max-h-[85vh] w-full max-w-sm overflow-hidden rounded-2xl shadow-2xl">
       <div className="absolute left-3 right-3 top-3 z-10 flex gap-1.5">
         {slides.map((item, index) => (
           <div key={item.id} className="h-1 flex-1 overflow-hidden rounded-full bg-white/30">

--- a/src/features/donor-rewards/data/mock-data.ts
+++ b/src/features/donor-rewards/data/mock-data.ts
@@ -271,7 +271,10 @@ export const LEAGUE_PEERS: Omit<LeaguePeer, "points" | "isUser">[] = [
 export const INITIAL_STATE: RewardsState = {
   balance: 48200,
   grantedThisYear: 16750,
+  lifetimeGranted: 64500,
+  investmentGains: 3850,
   annualGoal: 25000,
+  personalGoals: { causesTarget: 6, monthsTarget: 12 },
   xp: 2140,
   streakMonths: 4,
   longestStreak: 7,

--- a/src/features/donor-rewards/state/__tests__/rewards-context.test.tsx
+++ b/src/features/donor-rewards/state/__tests__/rewards-context.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for donor-rewards/state/rewards-context.tsx grant accounting.
+ *
+ * These lock in the windfall-first invariant behind the Gains card's promise:
+ * granting your investment gains must never draw down the principal balance.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it } from "vitest";
+import { INITIAL_STATE } from "../../data/mock-data";
+import { RewardsProvider, useRewards } from "../rewards-context";
+
+const ORG_ID = "org-rainforest";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <RewardsProvider>{children}</RewardsProvider>;
+}
+
+describe("rewards grant accounting", () => {
+  it("spends investment gains before principal, keeping the balance whole", () => {
+    const { result } = renderHook(() => useRewards(), { wrapper });
+
+    act(() => result.current.makeGrant(ORG_ID, 500, false));
+
+    // 500 <= 3850 gains, so the whole grant comes from gains and the
+    // "ready to deploy" balance is untouched.
+    expect(result.current.state.balance).toBe(INITIAL_STATE.balance);
+    expect(result.current.state.investmentGains).toBe(INITIAL_STATE.investmentGains - 500);
+    expect(result.current.state.grantedThisYear).toBe(INITIAL_STATE.grantedThisYear + 500);
+    expect(result.current.state.lifetimeGranted).toBe(INITIAL_STATE.lifetimeGranted + 500);
+  });
+
+  it("granting the full gains amount zeroes gains and leaves the balance whole", () => {
+    const { result } = renderHook(() => useRewards(), { wrapper });
+
+    act(() => result.current.makeGrant(ORG_ID, INITIAL_STATE.investmentGains, false));
+
+    expect(result.current.state.investmentGains).toBe(0);
+    expect(result.current.state.balance).toBe(INITIAL_STATE.balance);
+  });
+
+  it("draws principal only for the portion of a grant beyond the remaining gains", () => {
+    const { result } = renderHook(() => useRewards(), { wrapper });
+    const overGains = INITIAL_STATE.investmentGains + 1000;
+
+    act(() => result.current.makeGrant(ORG_ID, overGains, false));
+
+    expect(result.current.state.investmentGains).toBe(0);
+    expect(result.current.state.balance).toBe(INITIAL_STATE.balance - 1000);
+    expect(result.current.state.grantedThisYear).toBe(INITIAL_STATE.grantedThisYear + overGains);
+  });
+});

--- a/src/features/donor-rewards/state/rewards-context.tsx
+++ b/src/features/donor-rewards/state/rewards-context.tsx
@@ -8,13 +8,21 @@ import {
   XP_PER_GRANT,
   XP_RECURRING_BONUS,
 } from "../data/mock-data";
-import type { BadgeDef, CelebrationPayload, Quest, RewardsState } from "../types";
+import type {
+  BadgeDef,
+  CelebrationPayload,
+  PersonalGoalTargets,
+  Quest,
+  RewardsState,
+} from "../types";
 import { levelForXp } from "../utils/levels";
 import { questsCompletedByGrant, questsCompletedByRead } from "./quest-logic";
 
 type RewardsAction =
   | { type: "MAKE_GRANT"; orgId: string; amount: number; recurring: boolean }
   | { type: "READ_UPDATE"; updateId: string }
+  | { type: "SET_ANNUAL_GOAL"; amount: number }
+  | { type: "SET_PERSONAL_GOALS"; targets: Partial<PersonalGoalTargets> }
   | { type: "DISMISS_CELEBRATION" };
 
 function unlockBadge(badges: BadgeDef[], id: string, unlockedList: BadgeDef[]): BadgeDef[] {
@@ -100,6 +108,11 @@ function applyGrant(
     ...state,
     balance: state.balance - action.amount,
     grantedThisYear: state.grantedThisYear + action.amount,
+    lifetimeGranted: state.lifetimeGranted + action.amount,
+    // Windfall-first accounting: grants draw down this year's investment
+    // gains before principal, so the gains card always reflects what is
+    // actually left to "grant out."
+    investmentGains: Math.max(0, state.investmentGains - action.amount),
     xp: newXp,
     streakMonths,
     longestStreak: Math.max(state.longestStreak, streakMonths),
@@ -141,6 +154,10 @@ function rewardsReducer(state: RewardsState, action: RewardsAction): RewardsStat
       return applyGrant(state, action);
     case "READ_UPDATE":
       return applyReadUpdate(state, action.updateId);
+    case "SET_ANNUAL_GOAL":
+      return { ...state, annualGoal: action.amount };
+    case "SET_PERSONAL_GOALS":
+      return { ...state, personalGoals: { ...state.personalGoals, ...action.targets } };
     case "DISMISS_CELEBRATION":
       return { ...state, celebration: null };
     default:
@@ -152,6 +169,8 @@ interface RewardsContextValue {
   state: RewardsState;
   makeGrant: (orgId: string, amount: number, recurring: boolean) => void;
   readUpdate: (updateId: string) => void;
+  setAnnualGoal: (amount: number) => void;
+  setPersonalGoals: (targets: Partial<PersonalGoalTargets>) => void;
   dismissCelebration: () => void;
 }
 
@@ -166,6 +185,8 @@ export function RewardsProvider({ children }: { children: React.ReactNode }) {
       makeGrant: (orgId, amount, recurring) =>
         dispatch({ type: "MAKE_GRANT", orgId, amount, recurring }),
       readUpdate: (updateId) => dispatch({ type: "READ_UPDATE", updateId }),
+      setAnnualGoal: (amount) => dispatch({ type: "SET_ANNUAL_GOAL", amount }),
+      setPersonalGoals: (targets) => dispatch({ type: "SET_PERSONAL_GOALS", targets }),
       dismissCelebration: () => dispatch({ type: "DISMISS_CELEBRATION" }),
     }),
     [state]

--- a/src/features/donor-rewards/state/rewards-context.tsx
+++ b/src/features/donor-rewards/state/rewards-context.tsx
@@ -52,6 +52,14 @@ function applyGrant(
     recurring: action.recurring,
   };
 
+  // Windfall-first accounting with separate pools: a grant spends this year's
+  // investment gains before it ever touches principal. Granting exactly your
+  // gains therefore leaves the "ready to deploy" balance whole — matching the
+  // Gains card's promise — and only a grant larger than the remaining gains
+  // draws principal down.
+  const gainsApplied = Math.min(action.amount, state.investmentGains);
+  const balanceDrawn = action.amount - gainsApplied;
+
   const isNewCause = !state.causesSupported.includes(org.cause);
   const causesSupported = isNewCause
     ? [...state.causesSupported, org.cause]
@@ -106,13 +114,10 @@ function applyGrant(
 
   return {
     ...state,
-    balance: state.balance - action.amount,
+    balance: Math.max(0, state.balance - balanceDrawn),
     grantedThisYear: state.grantedThisYear + action.amount,
     lifetimeGranted: state.lifetimeGranted + action.amount,
-    // Windfall-first accounting: grants draw down this year's investment
-    // gains before principal, so the gains card always reflects what is
-    // actually left to "grant out."
-    investmentGains: Math.max(0, state.investmentGains - action.amount),
+    investmentGains: state.investmentGains - gainsApplied,
     xp: newXp,
     streakMonths,
     longestStreak: Math.max(state.longestStreak, streakMonths),

--- a/src/features/donor-rewards/types.ts
+++ b/src/features/donor-rewards/types.ts
@@ -85,10 +85,22 @@ export interface CelebrationPayload {
   newStreak: number | null;
 }
 
+export interface PersonalGoalTargets {
+  /** how many distinct cause areas to support this year */
+  causesTarget: number;
+  /** how many months in a row to give */
+  monthsTarget: number;
+}
+
 export interface RewardsState {
   balance: number;
   grantedThisYear: number;
+  /** cumulative dollars granted since the fund opened */
+  lifetimeGranted: number;
+  /** investment returns earned inside the fund this year */
+  investmentGains: number;
   annualGoal: number;
+  personalGoals: PersonalGoalTargets;
   xp: number;
   streakMonths: number;
   longestStreak: number;


### PR DESCRIPTION
## Summary

Phase 1 of the donor rewards product plan plus two advisor-requested features, built on the merged prototype (#1756). All mock data, no backend calls.

## Features

- **Impact-deployed hero**: header leads with cumulative dollars granted + verified milestones; balance is secondary. Reframes activity as impact generated instead of a shrinking balance (ideas42, Local Giving by Design).
- **Fund horizon**: a payout-rate slider showing how many years the fund lasts at the chosen rate and estimated verified milestones per year. Makes idle-balance pace tangible.
- **Investment gains + Grant it out** (advisor request): surfaces this year's investment returns with one-tap granting. The grant flow opens pre-seeded with the gains amount as a labeled chip. Grants draw down gains first (windfall-first accounting), and the card ends in an "all gains deployed" state so it never shows stale gains.
- **Personal goals** (advisor request): donor-set targets for causes supported and months-in-a-row with live progress bars, plus a plan-to-give editor on the goal ring (annual goal as a share of the fund, anchored on peer norms).
- **Ledger design pass**: palette collapsed from six hues to warm stone surfaces + deep evergreen ink + a single gold accent reserved for earned things (XP, streak, badges, gains). Spectral display face for headline moments, mono for figures, badge medallions, impact feed flattened into a divided list. Light and dark both restyled.

## Compatibility with post-merge fixes

Rebased over the quest-logic refactor, grant-sheet flex layout, z-index, focus, and confetti fixes that landed on the prototype branch before merge. Both sides preserved: the sheet keeps the shared IP math and scrollable-body/fixed-footer structure, the feed keeps pending-quest hints, xpAwarded, and the empty state.

## Pre-flight against CI gates

- Quality gate: pinned react-doctor 0.2.2 run locally: errors 63 (= baseline), warnings 3286 (baseline 3295), zero new findings from this diff
- Biome and tsc clean
- Anti-pattern checklist: no empty catches, no hardcoded colors/routes, suppression comments intact
- Manual QA of every new flow in the browser, light and dark: gains grant end to end (chip pre-selected, celebration, card flips to deployed), goal editing, target editing, slider math, and the existing streak/quest/badge/league/recap loops after the redesign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new donor rewards views for fund horizon estimates, personal goals editing, and gains deployment.
  * Grant flow can now start with a preselected amount, including a “your gains” option when available.
  * Users can now adjust annual goals and personal targets directly from the rewards experience.

* **Bug Fixes**
  * Donation and reward totals now update more consistently after granting funds.

* **Style**
  * Refreshed the donor rewards interface with updated spacing, rounded corners, typography, and a warmer stone/amber visual theme across cards and overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->