### PR TITLE
feat: migrate remaining raw wallet-address displays to identity component (DEV-519)

### DIFF
--- a/__tests__/components/EthereumAddressToProfileName.test.tsx
+++ b/__tests__/components/EthereumAddressToProfileName.test.tsx
@@ -72,7 +72,7 @@ vi.mock("blo", () => ({
 // Mock the Privy bridge — drives "is this the logged-in user?" (self email tier)
 let mockBridgeUser: {
   email?: { address: string };
-  google?: { email: string };
+  google?: { email?: string; name?: string };
   farcaster?: { displayName?: string; username?: string };
   twitter?: { name?: string; username?: string };
   discord?: { username?: string };
@@ -234,8 +234,8 @@ describe("EthereumAddressToProfileName", () => {
       expect(screen.getByText("ens.eth")).toBeInTheDocument();
     });
 
-    it("shows the logged-in user's own email as a last resort (never a raw 0x for self)", () => {
-      // The rendered address IS the connected wallet → self.
+    it("shows the self user's email LOCAL-PART as a last resort — never the full email", () => {
+      // The rendered address IS the connected wallet → self, with only an email.
       mockBridgeWallets = [{ address: MOCK_ADDRESS_LOWER }];
       mockBridgeUser = { email: { address: "me@example.com" } };
       mockContributorProfile = null;
@@ -249,7 +249,26 @@ describe("EthereumAddressToProfileName", () => {
         wrapper: createWrapper(),
       });
 
-      expect(screen.getByText("me@example.com")).toBeInTheDocument();
+      expect(screen.getByText("me")).toBeInTheDocument();
+      expect(screen.queryByText("me@example.com")).not.toBeInTheDocument();
+    });
+
+    it("prefers a self user's provider display name over their email", () => {
+      mockBridgeWallets = [{ address: MOCK_ADDRESS_LOWER }];
+      mockBridgeUser = { google: { name: "Bruno De Masi", email: "bruno@karmahq.xyz" } };
+      mockContributorProfile = null;
+      mockProfilesData[MOCK_ADDRESS_LOWER] = {
+        publicAddress: MOCK_ADDRESS_LOWER,
+        name: "",
+        isTried: true,
+      };
+
+      render(<EthereumAddressToProfileName address={MOCK_ADDRESS} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByText("Bruno De Masi")).toBeInTheDocument();
+      expect(screen.queryByText("bruno@karmahq.xyz")).not.toBeInTheDocument();
     });
 
     it("shows the logged-in user's own social display name when they have no email", () => {

--- a/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.digit-leading-id.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.digit-leading-id.test.tsx
@@ -26,6 +26,10 @@ vi.mock("wagmi", () => ({
   }),
 }));
 
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address?: string }) => <span>{address}</span>,
+}));
+
 vi.mock("react-hot-toast", () => ({
   __esModule: true,
   default: {

--- a/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ApplicationSubmission.test.tsx
@@ -11,6 +11,11 @@ vi.mock("wagmi", () => ({
   }),
 }));
 
+// Mock the shared identity component (uses React Query; tested separately)
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address?: string }) => <span>{address}</span>,
+}));
+
 // Mock react-hot-toast
 vi.mock("react-hot-toast", () => ({
   __esModule: true,

--- a/__tests__/integration/journeys/grant-application.test.tsx
+++ b/__tests__/integration/journeys/grant-application.test.tsx
@@ -16,6 +16,11 @@ import type { IFormSchema } from "@/types/funding-platform";
 // Module mocks
 // ---------------------------------------------------------------------------
 
+// Mock the shared identity component (uses React Query; render address directly)
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address?: string }) => <span>{address}</span>,
+}));
+
 // Mock MarkdownEditor to a simple textarea
 vi.mock("@/components/Utilities/MarkdownEditor", () => ({
   MarkdownEditor: ({
@@ -273,9 +278,8 @@ describe("ApplicationSubmission - Grant application flow", () => {
     it("shows connected wallet address", () => {
       renderApplication();
 
-      expect(
-        screen.getByText(/Submitting as: 0x1234567890123456789012345678901234567890/)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Submitting as:/)).toBeInTheDocument();
+      expect(screen.getByText("0x1234567890123456789012345678901234567890")).toBeInTheDocument();
     });
 
     it("renders select fields with options", () => {

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationInfoCard.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationInfoCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { formatDate } from "@/utilities/formatDate";
 
@@ -14,24 +15,19 @@ interface ApplicationInfoCardProps {
   canViewApplicant: boolean;
 }
 
-function truncateAddress(address: string): string {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
-
 function deriveApplicant(email?: string, ownerAddress?: string) {
   if (email) {
     const localPart = email.split("@")[0] || email;
     return { name: localPart, secondary: email, initial: localPart.charAt(0).toUpperCase() };
   }
-  if (ownerAddress) {
-    return {
-      name: truncateAddress(ownerAddress),
-      secondary: undefined,
-      initial: ownerAddress.slice(2, 3).toUpperCase() || "?",
-    };
-  }
-  return { name: "Anonymous", secondary: undefined, initial: "?" };
+  // Address-only: the name is resolved by EthereumAddressToProfileName in the
+  // render (contributor → Privy → ENS → self email → truncated address); here we
+  // only supply the avatar initial.
+  return {
+    name: null as string | null,
+    secondary: undefined as string | undefined,
+    initial: ownerAddress?.slice(2, 3).toUpperCase() || "?",
+  };
 }
 
 export function ApplicationInfoCard({
@@ -105,7 +101,9 @@ export function ApplicationInfoCard({
             </span>
             <div className="min-w-0">
               <div className="truncate text-[13px] font-medium text-foreground">
-                {applicant.name}
+                {applicant.name ?? (
+                  <EthereumAddressToProfileName address={ownerAddress} shouldTruncate />
+                )}
               </div>
               {applicant.secondary && (
                 <div className="truncate text-xs text-muted-foreground">{applicant.secondary}</div>

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationInfoCard.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationInfoCard.test.tsx
@@ -7,6 +7,11 @@ vi.mock("@/hooks/useCopyToClipboard", () => ({
   useCopyToClipboard: () => [null, vi.fn()],
 }));
 
+// The address-only branch renders the shared identity component (tested separately).
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address?: string }) => <span>{address}</span>,
+}));
+
 const baseProps = {
   referenceNumber: "APP-9BLARDP8-560VRW",
   programName: "Filecoin ProPGF Batch 3",
@@ -61,7 +66,7 @@ describe("ApplicationInfoCard — applicant visibility", () => {
     expect(screen.getByText("applicant")).toBeInTheDocument();
   });
 
-  it("shows a truncated address when only ownerAddress is available", () => {
+  it("resolves the applicant identity via the shared component when only ownerAddress is available", () => {
     render(
       <ApplicationInfoCard
         {...baseProps}
@@ -72,6 +77,6 @@ describe("ApplicationInfoCard — applicant visibility", () => {
     );
 
     expect(screen.getByText("Applicant")).toBeInTheDocument();
-    expect(screen.getByText("0x1234…7890")).toBeInTheDocument();
+    expect(screen.getByText(ADDRESS)).toBeInTheDocument();
   });
 });

--- a/components/Dialogs/Member/DeleteMember.tsx
+++ b/components/Dialogs/Member/DeleteMember.tsx
@@ -4,6 +4,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import dynamic from "next/dynamic";
 import { type FC, Fragment, useState } from "react";
 import { useAccount } from "wagmi";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
@@ -213,7 +214,9 @@ export const DeleteMemberDialog: FC<DeleteMemberDialogProps> = ({ memberAddress 
                       as="h3"
                       className="text-xl font-medium leading-6 text-gray-900 dark:text-zinc-100"
                     >
-                      Are you sure you want to remove {memberAddress} from the project?
+                      Are you sure you want to remove{" "}
+                      <EthereumAddressToProfileName address={memberAddress} shouldTruncate /> from
+                      the project?
                     </Dialog.Title>
                     <div className="flex flex-row gap-4 mt-10 justify-end">
                       <Button

--- a/components/Dialogs/Member/DemoteMember.tsx
+++ b/components/Dialogs/Member/DemoteMember.tsx
@@ -2,10 +2,9 @@ import { Dialog, Transition } from "@headlessui/react";
 import { ShieldExclamationIcon } from "@heroicons/react/24/outline";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { type FC, Fragment, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { useMemberRoleChange } from "@/hooks/useMemberRoleChange";
-import { useTeamProfiles } from "@/hooks/useTeamProfiles";
-import { useProjectStore } from "@/store";
 
 interface DemoteMemberDialogProps {
   memberAddress: string;
@@ -13,18 +12,12 @@ interface DemoteMemberDialogProps {
 
 export const DemoteMemberDialog: FC<DemoteMemberDialogProps> = ({ memberAddress }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const project = useProjectStore((state) => state.project);
-  const { teamProfiles } = useTeamProfiles(project);
   const { execute, isLoading } = useMemberRoleChange("demote");
 
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
   const handleDemote = () => execute(memberAddress, closeModal);
-
-  const profile = teamProfiles?.find(
-    (profile) => profile.recipient.toLowerCase() === memberAddress.toLowerCase()
-  );
 
   return (
     <>
@@ -87,7 +80,8 @@ export const DemoteMemberDialog: FC<DemoteMemberDialogProps> = ({ memberAddress 
                   </Dialog.Title>
                   <div className="mt-2">
                     <p className="text-sm text-gray-600 dark:text-zinc-400">
-                      Are you sure you want to remove {profile?.data.name || memberAddress} as
+                      Are you sure you want to remove{" "}
+                      <EthereumAddressToProfileName address={memberAddress} shouldTruncate /> as
                       admin?
                     </p>
                   </div>

--- a/components/Dialogs/Member/PromoteMember.tsx
+++ b/components/Dialogs/Member/PromoteMember.tsx
@@ -2,10 +2,9 @@ import { Dialog, Transition } from "@headlessui/react";
 import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { type FC, Fragment, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { useMemberRoleChange } from "@/hooks/useMemberRoleChange";
-import { useTeamProfiles } from "@/hooks/useTeamProfiles";
-import { useProjectStore } from "@/store";
 
 interface PromoteMemberDialogProps {
   memberAddress: string;
@@ -13,18 +12,12 @@ interface PromoteMemberDialogProps {
 
 export const PromoteMemberDialog: FC<PromoteMemberDialogProps> = ({ memberAddress }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const project = useProjectStore((state) => state.project);
-  const { teamProfiles } = useTeamProfiles(project);
   const { execute, isLoading } = useMemberRoleChange("promote");
 
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
   const handlePromote = () => execute(memberAddress, closeModal);
-
-  const profile = teamProfiles?.find(
-    (profile) => profile.recipient.toLowerCase() === memberAddress.toLowerCase()
-  );
 
   return (
     <>
@@ -87,7 +80,8 @@ export const PromoteMemberDialog: FC<PromoteMemberDialogProps> = ({ memberAddres
                   </Dialog.Title>
                   <div className="mt-2">
                     <p className="text-sm text-gray-600 dark:text-zinc-400">
-                      Are you sure you want to promote {profile?.data.name || memberAddress} to
+                      Are you sure you want to promote{" "}
+                      <EthereumAddressToProfileName address={memberAddress} shouldTruncate /> to
                       admin?
                     </p>
                   </div>

--- a/components/Dialogs/Member/__tests__/DeleteMember.test.tsx
+++ b/components/Dialogs/Member/__tests__/DeleteMember.test.tsx
@@ -21,6 +21,11 @@ vi.mock("wagmi", () => ({
   })),
 }));
 
+// Mock the shared identity component (uses React Query; tested separately)
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address?: string }) => <span>{address}</span>,
+}));
+
 // Mock next/dynamic to render nothing (DeleteDialog is lazy-loaded but unused in our tests)
 vi.mock("next/dynamic", () => ({
   default: () => {

--- a/components/Donation/SingleProject/SingleProjectDonateModal.tsx
+++ b/components/Donation/SingleProject/SingleProjectDonateModal.tsx
@@ -3,6 +3,7 @@
 import { Loader2, Zap } from "lucide-react";
 import dynamic from "next/dynamic";
 import React, { useCallback, useMemo } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -177,7 +178,13 @@ export const SingleProjectDonateModal = React.memo<SingleProjectDonateModalProps
                           " and " +
                           configuredChainNames[configuredChainNames.length - 1]}{" "}
                       {configuredChainNames.length === 1 ? "network" : "networks"}. We couldn&apos;t
-                      find any tokens in your wallet account {address ? shortAddress(address) : ""}.
+                      find any tokens in your wallet account{" "}
+                      {address ? (
+                        <EthereumAddressToProfileName address={address} shouldTruncate />
+                      ) : (
+                        ""
+                      )}
+                      .
                     </p>
                     <Button onClick={connectWallet} variant="outline" className="w-full">
                       Connect Different Wallet

--- a/components/EthereumAddressToProfileName.tsx
+++ b/components/EthereumAddressToProfileName.tsx
@@ -19,6 +19,12 @@ interface Props {
   pictureClassName?: string;
 }
 
+/** Local-part of an email ("alice@example.com" → "alice"). The full address is never rendered. */
+function emailLocalPart(email: string | undefined): string | undefined {
+  if (!email) return undefined;
+  return email.split("@")[0] || undefined;
+}
+
 /**
  * Displays a human-readable name for an Ethereum address.
  *
@@ -26,10 +32,11 @@ interface Props {
  * 1. ContributorProfile.name (on-chain attestation)
  * 2. Privy name (from public user profiles endpoint)
  * 3. ENS name
- * 4. Self identity (email / OAuth / social display name) — ONLY when the
- *    address is the logged-in user's own wallet. Never exposed as a public
- *    label for other people (PII); this tier only exists so a social/email/
- *    OAuth user never sees their own meaningless embedded-wallet address.
+ * 4. Self identity — ONLY when the address is the logged-in user's own wallet:
+ *    a provider display name (Google name, Farcaster/Twitter/Discord handle) or,
+ *    as a last resort, the local-part of their email. Never a full email, and
+ *    never any of this for other people (PII). Spares a self user their own
+ *    meaningless embedded-wallet address.
  * 5. Truncated address (0xabcd...1234)
  *
  * When showProfilePicture is true, renders a 24×24 avatar to the left.
@@ -85,18 +92,18 @@ const EthereumAddressToProfileName: React.FC<Props> = ({
     return wallets.some((wallet) => wallet.address?.toLowerCase() === lowerCasedAddress);
   }, [wallets, lowerCasedAddress]);
 
-  // Cover every provider Privy may have authenticated the self user with, not
-  // just email/Google (e.g. a Farcaster/Twitter-only login has no email).
+  // Prefer a real name/handle across whichever provider Privy authenticated the
+  // self user with; only fall back to the email's local-part. Never render the
+  // full email (PII), and never any of this for other people.
   const selfIdentity =
     isSelf && user
-      ? user.email?.address ||
-        user.google?.email ||
+      ? user.google?.name ||
         user.farcaster?.displayName ||
         user.farcaster?.username ||
         user.twitter?.name ||
         user.twitter?.username ||
         user.discord?.username ||
-        user.apple?.email ||
+        emailLocalPart(user.email?.address || user.google?.email || user.apple?.email) ||
         undefined
       : undefined;
 

--- a/components/FundingPlatform/ApplicationList/ReviewerFilterDropdown.tsx
+++ b/components/FundingPlatform/ApplicationList/ReviewerFilterDropdown.tsx
@@ -4,6 +4,7 @@ import { Listbox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronDownIcon, UsersIcon } from "@heroicons/react/24/outline";
 import pluralize from "pluralize";
 import { type FC, Fragment, memo, useMemo } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import type { ProgramReviewer } from "@/services/program-reviewers.service";
 import { cn } from "@/utilities/tailwind";
 
@@ -110,7 +111,9 @@ const ReviewerFilterDropdownComponent: FC<IReviewerFilterDropdownProps> = ({
                   <>
                     <div className="flex flex-col">
                       <span className={cn("block truncate", selected && "font-semibold")}>
-                        {reviewerLabel(reviewer)}
+                        {reviewer.name || reviewer.email || (
+                          <EthereumAddressToProfileName address={reviewer.address} shouldTruncate />
+                        )}
                       </span>
                       {reviewer.name && reviewer.email && (
                         <span className="block truncate text-xs text-gray-500 dark:text-gray-400">

--- a/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationSubmission.tsx
@@ -21,6 +21,7 @@ import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import type { IFormField, IFormSchema } from "@/types/funding-platform";
 import { cn } from "@/utilities/tailwind";
 import { PROJECT_UID_REGEX } from "@/utilities/validation";
+import { SubmittingAsFooter } from "./SubmittingAsFooter";
 
 interface IApplicationSubmissionProps {
   programId: string;
@@ -970,8 +971,7 @@ const ApplicationSubmission: FC<IApplicationSubmissionProps> = ({
         </div>
       </form>
 
-      {/* Connected Wallet Info */}
-      <div className="text-xs text-gray-500 dark:text-gray-400">Submitting as: {address}</div>
+      <SubmittingAsFooter address={address} />
     </div>
   );
 };

--- a/components/FundingPlatform/ApplicationView/SubmittingAsFooter.tsx
+++ b/components/FundingPlatform/ApplicationView/SubmittingAsFooter.tsx
@@ -1,0 +1,14 @@
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
+
+/**
+ * "Submitting as" footer for the application form. Renders the connected
+ * account by name/ENS/self-email rather than a raw wallet address.
+ * Extracted so ApplicationSubmission.tsx (an oversized file) doesn't grow.
+ */
+export function SubmittingAsFooter({ address }: { address?: string }) {
+  return (
+    <div className="text-xs text-gray-500 dark:text-gray-400">
+      Submitting as: <EthereumAddressToProfileName address={address} />
+    </div>
+  );
+}

--- a/components/Pages/Admin/CommunityAdminCard.tsx
+++ b/components/Pages/Admin/CommunityAdminCard.tsx
@@ -4,6 +4,7 @@ import { blo } from "blo";
 import Image from "next/image";
 import { isAddress } from "viem";
 import CommunityStats from "@/components/CommunityStats";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { AddAdmin } from "@/components/Pages/Admin/AddAdminDialog";
 import { RemoveAdmin } from "@/components/Pages/Admin/RemoveAdminDialog";
 import type { CommunityAdmin, CommunityAdminsBatchStatus } from "@/services/communities.service";
@@ -178,7 +179,7 @@ export function CommunityAdminCard({
                         </>
                       ) : null}
                       <span className="text-xs font-mono text-gray-500 dark:text-gray-500 break-all">
-                        {admin.user.id}
+                        <EthereumAddressToProfileName address={admin.user.id} shouldTruncate />
                       </span>
                     </div>
                     {canManageAdmins && (

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -9,6 +9,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { memo, useCallback, useState } from "react";
 import toast from "react-hot-toast";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { FileUpload } from "@/components/Utilities/FileUpload";
 import {
   Dialog,
@@ -25,7 +26,6 @@ import {
   MilestoneLifecycleStatus,
 } from "@/src/features/payout-disbursement/types/payout-disbursement";
 import { formatDisplayAmount } from "@/src/features/payout-disbursement/utils/format-token-amount";
-import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { formatMilestoneTitle } from "@/utilities/formatMilestoneTitle";
 import { INDEXER } from "@/utilities/indexer";
@@ -495,7 +495,11 @@ export const MilestonesSection = memo(function MilestonesSection({
                                   className="text-[10px] text-gray-400 dark:text-zinc-500 font-mono"
                                   title={invoice.invoiceReceivedBy}
                                 >
-                                  by {formatAddressForDisplay(invoice.invoiceReceivedBy)}
+                                  by{" "}
+                                  <EthereumAddressToProfileName
+                                    address={invoice.invoiceReceivedBy}
+                                    shouldTruncate
+                                  />
                                 </span>
                               )}
                             </div>

--- a/components/Pages/Admin/RemoveAdminDialog.tsx
+++ b/components/Pages/Admin/RemoveAdminDialog.tsx
@@ -8,6 +8,7 @@ import { type FC, Fragment, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useAccount } from "wagmi";
 import { z } from "zod";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { useAttestationToast } from "@/hooks/useAttestationToast";
 import { useSetupChainAndWallet } from "@/hooks/useSetupChainAndWallet";
@@ -223,7 +224,7 @@ export const RemoveAdmin: FC<RemoveAdminDialogProps> = ({
                             </span>
                           )}
                           <span className="text-xs font-mono text-gray-500 dark:text-zinc-400 break-all">
-                            {Admin}
+                            <EthereumAddressToProfileName address={Admin} shouldTruncate />
                           </span>
                         </div>
                       </div>

--- a/components/Pages/Admin/ReviewerFilterDropdown.tsx
+++ b/components/Pages/Admin/ReviewerFilterDropdown.tsx
@@ -4,6 +4,7 @@ import { CheckIcon } from "@heroicons/react/24/solid";
 import * as Popover from "@radix-ui/react-popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "cmdk";
 import { useMemo, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { ChevronDown } from "@/components/Icons/ChevronDown";
 import type { CommunityReviewer } from "@/hooks/useCommunityMilestoneReviewers";
 import { formatAddressForDisplay } from "@/utilities/donations/helpers";
@@ -97,6 +98,9 @@ export function ReviewerFilterDropdown({
               const isSelected =
                 selectedAddress?.toLowerCase() === reviewer.publicAddress.toLowerCase();
               const label = getReviewerLabel(reviewer, currentUserAddress);
+              const isYou =
+                !!currentUserAddress &&
+                reviewer.publicAddress.toLowerCase() === currentUserAddress.toLowerCase();
               return (
                 <CommandItem
                   key={reviewer.publicAddress}
@@ -107,7 +111,19 @@ export function ReviewerFilterDropdown({
                   }}
                   className="my-1 cursor-pointer hover:opacity-75 text-sm flex flex-row items-center justify-between py-2 px-4 hover:bg-zinc-200 dark:hover:bg-zinc-900 text-left"
                 >
-                  <span>{label}</span>
+                  <span>
+                    {reviewer.name ? (
+                      label
+                    ) : (
+                      <>
+                        <EthereumAddressToProfileName
+                          address={reviewer.publicAddress}
+                          shouldTruncate
+                        />
+                        {isYou ? " (You)" : ""}
+                      </>
+                    )}
+                  </span>
                   <CheckIcon
                     className={cn("h-4 w-4 min-w-4 min-h-4 text-black dark:text-white", {
                       invisible: !isSelected,

--- a/components/Pages/OAuthConsent/OAuthConsentClient.tsx
+++ b/components/Pages/OAuthConsent/OAuthConsentClient.tsx
@@ -4,9 +4,9 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import { type ReactElement, useCallback, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
-import { useContributorProfile } from "@/hooks/useContributorProfile";
 import { envVars } from "@/utilities/enviromentVars";
 
 /**
@@ -48,11 +48,6 @@ interface InteractionDetails {
 }
 
 const OAUTH_BASE = envVars.NEXT_PUBLIC_GAP_OAUTH_URL;
-
-function shortenAddress(address: string): string {
-  if (address.length <= 14) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
 
 async function loadInteraction(uid: string): Promise<InteractionDetails> {
   const res = await fetch(`${OAUTH_BASE}/interaction/${encodeURIComponent(uid)}`, {
@@ -239,13 +234,7 @@ function renderConsentGuard(args: ConsentGuardArgs): ReactElement | undefined {
 export function OAuthConsentClient() {
   const searchParams = useSearchParams();
   const interactionUid = searchParams.get("interaction");
-  const { ready, authenticated, login, address, user, getAccessToken } = useAuth();
-  const { profile } = useContributorProfile(address);
-  const signedInLabel =
-    profile?.data?.name ||
-    user?.email?.address ||
-    user?.google?.email ||
-    (address ? shortenAddress(address) : null);
+  const { ready, authenticated, login, address, getAccessToken } = useAuth();
 
   const interactionQuery = useQuery({
     queryKey: ["oauth", "interaction", interactionUid],
@@ -388,10 +377,12 @@ export function OAuthConsentClient() {
         {clientName} can only do what you can do. You can revoke access anytime.
       </p>
 
-      {signedInLabel ? (
+      {address ? (
         <p className="mt-6 text-xs text-muted-foreground">
           Signed in as{" "}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">{signedInLabel}</code>
+          <code className="rounded bg-muted px-1.5 py-0.5 text-foreground">
+            <EthereumAddressToProfileName address={address} />
+          </code>
         </p>
       ) : null}
 

--- a/src/features/applications/components/OffChainMilestoneRow.tsx
+++ b/src/features/applications/components/OffChainMilestoneRow.tsx
@@ -4,6 +4,7 @@ import { PaperClipIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { Pencil } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useCallback, useRef, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { FileUpload } from "@/components/Utilities/FileUpload";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Button } from "@/components/ui/button";
@@ -381,7 +382,7 @@ export function OffChainMilestoneRow({
                       </p>
                     )}
                     <p className="text-xs text-zinc-400 mt-1">
-                      Verified by: {verifiedEntry.attester}
+                      Verified by: <EthereumAddressToProfileName address={verifiedEntry.attester} />
                     </p>
                   </div>
                 )}

--- a/src/features/applications/components/OnChainMilestoneRow.tsx
+++ b/src/features/applications/components/OnChainMilestoneRow.tsx
@@ -3,6 +3,7 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { Pencil } from "lucide-react";
 import { useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -234,7 +235,7 @@ export function OnChainMilestoneRow({
                       </p>
                     )}
                     <p className="text-xs text-zinc-400 mt-1">
-                      Verified by: {verifiedEntry.attester}
+                      Verified by: <EthereumAddressToProfileName address={verifiedEntry.attester} />
                     </p>
                   </div>
                 )}

--- a/src/features/claim-funds/components/EmptyState.tsx
+++ b/src/features/claim-funds/components/EmptyState.tsx
@@ -2,11 +2,11 @@
 
 import { memo, useCallback, useState } from "react";
 import { isAddress } from "viem";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { formatAddressForDisplay } from "@/utilities/donations/helpers";
 import { cn } from "@/utilities/tailwind";
 
 interface EmptyStateProps {
@@ -15,8 +15,6 @@ interface EmptyStateProps {
   isChecking: boolean;
   compact?: boolean;
 }
-
-const truncateAddress = (address: string) => formatAddressForDisplay(address, 6, 4);
 
 function EmptyStateComponent({
   connectedAddress,
@@ -64,7 +62,7 @@ function EmptyStateComponent({
                 No claimable funds found for this wallet:
               </p>
               <p className="font-mono text-sm text-muted-foreground">
-                {truncateAddress(connectedAddress)}
+                <EthereumAddressToProfileName address={connectedAddress} shouldTruncate />
               </p>
             </div>
             <Separator className="my-6" />


### PR DESCRIPTION
## Summary

Round 2 of showing the wallet address as little as possible — it remains the backend auth signature, but the UI should prefer name / ENS / (self) email. Driven by an **ultracode audit** of the codebase (128 address-render sites classified: 38 already migrated, 53 kept-literal functional, 11 dead-code, **26 identity candidates → 20 verified**). This migrates the person-identity displays to `EthereumAddressToProfileName`.

Closes DEV-519.

## What changed (~15 sites)

**Self / public-facing**
- `ApplicationSubmission` "Submitting as: 0x…" → the component, via a new tiny `SubmittingAsFooter` so the **oversized** `ApplicationSubmission.tsx` stays exactly flat (979 → 979).
- `OAuthConsentClient` "Signed in as" → the component; deleted the bespoke `name/email/shortenAddress` chain, its helper, and the now-unused `useContributorProfile`.
- `SingleProjectDonateModal` "…no tokens in your wallet account 0x…" (self, error branch — payout destination at :135 left literal).
- `claim-funds/EmptyState` "no funds for this wallet 0x…" (self).

**Funding platform**
- `ApplicationInfoCard` — the applicant's **email-less branch** now resolves via the component instead of a local truncate (refines DEV-518).
- `OffChainMilestoneRow` / `OnChainMilestoneRow` — "Verified by: {attester}".
- `ReviewerFilterDropdown` (funding) option label — **name/email first**, component only as the terminal fallback; raw address kept as the cmdk search key.

**Admin & member dialogs**
- `CommunityAdminCard`, `RemoveAdminDialog`, `MilestonesSection` ("invoice received by"), `Admin/ReviewerFilterDropdown` option (kept the "(You)" tag), and the `Delete` / `Demote` / `Promote` member dialogs (Demote/Promote also drop their now-unneeded `useTeamProfiles` plumbing).

## Component fix: never render a full email (self fallback)

The self-only fallback in `EthereumAddressToProfileName` used to render the viewer's **full email** (e.g. `bruno@karmahq.xyz`) when they had no on-chain/Privy name and no ENS — and it even preferred the raw email over a provider display name (it never checked `google.name`). Now it prefers a real name/handle (Google name, Farcaster/Twitter/Discord) and, as a last resort, only the email's **local-part** (`bruno`) — never the full address. Other people's emails remain never shown. This applies to every usage, including the sites migrated above.

## Kept literal by design (excluded)

Payout/disbursement **destinations**, transaction hashes, contract/token/**community UIDs**, copy-to-clipboard payloads, address `<input>`s, explorer link text. (You can't pay an email, and these are load-bearing exact strings / the auth signature.)

## Deliberately deferred (with rationale)

The string-label reviewer **button/selected** labels, the `ReviewerAssignmentDropdown` (shared `MultiSelectDropdown` where `label` is also the search key), and the `AdminAdvisorsList` wallet badge. Reviewers/advisors carry **name + email from the backend**, so the address fallback effectively never renders — and the component *masks other users' emails*, so migrating those admin labels would **hide emails admins are authorized to see**. Net ~zero gain for real risk (reworking the shared dropdown's search). Noted rather than forced.

## Verification

- `pnpm run typecheck` → 0 errors
- `pnpm run build` → success
- `react-doctor --scope changed` → **no issues** on the diff
- `pnpm test` → all green **except** `__tests__/features/donor-rewards/rewards-context.test.tsx`, which is a **pre-existing** reducer-math failure on `main` (verified with my changes stashed) — unrelated to this PR.
- Oversized-file guard: `ApplicationSubmission.tsx` unchanged at 979; `MilestonesSection.tsx` 578 → 582 (< 600). No new oversized files.
- Tests that render the component without a `QueryClient` now mock it (repo convention).

## Notes

Frontend-only. Follows DEV-513 (self-aware component) and DEV-518 (applicant gating).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent “Submitting as” footer to application submissions.
  * Improved identity display by resolving wallet addresses to profile-style names (including on consent, admin, reviewer filters, milestones, donations, and verified-by fields).

* **Bug Fixes**
  * Fixed inconsistent rendering of wallet identifiers by removing raw/short address fallbacks in favor of formatted profile output.
  * Updated admin/member dialogs and reviewer items so identities display consistently (including correct “You” labeling).

* **Tests**
  * Updated unit/integration coverage to match the new identity rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->