### PR TITLE
feat(identity): show names for note editors and endorsers, not raw wallets

### DIFF
--- a/__tests__/features/application-notes/PrivateNotesTab.test.tsx
+++ b/__tests__/features/application-notes/PrivateNotesTab.test.tsx
@@ -12,6 +12,13 @@ vi.mock("react-hot-toast", () => ({
   default: { error: vi.fn(), success: vi.fn() },
 }));
 
+// The shared identity component pulls in React Query / Privy context; stub it to
+// the raw address so this suite can assert the byline delegates to it (no local
+// truncation) without wiring up those providers.
+vi.mock("@/components/EthereumAddressToProfileName", () => ({
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
 const mockHook = vi.mocked(useApplicationNote);
 
 type HookReturn = ReturnType<typeof useApplicationNote>;
@@ -90,6 +97,18 @@ describe("PrivateNotesTab", () => {
 
     expect(screen.getByDisplayValue("internal flag")).toBeInTheDocument();
     expect(screen.getByText(/Last edited by Greta/)).toBeInTheDocument();
+  });
+
+  it("delegates editor identity to the shared component when the note has no stored name", () => {
+    mockHook.mockReturnValue(hookState({ note: createMockNote({ updatedByName: null }) }));
+
+    render(<PrivateNotesTab referenceNumber="APP-1" canViewNotes />);
+
+    expect(screen.getByText(/Last edited by/)).toBeInTheDocument();
+    // Falls through to EthereumAddressToProfileName (name/ENS/masked) instead of
+    // the old home-grown 6/4 truncation of the raw address.
+    expect(screen.queryByText(/0xabcd…0000/)).not.toBeInTheDocument();
+    expect(screen.getByText("0xabcdef0000000000000000000000000000000000")).toBeInTheDocument();
   });
 
   it("should surface an error toast when saving fails (not silent)", async () => {

--- a/components/Pages/Communities/Impact/ProjectDiscovery.tsx
+++ b/components/Pages/Communities/Impact/ProjectDiscovery.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { useMemo, useState } from "react";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/Utilities/Button";
 import { useCommunityCategories } from "@/hooks/communities/useCommunityCategories";
 import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
@@ -251,7 +252,9 @@ export const ProjectDiscovery = () => {
                   key={endorser}
                   className="flex items-center gap-2 bg-primary/5 text-primary rounded-full px-4 py-2 group hover:bg-primary/10 transition-colors"
                 >
-                  <span className="text-sm font-medium truncate max-w-[200px]">{endorser}</span>
+                  <span className="text-sm font-medium truncate max-w-[200px]" title={endorser}>
+                    <EthereumAddressToProfileName address={endorser} />
+                  </span>
                   <button
                     type="button"
                     onClick={() => handleEndorserRemove(endorser)}

--- a/src/features/application-notes/components/PrivateNotesTab.tsx
+++ b/src/features/application-notes/components/PrivateNotesTab.tsx
@@ -3,6 +3,7 @@
 import { AlertCircle, Lock, RefreshCw, Save } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
@@ -17,11 +18,6 @@ interface PrivateNotesTabProps {
 }
 
 const MAX_NOTE_LENGTH = 10000;
-
-function formatEditor(name: string | null | undefined, address: string): string {
-  if (name) return name;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
 
 // Deterministic date display from the ISO timestamp — no locale/timezone
 // formatting APIs, so it is hydration-safe and renders identically everywhere.
@@ -114,12 +110,15 @@ function NoteEditor({
     }
   };
 
-  const metaLine = note
-    ? `Last edited by ${formatEditor(
-        note.updatedByName,
-        note.updatedByAddress
-      )} · ${formatEditedAt(note.updatedAt)}`
-    : "No note yet.";
+  const metaLine = note ? (
+    <>
+      Last edited by{" "}
+      {note.updatedByName || <EthereumAddressToProfileName address={note.updatedByAddress} />} ·{" "}
+      {formatEditedAt(note.updatedAt)}
+    </>
+  ) : (
+    "No note yet."
+  );
 
   return (
     <section className="rounded-2xl border border-border bg-card shadow-sm">


### PR DESCRIPTION
## Summary

Follow-up to the "show the wallet address as little as possible" work (DEV-513 / DEV-518 / DEV-519). A fresh multi-agent audit of every address-display site on `main` — **81 sites classified** (44 kept-literal functional, 25 already migrated, 5 dead-code, 7 identity candidates → **4 verified**) — surfaced two person-identity displays still rendering a raw / home-grown-truncated wallet address. This migrates both to `EthereumAddressToProfileName`.

## What changed

- **Private notes — "Last edited by …" byline** (`PrivateNotesTab`, the DEV-515 feature): the note author (a reviewer/admin) was resolved by a home-grown `name || 6/4-truncate(address)` helper. The byline is now JSX — `updatedByName` if present, else `<EthereumAddressToProfileName>` — so contributor/Privy/ENS names resolve and an unknown author's address is masked instead of shown raw. Removed the now-dead `formatEditor` helper.
- **Project Discovery — "Trusted Circle" endorser chips** (`ProjectDiscovery`): each endorser (a person) rendered its full address (CSS-truncated only). Now wrapped in `<EthereumAddressToProfileName>`; the raw address is kept in the chip `title=` so the admin can verify what they pasted.

## Kept literal by design (excluded)

Payout/disbursement destinations, tx hashes, contract/token/community UIDs, copy payloads, address `<input>`s, explorer link text — the address is the point there.

## Deliberately deferred (from the audit)

The `ReviewerAssignmentDropdown` reviewer label and the `AdminAdvisorsList` advisor badge. Both are blocked on the same thing — `MultiSelectDropdown` / the chip take a **plain-string** label, so they can't host the JSX component — and both already show **name + email** from the backend, so the raw fallback rarely renders. A shared string-returning `useAddressToName` hook would unblock them; skipped here as net-zero gain for real refactor risk.

## Verification

- `pnpm run build` → success
- `pnpm run typecheck` → clean (a transient `.next/types` phantom for an unrelated route cleared on a fresh build)
- `pnpm test …/PrivateNotesTab.test.tsx` → **7/7** (added a test for the anonymous-author branch asserting the byline delegates to the component, not the old 6/4 truncation)
- `react-doctor --scope changed` → **no issues**
- Biome clean; neither file oversized (314 / 155 lines)

Frontend-only. Continues DEV-513 (self-aware component) → DEV-518 → DEV-519.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endorser selections now display profile-derived names instead of raw wallet addresses.
  * “Last edited by” attribution now shows the editor’s profile name when available.
  * When no profile name is stored, the editor’s full address is displayed for clarity.
  * Endorser address details remain accessible via a tooltip while the displayed name stays concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->