### PR TITLE
fix(community): fill card artwork height and ease title truncation

### DIFF
--- a/components/CommunityGrants/ProjectBlock.tsx
+++ b/components/CommunityGrants/ProjectBlock.tsx
@@ -28,13 +28,14 @@ function ProjectBlockComponent({ project }: ProjectBlockProps) {
           title={title}
           imageUrl={project.details.logoUrl}
           categories={project.categories}
-          className="w-full self-start"
+          variant="fill"
+          className="h-full w-full"
         />
 
         <div className="flex min-w-0 flex-col p-4 sm:p-5">
           <div className="mb-2 flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <h3 className="line-clamp-2 text-base font-semibold leading-snug text-zinc-950 dark:text-zinc-100 sm:text-lg">
+              <h3 className="line-clamp-2 text-base font-semibold leading-snug text-zinc-950 dark:text-zinc-100 lg:text-lg">
                 {title}
               </h3>
             </div>

--- a/components/CommunityGrants/ProjectVisual.tsx
+++ b/components/CommunityGrants/ProjectVisual.tsx
@@ -21,7 +21,7 @@ interface ProjectVisualProps {
   categories?: string[];
   className?: string;
   priority?: boolean;
-  variant?: "square" | "banner";
+  variant?: "square" | "banner" | "fill";
 }
 
 interface VisualTheme {
@@ -253,7 +253,7 @@ export function ProjectVisual({
       className={cn(
         "relative isolate overflow-hidden bg-gradient-to-br",
         theme.background,
-        variant === "square" ? "aspect-square" : "h-full min-h-64",
+        variant === "square" ? "aspect-square" : variant === "fill" ? "h-full" : "h-full min-h-64",
         className
       )}
     >

--- a/components/CommunityGrants/ProjectsGridSkeleton.tsx
+++ b/components/CommunityGrants/ProjectsGridSkeleton.tsx
@@ -12,7 +12,7 @@ function ProjectBlockSkeleton() {
       className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
     >
       <div className="grid min-h-36 grid-cols-[112px_minmax(0,1fr)] lg:grid-cols-[152px_minmax(0,1fr)]">
-        <Skeleton className="aspect-square h-full w-full self-start rounded-none" />
+        <Skeleton className="h-full min-h-36 w-full rounded-none" />
 
         <div className="flex min-w-0 flex-col p-4 sm:p-5">
           <div className="mb-2 flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary

Follow-up polish on the funded-project cards after the medium-screen rework (#1842). Two problems were visible on small/medium screens:

1. **Blank space below the artwork.** The card's left visual was a fixed `aspect-square` block pinned to the top (`self-start`), so on any card taller than the image it left a large empty gap below it — e.g. a 112px square inside a 177px card (65px of blank space).
2. **Titles truncated too early.** At the narrow `md` two-column width, titles jumped to `text-lg` (18px) and clamped to 2 lines very aggressively (e.g. "Portrait and the Open Internet…").

## Changes

- Add a `fill` variant to `ProjectVisual` and use it in `ProjectBlock` so the artwork stretches to the **full card height** as a cover strip (no blank space, at every width and for both real logos and fallback artwork).
- Hold the title at `text-base` until `lg` (was `sm:text-lg`), so more names fit within two lines at the tighter medium-screen columns; it grows to `text-lg` once the two-column cards are wide enough.
- Update `ProjectsGridSkeleton` so the loading placeholder mirrors the full-height artwork.

## Testing

Verified on a local dev build (light + dark) across **500 / 800 / 820 / 1440px**, on both fallback-artwork (`filecoin`) and real-logo (`optimism`) communities:
- Artwork now fills the full card height — measured `blankBelowImage: 0` (was 65px at 800px).
- Titles like "Portrait and the Open Internet Protocol" and "IPNI (InterPlanetary Network Indexer)" now show fully on two lines; only genuinely long titles still truncate.
- Real project logos remain centered in the (now full-height) cover strip; dark mode intact.

- `pnpm exec vitest run --project unit __tests__/components/CommunityGrants/` — 29 tests pass.
- `pnpm typecheck` — passes. Scoped Biome — clean.
- Pure Tailwind/prop changes — no new components; quality gate unaffected, no baseline change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project visual sizing so images and placeholders fill their available space more consistently.
  * Updated responsive project title sizing for better readability across screen sizes.
  * Enhanced project grid loading placeholders with improved height and width behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->