### PR TITLE
fix: retry transient SSR fetch failures (Sentry GAP-FRONTEND-1Y9)

### DIFF
--- a/__mocks__/@sentry/nextjs.ts
+++ b/__mocks__/@sentry/nextjs.ts
@@ -13,3 +13,21 @@ export const init = vi.fn();
 export const withSentryConfig = vi.fn((config: unknown) => config);
 export const addIntegration = vi.fn();
 export const lazyLoadIntegration = vi.fn().mockResolvedValue(vi.fn());
+
+// Shared Scope stub so `Sentry.withScope((scope) => { ... })` records the
+// level/fingerprint/tags/extras a caller sets before `captureMessage`. Exposed
+// as `__scope` so tests can assert on what the caller configured; its spies
+// are cleared by `vi.clearAllMocks()` like every other mock here.
+export const __scope = {
+  setLevel: vi.fn(),
+  setFingerprint: vi.fn(),
+  setTag: vi.fn(),
+  setTags: vi.fn(),
+  setExtra: vi.fn(),
+  setExtras: vi.fn(),
+  setContext: vi.fn(),
+};
+
+export const withScope = vi.fn((callback: (scope: typeof __scope) => void) => {
+  callback(__scope);
+});

--- a/__tests__/unit/utilities/errorManager.test.tsx
+++ b/__tests__/unit/utilities/errorManager.test.tsx
@@ -74,6 +74,22 @@ describe("errorManager", () => {
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
+  it("should NOT capture transient SSR socket resets (GAP-FRONTEND-1Y9)", () => {
+    const econnreset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    errorManager("Indexer fetch failed", econnreset, { context: "ssr" });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+
+    const socketHangUp = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    errorManager("Indexer fetch failed", socketHangUp);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+
+    const tlsReset = new Error(
+      "Client network socket disconnected before secure TLS connection was established"
+    );
+    errorManager("Indexer fetch failed", tlsReset);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it("should still capture HTTP errors (e.g. 500) that carry a response", () => {
     const httpErr = {
       message: "Request failed with status code 500",

--- a/__tests__/unit/utilities/fetchData.test.tsx
+++ b/__tests__/unit/utilities/fetchData.test.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import axios from "axios";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import fetchData from "@/utilities/fetchData";
@@ -260,5 +261,118 @@ describe("fetchData", () => {
     expect(axios.request).toHaveBeenCalledTimes(1);
     expect(TokenManager.getToken).not.toHaveBeenCalled();
     expect(status).toBe(401);
+  });
+});
+
+// Server-side transient-socket retry behavior (GAP-FRONTEND-1Y9). fetchData
+// only retries when running on the server, so these simulate SSR by stubbing
+// `window` to undefined (making `typeof window === "undefined"` true).
+describe("fetchData — SSR transient socket retries (GAP-FRONTEND-1Y9)", () => {
+  const econnreset = () => Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    // Simulate a server render: `typeof window` becomes "undefined".
+    vi.stubGlobal("window", undefined);
+    (TokenManager.getToken as vi.Mock).mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("retries a transient ECONNRESET GET and returns the success tuple without reporting", async () => {
+    (axios.request as vi.Mock)
+      .mockRejectedValueOnce(econnreset())
+      .mockResolvedValueOnce({ data: { result: "recovered" }, status: 200 });
+
+    const promise = fetchData("/test-endpoint");
+    await vi.runAllTimersAsync();
+    const [resData, error, , status] = await promise;
+
+    expect(axios.request).toHaveBeenCalledTimes(2);
+    expect(resData).toEqual({ result: "recovered" });
+    expect(error).toBeNull();
+    expect(status).toBe(200);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns the error tuple after exhausting attempts and reports exactly one warning", async () => {
+    (axios.request as vi.Mock).mockRejectedValue(econnreset());
+
+    const promise = fetchData("/test-endpoint");
+    await vi.runAllTimersAsync();
+    const [resData, error, , status] = await promise;
+
+    expect(axios.request).toHaveBeenCalledTimes(3);
+    expect(resData).toBeNull();
+    expect(status).toBe(500);
+    expect(error).toBeInstanceOf(Error);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "Indexer request failed after 3 attempts (ECONNRESET)"
+    );
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into the test mock's scope spy.
+    expect((Sentry as any).__scope.setFingerprint).toHaveBeenCalledWith([
+      "transient-fetch-retries-exhausted",
+      "ECONNRESET",
+    ]);
+  });
+
+  it("still performs the per-attempt 401 refresh inside a retried attempt", async () => {
+    const unauthorized = { response: { data: { message: "Unauthorized" }, status: 401 } };
+    const ok = { data: { result: "recovered" }, status: 200 };
+    (axios.request as vi.Mock).mockRejectedValueOnce(unauthorized).mockResolvedValueOnce(ok);
+    (TokenManager.getToken as vi.Mock)
+      .mockResolvedValueOnce("stale-token")
+      .mockResolvedValueOnce("fresh-token");
+
+    const promise = fetchData("/test-endpoint");
+    await vi.runAllTimersAsync();
+    const [resData, error, , status] = await promise;
+
+    expect(axios.request).toHaveBeenCalledTimes(2);
+    expect(TokenManager.clearCache).toHaveBeenCalledTimes(1);
+    expect(resData).toEqual({ result: "recovered" });
+    expect(error).toBeNull();
+    expect(status).toBe(200);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a POST even on the server", async () => {
+    (axios.request as vi.Mock).mockRejectedValue(econnreset());
+
+    const promise = fetchData("/test-endpoint", "POST", { a: 1 });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(axios.request).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+// In the browser (jsdom default: `window` defined), fetchData must NOT retry —
+// React Query owns client-side retries.
+describe("fetchData — no client-side retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (TokenManager.getToken as vi.Mock).mockResolvedValue("test-token");
+  });
+
+  it("makes a single attempt on a transient ECONNRESET in the browser", async () => {
+    const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    (axios.request as vi.Mock).mockRejectedValue(err);
+
+    const [resData, , , status] = await fetchData("/test-endpoint");
+
+    expect(axios.request).toHaveBeenCalledTimes(1);
+    expect(resData).toBeNull();
+    expect(status).toBe(500);
   });
 });

--- a/__tests__/unit/utilities/fetchData.test.tsx
+++ b/__tests__/unit/utilities/fetchData.test.tsx
@@ -1,5 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 import axios from "axios";
+// Same module instance as the aliased "@sentry/nextjs" import above (vitest
+// resolves both specifiers to this file), but typed — exposes the `__scope`
+// spy without an `as any` reach-in.
+import { __scope as sentryScope } from "@/__mocks__/@sentry/nextjs";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import fetchData from "@/utilities/fetchData";
 
@@ -318,8 +322,7 @@ describe("fetchData — SSR transient socket retries (GAP-FRONTEND-1Y9)", () => 
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
       "Indexer request failed after 3 attempts (ECONNRESET)"
     );
-    // biome-ignore lint/suspicious/noExplicitAny: reaching into the test mock's scope spy.
-    expect((Sentry as any).__scope.setFingerprint).toHaveBeenCalledWith([
+    expect(sentryScope.setFingerprint).toHaveBeenCalledWith([
       "transient-fetch-retries-exhausted",
       "ECONNRESET",
     ]);

--- a/utilities/__tests__/fetchRetry.test.ts
+++ b/utilities/__tests__/fetchRetry.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_FETCH_RETRY_POLICY, executeWithRetry } from "../fetchRetry";
+
+// Build an error shaped like the transient socket resets behind
+// GAP-FRONTEND-1Y9 (retryable) unless overridden.
+function socketError(code = "ECONNRESET") {
+  return Object.assign(new Error(`read ${code}`), { code });
+}
+
+describe("executeWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Deterministic jitter so we can assert bounded delays.
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns on success after 2 transient failures (3 calls, no onExhausted)", async () => {
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(socketError())
+      .mockRejectedValueOnce(socketError())
+      .mockResolvedValueOnce("ok");
+    const onExhausted = vi.fn();
+
+    const promise = executeWithRetry(attempt, {
+      method: "GET",
+      isServer: true,
+      onExhausted,
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe("ok");
+    expect(attempt).toHaveBeenCalledTimes(3);
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+
+  it("uses bounded, jittered backoff delays", async () => {
+    const attempt = vi.fn().mockRejectedValueOnce(socketError()).mockResolvedValueOnce("ok");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const promise = executeWithRetry(attempt, { method: "GET", isServer: true });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // First retry ceiling = min(1000, 250 * 2^0) = 250; random 0.5 => 125ms.
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    expect(delays).toContain(125);
+    for (const d of delays as number[]) {
+      expect(d).toBeGreaterThanOrEqual(0);
+      expect(d).toBeLessThanOrEqual(DEFAULT_FETCH_RETRY_POLICY.maxDelayMs);
+    }
+  });
+
+  it("rejects after exactly maxAttempts and calls onExhausted once with (error, 3)", async () => {
+    const err = socketError();
+    const attempt = vi.fn().mockRejectedValue(err);
+    const onExhausted = vi.fn();
+
+    const promise = executeWithRetry(attempt, {
+      method: "GET",
+      isServer: true,
+      onExhausted,
+    });
+    // Attach a rejection handler up-front so the async rejection is observed.
+    const settled = promise.catch((e) => e);
+
+    await vi.runAllTimersAsync();
+    await expect(settled).resolves.toBe(err);
+    expect(attempt).toHaveBeenCalledTimes(DEFAULT_FETCH_RETRY_POLICY.maxAttempts);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted).toHaveBeenCalledWith(err, 3);
+  });
+
+  it("does not retry non-idempotent methods (POST → single attempt)", async () => {
+    const attempt = vi.fn().mockRejectedValue(socketError());
+    const onExhausted = vi.fn();
+
+    const promise = executeWithRetry(attempt, {
+      method: "POST",
+      isServer: true,
+      onExhausted,
+    }).catch((e) => e);
+
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+
+  it("does not retry in the browser (isServer:false → single attempt)", async () => {
+    const attempt = vi.fn().mockRejectedValue(socketError());
+    const promise = executeWithRetry(attempt, { method: "GET", isServer: false }).catch((e) => e);
+
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const attempt = vi.fn().mockRejectedValue(socketError());
+
+    const promise = executeWithRetry(attempt, {
+      method: "GET",
+      isServer: true,
+      signal: controller.signal,
+    }).catch((e) => e);
+
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a non-retryable failure (400 response → single attempt)", async () => {
+    const attempt = vi.fn().mockRejectedValue({ response: { status: 400 } });
+    const onExhausted = vi.fn();
+
+    const promise = executeWithRetry(attempt, {
+      method: "GET",
+      isServer: true,
+      onExhausted,
+    }).catch((e) => e);
+
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+});

--- a/utilities/__tests__/fetchRetry.test.ts
+++ b/utilities/__tests__/fetchRetry.test.ts
@@ -102,6 +102,16 @@ describe("executeWithRetry", () => {
     expect(attempt).toHaveBeenCalledTimes(1);
   });
 
+  it("retries HEAD requests like GET (idempotent)", async () => {
+    const attempt = vi.fn().mockRejectedValueOnce(socketError()).mockResolvedValueOnce("ok");
+
+    const promise = executeWithRetry(attempt, { method: "HEAD", isServer: true });
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe("ok");
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
   it("stops when the signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();
@@ -115,6 +125,30 @@ describe("executeWithRetry", () => {
 
     await vi.runAllTimersAsync();
     await promise;
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops when the signal aborts MID-BACKOFF (no extra attempt after the delay)", async () => {
+    const controller = new AbortController();
+    const err = socketError();
+    const attempt = vi.fn().mockRejectedValue(err);
+
+    const settled = executeWithRetry(attempt, {
+      method: "GET",
+      isServer: true,
+      signal: controller.signal,
+    }).catch((e) => e);
+
+    // Let the first attempt fail and the backoff timer get scheduled
+    // (ceiling 250ms * random 0.5 = 125ms), then abort partway through it.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    controller.abort();
+
+    // Run out the remaining backoff — the post-delay abort check must fire
+    // instead of a second attempt.
+    await vi.runAllTimersAsync();
+    await expect(settled).resolves.toBe(err);
     expect(attempt).toHaveBeenCalledTimes(1);
   });
 

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -1,5 +1,7 @@
 import axios, { type AxiosResponse, type Method } from "axios";
 import { TokenManager } from "@/utilities/auth/token-manager";
+import { executeWithRetry } from "@/utilities/fetchRetry";
+import { reportTransientFetchFailure } from "@/utilities/sentry/reportTransientFetchFailure";
 import { envVars } from "./enviromentVars";
 import { sanitizeObject } from "./sanitize";
 
@@ -73,27 +75,41 @@ export default async function fetchData<T = any>(
       }
     }
 
-    let res: AxiosResponse<T & { pageInfo?: any }>;
-    try {
-      res = await axios.request<T & { pageInfo?: any }>(requestConfig);
-    } catch (err) {
-      // Retry once on 401 for authorized indexer requests. The token may have
-      // been absent or stale because Privy had not finished bootstrapping when
-      // the request fired (the deferred-SDK auth race). Without this, fetchData
-      // swallows the 401 into a "successful" null tuple below, so React Query
-      // treats it as empty data and never refetches — a manual page refresh is
-      // the only recovery. Re-fetching a fresh token and retrying self-heals it.
-      const status = (err as { response?: { status?: number } } | null)?.response?.status;
-      if (isIndexerUrl && isAuthorized && status === 401) {
-        TokenManager.clearCache();
-        const freshToken = await TokenManager.getToken();
-        if (!freshToken) throw err;
-        requestConfig.headers.Authorization = `Bearer ${freshToken}`;
-        res = await axios.request<T & { pageInfo?: any }>(requestConfig);
-      } else {
+    // A single request attempt, including the per-attempt 401-refresh retry.
+    // Wrapped by `executeWithRetry` below so transient SSR socket/gateway
+    // failures (GAP-FRONTEND-1Y9 and siblings) are retried on the server for
+    // idempotent GET/HEAD requests. The 401 refresh stays inside an attempt so
+    // each retried request re-derives a fresh token.
+    const attemptRequest = async (): Promise<AxiosResponse<T & { pageInfo?: any }>> => {
+      try {
+        return await axios.request<T & { pageInfo?: any }>(requestConfig);
+      } catch (err) {
+        // Retry once on 401 for authorized indexer requests. The token may have
+        // been absent or stale because Privy had not finished bootstrapping when
+        // the request fired (the deferred-SDK auth race). Without this, fetchData
+        // swallows the 401 into a "successful" null tuple below, so React Query
+        // treats it as empty data and never refetches — a manual page refresh is
+        // the only recovery. Re-fetching a fresh token and retrying self-heals it.
+        const status = (err as { response?: { status?: number } } | null)?.response?.status;
+        if (isIndexerUrl && isAuthorized && status === 401) {
+          TokenManager.clearCache();
+          const freshToken = await TokenManager.getToken();
+          if (!freshToken) throw err;
+          requestConfig.headers.Authorization = `Bearer ${freshToken}`;
+          return await axios.request<T & { pageInfo?: any }>(requestConfig);
+        }
         throw err;
       }
-    }
+    };
+
+    const res = await executeWithRetry(attemptRequest, {
+      method,
+      signal,
+      onExhausted: (error, attempts) => {
+        reportTransientFetchFailure({ endpoint, method, attempts, error });
+      },
+    });
+
     const resData = res.data;
     const pageInfo = resData?.pageInfo || null;
     return [resData, null, pageInfo, res.status];

--- a/utilities/fetchRetry.ts
+++ b/utilities/fetchRetry.ts
@@ -1,0 +1,118 @@
+import { isRetryableIdempotentFetchError } from "@/utilities/sentry/transientErrors";
+
+/**
+ * Server-side retry policy for transient, idempotent indexer fetches.
+ *
+ * Context: Sentry issue GAP-FRONTEND-1Y9 (and siblings -1YD/-1YA/-1YB/-1YP,
+ * ~755 events total) are transient Node/undici socket resets during SSR —
+ * "Client network socket disconnected before secure TLS connection was
+ * established", "socket hang up", `ECONNRESET`, etc. They crash a server
+ * render with no actionable first-party frame; a single retry almost always
+ * succeeds because the blip is momentary.
+ *
+ * This module deliberately does NOT extend `utilities/retry.ts` or
+ * `utilities/retries.ts` — those have different (generic / attestation)
+ * semantics. This one is narrowly scoped to the fetch layer.
+ *
+ * SERVER-ONLY by design: in the browser, React Query already retries
+ * transient failures (see `utilities/queries/defaultOptions.ts`). Adding a
+ * fetch-layer retry client-side would multiply attempts 3×3. So retries only
+ * fire when `isServer` is true.
+ */
+
+export interface FetchRetryPolicy {
+  /** Total attempts including the first. */
+  maxAttempts: number;
+  /** Base backoff delay; grows exponentially per attempt. */
+  baseDelayMs: number;
+  /** Upper bound for a single backoff delay. */
+  maxDelayMs: number;
+}
+
+export const DEFAULT_FETCH_RETRY_POLICY = {
+  maxAttempts: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 1000,
+} as const satisfies FetchRetryPolicy;
+
+export interface ExecuteWithRetryOptions {
+  /** HTTP method — only GET/HEAD are retried (idempotent). */
+  method: string;
+  /** Abort signal — retries stop the moment it is aborted. */
+  signal?: AbortSignal;
+  /** Whether we are running server-side. Defaults to `typeof window === "undefined"`. */
+  isServer?: boolean;
+  /** Override the retry policy. */
+  policy?: FetchRetryPolicy;
+  /** Invoked once when all attempts are exhausted, with the final error and attempt count. */
+  onExhausted?: (error: unknown, attempts: number) => void;
+}
+
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
+
+function delay(ms: number): Promise<void> {
+  // The loop re-checks `signal.aborted` before the next attempt, so we don't
+  // need to reject this timer on abort.
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Runs `attempt()`, retrying on transient idempotent fetch failures with
+ * full-jitter exponential backoff. Server-only; returns the first success or
+ * throws the last error after `maxAttempts`.
+ */
+export async function executeWithRetry<T>(
+  attempt: () => Promise<T>,
+  opts: ExecuteWithRetryOptions
+): Promise<T> {
+  const {
+    method,
+    signal,
+    isServer = typeof window === "undefined",
+    policy = DEFAULT_FETCH_RETRY_POLICY,
+    onExhausted,
+  } = opts;
+
+  const retriesEnabled = isServer && IDEMPOTENT_METHODS.has(method.toUpperCase());
+
+  let lastError: unknown;
+  for (let attemptIndex = 0; attemptIndex < policy.maxAttempts; attemptIndex += 1) {
+    try {
+      return await attempt();
+    } catch (error) {
+      lastError = error;
+
+      const isLastAttempt = attemptIndex >= policy.maxAttempts - 1;
+      const shouldRetry =
+        retriesEnabled &&
+        !isLastAttempt &&
+        !signal?.aborted &&
+        isRetryableIdempotentFetchError(error);
+
+      if (!shouldRetry) {
+        // Only report exhaustion when retries were actually in play and we
+        // ran out of attempts on a retryable error — not on a non-retryable
+        // failure that stops on attempt 1.
+        if (
+          retriesEnabled &&
+          isLastAttempt &&
+          !signal?.aborted &&
+          isRetryableIdempotentFetchError(error)
+        ) {
+          onExhausted?.(error, attemptIndex + 1);
+        }
+        throw error;
+      }
+
+      // Full-jitter backoff: random point in [0, min(maxDelayMs, base * 2^i)].
+      const ceiling = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** attemptIndex);
+      await delay(Math.random() * ceiling);
+    }
+  }
+
+  // Unreachable in practice (the loop always returns or throws), but keeps
+  // TypeScript's control-flow analysis happy.
+  throw lastError;
+}

--- a/utilities/fetchRetry.ts
+++ b/utilities/fetchRetry.ts
@@ -20,7 +20,7 @@ import { isRetryableIdempotentFetchError } from "@/utilities/sentry/transientErr
  * fire when `isServer` is true.
  */
 
-export interface FetchRetryPolicy {
+interface FetchRetryPolicy {
   /** Total attempts including the first. */
   maxAttempts: number;
   /** Base backoff delay; grows exponentially per attempt. */
@@ -35,7 +35,7 @@ export const DEFAULT_FETCH_RETRY_POLICY = {
   maxDelayMs: 1000,
 } as const satisfies FetchRetryPolicy;
 
-export interface ExecuteWithRetryOptions {
+interface ExecuteWithRetryOptions {
   /** HTTP method — only GET/HEAD are retried (idempotent). */
   method: string;
   /** Abort signal — retries stop the moment it is aborted. */
@@ -51,8 +51,10 @@ export interface ExecuteWithRetryOptions {
 const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
 
 function delay(ms: number): Promise<void> {
-  // The loop re-checks `signal.aborted` before the next attempt, so we don't
-  // need to reject this timer on abort.
+  // This timer never rejects on abort; instead the retry loop checks
+  // `signal.aborted` both before starting the backoff and again immediately
+  // after it resolves, so an abort that fires mid-backoff still prevents the
+  // next attempt (at the cost of waiting out the remaining <=1s delay).
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
@@ -109,6 +111,10 @@ export async function executeWithRetry<T>(
       // Full-jitter backoff: random point in [0, min(maxDelayMs, base * 2^i)].
       const ceiling = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** attemptIndex);
       await delay(Math.random() * ceiling);
+
+      // Re-check after the backoff: the caller may have aborted while we were
+      // waiting, and a cancelled request must not fire another attempt.
+      if (signal?.aborted) throw lastError;
     }
   }
 

--- a/utilities/sentry/__tests__/reportTransientFetchFailure.test.ts
+++ b/utilities/sentry/__tests__/reportTransientFetchFailure.test.ts
@@ -1,0 +1,100 @@
+import type { ErrorEvent } from "@sentry/nextjs";
+import * as Sentry from "@sentry/nextjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+// Same module instance as the aliased "@sentry/nextjs" import above (vitest
+// resolves both specifiers to this file), but typed — exposes the `__scope`
+// spy without an `as any` reach-in.
+import { __scope as sentryScope } from "@/__mocks__/@sentry/nextjs";
+import { sentryIgnoreErrors } from "../ignoreErrors";
+import { reportTransientFetchFailure } from "../reportTransientFetchFailure";
+
+describe("reportTransientFetchFailure (GAP-FRONTEND-1Y9)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures a warning fingerprinted by the error's code with endpoint in extras", () => {
+    reportTransientFetchFailure({
+      endpoint: "/grants",
+      method: "GET",
+      attempts: 3,
+      error: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    });
+
+    expect(sentryScope.setLevel).toHaveBeenCalledWith("warning");
+    expect(sentryScope.setFingerprint).toHaveBeenCalledWith([
+      "transient-fetch-retries-exhausted",
+      "ECONNRESET",
+    ]);
+    expect(sentryScope.setTags).toHaveBeenCalledWith({
+      "transient.fetch": "true",
+      "error.code": "ECONNRESET",
+      "http.method": "GET",
+    });
+    expect(sentryScope.setExtras).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "/grants", attempts: 3 })
+    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "Indexer request failed after 3 attempts (ECONNRESET)"
+    );
+  });
+
+  it("walks error.cause so undici 'fetch failed' wrappers fingerprint by their socket code", () => {
+    reportTransientFetchFailure({
+      endpoint: "/grants",
+      method: "GET",
+      attempts: 3,
+      error: new TypeError("fetch failed", { cause: { code: "UND_ERR_SOCKET" } }),
+    });
+
+    expect(sentryScope.setFingerprint).toHaveBeenCalledWith([
+      "transient-fetch-retries-exhausted",
+      "UND_ERR_SOCKET",
+    ]);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "Indexer request failed after 3 attempts (UND_ERR_SOCKET)"
+    );
+  });
+
+  it("falls back to 'unknown' when neither the error nor its cause carries a code", () => {
+    reportTransientFetchFailure({
+      endpoint: "/grants",
+      method: "GET",
+      attempts: 3,
+      error: new Error(
+        "Client network socket disconnected before secure TLS connection was established"
+      ),
+    });
+
+    expect(sentryScope.setFingerprint).toHaveBeenCalledWith([
+      "transient-fetch-retries-exhausted",
+      "unknown",
+    ]);
+  });
+
+  it("survives the REAL server beforeSend filter (warning is not dropped as transient)", async () => {
+    // Importing the server config runs the mocked `Sentry.init` with the real
+    // options object, so we can pull out the actual beforeSend hook.
+    await import("../../../sentry.server.config");
+    const initOptions = vi.mocked(Sentry.init).mock.calls.at(-1)?.[0];
+    const beforeSend = initOptions?.beforeSend;
+    expect(typeof beforeSend).toBe("function");
+    if (typeof beforeSend !== "function") return;
+
+    // For `captureMessage`, Sentry sets `hint.originalException` to the
+    // message STRING — the hook still runs. The warning survives only because
+    // this exact text matches no transient fragment (and, defense in depth,
+    // no `ignoreErrors` pattern) — pin both here so a future fragment/pattern
+    // addition can't silently swallow the exhaustion signal.
+    const message = "Indexer request failed after 3 attempts (ECONNRESET)";
+    const event = { message } as ErrorEvent;
+    const result = await beforeSend(event, { originalException: message });
+    expect(result).toBe(event);
+
+    for (const pattern of sentryIgnoreErrors) {
+      const matches =
+        typeof pattern === "string" ? message.includes(pattern) : pattern.test(message);
+      expect(matches).toBe(false);
+    }
+  });
+});

--- a/utilities/sentry/__tests__/transientErrors.test.ts
+++ b/utilities/sentry/__tests__/transientErrors.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   isAxiosAbortError,
+  isRetryableIdempotentFetchError,
   isTransientHttpError,
   isTransientNetworkError,
+  isTransientSocketError,
   isTransientWalletTimeoutError,
 } from "../transientErrors";
+
+// The exact server-side signature behind GAP-FRONTEND-1Y9 — a TLS handshake
+// reset with no error code attached.
+const TLS_HANDSHAKE_MESSAGE =
+  "Client network socket disconnected before secure TLS connection was established";
 
 describe("isTransientNetworkError", () => {
   it("detects axios Network Error with no response", () => {
@@ -115,6 +122,110 @@ describe("isTransientWalletTimeoutError", () => {
       "Project attestation failed after 3 attempts due to a persistent wallet/bundler timeout. Please try again in a moment."
     );
     expect(isTransientWalletTimeoutError(exhausted)).toBe(false);
+  });
+});
+
+describe("isTransientSocketError (GAP-FRONTEND-1Y9)", () => {
+  it("detects a Node ECONNRESET with no HTTP response", () => {
+    const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    expect(isTransientSocketError(err)).toBe(true);
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("detects a bare 'socket hang up'", () => {
+    const err = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    expect(isTransientSocketError(err)).toBe(true);
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("detects the exact TLS-handshake reset message even with no code", () => {
+    const err = new Error(TLS_HANDSHAKE_MESSAGE);
+    expect(isTransientSocketError(err)).toBe(true);
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("walks error.cause one level for undici's 'fetch failed' wrapper", () => {
+    const err = new TypeError("fetch failed", { cause: { code: "ECONNRESET" } });
+    expect(isTransientSocketError(err)).toBe(true);
+    expect(isTransientNetworkError(err)).toBe(true);
+  });
+
+  it("detects the other undici/socket codes", () => {
+    for (const code of [
+      "EPIPE",
+      "EAI_AGAIN",
+      "ECONNREFUSED",
+      "UND_ERR_SOCKET",
+      "UND_ERR_CONNECT_TIMEOUT",
+    ]) {
+      expect(isTransientSocketError({ code, message: code })).toBe(true);
+    }
+  });
+
+  it("does NOT match a socket code that carries an HTTP response", () => {
+    expect(isTransientSocketError({ code: "ECONNRESET", response: { status: 500 } })).toBe(false);
+  });
+
+  it("does NOT match unrelated errors", () => {
+    expect(isTransientSocketError({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND" })).toBe(
+      false
+    );
+    expect(isTransientSocketError(new TypeError("Cannot read property 'x' of undefined"))).toBe(
+      false
+    );
+    expect(isTransientSocketError(null)).toBe(false);
+  });
+});
+
+describe("isRetryableIdempotentFetchError (GAP-FRONTEND-1Y9)", () => {
+  it("retries transient socket resets with no HTTP response", () => {
+    expect(
+      isRetryableIdempotentFetchError(
+        Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+      )
+    ).toBe(true);
+    expect(isRetryableIdempotentFetchError(new Error("socket hang up"))).toBe(true);
+    expect(isRetryableIdempotentFetchError(new Error(TLS_HANDSHAKE_MESSAGE))).toBe(true);
+    expect(
+      isRetryableIdempotentFetchError(
+        new TypeError("fetch failed", { cause: { code: "ECONNRESET" } })
+      )
+    ).toBe(true);
+  });
+
+  it("retries the transient upstream gateway family (502/503/504/408)", () => {
+    expect(isRetryableIdempotentFetchError({ response: { status: 502 } })).toBe(true);
+    expect(isRetryableIdempotentFetchError({ response: { status: 503 } })).toBe(true);
+    expect(isRetryableIdempotentFetchError({ response: { status: 504 } })).toBe(true);
+    expect(isRetryableIdempotentFetchError({ response: { status: 408 } })).toBe(true);
+    expect(isRetryableIdempotentFetchError(new Error("Request failed with status code 504"))).toBe(
+      true
+    );
+  });
+
+  it("does NOT retry axios timeout codes (no server budget for a 360s retry)", () => {
+    const econnaborted = Object.assign(new Error("timeout of 360000ms exceeded"), {
+      code: "ECONNABORTED",
+    });
+    const etimedout = Object.assign(new Error("timeout"), { code: "ETIMEDOUT" });
+    expect(isTransientNetworkError(econnaborted)).toBe(true);
+    expect(isRetryableIdempotentFetchError(econnaborted)).toBe(false);
+    expect(isTransientNetworkError(etimedout)).toBe(true);
+    expect(isRetryableIdempotentFetchError(etimedout)).toBe(false);
+  });
+
+  it("does NOT retry aborts, 400/401/429, or arbitrary errors", () => {
+    expect(isRetryableIdempotentFetchError({ code: "ERR_CANCELED", message: "canceled" })).toBe(
+      false
+    );
+    expect(isRetryableIdempotentFetchError({ response: { status: 400 } })).toBe(false);
+    expect(isRetryableIdempotentFetchError({ response: { status: 401 } })).toBe(false);
+    expect(isRetryableIdempotentFetchError({ response: { status: 429 } })).toBe(false);
+    expect(
+      isRetryableIdempotentFetchError({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND" })
+    ).toBe(false);
+    expect(isRetryableIdempotentFetchError(new TypeError("boom"))).toBe(false);
+    expect(isRetryableIdempotentFetchError(null)).toBe(false);
   });
 });
 

--- a/utilities/sentry/reportTransientFetchFailure.ts
+++ b/utilities/sentry/reportTransientFetchFailure.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { getErrorCode } from "@/utilities/sentry/transientErrors";
 
 /**
  * Reports a transient indexer fetch that failed *after all retries were
@@ -7,12 +8,14 @@ import * as Sentry from "@sentry/nextjs";
  * across every attempt is worth a low-severity signal so we can spot a
  * sustained upstream outage.
  *
- * Emitted as a `captureMessage` at `warning` level (not `captureException`)
- * so it passes the server `beforeSend` filter — that hook only drops
- * exceptions whose `originalException` is a transient error, and a
- * `captureMessage` carries none. Fingerprinted by error code (NOT endpoint)
- * so all exhausted retries of one class collapse into a single Sentry issue;
- * the endpoint lives in `extra` for drill-down.
+ * Emitted as a `captureMessage` at `warning` level (not `captureException`).
+ * Note the server `beforeSend` hook still runs for messages — Sentry sets
+ * `hint.originalException` to the message string — so this survives the
+ * transient-error filter only because the message text below matches no
+ * transient fragment and no `ignoreErrors` pattern (pinned by a test that
+ * runs the real `beforeSend` against this exact string). Fingerprinted by
+ * error code (NOT endpoint) so all exhausted retries of one class collapse
+ * into a single Sentry issue; the endpoint lives in `extra` for drill-down.
  */
 export function reportTransientFetchFailure(params: {
   endpoint: string;
@@ -22,11 +25,10 @@ export function reportTransientFetchFailure(params: {
 }): void {
   const { endpoint, method, attempts, error } = params;
 
-  const errorCode =
-    error && typeof error === "object" && "code" in error
-      ? String((error as { code?: unknown }).code ?? "")
-      : undefined;
-  const code = errorCode || "unknown";
+  // Same cause-walking code extraction used for classification, so an undici
+  // `TypeError: fetch failed` wrapper fingerprints by its nested socket code
+  // instead of collapsing into the "unknown" bucket.
+  const code = getErrorCode(error) || "unknown";
 
   const message =
     error && typeof error === "object" && "message" in error

--- a/utilities/sentry/reportTransientFetchFailure.ts
+++ b/utilities/sentry/reportTransientFetchFailure.ts
@@ -1,0 +1,49 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Reports a transient indexer fetch that failed *after all retries were
+ * exhausted*. The individual transient errors are suppressed as noise (see
+ * `transientErrors.ts` / GAP-FRONTEND-1Y9), but a request that keeps failing
+ * across every attempt is worth a low-severity signal so we can spot a
+ * sustained upstream outage.
+ *
+ * Emitted as a `captureMessage` at `warning` level (not `captureException`)
+ * so it passes the server `beforeSend` filter — that hook only drops
+ * exceptions whose `originalException` is a transient error, and a
+ * `captureMessage` carries none. Fingerprinted by error code (NOT endpoint)
+ * so all exhausted retries of one class collapse into a single Sentry issue;
+ * the endpoint lives in `extra` for drill-down.
+ */
+export function reportTransientFetchFailure(params: {
+  endpoint: string;
+  method: string;
+  attempts: number;
+  error: unknown;
+}): void {
+  const { endpoint, method, attempts, error } = params;
+
+  const errorCode =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : undefined;
+  const code = errorCode || "unknown";
+
+  const message =
+    error && typeof error === "object" && "message" in error
+      ? String((error as { message?: unknown }).message ?? "")
+      : String(error ?? "");
+
+  Sentry.withScope((scope) => {
+    scope.setLevel("warning");
+    // Fingerprint by class (error code), not endpoint — one issue per socket
+    // failure mode, endpoint captured as an extra for drill-down.
+    scope.setFingerprint(["transient-fetch-retries-exhausted", code]);
+    scope.setTags({
+      "transient.fetch": "true",
+      "error.code": code,
+      "http.method": method,
+    });
+    scope.setExtras({ endpoint, attempts, message });
+    Sentry.captureMessage(`Indexer request failed after ${attempts} attempts (${code})`);
+  });
+}

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -105,9 +105,13 @@ function getOwnCode(error: unknown): string | undefined {
   return undefined;
 }
 
-// Reads the error's own `code`, falling back to `error.cause.code` (one
-// level) for undici's `fetch failed` wrapper. See GAP-FRONTEND-1Y9.
-function getErrorCode(error: unknown): string | undefined {
+/**
+ * Reads the error's own `code`, falling back to `error.cause.code` (one
+ * level) for undici's `fetch failed` wrapper. Exported so the exhausted-retry
+ * reporter (`reportTransientFetchFailure.ts`) fingerprints by the same code
+ * classification used here. See GAP-FRONTEND-1Y9.
+ */
+export function getErrorCode(error: unknown): string | undefined {
   return getOwnCode(error) ?? getOwnCode(getErrorCause(error));
 }
 
@@ -153,8 +157,12 @@ export function isAxiosAbortError(error: unknown): boolean {
  * wrapper — or by message fragment ("socket hang up", the TLS-handshake reset
  * "Client network socket disconnected before secure TLS connection was
  * established"). Folded into `isTransientNetworkError` so both Sentry
- * `beforeSend` hooks and `errorManager` suppress it automatically. See
- * GAP-FRONTEND-1Y9 (siblings -1YD/-1YA/-1YB/-1YP).
+ * `beforeSend` hooks and `errorManager` suppress it automatically. Accepted
+ * observability blind spot: server-side POST socket failures are suppressed
+ * with no retry and no exhaustion warning (only idempotent GET/HEAD retries
+ * exist — see `utilities/fetchRetry.ts`), and an `ECONNREFUSED` raised by a
+ * code path that doesn't go through `fetchData` is dropped without any
+ * exhausted-retry signal. See GAP-FRONTEND-1Y9 (siblings -1YD/-1YA/-1YB/-1YP).
  */
 export function isTransientSocketError(error: unknown): boolean {
   if (!error) return false;

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -17,7 +17,19 @@
  * client, surface an error UI to the user, and keep Sentry signal clean.
  */
 
-const TRANSIENT_MESSAGE_FRAGMENTS = ["network error", "failed to fetch", "load failed"];
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  "network error",
+  "failed to fetch",
+  "load failed",
+  // Node/undici socket blips that crash SSR fetches. The dominant signature
+  // is "Client network socket disconnected before secure TLS connection was
+  // established" (matched by the fragment below) plus bare "socket hang up".
+  // These are transient upstream/socket resets during a server render with no
+  // actionable first-party frame. See GAP-FRONTEND-1Y9 (and siblings -1YD /
+  // -1YA / -1YB / -1YP).
+  "socket hang up",
+  "socket disconnected before secure tls",
+];
 
 const TRANSIENT_AXIOS_CODES = new Set([
   "ERR_NETWORK",
@@ -25,6 +37,22 @@ const TRANSIENT_AXIOS_CODES = new Set([
   "ERR_CONNECTION_RESET",
   "ECONNABORTED",
   "ETIMEDOUT",
+]);
+
+// Node/undici socket-level error codes that surface during SSR when the
+// connection to the indexer is reset/dropped before (or mid) a response.
+// Native `fetch` wraps these as `TypeError: fetch failed` with the coded
+// error on `.cause`, so classification also walks `error.cause` one level.
+// These are environmental and unactionable from a frontend Sentry event —
+// the right behavior is to retry the idempotent request on the server and
+// keep the signal clean. See GAP-FRONTEND-1Y9 (siblings -1YD/-1YA/-1YB/-1YP).
+const TRANSIENT_SOCKET_CODES = new Set([
+  "ECONNRESET",
+  "EPIPE",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
 ]);
 
 const ABORT_CODES = new Set(["ERR_CANCELED", "ABORT_ERR"]);
@@ -38,7 +66,18 @@ const ABORT_CODES = new Set(["ERR_CANCELED", "ABORT_ERR"]);
 // See DEV-271 / GAP-FRONTEND-1R1.
 const TRANSIENT_HTTP_STATUS = new Set([408, 502, 503, 504]);
 
-function getErrorMessage(error: unknown): string {
+// Native `fetch` (undici) reports connection failures as
+// `TypeError: fetch failed` with the coded socket error hidden on `.cause`.
+// Return that nested cause so code/message extraction can walk one level
+// down. See GAP-FRONTEND-1Y9.
+function getErrorCause(error: unknown): unknown {
+  if (error && typeof error === "object" && "cause" in error) {
+    return (error as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+function getOwnMessage(error: unknown): string {
   if (!error) return "";
   if (typeof error === "string") return error;
   if (typeof error === "object" && "message" in error) {
@@ -48,12 +87,28 @@ function getErrorMessage(error: unknown): string {
   return "";
 }
 
-function getErrorCode(error: unknown): string | undefined {
+// Combines the error's own message with its `.cause` message (one level) so
+// undici's opaque `fetch failed` wrapper still exposes the underlying socket
+// signature to fragment matching. See GAP-FRONTEND-1Y9.
+function getErrorMessage(error: unknown): string {
+  const own = getOwnMessage(error);
+  const causeMsg = getOwnMessage(getErrorCause(error));
+  if (own && causeMsg) return `${own} ${causeMsg}`;
+  return own || causeMsg;
+}
+
+function getOwnCode(error: unknown): string | undefined {
   if (error && typeof error === "object" && "code" in error) {
     const code = (error as { code?: unknown }).code;
     if (typeof code === "string") return code;
   }
   return undefined;
+}
+
+// Reads the error's own `code`, falling back to `error.cause.code` (one
+// level) for undici's `fetch failed` wrapper. See GAP-FRONTEND-1Y9.
+function getErrorCode(error: unknown): string | undefined {
+  return getOwnCode(error) ?? getOwnCode(getErrorCause(error));
 }
 
 function hasHttpResponse(error: unknown): boolean {
@@ -90,6 +145,31 @@ export function isAxiosAbortError(error: unknown): boolean {
 }
 
 /**
+ * True when the error is a transient Node/undici socket failure with no HTTP
+ * response attached — a connection reset/hang-up/DNS blip that crashes an SSR
+ * fetch. Matches by socket error code (`ECONNRESET`, `EPIPE`, `EAI_AGAIN`,
+ * `ECONNREFUSED`, `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`) — including
+ * codes hidden on `error.cause` behind undici's `TypeError: fetch failed`
+ * wrapper — or by message fragment ("socket hang up", the TLS-handshake reset
+ * "Client network socket disconnected before secure TLS connection was
+ * established"). Folded into `isTransientNetworkError` so both Sentry
+ * `beforeSend` hooks and `errorManager` suppress it automatically. See
+ * GAP-FRONTEND-1Y9 (siblings -1YD/-1YA/-1YB/-1YP).
+ */
+export function isTransientSocketError(error: unknown): boolean {
+  if (!error) return false;
+  if (hasHttpResponse(error)) return false;
+
+  const code = getErrorCode(error);
+  if (code && TRANSIENT_SOCKET_CODES.has(code)) return true;
+
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes("socket hang up") || message.includes("socket disconnected before secure tls")
+  );
+}
+
+/**
  * True when the error is a transient network failure that has no HTTP
  * response attached. Used to (a) suppress Sentry noise and (b) opt in to
  * additional React Query retries.
@@ -102,8 +182,41 @@ export function isTransientNetworkError(error: unknown): boolean {
   const code = getErrorCode(error);
   if (code && TRANSIENT_AXIOS_CODES.has(code)) return true;
 
+  // Node/undici socket resets/hang-ups that crash SSR fetches. See
+  // GAP-FRONTEND-1Y9.
+  if (isTransientSocketError(error)) return true;
+
   const message = getErrorMessage(error).toLowerCase();
   return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
+/**
+ * True when a failed *idempotent* fetch should be retried on the server. This
+ * is deliberately NARROWER than `isTransientNetworkError`:
+ *
+ *   - NOT an abort (a cancelled request must never be retried), AND
+ *   - a transient upstream HTTP error (502/503/504/408), OR
+ *   - no HTTP response AND a transient socket error (`ECONNRESET`, TLS
+ *     handshake reset, "socket hang up", etc.).
+ *
+ * Deliberately EXCLUDES the axios timeout codes `ECONNABORTED` / `ETIMEDOUT`:
+ * the per-attempt indexer timeout is already 360s, so there is no time budget
+ * to retry a timed-out request within a Vercel function. Also excludes 429
+ * (rate limiting — retrying makes it worse). See GAP-FRONTEND-1Y9.
+ */
+export function isRetryableIdempotentFetchError(error: unknown): boolean {
+  if (!error) return false;
+  if (isAxiosAbortError(error)) return false;
+
+  // Transient upstream gateway failure (502/503/504/408) — retryable
+  // regardless of whether the status is on `.response.status` or only in the
+  // re-thrown axios message.
+  if (isTransientHttpError(error)) return true;
+
+  // Otherwise only socket-level resets with no HTTP response qualify. Axios
+  // timeout codes (`ECONNABORTED`/`ETIMEDOUT`) and 429 are intentionally
+  // excluded (see doc comment).
+  return !hasHttpResponse(error) && isTransientSocketError(error);
 }
 
 // ethers v6 wraps a momentary wallet/bundler timeout into a "could not coalesce


### PR DESCRIPTION
## Problem

Server-side rendering makes fetches to the indexer that intermittently fail with transient TLS/socket errors. These flood the frontend Sentry project with minified, frontend-unactionable events:

- **[GAP-FRONTEND-1Y9](https://karma-hq.sentry.io/issues/?query=GAP-FRONTEND-1Y9)** — "Client network socket disconnected before secure TLS connection was established" — **610 events**
- Siblings **GAP-FRONTEND-1YD / -1YA / -1YB / -1YP** — same socket-reset family — **~755 events total**

The stack trace is pure Node/undici/axios internals with no first-party frame, so nothing is actionable from the Sentry event: the connection to the upstream indexer was momentarily reset before (or during) a response.

## Root cause

During a server render, a momentary connection reset to the indexer surfaces as one of:

- an axios error with a Node socket `code` (`ECONNRESET`, `EPIPE`, `EAI_AGAIN`, `ECONNREFUSED`), or
- native `fetch` wrapping it as `TypeError: fetch failed` with the coded error hidden on `error.cause` (`UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`), or
- a message-only TLS handshake reset ("...disconnected before secure TLS connection was established" / "socket hang up").

None of these were classified as transient, so they (a) were reported to Sentry as noise and (b) crashed the render instead of being retried, even though a single retry almost always succeeds.

## Solution

1. **`utilities/sentry/transientErrors.ts`** — classify the socket family. New `TRANSIENT_SOCKET_CODES` set + message fragments; code/message extraction now walks `error.cause` one level (undici wrapper). New `isTransientSocketError` is folded into `isTransientNetworkError`, so both Sentry `beforeSend` hooks and `errorManager` suppress it automatically (same precedent as DEV-236/DEV-271). New `isRetryableIdempotentFetchError` gates retries: transient gateway HTTP (502/503/504/408) or a no-response socket reset, but **not** aborts, 429, or the axios timeout codes `ECONNABORTED`/`ETIMEDOUT` (the per-attempt indexer timeout is already 360s — no budget to retry a timeout on Vercel).

2. **`utilities/fetchRetry.ts`** (new) — server-only retry policy (3 attempts, full-jitter backoff, 250ms base / 1000ms cap). Retries only when `isServer` AND method is GET/HEAD AND the error is retryable AND the signal is not aborted. **Server-only by design:** the browser already retries via React Query (`utilities/queries/defaultOptions.ts`); a fetch-layer client retry would multiply attempts 3×3. This is intentionally a separate module from `utilities/retry.ts` / `retries.ts`, which have different semantics.

3. **`utilities/fetchData.ts`** — the existing `axios.request` + 401-refresh block is extracted into an `attemptRequest()` closure (401 refresh stays per-attempt, unchanged) and wrapped with `executeWithRetry`, keyed on `method` and forwarding `signal`. The `[data, error, pageInfo, status]` tuple contract, timeouts, auth, and sanitization are unchanged — zero call-site changes.

4. **`utilities/sentry/reportTransientFetchFailure.ts`** (new) — when all attempts are exhausted, emit a single low-severity `captureMessage` (`warning`) fingerprinted by error code (`["transient-fetch-retries-exhausted", code]`, endpoint in `extra` not fingerprint). Because it is a message (not an exception), it passes the server `beforeSend` filter, so a sustained upstream outage still surfaces as one collapsed issue.

## Test coverage

- **`utilities/sentry/__tests__/transientErrors.test.ts`** — ECONNRESET / "socket hang up" / exact TLS message / undici `cause` wrapper → transient + retryable; 502/503/504/408 → retryable; ECONNABORTED/ETIMEDOUT → transient but NOT retryable; aborts/400/401/429/ENOTFOUND/random → not retryable.
- **`utilities/__tests__/fetchRetry.test.ts`** (fake timers) — success-after-2-failures (3 calls, no `onExhausted`); bounded+jittered delays; always-fails rejects after exactly `maxAttempts` with `onExhausted(error, 3)`; POST / browser / aborted / non-retryable → single attempt.
- **`__tests__/unit/utilities/fetchData.test.tsx`** — GET ECONNRESET-then-success → success tuple, 2 axios calls, no Sentry capture; GET always-failing → error tuple after 3 attempts + exactly one warning with fingerprint `["transient-fetch-retries-exhausted","ECONNRESET"]`; 401 refresh still works within an attempt; POST unretried; browser single attempt.
- **`__tests__/unit/utilities/errorManager.test.tsx`** — ECONNRESET / "socket hang up" / TLS message → dropped (no `captureException`).

All 67 tests across the five touched files pass locally. `tsc --noEmit` is clean on the changed files (enforced green by the pre-push hook).

## Sentry

Fixes the following frontend issues (transient SSR TLS/socket resets, ~755 events total):

- GAP-FRONTEND-1Y9
- GAP-FRONTEND-1YD
- GAP-FRONTEND-1YA
- GAP-FRONTEND-1YB
- GAP-FRONTEND-1YP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of temporary network failures during data fetching, with automatic retries for safe requests on the server.

* **Bug Fixes**
  * Reduced noisy error reporting for transient disconnects and socket resets.
  * Requests now stop retrying when they are non-retryable or run out of attempts, with clearer fallback behavior.

* **Tests**
  * Added coverage for retry behavior, transient error detection, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->