### PR TITLE
ci: raise unit-test shards to --maxWorkers=2 for speed

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -63,8 +63,8 @@ jobs:
   # ── Step 1: run tests (6 shards) ────────────────────────────────────────────
   test:
     runs-on: ubuntu-latest
-    # Raised from 10: --maxWorkers=1 runs each shard's files sequentially to
-    # cap peak memory, which is slower per shard than the old parallel run.
+    # Raised from 10: the memory-capped run (see below) is slower per shard
+    # than the old uncapped parallel run.
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -99,16 +99,17 @@ jobs:
         # With --max-old-space-size=8192 on a 16 GB runner V8 had no reason to
         # GC until ~8 GB, so a shard's heap plus external memory accumulated
         # until the OS killed the worker (a crash with no test failures, no V8
-        # "heap limit" line). Two changes bound it: a 6144 MB heap cap makes V8
-        # collect aggressively so RSS stays well under the runner limit, and
-        # --maxWorkers=1 keeps a single file's heap on the shared thread pool at
-        # a time (concurrent heavy files would otherwise share, then blow, that
-        # cap). Combined with the six-way split and the render-once homepage
-        # a11y suite, shards stay comfortably in memory.
+        # "heap limit" line). The real fix is the 6144 MB heap cap: it makes V8
+        # collect aggressively so RSS stays well under the 16 GB runner limit.
+        # --maxWorkers=2 (down from the default = CPU count, but not fully
+        # serial) keeps at most two files' live heaps on the shared thread pool
+        # at once — comfortably inside the 6 GB cap given the six-way split and
+        # the render-once homepage a11y suite — while recovering most of the
+        # parallelism that --maxWorkers=1 gave up.
         run: |
           pnpm exec vitest run --project unit \
             --reporter=dot \
-            --maxWorkers=1 \
+            --maxWorkers=2 \
             --shard=${{ matrix.shard }}/${{ env.SHARD_COUNT }}
         env:
           NODE_ENV: test


### PR DESCRIPTION
Follow-up to #1782. The shard OOM was fixed by the **6144 MB heap cap**; `--maxWorkers=1` was the redundant belt-and-suspenders half and forced each shard fully serial (~5.1 min slowest vs ~3.2 min before). Two files' live heaps fit inside the 6 GB cap given the 6-way split + render-once a11y suite, so **`--maxWorkers=2`** recovers ~1.5 min of shard wall-clock while keeping the OOM fixed.

**Validation:** this PR's own `PR Tests` run — all 6 shards must stay green (no OOM crash, no V8 heap-limit). Opened as draft so only the cheap checks run; will mark ready + merge once shards are green.