### PR TITLE
feat(portfolio-report): Export Data menu on community reports (DEV-510 FE)

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -12,6 +12,9 @@ vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => (
 vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () => ({
   ReportChartsSection: () => <div data-testid="report-charts-section" />,
 }));
+vi.mock("@/components/Pages/Community/PortfolioReports/ExportDataMenu", () => ({
+  ExportDataMenu: () => <div data-testid="export-data-menu" />,
+}));
 
 const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
 

--- a/__tests__/unit/components/ExportDataMenu.test.tsx
+++ b/__tests__/unit/components/ExportDataMenu.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExportDataMenu } from "@/components/Pages/Community/PortfolioReports/ExportDataMenu";
+import * as portfolioService from "@/services/portfolio-reports.service";
+
+vi.mock("@/services/portfolio-reports.service");
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, node);
+}
+
+function renderMenu() {
+  return render(
+    wrap(createElement(ExportDataMenu, { communitySlug: "filecoin", reportId: "r-1" }))
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window.URL, "createObjectURL", {
+    value: vi.fn(() => "blob:mock"),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window.URL, "revokeObjectURL", {
+    value: vi.fn(),
+    writable: true,
+    configurable: true,
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  vi.mocked(portfolioService.getReportExportManifest).mockResolvedValue({
+    snapshotSource: "generation",
+    sections: [
+      { key: "pending_invoices", title: "Pending Invoices", rowCount: 2 },
+      { key: "aging_analysis", title: "Milestone/Payment Age", rowCount: 5 },
+    ],
+  });
+});
+
+describe("ExportDataMenu", () => {
+  it("renders the trigger without fetching the manifest", () => {
+    renderMenu();
+    expect(screen.getByRole("button", { name: /export data/i })).toBeInTheDocument();
+    expect(portfolioService.getReportExportManifest).not.toHaveBeenCalled();
+  });
+
+  it("lists sections (aging first, pluralized) plus an all-sections item on open", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: /export data/i }));
+
+    const agingItem = await screen.findByText("Milestone/Payment Age — 5 rows");
+    const invoicesItem = screen.getByText("Pending Invoices — 2 rows");
+    expect(agingItem).toBeInTheDocument();
+    expect(invoicesItem).toBeInTheDocument();
+    expect(screen.getByText("All sections (JSON)")).toBeInTheDocument();
+
+    // Aging section is ordered before the others.
+    expect(agingItem.compareDocumentPosition(invoicesItem)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("exports a section when its item is clicked", async () => {
+    vi.mocked(portfolioService.exportReportSection).mockResolvedValue({
+      blob: new Blob(["a,b"], { type: "text/csv" }),
+      filename: "report-data.csv",
+      snapshotSource: "generation",
+    });
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: /export data/i }));
+    await user.click(await screen.findByText("Milestone/Payment Age — 5 rows"));
+
+    await waitFor(() =>
+      expect(portfolioService.exportReportSection).toHaveBeenCalledWith(
+        "filecoin",
+        "r-1",
+        "aging_analysis"
+      )
+    );
+  });
+});

--- a/__tests__/unit/components/ExportDataMenu.test.tsx
+++ b/__tests__/unit/components/ExportDataMenu.test.tsx
@@ -86,4 +86,27 @@ describe("ExportDataMenu", () => {
       )
     );
   });
+
+  it("warns that a legacy (live-recompute) report may not match the original", async () => {
+    vi.mocked(portfolioService.getReportExportManifest).mockResolvedValue({
+      snapshotSource: "live-recompute",
+      sections: [{ key: "aging_analysis", title: "Milestone/Payment Age", rowCount: 5 }],
+    });
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: /export data/i }));
+
+    expect(await screen.findByText(/predates data snapshots/i)).toBeInTheDocument();
+  });
+
+  it("does not warn for a snapshot-backed report", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: /export data/i }));
+
+    await screen.findByText("Milestone/Payment Age — 5 rows");
+    expect(screen.queryByText(/predates data snapshots/i)).not.toBeInTheDocument();
+  });
 });

--- a/__tests__/unit/hooks/useReportExport.test.tsx
+++ b/__tests__/unit/hooks/useReportExport.test.tsx
@@ -108,7 +108,7 @@ describe("useExportReportSection", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(toast.success).toHaveBeenCalledWith(
-      expect.stringContaining("reflects current data"),
+      expect.stringContaining("reconstructed"),
       expect.objectContaining({ icon: "ℹ️" })
     );
   });

--- a/__tests__/unit/hooks/useReportExport.test.tsx
+++ b/__tests__/unit/hooks/useReportExport.test.tsx
@@ -1,0 +1,145 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import toast from "react-hot-toast";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useExportReportAll,
+  useExportReportSection,
+  useReportExportManifest,
+} from "@/hooks/portfolio-reports/useReportExport";
+import * as portfolioService from "@/services/portfolio-reports.service";
+import type { ReportExportDownload } from "@/types/portfolio-report";
+
+vi.mock("@/services/portfolio-reports.service");
+
+const SLUG = "filecoin";
+const REPORT_ID = "r-1";
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+function makeDownload(overrides: Partial<ReportExportDownload> = {}): ReportExportDownload {
+  return {
+    blob: new Blob(["a,b\n1,2"], { type: "text/csv" }),
+    filename: "report-data_2026-04-30_aging_analysis.csv",
+    snapshotSource: "generation",
+    ...overrides,
+  };
+}
+
+let clickSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window.URL, "createObjectURL", {
+    value: vi.fn(() => "blob:mock"),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(window.URL, "revokeObjectURL", {
+    value: vi.fn(),
+    writable: true,
+    configurable: true,
+  });
+  clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+});
+
+describe("useReportExportManifest", () => {
+  it("does not fetch until enabled", () => {
+    renderHook(() => useReportExportManifest(SLUG, REPORT_ID, false), {
+      wrapper: createWrapper(),
+    });
+    expect(portfolioService.getReportExportManifest).not.toHaveBeenCalled();
+  });
+
+  it("fetches the manifest when enabled", async () => {
+    vi.mocked(portfolioService.getReportExportManifest).mockResolvedValue({
+      snapshotSource: "generation",
+      sections: [{ key: "aging_analysis", title: "Aging", rowCount: 3 }],
+    });
+
+    const { result } = renderHook(() => useReportExportManifest(SLUG, REPORT_ID, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(portfolioService.getReportExportManifest).toHaveBeenCalledWith(SLUG, REPORT_ID);
+    expect(result.current.data?.sections[0].key).toBe("aging_analysis");
+  });
+});
+
+describe("useExportReportSection", () => {
+  it("downloads the section and toasts success", async () => {
+    vi.mocked(portfolioService.exportReportSection).mockResolvedValue(makeDownload());
+
+    const { result } = renderHook(() => useExportReportSection(SLUG, REPORT_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate("aging_analysis");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(portfolioService.exportReportSection).toHaveBeenCalledWith(
+      SLUG,
+      REPORT_ID,
+      "aging_analysis"
+    );
+    expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith("Data exported");
+  });
+
+  it("warns that a legacy export reflects current data", async () => {
+    vi.mocked(portfolioService.exportReportSection).mockResolvedValue(
+      makeDownload({ snapshotSource: "live-recompute" })
+    );
+
+    const { result } = renderHook(() => useExportReportSection(SLUG, REPORT_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate("aging_analysis");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining("reflects current data"),
+      expect.objectContaining({ icon: "ℹ️" })
+    );
+  });
+
+  it("toasts an error and does not download when the export fails", async () => {
+    vi.mocked(portfolioService.exportReportSection).mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useExportReportSection(SLUG, REPORT_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate("aging_analysis");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Failed to export data");
+  });
+});
+
+describe("useExportReportAll", () => {
+  it("downloads the all-sections JSON", async () => {
+    vi.mocked(portfolioService.exportReportAll).mockResolvedValue(
+      makeDownload({ filename: "report-data_r-1.json" })
+    );
+
+    const { result } = renderHook(() => useExportReportAll(SLUG, REPORT_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(portfolioService.exportReportAll).toHaveBeenCalledWith(SLUG, REPORT_ID);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
+++ b/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
@@ -54,7 +54,11 @@ export const ExportDataMenu: FC<ExportDataMenuProps> = ({ communitySlug, reportI
     if (manifest.isError) {
       return (
         <DropdownMenuItem
-          onClick={() => manifest.refetch()}
+          onSelect={(e) => {
+            // Keep the menu open so the loading → result is visible on retry.
+            e.preventDefault();
+            manifest.refetch();
+          }}
           className="text-sm text-red-600 dark:text-red-400 cursor-pointer"
         >
           Couldn’t load export options — retry

--- a/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
+++ b/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ChevronDown, Download } from "lucide-react";
+import pluralize from "pluralize";
+import { type FC, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  useExportReportAll,
+  useExportReportSection,
+  useReportExportManifest,
+} from "@/hooks/portfolio-reports/useReportExport";
+import type { ReportExportManifestEntry } from "@/types/portfolio-report";
+
+interface ExportDataMenuProps {
+  communitySlug: string;
+  reportId: string;
+}
+
+/** Aging sections lead the list — they are the bi-weekly report's priority data. */
+function orderSections(sections: ReportExportManifestEntry[]): ReportExportManifestEntry[] {
+  return [...sections].sort((a, b) => {
+    const aAging = a.key.startsWith("aging_analysis") ? 0 : 1;
+    const bAging = b.key.startsWith("aging_analysis") ? 0 : 1;
+    return aAging - bAging;
+  });
+}
+
+export const ExportDataMenu: FC<ExportDataMenuProps> = ({ communitySlug, reportId }) => {
+  const [open, setOpen] = useState(false);
+  const manifest = useReportExportManifest(communitySlug, reportId, open);
+  const exportSection = useExportReportSection(communitySlug, reportId);
+  const exportAll = useExportReportAll(communitySlug, reportId);
+
+  const isExporting = exportSection.isPending || exportAll.isPending;
+  const sections = orderSections(manifest.data?.sections ?? []);
+
+  const renderSections = () => {
+    if (manifest.isLoading) {
+      return (
+        <DropdownMenuItem disabled className="text-sm text-zinc-500">
+          Loading sections…
+        </DropdownMenuItem>
+      );
+    }
+    if (manifest.isError) {
+      return (
+        <DropdownMenuItem
+          onClick={() => manifest.refetch()}
+          className="text-sm text-red-600 dark:text-red-400 cursor-pointer"
+        >
+          Couldn’t load export options — retry
+        </DropdownMenuItem>
+      );
+    }
+    if (sections.length === 0) {
+      return (
+        <DropdownMenuItem disabled className="text-sm text-zinc-500">
+          No exportable data in this report
+        </DropdownMenuItem>
+      );
+    }
+    return (
+      <>
+        {sections.map((section) => (
+          <DropdownMenuItem
+            key={section.key}
+            disabled={isExporting}
+            onClick={() => exportSection.mutate(section.key)}
+            className="flex items-center gap-2 text-sm cursor-pointer"
+          >
+            <Download className="h-3.5 w-3.5" />
+            {section.title} — {pluralize("row", section.rowCount, true)}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          disabled={isExporting}
+          onClick={() => exportAll.mutate()}
+          className="flex items-center gap-2 text-sm cursor-pointer"
+        >
+          <Download className="h-3.5 w-3.5" />
+          All sections (JSON)
+        </DropdownMenuItem>
+      </>
+    );
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" disabled={isExporting}>
+          <Download className="mr-1 h-3 w-3" />
+          Export Data
+          <ChevronDown className="ml-1 h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel>Export raw data</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {renderSections()}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ExportDataMenu;

--- a/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
+++ b/components/Pages/Community/PortfolioReports/ExportDataMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Download } from "lucide-react";
+import { AlertTriangle, ChevronDown, Download } from "lucide-react";
 import pluralize from "pluralize";
 import { type FC, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,7 @@ export const ExportDataMenu: FC<ExportDataMenuProps> = ({ communitySlug, reportI
 
   const isExporting = exportSection.isPending || exportAll.isPending;
   const sections = orderSections(manifest.data?.sections ?? []);
+  const isLegacyReport = manifest.data?.snapshotSource === "live-recompute";
 
   const renderSections = () => {
     if (manifest.isLoading) {
@@ -102,8 +103,20 @@ export const ExportDataMenu: FC<ExportDataMenuProps> = ({ communitySlug, reportI
           <ChevronDown className="ml-1 h-3 w-3" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
+      <DropdownMenuContent align="end" className="w-72">
         <DropdownMenuLabel>Export raw data</DropdownMenuLabel>
+        {isLegacyReport ? (
+          <div
+            role="note"
+            className="mx-1 mb-1 flex items-start gap-2 rounded-md bg-amber-50 px-2 py-2 text-xs text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+          >
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              This report predates data snapshots. Its data is reconstructed from source records and
+              may not exactly match the report as it was originally generated.
+            </span>
+          </div>
+        ) : null}
         <DropdownMenuSeparator />
         {renderSections()}
       </DropdownMenuContent>

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -7,6 +7,7 @@ import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 import { BackToTop } from "./BackToTop";
+import { ExportDataMenu } from "./ExportDataMenu";
 import { HtmlReportFrame } from "./HtmlReportFrame";
 import { ReadingProgress } from "./ReadingProgress";
 import { ReportChartsSection } from "./ReportChartsSection";
@@ -75,16 +76,21 @@ export function PortfolioReportDocumentView({
               </li>
             </ol>
           </nav>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => window.print()}
-            disabled={!report.content}
-            title="Tip: turn off 'Headers and footers' in the print dialog for a cleaner PDF"
-          >
-            <Download className="mr-1 h-3 w-3" />
-            Export PDF
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            {isAdmin ? (
+              <ExportDataMenu communitySlug={community.details.slug} reportId={report.id} />
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.print()}
+              disabled={!report.content}
+              title="Tip: turn off 'Headers and footers' in the print dialog for a cleaner PDF"
+            >
+              <Download className="mr-1 h-3 w-3" />
+              Export PDF
+            </Button>
+          </div>
         </div>
 
         <div className="report-print-area mx-auto max-w-[1100px] rounded-xl bg-[#f5f6f8] p-4 sm:p-6">

--- a/hooks/portfolio-reports/useReportExport.ts
+++ b/hooks/portfolio-reports/useReportExport.ts
@@ -36,7 +36,7 @@ function triggerDownload(blob: Blob, filename: string): void {
 function notifySource(snapshotSource: ReportSnapshotSource | null): void {
   if (snapshotSource === "live-recompute") {
     toast.success(
-      "Exported — this report predates data snapshots, so it reflects current data, not the data at the time it was generated.",
+      "Exported — this report predates data snapshots, so its data is reconstructed from source records and may not exactly match the original report.",
       { icon: "ℹ️", duration: 6000 }
     );
     return;

--- a/hooks/portfolio-reports/useReportExport.ts
+++ b/hooks/portfolio-reports/useReportExport.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import * as portfolioService from "@/services/portfolio-reports.service";
+import type { ReportExportDownload, ReportSnapshotSource } from "@/types/portfolio-report";
+
+const EXPORT_KEYS = {
+  manifest: (slug: string, id: string) => ["portfolio-report-export-manifest", slug, id] as const,
+};
+
+/**
+ * Loads the export manifest (data-bearing sections) for a report. Pass
+ * `enabled` so the query only fires when the export menu is opened.
+ */
+export function useReportExportManifest(communitySlug: string, reportId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: EXPORT_KEYS.manifest(communitySlug, reportId),
+    queryFn: () => portfolioService.getReportExportManifest(communitySlug, reportId),
+    enabled: Boolean(communitySlug && reportId && enabled),
+    staleTime: 60_000,
+  });
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}
+
+function notifySource(snapshotSource: ReportSnapshotSource | null): void {
+  if (snapshotSource === "live-recompute") {
+    toast.success(
+      "Exported — this report predates data snapshots, so it reflects current data, not the data at the time it was generated.",
+      { icon: "ℹ️", duration: 6000 }
+    );
+    return;
+  }
+  toast.success("Data exported");
+}
+
+function handleDownload(download: ReportExportDownload): void {
+  triggerDownload(download.blob, download.filename);
+  notifySource(download.snapshotSource);
+}
+
+/** Download one section as CSV. */
+export function useExportReportSection(communitySlug: string, reportId: string) {
+  return useMutation({
+    mutationFn: (section: string) =>
+      portfolioService.exportReportSection(communitySlug, reportId, section),
+    onSuccess: handleDownload,
+    onError: () => {
+      toast.error("Failed to export data");
+    },
+  });
+}
+
+/** Download every section as a single JSON file. */
+export function useExportReportAll(communitySlug: string, reportId: string) {
+  return useMutation({
+    mutationFn: () => portfolioService.exportReportAll(communitySlug, reportId),
+    onSuccess: handleDownload,
+    onError: () => {
+      toast.error("Failed to export data");
+    },
+  });
+}

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -4,6 +4,9 @@ import type {
   GenerateReportRequest,
   PortfolioReport,
   ReportConfig,
+  ReportExportDownload,
+  ReportExportManifest,
+  ReportSnapshotSource,
   UpdateReportConfigRequest,
 } from "@/types/portfolio-report";
 import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
@@ -166,4 +169,64 @@ export async function getPublishedReportByRunDate(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`API error: ${res.status} ${res.statusText}`);
   return res.json() as Promise<PortfolioReport>;
+}
+
+// ── Data export (admin-only) ─────────────────────────────────
+
+function parseFilename(contentDisposition: string | undefined, fallback: string): string {
+  if (!contentDisposition) return fallback;
+  const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+  return match?.[1] ? match[1].replace(/['"]/g, "") : fallback;
+}
+
+function readSnapshotSource(headers: Record<string, unknown>): ReportSnapshotSource | null {
+  const raw = headers["x-snapshot-source"];
+  return raw === "generation" || raw === "live-recompute" ? raw : null;
+}
+
+/** List the data-bearing sections of a report — drives the export menu. */
+export async function getReportExportManifest(
+  communitySlug: string,
+  reportId: string
+): Promise<ReportExportManifest> {
+  const { data } = await apiClient.get(
+    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=manifest`
+  );
+  return data;
+}
+
+/** Download one section's raw rows as CSV. */
+export async function exportReportSection(
+  communitySlug: string,
+  reportId: string,
+  section: string
+): Promise<ReportExportDownload> {
+  const response = await apiClient.get(
+    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=csv&section=${encodeURIComponent(section)}`,
+    { responseType: "blob" }
+  );
+  return {
+    blob: response.data,
+    filename: parseFilename(response.headers["content-disposition"], `report-data_${section}.csv`),
+    snapshotSource: readSnapshotSource(response.headers),
+  };
+}
+
+/** Download every section's raw rows as a single JSON file. */
+export async function exportReportAll(
+  communitySlug: string,
+  reportId: string
+): Promise<ReportExportDownload> {
+  const response = await apiClient.get(
+    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=json`,
+    { responseType: "blob" }
+  );
+  return {
+    blob: response.data,
+    filename: parseFilename(
+      response.headers["content-disposition"],
+      `report-data_${reportId}.json`
+    ),
+    snapshotSource: readSnapshotSource(response.headers),
+  };
 }

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -184,14 +184,16 @@ function readSnapshotSource(headers: Record<string, unknown>): ReportSnapshotSou
   return raw === "generation" || raw === "live-recompute" ? raw : null;
 }
 
+function exportPath(communitySlug: string, reportId: string): string {
+  return `/v2/communities/${encodeURIComponent(communitySlug)}/reports/${encodeURIComponent(reportId)}/export`;
+}
+
 /** List the data-bearing sections of a report — drives the export menu. */
 export async function getReportExportManifest(
   communitySlug: string,
   reportId: string
 ): Promise<ReportExportManifest> {
-  const { data } = await apiClient.get(
-    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=manifest`
-  );
+  const { data } = await apiClient.get(`${exportPath(communitySlug, reportId)}?format=manifest`);
   return data;
 }
 
@@ -202,7 +204,7 @@ export async function exportReportSection(
   section: string
 ): Promise<ReportExportDownload> {
   const response = await apiClient.get(
-    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=csv&section=${encodeURIComponent(section)}`,
+    `${exportPath(communitySlug, reportId)}?format=csv&section=${encodeURIComponent(section)}`,
     { responseType: "blob" }
   );
   return {
@@ -217,10 +219,9 @@ export async function exportReportAll(
   communitySlug: string,
   reportId: string
 ): Promise<ReportExportDownload> {
-  const response = await apiClient.get(
-    `/v2/communities/${communitySlug}/reports/${reportId}/export?format=json`,
-    { responseType: "blob" }
-  );
+  const response = await apiClient.get(`${exportPath(communitySlug, reportId)}?format=json`, {
+    responseType: "blob",
+  });
   return {
     blob: response.data,
     filename: parseFilename(

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -126,3 +126,31 @@ export interface UpdateReportConfigRequest {
 export interface GenerateReportRequest {
   configId: string;
 }
+
+// ── Data export ──────────────────────────────────────────────
+
+export type ReportExportFormat = "manifest" | "csv" | "json";
+
+/**
+ * Whether an export came from the report's generation-time snapshot
+ * (`generation`) or a live recompute for a legacy report predating snapshots
+ * (`live-recompute` — reflects current data, not the data at generation time).
+ */
+export type ReportSnapshotSource = "generation" | "live-recompute";
+
+export interface ReportExportManifestEntry {
+  key: string;
+  title: string;
+  rowCount: number;
+}
+
+export interface ReportExportManifest {
+  snapshotSource: ReportSnapshotSource;
+  sections: ReportExportManifestEntry[];
+}
+
+export interface ReportExportDownload {
+  blob: Blob;
+  filename: string;
+  snapshotSource: ReportSnapshotSource | null;
+}


### PR DESCRIPTION
## Overview

Frontend for **DEV-510** — an admin-only **Export Data** control on community portfolio reports. The menu is **section-agnostic**: on open it loads a manifest and lists exactly the data-bearing sections *that* report has, whatever they are — so a KPI report, an aging report, or a report with a mix all get the right menu, driven by the report's own config. Milestone/payment aging (bi-weekly) is the first use case, not the scope. Pairs with the backend PR **show-karma/gap-indexer#2179**.

## What changed

- **Export Data dropdown** (`ExportDataMenu.tsx`) beside "Export PDF" on the report document view (`PortfolioReportDocumentView.tsx`), rendered only when `isAdmin`. It lists whatever sections the manifest returns (aging surfaced first when present, since it's the priority use case), each downloading one section as CSV, plus an "All sections (JSON)" item. Loading / error (retry) / empty states; row counts use `pluralize`.
- **Recompute label**: when the manifest reports a `live-recompute` source, the menu shows an amber notice — the report predates data snapshots, so its export is reconstructed from source records and may not exactly match the report as originally generated. The post-download toast carries the same framing.
- **Service** (`services/portfolio-reports.service.ts`): `getReportExportManifest`, `exportReportSection` (CSV blob), `exportReportAll` (JSON blob) — via the authenticated client, parsing the download filename from `Content-Disposition` and reading `X-Snapshot-Source`. `communitySlug`/`reportId`/`section` are URL-encoded.
- **Hooks** (`hooks/portfolio-reports/useReportExport.ts`): `useReportExportManifest` (query, gated on menu-open) + `useExportReportSection` / `useExportReportAll` mutations that trigger the blob download and toast.
- **Types** (`types/portfolio-report/index.ts`): `ReportExportManifest`, `ReportExportManifestEntry`, `ReportSnapshotSource`, `ReportExportDownload`.

## Testing

- `__tests__/unit/hooks/useReportExport.test.tsx` — manifest gating; section + all-sections downloads (object-URL created, anchor clicked, revoked); success vs `live-recompute` toast; error path (no download, error toast).
- `__tests__/unit/components/ExportDataMenu.test.tsx` — trigger renders without fetching; opening lists the report's sections (pluralized) + all-sections item; clicking a section calls the export service; the legacy-report warning renders only for `live-recompute`.
- `PortfolioReportPreviewPage.test.tsx` updated to mock `ExportDataMenu` (it now pulls in react-query) the same way it mocks `ReportChartsSection`.
- CI green: all test shards, static-checks, smoke, Vercel, CodeRabbit. (The red `build`/`quality-gate` checks are a repo-wide QA-pipeline pnpm-setup infra issue and the known-broken coverage gate — neither is the app build nor a merge gate.)

## Review

Both CodeRabbit findings addressed and resolved: the retry menu item uses `onSelect` + `preventDefault` so the dropdown stays open through a retry; URL path segments are encoded.

## Depends on

- Backend endpoint from **gap-indexer#2179** (`GET /v2/communities/:uidOrSlug/reports/:reportId/export`). The FE calls the indexer directly (no Next.js proxy).

## Smoke results

- [ ] Deferred to the cross-service gate (with gap-indexer#2179): FE + BE on the same preview, flows walked — a fresh report (CSV + all-sections JSON, incl. a non-aging report to confirm the menu is section-agnostic), a legacy report (the `live-recompute` notice + reconstructed aging), and the 401/403 failure paths.

Closes DEV-510 (frontend).
