### PR TITLE
feat(admin): restore community listing public/rank controls dropped in card-grid redesign

### DIFF
--- a/__tests__/components/Admin/CommunityAdminCard.test.tsx
+++ b/__tests__/components/Admin/CommunityAdminCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { CommunityAdminCard } from "@/components/Pages/Admin/CommunityAdminCard";
+import type { Community } from "@/types/v2/community";
+import "@testing-library/jest-dom";
+
+// The Listing controls are exercised in their own suite; here we only assert
+// the card mounts them behind the owner gate (no-glimpse: never rendered — and
+// therefore never fetches config — for non-owners).
+vi.mock("@/components/Pages/Admin/CommunityListingControls", () => ({
+  CommunityListingControls: vi.fn(() => <div data-testid="listing-controls" />),
+}));
+
+// Heavy children that pull in network/hooks — stub to inert nodes.
+vi.mock("@/components/CommunityStats", () => ({ default: () => <div data-testid="stats" /> }));
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+vi.mock("@/components/Pages/Admin/AddAdminDialog", () => ({
+  AddAdmin: () => <button type="button">add</button>,
+}));
+vi.mock("@/components/Pages/Admin/RemoveAdminDialog", () => ({
+  RemoveAdmin: () => <button type="button">remove</button>,
+}));
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
+}));
+vi.mock("next/image", () => ({ default: () => <img alt="" /> }));
+
+const community: Community = {
+  uid: "0x1234567890123456789012345678901234567890" as `0x${string}`,
+  chainID: 10,
+  details: { name: "Filecoin", slug: "filecoin" },
+} as Community;
+
+const baseProps = {
+  community,
+  matchingCommunityAdmin: undefined,
+  canManageAdmins: true,
+  isExpanded: false,
+  onToggleExpansion: vi.fn(),
+  adminProfiles: undefined,
+  onRefetch: vi.fn(),
+};
+
+describe("CommunityAdminCard — Listing gate", () => {
+  it("hides the Listing section (and never mounts the config controls) when canManageConfig is false", () => {
+    render(<CommunityAdminCard {...baseProps} canManageConfig={false} />);
+
+    expect(screen.queryByText("Listing")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("listing-controls")).not.toBeInTheDocument();
+  });
+
+  it("shows the Listing section with the config controls when canManageConfig is true", () => {
+    render(<CommunityAdminCard {...baseProps} canManageConfig={true} />);
+
+    expect(screen.getByText("Listing")).toBeInTheDocument();
+    expect(screen.getByTestId("listing-controls")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Admin/CommunityListingControls.test.tsx
+++ b/__tests__/components/Admin/CommunityListingControls.test.tsx
@@ -1,0 +1,163 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { CommunityListingControls } from "@/components/Pages/Admin/CommunityListingControls";
+import {
+  type CommunityConfig,
+  useCommunityConfig,
+  useCommunityConfigMutation,
+} from "@/hooks/useCommunityConfig";
+import "@testing-library/jest-dom";
+
+vi.mock("@/hooks/useCommunityConfig", () => ({
+  useCommunityConfig: vi.fn(),
+  useCommunityConfigMutation: vi.fn(),
+}));
+
+const mockUseCommunityConfig = useCommunityConfig as ReturnType<typeof vi.fn>;
+const mockUseCommunityConfigMutation = useCommunityConfigMutation as ReturnType<typeof vi.fn>;
+
+const mockMutate = vi.fn();
+
+const setConfig = (config: CommunityConfig | null, isLoading = false) => {
+  mockUseCommunityConfig.mockReturnValue({ data: config, isLoading });
+};
+
+const setMutation = (overrides: Partial<{ isPending: boolean; isError: boolean }> = {}) => {
+  mockUseCommunityConfigMutation.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  });
+};
+
+const renderControls = (slug = "filecoin", name = "Filecoin") =>
+  render(<CommunityListingControls slug={slug} communityName={name} />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setMutation();
+});
+
+describe("CommunityListingControls", () => {
+  describe("loading state", () => {
+    it("renders skeletons and no controls while the config is loading", () => {
+      setConfig(null, true);
+      renderControls();
+
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("public default semantics", () => {
+    it("treats a null config as public (checkbox checked, rank 0)", () => {
+      setConfig(null);
+      renderControls();
+
+      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(screen.getByRole("spinbutton")).toHaveValue(0);
+    });
+
+    it("treats an unset public field as public", () => {
+      setConfig({ rank: 3 });
+      renderControls();
+
+      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(screen.getByRole("spinbutton")).toHaveValue(3);
+    });
+
+    it("only an explicit false unchecks the box", () => {
+      setConfig({ public: false, rank: 7 });
+      renderControls();
+
+      expect(screen.getByRole("checkbox")).not.toBeChecked();
+      expect(screen.getByRole("spinbutton")).toHaveValue(7);
+    });
+  });
+
+  describe("public toggle", () => {
+    it("saves immediately, carrying the current rank", () => {
+      setConfig({ public: true, rank: 4 });
+      renderControls();
+
+      fireEvent.click(screen.getByRole("checkbox"));
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith({
+        slug: "filecoin",
+        config: { public: false, rank: 4 },
+      });
+    });
+  });
+
+  describe("rank input", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("debounces the rank save and sends the new rank with the current public flag", () => {
+      setConfig({ public: true, rank: 0 });
+      renderControls();
+
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "12" } });
+
+      // Nothing fires before the debounce window elapses.
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith({
+        slug: "filecoin",
+        config: { public: true, rank: 12 },
+      });
+    });
+
+    it("does not save when the rank is unchanged from the server value", () => {
+      setConfig({ public: true, rank: 5 });
+      renderControls();
+
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "5" } });
+      act(() => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it("ignores negative rank input", () => {
+      setConfig({ public: true, rank: 2 });
+      renderControls();
+
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "-1" } });
+      act(() => {
+        vi.advanceTimersByTime(800);
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+      expect(screen.getByRole("spinbutton")).toHaveValue(2);
+    });
+  });
+
+  describe("pending state", () => {
+    it("disables both controls while a save is in flight", () => {
+      setConfig({ public: true, rank: 1 });
+      setMutation({ isPending: true });
+      renderControls();
+
+      expect(screen.getByRole("checkbox")).toBeDisabled();
+      expect(screen.getByRole("spinbutton")).toBeDisabled();
+    });
+  });
+
+  describe("error state", () => {
+    it("surfaces a retry message when the save fails", () => {
+      setConfig({ public: true, rank: 1 });
+      setMutation({ isError: true });
+      renderControls();
+
+      expect(screen.getByText(/failed to save/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/Admin/CommunityListingControls.test.tsx
+++ b/__tests__/components/Admin/CommunityListingControls.test.tsx
@@ -89,7 +89,8 @@ describe("CommunityListingControls", () => {
       });
     });
 
-    it("carries an in-progress (unsaved) rank edit when toggling public", () => {
+    it("cancels a pending debounced rank save and carries the edited rank", () => {
+      vi.useFakeTimers();
       setConfig({ public: true, rank: 0 });
       renderControls();
 
@@ -98,10 +99,19 @@ describe("CommunityListingControls", () => {
       fireEvent.click(screen.getByRole("checkbox"));
 
       // The public save fires immediately with the typed-but-unsaved rank.
+      expect(mockMutate).toHaveBeenCalledTimes(1);
       expect(mockMutate).toHaveBeenCalledWith({
         slug: "filecoin",
         config: { public: false, rank: 9 },
       });
+
+      // The pending rank debounce was cancelled — no second save fires.
+      act(() => {
+        vi.advanceTimersByTime(800);
+      });
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
     });
   });
 

--- a/__tests__/components/Admin/CommunityListingControls.test.tsx
+++ b/__tests__/components/Admin/CommunityListingControls.test.tsx
@@ -88,6 +88,21 @@ describe("CommunityListingControls", () => {
         config: { public: false, rank: 4 },
       });
     });
+
+    it("carries an in-progress (unsaved) rank edit when toggling public", () => {
+      setConfig({ public: true, rank: 0 });
+      renderControls();
+
+      // Type a new rank but do not wait for the debounce to fire.
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "9" } });
+      fireEvent.click(screen.getByRole("checkbox"));
+
+      // The public save fires immediately with the typed-but-unsaved rank.
+      expect(mockMutate).toHaveBeenCalledWith({
+        slug: "filecoin",
+        config: { public: false, rank: 9 },
+      });
+    });
   });
 
   describe("rank input", () => {
@@ -136,7 +151,6 @@ describe("CommunityListingControls", () => {
       });
 
       expect(mockMutate).not.toHaveBeenCalled();
-      expect(screen.getByRole("spinbutton")).toHaveValue(2);
     });
   });
 

--- a/__tests__/components/Pages/Admin/CommunityAdmin.test.tsx
+++ b/__tests__/components/Pages/Admin/CommunityAdmin.test.tsx
@@ -33,6 +33,12 @@ vi.mock("@/components/Pages/Admin/RemoveAdminDialog", () => ({
   RemoveAdmin: () => <button type="button">Remove Admin</button>,
 }));
 
+// Stubbed here (it has its own test) so this page test doesn't pull the
+// component's React Query hooks into a tree without a QueryClientProvider.
+vi.mock("@/components/Pages/Admin/CommunityListingControls", () => ({
+  CommunityListingControls: () => <div data-testid="listing-controls" />,
+}));
+
 vi.mock("@/hooks/useAdminCommunities", () => ({
   useAdminCommunities: vi.fn(),
 }));

--- a/components/Pages/Admin/CommunityAdmin.tsx
+++ b/components/Pages/Admin/CommunityAdmin.tsx
@@ -380,7 +380,7 @@ export default function CommunitiesToAdminPage() {
                       community={community}
                       matchingCommunityAdmin={communityAdminsById.get(community.uid)}
                       canManageAdmins={isSuperAdminOrOwner || isAdminOfThisCommunity}
-                      canManageConfig={isOwner}
+                      canManageConfig={isSuperAdminOrOwner}
                       isExpanded={expandedAdmins.has(community.uid)}
                       onToggleExpansion={toggleAdminExpansion}
                       adminProfiles={adminProfiles}

--- a/components/Pages/Admin/CommunityAdmin.tsx
+++ b/components/Pages/Admin/CommunityAdmin.tsx
@@ -380,8 +380,9 @@ export default function CommunitiesToAdminPage() {
                       community={community}
                       matchingCommunityAdmin={communityAdminsById.get(community.uid)}
                       canManageAdmins={isSuperAdminOrOwner || isAdminOfThisCommunity}
+                      canManageConfig={isOwner}
                       isExpanded={expandedAdmins.has(community.uid)}
-                      onToggleExpansion={() => toggleAdminExpansion(community.uid)}
+                      onToggleExpansion={toggleAdminExpansion}
                       adminProfiles={adminProfiles}
                       onRefetch={handleRefetch}
                     />

--- a/components/Pages/Admin/CommunityAdminCard.tsx
+++ b/components/Pages/Admin/CommunityAdminCard.tsx
@@ -2,10 +2,12 @@
 import { ChevronDownIcon, ChevronUpIcon, LinkIcon } from "@heroicons/react/24/solid";
 import { blo } from "blo";
 import Image from "next/image";
+import { memo } from "react";
 import { isAddress } from "viem";
 import CommunityStats from "@/components/CommunityStats";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { AddAdmin } from "@/components/Pages/Admin/AddAdminDialog";
+import { CommunityListingControls } from "@/components/Pages/Admin/CommunityListingControls";
 import { RemoveAdmin } from "@/components/Pages/Admin/RemoveAdminDialog";
 import type { CommunityAdmin, CommunityAdminsBatchStatus } from "@/services/communities.service";
 import type { UserProfileInfo } from "@/services/community-admins.service";
@@ -43,16 +45,18 @@ interface CommunityAdminCardProps {
   community: Community;
   matchingCommunityAdmin: CommunityAdmin | undefined;
   canManageAdmins: boolean;
+  canManageConfig: boolean;
   isExpanded: boolean;
-  onToggleExpansion: () => void;
+  onToggleExpansion: (communityUid: string) => void;
   adminProfiles: Map<string, UserProfileInfo> | undefined;
   onRefetch: () => void;
 }
 
-export function CommunityAdminCard({
+function CommunityAdminCardComponent({
   community,
   matchingCommunityAdmin,
   canManageAdmins,
+  canManageConfig,
   isExpanded,
   onToggleExpansion,
   adminProfiles,
@@ -61,6 +65,8 @@ export function CommunityAdminCard({
   const adminBatchStatus = matchingCommunityAdmin?.status;
   // Safely format community UID as hex address
   const communityId = formatAdminAddress(community.uid);
+  const slug = community.details?.slug || community.uid;
+  const communityLabel = community.details?.name || community.uid;
 
   return (
     <div className="border border-zinc-300 rounded-lg p-6 bg-white dark:bg-zinc-900 shadow-sm hover:shadow-md transition-shadow">
@@ -88,7 +94,7 @@ export function CommunityAdminCard({
           width={64}
           height={64}
           className="h-16 w-16 rounded-lg object-cover flex-shrink-0"
-          alt={community.details?.name || community.uid}
+          alt={communityLabel}
           unoptimized
         />
         <div className="flex-1 min-w-0">
@@ -114,14 +120,14 @@ export function CommunityAdminCard({
         <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Quick Links</p>
         <div className="flex flex-col gap-2">
           <Link
-            href={PAGES.COMMUNITY.ALL_GRANTS(community.details?.slug || community.uid)}
+            href={PAGES.COMMUNITY.ALL_GRANTS(slug)}
             className="flex flex-row items-center gap-2 text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 text-sm"
           >
             <LinkIcon className="w-4 h-4" />
             <span>Community Page</span>
           </Link>
           <Link
-            href={PAGES.ADMIN.ROOT(community.details?.slug || community.uid)}
+            href={PAGES.ADMIN.ROOT(slug)}
             className="flex flex-row items-center gap-2 text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 text-sm"
           >
             <LinkIcon className="w-4 h-4" />
@@ -198,11 +204,9 @@ export function CommunityAdminCard({
               {matchingCommunityAdmin.admins.length > ADMINS_COLLAPSED_COUNT && (
                 <button
                   type="button"
-                  onClick={onToggleExpansion}
+                  onClick={() => onToggleExpansion(community.uid)}
                   aria-expanded={isExpanded}
-                  aria-label={`${isExpanded ? "Collapse" : "Expand"} admin list for ${
-                    community.details?.name || community.uid
-                  }`}
+                  aria-label={`${isExpanded ? "Collapse" : "Expand"} admin list for ${communityLabel}`}
                   className="flex items-center gap-1 text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 mt-1"
                 >
                   {isExpanded ? (
@@ -224,6 +228,16 @@ export function CommunityAdminCard({
           )}
         </div>
       </div>
+
+      {/* Listing (public directory visibility + rank) — platform-owner only */}
+      {canManageConfig && (
+        <div className="pt-4 border-t border-zinc-200 dark:border-zinc-700">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Listing</p>
+          <CommunityListingControls slug={slug} communityName={communityLabel} />
+        </div>
+      )}
     </div>
   );
 }
+
+export const CommunityAdminCard = memo(CommunityAdminCardComponent);

--- a/components/Pages/Admin/CommunityListingControls.tsx
+++ b/components/Pages/Admin/CommunityListingControls.tsx
@@ -1,0 +1,126 @@
+"use client";
+import debounce from "lodash.debounce";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Skeleton } from "@/components/Utilities/Skeleton";
+import { Spinner } from "@/components/Utilities/Spinner";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCommunityConfig, useCommunityConfigMutation } from "@/hooks/useCommunityConfig";
+
+interface CommunityListingControlsProps {
+  slug: string;
+  communityName: string;
+}
+
+/**
+ * Owner-only editor for a community's public-directory listing: whether it
+ * shows up in `GET /v2/communities` (`public`) and its position there
+ * (`rank`, sorted DESC). Reuses the live `useCommunityConfig` hooks; only
+ * `{ public, rank }` are ever PUT so the masked `slackWebhookUrls` the GET
+ * returns are never written back.
+ */
+export function CommunityListingControls({ slug, communityName }: CommunityListingControlsProps) {
+  const { data: config, isLoading } = useCommunityConfig(slug);
+  const mutation = useCommunityConfigMutation();
+
+  // BE default: a community with no config row (or `public` unset) is public.
+  // Mirror the indexer directory filter `config.public !== false`.
+  const isPublic = config?.public !== false;
+  const serverRank = config?.rank ?? 0;
+
+  const [localRank, setLocalRank] = useState(serverRank);
+
+  useEffect(() => {
+    setLocalRank(serverRank);
+  }, [serverRank]);
+
+  // Snapshot the latest values so the debounced commit is created once and
+  // never captures stale closures (the mutation object is a new identity each
+  // render — porting the old useEffect-in-deps debounce would recreate it).
+  const latest = useRef({ slug, serverRank, isPublic, mutate: mutation.mutate });
+  latest.current = { slug, serverRank, isPublic, mutate: mutation.mutate };
+
+  const commitRank = useMemo(
+    () =>
+      debounce((rank: number) => {
+        const current = latest.current;
+        if (rank !== current.serverRank) {
+          current.mutate({ slug: current.slug, config: { public: current.isPublic, rank } });
+        }
+      }, 800),
+    []
+  );
+
+  useEffect(() => () => commitRank.cancel(), [commitRank]);
+
+  const handleRankChange = (value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    const next = Number.isNaN(parsed) ? 0 : parsed;
+    if (next < 0) return;
+    setLocalRank(next);
+    commitRank(next);
+  };
+
+  const handlePublicChange = (checked: boolean) => {
+    // Public toggles save immediately and carry any in-progress rank edit.
+    commitRank.cancel();
+    mutation.mutate({ slug, config: { public: checked, rank: localRank } });
+  };
+
+  const publicCheckboxId = `community-public-${slug}`;
+  const rankInputId = `community-rank-${slug}`;
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={publicCheckboxId}
+          checked={isPublic}
+          onCheckedChange={(checked) => handlePublicChange(checked === true)}
+          disabled={mutation.isPending}
+          aria-label={`Toggle public listing for ${communityName}`}
+        />
+        <Label htmlFor={publicCheckboxId} className="cursor-pointer">
+          Publicly listed
+        </Label>
+        {mutation.isPending && <Spinner className="h-3.5 w-3.5 border-2" />}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor={rankInputId} className="text-muted-foreground">
+          Rank
+        </Label>
+        <div className="flex items-center gap-2">
+          <Input
+            id={rankInputId}
+            type="number"
+            min={0}
+            value={localRank}
+            onChange={(e) => handleRankChange(e.target.value)}
+            disabled={mutation.isPending}
+            className="w-24"
+            aria-label={`Listing rank for ${communityName}`}
+          />
+          {mutation.isPending && <Spinner className="h-3.5 w-3.5 border-2" />}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Higher rank appears first on the public directory.
+        </p>
+      </div>
+
+      {mutation.isError && (
+        <p className="text-xs text-red-600 dark:text-red-400">Failed to save. Please try again.</p>
+      )}
+    </div>
+  );
+}

--- a/components/Pages/Admin/CommunityListingControls.tsx
+++ b/components/Pages/Admin/CommunityListingControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 import debounce from "lodash.debounce";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Skeleton } from "@/components/Utilities/Skeleton";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -11,6 +11,13 @@ import { useCommunityConfig, useCommunityConfigMutation } from "@/hooks/useCommu
 interface CommunityListingControlsProps {
   slug: string;
   communityName: string;
+}
+
+/** Parse a rank input into a non-negative integer, or null if invalid. */
+function parseRank(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return null;
+  return parsed;
 }
 
 /**
@@ -24,20 +31,21 @@ export function CommunityListingControls({ slug, communityName }: CommunityListi
   const { data: config, isLoading } = useCommunityConfig(slug);
   const mutation = useCommunityConfigMutation();
 
-  // BE default: a community with no config row (or `public` unset) is public.
-  // Mirror the indexer directory filter `config.public !== false`.
+  // Derived during render — never copied into state (a derived-state effect
+  // would cost an extra render per keystroke and per server sync).
+  // BE default: no config row (or `public` unset) = public. Mirror the
+  // indexer directory filter `config.public !== false`.
   const isPublic = config?.public !== false;
   const serverRank = config?.rank ?? 0;
 
-  const [localRank, setLocalRank] = useState(serverRank);
+  // The rank field is uncontrolled: typing writes straight to the DOM (no
+  // re-render), and the debounced save reads the parsed value. `defaultValue`
+  // re-seeds only on remount, which is fine — the only source that changes
+  // `serverRank` is this component's own save, which echoes what was typed.
+  const rankInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    setLocalRank(serverRank);
-  }, [serverRank]);
-
-  // Snapshot the latest values so the debounced commit is created once and
-  // never captures stale closures (the mutation object is a new identity each
-  // render — porting the old useEffect-in-deps debounce would recreate it).
+  // Live snapshot so the once-created debounced commit never captures stale
+  // values (the mutation object gets a new identity on every render).
   const latest = useRef({ slug, serverRank, isPublic, mutate: mutation.mutate });
   latest.current = { slug, serverRank, isPublic, mutate: mutation.mutate };
 
@@ -55,17 +63,15 @@ export function CommunityListingControls({ slug, communityName }: CommunityListi
   useEffect(() => () => commitRank.cancel(), [commitRank]);
 
   const handleRankChange = (value: string) => {
-    const parsed = Number.parseInt(value, 10);
-    const next = Number.isNaN(parsed) ? 0 : parsed;
-    if (next < 0) return;
-    setLocalRank(next);
-    commitRank(next);
+    const rank = parseRank(value);
+    if (rank !== null) commitRank(rank);
   };
 
   const handlePublicChange = (checked: boolean) => {
     // Public toggles save immediately and carry any in-progress rank edit.
     commitRank.cancel();
-    mutation.mutate({ slug, config: { public: checked, rank: localRank } });
+    const typed = parseRank(rankInputRef.current?.value ?? "");
+    mutation.mutate({ slug, config: { public: checked, rank: typed ?? serverRank } });
   };
 
   const publicCheckboxId = `community-public-${slug}`;
@@ -102,10 +108,11 @@ export function CommunityListingControls({ slug, communityName }: CommunityListi
         </Label>
         <div className="flex items-center gap-2">
           <Input
+            ref={rankInputRef}
             id={rankInputId}
             type="number"
             min={0}
-            value={localRank}
+            defaultValue={serverRank}
             onChange={(e) => handleRankChange(e.target.value)}
             disabled={mutation.isPending}
             className="w-24"


### PR DESCRIPTION
## Overview

Restores the owner-only **"Public?"** and **"Rank"** per-community listing controls to the `/admin` page. They were dropped when the admin page was redesigned into a card grid — the controls were orphaned (not deleted), and the backend endpoint + React Query hooks stayed live the whole time, so this is a re-integration, not a rebuild.

## Problem

The Nov 5 redesign (`5daff00c`, "refactor admin pages…") replaced the old `<CommunitiesToAdmin/>` table with the new card grid `<CommunitiesToAdminPage/>`. The table carried two owner-only columns that never made it onto the card:

- **Public?** — toggles `config.public`: whether a community appears in the public directory (`GET /v2/communities`).
- **Rank** — sets `config.rank`: its ordering position in that directory (sorted DESC).

The redesign only changed which component `app/admin/page.tsx` renders; the old table (`components/Pages/Admin/index.tsx`) became dead code, and the `useCommunityConfig` hooks + `PUT/GET /v2/community-configs/:slug` endpoint remained live and in use by notification settings, access-denied messages, and Telegram pairing.

## Solution

Extract a small config editor and drop it onto each community card as an owner-only **"Listing"** footer, reusing the live hooks verbatim.

- **New `components/Pages/Admin/CommunityListingControls.tsx`** — design-system `Checkbox` + `Input`, a ref-backed debounced rank save, and `useCommunityConfig` / `useCommunityConfigMutation` used as-is (optimistic update + rollback + invalidate). Three states (skeleton / controls / inline error), never returns `null`.
- **`CommunityAdminCard.tsx`** — renders the Listing section behind a new `canManageConfig` prop; wrapped in `React.memo`; repeated `slug`/`name` derivations hoisted to consts.
- **`CommunityAdmin.tsx`** — passes `canManageConfig={isOwner}` and hoists `onToggleExpansion` to the stable callback so `memo` is effective.

## Why This Approach

- **Reuse over revival** — the hooks and endpoint are live, so no new data layer is needed and the dead `index.tsx` table is left untouched (not imported).
- **Gate on `isOwner` (contract owner), not `isSuperAdminOrOwner`** — the backend `CommunityInfoService.authorizeUser` guard authorizes contract-owner / static staff-allowlist / that-community's on-chain admin, and has **no RBAC `SUPER_ADMIN` branch**. Gating on super-admin would show controls to a pure-RBAC super-admin who then gets a 403 on GET + PUT. `isOwner` maps 1:1 to the backend's contract-owner tier → no glimpse, no 403. It's resolved before any card paints (the page's `isLoadingData` already folds `isOwnerLoading`).
- **Send only `{ public, rank }`** — the GET masks `slackWebhookUrls` to `••••1234`; spreading the full config into the PUT would write masked secrets back. `public`/`rank` are never masked.
- **`public` defaults to true** (`config?.public !== false`) to mirror the directory filter; **no admin-grid sort change** — `rank` isn't in the `getCommunities` list payload and only affects the public directory, so the grid stays alphabetical (as it was; the old table didn't sort by rank either).

## Testing Steps

1. Sign in as a **contract-owner / super-admin** wallet and open `/admin`.
2. Each community card shows a **"Listing"** section with a **Publicly listed** checkbox and a **Rank** input.
3. Toggle **Publicly listed** → saves immediately (optimistic); the spinner shows while in flight.
4. Change **Rank** → saves after the debounce; help text notes higher rank appears first.
5. Sign in as a **non-owner** (e.g. a community admin) → the Listing section is absent and **no** `community-config` request fires (check the Network tab).
6. Verify effect on the public directory (`GET /v2/communities`): a community set to not-public drops out of the list; higher rank sorts earlier.

Automated: `pnpm test __tests__/components/Admin/CommunityListingControls.test.tsx __tests__/components/Admin/CommunityAdminCard.test.tsx` — 12 tests (public-default semantics, immediate public toggle, debounced rank save, pending/disabled, error, and the owner-gate/no-glimpse assertion). `tsc --noEmit` clean; `pnpm run build` green.

## Technical Details

- Wire contract (unchanged, already live): `GET /v2/community-configs/:slug` → `{ community, config }`; `PUT` accepts partial `{ public?, rank? }` and upserts a `community_configs` row (defaults `public: true`, `rank: 0`). Higher `rank` sorts first (`{ rank: -1, createdAt: -1 }`).
- The shared query key `["community-config", slug]` is also read by notification/access-denied surfaces; none are mounted on `/admin`, and only `{ public, rank }` is written, so there's no cross-surface interference here.

## Breaking Changes

None. Additive UI restore; no API or schema changes.

## Checklist

- [x] Tests added (12, covering loading/empty/success/error + owner gate)
- [x] Reuses `useMutation` with optimistic updates (no local `useState` + direct service calls)
- [x] Design-system components (`Checkbox`/`Input`/`Label`), no raw inputs or hardcoded colors
- [x] Tri-state / no-glimpse owner gating; non-owners fire zero config requests
- [x] `React.memo` on the mapped card; `"use client"` on the new component
- [x] Lint (`biome`) clean, `tsc --noEmit` clean, `pnpm run build` green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community owners can manage directory listing visibility and ranking from the admin page.
  * Listing controls provide loading, saving, validation, and error feedback.
  * Community links, labels, and accessibility text now use community details when available.

* **Performance**
  * Improved admin card rendering efficiency and expansion handling.

* **Tests**
  * Added coverage for listing permissions, visibility changes, rank updates, loading, validation, and save errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->