### PR TITLE
fix: payout-config rate-limit fan-out on milestones pages (Sentry GAP-FRONTEND-245)

### DIFF
--- a/__tests__/hooks/useCommunityMilestoneAllocations.test.ts
+++ b/__tests__/hooks/useCommunityMilestoneAllocations.test.ts
@@ -1,9 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGrantAllocationTotalMap,
   buildMilestoneAllocationMap,
   resolveTokenSymbol,
+  useCommunityMilestoneAllocations,
+  useMilestoneAllocationsByGrants,
 } from "@/hooks/useCommunityMilestoneAllocations";
 import type { PayoutGrantConfig } from "@/src/features/payout-disbursement/types/payout-disbursement";
+import type { CommunityMilestoneUpdate } from "@/types/community-updates";
+
+vi.mock("@/src/features/payout-disbursement/services/payout-disbursement.service", () => ({
+  getPayoutConfigByGrantPublic: vi.fn(),
+  getPayoutConfigsByCommunityPublic: vi.fn(),
+}));
+
+import * as payoutService from "@/src/features/payout-disbursement/services/payout-disbursement.service";
+
+const mockGetByGrant = vi.mocked(payoutService.getPayoutConfigByGrantPublic);
+const mockGetByCommunity = vi.mocked(payoutService.getPayoutConfigsByCommunityPublic);
+
+function makeConfig(grantUID: string): PayoutGrantConfig {
+  return {
+    grantUID,
+    milestoneAllocations: [
+      { id: `alloc-${grantUID}`, milestoneUID: `ms-${grantUID}`, label: "M1", amount: "1000" },
+    ],
+  } as PayoutGrantConfig;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Number.POSITIVE_INFINITY } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
 
 describe("resolveTokenSymbol", () => {
   it("should_return_grant_currency_when_provided", () => {
@@ -405,5 +440,127 @@ describe("buildGrantAllocationTotalMap", () => {
 
     expect(result.size).toBe(1);
     expect(result.get("grant-1")).toBe("$5,000");
+  });
+});
+
+describe("usePayoutConfigsForGrants (via public hooks) — request batching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetByGrant.mockImplementation((grantUID: string) => Promise.resolve(makeConfig(grantUID)));
+    mockGetByCommunity.mockImplementation((_communityUID: string) =>
+      Promise.resolve(Array.from({ length: 50 }, (_, i) => makeConfig(`g${i}`)))
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_fetch_once_via_community_endpoint_when_communityUID_provided", async () => {
+    const grantUIDs = Array.from({ length: 50 }, (_, i) => `g${i}`);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useMilestoneAllocationsByGrants(grantUIDs, undefined, { communityUID: "0xComm" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetByCommunity).toHaveBeenCalledTimes(1);
+    expect(mockGetByGrant).not.toHaveBeenCalled();
+    expect(result.current.allocationMap.get("ms-g0")).toBe("$1,000");
+    expect(result.current.allocationMap.size).toBe(50);
+  });
+
+  it("should_dedupe_duplicate_grant_uids_in_per_grant_mode", async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useMilestoneAllocationsByGrants(["g1", "g1", "g2", "g2", "g2"]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetByGrant).toHaveBeenCalledTimes(2);
+    expect(mockGetByCommunity).not.toHaveBeenCalled();
+  });
+
+  it("should_issue_single_community_call_for_two_hooks_sharing_communityUID", async () => {
+    const grantUIDs = Array.from({ length: 50 }, (_, i) => `g${i}`);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => ({
+        a: useMilestoneAllocationsByGrants(grantUIDs, undefined, { communityUID: "0xComm" }),
+        b: useMilestoneAllocationsByGrants(grantUIDs.slice(0, 10), undefined, {
+          communityUID: "0xComm",
+        }),
+      }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.a.isLoading).toBe(false);
+      expect(result.current.b.isLoading).toBe(false);
+    });
+
+    expect(mockGetByCommunity).toHaveBeenCalledTimes(1);
+    expect(mockGetByGrant).not.toHaveBeenCalled();
+    // The second hook filters the shared payload down to its 10 requested grants.
+    expect(result.current.b.allocationMap.size).toBe(10);
+  });
+
+  it("should_fetch_once_per_unique_grant_when_no_communityUID", async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMilestoneAllocationsByGrants(["g0", "g1", "g2"]), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetByGrant).toHaveBeenCalledTimes(3);
+    expect(mockGetByCommunity).not.toHaveBeenCalled();
+  });
+
+  it("should_produce_identical_allocationMap_shape_in_both_fetch_modes", async () => {
+    const grantUIDs = ["g0", "g1", "g2"];
+
+    mockGetByCommunity.mockResolvedValue(grantUIDs.map(makeConfig));
+
+    const perGrant = renderHook(() => useMilestoneAllocationsByGrants(grantUIDs), {
+      wrapper: createWrapper().wrapper,
+    });
+    await waitFor(() => expect(perGrant.result.current.isLoading).toBe(false));
+
+    const community = renderHook(
+      () => useMilestoneAllocationsByGrants(grantUIDs, undefined, { communityUID: "0xComm" }),
+      { wrapper: createWrapper().wrapper }
+    );
+    await waitFor(() => expect(community.result.current.isLoading).toBe(false));
+
+    const perGrantEntries = [...perGrant.result.current.allocationMap.entries()].sort();
+    const communityEntries = [...community.result.current.allocationMap.entries()].sort();
+
+    expect(perGrantEntries).toEqual(communityEntries);
+  });
+
+  it("should_derive_communityUID_from_milestone_payload_for_updates_page", async () => {
+    mockGetByCommunity.mockResolvedValue([makeConfig("g0"), makeConfig("g1")]);
+    const milestones: CommunityMilestoneUpdate[] = [
+      { uid: "u0", communityUID: "0xDerived", grant: { uid: "g0" } } as CommunityMilestoneUpdate,
+      { uid: "u1", communityUID: "0xDerived", grant: { uid: "g1" } } as CommunityMilestoneUpdate,
+    ];
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCommunityMilestoneAllocations(milestones), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetByCommunity).toHaveBeenCalledTimes(1);
+    expect(mockGetByCommunity).toHaveBeenCalledWith("0xDerived");
+    expect(mockGetByGrant).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/integration/services/payout-service.test.ts
+++ b/__tests__/integration/services/payout-service.test.ts
@@ -1,8 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/utilities/fetchData", () => ({
-  default: vi.fn(),
-}));
+vi.mock("@/utilities/fetchData", async () => {
+  // Preserve the real FetchDataError / parseRetryAfterMs named exports so the
+  // service can construct status-carrying errors; only the network calls are
+  // stubbed. fetchDataThrow mirrors the real semantics (throw FetchDataError
+  // on a tuple error) on top of the same stub, so tests keep driving both
+  // code paths through mockFetchData tuple values.
+  const actual =
+    await vi.importActual<typeof import("@/utilities/fetchData")>("@/utilities/fetchData");
+  const fetchDataMock = vi.fn();
+  return {
+    ...actual,
+    default: fetchDataMock,
+    fetchDataThrow: async (...args: unknown[]) => {
+      const [data, error, , status] = await fetchDataMock(...args);
+      if (error !== null && error !== undefined) {
+        throw new actual.FetchDataError(
+          typeof error === "string" ? error : "Request failed",
+          status
+        );
+      }
+      return data;
+    },
+  };
+});
 
 vi.mock("@/utilities/indexer", () => ({
   INDEXER: {

--- a/__tests__/integration/services/react-query-integration.test.ts
+++ b/__tests__/integration/services/react-query-integration.test.ts
@@ -176,21 +176,25 @@ describe("React Query integration trust tests", () => {
     });
   });
 
-  // --- FIXED: 429 no longer retried ---
+  // --- 429 bounded retry (GAP-FRONTEND-245) ---
 
-  describe("FIXED: 429 rate-limited requests are not retried", () => {
-    it("retry is a function that skips 429 errors", () => {
+  describe("429 rate-limited requests use a bounded retry (max 2)", () => {
+    it("retry is a status-aware function, not a static number", () => {
       // Previously retry was set to 1, retrying all errors including 429.
-      // Now it is a function that checks the HTTP status code.
+      // Now it is a function that checks the HTTP status code: 401 never
+      // retried, 429 retried at most twice with capped backoff.
       expect(typeof defaultQueryOptions.retry).toBe("function");
     });
 
-    it("429 error is not retried", async () => {
+    it("429 error is retried exactly twice (3 calls total)", async () => {
       let callCount = 0;
 
       const retryClient = new QueryClient({
         defaultOptions: {
-          queries: defaultQueryOptions,
+          queries: {
+            ...defaultQueryOptions,
+            retryDelay: 0, // no real backoff in tests
+          },
         },
       });
 
@@ -205,11 +209,11 @@ describe("React Query integration trust tests", () => {
           },
         });
       } catch {
-        // Expected to throw
+        // Expected to throw after retries are exhausted
       }
 
-      // With the fix, 429 should NOT be retried -- only 1 call
-      expect(callCount).toBe(1);
+      // Bounded retry: initial call + 2 retries, never unbounded.
+      expect(callCount).toBe(3);
 
       retryClient.clear();
     });

--- a/__tests__/react-query/retry-and-stale-config.test.ts
+++ b/__tests__/react-query/retry-and-stale-config.test.ts
@@ -7,6 +7,7 @@
  */
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FetchDataError } from "@/utilities/fetchData";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 
 describe("defaultQueryOptions — configuration correctness", () => {
@@ -38,8 +39,17 @@ describe("defaultQueryOptions — configuration correctness", () => {
 describe("defaultQueryOptions.retry — error classification", () => {
   const retryFn = defaultQueryOptions.retry as (failureCount: number, error: unknown) => boolean;
 
-  it("does NOT retry 429 rate-limit errors", () => {
-    expect(retryFn(0, { response: { status: 429 } })).toBe(false);
+  it("retries 429 rate-limit errors up to twice", () => {
+    expect(retryFn(0, { response: { status: 429 } })).toBe(true);
+    expect(retryFn(1, { response: { status: 429 } })).toBe(true);
+    expect(retryFn(2, { response: { status: 429 } })).toBe(false);
+  });
+
+  it("retries a FetchDataError(429) up to twice via its status field", () => {
+    const err = new FetchDataError("Rate limit exceeded. Try again later.", 429);
+    expect(retryFn(0, err)).toBe(true);
+    expect(retryFn(1, err)).toBe(true);
+    expect(retryFn(2, err)).toBe(false);
   });
 
   it("does NOT retry 401 unauthorized errors", () => {
@@ -66,14 +76,42 @@ describe("defaultQueryOptions.retry — error classification", () => {
     expect(retryFn(1, new Error("fetch failed"))).toBe(false);
   });
 
-  it("handles error with status directly on error object", () => {
-    expect(retryFn(0, { status: 429 })).toBe(false);
+  it("handles a rate-limit status directly on the error object (retries)", () => {
+    expect(retryFn(0, { status: 429 })).toBe(true);
+    expect(retryFn(2, { status: 429 })).toBe(false);
   });
 
   it("handles null/undefined errors without crashing", () => {
     expect(retryFn(0, null)).toBe(true); // Allows retry for unknown errors
     expect(retryFn(0, undefined)).toBe(true);
     expect(retryFn(1, null)).toBe(false); // But only once
+  });
+});
+
+describe("defaultQueryOptions.retryDelay — backoff schedule", () => {
+  const retryDelayFn = defaultQueryOptions.retryDelay as (
+    attemptIndex: number,
+    error: unknown
+  ) => number;
+
+  it("honors a server Retry-After hint (error.retryAfterMs)", () => {
+    const err = new FetchDataError("Rate limited", 429, 5_000);
+    const delay = retryDelayFn(0, err);
+    // 5s hint + up to 250ms jitter.
+    expect(delay).toBeGreaterThanOrEqual(5_000);
+    expect(delay).toBeLessThanOrEqual(5_250);
+  });
+
+  it("caps the Retry-After hint at 30s", () => {
+    const err = new FetchDataError("Rate limited", 429, 120_000);
+    expect(retryDelayFn(0, err)).toBeLessThanOrEqual(30_000);
+  });
+
+  it("falls back to exponential backoff capped at 30s when no hint", () => {
+    // 2000 * 2^attempt: 2s, 4s, 8s ... capped at 30s (+jitter, still <= 30s cap).
+    expect(retryDelayFn(0, new Error("x"))).toBeGreaterThanOrEqual(2_000);
+    expect(retryDelayFn(0, new Error("x"))).toBeLessThanOrEqual(30_000);
+    expect(retryDelayFn(10, new Error("x"))).toBeLessThanOrEqual(30_000);
   });
 });
 
@@ -95,7 +133,7 @@ describe("QueryClient integration — retry behavior", () => {
     queryClient.clear();
   });
 
-  it("rate-limited query is called exactly once (no retry)", async () => {
+  it("rate-limited query is retried up to twice (initial + 2 retries)", async () => {
     let callCount = 0;
 
     try {
@@ -112,7 +150,26 @@ describe("QueryClient integration — retry behavior", () => {
       // Expected
     }
 
-    expect(callCount).toBe(1);
+    expect(callCount).toBe(3);
+  });
+
+  it("rate-limited query that recovers on retry resolves silently", async () => {
+    let callCount = 0;
+
+    const result = await queryClient.fetchQuery({
+      queryKey: ["rate-limit-recovery-test"],
+      queryFn: async () => {
+        callCount++;
+        if (callCount < 2) {
+          const err = new FetchDataError("Rate limit exceeded. Try again later.", 429);
+          throw err;
+        }
+        return { data: "recovered" };
+      },
+    });
+
+    expect(callCount).toBe(2);
+    expect(result).toEqual({ data: "recovered" });
   });
 
   it("server error query is called exactly twice (initial + 1 retry)", async () => {

--- a/__tests__/regression/retry-429-exclusion.test.ts
+++ b/__tests__/regression/retry-429-exclusion.test.ts
@@ -1,27 +1,32 @@
 /**
- * Regression test for Bug #2: 429 responses retried by React Query
+ * Regression test for the 429 retry policy.
  *
- * Previously, defaultQueryOptions used `retry: 1` (a number), which retried
- * ALL failed requests including 429 rate-limited responses. This caused
- * unnecessary load on rate-limited endpoints.
+ * History: defaultQueryOptions originally used `retry: 1` (a number), which
+ * blindly retried ALL failures including 429s. That was first fixed by never
+ * retrying 429; GAP-FRONTEND-245 then showed that "never retry" surfaces
+ * errors for what is expected load-shedding under the indexer's per-route
+ * rate limit. The current contract is a BOUNDED retry: up to 2 retries with
+ * capped backoff (honoring Retry-After when present), never unbounded.
  *
- * Fixed by replacing `retry: 1` with a function that skips retries for
- * 429 (rate limited) and 401 (unauthorized) responses.
+ * This suite guards both edges: 429s are retried at most twice (3 calls
+ * total), and 401s are never retried.
  */
 
 import { QueryClient } from "@tanstack/react-query";
 import { defaultQueryOptions } from "@/utilities/queries/defaultOptions";
 
-describe("Regression: 429 rate-limited responses should not be retried", () => {
+describe("Regression: 429 rate-limited responses use a bounded retry (max 2)", () => {
   it("retry is a function, not a static number", () => {
     expect(typeof defaultQueryOptions.retry).toBe("function");
   });
 
-  it("retry function returns false for 429 errors", () => {
+  it("retry function allows up to 2 retries for 429 errors, then stops", () => {
     const retryFn = defaultQueryOptions.retry as (failureCount: number, error: unknown) => boolean;
     const rateLimitError = { response: { status: 429 } };
 
-    expect(retryFn(0, rateLimitError)).toBe(false);
+    expect(retryFn(0, rateLimitError)).toBe(true);
+    expect(retryFn(1, rateLimitError)).toBe(true);
+    expect(retryFn(2, rateLimitError)).toBe(false);
   });
 
   it("retry function returns false for 401 errors", () => {
@@ -47,12 +52,15 @@ describe("Regression: 429 rate-limited responses should not be retried", () => {
     expect(retryFn(1, genericError)).toBe(false);
   });
 
-  it("429 error causes only one call (no retry) in QueryClient", async () => {
+  it("429 error causes exactly three calls (initial + 2 retries) in QueryClient", async () => {
     let callCount = 0;
 
     const testClient = new QueryClient({
       defaultOptions: {
-        queries: defaultQueryOptions,
+        queries: {
+          ...defaultQueryOptions,
+          retryDelay: 0, // no delay for test speed
+        },
       },
     });
 
@@ -70,8 +78,8 @@ describe("Regression: 429 rate-limited responses should not be retried", () => {
       // Expected to throw
     }
 
-    // With the fix, 429 should NOT be retried -- only 1 call
-    expect(callCount).toBe(1);
+    // Bounded retry: initial call + 2 retries, never more.
+    expect(callCount).toBe(3);
 
     testClient.clear();
   });

--- a/__tests__/trust/api/payout-service.test.ts
+++ b/__tests__/trust/api/payout-service.test.ts
@@ -1,8 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/utilities/fetchData", () => ({
-  default: vi.fn(),
-}));
+vi.mock("@/utilities/fetchData", async () => {
+  // Preserve the real FetchDataError / parseRetryAfterMs named exports so the
+  // service can construct status-carrying errors; only the network calls are
+  // stubbed. fetchDataThrow mirrors the real semantics (throw FetchDataError
+  // on a tuple error) on top of the same stub, so tests keep driving both
+  // code paths through mockFetchData tuple values.
+  const actual =
+    await vi.importActual<typeof import("@/utilities/fetchData")>("@/utilities/fetchData");
+  const fetchDataMock = vi.fn();
+  return {
+    ...actual,
+    default: fetchDataMock,
+    fetchDataThrow: async (...args: unknown[]) => {
+      const [data, error, , status] = await fetchDataMock(...args);
+      if (error !== null && error !== undefined) {
+        throw new actual.FetchDataError(
+          typeof error === "string" ? error : "Request failed",
+          status
+        );
+      }
+      return data;
+    },
+  };
+});
 
 vi.mock("@/utilities/indexer", () => ({
   INDEXER: {

--- a/__tests__/trust/api/react-query-integration.test.ts
+++ b/__tests__/trust/api/react-query-integration.test.ts
@@ -73,7 +73,7 @@ describe("React Query integration trust tests", () => {
   // --- Default query options ---
 
   describe("default query options", () => {
-    it("retry is a smart function that skips 429s and 401s", () => {
+    it("retry is a smart status-aware function (401 never, 429 bounded)", () => {
       expect(typeof defaultQueryOptions.retry).toBe("function");
     });
 
@@ -186,22 +186,24 @@ describe("React Query integration trust tests", () => {
     });
   });
 
-  // --- FIXED: 429 no longer retried ---
+  // --- 429 bounded retry (GAP-FRONTEND-245) ---
 
-  describe("429 rate-limited requests are NOT retried (fixed)", () => {
-    it("retry function skips 429 rate-limited responses", () => {
-      // The defaultQueryOptions now uses a smart retry function that
-      // skips retries for rate-limited (429) and unauthorized (401) responses.
+  describe("429 rate-limited requests use a bounded retry (max 2)", () => {
+    it("retry function applies status-aware policy (function, not a number)", () => {
+      // defaultQueryOptions uses a smart retry function: 401 never retried,
+      // 429 retried at most twice with capped backoff, transient network
+      // errors retried twice, everything else once.
       expect(typeof defaultQueryOptions.retry).toBe("function");
     });
 
-    it("demonstrates 429 is not retried with QueryClient", async () => {
+    it("demonstrates 429 is retried exactly twice (3 calls) with QueryClient", async () => {
       let callCount = 0;
 
       const retryClient = new QueryClient({
         defaultOptions: {
           queries: {
             ...defaultQueryOptions,
+            retryDelay: 0, // no real backoff in tests
           },
         },
       });
@@ -218,11 +220,11 @@ describe("React Query integration trust tests", () => {
           retry: defaultQueryOptions.retry,
         });
       } catch {
-        // Expected to throw immediately without retries
+        // Expected to throw after retries are exhausted
       }
 
-      // With smart retry, 429 is not retried - only called once
-      expect(callCount).toBe(1);
+      // Bounded retry: initial call + 2 retries, never unbounded.
+      expect(callCount).toBe(3);
 
       retryClient.clear();
     });

--- a/__tests__/unit/services/payout-disbursement.service.test.ts
+++ b/__tests__/unit/services/payout-disbursement.service.test.ts
@@ -6,9 +6,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchData = vi.fn();
-vi.mock("@/utilities/fetchData", () => ({
-  default: (...args: unknown[]) => mockFetchData(...args),
-}));
+vi.mock("@/utilities/fetchData", async () => {
+  // Preserve the real FetchDataError / parseRetryAfterMs named exports so the
+  // service can construct status-carrying errors; only the default export
+  // (the network call) is stubbed.
+  const actual =
+    await vi.importActual<typeof import("@/utilities/fetchData")>("@/utilities/fetchData");
+  return {
+    ...actual,
+    default: (...args: unknown[]) => mockFetchData(...args),
+  };
+});
 
 vi.mock("@/utilities/indexer", () => ({
   INDEXER: {
@@ -411,6 +419,18 @@ describe("payout-disbursement.service", () => {
       await expect(getPayoutConfigByGrantPublic("g1")).rejects.toThrow(
         /Failed to fetch payout config/
       );
+    });
+
+    it("throws a FetchDataError carrying status 429 on rate limit", async () => {
+      mockFetchData.mockResolvedValue([null, "Rate limit exceeded. Try again later.", null, 429]);
+
+      const err = await getPayoutConfigByGrantPublic("g1").then(
+        () => null,
+        (e) => e
+      );
+
+      expect(err).toMatchObject({ name: "FetchDataError", status: 429 });
+      expect(err.message).toContain("Rate limit exceeded");
     });
   });
 

--- a/__tests__/unit/services/payout-disbursement.service.test.ts
+++ b/__tests__/unit/services/payout-disbursement.service.test.ts
@@ -6,15 +6,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchData = vi.fn();
+const mockFetchDataThrow = vi.fn();
 vi.mock("@/utilities/fetchData", async () => {
   // Preserve the real FetchDataError / parseRetryAfterMs named exports so the
-  // service can construct status-carrying errors; only the default export
-  // (the network call) is stubbed.
+  // service can construct status-carrying errors; only the network calls are
+  // stubbed.
   const actual =
     await vi.importActual<typeof import("@/utilities/fetchData")>("@/utilities/fetchData");
   return {
     ...actual,
     default: (...args: unknown[]) => mockFetchData(...args),
+    fetchDataThrow: (...args: unknown[]) => mockFetchDataThrow(...args),
   };
 });
 
@@ -99,10 +101,21 @@ import type {
   SavePayoutConfigRequest,
   UpdateStatusRequest,
 } from "@/features/payout-disbursement/types/payout-disbursement";
+import { FetchDataError } from "@/utilities/fetchData";
 
 describe("payout-disbursement.service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default fetchDataThrow behavior mirrors production: unwrap the tuple
+    // from mockFetchData and throw a FetchDataError on error. Individual
+    // tests may override (e.g. to inject retryAfterMs).
+    mockFetchDataThrow.mockImplementation(async (...args: unknown[]) => {
+      const [data, error, , status] = await mockFetchData(...args);
+      if (error !== null && error !== undefined) {
+        throw new FetchDataError(typeof error === "string" ? error : "Request failed", status);
+      }
+      return data;
+    });
   });
 
   // =========================================================================
@@ -431,6 +444,19 @@ describe("payout-disbursement.service", () => {
 
       expect(err).toMatchObject({ name: "FetchDataError", status: 429 });
       expect(err.message).toContain("Rate limit exceeded");
+    });
+
+    it("propagates retryAfterMs from the transport error through the wrapper", async () => {
+      mockFetchDataThrow.mockRejectedValueOnce(
+        new FetchDataError("Rate limit exceeded. Try again later.", 429, 30_000)
+      );
+
+      const err = await getPayoutConfigByGrantPublic("g1").then(
+        () => null,
+        (e) => e
+      );
+
+      expect(err).toMatchObject({ name: "FetchDataError", status: 429, retryAfterMs: 30_000 });
     });
   });
 

--- a/__tests__/unit/utilities/errorManager.test.tsx
+++ b/__tests__/unit/utilities/errorManager.test.tsx
@@ -1,11 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 import { errorManager } from "@/components/Utilities/errorManager";
+import { FetchDataError } from "@/utilities/fetchData";
 
 // Unmock errorManager from global setup to test the actual implementation
 vi.unmock("@/components/Utilities/errorManager");
 vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
   captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
   setUser: vi.fn(),
   setTag: vi.fn(),
   setContext: vi.fn(),
@@ -83,5 +85,29 @@ describe("errorManager", () => {
     errorManager("Project Grants API Error", httpErr);
 
     expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it("should NOT capture 429 rate-limit errors but should add a breadcrumb (GAP-FRONTEND-245)", () => {
+    const rateLimitErr = new FetchDataError("Rate limit exceeded. Try again later.", 429);
+
+    errorManager("Error fetching public payout config for grant g1", rateLimitErr);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "rate-limit",
+        level: "warning",
+        message: "Error fetching public payout config for grant g1",
+      })
+    );
+  });
+
+  it("should still capture a 500 FetchDataError (not rate-limited)", () => {
+    const serverErr = new FetchDataError("Internal server error", 500);
+
+    errorManager("Error fetching public payout config for grant g1", serverErr);
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/utilities/fetchData.test.tsx
+++ b/__tests__/unit/utilities/fetchData.test.tsx
@@ -1,6 +1,10 @@
 import axios from "axios";
 import { TokenManager } from "@/utilities/auth/token-manager";
-import fetchData from "@/utilities/fetchData";
+import fetchData, {
+  FetchDataError,
+  fetchDataThrow,
+  parseRetryAfterMs,
+} from "@/utilities/fetchData";
 
 vi.mock("axios");
 vi.mock("@/utilities/auth/token-manager");
@@ -260,5 +264,69 @@ describe("fetchData", () => {
     expect(axios.request).toHaveBeenCalledTimes(1);
     expect(TokenManager.getToken).not.toHaveBeenCalled();
     expect(status).toBe(401);
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses a delta-seconds header into milliseconds", () => {
+    expect(parseRetryAfterMs("120")).toBe(120_000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses an HTTP-date header into a non-negative delay", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const delay = parseRetryAfterMs(future);
+    expect(delay).toBeGreaterThan(0);
+    expect(delay).toBeLessThanOrEqual(10_000);
+  });
+
+  it("clamps a past HTTP-date to zero", () => {
+    const past = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfterMs(past)).toBe(0);
+  });
+
+  it("returns undefined for absent or unparseable values", () => {
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
+  });
+});
+
+describe("fetchDataThrow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the response body on success", async () => {
+    (axios.request as vi.Mock).mockResolvedValue({ data: { ok: true }, status: 200 });
+    (TokenManager.getToken as vi.Mock).mockResolvedValue(null);
+
+    const data = await fetchDataThrow<{ ok: boolean }>("/test-endpoint", "GET", {}, {}, {}, false);
+
+    expect(data).toEqual({ ok: true });
+  });
+
+  it("throws a FetchDataError carrying status and Retry-After on 429", async () => {
+    const axiosErr = {
+      response: {
+        status: 429,
+        data: { message: "Rate limit exceeded. Try again later." },
+        headers: { "retry-after": "30" },
+      },
+      message: "Request failed with status code 429",
+    };
+    (axios.request as vi.Mock).mockRejectedValue(axiosErr);
+    (TokenManager.getToken as vi.Mock).mockResolvedValue(null);
+
+    const err = await fetchDataThrow("/test-endpoint", "GET", {}, {}, {}, false).then(
+      () => null,
+      (e) => e
+    );
+
+    expect(err).toBeInstanceOf(FetchDataError);
+    expect(err.status).toBe(429);
+    expect(err.retryAfterMs).toBe(30_000);
+    expect(err.message).toBe("Rate limit exceeded. Try again later.");
   });
 });

--- a/__tests__/unit/utilities/sentry/transientErrors.test.ts
+++ b/__tests__/unit/utilities/sentry/transientErrors.test.ts
@@ -1,5 +1,7 @@
+import { FetchDataError } from "../../../../utilities/fetchData";
 import {
   isAxiosAbortError,
+  isRateLimitError,
   isTransientNetworkError,
 } from "../../../../utilities/sentry/transientErrors";
 
@@ -46,5 +48,34 @@ describe("isTransientNetworkError", () => {
   it("treats cancellations as transient (abort during navigation/unmount)", () => {
     expect(isAxiosAbortError({ code: "ERR_CANCELED" })).toBe(true);
     expect(isTransientNetworkError({ name: "AbortError" })).toBe(true);
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("matches a 429 via error.response.status", () => {
+    expect(isRateLimitError({ response: { status: 429 } })).toBe(true);
+  });
+
+  it("matches a 429 via error.status (FetchDataError)", () => {
+    expect(isRateLimitError(new FetchDataError("Rate limit exceeded. Try again later.", 429))).toBe(
+      true
+    );
+  });
+
+  it("matches the 'rate limit exceeded' message when status is missing", () => {
+    expect(isRateLimitError(new Error("Rate limit exceeded. Try again later."))).toBe(true);
+    expect(isRateLimitError("RATE LIMIT EXCEEDED")).toBe(true);
+  });
+
+  it("matches the re-wrapped 'status code 429' message", () => {
+    expect(isRateLimitError(new Error("Request failed with status code 429"))).toBe(true);
+  });
+
+  it("does NOT match other statuses or unrelated messages", () => {
+    expect(isRateLimitError({ response: { status: 500 } })).toBe(false);
+    expect(isRateLimitError(new FetchDataError("Server error", 500))).toBe(false);
+    expect(isRateLimitError(new Error("Something else broke"))).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
   });
 });

--- a/components/Pages/Admin/ReportMilestonePage.tsx
+++ b/components/Pages/Admin/ReportMilestonePage.tsx
@@ -137,7 +137,13 @@ export const ReportMilestonePage = ({ community, grantPrograms }: ReportMileston
     return Array.from(uids);
   }, [reportData.pendingMilestones, reportData.reports]);
 
-  const { allocationMap, grantTotalMap } = useMilestoneAllocationsByGrants(allGrantUIDs);
+  // Batch into a single community-wide request — this page fans out 50–200+
+  // grants and per-grant fetches burst past the indexer rate limit (GAP-FRONTEND-245).
+  const { allocationMap, grantTotalMap } = useMilestoneAllocationsByGrants(
+    allGrantUIDs,
+    undefined,
+    { communityUID: community?.uid }
+  );
 
   useEffect(() => {
     if (isReviewersError) {

--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -1,5 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
-import { isTransientHttpError, isTransientNetworkError } from "@/utilities/sentry/transientErrors";
+import {
+  isRateLimitError,
+  isTransientHttpError,
+  isTransientNetworkError,
+} from "@/utilities/sentry/transientErrors";
 
 // Lazy import toast to avoid issues in server components
 let toast: typeof import("react-hot-toast").default | null = null;
@@ -90,6 +94,20 @@ export const errorManager = (
   // are tracked on the infra/indexer side, not here. See DEV-271 /
   // GAP-FRONTEND-1R1.
   if (isTransientHttpError(error)) {
+    return;
+  }
+
+  // Rate-limit (429) responses are expected load-shedding, not first-party
+  // bugs — the data layer retries with backoff and the affected UI degrades
+  // gracefully. Don't capture them (they burst at dozens/sec and drown out
+  // real signal), but leave a breadcrumb so the pressure is still visible on
+  // whatever event does get captured next. See GAP-FRONTEND-245 / -23E.
+  if (isRateLimitError(error)) {
+    Sentry.addBreadcrumb({
+      category: "rate-limit",
+      level: "warning",
+      message: errorMessage,
+    });
     return;
   }
 

--- a/hooks/useCommunityMilestoneAllocations.ts
+++ b/hooks/useCommunityMilestoneAllocations.ts
@@ -1,5 +1,5 @@
-import { useQueries } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 import { getNativeTokenSymbol, NATIVE_TOKEN_ADDRESS } from "@/config/tokens";
 import { getTokenByAddressAndChain } from "@/constants/supportedTokens";
 import { payoutDisbursementKeys } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
@@ -7,6 +7,16 @@ import * as payoutService from "@/src/features/payout-disbursement/services/payo
 import type { PayoutGrantConfig } from "@/src/features/payout-disbursement/types/payout-disbursement";
 import type { CommunityMilestoneUpdate } from "@/types/community-updates";
 import { formatMilestoneAmount } from "@/utilities/formatMilestoneAmount";
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+// Keep per-grant public configs cached well beyond staleTime so navigating
+// between project pages reuses them instead of re-fetching (and re-risking the
+// rate limit) on every mount.
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+// Stable empty reference so downstream `useMemo`s don't re-run while the
+// community query is still loading (undefined data).
+const EMPTY_CONFIGS: (PayoutGrantConfig | null | undefined)[] = [];
 
 /**
  * Resolves a token symbol from a payout config's tokenAddress and chainID.
@@ -136,43 +146,124 @@ export function buildGrantAllocationTotalMap(
   return map;
 }
 
+interface PayoutConfigsForGrantsOptions {
+  /**
+   * When supplied, fetch every payout config for the community in a SINGLE
+   * request (`getPayoutConfigsByCommunityPublic`) and filter client-side to the
+   * requested grants — instead of one request per grant. This is what keeps
+   * milestone-report pages (50–200+ grants) from bursting past the indexer's
+   * 30 req/min/IP per-route rate limit. Must be the on-chain community UID, not
+   * a slug (the indexer matches the column exactly). See GAP-FRONTEND-245.
+   */
+  communityUID?: string;
+}
+
+interface PayoutConfigsForGrantsResult {
+  configs: (PayoutGrantConfig | null | undefined)[];
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+}
+
 /**
- * Generic hook: fetches payout configs for given grant UIDs
- * and returns both milestone-level and grant-level allocation maps.
+ * Internal hook: resolves the public payout configs for a set of grant UIDs.
+ *
+ * Two fetch strategies, selected by whether a `communityUID` is available:
+ * - **With `communityUID`** — one shared community-wide query, filtered by
+ *   `select` to the requested grants (5-min staleTime). One network request
+ *   regardless of grant count, and it shares the cache entry with
+ *   `usePayoutConfigsByCommunityPublic` (PublicControlCenter).
+ * - **Without** — per-grant `useQueries` on the public single-grant key, cached
+ *   for 30 min so navigation reuses them. Used by project-scoped callers that
+ *   only have a handful of grants and no community UID at hand.
+ *
+ * Both `useQuery` and `useQueries` are always called (stable hook order); the
+ * inactive strategy is simply disabled / fed an empty list.
  */
-export function useMilestoneAllocationsByGrants(
+function usePayoutConfigsForGrants(
   grantUIDs: string[],
-  currencyByGrant?: Map<string, string>
-) {
-  const queries = useQueries({
-    queries: grantUIDs.map((grantUID) => ({
-      queryKey: [...payoutDisbursementKeys.payoutConfigs.byGrant(grantUID), "public"] as const,
+  options?: PayoutConfigsForGrantsOptions
+): PayoutConfigsForGrantsResult {
+  const communityUID = options?.communityUID;
+
+  const uniqueGrantUIDs = useMemo(() => Array.from(new Set(grantUIDs)), [grantUIDs]);
+  const requestedSet = useMemo(() => new Set(uniqueGrantUIDs), [uniqueGrantUIDs]);
+
+  const selectRequested = useCallback(
+    (all: PayoutGrantConfig[]) => all.filter((config) => requestedSet.has(config.grantUID)),
+    [requestedSet]
+  );
+
+  // Batched, community-wide strategy (single request). Disabled when no
+  // communityUID or nothing to fetch.
+  const communityQuery = useQuery({
+    queryKey: payoutDisbursementKeys.payoutConfigs.byCommunityPublic(communityUID ?? ""),
+    queryFn: () => payoutService.getPayoutConfigsByCommunityPublic(communityUID as string),
+    enabled: !!communityUID && uniqueGrantUIDs.length > 0,
+    staleTime: FIVE_MINUTES_MS,
+    gcTime: THIRTY_MINUTES_MS,
+    select: selectRequested,
+  });
+
+  // Per-grant strategy (one request per unique grant). Fed an empty list when
+  // the community strategy is active so it fires zero requests.
+  const perGrantQueries = useQueries({
+    queries: (communityUID ? [] : uniqueGrantUIDs).map((grantUID) => ({
+      queryKey: payoutDisbursementKeys.payoutConfigs.byGrantPublic(grantUID),
       queryFn: () => payoutService.getPayoutConfigByGrantPublic(grantUID),
-      staleTime: 5 * 60 * 1000,
+      staleTime: FIVE_MINUTES_MS,
+      gcTime: THIRTY_MINUTES_MS,
     })),
   });
 
-  const isLoading = queries.some((q) => q.isLoading);
-  const isError = queries.some((q) => q.isError);
-  const error = queries.find((q) => q.error)?.error ?? null;
+  const perGrantKey = perGrantQueries.map((q) => q.dataUpdatedAt).join(",");
 
-  const dataKey = useMemo(() => queries.map((q) => q.dataUpdatedAt).join(","), [queries]);
-
-  const allocationMap = useMemo(() => {
-    return buildMilestoneAllocationMap(
-      queries.map((q) => q.data),
-      currencyByGrant
-    );
+  const perGrantConfigs = useMemo(
+    () => perGrantQueries.map((q) => q.data),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataKey, currencyByGrant]);
+    [perGrantKey]
+  );
 
-  const grantTotalMap = useMemo(() => {
-    return buildGrantAllocationTotalMap(
-      queries.map((q) => q.data),
-      currencyByGrant
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataKey, currencyByGrant]);
+  if (communityUID) {
+    return {
+      configs: communityQuery.data ?? EMPTY_CONFIGS,
+      isLoading: communityQuery.isLoading,
+      isError: communityQuery.isError,
+      error: communityQuery.error ?? null,
+    };
+  }
+
+  return {
+    configs: perGrantConfigs,
+    isLoading: perGrantQueries.some((q) => q.isLoading),
+    isError: perGrantQueries.some((q) => q.isError),
+    error: perGrantQueries.find((q) => q.error)?.error ?? null,
+  };
+}
+
+/**
+ * Generic hook: fetches payout configs for given grant UIDs
+ * and returns both milestone-level and grant-level allocation maps.
+ *
+ * Pass `communityUID` to batch the fetch into one community-wide request
+ * (recommended for pages that fan out many grants).
+ */
+export function useMilestoneAllocationsByGrants(
+  grantUIDs: string[],
+  currencyByGrant?: Map<string, string>,
+  options?: PayoutConfigsForGrantsOptions
+) {
+  const { configs, isLoading, isError, error } = usePayoutConfigsForGrants(grantUIDs, options);
+
+  const allocationMap = useMemo(
+    () => buildMilestoneAllocationMap(configs, currencyByGrant),
+    [configs, currencyByGrant]
+  );
+
+  const grantTotalMap = useMemo(
+    () => buildGrantAllocationTotalMap(configs, currencyByGrant),
+    [configs, currencyByGrant]
+  );
 
   return { allocationMap, grantTotalMap, isLoading, isError, error };
 }
@@ -180,8 +271,16 @@ export function useMilestoneAllocationsByGrants(
 /**
  * Fetches payout configs for all unique grants in the milestone list
  * and returns a milestoneUID → formatted amount map.
+ *
+ * The batched community-wide request is used automatically when every
+ * milestone shares one `communityUID` (the milestone payload carries it), or
+ * when an explicit `communityUID` override is passed. Falls back to per-grant
+ * fetches otherwise.
  */
-export function useCommunityMilestoneAllocations(milestones: CommunityMilestoneUpdate[]) {
+export function useCommunityMilestoneAllocations(
+  milestones: CommunityMilestoneUpdate[],
+  options?: PayoutConfigsForGrantsOptions
+) {
   const uniqueGrantUIDs = useMemo(() => {
     const uids = new Set<string>();
     for (const m of milestones) {
@@ -202,27 +301,31 @@ export function useCommunityMilestoneAllocations(milestones: CommunityMilestoneU
     return map;
   }, [milestones]);
 
-  const queries = useQueries({
-    queries: uniqueGrantUIDs.map((grantUID) => ({
-      queryKey: [...payoutDisbursementKeys.payoutConfigs.byGrant(grantUID), "public"] as const,
-      queryFn: () => payoutService.getPayoutConfigByGrantPublic(grantUID),
-      staleTime: 5 * 60 * 1000,
-    })),
-  });
+  // Derive the community UID straight from the milestone payload so the batched
+  // single-request path is used without every caller having to thread it. Only
+  // batch when the whole list belongs to exactly one community.
+  const derivedCommunityUID = useMemo(() => {
+    const uids = new Set<string>();
+    for (const m of milestones) {
+      if (m.communityUID) uids.add(m.communityUID);
+    }
+    return uids.size === 1 ? [...uids][0] : undefined;
+  }, [milestones]);
 
-  const isLoading = queries.some((q) => q.isLoading);
-  const isError = queries.some((q) => q.isError);
-  const error = queries.find((q) => q.error)?.error ?? null;
+  const resolvedOptions = useMemo<PayoutConfigsForGrantsOptions>(
+    () => ({ communityUID: options?.communityUID ?? derivedCommunityUID }),
+    [options?.communityUID, derivedCommunityUID]
+  );
 
-  const dataKey = useMemo(() => queries.map((q) => q.dataUpdatedAt).join(","), [queries]);
+  const { configs, isLoading, isError, error } = usePayoutConfigsForGrants(
+    uniqueGrantUIDs,
+    resolvedOptions
+  );
 
-  const allocationMap = useMemo(() => {
-    return buildMilestoneAllocationMap(
-      queries.map((q) => q.data),
-      currencyByGrant
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataKey, currencyByGrant]);
+  const allocationMap = useMemo(
+    () => buildMilestoneAllocationMap(configs, currencyByGrant),
+    [configs, currencyByGrant]
+  );
 
   return { allocationMap, isLoading, isError, error };
 }

--- a/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
+++ b/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
@@ -48,8 +48,15 @@ export const payoutDisbursementKeys = {
     all: ["payoutConfig"] as const,
     byCommunity: (communityUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.all, "community", communityUID] as const,
+    // Public (no-auth) community-wide configs. Shared by the batch milestone-
+    // allocation hooks and PublicControlCenter so both hit the same cache entry.
+    byCommunityPublic: (communityUID: string) =>
+      [...payoutDisbursementKeys.payoutConfigs.all, "communityPublic", communityUID] as const,
     byGrant: (grantUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.all, "grant", grantUID] as const,
+    // Public (no-auth) single-grant config.
+    byGrantPublic: (grantUID: string) =>
+      [...payoutDisbursementKeys.payoutConfigs.byGrant(grantUID), "public"] as const,
   },
   granteeInvoiceCheck: (grantUID: string) =>
     [...payoutDisbursementKeys.all, "granteeInvoiceCheck", grantUID] as const,
@@ -383,11 +390,7 @@ export function usePayoutConfigsByCommunityPublic(
   options?: { enabled?: boolean }
 ) {
   return useQuery<PayoutGrantConfig[], Error>({
-    queryKey: [
-      ...payoutDisbursementKeys.payoutConfigs.all,
-      "communityPublic",
-      communityUID,
-    ] as const,
+    queryKey: payoutDisbursementKeys.payoutConfigs.byCommunityPublic(communityUID),
     queryFn: () => payoutService.getPayoutConfigsByCommunityPublic(communityUID),
     enabled: options?.enabled ?? !!communityUID,
     staleTime: 1000 * 60 * 5,
@@ -487,7 +490,7 @@ export function usePayoutConfigByGrant(grantUID: string, options?: { enabled?: b
  */
 export function usePayoutConfigByGrantPublic(grantUID: string, options?: { enabled?: boolean }) {
   return useQuery<PayoutGrantConfig | null, Error>({
-    queryKey: [...payoutDisbursementKeys.payoutConfigs.byGrant(grantUID), "public"] as const,
+    queryKey: payoutDisbursementKeys.payoutConfigs.byGrantPublic(grantUID),
     queryFn: () => payoutService.getPayoutConfigByGrantPublic(grantUID),
     enabled: options?.enabled ?? !!grantUID,
     staleTime: 1000 * 60 * 5, // 5 minutes

--- a/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
+++ b/src/features/payout-disbursement/hooks/use-payout-disbursement.ts
@@ -48,13 +48,10 @@ export const payoutDisbursementKeys = {
     all: ["payoutConfig"] as const,
     byCommunity: (communityUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.all, "community", communityUID] as const,
-    // Public (no-auth) community-wide configs. Shared by the batch milestone-
-    // allocation hooks and PublicControlCenter so both hit the same cache entry.
     byCommunityPublic: (communityUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.all, "communityPublic", communityUID] as const,
     byGrant: (grantUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.all, "grant", grantUID] as const,
-    // Public (no-auth) single-grant config.
     byGrantPublic: (grantUID: string) =>
       [...payoutDisbursementKeys.payoutConfigs.byGrant(grantUID), "public"] as const,
   },

--- a/src/features/payout-disbursement/services/payout-disbursement.service.ts
+++ b/src/features/payout-disbursement/services/payout-disbursement.service.ts
@@ -1,5 +1,5 @@
 import { errorManager } from "@/components/Utilities/errorManager";
-import fetchData, { FetchDataError } from "@/utilities/fetchData";
+import fetchData, { FetchDataError, fetchDataThrow } from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import type {
   CommunityPayoutAgreementInfo,
@@ -23,6 +23,18 @@ import type {
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+// Wraps an upstream failure in a caller-friendly message while preserving the
+// HTTP status and Retry-After hint (FetchDataError) so React Query's retry
+// policy stays 429-aware end-to-end. See GAP-FRONTEND-245.
+function wrapFetchError(error: unknown, prefix: string): FetchDataError {
+  const cause = error instanceof FetchDataError ? error : undefined;
+  return new FetchDataError(
+    `${prefix}: ${getErrorMessage(error)}`,
+    cause?.status,
+    cause?.retryAfterMs
+  );
 }
 
 /**
@@ -402,7 +414,7 @@ export const getPayoutConfigsByCommunityPublic = async (
   communityUID: string
 ): Promise<PayoutGrantConfig[]> => {
   try {
-    const [data, error, , status] = await fetchData<{ configs: PayoutGrantConfig[] }>(
+    const data = await fetchDataThrow<{ configs: PayoutGrantConfig[] }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_COMMUNITY_PUBLIC(communityUID),
       "GET",
       {},
@@ -411,20 +423,11 @@ export const getPayoutConfigsByCommunityPublic = async (
       false,
       false
     );
-
-    if (error || !data) {
-      // Throw a status-carrying error so the data layer can apply 429-aware
-      // retry/backoff and errorManager can suppress rate-limit noise.
-      throw new FetchDataError(error || "Failed to fetch payout configs", status);
-    }
-
+    if (!data) throw new FetchDataError("Failed to fetch payout configs");
     return data.configs;
   } catch (error: unknown) {
     errorManager(`Error fetching public payout configs for community ${communityUID}`, error);
-    // Re-throw with the descriptive wrapper message but preserve the HTTP
-    // status so React Query can apply 429-aware retry/backoff.
-    const status = error instanceof FetchDataError ? error.status : undefined;
-    throw new FetchDataError(`Failed to fetch payout configs: ${getErrorMessage(error)}`, status);
+    throw wrapFetchError(error, "Failed to fetch payout configs");
   }
 };
 
@@ -491,7 +494,7 @@ export const getPayoutConfigByGrant = async (
   grantUID: string
 ): Promise<PayoutGrantConfig | null> => {
   try {
-    const [data, error, , status] = await fetchData<{ config: PayoutGrantConfig | null }>(
+    const data = await fetchDataThrow<{ config: PayoutGrantConfig | null }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_GRANT(grantUID),
       "GET",
       {},
@@ -500,16 +503,11 @@ export const getPayoutConfigByGrant = async (
       true,
       false
     );
-
-    if (error || !data) {
-      throw new FetchDataError(error || "Failed to fetch payout config", status);
-    }
-
+    if (!data) throw new FetchDataError("Failed to fetch payout config");
     return data.config;
   } catch (error: unknown) {
     errorManager(`Error fetching payout config for grant ${grantUID}`, error);
-    const status = error instanceof FetchDataError ? error.status : undefined;
-    throw new FetchDataError(`Failed to fetch payout config: ${getErrorMessage(error)}`, status);
+    throw wrapFetchError(error, "Failed to fetch payout config");
   }
 };
 
@@ -520,7 +518,7 @@ export const getPayoutConfigByGrantPublic = async (
   grantUID: string
 ): Promise<PayoutGrantConfig | null> => {
   try {
-    const [data, error, , status] = await fetchData<{ config: PayoutGrantConfig | null }>(
+    const data = await fetchDataThrow<{ config: PayoutGrantConfig | null }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_GRANT_PUBLIC(grantUID),
       "GET",
       {},
@@ -529,16 +527,11 @@ export const getPayoutConfigByGrantPublic = async (
       false,
       false
     );
-
-    if (error || !data) {
-      throw new FetchDataError(error || "Failed to fetch payout config", status);
-    }
-
+    if (!data) throw new FetchDataError("Failed to fetch payout config");
     return data.config;
   } catch (error: unknown) {
     errorManager(`Error fetching public payout config for grant ${grantUID}`, error);
-    const status = error instanceof FetchDataError ? error.status : undefined;
-    throw new FetchDataError(`Failed to fetch payout config: ${getErrorMessage(error)}`, status);
+    throw wrapFetchError(error, "Failed to fetch payout config");
   }
 };
 

--- a/src/features/payout-disbursement/services/payout-disbursement.service.ts
+++ b/src/features/payout-disbursement/services/payout-disbursement.service.ts
@@ -1,5 +1,5 @@
 import { errorManager } from "@/components/Utilities/errorManager";
-import fetchData from "@/utilities/fetchData";
+import fetchData, { FetchDataError } from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 import type {
   CommunityPayoutAgreementInfo,
@@ -402,7 +402,7 @@ export const getPayoutConfigsByCommunityPublic = async (
   communityUID: string
 ): Promise<PayoutGrantConfig[]> => {
   try {
-    const [data, error] = await fetchData<{ configs: PayoutGrantConfig[] }>(
+    const [data, error, , status] = await fetchData<{ configs: PayoutGrantConfig[] }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_COMMUNITY_PUBLIC(communityUID),
       "GET",
       {},
@@ -413,13 +413,18 @@ export const getPayoutConfigsByCommunityPublic = async (
     );
 
     if (error || !data) {
-      throw new Error(error || "Failed to fetch payout configs");
+      // Throw a status-carrying error so the data layer can apply 429-aware
+      // retry/backoff and errorManager can suppress rate-limit noise.
+      throw new FetchDataError(error || "Failed to fetch payout configs", status);
     }
 
     return data.configs;
   } catch (error: unknown) {
     errorManager(`Error fetching public payout configs for community ${communityUID}`, error);
-    throw new Error(`Failed to fetch payout configs: ${getErrorMessage(error)}`);
+    // Re-throw with the descriptive wrapper message but preserve the HTTP
+    // status so React Query can apply 429-aware retry/backoff.
+    const status = error instanceof FetchDataError ? error.status : undefined;
+    throw new FetchDataError(`Failed to fetch payout configs: ${getErrorMessage(error)}`, status);
   }
 };
 
@@ -486,7 +491,7 @@ export const getPayoutConfigByGrant = async (
   grantUID: string
 ): Promise<PayoutGrantConfig | null> => {
   try {
-    const [data, error] = await fetchData<{ config: PayoutGrantConfig | null }>(
+    const [data, error, , status] = await fetchData<{ config: PayoutGrantConfig | null }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_GRANT(grantUID),
       "GET",
       {},
@@ -497,13 +502,14 @@ export const getPayoutConfigByGrant = async (
     );
 
     if (error || !data) {
-      throw new Error(error || "Failed to fetch payout config");
+      throw new FetchDataError(error || "Failed to fetch payout config", status);
     }
 
     return data.config;
   } catch (error: unknown) {
     errorManager(`Error fetching payout config for grant ${grantUID}`, error);
-    throw new Error(`Failed to fetch payout config: ${getErrorMessage(error)}`);
+    const status = error instanceof FetchDataError ? error.status : undefined;
+    throw new FetchDataError(`Failed to fetch payout config: ${getErrorMessage(error)}`, status);
   }
 };
 
@@ -514,7 +520,7 @@ export const getPayoutConfigByGrantPublic = async (
   grantUID: string
 ): Promise<PayoutGrantConfig | null> => {
   try {
-    const [data, error] = await fetchData<{ config: PayoutGrantConfig | null }>(
+    const [data, error, , status] = await fetchData<{ config: PayoutGrantConfig | null }>(
       INDEXER.V2.PAYOUT_CONFIG.BY_GRANT_PUBLIC(grantUID),
       "GET",
       {},
@@ -525,13 +531,14 @@ export const getPayoutConfigByGrantPublic = async (
     );
 
     if (error || !data) {
-      throw new Error(error || "Failed to fetch payout config");
+      throw new FetchDataError(error || "Failed to fetch payout config", status);
     }
 
     return data.config;
   } catch (error: unknown) {
     errorManager(`Error fetching public payout config for grant ${grantUID}`, error);
-    throw new Error(`Failed to fetch payout config: ${getErrorMessage(error)}`);
+    const status = error instanceof FetchDataError ? error.status : undefined;
+    throw new FetchDataError(`Failed to fetch payout config: ${getErrorMessage(error)}`, status);
   }
 };
 

--- a/utilities/auth/api-client.ts
+++ b/utilities/auth/api-client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from "axios";
 import toast from "react-hot-toast";
 import { envVars } from "../enviromentVars";
+import { parseRetryAfterMs } from "../fetchData";
 import { TokenManager } from "./token-manager";
 
 /**
@@ -67,15 +68,6 @@ function isTransientlyRetryable(error: AxiosError, config: RetryableRequestConfi
     default:
       return false;
   }
-}
-
-function parseRetryAfterMs(headerValue: unknown): number | null {
-  if (typeof headerValue !== "string" || headerValue.trim() === "") return null;
-  const seconds = Number(headerValue);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
-  const dateMs = Date.parse(headerValue);
-  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
-  return null;
 }
 
 function backoffDelayMs(attempt: number, error: AxiosError, opts: RetryOptions): number {

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -67,8 +67,8 @@ async function runFetch<T = any>(
   signal?: AbortSignal
 ): Promise<{
   data: T | null;
-  error: any;
-  pageInfo: any;
+  error: unknown;
+  pageInfo: unknown;
   status: number;
   retryAfterMs?: number;
 }> {
@@ -135,7 +135,7 @@ async function runFetch<T = any>(
     const pageInfo = resData?.pageInfo || null;
     return { data: resData, error: null, pageInfo, status: res.status };
   } catch (err: any) {
-    let error = "";
+    let error: unknown = "";
     let status = 500;
     let retryAfterMs: number | undefined;
     if (!err.response) {
@@ -193,7 +193,10 @@ export default async function fetchData<T = any>(
     signal
   );
   if (result.error !== null) {
-    return [null, result.error, null, result.status];
+    // The tuple's error slot is typed `string` but has historically carried
+    // the raw error object when no HTTP response was attached — preserved
+    // as-is for the many existing callers that rely on that shape.
+    return [null, result.error as string, null, result.status];
   }
   return [result.data as T, null, result.pageInfo, result.status];
 }
@@ -229,7 +232,11 @@ export async function fetchDataThrow<T = any>(
   );
   if (result.error !== null) {
     const message =
-      typeof result.error === "string" ? result.error : result.error?.message || "Request failed";
+      typeof result.error === "string"
+        ? result.error
+        : result.error instanceof Error
+          ? result.error.message
+          : "Request failed";
     throw new FetchDataError(message, result.status, result.retryAfterMs);
   }
   return result.data as T;

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -4,27 +4,58 @@ import { envVars } from "./enviromentVars";
 import { sanitizeObject } from "./sanitize";
 
 /**
- * Fetch data utility that uses Privy's TokenManager for authentication
- *
- * This replaces the complex cookie-based token retrieval with
- * Privy's simplified token management.
- *
- * The optional `signal` is forwarded to axios so a long-running request
- * is cancelled when the caller aborts — used by the milestone-completion
- * polling hook to halt in-flight fetches when a component unmounts mid-
- * poll. Without it, an aborted poll iteration still completes its
- * current request before the next abort check fires.
- *
- * **Caller contract** when passing `signal`: an aborted request lands in
- * the catch path as an axios cancel error. The function returns the
- * standard `[null, error, null, status]` tuple in that case; callers
- * should use `isAbortError(err)` (from `utilities/retries`) when
- * inspecting the error to distinguish cancellation from real failures.
- *
- * @template T - Optional type parameter for response data (defaults to any for backward compatibility)
- * @returns Promise<[T, null, any, number] | [null, string, null, number]> - Tuple of [data, error, pageInfo, status]
+ * Error thrown by {@link fetchDataThrow} (and constructed by services that
+ * need to surface the HTTP status to the data layer). Unlike the bare `Error`
+ * that services used to re-throw, this carries the numeric `status` so that
+ * `utilities/queries/defaultOptions.ts` can apply status-aware retry policy
+ * and `errorManager` can suppress expected rate-limit noise. `retryAfterMs`
+ * mirrors an upstream `Retry-After` header when the server sends one.
  */
-export default async function fetchData<T = any>(
+export class FetchDataError extends Error {
+  status?: number;
+  retryAfterMs?: number;
+
+  constructor(message: string, status?: number, retryAfterMs?: number) {
+    super(message);
+    this.name = "FetchDataError";
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
+ * Parses an HTTP `Retry-After` header value into milliseconds.
+ * The header is either a non-negative integer number of seconds ("120") or an
+ * HTTP-date. Returns `undefined` when the value is absent or unparseable so
+ * callers can fall back to their own backoff schedule.
+ */
+export function parseRetryAfterMs(headerValue: unknown): number | undefined {
+  if (headerValue === undefined || headerValue === null) return undefined;
+  const raw = String(headerValue).trim();
+  if (!raw) return undefined;
+
+  // Delta-seconds form.
+  if (/^\d+$/.test(raw)) {
+    return Number(raw) * 1000;
+  }
+
+  // HTTP-date form: clamp to >= 0 so a slightly-past date doesn't yield a
+  // negative delay.
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return undefined;
+}
+
+/**
+ * Internal fetch core shared by {@link fetchData} (tuple contract) and
+ * {@link fetchDataThrow} (throwing contract). Returns a normalized result
+ * object so the throwing variant can also surface the HTTP status and any
+ * `Retry-After` hint — data the flat tuple has no room for.
+ */
+async function runFetch<T = any>(
   endpoint: string,
   method: Method = "GET",
   axiosData = {},
@@ -34,7 +65,13 @@ export default async function fetchData<T = any>(
   cache: boolean | undefined = false,
   baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
   signal?: AbortSignal
-): Promise<[T, null, any, number] | [null, string, null, number]> {
+): Promise<{
+  data: T | null;
+  error: any;
+  pageInfo: any;
+  status: number;
+  retryAfterMs?: number;
+}> {
   try {
     const sanitizedData = sanitizeObject(axiosData);
     const isIndexerUrl = baseUrl === envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
@@ -96,16 +133,104 @@ export default async function fetchData<T = any>(
     }
     const resData = res.data;
     const pageInfo = resData?.pageInfo || null;
-    return [resData, null, pageInfo, res.status];
+    return { data: resData, error: null, pageInfo, status: res.status };
   } catch (err: any) {
     let error = "";
     let status = 500;
+    let retryAfterMs: number | undefined;
     if (!err.response) {
       error = err;
     } else {
       error = err.response.data.message || err.message;
       status = err.response.status;
+      retryAfterMs = parseRetryAfterMs(err.response.headers?.["retry-after"]);
     }
-    return [null, error, null, status];
+    return { data: null, error, pageInfo: null, status, retryAfterMs };
   }
+}
+
+/**
+ * Fetch data utility that uses Privy's TokenManager for authentication
+ *
+ * This replaces the complex cookie-based token retrieval with
+ * Privy's simplified token management.
+ *
+ * The optional `signal` is forwarded to axios so a long-running request
+ * is cancelled when the caller aborts — used by the milestone-completion
+ * polling hook to halt in-flight fetches when a component unmounts mid-
+ * poll. Without it, an aborted poll iteration still completes its
+ * current request before the next abort check fires.
+ *
+ * **Caller contract** when passing `signal`: an aborted request lands in
+ * the catch path as an axios cancel error. The function returns the
+ * standard `[null, error, null, status]` tuple in that case; callers
+ * should use `isAbortError(err)` (from `utilities/retries`) when
+ * inspecting the error to distinguish cancellation from real failures.
+ *
+ * @template T - Optional type parameter for response data (defaults to any for backward compatibility)
+ * @returns Promise<[T, null, any, number] | [null, string, null, number]> - Tuple of [data, error, pageInfo, status]
+ */
+export default async function fetchData<T = any>(
+  endpoint: string,
+  method: Method = "GET",
+  axiosData = {},
+  params = {},
+  headers = {},
+  isAuthorized = true,
+  cache: boolean | undefined = false,
+  baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
+  signal?: AbortSignal
+): Promise<[T, null, any, number] | [null, string, null, number]> {
+  const result = await runFetch<T>(
+    endpoint,
+    method,
+    axiosData,
+    params,
+    headers,
+    isAuthorized,
+    cache,
+    baseUrl,
+    signal
+  );
+  if (result.error !== null) {
+    return [null, result.error, null, result.status];
+  }
+  return [result.data as T, null, result.pageInfo, result.status];
+}
+
+/**
+ * Throwing variant of {@link fetchData}. On success it returns the response
+ * body directly; on failure it throws a {@link FetchDataError} carrying the
+ * HTTP status and any `Retry-After` hint. Use this from React Query queryFns
+ * that want status-aware retry/Sentry handling without unpacking the tuple.
+ * The tuple contract of {@link fetchData} is unchanged for existing callers.
+ */
+export async function fetchDataThrow<T = any>(
+  endpoint: string,
+  method: Method = "GET",
+  axiosData = {},
+  params = {},
+  headers = {},
+  isAuthorized = true,
+  cache: boolean | undefined = false,
+  baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
+  signal?: AbortSignal
+): Promise<T> {
+  const result = await runFetch<T>(
+    endpoint,
+    method,
+    axiosData,
+    params,
+    headers,
+    isAuthorized,
+    cache,
+    baseUrl,
+    signal
+  );
+  if (result.error !== null) {
+    const message =
+      typeof result.error === "string" ? result.error : result.error?.message || "Request failed";
+    throw new FetchDataError(message, result.status, result.retryAfterMs);
+  }
+  return result.data as T;
 }

--- a/utilities/queries/__tests__/defaultOptions.test.ts
+++ b/utilities/queries/__tests__/defaultOptions.test.ts
@@ -9,9 +9,14 @@ describe("defaultQueryOptions.retry", () => {
     expect(retry(0, err)).toBe(false);
   });
 
-  it("never retries 429 rate-limit", () => {
+  it("retries 429 rate-limit up to 2 times (capped backoff drains the window)", () => {
+    // See GAP-FRONTEND-245: 429s are expected load-shedding under the
+    // indexer's per-route rate limit; a short capped backoff lets the window
+    // drain instead of failing decorative data.
     const err = { response: { status: 429 } };
-    expect(retry(0, err)).toBe(false);
+    expect(retry(0, err)).toBe(true);
+    expect(retry(1, err)).toBe(true);
+    expect(retry(2, err)).toBe(false);
   });
 
   it("never retries aborted requests", () => {

--- a/utilities/queries/defaultOptions.ts
+++ b/utilities/queries/defaultOptions.ts
@@ -1,9 +1,16 @@
 import { isAxiosAbortError, isTransientNetworkError } from "@/utilities/sentry/transientErrors";
 
+const RATE_LIMIT_MAX_RETRIES = 2;
+const RATE_LIMIT_BACKOFF_CAP_MS = 30_000;
+
 /**
  * Smart retry function:
- * - Never retry rate limits (429) or auth failures (401)
+ * - Never retry auth failures (401)
  * - Never retry user-cancelled requests (route change / abort)
+ * - Allow up to 2 retries for rate limits (429). Under the indexer's
+ *   30 req/min/IP per-route cap, a page that fans out many requests bursts
+ *   past the cap; a short capped backoff lets the window drain instead of
+ *   surfacing an error for what is decorative data (GAP-FRONTEND-245).
  * - Allow up to 2 retries for transient network errors (no HTTP response —
  *   offline blip, CORS preflight, blocker, etc.). These are the dominant
  *   cause of the funding-page Sentry noise (DEV-236) and usually succeed
@@ -16,8 +23,12 @@ function shouldRetry(failureCount: number, error: unknown): boolean {
   }
 
   const status = (error as any)?.response?.status ?? (error as any)?.status ?? undefined;
-  if (status === 429 || status === 401) {
+  if (status === 401) {
     return false;
+  }
+
+  if (status === 429) {
+    return failureCount < RATE_LIMIT_MAX_RETRIES;
   }
 
   if (isTransientNetworkError(error)) {
@@ -27,6 +38,23 @@ function shouldRetry(failureCount: number, error: unknown): boolean {
   return failureCount < 1;
 }
 
+/**
+ * Backoff schedule. Honors a server-provided `Retry-After` hint
+ * (`error.retryAfterMs`, set by `FetchDataError`) when present, otherwise
+ * exponential backoff capped at 30s with jitter. The jitter de-syncs the many
+ * parallel requests a fan-out page fires so their retries don't all land in the
+ * same second and re-trip the rate limit (thundering herd).
+ */
+function retryDelay(attemptIndex: number, error: unknown): number {
+  const retryAfterMs = (error as { retryAfterMs?: unknown })?.retryAfterMs;
+  const base =
+    typeof retryAfterMs === "number" && retryAfterMs > 0
+      ? Math.min(retryAfterMs, RATE_LIMIT_BACKOFF_CAP_MS)
+      : Math.min(2000 * 2 ** attemptIndex, RATE_LIMIT_BACKOFF_CAP_MS);
+  const jitter = Math.random() * 250;
+  return Math.min(base + jitter, RATE_LIMIT_BACKOFF_CAP_MS);
+}
+
 export const defaultQueryOptions = {
   staleTime: 1000 * 60 * 1, // 1 minute
   gcTime: 1000 * 60 * 1, // 1 minute
@@ -34,8 +62,5 @@ export const defaultQueryOptions = {
   refetchOnMount: true,
   refetchOnReconnect: false,
   retry: shouldRetry,
-  // Exponential backoff capped at 5s. Default is a constant 1s which
-  // hammers the indexer during a transient outage and fails fast enough
-  // that the user sees the error UI before the network recovers.
-  retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 5000),
+  retryDelay,
 };

--- a/utilities/sentry/transientErrors.ts
+++ b/utilities/sentry/transientErrors.ts
@@ -130,6 +130,29 @@ export function isTransientWalletTimeoutError(error: unknown): boolean {
   return TRANSIENT_WALLET_TIMEOUT_FRAGMENTS.some((fragment) => message.includes(fragment));
 }
 
+// Rate-limit pressure (HTTP 429) is expected load-shedding, not a first-party
+// bug: the indexer caps public payout-config reads at 30 req/min/IP per route
+// template, so a milestones page that fans out one request per grant can burst
+// past the cap. The failed reads are retried by React Query and the affected UI
+// is decorative (allocation badges), so these must not page Sentry. The service
+// re-throws a `FetchDataError` carrying `status`, but SSR/re-wrapped paths can
+// arrive as a bare message ("Rate limit exceeded. Try again later." /
+// "Request failed with status code 429"), so match on both. See GAP-FRONTEND-245.
+const RATE_LIMIT_MESSAGE_FRAGMENTS = ["rate limit exceeded", "status code 429"];
+
+/**
+ * True when the error represents an HTTP 429 rate-limit response — detected
+ * either by status (`error.response.status` / `error.status`, incl.
+ * `FetchDataError`) or by a rate-limit message fragment for re-wrapped errors
+ * that lost their status. Used to suppress Sentry noise while still retrying.
+ */
+export function isRateLimitError(error: unknown): boolean {
+  if (!error) return false;
+  if (getHttpStatus(error) === 429) return true;
+  const message = getErrorMessage(error).toLowerCase();
+  return RATE_LIMIT_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
 /**
  * True when the error is a transient upstream HTTP failure (gateway timeout
  * / bad gateway / service unavailable / request timeout). Unlike


### PR DESCRIPTION
## Problem

Sentry **[GAP-FRONTEND-245](https://karma-hq.sentry.io/issues/?query=GAP-FRONTEND-245)** (`Error: Rate limit exceeded. Try again later.`) — **456 events / 12 users**, plus sibling **GAP-FRONTEND-23E**.

The admin **milestones report** page (`ReportMilestonePage`) renders decorative allocation badges by fetching one payout config per grant:

- `hooks/useCommunityMilestoneAllocations.ts` fires `GET /v2/payout-config/grant/:grantUID/public` per grant via `useQueries`.
- `ReportMilestonePage` fans out **50–200+ grants** per page load.

Since gap-indexer PR #2134 (2026-07-02) the indexer rate-limits public reads at **30 req/min/IP per route template**, so a single page load of ≥31 grants deterministically 429s the rest. Each failure produced one Sentry event (bursts of ~34/sec) because:

- `utilities/fetchData.ts` collapsed errors to a string tuple; the service re-threw a bare `Error` with **no status**.
- `utilities/queries/defaultOptions.ts` couldn't detect the 429 (did a blind extra retry, doubling the load).
- `errorManager` couldn't recognize it as expected load-shedding → captured every one.

Request-volume math: 150 grants → 150 requests → first 30 succeed, ~120 × (1 + 1 blind retry) ≈ **240 failing requests → 240 Sentry events per load**.

## Root cause

Per-grant fan-out against a per-route rate limit, compounded by a status-less error contract that defeated both retry classification and Sentry suppression.

## Solution

### Layer 1 — batch the fetches
- New internal `usePayoutConfigsForGrants(grantUIDs, { communityUID? })`:
  - **With `communityUID`** → a single `getPayoutConfigsByCommunityPublic` request (endpoint already used by `PublicControlCenter`), filtered client-side via `select`, `staleTime` 5 min. Shares the cache entry with `usePayoutConfigsByCommunityPublic`.
  - **Without** → per-grant `useQueries` (project pages, few grants) with `gcTime` 30 min so navigation reuses cache.
- `ReportMilestonePage` now passes `community.uid` — the confirmed 245 offender collapses from 50–200+ requests to **1**.
- `useCommunityMilestoneAllocations` derives the community UID straight from the milestone payload (`CommunityMilestoneUpdate.communityUID`), so the community-updates page batches automatically.
- Extracted `byGrantPublic` / `byCommunityPublic` to `payoutDisbursementKeys` (removes a 3× duplicated key literal).

### Layer 2 — 429-aware fetch / retry / Sentry
- `fetchData.ts`: export `FetchDataError` (carries `status` + `retryAfterMs`), `parseRetryAfterMs`, and a `fetchDataThrow` wrapper. **Existing tuple contract untouched.**
- Payout-config services throw `FetchDataError` with the tuple status instead of a status-less `Error`.
- `transientErrors.ts`: add `isRateLimitError` (status 429 or rate-limit message) — additive only.
- `errorManager`: early-return on rate-limit (no `captureException`) and add a `Sentry.addBreadcrumb` so the pressure stays observable.
- `defaultOptions.ts`: retry 429 up to twice with capped exponential backoff (30s cap) that honors `Retry-After` when present, plus jitter to de-sync fan-out retries.
- The three payout-config service fetchers now call `fetchDataThrow` directly, so a server-sent `Retry-After` header flows end-to-end: axios headers -> `FetchDataError.retryAfterMs` -> service wrapper (preserved by `wrapFetchError`) -> `retryDelay`.

**Note on global retry-delay scope:** `retryDelay` is a QueryClient-wide default, so the new schedule (2s/4s/8s..., 30s cap, +jitter) also applies to non-429 retries that previously used 1s/2s with a 5s cap. This is intentional and safe: non-429 errors get at most 1-2 retries (unchanged counts), so the worst-case added wait is a few seconds on an already-failing request, while the longer cap prevents retry storms against a struggling indexer and the jitter de-syncs concurrent retries. User-facing loading states are unaffected on the success path.

Allocation amounts are decorative badges — pages render fine with empty maps (verified). No new toasts.

## Test coverage

All new/updated tests green (`vitest run`, 6 files / 153 tests):

- `__tests__/hooks/useCommunityMilestoneAllocations.test.ts` — 50 grants + communityUID → community fetcher called **exactly once**, per-grant **zero**; duplicate UIDs deduped; two hooks/one communityUID → one call; no-communityUID → one call per unique grant; identical `allocationMap` shape either way; UID derived from milestone payload.
- `__tests__/react-query/retry-and-stale-config.test.ts` — `FetchDataError(429)` retried ≤2, `retryAfterMs` honored + 30s cap, 401 not retried, 500 unchanged, silent recovery on 429→200.
- `__tests__/unit/utilities/sentry/transientErrors.test.ts` — `isRateLimitError` truth table.
- `__tests__/unit/utilities/errorManager.test.tsx` — 429 → not captured (breadcrumb added); 500 → captured.
- `__tests__/unit/services/payout-disbursement.service.test.ts` — tuple `[null, "Rate limit…", null, 429]` → thrown `FetchDataError`, status 429.
- `__tests__/unit/utilities/fetchData.test.tsx` — `fetchDataThrow` + `parseRetryAfterMs` (seconds / HTTP-date / cap).

Legacy suites that encoded the old "429 is never retried" contract (`utilities/queries/__tests__/defaultOptions.test.ts`, `__tests__/regression/retry-429-exclusion.test.ts`, `__tests__/trust/api/react-query-integration.test.ts`, `__tests__/integration/services/react-query-integration.test.ts`) were updated and retitled to the new bounded-retry contract (initial + 2 retries = 3 calls, `retryDelay: 0` in QueryClient-based tests). The payout-service trust/integration mocks now expose the real `FetchDataError` and a delegating `fetchDataThrow`.

Consumer component tests (`PublicControlCenter`, `ActivityFeed`, `MilestonesList` ×2, `InboxMilestoneDetail`) — 60/60 still green. `tsc --noEmit` clean.

> MSW request-counter integration case skipped: the `payouts.handlers.ts` harness has no public payout-config route and these authless routes need extra server/counter wiring. The same guarantees are already covered by the hook tests (service-call count is 1:1 with network hits) and the React Query 429→200 recovery integration test.

## Sentry

- Primary: **GAP-FRONTEND-245** — `Error: Rate limit exceeded. Try again later.` (456 events / 12 users)
- Sibling: **GAP-FRONTEND-23E**

Both are resolved by (1) eliminating the fan-out on the offending page and (2) suppressing residual 429s from capture while retrying them with backoff.

## CI notes

- The github-actions "Anti-Pattern Violations" comment (`EMPTY_CATCH` in `payout-disbursement.service.ts` L105/135/161 and `fetchData.ts` L116/137) is a **false positive on pre-existing catch blocks**: every flagged catch either calls `errorManager(...)` and rethrows (service) or returns the error tuple / rethrows (fetchData). None are empty; none were introduced by this PR.

## Follow-ups

- **gap-indexer (separate PR):** the public payout-config 429 responses do **not** currently emit a `Retry-After` header. The FE now honors it end-to-end (`parseRetryAfterMs` → `FetchDataError.retryAfterMs` → `wrapFetchError` → `retryDelay`), so adding `Retry-After` on the indexer's 429s would let the client back off exactly as long as needed instead of using its exponential fallback.
- `MilestonesReview` (single-grant) and project-page callers intentionally stay per-grant — batching one grant against the community-wide endpoint would fetch all community configs for one badge.
