### PR TITLE
feat: gate application "Applicant" section to authorized viewers (DEV-518)

### DIFF
--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -13,8 +13,8 @@ import { Role } from "@/src/core/rbac/types/role";
 import { CommentTimeline } from "@/src/features/application-comments/components/CommentTimeline";
 import { PublicComments } from "@/src/features/application-comments/components/PublicComments";
 import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
+import { useApplication } from "@/src/features/applications/hooks/use-application";
 import { useApplicationAccess } from "@/src/features/applications/hooks/use-application-access";
-import { useApplicationStatusHistory } from "@/src/features/applications/hooks/use-application-status-history";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
 import type { Application, ApplicationStatus, FundingProgram } from "@/types/whitelabel-entities";
 import { formatDate } from "@/utilities/formatDate";
@@ -49,7 +49,7 @@ export function ApplicationPageClient({
   application,
   program,
 }: ApplicationPageClientProps) {
-  const { user } = useAuth();
+  const { user, authenticated } = useAuth();
   const isAdmin = useIsFundingPlatformAdmin();
   const { hasRoleOrHigher, isReviewer, can } = usePermissionContext();
   const isAdminOrReviewer = hasRoleOrHigher(Role.MILESTONE_REVIEWER) || isReviewer;
@@ -117,14 +117,23 @@ export function ApplicationPageClient({
       : "guest";
 
   // The whitelabel page is fetched server-side without a Privy token, so the
-  // backend serves it anonymously and strips the private status-change reasons
-  // (rejection/revision messages) — the backend is the guard. Authenticated
-  // viewers re-fetch with their token; the backend returns the reasons only to
-  // the applicant, reviewers, and admins. Guests keep the sanitized SSR payload.
-  const { statusHistory: authedStatusHistory } = useApplicationStatusHistory(
-    application.referenceNumber
+  // backend serves it anonymously and strips the fields it gates by viewer: the
+  // private status-change reasons (rejection/revision messages) AND the
+  // applicant identity (ownerAddress / applicantEmail). The backend is the
+  // guard. Authenticated viewers re-fetch the full application with their token
+  // — one call restores both — and the backend returns those fields only to the
+  // applicant, reviewers, and admins. Guests keep the sanitized SSR payload.
+  const { application: liveApplication } = useApplication(
+    communityId,
+    application.referenceNumber,
+    { initialData: application, enabled: authenticated }
   );
-  const statusHistory = authedStatusHistory ?? application.statusHistory ?? [];
+  const app = liveApplication ?? application;
+  const statusHistory = app.statusHistory ?? [];
+
+  // Applicant identity is shown only to the applicant (owner) and
+  // reviewers/admins; everyone else gets no Applicant section at all.
+  const canViewApplicant = viewerRole !== "guest";
 
   const editHref = PAGES.COMMUNITY.APPLICATION_EDIT(communityId, application.referenceNumber);
   const reviewHref = PAGES.REVIEWER.APPLICATION_DETAIL(
@@ -267,10 +276,11 @@ export function ApplicationPageClient({
         {/* SIDEBAR */}
         <div className="order-1 lg:order-2">
           <ApplicationSidebar
-            application={application}
+            application={app}
             program={program}
             programName={programName}
             viewerRole={viewerRole}
+            canViewApplicant={canViewApplicant}
             hasMilestones={hasMilestones}
             postApprovalPending={postApprovalPending}
             editHref={editHref}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationInfoCard.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationInfoCard.tsx
@@ -11,6 +11,7 @@ interface ApplicationInfoCardProps {
   deadline?: string;
   applicantEmail?: string;
   ownerAddress?: string;
+  canViewApplicant: boolean;
 }
 
 function truncateAddress(address: string): string {
@@ -40,10 +41,16 @@ export function ApplicationInfoCard({
   deadline,
   applicantEmail,
   ownerAddress,
+  canViewApplicant,
 }: ApplicationInfoCardProps) {
   const [copiedText, copy] = useCopyToClipboard();
   const isCopied = copiedText === referenceNumber;
-  const applicant = deriveApplicant(applicantEmail, ownerAddress);
+  // The applicant identity is shown only to the applicant themselves and to
+  // reviewers/admins. For everyone else the section is hidden entirely (rather
+  // than shown as "Anonymous"); unauthorized viewers also receive no identity
+  // data because the backend redacts it.
+  const showApplicant = canViewApplicant && Boolean(applicantEmail || ownerAddress);
+  const applicant = showApplicant ? deriveApplicant(applicantEmail, ownerAddress) : null;
 
   return (
     <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
@@ -87,20 +94,26 @@ export function ApplicationInfoCard({
         </div>
       </dl>
 
-      <p className="mb-3 mt-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        Applicant
-      </p>
-      <div className="flex items-center gap-3">
-        <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[rgb(var(--color-primary))]/10 text-sm font-semibold text-[rgb(var(--color-primary-dark))]">
-          {applicant.initial}
-        </span>
-        <div className="min-w-0">
-          <div className="truncate text-[13px] font-medium text-foreground">{applicant.name}</div>
-          {applicant.secondary && (
-            <div className="truncate text-xs text-muted-foreground">{applicant.secondary}</div>
-          )}
-        </div>
-      </div>
+      {showApplicant && applicant && (
+        <>
+          <p className="mb-3 mt-5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Applicant
+          </p>
+          <div className="flex items-center gap-3">
+            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[rgb(var(--color-primary))]/10 text-sm font-semibold text-[rgb(var(--color-primary-dark))]">
+              {applicant.initial}
+            </span>
+            <div className="min-w-0">
+              <div className="truncate text-[13px] font-medium text-foreground">
+                {applicant.name}
+              </div>
+              {applicant.secondary && (
+                <div className="truncate text-xs text-muted-foreground">{applicant.secondary}</div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
@@ -10,6 +10,7 @@ interface ApplicationSidebarProps {
   program: FundingProgram | null;
   programName: string;
   viewerRole: ApplicationViewerRole;
+  canViewApplicant: boolean;
   hasMilestones: boolean;
   postApprovalPending: boolean;
   editHref: string;
@@ -30,6 +31,7 @@ export function ApplicationSidebar({
   program,
   programName,
   viewerRole,
+  canViewApplicant,
   hasMilestones,
   postApprovalPending,
   editHref,
@@ -62,6 +64,7 @@ export function ApplicationSidebar({
         deadline={program?.metadata.endsAt}
         applicantEmail={application.applicantEmail}
         ownerAddress={application.ownerAddress}
+        canViewApplicant={canViewApplicant}
       />
     </aside>
   );

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationInfoCard.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationInfoCard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ApplicationInfoCard } from "../ApplicationInfoCard";
+
+// Clipboard hook is irrelevant to applicant visibility; stub it.
+vi.mock("@/hooks/useCopyToClipboard", () => ({
+  useCopyToClipboard: () => [null, vi.fn()],
+}));
+
+const baseProps = {
+  referenceNumber: "APP-9BLARDP8-560VRW",
+  programName: "Filecoin ProPGF Batch 3",
+  lastSubmission: "2026-07-07T00:00:00.000Z",
+  deadline: "2026-06-16T00:00:00.000Z",
+};
+
+const ADDRESS = "0x1234567890123456789012345678901234567890";
+
+describe("ApplicationInfoCard — applicant visibility", () => {
+  it("hides the Applicant section for unauthorized viewers, even when identity data is present", () => {
+    render(
+      <ApplicationInfoCard
+        {...baseProps}
+        applicantEmail="applicant@example.com"
+        ownerAddress={ADDRESS}
+        canViewApplicant={false}
+      />
+    );
+
+    expect(screen.queryByText("Applicant")).not.toBeInTheDocument();
+    expect(screen.queryByText("applicant@example.com")).not.toBeInTheDocument();
+  });
+
+  it("never renders 'Anonymous' — hides the section when there is no identity", () => {
+    render(
+      <ApplicationInfoCard
+        {...baseProps}
+        applicantEmail=""
+        ownerAddress=""
+        canViewApplicant={true}
+      />
+    );
+
+    expect(screen.queryByText("Applicant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
+  });
+
+  it("shows the applicant email to authorized viewers", () => {
+    render(
+      <ApplicationInfoCard
+        {...baseProps}
+        applicantEmail="applicant@example.com"
+        ownerAddress=""
+        canViewApplicant={true}
+      />
+    );
+
+    expect(screen.getByText("Applicant")).toBeInTheDocument();
+    expect(screen.getByText("applicant@example.com")).toBeInTheDocument();
+    // Name is the email local-part.
+    expect(screen.getByText("applicant")).toBeInTheDocument();
+  });
+
+  it("shows a truncated address when only ownerAddress is available", () => {
+    render(
+      <ApplicationInfoCard
+        {...baseProps}
+        applicantEmail=""
+        ownerAddress={ADDRESS}
+        canViewApplicant={true}
+      />
+    );
+
+    expect(screen.getByText("Applicant")).toBeInTheDocument();
+    expect(screen.getByText("0x1234…7890")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

On the whitelabel application detail page, the sidebar **"Applicant"** always showed **"Anonymous"** — even for reviewers/admins authorized to see who applied. This shows the real applicant to authorized viewers and hides the section from everyone else.

Closes DEV-518.

## Root cause

The page (`.../applications/[applicationId]/page.tsx`) is a **Server Component** that fetches `GET /v2/funding-applications/:id` **server-side**. There's no Privy token on the server (Privy keeps it in localStorage), so the request is effectively **unauthenticated**, and the backend **redacts** applicant identity (`ownerAddress`, and `applicantEmail` for public). Both arrive empty → `ApplicationInfoCard.deriveApplicant()` falls through to "Anonymous". Because the card is fed by that redacted SSR payload, even a logged-in reviewer/admin saw "Anonymous".

## Approach — reuse the existing authed fetch (no extra request)

DEV-517 already added a client-side authenticated re-fetch of the **full application** (`getApplicationStatusHistory` → `GET /v2/funding-applications/:ref`) to un-redact the private status-change reasons — it just discarded everything except `statusHistory`. That same response already carries the applicant identity.

So instead of adding a second call, the detail page now uses the general **`useApplication`** hook (same endpoint, full app, `initialData` = SSR payload, `enabled: authenticated`) for **one** authenticated re-fetch that restores **both** `statusHistory` reasons **and** the applicant identity. The detail page drops its separate `useApplicationStatusHistory` call; the hook stays (the edit page still uses it).

## What changed (3 files + 1 test)

1. **`ApplicationPageClient`** — swap `useApplicationStatusHistory` → `useApplication`; derive both `statusHistory` and the applicant identity from the one live application; compute `canViewApplicant = viewerRole !== "guest"`.
2. **`ApplicationSidebar`** — thread `canViewApplicant` through; render from the live application.
3. **`ApplicationInfoCard`** — render the "Applicant" section **only** when `canViewApplicant && (applicantEmail || ownerAddress)`. The "Anonymous" fallback is gone.

## Behavior

| Viewer | Applicant section |
|--------|-------------------|
| Applicant (owner) | shown — their own identity |
| Reviewer / community admin / super admin | shown — real applicant email/address |
| Guest / public | **hidden entirely** (no "Anonymous") |

No new PII exposure: the backend already hard-gates whether a viewer receives the applicant's address/email; the FE only surfaces identity to viewers the backend already authorizes, and stops rendering a useless "Anonymous" row.

## Verification

- `pnpm run typecheck` → 0 errors
- `pnpm run build` → success
- Tests: new `ApplicationInfoCard.test.tsx` (hidden for unauthorized; **never** renders "Anonymous"; shows email / truncated address for authorized) + existing whitelabel smoke suite + DEV-517's status-history hook/service tests — all pass.

## Notes

Rebased onto current `main` (which includes DEV-517 #1760). Related to DEV-513 (identity display).
