### PR TITLE
fix(community): match funded-project loading skeleton to new grid

### DIFF
--- a/__tests__/components/CommunityGrants/ProjectsGridSkeleton.test.tsx
+++ b/__tests__/components/CommunityGrants/ProjectsGridSkeleton.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProjectsGridSkeleton } from "@/components/CommunityGrants/ProjectsGridSkeleton";
+
+describe("ProjectsGridSkeleton", () => {
+  it("renders the default number of block placeholders", () => {
+    render(<ProjectsGridSkeleton />);
+
+    expect(screen.getAllByTestId("project-block-skeleton")).toHaveLength(8);
+  });
+
+  it("renders the requested number of block placeholders", () => {
+    render(<ProjectsGridSkeleton count={4} />);
+
+    expect(screen.getAllByTestId("project-block-skeleton")).toHaveLength(4);
+  });
+});

--- a/components/CommunityGrants.tsx
+++ b/components/CommunityGrants.tsx
@@ -10,10 +10,10 @@ import type { CommunityProjects } from "@/types/v2/community";
 import { CategoryFilter } from "./CommunityGrants/CategoryFilter";
 import { MaturityStageFilter } from "./CommunityGrants/MaturityStageFilter";
 import { ProjectsGrid } from "./CommunityGrants/ProjectsGrid";
+import { ProjectsGridSkeleton } from "./CommunityGrants/ProjectsGridSkeleton";
 import { SortFilter } from "./CommunityGrants/SortFilter";
 import { ProgramFilter } from "./Pages/Communities/Impact/ProgramFilter";
 import { TrackFilter } from "./Pages/Communities/Impact/TrackFilter";
-import { CardListSkeleton } from "./Pages/Communities/Loading";
 import { ProgramBanner } from "./ProgramBanner";
 import { errorManager } from "./Utilities/errorManager";
 
@@ -225,7 +225,7 @@ export const CommunityGrants = ({
 
           {(isFilterLoading || isFetchingNextPage) && (
             <div className="w-full flex items-center justify-center">
-              <CardListSkeleton />
+              <ProjectsGridSkeleton />
             </div>
           )}
 

--- a/components/CommunityGrants/ProjectsGridSkeleton.tsx
+++ b/components/CommunityGrants/ProjectsGridSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from "@/components/Utilities/Skeleton";
+
+interface ProjectsGridSkeletonProps {
+  count?: number;
+}
+
+function ProjectBlockSkeleton() {
+  return (
+    <div
+      data-testid="project-block-skeleton"
+      aria-hidden
+      className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <div className="grid min-h-36 grid-cols-[112px_minmax(0,1fr)] sm:grid-cols-[152px_minmax(0,1fr)]">
+        <Skeleton className="aspect-square h-full w-full self-start rounded-none" />
+
+        <div className="flex min-w-0 flex-col p-4 sm:p-5">
+          <div className="mb-2 flex flex-col gap-1.5">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-5 w-1/2" />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+
+          <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-1 pt-4">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ProjectsGridSkeleton({ count = 8 }: ProjectsGridSkeletonProps) {
+  const items = Array.from({ length: count }, (_, index) => `project-block-skeleton-${index}`);
+
+  return (
+    <div className="grid w-full grid-cols-1 gap-4 xl:grid-cols-2">
+      {items.map((id) => (
+        <ProjectBlockSkeleton key={id} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The funded-project showcase was redesigned into a responsive two-column `ProjectBlock` grid (#1827), but the **loading skeleton still rendered the old GrantCard shape** (colored top bar, "Created on" line, category pills, three-column layout). During filter/data loading and infinite-scroll fetches the page visibly flipped between two different card designs.

This adds `ProjectsGridSkeleton`, which mirrors the new `ProjectBlock`: a square visual placeholder on the left (112px mobile / 152px desktop) and title / description / footer-count placeholders on the right, in the same `grid-cols-1 xl:grid-cols-2` layout. It replaces `CardListSkeleton` only on the funded-project page.

## Scope / blast radius

- `CardListSkeleton` is **shared** — it is still used by the donate flow (`donate/[programId]/loading.tsx`, `checkout/loading.tsx`, `CommunityGrantsDonate`) and `CommunitiesLoading`, all of which still render the old `GrantCard`. Those are intentionally left untouched.
- Route-level `loading.tsx` for the community pages renders a `<Spinner />` (not the old cards), so no change needed there.

## Testing

- New `ProjectsGridSkeleton.test.tsx` — asserts default (8) and custom block counts. Passes.
- `pnpm typecheck` — passes.
- Scoped Biome — clean.
- Quality gate (react-doctor) — no regression (3337 → 3337); used stable keys to avoid an `no-array-index-as-key` warning, so no baseline bump.

## Smoke results

- To verify on the Vercel preview: open `/community/filecoin`, apply a Category/Sort filter, and confirm the loading placeholders now match the two-column `ProjectBlock` grid (square visual + title/description/counts) instead of the old card shape, in both light and dark mode. _(Preview link will be posted by Vercel below.)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive project-grid loading skeleton with a configurable number of placeholders.
  * Community Grants loading states now display project-style placeholders for a more consistent layout.

* **Tests**
  * Added coverage verifying the default and custom placeholder counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->