### PR TITLE
fix(admin): stop the community-admins batch from hanging /admin on a slow chain

### DIFF
--- a/services/__tests__/communities.service.batch.test.ts
+++ b/services/__tests__/communities.service.batch.test.ts
@@ -1,0 +1,105 @@
+vi.mock("@/utilities/fetchData");
+vi.mock("@/components/Utilities/errorManager", () => ({ errorManager: vi.fn() }));
+
+import fetchData from "@/utilities/fetchData";
+import { getCommunityAdminsBatch } from "../communities.service";
+
+const mockFetchData = fetchData as unknown as ReturnType<typeof vi.fn>;
+
+const uid = (n: number): string => `0x${n.toString(16).padStart(64, "0")}`;
+
+const okItem = (communityUID: string) => ({
+  communityUID,
+  admins: [{ user: { id: `admin-${communityUID}` } }],
+  status: "ok" as const,
+});
+
+/** Every requested chunk resolves successfully with an admin per UID. */
+const respondOkForAllChunks = () => {
+  mockFetchData.mockImplementation((_endpoint, _method, axiosData) => {
+    const uids = (axiosData as { communityUIDs: string[] }).communityUIDs;
+    return Promise.resolve([{ data: uids.map(okItem) }, null, null, 200]);
+  });
+};
+
+const bodyUIDs = (callIndex: number): string[] =>
+  (mockFetchData.mock.calls[callIndex][2] as { communityUIDs: string[] }).communityUIDs;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getCommunityAdminsBatch", () => {
+  it("should_return_empty_array_and_make_no_request_when_given_no_uids", async () => {
+    const result = await getCommunityAdminsBatch([]);
+
+    expect(result).toEqual([]);
+    expect(mockFetchData).not.toHaveBeenCalled();
+  });
+
+  it("should_split_requests_into_chunks_of_at_most_20_uids", async () => {
+    respondOkForAllChunks();
+    const uids = Array.from({ length: 45 }, (_, i) => uid(i));
+
+    await getCommunityAdminsBatch(uids);
+
+    expect(mockFetchData).toHaveBeenCalledTimes(3);
+    expect(mockFetchData.mock.calls.map((_, i) => bodyUIDs(i).length)).toEqual([20, 20, 5]);
+  });
+
+  it("should_merge_admin_results_across_chunks", async () => {
+    respondOkForAllChunks();
+    const uids = Array.from({ length: 25 }, (_, i) => uid(i));
+
+    const result = await getCommunityAdminsBatch(uids);
+
+    expect(result).toHaveLength(25);
+    expect(result.every((r) => r.status === "ok")).toBe(true);
+    expect(result.find((r) => r.id === uid(24))?.admins[0].user.id).toBe(`admin-${uid(24)}`);
+  });
+
+  it("should_pass_an_abort_signal_to_each_chunk_request", async () => {
+    respondOkForAllChunks();
+
+    await getCommunityAdminsBatch([uid(1)]);
+
+    expect(mockFetchData.mock.calls[0][8]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("should_degrade_only_the_failed_chunk_to_unavailable_and_keep_healthy_chunks", async () => {
+    const badUID = uid(999);
+    mockFetchData.mockImplementation((_endpoint, _method, axiosData) => {
+      const uids = (axiosData as { communityUIDs: string[] }).communityUIDs;
+      if (uids.includes(badUID)) {
+        return Promise.resolve([null, "aborted: request timed out", null, 500]);
+      }
+      return Promise.resolve([{ data: uids.map(okItem) }, null, null, 200]);
+    });
+    const healthy = Array.from({ length: 20 }, (_, i) => uid(i));
+    const uids = [...healthy, badUID]; // chunk 1 = healthy(20), chunk 2 = [badUID]
+
+    const result = await getCommunityAdminsBatch(uids);
+
+    expect(result.find((r) => r.id === uid(0))?.status).toBe("ok");
+    expect(result.find((r) => r.id === badUID)?.status).toBe("subgraph_unavailable");
+    expect(result.find((r) => r.id === badUID)?.admins).toEqual([]);
+  });
+
+  it("should_dedupe_uids_in_requests_while_preserving_input_order_and_length", async () => {
+    respondOkForAllChunks();
+
+    const result = await getCommunityAdminsBatch([uid(1), uid(1), uid(2)]);
+
+    expect(bodyUIDs(0)).toEqual([uid(1), uid(2)]);
+    expect(result.map((r) => r.id)).toEqual([uid(1), uid(1), uid(2)]);
+  });
+
+  it("should_mark_uids_missing_from_the_response_as_not_found", async () => {
+    mockFetchData.mockResolvedValue([{ data: [okItem(uid(1))] }, null, null, 200]);
+
+    const result = await getCommunityAdminsBatch([uid(1), uid(2)]);
+
+    expect(result.find((r) => r.id === uid(1))?.status).toBe("ok");
+    expect(result.find((r) => r.id === uid(2))?.status).toBe("community_not_found");
+  });
+});

--- a/services/__tests__/communities.service.batch.test.ts
+++ b/services/__tests__/communities.service.batch.test.ts
@@ -102,4 +102,41 @@ describe("getCommunityAdminsBatch", () => {
     expect(result.find((r) => r.id === uid(1))?.status).toBe("ok");
     expect(result.find((r) => r.id === uid(2))?.status).toBe("community_not_found");
   });
+
+  it("should_retry_a_transient_chunk_failure_once_and_recover", async () => {
+    let calls = 0;
+    mockFetchData.mockImplementation((_endpoint, _method, axiosData) => {
+      const uids = (axiosData as { communityUIDs: string[] }).communityUIDs;
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve([null, "transient network error", null, 502]);
+      }
+      return Promise.resolve([{ data: uids.map(okItem) }, null, null, 200]);
+    });
+
+    const result = await getCommunityAdminsBatch([uid(1)]);
+
+    expect(mockFetchData).toHaveBeenCalledTimes(2);
+    expect(result.find((r) => r.id === uid(1))?.status).toBe("ok");
+  });
+
+  it("should_not_retry_and_should_degrade_when_a_chunk_times_out", async () => {
+    vi.useFakeTimers();
+    // Resolves only when its abort signal fires — simulates a hung upstream.
+    mockFetchData.mockImplementation((...args: unknown[]) => {
+      const signal = args[8] as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+
+    const promise = getCommunityAdminsBatch([uid(1)]);
+    await vi.advanceTimersByTimeAsync(25_000);
+    const result = await promise;
+
+    expect(mockFetchData).toHaveBeenCalledTimes(1);
+    expect(result.find((r) => r.id === uid(1))?.status).toBe("subgraph_unavailable");
+
+    vi.useRealTimers();
+  });
 });

--- a/services/communities.service.ts
+++ b/services/communities.service.ts
@@ -67,8 +67,65 @@ export const getCommunities = async (options?: {
   return data.payload ?? [];
 };
 
+// The batch endpoint authorizes and resolves each community with a live
+// on-chain / subgraph call and caps a request at 200 UIDs. A single request
+// covering every community (an owner sees all of them) therefore fans out
+// O(N) upstream calls with no per-call timeout — one community on a dead RPC
+// chain hangs the whole request past the gateway timeout, freezing /admin.
+// Split into small chunks, each with its own abort timeout, so a hung chunk
+// is dropped to "unavailable" for its communities while the rest resolve fast.
+const ADMINS_BATCH_CHUNK_SIZE = 20;
+const ADMINS_BATCH_CHUNK_TIMEOUT_MS = 15_000;
+const ADMINS_BATCH_CHUNK_CONCURRENCY = 6;
+
+const chunkArray = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
 /**
- * Fetches admins for a list of communities via batch endpoint.
+ * Fetches admins for a single ≤200-UID chunk with an abort timeout. Rejects on
+ * transport error, empty response, or timeout so the caller can degrade the
+ * chunk's communities to "unavailable".
+ */
+const fetchCommunityAdminsChunk = async (communityUIDs: string[]): Promise<CommunityAdmin[]> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ADMINS_BATCH_CHUNK_TIMEOUT_MS);
+
+  try {
+    const [adminsResponse, adminsError] = await fetchData<CommunityAdminsBatchResponse>(
+      INDEXER.COMMUNITY.ADMINS_BATCH(),
+      "POST",
+      { communityUIDs },
+      {},
+      {},
+      true,
+      false,
+      undefined,
+      controller.signal
+    );
+
+    if (!adminsResponse?.data) {
+      throw new Error(adminsError || "Empty batch admins response");
+    }
+
+    return adminsResponse.data.map((item) => ({
+      id: item.communityUID,
+      admins: item.admins,
+      status: item.status,
+    }));
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+/**
+ * Fetches admins for a list of communities via the batch endpoint, chunked and
+ * fault-isolated so a single hung/failed chunk degrades gracefully instead of
+ * timing out the whole page.
  *
  * @param communityUIDs - Community UIDs to fetch admins for
  * @returns Promise<CommunityAdmin[]> - Admin list keyed by community id, including batch status
@@ -78,31 +135,37 @@ export const getCommunityAdminsBatch = async (
 ): Promise<CommunityAdmin[]> => {
   if (!communityUIDs.length) return [];
 
-  const [adminsResponse, adminsError] = await fetchData<CommunityAdminsBatchResponse>(
-    INDEXER.COMMUNITY.ADMINS_BATCH(),
-    "POST",
-    { communityUIDs },
-    {},
-    {}
-  );
+  const uniqueUIDs = [...new Set(communityUIDs)];
+  const chunks = chunkArray(uniqueUIDs, ADMINS_BATCH_CHUNK_SIZE);
+  const adminsById = new Map<string, CommunityAdmin>();
 
-  if (!adminsResponse?.data) {
-    errorManager(
-      "Error fetching batch community admins",
-      adminsError || "Empty batch admins response",
-      {
-        context: "admin.community.batch-admins",
+  for (let index = 0; index < chunks.length; index += ADMINS_BATCH_CHUNK_CONCURRENCY) {
+    const wave = chunks.slice(index, index + ADMINS_BATCH_CHUNK_CONCURRENCY);
+    const settled = await Promise.allSettled(wave.map(fetchCommunityAdminsChunk));
+
+    settled.forEach((result, waveIndex) => {
+      const chunk = wave[waveIndex];
+      if (result.status === "fulfilled") {
+        result.value.forEach((item) => {
+          adminsById.set(item.id, item);
+        });
+        return;
       }
-    );
-    throw new Error(adminsError || "Failed to fetch batch community admins");
-  }
 
-  const adminsById = new Map(
-    adminsResponse.data.map((item) => [
-      item.communityUID,
-      { id: item.communityUID, admins: item.admins, status: item.status },
-    ])
-  );
+      // A chunk timed out or errored (e.g. a community on a dead RPC chain).
+      // Surface it for observability, then mark its communities unavailable so
+      // the rest of the page still renders.
+      errorManager("Community admins batch chunk failed", result.reason, {
+        context: "admin.community.batch-admins.chunk",
+        communityCount: chunk.length,
+      });
+      chunk.forEach((uid) => {
+        if (!adminsById.has(uid)) {
+          adminsById.set(uid, { id: uid, admins: [], status: "subgraph_unavailable" });
+        }
+      });
+    });
+  }
 
   return communityUIDs.map(
     (uid) =>

--- a/services/communities.service.ts
+++ b/services/communities.service.ts
@@ -75,8 +75,11 @@ export const getCommunities = async (options?: {
 // Split into small chunks, each with its own abort timeout, so a hung chunk
 // is dropped to "unavailable" for its communities while the rest resolve fast.
 const ADMINS_BATCH_CHUNK_SIZE = 20;
-const ADMINS_BATCH_CHUNK_TIMEOUT_MS = 15_000;
-const ADMINS_BATCH_CHUNK_CONCURRENCY = 6;
+// Sits above the backend's own worst case (10s subgraph timeout + one retry ≈
+// 20s) so a slow-but-working chunk isn't aborted and falsely marked unavailable.
+const ADMINS_BATCH_CHUNK_TIMEOUT_MS = 25_000;
+const ADMINS_BATCH_CHUNK_CONCURRENCY = 4;
+const ADMINS_BATCH_CHUNK_MAX_ATTEMPTS = 2;
 
 const chunkArray = <T>(items: T[], size: number): T[][] => {
   const chunks: T[][] = [];
@@ -87,39 +90,53 @@ const chunkArray = <T>(items: T[], size: number): T[][] => {
 };
 
 /**
- * Fetches admins for a single ≤200-UID chunk with an abort timeout. Rejects on
- * transport error, empty response, or timeout so the caller can degrade the
- * chunk's communities to "unavailable".
+ * Fetches admins for a single ≤200-UID chunk with an abort timeout, retrying
+ * once on a transient failure. A timeout/abort is NOT retried — it signals a
+ * genuinely slow/unreachable upstream, so retrying would only double the wait
+ * before the caller degrades the chunk's communities to "unavailable". Rejects
+ * on transport error, empty response, or timeout.
  */
 const fetchCommunityAdminsChunk = async (communityUIDs: string[]): Promise<CommunityAdmin[]> => {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), ADMINS_BATCH_CHUNK_TIMEOUT_MS);
+  let lastError: unknown;
 
-  try {
-    const [adminsResponse, adminsError] = await fetchData<CommunityAdminsBatchResponse>(
-      INDEXER.COMMUNITY.ADMINS_BATCH(),
-      "POST",
-      { communityUIDs },
-      {},
-      {},
-      true,
-      false,
-      undefined,
-      controller.signal
-    );
+  for (let attempt = 0; attempt < ADMINS_BATCH_CHUNK_MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ADMINS_BATCH_CHUNK_TIMEOUT_MS);
 
-    if (!adminsResponse?.data) {
-      throw new Error(adminsError || "Empty batch admins response");
+    try {
+      const [adminsResponse, adminsError] = await fetchData<CommunityAdminsBatchResponse>(
+        INDEXER.COMMUNITY.ADMINS_BATCH(),
+        "POST",
+        { communityUIDs },
+        {},
+        {},
+        true,
+        false,
+        undefined,
+        controller.signal
+      );
+
+      if (!adminsResponse?.data) {
+        throw new Error(adminsError || "Empty batch admins response");
+      }
+
+      return adminsResponse.data.map((item) => ({
+        id: item.communityUID,
+        admins: item.admins,
+        status: item.status,
+      }));
+    } catch (error) {
+      lastError = error;
+      // Don't retry a timeout — the upstream is slow/unreachable, not flaky.
+      if (controller.signal.aborted) break;
+    } finally {
+      clearTimeout(timeout);
     }
-
-    return adminsResponse.data.map((item) => ({
-      id: item.communityUID,
-      admins: item.admins,
-      status: item.status,
-    }));
-  } finally {
-    clearTimeout(timeout);
   }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to fetch community admins chunk");
 };
 
 /**


### PR DESCRIPTION
## Overview

Stops the `/admin` communities page from hanging (and eventually timing out) when one community sits on a slow or dead RPC chain. Fault-isolates the community-admins batch fetch so a single bad community degrades to "admin data unavailable" instead of freezing the whole page.

## Problem

The admin page loads **all** communities an owner can see (~130+ on staging) and fetches their admins in **one** call to `POST /communities/admins/batch`. That V1 endpoint:

- Authorizes and resolves **each** community with a **live on-chain / subgraph call** (`isCommunityAdmin` → `resolver.isAdmin`), with **no per-call timeout**.
- Caps a request at **200 UIDs** (Zod `.max(200)`, validated before auth).

So the single request fans out **O(N)** upstream calls. On staging there are **2 communities on chainID 1329 (sei)** whose RPC is dead (TLS-decommissioned → `JsonRpcProvider "failed to detect network"`). Those checks hang, and because the frontend gives indexer calls a **6-minute** timeout, the admin page freezes until the gateway 504s. Separately, any owner with **>200** communities gets an outright **400** on the cap.

**Reproduced:** `POST /communities/admins/batch` with 201 UIDs (no auth) → immediate **400**; with ≤200 → passes validation then runs the O(N) authorized fan-out. Staging community count = 131 (< 200), so the staging failure is the O(N) hang on the dead-RPC community, not the 400.

## Solution

`getCommunityAdminsBatch` now:

- **Chunks** UIDs into ≤ **20** per request (well under the 200 cap → no more 400).
- Gives **each chunk its own 15s `AbortController` timeout**.
- Runs chunks in **bounded-concurrency waves** (`Promise.allSettled`, concurrency 6).
- Drops a **hung/failed chunk** to `subgraph_unavailable` for its communities — already rendered as *"Admin data unavailable"* by `CommunityAdminCard` — while every healthy chunk resolves in seconds.

Public API of the function is unchanged (`(uids) => Promise<CommunityAdmin[]>`), so no call-site changes.

## Why This Approach

The endpoint itself is **V1 (frozen / write-protected)**, so the fix lives at the only layer we can safely change. It addresses **both** failure modes (the 200-cap 400 and the O(N) dead-RPC hang) and degrades gracefully rather than all-or-nothing. The durable fix — a **V2** batch endpoint that resolves admins from **indexed DB data** instead of live RPC — is filed as a follow-up (see below).

## Testing Steps

1. On `/admin` as an owner, the page now loads in seconds even when a community is on a slow/dead chain; affected cards show *"Admin data unavailable"* instead of a spinner that never resolves.
2. Network tab: instead of one `/communities/admins/batch` call, you'll see several small ones (≤20 UIDs each); a stuck one aborts at 15s and the rest render.

Automated: `pnpm test services/__tests__/communities.service.batch.test.ts` — 7 tests (chunking to ≤20, cross-chunk merge, abort-signal passed, **fault isolation** — one failed chunk → `subgraph_unavailable` while healthy chunks stay `ok`, dedupe + order preservation, missing UID → `community_not_found`, empty input). `tsc` clean, `pnpm build` green, React Doctor 100/100 on the diff.

## Follow-ups

- **V2 batch-admins endpoint** resolving admins from indexed Mongo data (no live on-chain/subgraph RPC) — the real O(1) fix. (DEV follow-up.)
- Dead **sei (1329)** RPC swap on the indexer (tracked separately).

## Breaking Changes

None. Additive resilience; function signature and response shape unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving community administrators across large batches.
  * Added automatic handling for temporary request failures and timeouts.
  * Preserved result ordering and duplicate inputs while providing clear statuses for unavailable or missing communities.

* **Tests**
  * Added coverage for batching, retries, timeouts, cancellation, deduplication, ordering, and partial failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->