### PR TITLE
feat(kyc): restore applicant KYC/KYB verification card on the application page

### DIFF
--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -301,6 +301,7 @@ export function ApplicationPageClient({
             application={app}
             program={program}
             programName={programName}
+            communityId={communityId}
             viewerRole={viewerRole}
             canViewApplicant={canViewApplicant}
             hasMilestones={hasMilestones}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationKycCard.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationKycCard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { getEffectiveKycStatus, KycStatusBadge } from "@/components/KycStatusIcon";
+import { useKycConfig, useKycStatus } from "@/hooks/useKycStatus";
+import { kycStatusDescriptions } from "@/src/features/kyc/lib/status-config";
+
+interface ApplicationKycCardProps {
+  communityId: string;
+  referenceNumber: string;
+}
+
+/**
+ * Applicant-facing KYC/KYB verification card for the application sidebar.
+ * Rendered only for the applicant and reviewers/admins (the parent gates on
+ * `canViewApplicant`). Status is resolved by application reference, so a Batch-3
+ * applicant who inherited verification via their Karma Profile is shown as
+ * verified here too.
+ */
+export function ApplicationKycCard({ communityId, referenceNumber }: ApplicationKycCardProps) {
+  const { isEnabled, isLoading: isConfigLoading } = useKycConfig(communityId);
+  const {
+    status,
+    isLoading: isStatusLoading,
+    isError,
+  } = useKycStatus(referenceNumber, communityId, { enabled: isEnabled });
+
+  // KYC/KYB is not configured for this community — the card has nothing to show.
+  if (!isConfigLoading && !isEnabled) {
+    return null;
+  }
+
+  const isLoading = isConfigLoading || (isEnabled && isStatusLoading);
+
+  return (
+    <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+      <p className="mb-4 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Identity verification
+      </p>
+
+      {isLoading ? (
+        <div className="h-6 w-44 animate-pulse rounded-full bg-muted" aria-hidden />
+      ) : isError ? (
+        <p className="text-[13px] text-muted-foreground">
+          Unable to load verification status. Please try again later.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <KycStatusBadge status={status ?? null} className="w-fit" />
+          <p className="text-xs text-muted-foreground">
+            {kycStatusDescriptions[getEffectiveKycStatus(status ?? null)]}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
@@ -2,6 +2,7 @@
 
 import type { Application, FundingProgram } from "@/types/whitelabel-entities";
 import { ApplicationInfoCard } from "./ApplicationInfoCard";
+import { ApplicationKycCard } from "./ApplicationKycCard";
 import { ApplicationStatusStepper } from "./ApplicationStatusStepper";
 import { type ApplicationViewerRole, NextStepCard } from "./NextStepCard";
 
@@ -9,6 +10,7 @@ interface ApplicationSidebarProps {
   application: Application;
   program: FundingProgram | null;
   programName: string;
+  communityId: string;
   viewerRole: ApplicationViewerRole;
   canViewApplicant: boolean;
   hasMilestones: boolean;
@@ -30,6 +32,7 @@ export function ApplicationSidebar({
   application,
   program,
   programName,
+  communityId,
   viewerRole,
   canViewApplicant,
   hasMilestones,
@@ -66,6 +69,15 @@ export function ApplicationSidebar({
         ownerAddress={application.ownerAddress}
         canViewApplicant={canViewApplicant}
       />
+
+      {/* KYC/KYB verification is applicant identity data — shown only to the
+          applicant and reviewers/admins, never anonymous public viewers. */}
+      {canViewApplicant && (
+        <ApplicationKycCard
+          communityId={communityId}
+          referenceNumber={application.referenceNumber}
+        />
+      )}
     </aside>
   );
 }

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationKycCard.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationKycCard.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { KycVerificationStatus } from "@/types/kyc";
+import { ApplicationKycCard } from "../ApplicationKycCard";
+
+const mockUseKycConfig = vi.fn();
+const mockUseKycStatus = vi.fn();
+
+vi.mock("@/hooks/useKycStatus", () => ({
+  useKycConfig: (...args: unknown[]) => mockUseKycConfig(...args),
+  useKycStatus: (...args: unknown[]) => mockUseKycStatus(...args),
+}));
+
+const COMMUNITY = "filecoin";
+const REF = "APP-41FY6MKU-26HL9O";
+
+function renderCard() {
+  return render(<ApplicationKycCard communityId={COMMUNITY} referenceNumber={REF} />);
+}
+
+describe("ApplicationKycCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseKycConfig.mockReturnValue({ isEnabled: true, isLoading: false });
+    mockUseKycStatus.mockReturnValue({ status: null, isLoading: false, isError: false });
+  });
+
+  it("renders nothing when KYC is not configured for the community", () => {
+    mockUseKycConfig.mockReturnValue({ isEnabled: false, isLoading: false });
+
+    const { container } = renderCard();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("resolves status by application reference so inheritance flows through", () => {
+    renderCard();
+
+    expect(mockUseKycStatus).toHaveBeenCalledWith(REF, COMMUNITY, { enabled: true });
+  });
+
+  it("shows the verified description when the applicant is verified", () => {
+    mockUseKycStatus.mockReturnValue({
+      status: {
+        status: KycVerificationStatus.VERIFIED,
+        verificationType: "KYB",
+        isExpired: false,
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderCard();
+
+    expect(screen.getByText("Identity verification")).toBeInTheDocument();
+    expect(screen.getByText("Your identity has been verified successfully.")).toBeInTheDocument();
+  });
+
+  it("shows a not-started description when there is no verification yet", () => {
+    renderCard();
+
+    expect(
+      screen.getByText(/Identity verification is required for this program/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error message when the status fails to load", () => {
+    mockUseKycStatus.mockReturnValue({ status: null, isLoading: false, isError: true });
+
+    renderCard();
+
+    expect(
+      screen.getByText("Unable to load verification status. Please try again later.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows only the skeleton (no status text) while loading", () => {
+    mockUseKycConfig.mockReturnValue({ isEnabled: true, isLoading: true });
+    mockUseKycStatus.mockReturnValue({ status: null, isLoading: true, isError: false });
+
+    renderCard();
+
+    expect(screen.getByText("Identity verification")).toBeInTheDocument();
+    expect(screen.queryByText(/Identity verification is required/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Overview

Re-adds the applicant-facing **KYC/KYB verification card** to the funding application page. Part of DEV-524.

## Problem

The applicant KYC/KYB status card (an "Identity Verification" panel) was present when filpgf.io ran on `gap-whitelabel-app`. When that platform was ported into gap-app-v2 (**PR #1046**, `cfe4507c`), only the KYC **hooks + status-config** were carried over — the `src/features/kyc/components/` (including the verification card) were left behind and never re-wired into the applicant page. So applicants lost visibility of their KYC/KYB status. (The June redesign #1595 is not the cause — it removed 0 KYC lines.)

## Solution

New `ApplicationKycCard` in the application sidebar:
- Resolves status via `useKycStatus(referenceNumber, communityId)` (the by-application-reference path) + `useKycConfig(communityId)`.
- Reuses the shared `KycStatusBadge` and `kycStatusDescriptions` — no duplicated status logic.
- **Gated to the applicant and reviewers/admins** (`canViewApplicant`, i.e. `viewerRole !== "guest"`); never rendered for anonymous public viewers, since KYC/KYB is applicant identity data.
- Hidden entirely when KYC is not configured for the community.
- Handles loading (skeleton), error (message), and all status states (badge + description).

**Bonus:** because the by-application-reference read path inherits KYC/KYB via the Karma Profile field, an approved Batch-3 applicant who inherited their Batch-2 verification now correctly shows **Verified** here.

## Testing

- New unit test `ApplicationKycCard.test.tsx` (6 cases): not-configured → renders nothing; resolves by app reference; verified description; not-started description; error state; loading skeleton.
- `pnpm exec vitest run` green; full `pnpm test:unit` green (2920); `pnpm run build` clean (Next strict typecheck).

## Screenshots

_Manual walkthrough on preview pending — will attach applicant/reviewer views (verified + not-started) and confirm the card is absent for anonymous viewers._