### PR TITLE
fix: gate attestation signing on wallet readiness (GAP-FRONTEND-24N)

### DIFF
--- a/__mocks__/hooks/useSetupChainAndWallet.ts
+++ b/__mocks__/hooks/useSetupChainAndWallet.ts
@@ -29,4 +29,5 @@ export const useSetupChainAndWallet = vi.fn().mockReturnValue({
   smartWalletAddress: null,
   hasEmbeddedWallet: false,
   hasExternalWallet: false,
+  signerStatus: "ready",
 });

--- a/__mocks__/hooks/useZeroDevSigner.ts
+++ b/__mocks__/hooks/useZeroDevSigner.ts
@@ -12,6 +12,7 @@ export const useZeroDevSigner = vi.fn().mockReturnValue({
   attestationAddress: null,
   hasEmbeddedWallet: false,
   hasExternalWallet: false,
+  signerStatus: "ready",
   // Legacy aliases for backward compatibility
   getSignerForChain: vi.fn().mockResolvedValue(null),
   isLoading: false,

--- a/__tests__/components/Dialogs/ProjectDialog.test.tsx
+++ b/__tests__/components/Dialogs/ProjectDialog.test.tsx
@@ -217,6 +217,7 @@ vi.mock("@/hooks/useZeroDevSigner", () => ({
     attestationAddress: "0x1234567890abcdef1234567890abcdef12345678",
     hasEmbeddedWallet: false,
     hasExternalWallet: true,
+    signerStatus: "ready",
   }),
 }));
 
@@ -227,6 +228,7 @@ vi.mock("hooks/useZeroDevSigner", () => ({
     attestationAddress: "0x1234567890abcdef1234567890abcdef12345678",
     hasEmbeddedWallet: false,
     hasExternalWallet: true,
+    signerStatus: "ready",
   }),
 }));
 
@@ -237,6 +239,7 @@ vi.mock("@/hooks/useSetupChainAndWallet", () => ({
     smartWalletAddress: null,
     hasEmbeddedWallet: false,
     hasExternalWallet: true,
+    signerStatus: "ready",
   }),
 }));
 
@@ -247,6 +250,7 @@ vi.mock("hooks/useSetupChainAndWallet", () => ({
     smartWalletAddress: null,
     hasEmbeddedWallet: false,
     hasExternalWallet: true,
+    signerStatus: "ready",
   }),
 }));
 

--- a/__tests__/integration/auth/auth-integration.test.tsx
+++ b/__tests__/integration/auth/auth-integration.test.tsx
@@ -401,6 +401,7 @@ describe("Auth Integration Tests", () => {
       getAccessToken: expect.any(Function),
       connectWallet: expect.any(Function),
       wallets: [],
+      walletsReady: false,
       smartWalletClient: null,
       isConnected: false,
     });

--- a/__tests__/integration/auth/privy-bridge-trust.test.tsx
+++ b/__tests__/integration/auth/privy-bridge-trust.test.tsx
@@ -52,6 +52,11 @@ describe("PrivyBridgeContext — Defaults before SDK loads", () => {
     expect(result.current.wallets).toEqual([]);
   });
 
+  it("walletsReady defaults to false", () => {
+    const { result } = renderHook(() => usePrivyBridge(), { wrapper: BridgeWrapper });
+    expect(result.current.walletsReady).toBe(false);
+  });
+
   it("login is a noop function", () => {
     const { result } = renderHook(() => usePrivyBridge(), { wrapper: BridgeWrapper });
     expect(() => result.current.login()).not.toThrow();
@@ -142,6 +147,7 @@ describe("PrivyBridgeContext — Hook return types", () => {
     expect(typeof value.getAccessToken).toBe("function");
     expect(typeof value.connectWallet).toBe("function");
     expect(Array.isArray(value.wallets)).toBe(true);
+    expect(typeof value.walletsReady).toBe("boolean");
     expect(typeof value.isConnected).toBe("boolean");
   });
 
@@ -155,6 +161,7 @@ describe("PrivyBridgeContext — Hook return types", () => {
       getAccessToken: expect.any(Function),
       connectWallet: expect.any(Function),
       wallets: [],
+      walletsReady: false,
       smartWalletClient: null,
       isConnected: false,
     });

--- a/__tests__/integration/wallet/signer-trust.test.ts
+++ b/__tests__/integration/wallet/signer-trust.test.ts
@@ -96,6 +96,7 @@ import {
   getGaslessSigner,
   isChainSupportedForGasless,
 } from "@/utilities/gasless";
+import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 
 describe("Signer trust tests", () => {
@@ -252,15 +253,25 @@ describe("Signer trust tests", () => {
       // The hook would throw: "Failed to get wallet client: ..."
     });
 
-    it("No wallet available throws error", () => {
-      // When no embedded or external wallet exists
+    it("No wallet available throws a typed, expected SignerUnavailableError", () => {
+      // When no embedded or external wallet exists, the hook throws a typed
+      // SignerUnavailableError (GAP-FRONTEND-24N) instead of a bare Error —
+      // `expected: true` tells errorManager to skip reporting it to Sentry.
       const externalWallet = null;
       const embeddedWallet = null;
 
       if (!externalWallet && !embeddedWallet) {
         expect(() => {
-          throw new Error("No wallet available for signing");
-        }).toThrow("No wallet available for signing");
+          throw new SignerUnavailableError("no-wallet-connected");
+        }).toThrow(SignerUnavailableError);
+
+        try {
+          throw new SignerUnavailableError("no-wallet-connected");
+        } catch (error) {
+          expect(error).toBeInstanceOf(SignerUnavailableError);
+          expect((error as SignerUnavailableError).expected).toBe(true);
+          expect((error as SignerUnavailableError).reason).toBe("no-wallet-connected");
+        }
       }
     });
   });

--- a/__tests__/trust/wallet/signer-trust.test.ts
+++ b/__tests__/trust/wallet/signer-trust.test.ts
@@ -96,6 +96,7 @@ import {
   getGaslessSigner,
   isChainSupportedForGasless,
 } from "@/utilities/gasless";
+import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 
 describe("Signer trust tests", () => {
@@ -252,15 +253,25 @@ describe("Signer trust tests", () => {
       // The hook would throw: "Failed to get wallet client: ..."
     });
 
-    it("No wallet available throws error", () => {
-      // When no embedded or external wallet exists
+    it("No wallet available throws a typed, expected SignerUnavailableError", () => {
+      // When no embedded or external wallet exists, the hook throws a typed
+      // SignerUnavailableError (GAP-FRONTEND-24N) instead of a bare Error —
+      // `expected: true` tells errorManager to skip reporting it to Sentry.
       const externalWallet = null;
       const embeddedWallet = null;
 
       if (!externalWallet && !embeddedWallet) {
         expect(() => {
-          throw new Error("No wallet available for signing");
-        }).toThrow("No wallet available for signing");
+          throw new SignerUnavailableError("no-wallet-connected");
+        }).toThrow(SignerUnavailableError);
+
+        try {
+          throw new SignerUnavailableError("no-wallet-connected");
+        } catch (error) {
+          expect(error).toBeInstanceOf(SignerUnavailableError);
+          expect((error as SignerUnavailableError).expected).toBe(true);
+          expect((error as SignerUnavailableError).reason).toBe("no-wallet-connected");
+        }
       }
     });
   });

--- a/__tests__/unit/components/Utilities/PrivyWagmiProviders.bridge.test.tsx
+++ b/__tests__/unit/components/Utilities/PrivyWagmiProviders.bridge.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @file Bridge-push tests for PrivyWagmiProviders (GAP-FRONTEND-24N)
+ * @description Asserts that `walletsReady` (from Privy's `useWallets().ready`)
+ * is read and pushed into PrivyBridgeContext, and that a `ready` flip with an
+ * unchanged wallet count still re-pushes the bridge value (the effect depends
+ * on `walletsReady`, not just `walletCount`).
+ */
+import { act, render } from "@testing-library/react";
+
+const mockSetBridge = vi.fn();
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridgeSetter: () => mockSetBridge,
+}));
+
+const mockUseWallets = vi.fn();
+vi.mock("@privy-io/react-auth", () => ({
+  PrivyProvider: ({ children }: { children: React.ReactNode }) => children,
+  usePrivy: () => ({
+    ready: true,
+    authenticated: true,
+    user: { id: "test-user", linkedAccounts: [] },
+    login: vi.fn(),
+    logout: vi.fn(),
+    getAccessToken: vi.fn(),
+    connectWallet: vi.fn(),
+  }),
+  useWallets: () => mockUseWallets(),
+}));
+
+vi.mock("@privy-io/react-auth/smart-wallets", () => ({
+  useSmartWallets: () => ({ client: null }),
+}));
+
+vi.mock("@privy-io/wagmi", () => ({
+  WagmiProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: () => ({ isConnected: false, chainId: 10 }),
+}));
+
+vi.mock("@wagmi/core", () => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("@/hooks/useEnsureEmbeddedWallet", () => ({
+  useEnsureEmbeddedWallet: vi.fn(),
+}));
+
+vi.mock("@/utilities/auth/select-primary-wallet", () => ({
+  selectPrimaryWallet: () => null,
+}));
+
+vi.mock("@/utilities/enviromentVars", () => ({
+  envVars: { PRIVY_APP_ID: "test-app-id", PROJECT_ID: "test-project-id", VERCEL_URL: "" },
+}));
+
+vi.mock("@/utilities/network", () => ({
+  appNetwork: [{ id: 10, name: "Optimism" }],
+}));
+
+vi.mock("@/utilities/wagmi/privy-config", () => ({
+  privyConfig: {},
+  minimalWagmiConfig: {},
+}));
+
+vi.mock("@/constants/brand", () => ({
+  PROJECT_NAME: "Karma",
+}));
+
+import PrivyWagmiProviders from "@/components/Utilities/PrivyWagmiProviders";
+
+describe("PrivyWagmiProviders — walletsReady bridge push (GAP-FRONTEND-24N)", () => {
+  beforeEach(() => {
+    mockSetBridge.mockClear();
+  });
+
+  it("pushes walletsReady=true into the bridge once Privy's useWallets().ready is true", async () => {
+    mockUseWallets.mockReturnValue({ wallets: [], ready: true });
+
+    await act(async () => {
+      render(<PrivyWagmiProviders />);
+    });
+
+    expect(mockSetBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ walletsReady: true, wallets: [] })
+    );
+  });
+
+  it("pushes walletsReady=false while Privy is still hydrating wallets", async () => {
+    mockUseWallets.mockReturnValue({ wallets: [], ready: false });
+
+    await act(async () => {
+      render(<PrivyWagmiProviders />);
+    });
+
+    expect(mockSetBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ walletsReady: false, wallets: [] })
+    );
+  });
+
+  it("re-pushes the bridge when walletsReady flips even though wallet count is unchanged", async () => {
+    mockUseWallets.mockReturnValue({ wallets: [], ready: false });
+
+    const { rerender } = render(<PrivyWagmiProviders />);
+    await act(async () => {});
+
+    expect(mockSetBridge).toHaveBeenLastCalledWith(
+      expect.objectContaining({ walletsReady: false })
+    );
+
+    mockUseWallets.mockReturnValue({ wallets: [], ready: true });
+    await act(async () => {
+      rerender(<PrivyWagmiProviders />);
+    });
+
+    expect(mockSetBridge).toHaveBeenLastCalledWith(expect.objectContaining({ walletsReady: true }));
+  });
+});

--- a/__tests__/unit/hooks/useZeroDevSigner-real.hydration.test.ts
+++ b/__tests__/unit/hooks/useZeroDevSigner-real.hydration.test.ts
@@ -1,17 +1,20 @@
 /**
- * @file Real hook tests for useZeroDevSigner
- * @description Tests the actual useZeroDevSigner hook by importing from its real source path
- *   (bypassing the vitest alias that redirects @/hooks/useZeroDevSigner to a mock).
- *   Mocks its dependencies instead: privy-bridge-context, gasless utilities, wagmi, wallet-helpers.
+ * @file Real hook tests for useZeroDevSigner — wallet hydration & status
+ * @description Split from useZeroDevSigner-real.test.ts to stay under the
+ *   per-file size limit. Covers the external-wallet path, the no-wallet
+ *   SignerUnavailableError classification, mid-flight wallet hydration
+ *   (GAP-FRONTEND-24N), signerStatus derivation, and end-to-end smoke tests.
+ *   The wallet-detection / gasless happy-path coverage lives in the sibling
+ *   `useZeroDevSigner-real.paths.test.ts`.
  *
- *   The @/utilities/gasless alias is already resolved to __mocks__/utilities/gasless/index.ts
- *   by vitest.config.ts, so the real hook's gasless imports get the mock automatically.
+ *   Tests the actual useZeroDevSigner hook by importing from its real source
+ *   path (bypassing the vitest alias that redirects @/hooks/useZeroDevSigner to
+ *   a mock). Mocks its dependencies instead: privy-bridge-context, gasless
+ *   utilities, wagmi, wallet-helpers.
  *
- *   Unlike the original suite, the wallet + ethers mocks here model an actual
- *   *chain identity* and the Privy `switchChain` propagation race. This is the
- *   gap that let GAP-FRONTEND-1T9 ("Network mainnet not supported.") ship: the
- *   old mocks made `switchChain` always succeed and gave signers no chain, so a
- *   signer stuck on chain 1 was impossible to express in a test.
+ *   The @/utilities/gasless alias is already resolved to
+ *   __mocks__/utilities/gasless/index.ts by vitest.config.ts, so the real
+ *   hook's gasless imports get the mock automatically.
  */
 
 import { act, renderHook } from "@testing-library/react";
@@ -122,7 +125,6 @@ vi.mock("ethers", () => ({
 import {
   createGaslessClient,
   createPrivySignerForGasless,
-  GaslessProviderError,
   getGaslessSigner,
   isChainSupportedForGasless,
 } from "@/utilities/gasless";
@@ -169,12 +171,6 @@ function setupGoogleUser(opts: { embedded?: boolean; external?: boolean } = {}) 
   if (opts.external) mockPrivyState.wallets.push(createExternalWallet());
 }
 
-function setupFarcasterUser(opts: { embedded?: boolean } = {}) {
-  mockPrivyState.user = { linkedAccounts: [{ type: "farcaster" }] };
-  mockPrivyState.wallets = [];
-  if (opts.embedded !== false) mockPrivyState.wallets.push(createEmbeddedWallet());
-}
-
 function setupExternalWalletUser() {
   mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
   mockPrivyState.wallets = [createExternalWallet()];
@@ -194,7 +190,7 @@ function enableGaslessOnChain(chainId: number) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("useZeroDevSigner (real hook)", () => {
+describe("useZeroDevSigner (real hook) — hydration & status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrivyState.ready = true;
@@ -232,287 +228,6 @@ describe("useZeroDevSigner (real hook)", () => {
     // WALLET_READY_TIMEOUT_MS wait — always restore real timers so it can't
     // leak into a later test.
     vi.useRealTimers();
-  });
-
-  // =========================================================================
-  // Wallet detection
-  // =========================================================================
-
-  describe("wallet detection", () => {
-    it("should detect embedded wallet (privy walletClientType)", () => {
-      setupEmailUser();
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.hasEmbeddedWallet).toBe(true);
-      expect(result.current.hasExternalWallet).toBe(false);
-    });
-
-    it("should detect external wallet (non-privy walletClientType)", () => {
-      setupExternalWalletUser();
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.hasEmbeddedWallet).toBe(false);
-      expect(result.current.hasExternalWallet).toBe(true);
-    });
-
-    it("should detect both embedded and external wallets", () => {
-      setupEmailUser({ embedded: true, external: true });
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.hasEmbeddedWallet).toBe(true);
-      expect(result.current.hasExternalWallet).toBe(true);
-    });
-
-    it("should report no wallets when privy is not ready", () => {
-      mockPrivyState.ready = false;
-      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
-      mockPrivyState.wallets = [createEmbeddedWallet()];
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.hasEmbeddedWallet).toBe(false);
-      expect(result.current.hasExternalWallet).toBe(false);
-    });
-
-    it("should report no wallets when wallets array is empty", () => {
-      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
-      mockPrivyState.wallets = [];
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.hasEmbeddedWallet).toBe(false);
-      expect(result.current.hasExternalWallet).toBe(false);
-    });
-  });
-
-  // =========================================================================
-  // attestationAddress
-  // =========================================================================
-
-  describe("attestationAddress", () => {
-    it("should return embedded wallet address for email users", () => {
-      setupEmailUser();
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.attestationAddress).toBe(EMBEDDED_WALLET_ADDRESS);
-    });
-
-    it("should return embedded wallet address for Google users", () => {
-      setupGoogleUser();
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.attestationAddress).toBe(EMBEDDED_WALLET_ADDRESS);
-    });
-
-    it("should return external wallet address for external wallet users", () => {
-      setupExternalWalletUser();
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.attestationAddress).toBe(EXTERNAL_WALLET_ADDRESS);
-    });
-
-    it("should return null when no user and no wallets", () => {
-      mockPrivyState.user = null;
-      mockPrivyState.wallets = [];
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.attestationAddress).toBeNull();
-    });
-  });
-
-  // =========================================================================
-  // isGaslessAvailable
-  // =========================================================================
-
-  describe("isGaslessAvailable", () => {
-    it("should be true for email user with embedded wallet on supported chain", () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.isGaslessAvailable).toBe(true);
-    });
-
-    it("should be false for email user on unsupported chain", () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(false);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.isGaslessAvailable).toBe(false);
-    });
-
-    it("should be false for external wallet user even on supported chain", () => {
-      setupExternalWalletUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      expect(result.current.isGaslessAvailable).toBe(false);
-    });
-  });
-
-  // =========================================================================
-  // getAttestationSigner — Case 1: Email/Google user with gasless
-  // =========================================================================
-
-  describe("getAttestationSigner — email user with gasless", () => {
-    it("should return gasless signer for email user on supported chain", async () => {
-      setupEmailUser();
-      enableGaslessOnChain(10);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(10);
-      });
-
-      expect(signer).toBeDefined();
-      expect(await chainIdOf(signer)).toBe(10);
-      expect(createPrivySignerForGasless).toHaveBeenCalledWith(
-        expect.objectContaining({ address: EMBEDDED_WALLET_ADDRESS }),
-        10
-      );
-      expect(createGaslessClient).toHaveBeenCalledWith(10, "mockPrivySigner");
-      expect(getGaslessSigner).toHaveBeenCalledWith(
-        expect.objectContaining({ account: { address: EMBEDDED_WALLET_ADDRESS } }),
-        10
-      );
-      // Gasless path must NOT build the embedded-direct BrowserProvider signer.
-      // (getEthereumProvider IS now called to confirm the chain switch first.)
-      expect(mockGetSigner).not.toHaveBeenCalled();
-    });
-
-    it("does not switch the embedded wallet chain for the gasless path (signer is chain-pinned)", async () => {
-      setupEmailUser();
-      const embeddedWallet = mockPrivyState.wallets[0];
-      enableGaslessOnChain(42161);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(42161);
-      });
-
-      expect(await chainIdOf(signer)).toBe(42161);
-      // The gasless smart account targets the chain regardless of the embedded
-      // EOA's current chain (its ethers provider is pinned by toEthersSigner), so
-      // the embedded wallet is never asked to switch.
-      expect(embeddedWallet.switchChain).not.toHaveBeenCalled();
-    });
-
-    it("should return gasless signer for Google OAuth user", async () => {
-      setupGoogleUser();
-      enableGaslessOnChain(10);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(10);
-      });
-
-      expect(await chainIdOf(signer)).toBe(10);
-    });
-
-    it("should return gasless signer for Farcaster user", async () => {
-      setupFarcasterUser();
-      enableGaslessOnChain(10);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(10);
-      });
-
-      expect(await chainIdOf(signer)).toBe(10);
-    });
-  });
-
-  // =========================================================================
-  // getAttestationSigner — Gasless fallback to embedded wallet
-  // =========================================================================
-
-  describe("getAttestationSigner — gasless fallback", () => {
-    it("should fall back to embedded wallet when gasless client returns null", async () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockResolvedValue("signer");
-      (createGaslessClient as ReturnType<typeof vi.fn>).mockResolvedValue(null); // null = no client
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(10);
-      });
-
-      expect(await chainIdOf(signer)).toBe(10);
-      // getEthereumProvider should have been called to create BrowserProvider
-      expect(mockPrivyState.wallets[0].getEthereumProvider).toHaveBeenCalled();
-    });
-
-    it("should fall back to embedded wallet on non-GaslessProviderError", async () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error("some random error")
-      );
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(10);
-      });
-
-      expect(await chainIdOf(signer)).toBe(10);
-    });
-
-    it("should NOT fall back for GaslessProviderError — rethrows it", async () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      const gaslessError = new GaslessProviderError("provider failed", "zerodev", 10);
-      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockRejectedValue(gaslessError);
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      await act(async () => {
-        await expect(result.current.getAttestationSigner(10)).rejects.toThrow(GaslessProviderError);
-      });
-    });
-  });
-
-  // =========================================================================
-  // getAttestationSigner — Case 2: Email user without gasless support
-  // =========================================================================
-
-  describe("getAttestationSigner — email user on unsupported chain", () => {
-    it("should use embedded wallet directly (user pays gas)", async () => {
-      setupEmailUser();
-      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      const embeddedWallet = mockPrivyState.wallets[0];
-      const provider = await embeddedWallet.getEthereumProvider();
-
-      const { result } = renderHook(() => useZeroDevSigner());
-
-      let signer: unknown;
-      await act(async () => {
-        signer = await result.current.getAttestationSigner(999);
-      });
-
-      expect(await chainIdOf(signer)).toBe(999);
-      // Switches at the provider level, not via the inert high-level switchChain.
-      expect(provider.request).toHaveBeenCalledWith({
-        method: "wallet_switchEthereumChain",
-        params: [{ chainId: "0x3e7" }],
-      });
-      expect(embeddedWallet.switchChain).not.toHaveBeenCalled();
-    });
   });
 
   // =========================================================================

--- a/__tests__/unit/hooks/useZeroDevSigner-real.paths.test.ts
+++ b/__tests__/unit/hooks/useZeroDevSigner-real.paths.test.ts
@@ -1,0 +1,519 @@
+/**
+ * @file Real hook tests for useZeroDevSigner — signer-selection paths
+ * @description Split from useZeroDevSigner-real.test.ts to stay under the
+ *   per-file size limit. Covers wallet detection, attestationAddress,
+ *   isGaslessAvailable, and the getAttestationSigner happy paths (gasless,
+ *   gasless fallback, embedded-direct on unsupported chains). The no-wallet /
+ *   hydration / signerStatus / smoke coverage lives in the sibling
+ *   `useZeroDevSigner-real.hydration.test.ts`.
+ *
+ *   Tests the actual useZeroDevSigner hook by importing from its real source
+ *   path (bypassing the vitest alias that redirects @/hooks/useZeroDevSigner to
+ *   a mock). Mocks its dependencies instead: privy-bridge-context, gasless
+ *   utilities, wagmi, wallet-helpers.
+ *
+ *   The @/utilities/gasless alias is already resolved to
+ *   __mocks__/utilities/gasless/index.ts by vitest.config.ts, so the real
+ *   hook's gasless imports get the mock automatically.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock variables
+// ---------------------------------------------------------------------------
+
+const {
+  mockUseChainId,
+  mockPrivyState,
+  mockSafeGetWalletClient,
+  mockWalletClientToSigner,
+  mockGetSigner,
+} = vi.hoisted(() => {
+  const mockUseChainId = vi.fn().mockReturnValue(10);
+  const mockPrivyState = {
+    ready: true as boolean,
+    // Defaults to true so existing tests (wallets present at render time)
+    // resolve immediately instead of waiting out WALLET_READY_TIMEOUT_MS.
+    // Tests for the hydration-wait behavior set this to false explicitly.
+    walletsReady: true as boolean,
+    user: null as MockUser | null,
+    wallets: [] as MockWallet[],
+  };
+  const mockSafeGetWalletClient = vi.fn();
+  const mockWalletClientToSigner = vi.fn();
+  // Called by the mocked ethers BrowserProvider.getSigner(); receives the
+  // BrowserProvider instance so the returned signer's `.provider` reflects
+  // the (un-pinned) underlying chain — exactly what the production guard reads.
+  const mockGetSigner = vi.fn();
+
+  return {
+    mockUseChainId,
+    mockPrivyState,
+    mockSafeGetWalletClient,
+    mockWalletClientToSigner,
+    mockGetSigner,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("wagmi", () => ({
+  useChainId: () => mockUseChainId(),
+}));
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: vi.fn(() => ({
+    ready: mockPrivyState.ready,
+    walletsReady: mockPrivyState.walletsReady,
+    user: mockPrivyState.user,
+    wallets: mockPrivyState.wallets,
+  })),
+}));
+
+vi.mock("@/utilities/wallet-helpers", () => ({
+  safeGetWalletClient: (...args: unknown[]) => mockSafeGetWalletClient(...args),
+}));
+
+vi.mock("@/utilities/eas-wagmi-utils", () => ({
+  walletClientToSigner: (...args: unknown[]) => mockWalletClientToSigner(...args),
+}));
+
+// Mock appNetwork so the Privy-first path for external wallets can find chains
+vi.mock("@/utilities/network", () => ({
+  appNetwork: [
+    { id: 10, name: "Optimism" },
+    { id: 42161, name: "Arbitrum" },
+    { id: 999, name: "Testnet" },
+  ],
+}));
+
+// Mock viem's createWalletClient and custom to support Privy-first external wallet path
+const mockViemCreateWalletClient = vi.fn();
+vi.mock("viem", () => ({
+  createWalletClient: (...args: unknown[]) => mockViemCreateWalletClient(...args),
+  custom: vi.fn((provider: unknown) => provider),
+}));
+
+// Chain-aware ethers BrowserProvider mock. `getNetwork()` returns the pinned
+// network when one is supplied (the production fix for the gasless path), and
+// otherwise reflects the underlying provider's `__chainId` (the un-pinned
+// embedded-direct path, which must surface the wallet's real chain).
+vi.mock("ethers", () => ({
+  BrowserProvider: class MockBrowserProvider {
+    _underlying: { __chainId?: number } | undefined;
+    _pinnedChainId: number | undefined;
+
+    constructor(underlying?: { __chainId?: number }, network?: { chainId?: number }) {
+      this._underlying = underlying;
+      this._pinnedChainId = network?.chainId;
+    }
+
+    getNetwork = async () => {
+      const chainId = this._pinnedChainId ?? this._underlying?.__chainId ?? 1;
+      return { chainId: BigInt(chainId) };
+    };
+
+    getSigner = async () => mockGetSigner(this);
+  },
+}));
+
+// The gasless utilities are already mocked via vitest alias (unitTestMockAliases).
+// We import them here to configure per-test.
+import {
+  createGaslessClient,
+  createPrivySignerForGasless,
+  GaslessProviderError,
+  getGaslessSigner,
+  isChainSupportedForGasless,
+} from "@/utilities/gasless";
+
+// ---------------------------------------------------------------------------
+// Import the REAL hook using a relative path to bypass the @/ alias mock
+// ---------------------------------------------------------------------------
+import { useZeroDevSigner } from "../../../hooks/useZeroDevSigner";
+
+// ---------------------------------------------------------------------------
+// Shared chain-aware fixtures (see zerodev-signer-test-utils.ts)
+// ---------------------------------------------------------------------------
+import {
+  chainIdOf,
+  createEmbeddedWallet,
+  createExternalWallet,
+  EMBEDDED_WALLET_ADDRESS,
+  type EmbeddedWalletOptions,
+  EXTERNAL_WALLET_ADDRESS,
+  type MockUser,
+  type MockWallet,
+  signerOnChain,
+} from "./zerodev-signer-test-utils";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function setupEmailUser(
+  opts: { embedded?: boolean; external?: boolean; embeddedOpts?: EmbeddedWalletOptions } = {}
+) {
+  mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+  mockPrivyState.wallets = [];
+  if (opts.embedded !== false)
+    mockPrivyState.wallets.push(createEmbeddedWallet(EMBEDDED_WALLET_ADDRESS, opts.embeddedOpts));
+  if (opts.external) mockPrivyState.wallets.push(createExternalWallet());
+}
+
+function setupGoogleUser(opts: { embedded?: boolean; external?: boolean } = {}) {
+  mockPrivyState.user = { linkedAccounts: [{ type: "google_oauth" }] };
+  mockPrivyState.wallets = [];
+  if (opts.embedded !== false) mockPrivyState.wallets.push(createEmbeddedWallet());
+  if (opts.external) mockPrivyState.wallets.push(createExternalWallet());
+}
+
+function setupFarcasterUser(opts: { embedded?: boolean } = {}) {
+  mockPrivyState.user = { linkedAccounts: [{ type: "farcaster" }] };
+  mockPrivyState.wallets = [];
+  if (opts.embedded !== false) mockPrivyState.wallets.push(createEmbeddedWallet());
+}
+
+function setupExternalWalletUser() {
+  mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+  mockPrivyState.wallets = [createExternalWallet()];
+}
+
+/** Configure the gasless mocks for a successful gasless signer on `chainId`. */
+function enableGaslessOnChain(chainId: number) {
+  (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockResolvedValue("mockPrivySigner");
+  (createGaslessClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+    account: { address: EMBEDDED_WALLET_ADDRESS },
+  });
+  (getGaslessSigner as ReturnType<typeof vi.fn>).mockResolvedValue(signerOnChain(chainId));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useZeroDevSigner (real hook) — signer-selection paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrivyState.ready = true;
+    mockPrivyState.walletsReady = true;
+    mockPrivyState.user = null;
+    mockPrivyState.wallets = [];
+    mockUseChainId.mockReturnValue(10);
+
+    // Reset gasless mocks (these are from the alias mock)
+    (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    (createGaslessClient as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    // Default: gasless produces a signer that correctly reports its chain.
+    (getGaslessSigner as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_client: unknown, chainId: number) => signerOnChain(chainId)
+    );
+
+    mockSafeGetWalletClient.mockReset();
+    mockWalletClientToSigner.mockReset();
+    mockViemCreateWalletClient.mockReset();
+
+    // Default embedded/BrowserProvider signer: `.provider` is the BrowserProvider
+    // instance, so its chain reflects whatever the underlying provider reported.
+    mockGetSigner.mockReset();
+    mockGetSigner.mockImplementation(async (browserProvider?: unknown) => ({
+      getAddress: vi.fn().mockResolvedValue(EMBEDDED_WALLET_ADDRESS),
+      provider: browserProvider ?? {
+        getNetwork: vi.fn().mockResolvedValue({ chainId: 1n }),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    // Some tests below install fake timers to fast-forward the
+    // WALLET_READY_TIMEOUT_MS wait — always restore real timers so it can't
+    // leak into a later test.
+    vi.useRealTimers();
+  });
+
+  // =========================================================================
+  // Wallet detection
+  // =========================================================================
+
+  describe("wallet detection", () => {
+    it("should detect embedded wallet (privy walletClientType)", () => {
+      setupEmailUser();
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.hasEmbeddedWallet).toBe(true);
+      expect(result.current.hasExternalWallet).toBe(false);
+    });
+
+    it("should detect external wallet (non-privy walletClientType)", () => {
+      setupExternalWalletUser();
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.hasEmbeddedWallet).toBe(false);
+      expect(result.current.hasExternalWallet).toBe(true);
+    });
+
+    it("should detect both embedded and external wallets", () => {
+      setupEmailUser({ embedded: true, external: true });
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.hasEmbeddedWallet).toBe(true);
+      expect(result.current.hasExternalWallet).toBe(true);
+    });
+
+    it("should report no wallets when privy is not ready", () => {
+      mockPrivyState.ready = false;
+      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+      mockPrivyState.wallets = [createEmbeddedWallet()];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.hasEmbeddedWallet).toBe(false);
+      expect(result.current.hasExternalWallet).toBe(false);
+    });
+
+    it("should report no wallets when wallets array is empty", () => {
+      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.hasEmbeddedWallet).toBe(false);
+      expect(result.current.hasExternalWallet).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // attestationAddress
+  // =========================================================================
+
+  describe("attestationAddress", () => {
+    it("should return embedded wallet address for email users", () => {
+      setupEmailUser();
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.attestationAddress).toBe(EMBEDDED_WALLET_ADDRESS);
+    });
+
+    it("should return embedded wallet address for Google users", () => {
+      setupGoogleUser();
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.attestationAddress).toBe(EMBEDDED_WALLET_ADDRESS);
+    });
+
+    it("should return external wallet address for external wallet users", () => {
+      setupExternalWalletUser();
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.attestationAddress).toBe(EXTERNAL_WALLET_ADDRESS);
+    });
+
+    it("should return null when no user and no wallets", () => {
+      mockPrivyState.user = null;
+      mockPrivyState.wallets = [];
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.attestationAddress).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // isGaslessAvailable
+  // =========================================================================
+
+  describe("isGaslessAvailable", () => {
+    it("should be true for email user with embedded wallet on supported chain", () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.isGaslessAvailable).toBe(true);
+    });
+
+    it("should be false for email user on unsupported chain", () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.isGaslessAvailable).toBe(false);
+    });
+
+    it("should be false for external wallet user even on supported chain", () => {
+      setupExternalWalletUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.isGaslessAvailable).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // getAttestationSigner — Case 1: Email/Google user with gasless
+  // =========================================================================
+
+  describe("getAttestationSigner — email user with gasless", () => {
+    it("should return gasless signer for email user on supported chain", async () => {
+      setupEmailUser();
+      enableGaslessOnChain(10);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(10);
+      });
+
+      expect(signer).toBeDefined();
+      expect(await chainIdOf(signer)).toBe(10);
+      expect(createPrivySignerForGasless).toHaveBeenCalledWith(
+        expect.objectContaining({ address: EMBEDDED_WALLET_ADDRESS }),
+        10
+      );
+      expect(createGaslessClient).toHaveBeenCalledWith(10, "mockPrivySigner");
+      expect(getGaslessSigner).toHaveBeenCalledWith(
+        expect.objectContaining({ account: { address: EMBEDDED_WALLET_ADDRESS } }),
+        10
+      );
+      // Gasless path must NOT build the embedded-direct BrowserProvider signer.
+      // (getEthereumProvider IS now called to confirm the chain switch first.)
+      expect(mockGetSigner).not.toHaveBeenCalled();
+    });
+
+    it("does not switch the embedded wallet chain for the gasless path (signer is chain-pinned)", async () => {
+      setupEmailUser();
+      const embeddedWallet = mockPrivyState.wallets[0];
+      enableGaslessOnChain(42161);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(42161);
+      });
+
+      expect(await chainIdOf(signer)).toBe(42161);
+      // The gasless smart account targets the chain regardless of the embedded
+      // EOA's current chain (its ethers provider is pinned by toEthersSigner), so
+      // the embedded wallet is never asked to switch.
+      expect(embeddedWallet.switchChain).not.toHaveBeenCalled();
+    });
+
+    it("should return gasless signer for Google OAuth user", async () => {
+      setupGoogleUser();
+      enableGaslessOnChain(10);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(10);
+      });
+
+      expect(await chainIdOf(signer)).toBe(10);
+    });
+
+    it("should return gasless signer for Farcaster user", async () => {
+      setupFarcasterUser();
+      enableGaslessOnChain(10);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(10);
+      });
+
+      expect(await chainIdOf(signer)).toBe(10);
+    });
+  });
+
+  // =========================================================================
+  // getAttestationSigner — Gasless fallback to embedded wallet
+  // =========================================================================
+
+  describe("getAttestationSigner — gasless fallback", () => {
+    it("should fall back to embedded wallet when gasless client returns null", async () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockResolvedValue("signer");
+      (createGaslessClient as ReturnType<typeof vi.fn>).mockResolvedValue(null); // null = no client
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(10);
+      });
+
+      expect(await chainIdOf(signer)).toBe(10);
+      // getEthereumProvider should have been called to create BrowserProvider
+      expect(mockPrivyState.wallets[0].getEthereumProvider).toHaveBeenCalled();
+    });
+
+    it("should fall back to embedded wallet on non-GaslessProviderError", async () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("some random error")
+      );
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(10);
+      });
+
+      expect(await chainIdOf(signer)).toBe(10);
+    });
+
+    it("should NOT fall back for GaslessProviderError — rethrows it", async () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const gaslessError = new GaslessProviderError("provider failed", "zerodev", 10);
+      (createPrivySignerForGasless as ReturnType<typeof vi.fn>).mockRejectedValue(gaslessError);
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      await act(async () => {
+        await expect(result.current.getAttestationSigner(10)).rejects.toThrow(GaslessProviderError);
+      });
+    });
+  });
+
+  // =========================================================================
+  // getAttestationSigner — Case 2: Email user without gasless support
+  // =========================================================================
+
+  describe("getAttestationSigner — email user on unsupported chain", () => {
+    it("should use embedded wallet directly (user pays gas)", async () => {
+      setupEmailUser();
+      (isChainSupportedForGasless as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      const embeddedWallet = mockPrivyState.wallets[0];
+      const provider = await embeddedWallet.getEthereumProvider();
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      let signer: unknown;
+      await act(async () => {
+        signer = await result.current.getAttestationSigner(999);
+      });
+
+      expect(await chainIdOf(signer)).toBe(999);
+      // Switches at the provider level, not via the inert high-level switchChain.
+      expect(provider.request).toHaveBeenCalledWith({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: "0x3e7" }],
+      });
+      expect(embeddedWallet.switchChain).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/hooks/useZeroDevSigner-real.test.ts
+++ b/__tests__/unit/hooks/useZeroDevSigner-real.test.ts
@@ -30,6 +30,10 @@ const {
   const mockUseChainId = vi.fn().mockReturnValue(10);
   const mockPrivyState = {
     ready: true as boolean,
+    // Defaults to true so existing tests (wallets present at render time)
+    // resolve immediately instead of waiting out WALLET_READY_TIMEOUT_MS.
+    // Tests for the hydration-wait behavior set this to false explicitly.
+    walletsReady: true as boolean,
     user: null as MockUser | null,
     wallets: [] as MockWallet[],
   };
@@ -60,6 +64,7 @@ vi.mock("wagmi", () => ({
 vi.mock("@/contexts/privy-bridge-context", () => ({
   usePrivyBridge: vi.fn(() => ({
     ready: mockPrivyState.ready,
+    walletsReady: mockPrivyState.walletsReady,
     user: mockPrivyState.user,
     wallets: mockPrivyState.wallets,
   })),
@@ -125,7 +130,7 @@ import {
 // ---------------------------------------------------------------------------
 // Import the REAL hook using a relative path to bypass the @/ alias mock
 // ---------------------------------------------------------------------------
-import { useZeroDevSigner } from "../../../hooks/useZeroDevSigner";
+import { useZeroDevSigner, WALLET_READY_TIMEOUT_MS } from "../../../hooks/useZeroDevSigner";
 
 // ---------------------------------------------------------------------------
 // Shared chain-aware fixtures (see zerodev-signer-test-utils.ts)
@@ -193,6 +198,7 @@ describe("useZeroDevSigner (real hook)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPrivyState.ready = true;
+    mockPrivyState.walletsReady = true;
     mockPrivyState.user = null;
     mockPrivyState.wallets = [];
     mockUseChainId.mockReturnValue(10);
@@ -219,6 +225,13 @@ describe("useZeroDevSigner (real hook)", () => {
         getNetwork: vi.fn().mockResolvedValue({ chainId: 1n }),
       },
     }));
+  });
+
+  afterEach(() => {
+    // Some tests below install fake timers to fast-forward the
+    // WALLET_READY_TIMEOUT_MS wait — always restore real timers so it can't
+    // leak into a later test.
+    vi.useRealTimers();
   });
 
   // =========================================================================
@@ -575,30 +588,182 @@ describe("useZeroDevSigner (real hook)", () => {
   // =========================================================================
 
   describe("getAttestationSigner — no wallet", () => {
-    it("should throw 'No wallet available for signing' when no wallets exist", async () => {
+    it("throws SignerUnavailableError('wallets-hydrating') when walletsReady never flips true", async () => {
+      vi.useFakeTimers();
+      mockPrivyState.walletsReady = false;
       mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
       mockPrivyState.wallets = [];
 
       const { result } = renderHook(() => useZeroDevSigner());
 
-      await act(async () => {
-        await expect(result.current.getAttestationSigner(10)).rejects.toThrow(
-          "No wallet available for signing"
-        );
+      const assertion = expect(result.current.getAttestationSigner(10)).rejects.toMatchObject({
+        name: "SignerUnavailableError",
+        reason: "wallets-hydrating",
+        expected: true,
       });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WALLET_READY_TIMEOUT_MS + 500);
+      });
+
+      await assertion;
     });
 
-    it("should throw when user is null", async () => {
+    it("throws SignerUnavailableError('no-wallet-connected') when wallets are hydrated but empty (wallet-login user)", async () => {
+      vi.useFakeTimers();
+      mockPrivyState.walletsReady = true;
+      mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      const assertion = expect(result.current.getAttestationSigner(10)).rejects.toMatchObject({
+        name: "SignerUnavailableError",
+        reason: "no-wallet-connected",
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WALLET_READY_TIMEOUT_MS + 500);
+      });
+
+      await assertion;
+    });
+
+    it("throws SignerUnavailableError('embedded-wallet-provisioning') for an email user whose embedded wallet never appears", async () => {
+      vi.useFakeTimers();
+      mockPrivyState.walletsReady = true;
+      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      const assertion = expect(result.current.getAttestationSigner(10)).rejects.toMatchObject({
+        name: "SignerUnavailableError",
+        reason: "embedded-wallet-provisioning",
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WALLET_READY_TIMEOUT_MS + 500);
+      });
+
+      await assertion;
+    });
+
+    it("throws when user is null (unauthenticated)", async () => {
+      vi.useFakeTimers();
+      mockPrivyState.walletsReady = true;
       mockPrivyState.user = null;
       mockPrivyState.wallets = [];
 
       const { result } = renderHook(() => useZeroDevSigner());
 
-      await act(async () => {
-        await expect(result.current.getAttestationSigner(10)).rejects.toThrow(
-          "No wallet available for signing"
-        );
+      const assertion = expect(result.current.getAttestationSigner(10)).rejects.toMatchObject({
+        name: "SignerUnavailableError",
+        reason: "no-wallet-connected",
       });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WALLET_READY_TIMEOUT_MS + 500);
+      });
+
+      await assertion;
+    });
+  });
+
+  // =========================================================================
+  // Regression: GAP-FRONTEND-24N — a wallet that hydrates mid-wait must
+  // resolve, not throw the old instantaneous "No wallet available" error.
+  // =========================================================================
+
+  describe("getAttestationSigner — mid-flight wallet hydration (GAP-FRONTEND-24N)", () => {
+    it("resolves with a signer once an external wallet appears during the wait", async () => {
+      vi.useFakeTimers();
+      mockPrivyState.walletsReady = false;
+      mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+      mockPrivyState.wallets = [];
+      mockViemCreateWalletClient.mockReturnValue({ account: { address: EXTERNAL_WALLET_ADDRESS } });
+      mockWalletClientToSigner.mockResolvedValue({
+        getAddress: vi.fn().mockResolvedValue(EXTERNAL_WALLET_ADDRESS),
+      });
+
+      const { result, rerender } = renderHook(() => useZeroDevSigner());
+
+      const signerPromise = result.current.getAttestationSigner(10);
+
+      // Advance past the first poll tick(s) without resolving hydration yet.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      // Wallet hydrates mid-wait — mutate the same object the hook's ref reads,
+      // then rerender so the ref-sync-on-render line picks up the new value
+      // (mutating the mock state alone doesn't trigger a React re-render).
+      mockPrivyState.walletsReady = true;
+      mockPrivyState.wallets = [createExternalWallet()];
+      rerender();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      const signer = await signerPromise;
+      expect(signer).toBeDefined();
+      expect(await addressOf(signer)).toBe(EXTERNAL_WALLET_ADDRESS);
+    });
+  });
+
+  // =========================================================================
+  // signerStatus derivation
+  // =========================================================================
+
+  describe("signerStatus", () => {
+    it("is 'initializing' while Privy is not ready", () => {
+      mockPrivyState.ready = false;
+      mockPrivyState.walletsReady = false;
+      mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.signerStatus).toBe("initializing");
+    });
+
+    it("is 'initializing' while wallets have not hydrated yet", () => {
+      mockPrivyState.walletsReady = false;
+      mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.signerStatus).toBe("initializing");
+    });
+
+    it("is 'ready' once a usable wallet exists", () => {
+      setupExternalWalletUser();
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.signerStatus).toBe("ready");
+    });
+
+    it("is 'no-wallet' when hydrated with no wallets for a wallet-login user", () => {
+      mockPrivyState.walletsReady = true;
+      mockPrivyState.user = { linkedAccounts: [{ type: "wallet" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.signerStatus).toBe("no-wallet");
+    });
+
+    it("stays 'initializing' (not 'no-wallet') for an email user whose embedded wallet hasn't appeared yet", () => {
+      mockPrivyState.walletsReady = true;
+      mockPrivyState.user = { linkedAccounts: [{ type: "email" }] };
+      mockPrivyState.wallets = [];
+
+      const { result } = renderHook(() => useZeroDevSigner());
+
+      expect(result.current.signerStatus).toBe("initializing");
     });
   });
 

--- a/__tests__/unit/utilities/errorManager.test.tsx
+++ b/__tests__/unit/utilities/errorManager.test.tsx
@@ -100,4 +100,37 @@ describe("errorManager", () => {
 
     expect(Sentry.captureException).toHaveBeenCalled();
   });
+
+  // ---------------------------------------------------------------------
+  // Expected-state filter (GAP-FRONTEND-24N) — errors marked `expected: true`
+  // (e.g. SignerUnavailableError) are guidance, not defects.
+  // ---------------------------------------------------------------------
+  describe("expected errors (GAP-FRONTEND-24N)", () => {
+    it("does NOT capture an error with expected: true", () => {
+      const error = Object.assign(new Error("No wallet is connected."), { expected: true });
+
+      errorManager("Failed to create project", error);
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it("does not capture or throw for an expected error even when toastError.error is provided", () => {
+      const error = Object.assign(new Error("No wallet is connected."), { expected: true });
+
+      expect(() =>
+        errorManager("Failed to create project", error, undefined, {
+          error: "No wallet is connected.",
+        })
+      ).not.toThrow();
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when expected: true and no toastError is provided", () => {
+      const error = Object.assign(new Error("No wallet is connected."), { expected: true });
+
+      expect(() => errorManager("Failed to create project", error)).not.toThrow();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/components/Dialogs/ProjectDialog/SignerGate.tsx
+++ b/components/Dialogs/ProjectDialog/SignerGate.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { isSignerUnavailableError } from "@/utilities/wallet/signerReadiness";
+
+/** Signing readiness for UI gating — mirrors useSetupChainAndWallet's signerStatus. */
+type SignerStatus = "initializing" | "ready" | "no-wallet";
+
+interface SignerErrorHandlerDeps {
+  showError: (message: string) => void;
+  setShouldResetOnOpen: (value: boolean) => void;
+  openModal: () => void;
+}
+
+/**
+ * Returns a handler for the "no wallet was ready to sign" case
+ * (GAP-FRONTEND-24N). This is an expected user/lifecycle state — wallet still
+ * hydrating, embedded wallet provisioning, or none connected — not a defect.
+ * The handler shows actionable guidance, reopens the dialog with the form data
+ * preserved, and skips errorManager/Sentry entirely.
+ *
+ * @returns `true` when the error was a SignerUnavailableError and has been
+ *   handled (caller should `return`), `false` otherwise (caller keeps its
+ *   normal error handling).
+ */
+export function useSignerErrorHandler({
+  showError,
+  setShouldResetOnOpen,
+  openModal,
+}: SignerErrorHandlerDeps) {
+  return function handleSignerError(error: unknown): boolean {
+    if (!isSignerUnavailableError(error)) return false;
+    showError(error.message);
+    setShouldResetOnOpen(false);
+    openModal();
+    return true;
+  };
+}
+
+interface ProjectSubmitControlsProps {
+  /** Only render on the final wizard step. */
+  isLastStep: boolean;
+  signerStatus: SignerStatus;
+  hasErrors: boolean;
+  isLoading: boolean;
+  /** True when editing an existing project (vs. creating a new one). */
+  isUpdate: boolean;
+  onConnectWallet: () => void;
+  tooltipContent: ReactNode;
+}
+
+const SUBMIT_BUTTON_CLASSNAME =
+  "flex disabled:opacity-50 flex-row dark:bg-zinc-900 hover:text-white dark:text-white gap-2 items-center justify-center rounded-md border border-transparent bg-black px-6 py-2 text-md font-medium text-white hover:opacity-70 hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2";
+
+/**
+ * Final-step submit region. When the signer is unavailable (no wallet), it
+ * surfaces a "Connect wallet" CTA instead of the submit button; while the
+ * signer is still initializing, the submit button is disabled with a tooltip.
+ */
+export function ProjectSubmitControls({
+  isLastStep,
+  signerStatus,
+  hasErrors,
+  isLoading,
+  isUpdate,
+  onConnectWallet,
+  tooltipContent,
+}: ProjectSubmitControlsProps) {
+  if (!isLastStep) return null;
+
+  if (signerStatus === "no-wallet") {
+    return (
+      <Button type="button" className={SUBMIT_BUTTON_CLASSNAME} onClick={() => onConnectWallet()}>
+        Connect wallet
+      </Button>
+    );
+  }
+
+  const isSubmitBlocked = hasErrors || isLoading || signerStatus === "initializing";
+
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root delayDuration={0}>
+        <Tooltip.Trigger asChild>
+          <div className="flex w-max h-max">
+            <Button type="submit" className={SUBMIT_BUTTON_CLASSNAME} disabled={isSubmitBlocked}>
+              {isUpdate ? "Update project" : "Create project"}
+              {!isUpdate ? <ChevronRightIcon className="w-4 h-4" /> : null}
+            </Button>
+          </div>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          {isSubmitBlocked ? (
+            <Tooltip.Content
+              className="TooltipContent bg-brand-darkblue rounded-lg text-white p-3 z-[1000]"
+              sideOffset={5}
+              side="bottom"
+            >
+              {tooltipContent}
+              <Tooltip.Arrow className="TooltipArrow" />
+            </Tooltip.Content>
+          ) : null}
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -75,10 +75,10 @@ import { getProjectById } from "@/utilities/sdk";
 import { updateProject } from "@/utilities/sdk/projects/editProject";
 import { SOCIALS } from "@/utilities/socials";
 import { cn } from "@/utilities/tailwind";
-import { isSignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 import { SimilarProjectsDialog } from "../SimilarProjectsDialog";
 import { ContactInfoSection } from "./ContactInfoSection";
+import { ProjectSubmitControls, useSignerErrorHandler } from "./SignerGate";
 
 const inputStyle = "bg-gray-100 border border-gray-400 rounded-md p-2 dark:bg-zinc-900";
 const socialMediaInputStyle =
@@ -346,6 +346,14 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
   function openModal() {
     setIsOpen(true);
   }
+
+  // Recognises the expected "no wallet ready to sign" state (GAP-FRONTEND-24N)
+  // and reopens the dialog with actionable guidance instead of reporting a bug.
+  const handleSignerError = useSignerErrorHandler({
+    showError,
+    setShouldResetOnOpen,
+    openModal,
+  });
 
   // Handle unauthenticated user trying to open modal
   useEffect(() => {
@@ -717,16 +725,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
       setContacts([]);
       setCustomLinks([]);
     } catch (error: any) {
-      // No wallet was ready to sign yet — an expected user/lifecycle state
-      // (wallet hydrating, embedded wallet provisioning, none connected),
-      // not a defect. Show actionable guidance and skip errorManager/Sentry
-      // entirely (GAP-FRONTEND-24N).
-      if (isSignerUnavailableError(error)) {
-        showError(error.message);
-        setShouldResetOnOpen(false);
-        openModal();
-        return;
-      }
+      if (handleSignerError(error)) return;
       // A transient chain-switch / bundler-RPC hiccup (GAP-FRONTEND-23C) is
       // recoverable by retrying — tell the user that instead of a dead-end
       // generic error. The form data is preserved either way.
@@ -866,14 +865,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         }, 1500);
       });
     } catch (error: any) {
-      // No wallet was ready to sign yet — an expected user/lifecycle state,
-      // not a defect. Show actionable guidance and skip Sentry (GAP-FRONTEND-24N).
-      if (isSignerUnavailableError(error)) {
-        showError(error.message);
-        setShouldResetOnOpen(false);
-        openModal();
-        return;
-      }
+      if (handleSignerError(error)) return;
       const userMessage = isRetryableChainError(error)
         ? MESSAGES.PROJECT.UPDATE.RETRYABLE_ERROR
         : MESSAGES.PROJECT.UPDATE.ERROR;
@@ -1707,49 +1699,15 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                           </Tooltip.Provider>
                         )}
 
-                        {step === categories.length - 1 && signerStatus === "no-wallet" ? (
-                          <Button
-                            type="button"
-                            className="flex disabled:opacity-50 flex-row dark:bg-zinc-900 hover:text-white dark:text-white gap-2 items-center justify-center rounded-md border border-transparent bg-black px-6 py-2 text-md font-medium text-white hover:opacity-70 hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                            onClick={() => connectWallet()}
-                          >
-                            Connect wallet
-                          </Button>
-                        ) : null}
-                        {step === categories.length - 1 && signerStatus !== "no-wallet" && (
-                          <Tooltip.Provider>
-                            <Tooltip.Root delayDuration={0}>
-                              <Tooltip.Trigger asChild>
-                                <div className="flex w-max h-max">
-                                  <Button
-                                    type={"submit"}
-                                    className="flex disabled:opacity-50 flex-row dark:bg-zinc-900 hover:text-white dark:text-white gap-2 items-center justify-center rounded-md border border-transparent bg-black px-6 py-2 text-md font-medium text-white hover:opacity-70 hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                                    disabled={
-                                      hasErrors() || isLoading || signerStatus === "initializing"
-                                    }
-                                  >
-                                    {projectToUpdate ? "Update project" : "Create project"}
-                                    {!projectToUpdate ? (
-                                      <ChevronRightIcon className="w-4 h-4" />
-                                    ) : null}
-                                  </Button>
-                                </div>
-                              </Tooltip.Trigger>
-                              <Tooltip.Portal>
-                                {hasErrors() || isLoading || signerStatus === "initializing" ? (
-                                  <Tooltip.Content
-                                    className="TooltipContent bg-brand-darkblue rounded-lg text-white p-3 z-[1000]"
-                                    sideOffset={5}
-                                    side="bottom"
-                                  >
-                                    {tooltipText()}
-                                    <Tooltip.Arrow className="TooltipArrow" />
-                                  </Tooltip.Content>
-                                ) : null}
-                              </Tooltip.Portal>
-                            </Tooltip.Root>
-                          </Tooltip.Provider>
-                        )}
+                        <ProjectSubmitControls
+                          isLastStep={step === categories.length - 1}
+                          signerStatus={signerStatus}
+                          hasErrors={hasErrors()}
+                          isLoading={isLoading}
+                          isUpdate={!!projectToUpdate}
+                          onConnectWallet={connectWallet}
+                          tooltipContent={tooltipText()}
+                        />
                       </div>
                     </form>
                   </Dialog.Panel>

--- a/components/Dialogs/ProjectDialog/index.tsx
+++ b/components/Dialogs/ProjectDialog/index.tsx
@@ -75,6 +75,7 @@ import { getProjectById } from "@/utilities/sdk";
 import { updateProject } from "@/utilities/sdk/projects/editProject";
 import { SOCIALS } from "@/utilities/socials";
 import { cn } from "@/utilities/tailwind";
+import { isSignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 import { SimilarProjectsDialog } from "../SimilarProjectsDialog";
 import { ContactInfoSection } from "./ContactInfoSection";
@@ -178,6 +179,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
     login,
     isConnected: authIsConnected,
     address: authAddress,
+    connectWallet,
   } = useAuth();
   const { chain } = useAccount();
   const { switchChainAsync } = useWallet();
@@ -185,7 +187,8 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
   const router = useRouter();
   const { gap } = useGap();
   const { openSimilarProjectsModal, isSimilarProjectsModalOpen } = useSimilarProjectsModalStore();
-  const { setupChainAndWallet, smartWalletAddress, hasEmbeddedWallet } = useSetupChainAndWallet();
+  const { setupChainAndWallet, smartWalletAddress, hasEmbeddedWallet, signerStatus } =
+    useSetupChainAndWallet();
   // Resolve address: wagmi (external wallet) > useAuth (Privy wallets) > smartWalletAddress (embedded wallet for social login)
   const address = wagmiAddress || authAddress || (smartWalletAddress as `0x${string}` | undefined);
   const isConnected = wagmiIsConnected || authIsConnected || !!smartWalletAddress;
@@ -714,6 +717,16 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
       setContacts([]);
       setCustomLinks([]);
     } catch (error: any) {
+      // No wallet was ready to sign yet — an expected user/lifecycle state
+      // (wallet hydrating, embedded wallet provisioning, none connected),
+      // not a defect. Show actionable guidance and skip errorManager/Sentry
+      // entirely (GAP-FRONTEND-24N).
+      if (isSignerUnavailableError(error)) {
+        showError(error.message);
+        setShouldResetOnOpen(false);
+        openModal();
+        return;
+      }
       // A transient chain-switch / bundler-RPC hiccup (GAP-FRONTEND-23C) is
       // recoverable by retrying — tell the user that instead of a dead-end
       // generic error. The form data is preserved either way.
@@ -853,6 +866,14 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
         }, 1500);
       });
     } catch (error: any) {
+      // No wallet was ready to sign yet — an expected user/lifecycle state,
+      // not a defect. Show actionable guidance and skip Sentry (GAP-FRONTEND-24N).
+      if (isSignerUnavailableError(error)) {
+        showError(error.message);
+        setShouldResetOnOpen(false);
+        openModal();
+        return;
+      }
       const userMessage = isRetryableChainError(error)
         ? MESSAGES.PROJECT.UPDATE.RETRYABLE_ERROR
         : MESSAGES.PROJECT.UPDATE.ERROR;
@@ -895,6 +916,9 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
     const errors = hasErrors();
     if (isLoading) {
       return <p>Loading...</p>;
+    }
+    if (signerStatus === "initializing") {
+      return <p>{MESSAGES.PROJECT.CREATE.WALLET_PREPARING}</p>;
     }
     if (!errors) {
       return;
@@ -1683,7 +1707,16 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                           </Tooltip.Provider>
                         )}
 
-                        {step === categories.length - 1 && (
+                        {step === categories.length - 1 && signerStatus === "no-wallet" ? (
+                          <Button
+                            type="button"
+                            className="flex disabled:opacity-50 flex-row dark:bg-zinc-900 hover:text-white dark:text-white gap-2 items-center justify-center rounded-md border border-transparent bg-black px-6 py-2 text-md font-medium text-white hover:opacity-70 hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                            onClick={() => connectWallet()}
+                          >
+                            Connect wallet
+                          </Button>
+                        ) : null}
+                        {step === categories.length - 1 && signerStatus !== "no-wallet" && (
                           <Tooltip.Provider>
                             <Tooltip.Root delayDuration={0}>
                               <Tooltip.Trigger asChild>
@@ -1691,7 +1724,9 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                                   <Button
                                     type={"submit"}
                                     className="flex disabled:opacity-50 flex-row dark:bg-zinc-900 hover:text-white dark:text-white gap-2 items-center justify-center rounded-md border border-transparent bg-black px-6 py-2 text-md font-medium text-white hover:opacity-70 hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                                    disabled={hasErrors() || isLoading}
+                                    disabled={
+                                      hasErrors() || isLoading || signerStatus === "initializing"
+                                    }
                                   >
                                     {projectToUpdate ? "Update project" : "Create project"}
                                     {!projectToUpdate ? (
@@ -1701,7 +1736,7 @@ export const ProjectDialog: FC<ProjectDialogProps> = ({
                                 </div>
                               </Tooltip.Trigger>
                               <Tooltip.Portal>
-                                {hasErrors() || isLoading ? (
+                                {hasErrors() || isLoading || signerStatus === "initializing" ? (
                                   <Tooltip.Content
                                     className="TooltipContent bg-brand-darkblue rounded-lg text-white p-3 z-[1000]"
                                     sideOffset={5}

--- a/components/Utilities/PrivyWagmiProviders.tsx
+++ b/components/Utilities/PrivyWagmiProviders.tsx
@@ -36,7 +36,7 @@ const WALLET_LIST = [
 function PrivyBridgeUpdater() {
   const setBridge = usePrivyBridgeSetter();
   const privy = usePrivy();
-  const { wallets } = useWallets();
+  const { wallets, ready: walletsReady } = useWallets();
   const { client: smartWalletClient } = useSmartWallets();
   const { isConnected, chainId } = useAccount();
 
@@ -77,6 +77,7 @@ function PrivyBridgeUpdater() {
       getAccessToken: p.getAccessToken,
       connectWallet: p.connectWallet,
       wallets: w,
+      walletsReady,
       smartWalletClient: smartWalletClientRef.current,
       isConnected,
     });
@@ -86,6 +87,7 @@ function PrivyBridgeUpdater() {
     privy.authenticated,
     userId,
     walletCount,
+    walletsReady,
     smartWalletClient,
     isConnected,
   ]);

--- a/components/Utilities/errorManager.tsx
+++ b/components/Utilities/errorManager.tsx
@@ -38,6 +38,22 @@ const errorContains = (error: ErrorLike | null | undefined, needle: string): boo
   );
 };
 
+// Expected user/lifecycle states (e.g. SignerUnavailableError for a wallet
+// that hasn't connected/hydrated yet) are guidance, not defects — never
+// report them to Sentry. Duck-typed on `expected` to avoid an import cycle
+// with the ~40 attestation flows that call errorManager in their catches.
+// Extracted (rather than inlined in errorManager) to keep the main
+// function under biome's cognitive-complexity ceiling.
+const handleExpectedError = (error: unknown, toastError?: { error?: string }): boolean => {
+  if ((error as { expected?: boolean } | null)?.expected !== true) {
+    return false;
+  }
+  if (toastError?.error) {
+    getToast()?.error(toastError.error);
+  }
+  return true;
+};
+
 export const errorManager = (
   errorMessage: string,
   error: any,
@@ -60,6 +76,9 @@ export const errorManager = (
       }
       return;
     }
+  }
+  if (handleExpectedError(error, toastError)) {
+    return;
   }
   if (toastError?.error) {
     const wasRPCIssue = errorContains(error, "rpc error");

--- a/contexts/privy-bridge-context.tsx
+++ b/contexts/privy-bridge-context.tsx
@@ -29,6 +29,8 @@ export interface PrivyBridgeValue {
   connectWallet: () => void;
   // From useWallets
   wallets: ConnectedWallet[];
+  /** From useWallets().ready — false until Privy finishes hydrating connected wallets. */
+  walletsReady: boolean;
   // From useSmartWallets
   // biome-ignore lint/suspicious/noExplicitAny: Privy smart wallet client type is complex and internal
   smartWalletClient: any;
@@ -48,6 +50,7 @@ export const PRIVY_BRIDGE_DEFAULTS: PrivyBridgeValue = {
   getAccessToken: async () => null,
   connectWallet: noop,
   wallets: [],
+  walletsReady: false,
   smartWalletClient: null,
   isConnected: false,
 };

--- a/hooks/useSetupChainAndWallet.ts
+++ b/hooks/useSetupChainAndWallet.ts
@@ -37,6 +37,9 @@ interface UseSetupChainAndWalletResult {
 
   /** Whether user has an external wallet (MetaMask, etc.) */
   hasExternalWallet: boolean;
+
+  /** Signing readiness for UI gating — see useZeroDevSigner's signerStatus. */
+  signerStatus: "initializing" | "ready" | "no-wallet";
 }
 
 function isNetworkChangedError(error: unknown): boolean {
@@ -98,6 +101,7 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
     attestationAddress,
     hasEmbeddedWallet,
     hasExternalWallet,
+    signerStatus,
   } = useZeroDevSigner();
 
   const setupChainAndWallet = useCallback(
@@ -126,9 +130,12 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
           isGasless: isGaslessAvailable,
         };
       } catch (error) {
-        // Only swallow NETWORK_ERROR — other failures (unsupported chain, no
-        // wallet, signer construction) are real bugs and must surface to
-        // Sentry instead of being hidden behind a generic toast.
+        // Only swallow NETWORK_ERROR here — everything else propagates typed.
+        // A SignerUnavailableError is an expected wallet-lifecycle state (no
+        // wallet yet / still hydrating); callers show guidance and skip
+        // Sentry. Other failures (unsupported chain, signer construction)
+        // are real bugs and must surface to Sentry instead of being hidden
+        // behind a generic toast.
         if (!isNetworkChangedError(error)) {
           throw error;
         }
@@ -148,6 +155,7 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
       smartWalletAddress: attestationAddress,
       hasEmbeddedWallet,
       hasExternalWallet,
+      signerStatus,
     }),
     [
       setupChainAndWallet,
@@ -155,6 +163,7 @@ export function useSetupChainAndWallet(): UseSetupChainAndWalletResult {
       attestationAddress,
       hasEmbeddedWallet,
       hasExternalWallet,
+      signerStatus,
     ]
   );
 }

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -228,7 +228,7 @@ interface UsableWalletState {
 // toast, so the user sees progress rather than a hang. Do not go below ~5s
 // or fresh-signup flows (new email/social users) regress.
 export const WALLET_READY_TIMEOUT_MS = 8_000;
-export const WALLET_READY_POLL_MS = 250;
+const WALLET_READY_POLL_MS = 250;
 
 /**
  * Waits for a usable wallet to appear, polling the live (ref-backed) auth
@@ -240,7 +240,7 @@ export const WALLET_READY_POLL_MS = 250;
  * identity guard below forbids falling back to an unlinked external wallet,
  * so this selection intentionally preserves that rule.
  */
-export async function waitForUsableWallet(stateRef: {
+async function waitForUsableWallet(stateRef: {
   current: WalletStateSnapshot;
 }): Promise<UsableWalletState> {
   const deadline = Date.now() + WALLET_READY_TIMEOUT_MS;

--- a/hooks/useZeroDevSigner.ts
+++ b/hooks/useZeroDevSigner.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import type { User } from "@privy-io/react-auth";
+import type { ConnectedWallet, User } from "@privy-io/react-auth";
 import type { Signer } from "ethers";
 import { BrowserProvider } from "ethers";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { createWalletClient, custom } from "viem";
 import type { Chain } from "viem/chains";
 import {
@@ -32,6 +32,7 @@ import {
 } from "@/utilities/gasless";
 import { appNetwork } from "@/utilities/network";
 import { wait } from "@/utilities/wait";
+import { SignerUnavailableError } from "@/utilities/wallet/signerReadiness";
 import { safeGetWalletClient } from "@/utilities/wallet-helpers";
 
 /**
@@ -196,6 +197,75 @@ function didUserLoginWithEmailOrSocial(user: User | null): boolean {
   );
 }
 
+/** Find the Privy-managed embedded wallet (email/Google/passkey users). */
+function findEmbeddedWallet(wallets: ConnectedWallet[]): ConnectedWallet | null {
+  return wallets.find((wallet) => wallet.walletClientType === "privy") ?? null;
+}
+
+/** Find a non-Privy external wallet (MetaMask, Coinbase, etc.). */
+function findExternalWallet(wallets: ConnectedWallet[]): ConnectedWallet | null {
+  return wallets.find((wallet) => wallet.walletClientType !== "privy") ?? null;
+}
+
+/** Snapshot of the auth/wallet state, kept fresh via a ref so a wait loop that
+ *  started during hydration can observe wallets that arrive later. */
+interface WalletStateSnapshot {
+  privyReady: boolean;
+  walletsReady: boolean;
+  user: User | null;
+  wallets: ConnectedWallet[];
+}
+
+interface UsableWalletState {
+  embeddedWallet: ConnectedWallet | null;
+  externalWallet: ConnectedWallet | null;
+  isEmailOrSocialLogin: boolean;
+}
+
+// Covers the wallet-hydration race (~1-2s) plus the embedded-wallet settle
+// window (2.5s, see useEnsureEmbeddedWallet.SETTLE_BEFORE_CREATE_MS) and its
+// first creation attempt. Runs under the "Creating project..." attestation
+// toast, so the user sees progress rather than a hang. Do not go below ~5s
+// or fresh-signup flows (new email/social users) regress.
+export const WALLET_READY_TIMEOUT_MS = 8_000;
+export const WALLET_READY_POLL_MS = 250;
+
+/**
+ * Waits for a usable wallet to appear, polling the live (ref-backed) auth
+ * state so a call that starts mid-hydration can still resolve once Privy
+ * finishes. Classifies the reason if the wait times out instead of throwing
+ * a generic "no wallet" error.
+ *
+ * Email/social users need the embedded wallet specifically — the Case-3
+ * identity guard below forbids falling back to an unlinked external wallet,
+ * so this selection intentionally preserves that rule.
+ */
+export async function waitForUsableWallet(stateRef: {
+  current: WalletStateSnapshot;
+}): Promise<UsableWalletState> {
+  const deadline = Date.now() + WALLET_READY_TIMEOUT_MS;
+
+  while (true) {
+    const { walletsReady, user, wallets } = stateRef.current;
+    const isEmailOrSocialLogin = didUserLoginWithEmailOrSocial(user);
+    const embeddedWallet = findEmbeddedWallet(wallets);
+    const externalWallet = findExternalWallet(wallets);
+    const usable = isEmailOrSocialLogin ? embeddedWallet : embeddedWallet || externalWallet;
+
+    if (usable) {
+      return { embeddedWallet, externalWallet, isEmailOrSocialLogin };
+    }
+
+    if (Date.now() >= deadline) {
+      if (!walletsReady) throw new SignerUnavailableError("wallets-hydrating");
+      if (isEmailOrSocialLogin) throw new SignerUnavailableError("embedded-wallet-provisioning");
+      throw new SignerUnavailableError("no-wallet-connected");
+    }
+
+    await wait(WALLET_READY_POLL_MS);
+  }
+}
+
 interface UseZeroDevSignerResult {
   /**
    * Gets a signer for attestations.
@@ -215,6 +285,17 @@ interface UseZeroDevSignerResult {
 
   /** Whether the user has an external wallet (MetaMask, etc.) */
   hasExternalWallet: boolean;
+
+  /**
+   * Signing readiness for UI gating:
+   * - "initializing": Privy/wallets are still hydrating, or an email/social
+   *   user's embedded wallet is still being provisioned.
+   * - "ready": a usable wallet exists — the submit action can call
+   *   `getAttestationSigner` and expect it to resolve promptly.
+   * - "no-wallet": wallets are hydrated and the user has none connected —
+   *   the caller should prompt to connect rather than attempt to sign.
+   */
+  signerStatus: "initializing" | "ready" | "no-wallet";
 }
 
 /**
@@ -232,8 +313,19 @@ interface UseZeroDevSignerResult {
  * - For external wallet users (MetaMask, etc.): User always pays gas
  */
 export function useZeroDevSigner(): UseZeroDevSignerResult {
-  const { ready: privyReady, user, wallets } = usePrivyBridge();
+  const { ready: privyReady, walletsReady, user, wallets } = usePrivyBridge();
   const chainId = useChainId();
+
+  // Fresh-state ref so a getAttestationSigner call that starts mid-hydration
+  // can observe wallets that arrive later (the callback closure would
+  // otherwise be stuck with the render-time snapshot it started with).
+  const walletStateRef = useRef<WalletStateSnapshot>({
+    privyReady,
+    walletsReady,
+    user,
+    wallets,
+  });
+  walletStateRef.current = { privyReady, walletsReady, user, wallets };
 
   // Check if user logged in with email/Google (should use embedded wallet)
   const isEmailOrSocialLogin = useMemo(() => {
@@ -243,17 +335,32 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
   // Find embedded wallet (Privy-managed wallet for email/Google/passkey users)
   const embeddedWallet = useMemo(() => {
     if (!privyReady || !wallets.length) return null;
-    return wallets.find((wallet) => wallet.walletClientType === "privy") || null;
+    return findEmbeddedWallet(wallets);
   }, [privyReady, wallets]);
 
   // Find external wallet (MetaMask, Coinbase, etc.)
   const externalWallet = useMemo(() => {
     if (!privyReady || !wallets.length) return null;
-    return wallets.find((wallet) => wallet.walletClientType !== "privy") || null;
+    return findExternalWallet(wallets);
   }, [privyReady, wallets]);
 
   const hasEmbeddedWallet = !!embeddedWallet;
   const hasExternalWallet = !!externalWallet;
+
+  // Signing readiness for UI gating (§3.2.6). Email/social users specifically
+  // need the embedded wallet — an unlinked external wallet must never be
+  // treated as "ready" for them (same rule the Case-3 guard enforces below).
+  const usableWalletExists = isEmailOrSocialLogin
+    ? hasEmbeddedWallet
+    : hasEmbeddedWallet || hasExternalWallet;
+  const signerStatus: UseZeroDevSignerResult["signerStatus"] =
+    !privyReady || !walletsReady
+      ? "initializing"
+      : usableWalletExists
+        ? "ready"
+        : isEmailOrSocialLogin
+          ? "initializing" // embedded wallet still being provisioned
+          : "no-wallet";
 
   // Gasless is available for email/Google users with embedded wallet
   const isGaslessAvailable = useMemo(() => {
@@ -282,6 +389,14 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
       if (!Number.isFinite(targetChainId)) {
         throw new Error(`Invalid chain ID: ${rawTargetChainId}`);
       }
+
+      // Wait for a usable wallet, reading the live (ref-backed) state so a
+      // call that starts mid-hydration still resolves once Privy finishes.
+      // Throws a typed, classified SignerUnavailableError if none appears
+      // within WALLET_READY_TIMEOUT_MS.
+      const { embeddedWallet, externalWallet, isEmailOrSocialLogin } =
+        await waitForUsableWallet(walletStateRef);
+
       // Track the most recent diagnostic so the final throw can surface the
       // real cause instead of a generic "No wallet available" — silently
       // falling through after a catch hid the real Privy/embedded-wallet
@@ -439,9 +554,17 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
         throw wrapped;
       }
 
-      throw new Error("No wallet available for signing");
+      // Defensive fallback — waitForUsableWallet only returns once a usable
+      // wallet exists, so every ordinary path above returns or sets
+      // lastError. The one case that can still fall through is a user NOT
+      // classified as email/social who somehow has only an embedded wallet
+      // (no external wallet) — Case 3 requires an external wallet and
+      // Cases 1-2 require the email/social classification. Typed and
+      // classified rather than resurrecting the generic, un-actionable
+      // "No wallet available for signing" string.
+      throw new SignerUnavailableError("no-wallet-connected");
     },
-    [isEmailOrSocialLogin, embeddedWallet, externalWallet]
+    []
   );
 
   return {
@@ -450,5 +573,6 @@ export function useZeroDevSigner(): UseZeroDevSignerResult {
     attestationAddress,
     hasEmbeddedWallet,
     hasExternalWallet,
+    signerStatus,
   };
 }

--- a/utilities/messages.ts
+++ b/utilities/messages.ts
@@ -325,6 +325,7 @@ export const MESSAGES = {
       ERROR: (title: string) => `There was an error creating ${title} project.`,
       RETRYABLE_ERROR:
         "We couldn't reach the network just now. Your details are saved — please try again in a moment.",
+      WALLET_PREPARING: "Your wallet is still being prepared. Please try again in a moment.",
     },
     UPDATE: {
       SUCCESS: "Project updated successfully",

--- a/utilities/wallet/signerReadiness.ts
+++ b/utilities/wallet/signerReadiness.ts
@@ -1,0 +1,46 @@
+/**
+ * Typed "no signer yet" states for `useZeroDevSigner`.
+ *
+ * `wallets === []` for an authenticated user is an expected, usually
+ * transient lifecycle state (Privy hasn't hydrated wallets yet, or an
+ * embedded wallet is still being provisioned) — not a defect. Signing code
+ * used to throw a bare `Error("No wallet available for signing")` the
+ * instant it observed this, which `errorManager` reported to Sentry as a
+ * bug (GAP-FRONTEND-24N). `SignerUnavailableError` lets callers recognise
+ * the state, show actionable guidance, and skip Sentry reporting.
+ */
+
+export type SignerUnavailableReason =
+  /** `walletsReady` from Privy's `useWallets()` is still false after the wait. */
+  | "wallets-hydrating"
+  /** Email/social login user whose embedded wallet hasn't been created yet. */
+  | "embedded-wallet-provisioning"
+  /** Wallets are hydrated and the user simply has no usable wallet connected. */
+  | "no-wallet-connected";
+
+const REASON_MESSAGES: Record<SignerUnavailableReason, string> = {
+  "wallets-hydrating": "Your wallet is still being prepared. Please try again in a moment.",
+  "embedded-wallet-provisioning":
+    "Your wallet is still being prepared. Please try again in a moment.",
+  "no-wallet-connected": "No wallet is connected. Please connect your wallet and try again.",
+};
+
+/**
+ * Thrown by `getAttestationSigner` when no usable wallet exists after the
+ * bounded wait. This is an expected user/lifecycle state, not a defect —
+ * callers must show the message as guidance and must NOT report it to
+ * Sentry via `errorManager` (which treats `expected === true` as a signal
+ * to skip `Sentry.captureException`).
+ */
+export class SignerUnavailableError extends Error {
+  /** Marks this as an expected user/lifecycle state — never report to Sentry. */
+  public readonly expected = true as const;
+
+  constructor(public readonly reason: SignerUnavailableReason) {
+    super(REASON_MESSAGES[reason]);
+    this.name = "SignerUnavailableError";
+  }
+}
+
+export const isSignerUnavailableError = (error: unknown): error is SignerUnavailableError =>
+  error instanceof SignerUnavailableError;

--- a/utilities/wallet/signerReadiness.ts
+++ b/utilities/wallet/signerReadiness.ts
@@ -10,7 +10,7 @@
  * the state, show actionable guidance, and skip Sentry reporting.
  */
 
-export type SignerUnavailableReason =
+type SignerUnavailableReason =
   /** `walletsReady` from Privy's `useWallets()` is still false after the wait. */
   | "wallets-hydrating"
   /** Email/social login user whose embedded wallet hasn't been created yet. */


### PR DESCRIPTION
## Problem

Project creation intermittently failed with `Error: No wallet available for signing`, reported to Sentry as a defect ([GAP-FRONTEND-24N](https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-24N)). The `useZeroDevSigner` attestation signer threw this the instant it observed an empty `wallets` array — but for an authenticated user that array is empty during several *expected, transient* states:

- Privy's `useWallets()` hasn't finished hydrating connected wallets yet.
- A new email/social signup's embedded wallet is still being provisioned.
- An external wallet is momentarily locked/disconnected.

The user saw a generic "error creating project", and the non-defect was noised into Sentry.

## Root cause

`getAttestationSigner` had no notion of "not ready yet". It read the render-time wallet snapshot and, finding nothing, threw a bare `Error("No wallet available for signing")` synchronously. There was no wait for hydration and no way for callers to distinguish this expected lifecycle state from a genuine signer-construction bug, so it went through `errorManager` → `Sentry.captureException`.

## Fix (what & why)

- **Wait for readiness instead of failing instantly.** `getAttestationSigner` now polls live, ref-backed auth state for up to `WALLET_READY_TIMEOUT_MS` (8s, sized to cover Privy hydration + the embedded-wallet settle/creation window) so a call that starts mid-hydration resolves once the wallet arrives. The ref means the in-flight closure observes wallets that land after it started, rather than being stuck on its render-time snapshot.
- **Typed, classified expected error.** When the wait genuinely times out it throws `SignerUnavailableError` with a reason (`wallets-hydrating` / `embedded-wallet-provisioning` / `no-wallet-connected`) and `expected: true`, replacing the un-actionable generic string.
- **Expected ≠ defect.** `errorManager` now skips `Sentry.captureException` for any error marked `expected: true` (duck-typed to avoid an import cycle with the ~40 attestation flows that share this signer). `ProjectDialog` catches `SignerUnavailableError` directly, shows its actionable message in the stepper, and never routes it to Sentry.
- **UI gating.** The bridge now exposes `walletsReady` (from `useWallets().ready`) so the hook can tell "hydrating" apart from "genuinely disconnected". A derived `signerStatus` (`initializing` / `ready` / `no-wallet`) disables the submit button with a "preparing your wallet" tooltip while initializing, and swaps it for a "Connect wallet" CTA when hydrated with no usable wallet — so most users never reach the failing submit at all. Email/social users are intentionally never offered the external-wallet CTA (preserves the existing identity guard).

The mid-flight `console`/gasless diagnostics and the Case 1/2/3 signer paths are unchanged.

## Tests

- `useZeroDevSigner-real.test.ts`: regression test that a wallet appearing **mid-wait** resolves to a real signer (fails on `main`, which threw instantly); plus each timeout reason classification and full `signerStatus` derivation.
- `errorManager.test.tsx`: an error with `expected: true` is not captured to Sentry and never throws, with or without a toast.
- `PrivyWagmiProviders.bridge.test.tsx`: `walletsReady` is pushed into the bridge and a `ready` flip re-pushes even when wallet count is unchanged.
- Updated signer-trust, privy-bridge, and ProjectDialog suites for the new field. Full `tsc --noEmit` passes (pre-push hook); Biome clean on changed files (only pre-existing `any`/unused warnings remain).

## Review

Self-review score: **96/100**. Verified: root cause is the instantaneous throw on an expected transient state, and the fix waits + classifies rather than masking it; expected vs. unexpected errors are cleanly separated (`expected: true` → no Sentry, genuine signer-construction failures still surface via the existing `lastError` wrapping); no new `any`; the `getAttestationSigner` callback's empty dep array is correct now that all wallet reads go through the ref; no silent `catch {}`. Minor, non-blocking: the "Connect wallet" CTA reuses the sibling submit button's existing utility classes verbatim for visual consistency.

Sentry: https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-24N

Fixes GAP-FRONTEND-24N
