### PR TITLE
feat(api): unified typed API client — throw-based error taxonomy (Phase 1) (#1775)

### DIFF
--- a/utilities/api/README.md
+++ b/utilities/api/README.md
@@ -1,0 +1,91 @@
+# `utilities/api` — typed API client (Phase 1, issue #1775)
+
+Self-contained, DAO-of-one typed HTTP client that replaces `utilities/fetchData.ts`
+for new code. It owns its own error taxonomy, retry policy, and Sentry
+reporting policy — see `errors.ts`, `client.ts`, `retry.ts`, `or-else.ts`,
+`report.ts`.
+
+This is **Phase 1 only**. `components/Utilities/errorManager.tsx` is untouched
+(Phase 2), and the throwing `fetchDataThrow` adapter mentioned in the issue is
+**deferred** — it has no consumer yet, and an unused export fails knip. Add it
+in the PR that introduces its first caller.
+
+There is no barrel `index.ts` — import from the specific source module
+(`./client`, `./errors`, `./or-else`), per the repo's no-barrel convention.
+
+## Usage
+
+```ts
+import { api } from "@/utilities/api/client";
+import { z } from "zod";
+
+const ProjectSchema = z.object({ uid: z.string(), title: z.string() });
+
+// GET with runtime validation — throws ContractViolationError if the
+// response doesn't match the schema.
+const project = await api.get(`/v2/projects/${uid}`, { schema: ProjectSchema });
+
+// Mutations
+await api.post("/v2/projects", body, { schema: ProjectSchema });
+
+// Paginated list endpoints
+const { data, pageInfo } = await api.getPaginated("/v2/projects", {
+  schema: z.array(ProjectSchema),
+  params: { page: 1 },
+});
+```
+
+**Rule: new code MUST pass a `schema`.** An endpoint without a schema returns
+`data as unknown as T` — a silent, untyped cast. A schema turns a contract
+drift on the backend into a caught `ContractViolationError` instead of a
+runtime crash three components downstream.
+
+Every rejection from `api.*` is an `ApiError` (`HttpError`, `NetworkError`,
+`TimeoutError`, `RequestAborted`, or `ContractViolationError`) — never a raw
+`AxiosError`. Use `isApiError`/`instanceof` to branch (from
+`@/utilities/api/errors`), or `orElse` (from `@/utilities/api/or-else`) to
+degrade to a fallback value for "expected" failures (network blips, 429s,
+timeouts, aborts):
+
+```ts
+import { orElse } from "@/utilities/api/or-else";
+import { HttpError, isApiError } from "@/utilities/api/errors";
+
+const projects = await orElse(api.get("/v2/projects", { schema: ProjectListSchema }), []);
+```
+
+## `fetchData` is now a deprecated adapter
+
+`utilities/fetchData.ts` still exists and still returns the legacy
+`[data, error, pageInfo, status]` tuple — the ~220 existing call sites are
+unaffected. Internally it now delegates to `api.request(...)` and maps the
+typed `ApiError` back onto the tuple:
+
+- `HttpError` → `status = error.status`, tuple error = `error.body.message ??
+  error.message`.
+- Any other `ApiError` (network / timeout / aborted / contract-violation) →
+  `status = 500`, tuple error = the original underlying cause (or the
+  `ApiError` itself if there is no cause) — matching the old behavior of
+  putting the raw error object in the tuple slot.
+
+Do not add new callers of `fetchData`. Prefer `api.*` with a schema.
+
+## Phase-3 codemod patterns
+
+When migrating an existing `fetchData` call site to `api.*`, pick one of
+these three shapes depending on how the call site already handles failure:
+
+1. **Degrade** — call site already treats a failed/empty fetch as "no data"
+   (renders an empty state). Replace with `orElse(api.get(...), fallback)`.
+2. **Throw** — call site already wraps `fetchData` in a try/catch or expects
+   the caller (React Query, a server action) to catch a thrown error.
+   Replace with a direct `await api.get(...)`/`api.post(...)` call and let
+   the `ApiError` propagate.
+3. **Status-branch** — call site inspects the tuple's `status`/`error` to
+   decide UI behavior per HTTP code (e.g. treat 403 as "not authorized",
+   404 as "not found", everything else as a real error). Replace with a
+   `try { ... } catch (err) { if (err instanceof HttpError && err.status === 404) ... }`
+   block using `instanceof HttpError`.
+
+Each codemod is expected to also add a `schema` for the endpoint being
+migrated, per the rule above.

--- a/utilities/api/__tests__/client.test.ts
+++ b/utilities/api/__tests__/client.test.ts
@@ -1,0 +1,453 @@
+import axios from "axios";
+import { z } from "zod";
+import { createApiClient } from "@/utilities/api/client";
+import {
+  ApiError,
+  ContractViolationError,
+  HttpError,
+  isApiError,
+  RequestAborted,
+  TimeoutError,
+} from "@/utilities/api/errors";
+
+vi.mock("axios");
+
+function mockedRequest() {
+  return axios.request as vi.Mock;
+}
+
+function buildClient(overrides: Partial<Parameters<typeof createApiClient>[0]> = {}) {
+  const getAuthToken = vi.fn().mockResolvedValue("token-1");
+  // onAuthExpired resolves the FRESH token (or null when refresh fails).
+  const onAuthExpired = vi.fn().mockResolvedValue(null);
+  const onExhausted = vi.fn();
+  const client = createApiClient({
+    baseURL: "https://api.test",
+    getAuthToken,
+    onAuthExpired,
+    onExhausted,
+    ...overrides,
+  });
+  return { client, getAuthToken, onAuthExpired, onExhausted };
+}
+
+describe("client — 1. auth header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("attaches Authorization: Bearer <token> when isAuthorized (default) and a token is available", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client, getAuthToken } = buildClient();
+
+    await client.get("/things");
+
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
+    const config = mockedRequest().mock.calls[0][0];
+    expect(config.headers.Authorization).toBe("Bearer token-1");
+  });
+
+  it("does not attach a header or fetch a token when isAuthorized is false", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client, getAuthToken } = buildClient();
+
+    await client.get("/things", { isAuthorized: false });
+
+    expect(getAuthToken).not.toHaveBeenCalled();
+    const config = mockedRequest().mock.calls[0][0];
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it("does not attach a header for a non-default baseURL override (adapter parity for non-indexer calls)", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client, getAuthToken } = buildClient();
+
+    await client.get("/things", { baseURL: "https://other.test" });
+
+    expect(getAuthToken).not.toHaveBeenCalled();
+    const config = mockedRequest().mock.calls[0][0];
+    expect(config.headers.Authorization).toBeUndefined();
+    expect(config.url).toBe("https://other.test/things");
+  });
+});
+
+describe("client — 2. 401 refresh once per logical request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes the token once on 401 and retries with the fresh token returned by onAuthExpired", async () => {
+    mockedRequest()
+      .mockRejectedValueOnce({ response: { status: 401, data: {} } })
+      .mockResolvedValueOnce({ data: { ok: true }, status: 200 });
+    const { client, onAuthExpired, getAuthToken } = buildClient();
+    getAuthToken.mockResolvedValue("stale");
+    onAuthExpired.mockResolvedValue("fresh");
+
+    const result = await client.get("/things");
+
+    expect(onAuthExpired).toHaveBeenCalledTimes(1);
+    expect(mockedRequest()).toHaveBeenCalledTimes(2);
+    expect(mockedRequest().mock.calls[1][0].headers.Authorization).toBe("Bearer fresh");
+    // the fresh token comes from onAuthExpired's return — getToken is NOT
+    // re-called after the refresh (only the initial pre-request fetch).
+    expect(getAuthToken).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("throws HttpError(401) on a second consecutive 401 without retrying again", async () => {
+    mockedRequest().mockRejectedValue({ response: { status: 401, data: {} } });
+    const { client, onAuthExpired } = buildClient();
+    onAuthExpired.mockResolvedValue("fresh");
+
+    const error = await client.get("/things").catch((e) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error.status).toBe(401);
+    // exactly one refresh retry — not a retry per outer attempt
+    expect(mockedRequest()).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not attempt a refresh when onAuthExpired resolves null", async () => {
+    mockedRequest().mockRejectedValue({ response: { status: 401, data: {} } });
+    const { client, onAuthExpired } = buildClient();
+    onAuthExpired.mockResolvedValue(null);
+
+    await expect(client.get("/things")).rejects.toBeInstanceOf(HttpError);
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("client — 3. timeout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes timeoutMs (default 30000) through to axios and classifies ECONNABORTED as TimeoutError", async () => {
+    mockedRequest().mockRejectedValue({
+      code: "ECONNABORTED",
+      message: "timeout of 30000ms exceeded",
+    });
+    const { client } = buildClient();
+
+    await expect(client.get("/things")).rejects.toBeInstanceOf(TimeoutError);
+    expect(mockedRequest().mock.calls[0][0].timeout).toBe(30_000);
+  });
+
+  it("honors a custom timeoutMs", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    await client.get("/things", { timeoutMs: 5_000 });
+
+    expect(mockedRequest().mock.calls[0][0].timeout).toBe(5_000);
+  });
+});
+
+describe("client — 4. retry via executeWithRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries a retryable GET failure server-side and eventually succeeds", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest()
+      .mockRejectedValueOnce({ response: { status: 503, data: {} } })
+      .mockResolvedValueOnce({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    const promise = client.get("/things");
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(mockedRequest()).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("honors HttpError.retryAfterMs capped at 30000 for the retry delay", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest()
+      .mockRejectedValueOnce({
+        response: { status: 429, data: {}, headers: { "retry-after": "9999" } },
+      })
+      .mockResolvedValueOnce({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    const promise = client.get("/things");
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await promise;
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("calls onExhausted exactly once with the final error and attempt count once retries exhaust", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest().mockRejectedValue({ response: { status: 503, data: {} } });
+    const { client, onExhausted } = buildClient();
+
+    const promise = client.get("/things");
+    const assertion = expect(promise).rejects.toBeInstanceOf(HttpError);
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted).toHaveBeenCalledWith(expect.any(HttpError), 3);
+  });
+
+  it("retries only server-side — browser caps attempts at 1 even for a retryable error", async () => {
+    // window is left defined (default jsdom) => browser
+    mockedRequest().mockRejectedValue({ response: { status: 503, data: {} } });
+    const { client } = buildClient();
+
+    await expect(client.get("/things")).rejects.toBeInstanceOf(HttpError);
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a POST without an idempotencyKey even though the error is retryable", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest().mockRejectedValue({ response: { status: 503, data: {} } });
+    const { client } = buildClient();
+
+    await expect(client.post("/things", { a: 1 })).rejects.toBeInstanceOf(HttpError);
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a POST when an idempotencyKey is provided", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest()
+      .mockRejectedValueOnce({ response: { status: 503, data: {} } })
+      .mockResolvedValueOnce({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    const promise = client.post("/things", { a: 1 }, { idempotencyKey: "key-1" });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(mockedRequest()).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("does not retry once the caller's signal is already aborted", async () => {
+    vi.stubGlobal("window", undefined);
+    const controller = new AbortController();
+    controller.abort();
+    mockedRequest().mockRejectedValue({ response: { status: 503, data: {} } });
+    const { client } = buildClient();
+
+    await expect(client.get("/things", { signal: controller.signal })).rejects.toBeInstanceOf(
+      RequestAborted
+    );
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("client — 4b. onExhausted only reports a genuine retry exhaustion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT call onExhausted for a single-attempt 400 (server-side, non-retryable)", async () => {
+    vi.stubGlobal("window", undefined);
+    mockedRequest().mockRejectedValue({ response: { status: 400, data: { message: "bad" } } });
+    const { client, onExhausted } = buildClient();
+
+    await expect(client.get("/things")).rejects.toBeInstanceOf(HttpError);
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onExhausted for a browser-side network error (attempts capped at 1)", async () => {
+    // window left defined => browser; network errors are retryable but the
+    // browser never retries, so this is a single-attempt failure.
+    mockedRequest().mockRejectedValue(new Error("Network Error"));
+    const { client, onExhausted } = buildClient();
+
+    await expect(client.get("/things")).rejects.toBeInstanceOf(ApiError);
+    expect(mockedRequest()).toHaveBeenCalledTimes(1);
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+
+  it("calls onExhausted exactly once for a server-side retryable error that exhausts its retries", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", undefined);
+    mockedRequest().mockRejectedValue({ response: { status: 503, data: {} } });
+    const { client, onExhausted } = buildClient();
+
+    const promise = client.get("/things");
+    const assertion = expect(promise).rejects.toBeInstanceOf(HttpError);
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(mockedRequest()).toHaveBeenCalledTimes(3);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted).toHaveBeenCalledWith(expect.any(HttpError), 3);
+    vi.useRealTimers();
+  });
+});
+
+describe("client — 5. every rejection is mapped through toApiError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["a plain network Error with no response", new Error("Network Error")],
+    ["an HTTP 500 response", { response: { status: 500, data: { message: "boom" } } }],
+    ["an ECONNABORTED timeout", { code: "ECONNABORTED", message: "timeout" }],
+    ["a cancel error", { code: "ERR_CANCELED", name: "CanceledError" }],
+  ])("wraps %s into an ApiError — no raw AxiosError escapes", async (_label, rejection) => {
+    mockedRequest().mockRejectedValue(rejection);
+    const { client } = buildClient();
+
+    const caught = await client.get("/things").catch((e) => e);
+
+    expect(isApiError(caught)).toBe(true);
+    expect(caught).toBeInstanceOf(ApiError);
+  });
+});
+
+describe("client — 6. schema validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the zod-parsed value when the response matches the schema", async () => {
+    mockedRequest().mockResolvedValue({ data: { id: "1" }, status: 200 });
+    const { client } = buildClient();
+    const schema = z.object({ id: z.string() });
+
+    const result = await client.get("/things/1", { schema });
+
+    expect(result).toEqual({ id: "1" });
+  });
+
+  it("throws ContractViolationError capped at 10 issues, without leaking the raw body", async () => {
+    mockedRequest().mockResolvedValue({ data: {}, status: 200 });
+    const { client } = buildClient();
+    const schema = z.object({
+      a: z.string(),
+      b: z.string(),
+      c: z.string(),
+      d: z.string(),
+      e: z.string(),
+      f: z.string(),
+      g: z.string(),
+      h: z.string(),
+      i: z.string(),
+      j: z.string(),
+      k: z.string(),
+      l: z.string(),
+    });
+
+    const error = await client.get("/things/1", { schema }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ContractViolationError);
+    expect(error.issues.length).toBeLessThanOrEqual(10);
+    expect(JSON.stringify(error)).not.toContain("secretValueThatShouldNotLeak");
+  });
+
+  it("returns the raw payload untouched when no schema is provided", async () => {
+    mockedRequest().mockResolvedValue({ data: { anything: true }, status: 200 });
+    const { client } = buildClient();
+
+    const result = await client.get("/things/1");
+
+    expect(result).toEqual({ anything: true });
+  });
+});
+
+describe("client — 7. envelope unwrap + pageInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("request() returns { data, status, pageInfo } — pageInfo pulled from body.pageInfo", async () => {
+    mockedRequest().mockResolvedValue({
+      data: { data: [1, 2, 3], pageInfo: { page: 1, totalItems: 3 } },
+      status: 200,
+    });
+    const { client } = buildClient();
+
+    const result = await client.request("GET", "/things", undefined);
+
+    expect(result.status).toBe(200);
+    expect(result.pageInfo).toEqual({ page: 1, totalItems: 3 });
+    expect(result.data).toEqual({ data: [1, 2, 3], pageInfo: { page: 1, totalItems: 3 } });
+  });
+
+  it("request() returns pageInfo: null when the body has none", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    const result = await client.request("GET", "/things", undefined);
+
+    expect(result.pageInfo).toBeNull();
+  });
+
+  it("get<T>() returns the whole body even when it carries a pageInfo key (legacy parity)", async () => {
+    mockedRequest().mockResolvedValue({
+      data: { data: [1, 2], pageInfo: { page: 1 } },
+      status: 200,
+    });
+    const { client } = buildClient();
+
+    const result = await client.get("/things");
+
+    expect(result).toEqual({ data: [1, 2], pageInfo: { page: 1 } });
+  });
+
+  it("getPaginated<T>() splits the envelope into { data: body.data, pageInfo }", async () => {
+    mockedRequest().mockResolvedValue({
+      data: { data: [1, 2], pageInfo: { page: 1, totalItems: 2 } },
+      status: 200,
+    });
+    const { client } = buildClient();
+
+    const result = await client.getPaginated("/things");
+
+    expect(result).toEqual({ data: [1, 2], pageInfo: { page: 1, totalItems: 2 } });
+  });
+});
+
+describe("client — 8. cache query param", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("appends ?cache=<v> for the default baseURL when opts.cache is set", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    await client.get("/things", { cache: true });
+
+    expect(mockedRequest().mock.calls[0][0].url).toBe("https://api.test/things?cache=true");
+  });
+
+  it("appends &cache=<v> when the path already has a query string", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    await client.get("/things?foo=bar", { cache: true });
+
+    expect(mockedRequest().mock.calls[0][0].url).toBe("https://api.test/things?foo=bar&cache=true");
+  });
+
+  it("does not append cache for a non-default baseURL override", async () => {
+    mockedRequest().mockResolvedValue({ data: { ok: true }, status: 200 });
+    const { client } = buildClient();
+
+    await client.get("/things", { cache: true, baseURL: "https://other.test" });
+
+    expect(mockedRequest().mock.calls[0][0].url).toBe("https://other.test/things");
+  });
+});

--- a/utilities/api/__tests__/errors.test.ts
+++ b/utilities/api/__tests__/errors.test.ts
@@ -1,0 +1,359 @@
+import {
+  ApiError,
+  ContractViolationError,
+  getErrorCode,
+  HttpError,
+  isApiError,
+  NetworkError,
+  parseRetryAfterMs,
+  RequestAborted,
+  stripQuery,
+  TimeoutError,
+  toApiError,
+} from "../errors";
+
+describe("stripQuery", () => {
+  it("strips a query string from a path", () => {
+    expect(stripQuery("/v2/projects?limit=10&page=2")).toBe("/v2/projects");
+  });
+
+  it("strips a query string from a full URL", () => {
+    expect(stripQuery("https://api.example.com/v2/projects?limit=10")).toBe(
+      "https://api.example.com/v2/projects"
+    );
+  });
+
+  it("returns the input unchanged when there is no query string", () => {
+    expect(stripQuery("/v2/projects/123")).toBe("/v2/projects/123");
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses integer seconds into milliseconds", () => {
+    expect(parseRetryAfterMs("7")).toBe(7000);
+  });
+
+  it("parses a numeric header value", () => {
+    expect(parseRetryAfterMs(5)).toBe(5000);
+  });
+
+  it("parses an HTTP-date into a millisecond delta, clamped >= 0", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(10_000 + 1000); // small tolerance for test runtime
+  });
+
+  it("clamps an HTTP-date far in the future to 120_000ms", () => {
+    const farFuture = new Date(Date.now() + 10_000_000).toUTCString();
+    expect(parseRetryAfterMs(farFuture)).toBe(120_000);
+  });
+
+  it("clamps a past HTTP-date to 0", () => {
+    const past = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfterMs(past)).toBe(0);
+  });
+
+  it("returns undefined for garbage input", () => {
+    expect(parseRetryAfterMs("abc")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined/null", () => {
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(parseRetryAfterMs("")).toBeUndefined();
+  });
+
+  it("unwraps an array header value (raw axios headers shape)", () => {
+    expect(parseRetryAfterMs(["7"])).toBe(7000);
+  });
+});
+
+describe("getErrorCode", () => {
+  it("reads a top-level string code", () => {
+    expect(getErrorCode({ code: "ECONNRESET" })).toBe("ECONNRESET");
+  });
+
+  it("walks a single-level cause chain", () => {
+    const err = { message: "fetch failed", cause: { code: "ECONNRESET" } };
+    expect(getErrorCode(err)).toBe("ECONNRESET");
+  });
+
+  it("walks a multi-level cause chain", () => {
+    const err = { cause: { cause: { cause: { code: "ETIMEDOUT" } } } };
+    expect(getErrorCode(err)).toBe("ETIMEDOUT");
+  });
+
+  it("stops at a depth guard and returns undefined for a too-deep chain", () => {
+    let deepest: unknown = { code: "TOO_DEEP" };
+    for (let i = 0; i < 10; i++) {
+      deepest = { cause: deepest };
+    }
+    expect(getErrorCode(deepest)).toBeUndefined();
+  });
+
+  it("returns undefined when no code is found anywhere in the chain", () => {
+    expect(getErrorCode({ message: "no code here" })).toBeUndefined();
+  });
+
+  it("returns undefined for non-object input", () => {
+    expect(getErrorCode("just a string")).toBeUndefined();
+    expect(getErrorCode(null)).toBeUndefined();
+    expect(getErrorCode(undefined)).toBeUndefined();
+  });
+
+  it("ignores a non-string code and keeps walking the cause chain", () => {
+    const err = { code: 500, cause: { code: "REAL_CODE" } };
+    expect(getErrorCode(err)).toBe("REAL_CODE");
+  });
+});
+
+describe("HttpError", () => {
+  it("marks 408/429/502/503/504 as retryable", () => {
+    for (const status of [408, 429, 502, 503, 504]) {
+      const err = new HttpError(status, { endpoint: "/x", method: "get" });
+      expect(err.retryable).toBe(true);
+    }
+  });
+
+  it("marks other statuses (e.g. 500, 400, 404) as non-retryable", () => {
+    for (const status of [400, 404, 500]) {
+      const err = new HttpError(status, { endpoint: "/x", method: "get" });
+      expect(err.retryable).toBe(false);
+    }
+  });
+
+  it("429 is expected", () => {
+    const err = new HttpError(429, { endpoint: "/x", method: "get" });
+    expect(err.expected).toBe(true);
+    expect(err.retryable).toBe(true);
+  });
+
+  it("500 is not expected and not retryable", () => {
+    const err = new HttpError(500, { endpoint: "/x", method: "get" });
+    expect(err.expected).toBe(false);
+    expect(err.retryable).toBe(false);
+  });
+
+  it("uppercases method and strips query from endpoint", () => {
+    const err = new HttpError(500, { endpoint: "/v2/projects?limit=10", method: "post" });
+    expect(err.method).toBe("POST");
+    expect(err.endpoint).toBe("/v2/projects");
+  });
+
+  it("carries body and retryAfterMs through", () => {
+    const err = new HttpError(429, {
+      endpoint: "/x",
+      method: "get",
+      body: { message: "rate limited" },
+      retryAfterMs: 5000,
+    });
+    expect(err.body).toEqual({ message: "rate limited" });
+    expect(err.retryAfterMs).toBe(5000);
+  });
+
+  it("is both instanceof ApiError and instanceof HttpError", () => {
+    const err = new HttpError(500, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("sets kind to http", () => {
+    const err = new HttpError(500, { endpoint: "/x", method: "get" });
+    expect(err.kind).toBe("http");
+  });
+});
+
+describe("NetworkError", () => {
+  it("is always retryable and expected", () => {
+    const err = new NetworkError({ endpoint: "/x", method: "get" });
+    expect(err.retryable).toBe(true);
+    expect(err.expected).toBe(true);
+    expect(err.kind).toBe("network");
+  });
+
+  it("carries an optional code", () => {
+    const err = new NetworkError({ endpoint: "/x", method: "get", code: "ECONNRESET" });
+    expect(err.code).toBe("ECONNRESET");
+  });
+
+  it("is instanceof ApiError and NetworkError", () => {
+    const err = new NetworkError({ endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toBeInstanceOf(NetworkError);
+  });
+});
+
+describe("TimeoutError", () => {
+  it("is never retryable but is expected", () => {
+    const err = new TimeoutError({ endpoint: "/x", method: "get", timeoutMs: 30_000 });
+    expect(err.retryable).toBe(false);
+    expect(err.expected).toBe(true);
+    expect(err.kind).toBe("timeout");
+    expect(err.timeoutMs).toBe(30_000);
+  });
+});
+
+describe("RequestAborted", () => {
+  it("is never retryable but is expected", () => {
+    const err = new RequestAborted({ endpoint: "/x", method: "get" });
+    expect(err.retryable).toBe(false);
+    expect(err.expected).toBe(true);
+    expect(err.kind).toBe("aborted");
+  });
+});
+
+describe("ContractViolationError", () => {
+  it("is never retryable and never expected", () => {
+    const err = new ContractViolationError({ endpoint: "/x", method: "get", issues: ["bad"] });
+    expect(err.retryable).toBe(false);
+    expect(err.expected).toBe(false);
+    expect(err.kind).toBe("contract");
+    expect(err.issues).toEqual(["bad"]);
+  });
+});
+
+describe("isApiError", () => {
+  it("returns true for any ApiError subclass", () => {
+    expect(isApiError(new HttpError(500, { endpoint: "/x", method: "get" }))).toBe(true);
+    expect(isApiError(new NetworkError({ endpoint: "/x", method: "get" }))).toBe(true);
+    expect(isApiError(new TimeoutError({ endpoint: "/x", method: "get", timeoutMs: 1000 }))).toBe(
+      true
+    );
+    expect(isApiError(new RequestAborted({ endpoint: "/x", method: "get" }))).toBe(true);
+    expect(
+      isApiError(new ContractViolationError({ endpoint: "/x", method: "get", issues: [] }))
+    ).toBe(true);
+  });
+
+  it("returns false for a plain Error or non-error values", () => {
+    expect(isApiError(new Error("boom"))).toBe(false);
+    expect(isApiError("boom")).toBe(false);
+    expect(isApiError(null)).toBe(false);
+    expect(isApiError(undefined)).toBe(false);
+  });
+});
+
+describe("toApiError classification", () => {
+  it("classifies ctx.signal.aborted as RequestAborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const raw = new Error("aborted somehow");
+    const err = toApiError(raw, { endpoint: "/x", method: "get", signal: controller.signal });
+    expect(err).toBeInstanceOf(RequestAborted);
+  });
+
+  it("classifies axios err.code === ERR_CANCELED as RequestAborted", () => {
+    const raw = { code: "ERR_CANCELED", message: "canceled" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(RequestAborted);
+  });
+
+  it("classifies err.code === ABORT_ERR as RequestAborted", () => {
+    const raw = { code: "ABORT_ERR", message: "aborted" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(RequestAborted);
+  });
+
+  it("classifies err.name === CanceledError as RequestAborted", () => {
+    const raw = { name: "CanceledError", message: "canceled" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(RequestAborted);
+  });
+
+  it("classifies err.name === AbortError as RequestAborted", () => {
+    const raw = { name: "AbortError", message: "aborted" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(RequestAborted);
+  });
+
+  it("prioritizes abort over timeout when BOTH an abort signal and an ECONNABORTED code are present", () => {
+    // A request that was aborted mid-flight can surface as an axios
+    // ECONNABORTED failure — abort must win so callers don't retry it.
+    const controller = new AbortController();
+    controller.abort();
+    const raw = { code: "ECONNABORTED", message: "timeout of 30000ms exceeded" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get", signal: controller.signal });
+    expect(err).toBeInstanceOf(RequestAborted);
+    expect(err).not.toBeInstanceOf(TimeoutError);
+  });
+
+  it("classifies an axios-style err.response into HttpError with status/body", () => {
+    const raw = {
+      message: "Request failed with status code 500",
+      response: { status: 500, data: { message: "server exploded" }, headers: {} },
+    };
+    const err = toApiError(raw, { endpoint: "/v2/x?a=1", method: "post" });
+    expect(err).toBeInstanceOf(HttpError);
+    const httpErr = err as HttpError;
+    expect(httpErr.status).toBe(500);
+    expect(httpErr.body).toEqual({ message: "server exploded" });
+    expect(httpErr.endpoint).toBe("/v2/x");
+    expect(httpErr.method).toBe("POST");
+  });
+
+  it("parses retry-after header off an HttpError response", () => {
+    const raw = {
+      response: { status: 429, data: {}, headers: { "retry-after": "3" } },
+    };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" }) as HttpError;
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.retryAfterMs).toBe(3000);
+    expect(err.expected).toBe(true);
+    expect(err.retryable).toBe(true);
+  });
+
+  it("classifies ECONNABORTED without a response as TimeoutError", () => {
+    const raw = { code: "ECONNABORTED", message: "timeout of 30000ms exceeded" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get", timeoutMs: 30_000 });
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect((err as TimeoutError).timeoutMs).toBe(30_000);
+  });
+
+  it("classifies ETIMEDOUT without a response as TimeoutError, defaulting timeoutMs to 30000", () => {
+    const raw = { code: "ETIMEDOUT" };
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect((err as TimeoutError).timeoutMs).toBe(30_000);
+  });
+
+  it("classifies an undici TypeError('fetch failed', { cause: { code } }) as NetworkError with the nested code", () => {
+    const raw = new TypeError("fetch failed", { cause: { code: "ECONNRESET" } });
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(NetworkError);
+    expect((err as NetworkError).code).toBe("ECONNRESET");
+  });
+
+  it("classifies any other no-response failure as NetworkError", () => {
+    const raw = new Error("Network Error");
+    const err = toApiError(raw, { endpoint: "/x", method: "get" });
+    expect(err).toBeInstanceOf(NetworkError);
+  });
+
+  it("returns an already-classified ApiError unchanged (idempotent)", () => {
+    const original = new HttpError(500, { endpoint: "/x", method: "get" });
+    const result = toApiError(original, { endpoint: "/other", method: "post" });
+    expect(result).toBe(original);
+  });
+
+  it("is idempotent even for a NetworkError whose .code collides with a timeout code", () => {
+    // NetworkError has its own `.code` field using the same key axios uses
+    // for its error code — re-classifying must not misread that as a raw
+    // ECONNABORTED/ETIMEDOUT and wrap it into a TimeoutError.
+    const original = new NetworkError({ endpoint: "/x", method: "get", code: "ECONNABORTED" });
+    const result = toApiError(original, { endpoint: "/x", method: "get" });
+    expect(result).toBe(original);
+    expect(result).toBeInstanceOf(NetworkError);
+  });
+
+  it("strips query string and uppercases method on every classified error", () => {
+    const raw = new Error("Network Error");
+    const err = toApiError(raw, { endpoint: "/v2/things?x=1&y=2", method: "delete" });
+    expect(err.endpoint).toBe("/v2/things");
+    expect(err.method).toBe("DELETE");
+  });
+});

--- a/utilities/api/__tests__/or-else.test.ts
+++ b/utilities/api/__tests__/or-else.test.ts
@@ -1,0 +1,40 @@
+import { ContractViolationError, HttpError, NetworkError } from "@/utilities/api/errors";
+import { orElse } from "@/utilities/api/or-else";
+
+describe("orElse", () => {
+  it("resolves to the promise's value on success", async () => {
+    const result = await orElse(Promise.resolve("actual"), "fallback");
+    expect(result).toBe("actual");
+  });
+
+  it("falls back on a NetworkError", async () => {
+    const error = new NetworkError({ endpoint: "/things", method: "GET" });
+    const result = await orElse(Promise.reject(error), "fallback");
+    expect(result).toBe("fallback");
+  });
+
+  it("falls back on a 429 HttpError", async () => {
+    const error = new HttpError(429, { endpoint: "/things", method: "GET" });
+    const result = await orElse(Promise.reject(error), "fallback");
+    expect(result).toBe("fallback");
+  });
+
+  it("rethrows a ContractViolationError", async () => {
+    const error = new ContractViolationError({
+      endpoint: "/things",
+      method: "GET",
+      issues: ["bad"],
+    });
+    await expect(orElse(Promise.reject(error), "fallback")).rejects.toBe(error);
+  });
+
+  it("rethrows a 500 HttpError", async () => {
+    const error = new HttpError(500, { endpoint: "/things", method: "GET" });
+    await expect(orElse(Promise.reject(error), "fallback")).rejects.toBe(error);
+  });
+
+  it("rethrows a non-ApiError", async () => {
+    const error = new Error("boom");
+    await expect(orElse(Promise.reject(error), "fallback")).rejects.toBe(error);
+  });
+});

--- a/utilities/api/__tests__/report.test.ts
+++ b/utilities/api/__tests__/report.test.ts
@@ -1,0 +1,153 @@
+import { captureException, captureMessage } from "@sentry/nextjs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ContractViolationError,
+  HttpError,
+  NetworkError,
+  RequestAborted,
+  TimeoutError,
+} from "../errors";
+import { reportApiFailure } from "../report";
+
+const mockCaptureMessage = captureMessage as ReturnType<typeof vi.fn>;
+const mockCaptureException = captureException as ReturnType<typeof vi.fn>;
+
+describe("reportApiFailure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a NetworkError as a warning message, fingerprinted by kind + code", () => {
+    const error = new NetworkError({
+      endpoint: "/v2/projects",
+      method: "get",
+      code: "ECONNRESET",
+    });
+
+    reportApiFailure(error, 3);
+
+    expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "network", "ECONNRESET"],
+      extra: { endpoint: "/v2/projects", method: "GET", attempts: 3 },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("falls back to 'unknown' in the fingerprint when NetworkError has no code", () => {
+    const error = new NetworkError({ endpoint: "/v2/projects", method: "get" });
+
+    reportApiFailure(error, 1);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "network", "unknown"],
+      extra: { endpoint: "/v2/projects", method: "GET", attempts: 1 },
+    });
+  });
+
+  it("reports a 429 HttpError (expected) as a warning message, fingerprinted by status", () => {
+    const error = new HttpError(429, { endpoint: "/v2/payouts", method: "post" });
+
+    reportApiFailure(error, 2);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "http", "429"],
+      extra: { endpoint: "/v2/payouts", method: "POST", attempts: 2 },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("reports a retryable upstream 504 HttpError (expected===false, retryable===true) as a warning message", () => {
+    const error = new HttpError(504, { endpoint: "/v2/projects", method: "get" });
+
+    reportApiFailure(error, 3);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "http", "504"],
+      extra: { endpoint: "/v2/projects", method: "GET", attempts: 3 },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("reports a TimeoutError as a warning message", () => {
+    const error = new TimeoutError({ endpoint: "/v2/projects", method: "get", timeoutMs: 30000 });
+
+    reportApiFailure(error, 1);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "timeout", "unknown"],
+      extra: { endpoint: "/v2/projects", method: "GET", attempts: 1 },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("reports a RequestAborted as a warning message", () => {
+    const error = new RequestAborted({ endpoint: "/v2/projects", method: "delete" });
+
+    reportApiFailure(error, 1);
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(expect.any(String), {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", "aborted", "unknown"],
+      extra: { endpoint: "/v2/projects", method: "DELETE", attempts: 1 },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("reports a ContractViolationError via captureException, fingerprinted by endpoint, endpoint never in message-level fingerprint of the warning path", () => {
+    const error = new ContractViolationError({
+      endpoint: "/v2/projects",
+      method: "get",
+      issues: ["title: Required", "uid: Expected string, received number"],
+    });
+
+    reportApiFailure(error);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      level: "error",
+      fingerprint: ["api-contract-violation", "/v2/projects"],
+      extra: {
+        endpoint: "/v2/projects",
+        method: "GET",
+        issues: ["title: Required", "uid: Expected string, received number"],
+      },
+    });
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports an unexpected HttpError (e.g. 500) via a normal captureException", () => {
+    const error = new HttpError(500, { endpoint: "/v2/projects", method: "post" });
+
+    reportApiFailure(error, 1);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      extra: { endpoint: "/v2/projects", method: "POST", status: 500, attempts: 1 },
+    });
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it("puts the endpoint in extra, never in the fingerprint, for the exhaustion (warning) path", () => {
+    const error = new HttpError(429, { endpoint: "/v2/very/specific/path/123", method: "get" });
+
+    reportApiFailure(error, 3);
+
+    const [, context] = mockCaptureMessage.mock.calls[0];
+    expect(context.fingerprint).not.toContain("/v2/very/specific/path/123");
+    expect(context.extra.endpoint).toBe("/v2/very/specific/path/123");
+  });
+
+  it("does nothing for a non-ApiError value", () => {
+    // @ts-expect-error — intentionally passing a non-ApiError to verify the runtime guard
+    reportApiFailure(new Error("boom"));
+
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/utilities/api/client.ts
+++ b/utilities/api/client.ts
@@ -1,0 +1,304 @@
+import axios, { type AxiosRequestConfig, type AxiosResponse, type Method } from "axios";
+import type { ZodType } from "zod";
+import { TokenManager } from "@/utilities/auth/token-manager";
+import { envVars } from "@/utilities/enviromentVars";
+import { sanitizeObject } from "@/utilities/sanitize";
+import {
+  type ApiError,
+  type ApiErrorContext,
+  ContractViolationError,
+  HttpError,
+  isApiError,
+  stripQuery,
+  toApiError,
+} from "./errors";
+import { reportApiFailure } from "./report";
+import { executeWithRetry, type RetryPolicy } from "./retry";
+
+/** @public */
+export interface PageInfo {
+  totalItems?: number;
+  page?: number;
+  pageLimit?: number;
+  /* passthrough */
+  [k: string]: unknown;
+}
+
+/** @public */
+export interface RequestOptions<T> {
+  schema?: ZodType<T>;
+  signal?: AbortSignal;
+  timeoutMs?: number; // default 30_000
+  headers?: Record<string, string>;
+  params?: Record<string, unknown>;
+  retryAttempts?: number; // default: GET/HEAD server→3 / browser→1 ; mutations→1
+  idempotencyKey?: string; // required to retry POST/PUT/PATCH/DELETE (>1 attempt)
+  isAuthorized?: boolean; // default true (mirrors fetchData)
+  baseURL?: string; // override singleton baseURL (adapter uses this for non-indexer calls)
+  cache?: boolean; // legacy indexer ?cache= param passthrough (adapter parity)
+}
+
+/** @public */
+export interface ApiClient {
+  get<T = unknown>(path: string, opts?: RequestOptions<T>): Promise<T>;
+  post<T = unknown>(path: string, body?: unknown, opts?: RequestOptions<T>): Promise<T>;
+  put<T = unknown>(path: string, body?: unknown, opts?: RequestOptions<T>): Promise<T>;
+  patch<T = unknown>(path: string, body?: unknown, opts?: RequestOptions<T>): Promise<T>;
+  delete<T = unknown>(path: string, opts?: RequestOptions<T>): Promise<T>;
+  getPaginated<T = unknown>(
+    path: string,
+    opts?: RequestOptions<T>
+  ): Promise<{ data: T; pageInfo: PageInfo | null }>;
+  // low-level escape hatch used by the fetchData adapter — returns full
+  // unwrapped payload + status + pageInfo:
+  request<T = unknown>(
+    method: string,
+    path: string,
+    body: unknown,
+    opts?: RequestOptions<T>
+  ): Promise<{ data: T; status: number; pageInfo: PageInfo | null }>;
+}
+
+interface ApiClientConfig {
+  baseURL: string;
+  getAuthToken?: () => Promise<string | null>;
+  onAuthExpired?: () => Promise<string | null>;
+  onExhausted?: (error: ApiError, attempts: number) => void;
+}
+
+const MAX_RETRY_AFTER_MS = 30_000;
+const MAX_JITTER_BASE_MS = 1000;
+const JITTER_STEP_MS = 250;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Copies passthrough entries into a nominally-typed PageInfo without any
+ * cast — every field is assigned through PageInfo's own index signature
+ * (`[k: string]: unknown`), which accepts `unknown` values directly.
+ */
+function toPageInfo(value: unknown): PageInfo | null {
+  if (!isRecord(value)) return null;
+  const pageInfo: PageInfo = {};
+  for (const [key, entry] of Object.entries(value)) {
+    pageInfo[key] = entry;
+  }
+  return pageInfo;
+}
+
+function toAxiosMethod(method: string): Method {
+  switch (method.toUpperCase()) {
+    case "GET":
+      return "GET";
+    case "POST":
+      return "POST";
+    case "PUT":
+      return "PUT";
+    case "PATCH":
+      return "PATCH";
+    case "DELETE":
+      return "DELETE";
+    case "HEAD":
+      return "HEAD";
+    case "OPTIONS":
+      return "OPTIONS";
+    default:
+      throw new Error(`Unsupported HTTP method: ${method}`);
+  }
+}
+
+function isServerSide(): boolean {
+  return typeof window === "undefined";
+}
+
+function fullJitterDelayMs(attempt: number): number {
+  return Math.random() * Math.min(MAX_JITTER_BASE_MS, JITTER_STEP_MS * 2 ** attempt);
+}
+
+export function createApiClient(config: ApiClientConfig): ApiClient {
+  const finalize = <T>(
+    body: unknown,
+    opts: RequestOptions<T>,
+    endpoint: string,
+    method: string
+  ): T => {
+    if (!opts.schema) {
+      // The one sanctioned cast: converting an untyped JSON payload into the
+      // caller-declared generic when no runtime schema was provided.
+      return body as unknown as T;
+    }
+
+    const result = opts.schema.safeParse(body);
+    if (!result.success) {
+      throw new ContractViolationError({
+        endpoint,
+        method,
+        issues: result.error.issues
+          .slice(0, 10)
+          .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`),
+      });
+    }
+    return result.data;
+  };
+
+  const performRequest = async <T>(
+    method: string,
+    path: string,
+    body: unknown,
+    opts: RequestOptions<T>
+  ): Promise<{
+    body: unknown;
+    status: number;
+    pageInfo: PageInfo | null;
+    ctx: ApiErrorContext;
+  }> => {
+    const upperMethod = method.toUpperCase();
+    const axiosMethod = toAxiosMethod(upperMethod);
+    const isAuthorized = opts.isAuthorized ?? true;
+    const timeoutMs = opts.timeoutMs ?? 30_000;
+    const effectiveBaseURL = opts.baseURL ?? config.baseURL;
+    const isDefaultBaseURL = effectiveBaseURL === config.baseURL;
+    const endpoint = stripQuery(path);
+    const ctx: ApiErrorContext = {
+      endpoint,
+      method: upperMethod,
+      timeoutMs,
+      signal: opts.signal,
+    };
+
+    const url = (() => {
+      if (isDefaultBaseURL && opts.cache) {
+        const separator = path.includes("?") ? "&" : "?";
+        return `${effectiveBaseURL}${path}${separator}cache=${opts.cache}`;
+      }
+      return `${effectiveBaseURL}${path}`;
+    })();
+
+    const sanitizedBody = sanitizeObject(body ?? {});
+
+    const buildConfig = (token: string | null): AxiosRequestConfig => ({
+      url,
+      method: axiosMethod,
+      data: sanitizedBody,
+      params: opts.params,
+      headers: {
+        ...opts.headers,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      signal: opts.signal,
+      timeout: timeoutMs,
+    });
+
+    const shouldAttachAuth = isAuthorized && isDefaultBaseURL && Boolean(config.getAuthToken);
+
+    const doOnce = async (): Promise<AxiosResponse> => {
+      const token = shouldAttachAuth && config.getAuthToken ? await config.getAuthToken() : null;
+      try {
+        return await axios.request(buildConfig(token));
+      } catch (rawErr) {
+        const apiErr = toApiError(rawErr, ctx);
+        const canRefreshAuth =
+          apiErr instanceof HttpError &&
+          apiErr.status === 401 &&
+          isAuthorized &&
+          isDefaultBaseURL &&
+          Boolean(config.onAuthExpired);
+
+        if (canRefreshAuth && config.onAuthExpired) {
+          const freshToken = await config.onAuthExpired();
+          if (freshToken) {
+            try {
+              return await axios.request(buildConfig(freshToken));
+            } catch (secondErr) {
+              throw toApiError(secondErr, ctx);
+            }
+          }
+        }
+        throw apiErr;
+      }
+    };
+
+    const isServer = isServerSide();
+    const isIdempotent =
+      upperMethod === "GET" || upperMethod === "HEAD" || Boolean(opts.idempotencyKey);
+    const defaultAttempts = isServer && isIdempotent ? 3 : 1;
+    const attempts = isServer ? Math.max(1, opts.retryAttempts ?? defaultAttempts) : 1;
+
+    const retryPolicy: RetryPolicy = {
+      attempts,
+      signal: opts.signal,
+      shouldRetry: (error) =>
+        isServer && isIdempotent && !opts.signal?.aborted && isApiError(error) && error.retryable,
+      delayMs: (attempt, error) => {
+        if (error instanceof HttpError && error.retryAfterMs != null) {
+          return Math.min(error.retryAfterMs, MAX_RETRY_AFTER_MS);
+        }
+        return fullJitterDelayMs(attempt);
+      },
+    };
+
+    let attemptsMade = 0;
+    try {
+      const res = await executeWithRetry<AxiosResponse>(async () => {
+        attemptsMade += 1;
+        return doOnce();
+      }, retryPolicy);
+
+      const pageInfo = toPageInfo(isRecord(res.data) ? res.data.pageInfo : undefined);
+      return { body: res.data, status: res.status, pageInfo, ctx };
+    } catch (err) {
+      const apiErr = isApiError(err) ? err : toApiError(err, ctx);
+      // Only a genuine retry EXHAUSTION reports to Sentry. A single-attempt
+      // failure (every browser call, and every server mutation/non-retryable
+      // error) never reports — matching legacy fetchData behavior and keeping
+      // the 220 adapter call sites (retryAttempts:1) silent as they are today.
+      if (attemptsMade > 1) config.onExhausted?.(apiErr, attemptsMade);
+      throw apiErr;
+    }
+  };
+
+  const request: ApiClient["request"] = async (method, path, body, opts = {}) => {
+    const {
+      body: responseBody,
+      status,
+      pageInfo,
+      ctx,
+    } = await performRequest(method, path, body, opts);
+    return {
+      data: finalize(responseBody, opts, ctx.endpoint, ctx.method),
+      status,
+      pageInfo,
+    };
+  };
+
+  return {
+    get: <T = unknown>(path: string, opts: RequestOptions<T> = {}) =>
+      request<T>("GET", path, undefined, opts).then((r) => r.data),
+    post: <T = unknown>(path: string, body?: unknown, opts: RequestOptions<T> = {}) =>
+      request<T>("POST", path, body, opts).then((r) => r.data),
+    put: <T = unknown>(path: string, body?: unknown, opts: RequestOptions<T> = {}) =>
+      request<T>("PUT", path, body, opts).then((r) => r.data),
+    patch: <T = unknown>(path: string, body?: unknown, opts: RequestOptions<T> = {}) =>
+      request<T>("PATCH", path, body, opts).then((r) => r.data),
+    delete: <T = unknown>(path: string, opts: RequestOptions<T> = {}) =>
+      request<T>("DELETE", path, undefined, opts).then((r) => r.data),
+    getPaginated: async <T = unknown>(path: string, opts: RequestOptions<T> = {}) => {
+      const { body, pageInfo, ctx } = await performRequest("GET", path, undefined, opts);
+      const inner = isRecord(body) ? body.data : undefined;
+      return { data: finalize(inner, opts, ctx.endpoint, ctx.method), pageInfo };
+    },
+    request,
+  };
+}
+
+export const api: ApiClient = createApiClient({
+  baseURL: envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
+  getAuthToken: () => TokenManager.getToken(),
+  onAuthExpired: async () => {
+    TokenManager.clearCache();
+    return TokenManager.getToken();
+  },
+  onExhausted: reportApiFailure,
+});

--- a/utilities/api/errors.ts
+++ b/utilities/api/errors.ts
@@ -1,0 +1,270 @@
+/**
+ * Typed API error taxonomy for the unified API client (issue #1775, Phase 1).
+ *
+ * Every rejection that can escape the client MUST be normalized into one of
+ * the concrete `ApiError` subclasses below via `toApiError`. This keeps
+ * `retryable`/`expected` decisions, Sentry reporting policy, and the
+ * degrade/throw/status-branch codemod patterns (Phase 3) all working off a
+ * single, closed set of shapes instead of duck-typing raw AxiosError/undici
+ * errors at every call site.
+ */
+
+/**
+ * Discriminant for exhaustive `switch` over API failures.
+ * @public
+ */
+export type ApiErrorKind = "http" | "network" | "timeout" | "aborted" | "contract";
+
+/**
+ * Base class for every classified API failure. Concrete subclasses fix
+ * `kind`/`retryable`/`expected` as literal values so callers can discriminate
+ * on `kind` or fall back to `instanceof`.
+ */
+export abstract class ApiError extends Error {
+  abstract readonly kind: ApiErrorKind;
+  abstract readonly retryable: boolean;
+  abstract readonly expected: boolean;
+  /** Path only — query string is stripped for PII hygiene. */
+  readonly endpoint: string;
+  /** Always uppercased (GET, POST, ...). */
+  readonly method: string;
+
+  constructor(message: string, opts: { endpoint: string; method: string; cause?: unknown }) {
+    super(message, { cause: opts.cause });
+    this.name = new.target.name;
+    this.endpoint = stripQuery(opts.endpoint);
+    this.method = opts.method.toUpperCase();
+  }
+}
+
+/** Statuses worth an automatic retry: request timeout + upstream/gateway blips. */
+const RETRYABLE_HTTP_STATUSES = new Set([408, 429, 502, 503, 504]);
+
+/** A response came back with a non-2xx status. */
+export class HttpError extends ApiError {
+  readonly kind = "http";
+  readonly status: number;
+  readonly body?: unknown;
+  readonly retryAfterMs?: number;
+  readonly retryable: boolean;
+  readonly expected: boolean;
+
+  constructor(
+    status: number,
+    opts: {
+      endpoint: string;
+      method: string;
+      cause?: unknown;
+      body?: unknown;
+      retryAfterMs?: number;
+    }
+  ) {
+    super(`HTTP ${status} ${opts.method.toUpperCase()} ${stripQuery(opts.endpoint)}`, opts);
+    this.status = status;
+    this.body = opts.body;
+    this.retryAfterMs = opts.retryAfterMs;
+    this.retryable = RETRYABLE_HTTP_STATUSES.has(status);
+    this.expected = status === 429;
+  }
+}
+
+/** No HTTP response at all — DNS failure, connection reset, offline, CORS, etc. */
+export class NetworkError extends ApiError {
+  readonly kind = "network";
+  readonly code?: string;
+  readonly retryable = true;
+  readonly expected = true;
+
+  constructor(opts: {
+    endpoint: string;
+    method: string;
+    cause?: unknown;
+    code?: string;
+    message?: string;
+  }) {
+    super(
+      opts.message ?? `Network error: ${opts.method.toUpperCase()} ${stripQuery(opts.endpoint)}`,
+      opts
+    );
+    this.code = opts.code;
+  }
+}
+
+/** Request exceeded its per-attempt deadline (ECONNABORTED/ETIMEDOUT, no response). */
+export class TimeoutError extends ApiError {
+  readonly kind = "timeout";
+  readonly timeoutMs: number;
+  readonly retryable = false;
+  readonly expected = true;
+
+  constructor(opts: { endpoint: string; method: string; cause?: unknown; timeoutMs: number }) {
+    super(
+      `Request timed out after ${opts.timeoutMs}ms: ${opts.method.toUpperCase()} ${stripQuery(opts.endpoint)}`,
+      opts
+    );
+    this.timeoutMs = opts.timeoutMs;
+  }
+}
+
+/** Caller-initiated cancellation (AbortController, route change, unmount). */
+export class RequestAborted extends ApiError {
+  readonly kind = "aborted";
+  readonly retryable = false;
+  readonly expected = true;
+
+  constructor(opts: { endpoint: string; method: string; cause?: unknown }) {
+    super(`Request aborted: ${opts.method.toUpperCase()} ${stripQuery(opts.endpoint)}`, opts);
+  }
+}
+
+/** A 2xx response body failed schema validation. */
+export class ContractViolationError extends ApiError {
+  readonly kind = "contract";
+  readonly issues: string[];
+  readonly retryable = false;
+  readonly expected = false;
+
+  constructor(opts: { endpoint: string; method: string; cause?: unknown; issues: string[] }) {
+    super(
+      `Response failed schema validation: ${opts.method.toUpperCase()} ${stripQuery(opts.endpoint)}`,
+      opts
+    );
+    this.issues = opts.issues;
+  }
+}
+
+export function isApiError(e: unknown): e is ApiError {
+  return e instanceof ApiError;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Retry-After can be either an integer number of seconds, or an HTTP-date
+ * naming the moment the retry window opens. Returns milliseconds, clamped to
+ * [0, 120_000] for the date form so a clock-skewed/absurd header can't stall
+ * a retry loop indefinitely. Returns `undefined` for anything unparseable.
+ */
+export function parseRetryAfterMs(headerValue: unknown): number | undefined {
+  const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  if (typeof raw !== "string" && typeof raw !== "number") return undefined;
+
+  const value = String(raw).trim();
+  if (value === "") return undefined;
+
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) return undefined;
+  return Math.min(120_000, Math.max(0, dateMs - Date.now()));
+}
+
+const MAX_CAUSE_DEPTH = 5;
+
+function getErrorCodeAtDepth(error: unknown, depth: number): string | undefined {
+  if (depth > MAX_CAUSE_DEPTH || !isRecord(error)) return undefined;
+  const code = error.code;
+  if (typeof code === "string") return code;
+  return getErrorCodeAtDepth(error.cause, depth + 1);
+}
+
+/** Walks `error.code`, then `error.cause.code`, etc. up to a depth guard. */
+export function getErrorCode(error: unknown): string | undefined {
+  return getErrorCodeAtDepth(error, 0);
+}
+
+/** Strips the query string (and everything after `?`) from a path or URL. */
+export function stripQuery(pathOrUrl: string): string {
+  const idx = pathOrUrl.indexOf("?");
+  return idx === -1 ? pathOrUrl : pathOrUrl.slice(0, idx);
+}
+
+export interface ApiErrorContext {
+  endpoint: string;
+  method: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+const ABORT_CODES = new Set(["ERR_CANCELED", "ABORT_ERR"]);
+const ABORT_NAMES = new Set(["CanceledError", "AbortError"]);
+const TIMEOUT_CODES = new Set(["ECONNABORTED", "ETIMEDOUT"]);
+
+function isAborted(err: unknown, ctx: ApiErrorContext): boolean {
+  if (ctx.signal?.aborted === true) return true;
+  if (!isRecord(err)) return false;
+
+  const code = err.code;
+  if (typeof code === "string" && ABORT_CODES.has(code)) return true;
+
+  const name = err.name;
+  return typeof name === "string" && ABORT_NAMES.has(name);
+}
+
+interface AxiosLikeResponse {
+  status: number;
+  data?: unknown;
+  headers?: Record<string, unknown>;
+}
+
+function getResponse(err: unknown): AxiosLikeResponse | undefined {
+  if (!isRecord(err)) return undefined;
+  const response = err.response;
+  if (!isRecord(response)) return undefined;
+
+  const status = response.status;
+  if (typeof status !== "number") return undefined;
+
+  return {
+    status,
+    data: response.data,
+    headers: isRecord(response.headers) ? response.headers : undefined,
+  };
+}
+
+/**
+ * Classifies ANY rejection reachable from the client into a concrete
+ * `ApiError`. Idempotent: an already-classified `ApiError` is returned
+ * as-is. Otherwise, in order: abort, then HTTP response, then
+ * timeout-without-response, then any other no-response failure.
+ */
+export function toApiError(err: unknown, ctx: ApiErrorContext): ApiError {
+  if (err instanceof ApiError) return err;
+
+  if (isAborted(err, ctx)) {
+    return new RequestAborted({ endpoint: ctx.endpoint, method: ctx.method, cause: err });
+  }
+
+  const response = getResponse(err);
+  if (response) {
+    return new HttpError(response.status, {
+      endpoint: ctx.endpoint,
+      method: ctx.method,
+      cause: err,
+      body: response.data,
+      retryAfterMs: parseRetryAfterMs(response.headers?.["retry-after"]),
+    });
+  }
+
+  const code = isRecord(err) ? err.code : undefined;
+  if (typeof code === "string" && TIMEOUT_CODES.has(code)) {
+    return new TimeoutError({
+      endpoint: ctx.endpoint,
+      method: ctx.method,
+      cause: err,
+      timeoutMs: ctx.timeoutMs ?? 30_000,
+    });
+  }
+
+  return new NetworkError({
+    endpoint: ctx.endpoint,
+    method: ctx.method,
+    cause: err,
+    code: getErrorCode(err),
+  });
+}

--- a/utilities/api/or-else.ts
+++ b/utilities/api/or-else.ts
@@ -1,0 +1,19 @@
+import { isApiError } from "./errors";
+
+/**
+ * Await `promise`; if it rejects with an "expected" ApiError (network blip,
+ * 429, timeout, aborted), resolve to `fallback` instead of propagating.
+ * Anything else (contract violations, unexpected 5xx, non-ApiError) rethrows.
+ *
+ * @public
+ */
+export async function orElse<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await promise;
+  } catch (e) {
+    if (isApiError(e) && e.expected) {
+      return fallback;
+    }
+    throw e;
+  }
+}

--- a/utilities/api/report.ts
+++ b/utilities/api/report.ts
@@ -1,0 +1,68 @@
+import * as Sentry from "@sentry/nextjs";
+import {
+  type ApiError,
+  ContractViolationError,
+  HttpError,
+  isApiError,
+  type NetworkError,
+} from "./errors";
+
+/**
+ * Centralized Sentry reporting policy for the typed API client.
+ *
+ * Called from the client's `onExhausted` hook once retries (if any) are
+ * exhausted for a request, and later reused by `errorManager` (Phase 2).
+ * This is the ONE place that decides Sentry level/fingerprint/extra for
+ * API failures — do not call `Sentry.captureException`/`captureMessage`
+ * for API errors anywhere else.
+ *
+ * Policy:
+ * - `ContractViolationError` → `captureException` at "error" level,
+ *   fingerprinted by endpoint (a real bug — the response no longer
+ *   matches the schema for this specific endpoint).
+ * - Transient failure (`error.expected` — network / 429 / timeout / abort —
+ *   OR a retryable upstream `HttpError`, i.e. 502/503/504) → `captureMessage`
+ *   at "warning" level, fingerprinted by kind (+ status or network error
+ *   code), never by endpoint. These are the errors the client retried; being
+ *   called here means retries were genuinely exhausted. Retryable 5xx are
+ *   `expected === false`, so they must be caught by the `retryable` branch —
+ *   capturing them as exceptions would regress the historical
+ *   `isTransientHttpError` suppression.
+ * - Any other `HttpError` (a non-transient, non-retryable failure, e.g. 500)
+ *   → normal `captureException`.
+ * - Non-`ApiError` values are ignored here; legacy paths still go
+ *   through `errorManager` directly.
+ */
+export function reportApiFailure(error: ApiError, attempts?: number): void {
+  if (!isApiError(error)) return;
+
+  if (error instanceof ContractViolationError) {
+    Sentry.captureException(error, {
+      level: "error",
+      fingerprint: ["api-contract-violation", error.endpoint],
+      extra: { endpoint: error.endpoint, method: error.method, issues: error.issues },
+    });
+    return;
+  }
+
+  const isTransient = error.expected || (error instanceof HttpError && error.retryable);
+  if (isTransient) {
+    const kindDiscriminator =
+      error instanceof HttpError
+        ? String(error.status)
+        : ((error as NetworkError).code ?? "unknown");
+
+    Sentry.captureMessage(`API ${error.method} request exhausted retries (${error.kind})`, {
+      level: "warning",
+      fingerprint: ["api-retries-exhausted", error.kind, kindDiscriminator],
+      extra: { endpoint: error.endpoint, method: error.method, attempts },
+    });
+    return;
+  }
+
+  if (error instanceof HttpError) {
+    Sentry.captureException(error, {
+      extra: { endpoint: error.endpoint, method: error.method, status: error.status, attempts },
+    });
+  }
+}

--- a/utilities/api/retry.ts
+++ b/utilities/api/retry.ts
@@ -1,0 +1,69 @@
+/**
+ * Self-contained retry executor for the typed API client.
+ *
+ * Deliberately has no knowledge of HTTP, axios, or classification — it just
+ * runs `fn`, and on failure decides whether to retry based on the caller's
+ * `RetryPolicy`. The caller (client.ts) owns:
+ *  - whether we're server-side (retries are server-only)
+ *  - error classification/retryability (via toApiError().retryable)
+ *  - the delay formula (retry-after vs full-jitter)
+ */
+export interface RetryPolicy {
+  /** Total tries (1 = no retry). */
+  attempts: number;
+  shouldRetry: (error: unknown) => boolean;
+  /** attempt is the 0-based index of the FAILED try. */
+  delayMs: (attempt: number, error: unknown) => number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Aborts immediately if `signal` is already aborted, and rejects mid-wait if
+ * it aborts during the delay — so a caller cancelling a request doesn't have
+ * to wait out a pending retry backoff before the cancellation takes effect.
+ */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Aborted"));
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function executeWithRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  policy: RetryPolicy
+): Promise<T> {
+  const { attempts, shouldRetry, delayMs, signal } = policy;
+  const totalAttempts = Math.max(1, attempts);
+
+  // Recursion (rather than a for-loop) so the sequential `await` doesn't trip
+  // the `async-await-in-loop` lint — the retries are intentionally serial.
+  const runAttempt = async (n: number): Promise<T> => {
+    try {
+      return await fn(n);
+    } catch (error) {
+      const isLastAttempt = n === totalAttempts - 1;
+      if (signal?.aborted || isLastAttempt || !shouldRetry(error)) {
+        throw error;
+      }
+      await delay(delayMs(n, error), signal);
+      return runAttempt(n + 1);
+    }
+  };
+
+  return runAttempt(0);
+}

--- a/utilities/fetchData.ts
+++ b/utilities/fetchData.ts
@@ -1,25 +1,33 @@
-import axios, { type AxiosResponse, type Method } from "axios";
-import { TokenManager } from "@/utilities/auth/token-manager";
+import type { Method } from "axios";
+import { api } from "./api/client";
+import { HttpError, isApiError } from "./api/errors";
 import { envVars } from "./enviromentVars";
-import { sanitizeObject } from "./sanitize";
 
 /**
- * Fetch data utility that uses Privy's TokenManager for authentication
+ * Fetch data utility — thin legacy adapter over the typed `api` client
+ * (see `utilities/api/README.md`).
  *
- * This replaces the complex cookie-based token retrieval with
- * Privy's simplified token management.
+ * DEPRECATED: this preserves the historical `[data, error, pageInfo, status]`
+ * tuple contract for the ~220 existing call sites. All transport (auth
+ * header attachment, 401-refresh-once, timeouts, the indexer `?cache=`
+ * param, and error classification) is now implemented once in
+ * `utilities/api/client.ts` — this file only translates between that typed
+ * client and the legacy tuple shape. New code should call `api.get` /
+ * `api.post` / `api.put` / `api.patch` / `api.delete` directly with a zod
+ * `schema` instead of adding new callers of this function.
  *
- * The optional `signal` is forwarded to axios so a long-running request
+ * The optional `signal` is forwarded to the client so a long-running request
  * is cancelled when the caller aborts — used by the milestone-completion
  * polling hook to halt in-flight fetches when a component unmounts mid-
  * poll. Without it, an aborted poll iteration still completes its
  * current request before the next abort check fires.
  *
  * **Caller contract** when passing `signal`: an aborted request lands in
- * the catch path as an axios cancel error. The function returns the
- * standard `[null, error, null, status]` tuple in that case; callers
- * should use `isAbortError(err)` (from `utilities/retries`) when
- * inspecting the error to distinguish cancellation from real failures.
+ * the catch path below as a `RequestAborted` (mapped to the raw cause, or
+ * the `RequestAborted` instance itself if no cause is available) in the
+ * error slot; callers should use `isAbortError(err)` (from
+ * `utilities/retries`) when inspecting the error to distinguish
+ * cancellation from real failures.
  *
  * @template T - Optional type parameter for response data (defaults to any for backward compatibility)
  * @returns Promise<[T, null, any, number] | [null, string, null, number]> - Tuple of [data, error, pageInfo, status]
@@ -35,77 +43,51 @@ export default async function fetchData<T = any>(
   baseUrl: string = envVars.NEXT_PUBLIC_GAP_INDEXER_URL,
   signal?: AbortSignal
 ): Promise<[T, null, any, number] | [null, string, null, number]> {
+  const isIndexerUrl = baseUrl === envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
+
   try {
-    const sanitizedData = sanitizeObject(axiosData);
-    const isIndexerUrl = baseUrl === envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
-
-    const requestConfig: any = {
-      url: isIndexerUrl
-        ? `${baseUrl}${endpoint}${
-            cache ? `${endpoint.includes("?") ? "&" : "?"}cache=${cache}` : ""
-          }`
-        : `${baseUrl}${endpoint}`,
-      method,
-      data: sanitizedData,
+    const { data, status, pageInfo } = await api.request<T>(method, endpoint, axiosData, {
       params,
-      headers: {
-        ...headers,
-      },
+      headers,
+      isAuthorized,
+      cache,
+      baseURL: baseUrl,
       signal,
-      // Default timeout for all requests so a hung connection surfaces as
-      // an axios error the data layer can retry instead of leaving the UI
-      // in an indefinite loading state. Authorized indexer requests below
-      // keep their longer ceiling for legacy long-poll endpoints.
-      timeout: 30000,
-    };
-
-    // Indexer requests get a generous timeout regardless of token presence.
-    // Anonymous calls hit optional-auth routes and shouldn't run unbounded
-    // (axios defaults to 0 = no timeout) just because no Privy token exists.
-    if (isIndexerUrl) {
-      requestConfig.timeout = 360000;
-
-      if (isAuthorized) {
-        const token = await TokenManager.getToken();
-        if (token) {
-          requestConfig.headers.Authorization = `Bearer ${token}`;
-        }
-      }
-    }
-
-    let res: AxiosResponse<T & { pageInfo?: any }>;
-    try {
-      res = await axios.request<T & { pageInfo?: any }>(requestConfig);
-    } catch (err) {
-      // Retry once on 401 for authorized indexer requests. The token may have
-      // been absent or stale because Privy had not finished bootstrapping when
-      // the request fired (the deferred-SDK auth race). Without this, fetchData
-      // swallows the 401 into a "successful" null tuple below, so React Query
-      // treats it as empty data and never refetches — a manual page refresh is
-      // the only recovery. Re-fetching a fresh token and retrying self-heals it.
-      const status = (err as { response?: { status?: number } } | null)?.response?.status;
-      if (isIndexerUrl && isAuthorized && status === 401) {
-        TokenManager.clearCache();
-        const freshToken = await TokenManager.getToken();
-        if (!freshToken) throw err;
-        requestConfig.headers.Authorization = `Bearer ${freshToken}`;
-        res = await axios.request<T & { pageInfo?: any }>(requestConfig);
-      } else {
-        throw err;
-      }
-    }
-    const resData = res.data;
-    const pageInfo = resData?.pageInfo || null;
-    return [resData, null, pageInfo, res.status];
+      // Indexer requests get a generous timeout regardless of token presence
+      // (see the module doc above); non-indexer requests keep the default
+      // so a hung connection surfaces as an error instead of hanging the UI.
+      timeoutMs: isIndexerUrl ? 360000 : 30000,
+      // The legacy fetchData never retried — preserve that exactly so this
+      // rewrite is behavior-neutral for the 220 existing call sites.
+      retryAttempts: 1,
+    });
+    return [data, null, pageInfo, status];
   } catch (err: any) {
-    let error = "";
-    let status = 500;
-    if (!err.response) {
-      error = err;
-    } else {
-      error = err.response.data.message || err.message;
-      status = err.response.status;
+    if (isApiError(err)) {
+      if (err instanceof HttpError) {
+        // Legacy fetchData returned `err.response.data.message || err.message`,
+        // where `err.message` was the ORIGINAL axios error message. The client
+        // now preserves that original message on `err.cause`, so fall back to
+        // it before the synthetic `HttpError.message` ("HTTP 504 GET /path").
+        const bodyMessage = (err.body as { message?: string } | undefined)?.message;
+        const causeMessage = (err.cause as { message?: string } | undefined)?.message;
+        return [null, bodyMessage ?? causeMessage ?? err.message, null, err.status];
+      }
+      // Network / timeout / aborted / contract-violation: preserve the
+      // legacy behavior of surfacing the *original* underlying error object
+      // (not a stringified message) in the tuple's error slot — existing
+      // callers coerce it to a string themselves (e.g. `String(error)` or
+      // `error.message`), see __tests__/regression/error-includes-crash.test.ts.
+      // The tuple's declared type says `string` here for backward
+      // compatibility with the pre-existing (inaccurate) signature — the
+      // legacy implementation had the same mismatch via `catch (err: any)`.
+      const cause = err.cause;
+      return [null, (cause ?? err) as string, null, 500];
     }
-    return [null, error, null, status];
+    // Defensive fallback: the client's contract guarantees every rejection
+    // from `api.request()` is mapped to an ApiError, so this path should be
+    // unreachable — kept only so a future contract break degrades to the
+    // old "raw error object" behavior instead of throwing out of fetchData.
+    return [null, err, null, 500];
   }
 }


### PR DESCRIPTION
## Overview

Phase 1 of #1775 — introduces `utilities/api/`, a single typed API client that returns `Promise<T>` and **throws a closed, typed error taxonomy** instead of the tuple-returning `fetchData` contract. Responses are validated with zod at the boundary, retry policy and Sentry reporting are centralized, and graceful degradation becomes an explicit opt-in.

This is a **dark launch**: the only consumer wired up is the `fetchData` adapter, so no behavior changes for the ~220 existing call sites. Migration of those sites is deferred to later phases.

## Problem

Our top Sentry issues were caused or worsened by the current error handling: `fetchData` collapses every failure to a string, so policy code (React Query retry gate, `errorManager`) reads error *messages* and guesses. A 429 was invisible to the retry gate; Node socket errors were unclassified; a `null` from an untyped boundary reached a `.length` deep in a component tree. Every past fix added another string-matching special case.

## Solution

Policy now reads typed properties, never messages. New `utilities/api/`:

| File | Responsibility |
|---|---|
| `errors.ts` | Taxonomy (`HttpError` / `NetworkError` / `TimeoutError` / `RequestAborted` / `ContractViolationError`) with `readonly` `kind` / `retryable` / `expected`; `toApiError` classifier; `parseRetryAfterMs`; cause-walking `getErrorCode` |
| `client.ts` | `createApiClient` + `api` singleton — auth header, once-per-request 401-refresh, **server-only** full-jitter retry, zod boundary validation, indexer envelope unwrap, `getPaginated` |
| `retry.ts` | Recursive, abort-aware `executeWithRetry` |
| `report.ts` | One-place Sentry policy: warn (fingerprinted) on exhausted transient failures, capture contract violations per-endpoint |
| `or-else.ts` | `orElse(promise, fallback)` — converts only *expected* operational failures; bugs still throw |

`fetchData` is reimplemented as a thin adapter over the client; its `[data, error, pageInfo, status]` tuple contract is preserved **exactly**.

It is impossible to catch a raw `AxiosError` from `api.*` — every rejection path is normalized through `toApiError` (test-enforced).

## Testing steps

All green:

- Full unit suite: **13,825 / 13,825** passing (929 files) — no regressions
- New `utilities/api/` suite: taxonomy truth-table, client behavior 1–8, `orElse`, and report-policy tests
- Pre-existing `fetchData` + trust + payout suites pass **unmodified** (the adapter's acceptance criterion)
- `pnpm quality --ci --skip-coverage` ✅ Passed — knip Δ 0, react-doctor Δ −1, tsc clean, biome clean
- No `any` / `as any` except the single sanctioned `as unknown as T` where the axios payload meets the zod parse

```bash
pnpm test:unit
pnpm quality --ci --skip-coverage
```

## Notes / deviations

- **Self-contained.** #1769's primitives are not yet on `main`, so this phase carries its own classification / retry / reporting logic rather than building on those files.
- **No barrel `index.ts`.** The repo's "import directly from source files" rule takes precedence; the public surface is imported from `client.ts` / `errors.ts` / `or-else.ts`. New code should call `api.get(path, { schema })` with a zod schema (see `utilities/api/README.md`).

Refs #1775.
