### PR TITLE
fix: guard null InputEvent.data behind a single md-editor-rt boundary

### DIFF
--- a/.taskless/rules/no-direct-md-editor-import-tsx.yml
+++ b/.taskless/rules/no-direct-md-editor-import-tsx.yml
@@ -1,0 +1,27 @@
+id: no-direct-md-editor-import-tsx
+language: tsx
+severity: warning
+message: Import SafeMdEditor from components/Utilities/SafeMdEditor.tsx, never md-editor-rt directly.
+note: |
+  TSX variant of `no-direct-md-editor-import`. ast-grep scopes a rule to a
+  single language, and `.tsx` files are parsed as `tsx`, not `typescript`.
+  md-editor-rt@6.4.1 reads InputEvent.data.length unguarded in its CodeMirror
+  maxLength handler; data is null for Backspace/Enter/paste (Sentry
+  GAP-FRONTEND-1WY / GAP-FRONTEND-24S). SafeMdEditor normalizes the event and
+  the model value before the library sees them.
+ignores:
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "components/Utilities/SafeMdEditor.tsx"
+  - "scripts/**"
+rule:
+  kind: string
+  regex: '^["'']md-editor-rt'
+  inside:
+    stopBy: end
+    any:
+      - kind: import_statement
+      - kind: call_expression

--- a/.taskless/rules/no-direct-md-editor-import.yml
+++ b/.taskless/rules/no-direct-md-editor-import.yml
@@ -1,0 +1,25 @@
+id: no-direct-md-editor-import
+language: typescript
+severity: warning
+message: Import SafeMdEditor from components/Utilities/SafeMdEditor.tsx, never md-editor-rt directly.
+note: |
+  md-editor-rt@6.4.1 reads InputEvent.data.length unguarded in its CodeMirror
+  maxLength handler; data is null for Backspace/Enter/paste (Sentry
+  GAP-FRONTEND-1WY / GAP-FRONTEND-24S). SafeMdEditor normalizes the event and
+  the model value before the library sees them.
+ignores:
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "components/Utilities/SafeMdEditor.tsx"
+  - "scripts/**"
+rule:
+  kind: string
+  regex: '^["'']md-editor-rt'
+  inside:
+    stopBy: end
+    any:
+      - kind: import_statement
+      - kind: call_expression

--- a/__tests__/components/Utilities/MarkdownEditor.nullInputEvent.test.tsx
+++ b/__tests__/components/Utilities/MarkdownEditor.nullInputEvent.test.tsx
@@ -1,14 +1,17 @@
 /**
- * @file Regression tests for Sentry GAP-FRONTEND-1WY
+ * @file Regression tests for Sentry GAP-FRONTEND-1WY / GAP-FRONTEND-24S
  * @description md-editor-rt@6.4.1 reads `InputEvent.data.length` unguarded in
  * its CodeMirror `input` overlength (`maxLength`) handler. `data` is `null` by
  * spec for `deleteContentBackward`, `insertParagraph`/`insertLineBreak`,
  * `insertFromPaste` and `insertFromDrop` (common on mobile IME deletions /
  * Enter / paste), so the handler throws
- * `TypeError: Cannot read properties of null (reading 'length')`.
+ * `TypeError: Cannot read properties of null (reading 'length')` on V8
+ * (GAP-FRONTEND-1WY) or `null is not an object (evaluating 'r.length')` on
+ * WebKit/Safari (GAP-FRONTEND-24S) — same defect, engine-split grouping.
  *
  * The fix is `normalizeNullInputEventData` (in utils/normalize-null-input-event-data.ts), passed as
- * `onInput` to MdEditor: the library invokes the consumer's `onInput` with the
+ * `onInput` to MdEditor via the `SafeMdEditor` boundary (components/Utilities/SafeMdEditor.tsx):
+ * the library invokes the consumer's `onInput` with the
  * raw event BEFORE destructuring `.data`, so shadowing the null with an own
  * `""` property defuses the crash. These tests render the REAL editor
  * (md-editor-rt is intentionally NOT mocked) and drive native input events
@@ -16,9 +19,13 @@
  *   1. the normalize function itself behaves (unit tests),
  *   2. the shim defuses the crash while preserving the overlength behavior
  *      (raw MdEditor + onInput),
- *   3. the shared MarkdownEditor wrapper wires the shim (end-to-end),
+ *   3. the shared MarkdownEditor wrapper (via SafeMdEditor) wires the shim (end-to-end),
  *   4. the upstream bug still exists in the pristine library (canary — when
  *      this one starts failing, upstream fixed it and the shim can go).
+ *
+ * See also `SafeMdEditor.test.tsx` (the boundary itself, all consumers) and
+ * `CommentMarkdownInput.safety.test.tsx` (the comment box, GAP-FRONTEND-24S's
+ * direct regression target).
  */
 
 import { render, waitFor } from "@testing-library/react";
@@ -27,6 +34,13 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { normalizeNullInputEventData } from "@/components/Utilities/utils/normalize-null-input-event-data";
+import {
+  dispatchInputAndCollectErrors,
+  installCodeMirrorPolyfills,
+  LENGTH_CRASH,
+  nullDataInputTypes,
+  waitForEditorContent,
+} from "../../utils/codemirror-jsdom";
 
 // The wrapper pulls in next-themes and a heavy preview component — mock those
 // (NOT md-editor-rt itself, which is the code under test).
@@ -59,99 +73,6 @@ vi.mock("next/dynamic", () => ({
     return DynamicShim;
   },
 }));
-
-// ---------------------------------------------------------------------------
-// CodeMirror-in-jsdom polyfills. CodeMirror 6 measures the DOM on mount and on
-// every input; jsdom implements none of these, so without them the editor
-// throws while laying out rather than exercising the code path under test.
-// ---------------------------------------------------------------------------
-function installCodeMirrorPolyfills() {
-  const emptyRect = {
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-    width: 0,
-    height: 0,
-    x: 0,
-    y: 0,
-    toJSON: () => ({}),
-  } as DOMRect;
-
-  if (!Range.prototype.getClientRects) {
-    Range.prototype.getClientRects = () =>
-      ({
-        length: 0,
-        item: () => null,
-        [Symbol.iterator]: function* () {},
-      }) as unknown as DOMRectList;
-  }
-  if (!Range.prototype.getBoundingClientRect) {
-    Range.prototype.getBoundingClientRect = () => emptyRect;
-  }
-  if (!document.elementFromPoint) {
-    document.elementFromPoint = () => null;
-  }
-}
-
-/**
- * Dispatches a native `input` InputEvent on the CodeMirror content DOM and
- * returns every error surfaced through any channel (a thrown listener, the
- * window `error` event, or CodeMirror's logException -> console.error).
- */
-function dispatchInputAndCollectErrors(
-  content: Element,
-  init: { data: string | null; inputType: string }
-): string[] {
-  const errors: string[] = [];
-
-  const onWindowError = (event: ErrorEvent) => {
-    errors.push(String(event.error?.message ?? event.message ?? ""));
-  };
-  window.addEventListener("error", onWindowError);
-  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-    errors.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "));
-  });
-
-  try {
-    content.dispatchEvent(
-      new InputEvent("input", { data: init.data, inputType: init.inputType, bubbles: true })
-    );
-  } catch (err) {
-    errors.push(err instanceof Error ? err.message : String(err));
-  } finally {
-    window.removeEventListener("error", onWindowError);
-    consoleErrorSpy.mockRestore();
-  }
-
-  return errors;
-}
-
-const LENGTH_CRASH = /Cannot read properties of null|reading 'length'|reading "length"/;
-
-/** Waits for CodeMirror to mount its content DOM inside the given container. */
-async function waitForEditorContent(container: HTMLElement): Promise<Element> {
-  let content: Element | null = null;
-  await waitFor(
-    () => {
-      content = container.querySelector(".cm-content");
-      expect(content).not.toBeNull();
-    },
-    { timeout: 5000 }
-  );
-  return content as unknown as Element;
-}
-
-// Each of these inputTypes produces a native InputEvent whose `.data` is
-// `null` per the Input Events spec — the exact events that crashed in prod.
-// Note: the library's separate paste (clipboard) handler's only nullable
-// operand is `modelValue`, which the wrapper's `safeValue` already prevents.
-const nullDataInputTypes = [
-  "deleteContentBackward",
-  "insertLineBreak",
-  "insertFromPaste",
-  "insertFromDrop",
-];
 
 describe("normalizeNullInputEventData (GAP-FRONTEND-1WY)", () => {
   it("jsdom matches browsers: InputEvent.data is a prototype getter, null by default", () => {
@@ -273,7 +194,7 @@ describe("MarkdownEditor / md-editor-rt null InputEvent.data (GAP-FRONTEND-1WY)"
     // Documents that md-editor-rt still crashes without the shim. If this
     // test starts FAILING after a library upgrade, upstream fixed the null
     // guard: remove `normalizeNullInputEventData` (utils/normalize-null-input-event-data.ts
-    // and its wiring in MarkdownEditor.tsx) and delete this file.
+    // and its wiring in SafeMdEditor.tsx) and delete this file.
     it("unshimmed editor still throws the length TypeError on data:null", async () => {
       const utils = render(
         <MdEditor

--- a/__tests__/components/Utilities/SafeMdEditor.test.tsx
+++ b/__tests__/components/Utilities/SafeMdEditor.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @file Regression tests for Sentry GAP-FRONTEND-24S
+ * @description `SafeMdEditor` (components/Utilities/SafeMdEditor.tsx) is the
+ * single app boundary allowed to render md-editor-rt directly. It normalizes
+ * `InputEvent.data` (null for Backspace/Enter/paste, see
+ * GAP-FRONTEND-1WY/GAP-FRONTEND-24S) before the library's `maxLength`
+ * overlength check runs, and defaults `value` to `""`. These tests render the
+ * REAL editor through `SafeMdEditor` (md-editor-rt is intentionally NOT
+ * mocked) to prove the boundary itself — independent of which wrapper
+ * (`MarkdownEditor`, `CommentMarkdownInput`) consumes it — is safe.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeMdEditor } from "@/components/Utilities/SafeMdEditor";
+import {
+  dispatchInputAndCollectErrors,
+  installCodeMirrorPolyfills,
+  LENGTH_CRASH,
+  nullDataInputTypes,
+  waitForEditorContent,
+} from "../../utils/codemirror-jsdom";
+
+vi.mock("md-editor-rt/lib/style.css", () => ({}));
+
+// Replace next/dynamic with a shim that actually lazy-loads the REAL module,
+// so SafeMdEditor renders the genuine md-editor-rt editor in jsdom.
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: (importFn: () => Promise<React.ComponentType>) => {
+    const Lazy = React.lazy(async () => {
+      const component = await importFn();
+      return { default: component };
+    });
+    const DynamicShim = (props: Record<string, unknown>) => (
+      <React.Suspense fallback={null}>
+        <Lazy {...props} />
+      </React.Suspense>
+    );
+    return DynamicShim;
+  },
+}));
+
+describe("SafeMdEditor (GAP-FRONTEND-24S)", () => {
+  beforeEach(() => {
+    installCodeMirrorPolyfills();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(nullDataInputTypes)(
+    "does not throw a length TypeError for inputType=%s with data:null",
+    async (inputType) => {
+      const utils = render(
+        <SafeMdEditor
+          value="existing content"
+          onChange={() => {}}
+          maxLength={100}
+          preview={false}
+          language="en-US"
+        />
+      );
+      const content = await waitForEditorContent(utils.container as HTMLElement);
+
+      const errors = dispatchInputAndCollectErrors(content, { data: null, inputType });
+
+      expect(errors.filter((message) => LENGTH_CRASH.test(message))).toEqual([]);
+    }
+  );
+
+  it("still emits an overlength error when the input pushes past maxLength", async () => {
+    const onError = vi.fn();
+    const utils = render(
+      <SafeMdEditor
+        value=""
+        onChange={() => {}}
+        maxLength={100}
+        onError={onError}
+        preview={false}
+        language="en-US"
+      />
+    );
+    const content = await waitForEditorContent(utils.container as HTMLElement);
+
+    dispatchInputAndCollectErrors(content, {
+      data: "x".repeat(200),
+      inputType: "insertText",
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ name: "overlength" }));
+    });
+  });
+
+  it("composes with a consumer onInput instead of clobbering it", async () => {
+    const consumerOnInput = vi.fn();
+    const utils = render(
+      <SafeMdEditor
+        value="existing content"
+        onChange={() => {}}
+        onInput={consumerOnInput}
+        maxLength={100}
+        preview={false}
+        language="en-US"
+      />
+    );
+    const content = await waitForEditorContent(utils.container as HTMLElement);
+
+    dispatchInputAndCollectErrors(content, {
+      data: null,
+      inputType: "deleteContentBackward",
+    });
+
+    expect(consumerOnInput).toHaveBeenCalled();
+    // The consumer receives the already-normalized event: the null was
+    // shadowed with "" before onInput ran.
+    const receivedEvent = consumerOnInput.mock.calls[0]?.[0] as InputEvent;
+    expect(receivedEvent.data).toBe("");
+  });
+
+  it("renders an undefined value as an empty string without crashing", async () => {
+    const utils = render(
+      <SafeMdEditor
+        value={undefined}
+        onChange={() => {}}
+        maxLength={100}
+        preview={false}
+        language="en-US"
+      />
+    );
+
+    await waitForEditorContent(utils.container as HTMLElement);
+    // No throw during mount is the assertion; md-editor-rt renders an empty
+    // CodeMirror document for value="".
+  });
+});

--- a/__tests__/performance/lazy-imports.perf.test.ts
+++ b/__tests__/performance/lazy-imports.perf.test.ts
@@ -201,12 +201,35 @@ describe("Lazy import enforcement for heavy libraries", () => {
     expect(content).not.toMatch(/^import\s+(?!type\s)\w+\s+from\s+['"]streamdown['"]/m);
   });
 
-  it("verifies that MarkdownEditor uses dynamic() for the editor library", () => {
-    const filePath = path.join(COMPONENTS_DIR, "Utilities", "MarkdownEditor.tsx");
+  it("verifies that SafeMdEditor uses dynamic() for the editor library", () => {
+    // md-editor-rt is dynamically imported exactly once, in the shared
+    // SafeMdEditor boundary (Sentry GAP-FRONTEND-1WY / GAP-FRONTEND-24S) --
+    // every consumer (MarkdownEditor, CommentMarkdownInput) renders through
+    // it instead of calling dynamic()/import() on md-editor-rt itself.
+    const filePath = path.join(COMPONENTS_DIR, "Utilities", "SafeMdEditor.tsx");
     const content = fs.readFileSync(filePath, "utf-8");
 
     // Should use dynamic import
     expect(content).toMatch(/dynamic\(/);
+  });
+
+  it("verifies that MarkdownEditor and CommentMarkdownInput consume SafeMdEditor, not md-editor-rt directly", () => {
+    const consumerPaths = [
+      path.join(COMPONENTS_DIR, "Utilities", "MarkdownEditor.tsx"),
+      path.join(
+        SRC_DIR,
+        "features",
+        "application-comments",
+        "components",
+        "CommentMarkdownInput.tsx"
+      ),
+    ];
+
+    for (const filePath of consumerPaths) {
+      const content = fs.readFileSync(filePath, "utf-8");
+      expect(content).toMatch(/SafeMdEditor/);
+      expect(content).not.toMatch(/dynamic\(\(\)\s*=>\s*import\(["']md-editor-rt["']\)/);
+    }
   });
 
   it("verifies that Stats chart files use dynamic() for heavy Tremor chart components", () => {

--- a/__tests__/utils/codemirror-jsdom.tsx
+++ b/__tests__/utils/codemirror-jsdom.tsx
@@ -1,0 +1,111 @@
+/**
+ * Shared jsdom helpers for rendering the REAL md-editor-rt (CodeMirror-backed)
+ * editor in tests and driving native InputEvents against it.
+ *
+ * Extracted from the original GAP-FRONTEND-1WY regression suite
+ * (`__tests__/components/Utilities/MarkdownEditor.nullInputEvent.test.tsx`) so
+ * the same helpers can be reused by `SafeMdEditor.test.tsx` and
+ * `CommentMarkdownInput.safety.test.tsx` for GAP-FRONTEND-24S.
+ */
+import { waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// CodeMirror-in-jsdom polyfills. CodeMirror 6 measures the DOM on mount and on
+// every input; jsdom implements none of these, so without them the editor
+// throws while laying out rather than exercising the code path under test.
+// ---------------------------------------------------------------------------
+export function installCodeMirrorPolyfills() {
+  const emptyRect = {
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+
+  if (!Range.prototype.getClientRects) {
+    Range.prototype.getClientRects = () =>
+      ({
+        length: 0,
+        item: () => null,
+        [Symbol.iterator]: function* () {},
+      }) as unknown as DOMRectList;
+  }
+  if (!Range.prototype.getBoundingClientRect) {
+    Range.prototype.getBoundingClientRect = () => emptyRect;
+  }
+  if (!document.elementFromPoint) {
+    document.elementFromPoint = () => null;
+  }
+}
+
+/**
+ * Dispatches a native `input` InputEvent on the CodeMirror content DOM and
+ * returns every error surfaced through any channel (a thrown listener, the
+ * window `error` event, or CodeMirror's logException -> console.error).
+ */
+export function dispatchInputAndCollectErrors(
+  content: Element,
+  init: { data: string | null; inputType: string }
+): string[] {
+  const errors: string[] = [];
+
+  const onWindowError = (event: ErrorEvent) => {
+    errors.push(String(event.error?.message ?? event.message ?? ""));
+  };
+  window.addEventListener("error", onWindowError);
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errors.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "));
+  });
+
+  try {
+    content.dispatchEvent(
+      new InputEvent("input", { data: init.data, inputType: init.inputType, bubbles: true })
+    );
+  } catch (err) {
+    errors.push(err instanceof Error ? err.message : String(err));
+  } finally {
+    window.removeEventListener("error", onWindowError);
+    consoleErrorSpy.mockRestore();
+  }
+
+  return errors;
+}
+
+// Matches both the V8 phrasing (`Cannot read properties of null (reading
+// 'length')`, what jsdom always produces) and the WebKit/Safari phrasing
+// (`null is not an object (evaluating 'r.length')`, GAP-FRONTEND-24S) in
+// case a future test environment or transcript surfaces the WebKit wording
+// verbatim. jsdom itself only ever produces the V8 message today.
+export const LENGTH_CRASH =
+  /Cannot read properties of null|reading 'length'|reading "length"|null is not an object|evaluating '[a-zA-Z0-9_$]*\.length'/;
+
+/** Waits for CodeMirror to mount its content DOM inside the given container. */
+export async function waitForEditorContent(container: HTMLElement): Promise<Element> {
+  let content: Element | null = null;
+  await waitFor(
+    () => {
+      content = container.querySelector(".cm-content");
+      expect(content).not.toBeNull();
+    },
+    { timeout: 5000 }
+  );
+  return content as unknown as Element;
+}
+
+// Each of these inputTypes produces a native InputEvent whose `.data` is
+// `null` per the Input Events spec — the exact events that crashed in prod.
+// Note: the library's separate paste (clipboard) handler's only nullable
+// operand is `modelValue`, which `SafeMdEditor`'s `value ?? ""` already
+// prevents.
+export const nullDataInputTypes = [
+  "deleteContentBackward",
+  "insertLineBreak",
+  "insertFromPaste",
+  "insertFromDrop",
+];

--- a/components/Utilities/MarkdownEditor.tsx
+++ b/components/Utilities/MarkdownEditor.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { Eye, EyeOff, Loader2 } from "lucide-react";
-import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { MarkdownPreview } from "@/components/Utilities/MarkdownPreview";
-import { normalizeNullInputEventData } from "@/components/Utilities/utils/normalize-null-input-event-data";
+import { SafeMdEditor } from "@/components/Utilities/SafeMdEditor";
 import { cn } from "@/utilities/tailwind";
 
 // Constants for content validation and performance
@@ -42,18 +41,6 @@ interface MarkdownEditorProps {
   /** Override the label element's className. When omitted, a bold default is used. */
   labelClassName?: string;
 }
-
-import "md-editor-rt/lib/style.css";
-
-const MdEditor = dynamic(() => import("md-editor-rt").then((mod) => mod.MdEditor), {
-  ssr: false,
-  loading: () => (
-    <div className="flex items-center justify-center h-[300px] border border-gray-200 dark:border-gray-700 rounded-lg">
-      <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
-      <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">Loading editor...</span>
-    </div>
-  ),
-});
 
 // Toolbar buttons to exclude — removes overflow-causing and rarely-used items in modal contexts
 const EXCLUDED_TOOLBARS = [
@@ -119,8 +106,9 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   labelClassName,
 }) => {
   // md-editor-rt has TWO independent null sources that both throw
-  // `Cannot read properties of null (reading 'length')` inside its CodeMirror
-  // maxLength/overlength check (Sentry GAP-FRONTEND-1WY, 1.7k events):
+  // `Cannot read properties of null (reading 'length')` (or, on WebKit,
+  // `null is not an object (evaluating 'r.length')`) inside its CodeMirror
+  // maxLength/overlength check (Sentry GAP-FRONTEND-1WY / GAP-FRONTEND-24S):
   //
   //   1. `modelValue` — if a caller (or RHF default) passes `null`/`undefined`
   //      we hit the crash plus a setValue→onChange→re-render cycle that trips
@@ -131,10 +119,10 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   //      `insertFromDrop` (common on mobile IME deletions/Enter/paste). The
   //      library's `input` handler reads `.data.length` unguarded. `safeValue`
   //      does NOT cover this — the null is on the DOM event, not the model —
-  //      so the `onInput` normalize shim (defined above) rewrites the null to
-  //      "" before the library's check runs. Since `maxLength` is always set
-  //      here, that buggy branch is armed on every keystroke across all usage
-  //      sites, which is why the shim is required.
+  //      so `SafeMdEditor` normalizes it before the library's check runs.
+  //      Since `maxLength` is always set here, that buggy branch is armed on
+  //      every keystroke across all usage sites, which is why every consumer
+  //      must render through `SafeMdEditor` rather than `MdEditor` directly.
   const safeValue = value ?? "";
 
   // md-editor-rt builds `#${id} .cm-scroller` and runs querySelector on it.
@@ -151,18 +139,6 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
   // Ensure client-side only rendering to prevent hydration mismatches
   useEffect(() => {
     setMounted(true);
-  }, []);
-
-  // Configure markdown-it to treat single newlines as <br>.
-  // Done via dynamic import so md-editor-rt is never statically bundled.
-  useEffect(() => {
-    import("md-editor-rt").then(({ config }) => {
-      config({
-        markdownItConfig(md) {
-          md.options.breaks = true;
-        },
-      });
-    });
   }, []);
 
   // Use disabled prop if provided, otherwise use isDisabled
@@ -277,7 +253,7 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
             <MarkdownPreview source={safeValue} />
           </div>
         ) : (
-          <MdEditor
+          <SafeMdEditor
             id={safeId}
             className={cn(
               "flex-1",
@@ -287,7 +263,6 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({
             )}
             value={safeValue}
             onChange={handleChange}
-            onInput={normalizeNullInputEventData}
             onBlur={onBlur}
             theme={resolvedTheme === "dark" ? "dark" : "light"}
             preview={false}

--- a/components/Utilities/SafeMdEditor.tsx
+++ b/components/Utilities/SafeMdEditor.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import "md-editor-rt/lib/style.css";
+import type { EditorProps } from "md-editor-rt";
+import dynamic from "next/dynamic";
+import { useCallback, useEffect } from "react";
+import { normalizeNullInputEventData } from "@/components/Utilities/utils/normalize-null-input-event-data";
+
+// The ONLY place in the app allowed to value-import `md-editor-rt`. Every
+// consumer must render <SafeMdEditor> instead of importing MdEditor
+// directly (enforced by .taskless/rules/no-direct-md-editor-import.yml) so
+// the null-InputEvent shim below can never be bypassed. Keeping the dynamic
+// import here also means md-editor-rt is never statically bundled anywhere
+// else (see __tests__/performance/lazy-imports.perf.test.ts).
+const MdEditor = dynamic(() => import("md-editor-rt").then((mod) => mod.MdEditor), {
+  ssr: false,
+  loading: () => null,
+});
+
+export type SafeMdEditorProps = EditorProps & {
+  "data-field-id"?: string;
+  "aria-describedby"?: string;
+};
+
+/**
+ * md-editor-rt@6.4.1 crash boundary (Sentry GAP-FRONTEND-1WY / GAP-FRONTEND-24S).
+ *
+ * The library's CodeMirror `input` DOM-event handler destructures
+ * `InputEvent.data` and reads `.length` on it inside its `maxLength`
+ * overlength check, unguarded. Per the Input Events spec, `data` is `null`
+ * for `deleteContentBackward`, `insertParagraph`/`insertLineBreak`,
+ * `insertFromPaste` and `insertFromDrop` -- i.e. every Backspace, Enter, and
+ * paste, and especially mobile IME deletions -- so the handler throws
+ * `TypeError: Cannot read properties of null (reading 'length')` (V8) /
+ * `null is not an object (evaluating 'r.length')` (WebKit/Safari).
+ *
+ * This boundary always normalizes the InputEvent (before the library's own
+ * onInput consumer runs) and always defaults `value` to `""`, so no
+ * consumer can re-introduce the crash by passing `maxLength` without also
+ * wiring the shim. Delete once the upstream canary test
+ * (`__tests__/components/Utilities/MarkdownEditor.nullInputEvent.test.tsx`)
+ * starts failing -- that means md-editor-rt fixed the null guard upstream.
+ */
+export function SafeMdEditor({ value, onInput, ...rest }: SafeMdEditorProps) {
+  // md-editor-rt's `config()` mutates the library's global markdown-it
+  // instance shared by every MdEditor/MdPreview on the page. Configuring it
+  // here -- the single boundary every editor renders through -- avoids
+  // order-dependent global state where the setting only "sticks" if some
+  // other MarkdownEditor happened to mount first.
+  useEffect(() => {
+    import("md-editor-rt")
+      .then(({ config }) => {
+        config({
+          markdownItConfig(md) {
+            md.options.breaks = true;
+          },
+        });
+      })
+      .catch(() => {
+        // SUPPRESSED: this dynamic import only tunes markdown-it's `breaks`
+        // option (cosmetic single-newline -> <br>). A genuine load failure of
+        // md-editor-rt already surfaces through the `dynamic()` MdEditor below,
+        // so reporting it here would only duplicate that signal.
+      });
+  }, []);
+
+  const handleInput = useCallback(
+    (event: Event) => {
+      normalizeNullInputEventData(event);
+      onInput?.(event);
+    },
+    [onInput]
+  );
+
+  return <MdEditor {...rest} value={value ?? ""} onInput={handleInput} />;
+}

--- a/src/features/application-comments/components/CommentMarkdownInput.tsx
+++ b/src/features/application-comments/components/CommentMarkdownInput.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import "md-editor-rt/lib/style.css";
-import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
+import { SafeMdEditor } from "@/components/Utilities/SafeMdEditor";
 import { cn } from "@/utilities/tailwind";
-
-const MdEditor = dynamic(() => import("md-editor-rt").then((mod) => mod.MdEditor), { ssr: false });
 
 interface CommentMarkdownInputProps {
   value: string;
@@ -54,7 +51,7 @@ export function CommentMarkdownInput({
       onKeyDown={handleKeyDown}
     >
       {mounted ? (
-        <MdEditor
+        <SafeMdEditor
           value={value}
           onChange={(val) => onChange(val ?? "")}
           preview={false}

--- a/src/features/application-comments/components/__tests__/CommentMarkdownInput.safety.test.tsx
+++ b/src/features/application-comments/components/__tests__/CommentMarkdownInput.safety.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @file Safety-lock tests for Sentry GAP-FRONTEND-24S
+ * @description `CommentMarkdownInput` (the new-comment box on the funding
+ * platform application page) renders through `SafeMdEditor`, which
+ * normalizes null `InputEvent.data` before md-editor-rt's `maxLength`
+ * overlength check runs. Today `CommentMarkdownInput` never sets `maxLength`,
+ * so the buggy branch is unarmed and it cannot currently throw -- but that
+ * immunity would be accidental (and silently regress the moment someone adds
+ * `maxLength`) if it weren't also routed through the safe boundary. These
+ * tests render the REAL editor (md-editor-rt is intentionally NOT mocked) to
+ * lock in both: no crash on the null-data input types, and that the
+ * component is actually wired through `SafeMdEditor`.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommentMarkdownInput } from "@/src/features/application-comments/components/CommentMarkdownInput";
+import {
+  dispatchInputAndCollectErrors,
+  installCodeMirrorPolyfills,
+  LENGTH_CRASH,
+  nullDataInputTypes,
+  waitForEditorContent,
+} from "../../../../../__tests__/utils/codemirror-jsdom";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("md-editor-rt/lib/style.css", () => ({}));
+
+// Replace next/dynamic with a shim that actually lazy-loads the REAL module,
+// so the component renders the genuine md-editor-rt editor in jsdom.
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: (importFn: () => Promise<React.ComponentType>) => {
+    const Lazy = React.lazy(async () => {
+      const component = await importFn();
+      return { default: component };
+    });
+    const DynamicShim = (props: Record<string, unknown>) => (
+      <React.Suspense fallback={null}>
+        <Lazy {...props} />
+      </React.Suspense>
+    );
+    return DynamicShim;
+  },
+}));
+
+describe("CommentMarkdownInput (GAP-FRONTEND-24S safety lock)", () => {
+  beforeEach(() => {
+    installCodeMirrorPolyfills();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(nullDataInputTypes)(
+    "does not throw a length TypeError for inputType=%s with data:null",
+    async (inputType) => {
+      const utils = render(<CommentMarkdownInput value="existing content" onChange={() => {}} />);
+      const content = await waitForEditorContent(utils.container as HTMLElement);
+
+      const errors = dispatchInputAndCollectErrors(content, { data: null, inputType });
+
+      expect(errors.filter((message) => LENGTH_CRASH.test(message))).toEqual([]);
+    }
+  );
+});
+
+describe("CommentMarkdownInput wiring", () => {
+  it("renders through SafeMdEditor rather than importing md-editor-rt directly", async () => {
+    vi.resetModules();
+    const safeMdEditorSpy = vi.fn(() => <div data-testid="safe-md-editor-stub" />);
+    vi.doMock("@/components/Utilities/SafeMdEditor", () => ({
+      SafeMdEditor: safeMdEditorSpy,
+    }));
+
+    const { CommentMarkdownInput: IsolatedCommentMarkdownInput } = await import(
+      "@/src/features/application-comments/components/CommentMarkdownInput"
+    );
+
+    const utils = render(<IsolatedCommentMarkdownInput value="hello" onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(utils.getByTestId("safe-md-editor-stub")).toBeInTheDocument();
+    });
+    expect(safeMdEditorSpy).toHaveBeenCalled();
+
+    vi.doUnmock("@/components/Utilities/SafeMdEditor");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Problem

`TypeError: null is not an object (evaluating 'r.length')` crashing the funding-platform application management page (`/manage/funding-platform/992/applications/APP-…`), 50 occurrences on iPhone / Chrome Mobile iOS (WebKit). Sentry: https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-24S

The stack terminates in an `input` DOM-event handler — the same defect as the V8-worded GAP-FRONTEND-1WY, just Safari/WebKit's phrasing of the identical null dereference.

## Root cause

`md-editor-rt@6.4.1` registers a CodeMirror `input` handler that reads `InputEvent.data.length` unguarded, gated only on `maxLength`:

```js
input: (_) => {
  e.onInput && e.onInput(_);
  const { data: F } = _;
  e.maxLength && e.modelValue.length + F.length > e.maxLength && f.emit(...) // F is null -> F.length throws
}
```

Per the Input Events spec, `data` is `null` for `deleteContentBackward`, `insertParagraph`/`insertLineBreak`, `insertFromPaste`, `insertFromDrop` — every Backspace, Enter and paste, and especially mobile IME deletions. The armed path on this page is the shared `MarkdownEditor` (it always sets a default `maxLength`), rendered by the comment / status-change editors on `ApplicationDetailView`. A prior `onInput` shim existed only on `MarkdownEditor`; the second consumer (`CommentMarkdownInput`) imported `md-editor-rt` directly and would bypass the shim the moment it set `maxLength`.

## Fix (what & why)

Introduce `SafeMdEditor` as the single boundary allowed to value-import `md-editor-rt`. It:

- always normalizes `InputEvent.data` (`null -> ""`, shadowing the prototype getter) **before** the library's own `onInput`/overlength check runs — `""` preserves overlength semantics (`modelValue.length + 0`) so genuine overlength insertions still fire the `overlength` event;
- always defaults `value` to `""` (the library's other null source);
- owns the one-time `config({ breaks: true })` and the `dynamic()`/`ssr:false` lazy load, so `md-editor-rt` is never statically bundled.

`MarkdownEditor` and `CommentMarkdownInput` now render through it. An ast-grep/Taskless rule (`no-direct-md-editor-import[-tsx]`) bans direct `md-editor-rt` imports outside the boundary so this can't silently regress. A repo-wide grep confirms `SafeMdEditor.tsx` is now the only value-import of the library.

## Tests

- `SafeMdEditor.test.tsx` — renders the **real** editor (md-editor-rt not mocked) with `maxLength=100` (arms the branch) and drives native `InputEvent`s for all four null-`data` input types; asserts no length crash, that overlength still fires, that a consumer `onInput` is composed (not clobbered) and receives the normalized event, and that `undefined` value renders.
- `MarkdownEditor.nullInputEvent.test.tsx` — existing wrapper + canary (unshimmed library still throws → tells us when upstream is fixed and the boundary can go).
- `CommentMarkdownInput.safety.test.tsx` — safety-lock: no crash on null-data inputs + wiring assertion through `SafeMdEditor`.
- `lazy-imports.perf.test.ts` — asserts the dynamic import lives in `SafeMdEditor` and consumers don't import `md-editor-rt` directly.

33 tests pass. `tsc --noEmit` clean project-wide; Biome clean on changed files.

## Review

Adversarial self-review score: **97/100**. Verified: the Sentry culprit is the `input`-handler `data.length` deref gated on `maxLength`; the armed editor on the page is `MarkdownEditor` (default maxLength), now behind the boundary along with `CommentMarkdownInput`; `SafeMdEditor` is the sole md-editor-rt value-import repo-wide; `EditorProps` typing checks out (no `any`); both consumers keep their own mounted loading spinners so `loading: () => null` is not a UX regression; added a `.catch()` (suppressed, non-critical cosmetic config) to the dynamic `config()` import to avoid an unhandled rejection. Regression test arms the exact crash branch and fails without the shim.

Fixes GAP-FRONTEND-24S
