### PR TITLE
feat(portfolio-reports): delete action for draft/failed reports (DEV-509)

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { PortfolioReportListPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportListPage";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import {
+  useDeleteReport,
   useGenerateReport,
   usePortfolioReports,
   usePublishReport,
@@ -33,8 +34,35 @@ const mockUseGenerateReport = vi.mocked(useGenerateReport);
 const mockUsePublishReport = vi.mocked(usePublishReport);
 const mockUseUnpublishReport = vi.mocked(useUnpublishReport);
 const mockUseRegenerateReport = vi.mocked(useRegenerateReport);
+const mockUseDeleteReport = vi.mocked(useDeleteReport);
 const mockUseReportConfigs = vi.mocked(useReportConfigs);
 const mockUseReportRowSync = vi.mocked(useReportRowSync);
+
+function reportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "report-1",
+    reportConfigId: "config-1",
+    communityId: "community-1",
+    runDate: "2026-03-15",
+    status: "draft",
+    content: "# Report",
+    dataSnapshot: {},
+    modelId: "gpt-4.1",
+    tokenUsage: null,
+    generatedAt: "2026-04-01T00:00:00.000Z",
+    generationError: null,
+    publishedAt: null,
+    publishedBy: null,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const filecoinCommunity = {
+  uid: "community-1",
+  details: { slug: "filecoin", name: "Filecoin" },
+} as any;
 
 describe("PortfolioReportListPage", () => {
   beforeEach(() => {
@@ -49,6 +77,7 @@ describe("PortfolioReportListPage", () => {
     mockUsePublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
     mockUseUnpublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
     mockUseRegenerateReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+    mockUseDeleteReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
     mockUseReportConfigs.mockReturnValue({ data: [], isLoading: false } as any);
     // Return the initialReport passed as the second argument
     mockUseReportRowSync.mockImplementation((_slug, initialReport) => initialReport);
@@ -124,5 +153,59 @@ describe("PortfolioReportListPage", () => {
     );
 
     expect(screen.queryByRole("button", { name: /preview/i })).not.toBeInTheDocument();
+  });
+
+  it("deletes a draft report after confirmation", async () => {
+    const user = userEvent.setup();
+    const deleteMutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockUseDeleteReport.mockReturnValue({
+      isPending: false,
+      mutateAsync: deleteMutateAsync,
+    } as any);
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "draft-report", status: "draft" })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+    // Confirmation dialog
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(deleteMutateAsync).toHaveBeenCalledWith("draft-report");
+  });
+
+  it("shows a Delete action for failed reports", () => {
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "failed-report", status: "failed" })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("does not show a Delete action for published reports", () => {
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "published-report", status: "published" })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("does not show a Delete action for generating reports", () => {
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "generating-report", status: "generating" })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
   });
 });

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import {
   Eye,
   EyeOff,
@@ -208,6 +209,7 @@ export function PortfolioReportListPage({ community }: Props) {
       await generateMutation.mutateAsync({ configId });
       toast.success("Generation started, this can take a few minutes.");
     } catch (error) {
+      Sentry.captureException(error);
       toast.error(
         `Failed to start generation: ${error instanceof Error ? error.message : "Unknown error"}`
       );
@@ -222,7 +224,8 @@ export function PortfolioReportListPage({ community }: Props) {
     try {
       await publishMutation.mutateAsync(reportId);
       toast.success("Report published");
-    } catch {
+    } catch (error) {
+      Sentry.captureException(error);
       toast.error("Failed to publish report");
     } finally {
       setActiveReportId(null);
@@ -236,7 +239,8 @@ export function PortfolioReportListPage({ community }: Props) {
     try {
       await unpublishMutation.mutateAsync(reportId);
       toast.success("Report unpublished");
-    } catch {
+    } catch (error) {
+      Sentry.captureException(error);
       toast.error("Failed to unpublish report");
     } finally {
       setActiveReportId(null);
@@ -253,6 +257,7 @@ export function PortfolioReportListPage({ community }: Props) {
       await regenerateMutation.mutateAsync(reportId);
       toast.success("Regeneration started, this can take a few minutes.");
     } catch (error) {
+      Sentry.captureException(error);
       toast.error(
         `Failed to start regeneration: ${error instanceof Error ? error.message : "Unknown error"}`
       );
@@ -272,6 +277,7 @@ export function PortfolioReportListPage({ community }: Props) {
       await deleteMutation.mutateAsync(reportId);
       toast.success("Report deleted");
     } catch (error) {
+      Sentry.captureException(error);
       toast.error(
         `Failed to delete report: ${error instanceof Error ? error.message : "Unknown error"}`
       );

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { Eye, EyeOff, FileSearch, FileText, Play, Plus, RefreshCw, Settings } from "lucide-react";
+import {
+  Eye,
+  EyeOff,
+  FileSearch,
+  FileText,
+  Play,
+  Plus,
+  RefreshCw,
+  Settings,
+  Trash2,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
@@ -9,6 +19,7 @@ import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import {
+  useDeleteReport,
   useGenerateReport,
   usePortfolioReports,
   usePublishReport,
@@ -36,12 +47,13 @@ interface ReportTableRowProps {
   report: PortfolioReport;
   configName: string;
   rowPending: boolean;
-  activeMutationType: "publish" | "unpublish" | "regenerate" | null;
+  activeMutationType: "publish" | "unpublish" | "regenerate" | "delete" | null;
   onEdit: () => void;
   onPreview: () => void;
   onPublish: () => void;
   onUnpublish: () => void;
   onRegenerate: () => void;
+  onDelete: () => void;
 }
 
 function ReportTableRow({
@@ -55,12 +67,16 @@ function ReportTableRow({
   onPublish,
   onUnpublish,
   onRegenerate,
+  onDelete,
 }: ReportTableRowProps) {
   const report = useReportRowSync(slug, initialReport);
   const fmt = formatRunDate(report.runDate);
   const generating = isReportGenerating(report);
   const failed = report.status === "failed";
   const actionsDisabled = rowPending || generating;
+  // Drafts and failed generations can be removed; published reports back
+  // public URLs (unpublish first) and generating reports are still in flight.
+  const deletable = report.status === "draft" || failed;
   return (
     <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
       <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-100">{configName}</td>
@@ -109,6 +125,18 @@ function ReportTableRow({
                   ? "Retry"
                   : "Regen"}
           </Button>
+          {deletable ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onDelete}
+              disabled={actionsDisabled}
+              className="text-red-600 hover:text-red-700 dark:text-red-500 dark:hover:text-red-400"
+            >
+              <Trash2 className="mr-1 h-3 w-3" />
+              {rowPending && activeMutationType === "delete" ? "Deleting..." : "Delete"}
+            </Button>
+          ) : null}
         </div>
       </td>
     </tr>
@@ -129,6 +157,7 @@ export function PortfolioReportListPage({ community }: Props) {
   const publishMutation = usePublishReport(slug);
   const unpublishMutation = useUnpublishReport(slug);
   const regenerateMutation = useRegenerateReport(slug);
+  const deleteMutation = useDeleteReport(slug);
 
   const configById = useMemo(() => {
     const map = new Map<string, ReportConfig>();
@@ -151,10 +180,11 @@ export function PortfolioReportListPage({ community }: Props) {
   // Per-row pending state: track which report is being mutated and what action
   const [activeReportId, setActiveReportId] = useState<string | null>(null);
   const [activeMutationType, setActiveMutationType] = useState<
-    "publish" | "unpublish" | "regenerate" | null
+    "publish" | "unpublish" | "regenerate" | "delete" | null
   >(null);
   const [generatingConfigId, setGeneratingConfigId] = useState<string | null>(null);
   const [regenerateTargetId, setRegenerateTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   if (accessLoading || isLoading) {
     return (
@@ -233,9 +263,31 @@ export function PortfolioReportListPage({ community }: Props) {
     }
   };
 
+  const handleDelete = async () => {
+    if (!deleteTargetId) return;
+    const reportId = deleteTargetId;
+    setActiveReportId(reportId);
+    setActiveMutationType("delete");
+    try {
+      await deleteMutation.mutateAsync(reportId);
+      toast.success("Report deleted");
+    } catch (error) {
+      toast.error(
+        `Failed to delete report: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    } finally {
+      setActiveReportId(null);
+      setActiveMutationType(null);
+      setDeleteTargetId(null);
+    }
+  };
+
   const isRowPending = (reportId: string) =>
     activeReportId === reportId &&
-    (publishMutation.isPending || unpublishMutation.isPending || regenerateMutation.isPending);
+    (publishMutation.isPending ||
+      unpublishMutation.isPending ||
+      regenerateMutation.isPending ||
+      deleteMutation.isPending);
 
   const sortedReports = (reports ?? []).slice().sort((a, b) => b.runDate.localeCompare(a.runDate));
 
@@ -248,6 +300,17 @@ export function PortfolioReportListPage({ community }: Props) {
         externalIsOpen={regenerateTargetId !== null}
         externalSetIsOpen={(open) => {
           if (!open) setRegenerateTargetId(null);
+        }}
+        buttonElement={null}
+      />
+
+      <DeleteDialog
+        title="Delete this report? This can't be undone."
+        deleteFunction={handleDelete}
+        isLoading={deleteMutation.isPending}
+        externalIsOpen={deleteTargetId !== null}
+        externalSetIsOpen={(open) => {
+          if (!open) setDeleteTargetId(null);
         }}
         buttonElement={null}
       />
@@ -380,6 +443,7 @@ export function PortfolioReportListPage({ community }: Props) {
                   onPublish={() => handlePublish(report.id)}
                   onUnpublish={() => handleUnpublish(report.id)}
                   onRegenerate={() => setRegenerateTargetId(report.id)}
+                  onDelete={() => setDeleteTargetId(report.id)}
                 />
               ))}
             </tbody>

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -196,6 +196,21 @@ export function useRegenerateReport(communitySlug: string) {
   });
 }
 
+export function useDeleteReport(communitySlug: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (reportId: string) => portfolioService.deleteReport(communitySlug, reportId),
+    onSuccess: (_data, reportId) => {
+      queryClient.removeQueries({
+        queryKey: QUERY_KEYS.report(communitySlug, reportId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.reports(communitySlug),
+      });
+    },
+  });
+}
+
 export function usePublishReport(communitySlug: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -126,6 +126,10 @@ export async function regenerateReport(
   return data;
 }
 
+export async function deleteReport(communitySlug: string, reportId: string): Promise<void> {
+  await apiClient.delete(`/v2/communities/${communitySlug}/reports/${reportId}`);
+}
+
 export async function publishReport(
   communitySlug: string,
   reportId: string


### PR DESCRIPTION
## Overview

Adds a **Delete** action to the Portfolio Reports admin list so community admins can remove reports. Requested by Filecoin (Erin O'Connor) — there was no way to delete drafts (**DEV-509**).

Pairs with the backend PR show-karma/gap-indexer#2168, which adds `DELETE /v2/communities/:uidOrSlug/reports/:reportId`.

## What changed

- **`deleteReport` service call** → `DELETE .../reports/:reportId` via the shared authenticated API client (same path as publish/unpublish/regenerate).
- **`useDeleteReport` mutation** → on success removes the single-report query and invalidates the reports list.
- **Delete button** on the report row, shown only for `draft` and `failed` statuses, gated behind the shared `<DeleteDialog>` confirmation. Reuses the existing per-row pending/disabled state.

## Behavior

| Status | Actions |
|---|---|
| `draft` | Edit · Preview · Publish · Regen · **Delete** |
| `failed` | Edit · Retry · **Delete** |
| `published` | Edit · Unpublish _(no Delete — unpublish first)_ |
| `generating` | Edit · Generating… _(no Delete — in flight)_ |

Published reports back public URLs and generating reports are mid-write, so they aren't deletable here; the backend also enforces this (409), so the UI and API agree.

## Testing

`PortfolioReportListPage` tests: deletes a draft after confirmation (asserts the mutation is called with the report id), shows Delete for failed, and hides it for published and generating. `pnpm build` and Biome pass; full list-page suite (6) green.

## Smoke results

Deployed-preview click-through pending — to run against the Vercel preview once this and gap-indexer#2168 both deploy. Local run of the full authenticated flow needs the backend + DBs (Docker unavailable locally); the component test covers the button → confirmation → mutation → service path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin portfolio reports can now be deleted from the report list, with a confirmation prompt.
  * Delete is available for draft and failed reports only; published/generating reports don’t show the action.
* **Bug Fixes**
  * Delete now has correct loading/disabled states and shows “Deleting...” for the active row.
  * The report list refreshes after deletion, and errors surface via user messaging.
* **Tests**
  * Added/extended coverage for deletion confirmation, successful deletion, and conditional visibility of the Delete action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->