### PR TITLE
feat(funding-platform): reviewer-only notes tab on the applicant application page (DEV-515)

### DIFF
--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -12,6 +12,7 @@ import { Permission } from "@/src/core/rbac/types/permission";
 import { Role } from "@/src/core/rbac/types/role";
 import { CommentTimeline } from "@/src/features/application-comments/components/CommentTimeline";
 import { PublicComments } from "@/src/features/application-comments/components/PublicComments";
+import { PrivateNotesTab } from "@/src/features/application-notes/components/PrivateNotesTab";
 import { MilestonesTab } from "@/src/features/applications/components/MilestonesTab";
 import { useApplication } from "@/src/features/applications/hooks/use-application";
 import { useApplicationAccess } from "@/src/features/applications/hooks/use-application-access";
@@ -51,8 +52,19 @@ export function ApplicationPageClient({
 }: ApplicationPageClientProps) {
   const { user, authenticated } = useAuth();
   const isAdmin = useIsFundingPlatformAdmin();
-  const { hasRoleOrHigher, isReviewer, can } = usePermissionContext();
+  const {
+    hasRoleOrHigher,
+    isReviewer,
+    can,
+    isLoading: isPermissionsLoading,
+  } = usePermissionContext();
   const isAdminOrReviewer = hasRoleOrHigher(Role.MILESTONE_REVIEWER) || isReviewer;
+  // Private notes are reviewer/admin-only. Gate FAILS CLOSED: false while
+  // permissions resolve, so on this public/anonymous page the Notes tab never
+  // renders (nor even a frame) for applicants/guests. The backend endpoint is
+  // the real wall — it 403s anyone who isn't a program/milestone reviewer,
+  // community admin, or staff, and the notes query only fires when this is true.
+  const canViewNotes = !isPermissionsLoading && isAdminOrReviewer;
 
   const [selectedTab, setActiveTab] = useUrlTabState();
 
@@ -171,8 +183,12 @@ export function ApplicationPageClient({
     if (hasCommentsSurface) {
       list.push({ key: "comments", label: "Comments", Icon: TAB_ICONS.comments });
     }
+    // Reviewer/admin-only — never added for applicants/guests (fail-closed).
+    if (canViewNotes) {
+      list.push({ key: "notes", label: "Notes", Icon: TAB_ICONS.notes });
+    }
     return list;
-  }, [hasMilestones, milestoneCount, showPostApproval, hasCommentsSurface]);
+  }, [hasMilestones, milestoneCount, showPostApproval, hasCommentsSurface, canViewNotes]);
 
   // A lone Details tab isn't worth a switcher — render the card directly.
   const hasTabs = tabs.length > 1;
@@ -271,6 +287,12 @@ export function ApplicationPageClient({
             />
           )}
           {hasTabs && activeTab === "comments" && commentsSection}
+          {hasTabs && activeTab === "notes" && canViewNotes && (
+            <PrivateNotesTab
+              referenceNumber={application.referenceNumber}
+              canViewNotes={canViewNotes}
+            />
+          )}
         </div>
 
         {/* SIDEBAR */}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationTabBar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationTabBar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { CheckCircle2, FileText, type LucideIcon, MessageSquare, Target } from "lucide-react";
+import { CheckCircle2, FileText, Lock, type LucideIcon, MessageSquare, Target } from "lucide-react";
 import { cn } from "@/utilities/tailwind";
 
-export type ApplicationTabKey = "details" | "milestones" | "post-approval" | "comments";
+export type ApplicationTabKey = "details" | "milestones" | "post-approval" | "comments" | "notes";
 
 export interface TabDescriptor {
   key: ApplicationTabKey;
@@ -65,4 +65,5 @@ export const TAB_ICONS = {
   milestones: Target,
   "post-approval": CheckCircle2,
   comments: MessageSquare,
+  notes: Lock,
 } satisfies Record<ApplicationTabKey, LucideIcon>;


### PR DESCRIPTION
## Summary

Follow-up to [#1800](https://github.com/show-karma/gap-app-v2/pull/1800) (merged): surface the reviewer-only private notes on the **applicant / whitelabel application page** (`ApplicationPageClient`) too, in addition to the `/manage` reviewer view. [DEV-515](https://linear.app/showkarma/issue/DEV-515/admin-should-be-able-to-add-private-notes-to-a-funding-application).

Reuses the existing `PrivateNotesTab` and `useApplicationNote` from #1800 — no new BE work; the notes endpoint already gates to exactly this role set.

## Who can see it

Only **program reviewers, milestone reviewers, community admins** (and staff). Applicants and guests never see the tab, the note, or a network request for it.

## No-glimpse on a public page (this route is anonymous-SSR-readable)

Six independent layers, all fail-closed:

1. **Anonymous SSR** — `ApplicationPageClient` is `"use client"` and permissions resolve async, so during server render `canViewNotes` is false → the Notes tab and its data are never in the public HTML.
2. **Initial hydration** matches SSR (perms still loading) → no flash, no mismatch.
3. **Gate fails closed** — `canViewNotes = !isPermissionsLoading && (hasRoleOrHigher(MILESTONE_REVIEWER) || isReviewer)`; false until permissions resolve to a reviewer/admin.
4. **Query never fires for guests** — `useApplicationNote` is `enabled` on `authenticated && canViewNotes` → zero `/notes` requests in a guest's network tab.
5. **Component null-gate** — `PrivateNotesTab` returns null when `!canViewNotes`; a stale `?tab=notes` for a guest falls back to Details (the notes tab isn't in their `tabs`).
6. **Backend is the wall** — the endpoint 403s anyone who isn't a program/milestone reviewer, community admin, or staff, re-checked across linked wallets.

## Changes

- `ApplicationPageClient.tsx` — derive `canViewNotes` (fail-closed), add a gated Notes tab + content.
- `ApplicationTabBar.tsx` — add the `"notes"` tab key + `Lock` icon.

## Testing

- `pnpm typecheck` clean, `pnpm run build` green.
- Gating covered by the existing unit tests from #1800 (`PrivateNotesTab` renders null when not a reviewer; `useApplicationNote` fires zero requests when gated) + the BE route access-control test.

## Smoke to run on preview

- As a **guest / applicant**: open the application page → no Notes tab, and zero `/notes` requests in the network tab.
- As a **reviewer/admin**: Notes tab present, write + save works.

## Review waivers

None.
