### PR TITLE
fix: enforce project indexability and SSR discovery

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -187,6 +187,14 @@ agent-browser --session {SESSION} close
 
 3. Tell the user the report is ready and summarize findings: total issues, breakdown by severity, and the most critical items.
 
+## Interaction validity (avoid false negatives)
+
+Before reporting any interaction failure, make sure the interaction itself was valid. A driver mistake is not an app bug. These rules are mandatory:
+
+1. **Clearing a controlled input** -- never use `fill @ref ""` (an empty fill) to clear a React/controlled input. Setting the value to empty emits a single untrusted event that React's value-tracker ignores, so the field's state and any derived URL/results do **not** update -- looking like a stale-state bug that does not exist for real users. To clear, `focus` (or `click`) the field, then `press Control+a` and `press Backspace`, and wait for any debounce before asserting the URL, state, or results. To enter text, prefer `type` / `keyboard type` (trusted keystrokes) over `fill`.
+
+2. **Click / navigation "failures"** -- before reporting a click or navigation as broken, `scrollintoview @ref`, wait for the layout to settle, take a fresh `snapshot -i` to get a current ref, and click that ref. If it still does not navigate, confirm the trusted event actually targeted the intended element (not `<html>` or an overlay from a layout shift or off-screen coordinate). If the target was wrong, classify it as a **driver/harness miss, not an app bug**.
+
 ## Guidance
 
 - **Repro is everything.** Every issue needs proof -- but match the evidence to the issue. Interactive bugs need video and step-by-step screenshots. Static bugs (typos, placeholder text, visual glitches visible on load) only need a single annotated screenshot.

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -197,7 +197,7 @@ Before reporting any interaction failure, make sure the interaction itself was v
 
 3. **Repeated labels/titles are not duplicate records** -- before reporting duplicate or repeated items (cards, rows, list entries), compare a stable identity: `href`, slug, or id. Distinct identities mean distinct records (usually seeded data) -- **no finding**. Report a duplicate only when the stable identity itself repeats.
 
-**Scope vs. causation.** A changed or touched file establishes *scope* (what to inspect), not that the PR caused an issue. Mark a finding `pr-caused` only with a directly observed before/after regression or clear causal evidence; otherwise classify it `pre-existing`.
+**Scope vs. causation.** A changed or touched file establishes *scope* (what to inspect), not that the PR caused an issue. Each classification needs its own evidence: mark a finding `pr-caused` only with a directly observed before/after regression or clear causal evidence, and `pre-existing` only with evidence it predates the PR (baseline/existing behavior). Lack of PR causation does **not** prove `pre-existing`. If neither is established, gather more evidence or do not report it -- it is not a blocking finding.
 
 ## Guidance
 

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -195,6 +195,10 @@ Before reporting any interaction failure, make sure the interaction itself was v
 
 2. **Click / navigation "failures"** -- before reporting a click or navigation as broken, `scrollintoview @ref`, wait for the layout to settle, take a fresh `snapshot -i` to get a current ref, and click that ref. If it still does not navigate, confirm the trusted event actually targeted the intended element (not `<html>` or an overlay from a layout shift or off-screen coordinate). If the target was wrong, classify it as a **driver/harness miss, not an app bug**.
 
+3. **Repeated labels/titles are not duplicate records** -- before reporting duplicate or repeated items (cards, rows, list entries), compare a stable identity: `href`, slug, or id. Distinct identities mean distinct records (usually seeded data) -- **no finding**. Report a duplicate only when the stable identity itself repeats.
+
+**Scope vs. causation.** A changed or touched file establishes *scope* (what to inspect), not that the PR caused an issue. Mark a finding `pr-caused` only with a directly observed before/after regression or clear causal evidence; otherwise classify it `pre-existing`.
+
 ## Guidance
 
 - **Repro is everything.** Every issue needs proof -- but match the evidence to the issue. Interactive bugs need video and step-by-step screenshots. Static bugs (typos, placeholder text, visual glitches visible on load) only need a single annotated screenshot.

--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -187,7 +187,7 @@ agent-browser --session {SESSION} close
 
 3. Tell the user the report is ready and summarize findings: total issues, breakdown by severity, and the most critical items.
 
-## Interaction validity (avoid false negatives)
+## Interaction validity (avoid false positives)
 
 Before reporting any interaction failure, make sure the interaction itself was valid. A driver mistake is not an app bug. These rules are mandatory:
 

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -1274,7 +1274,9 @@ jobs:
                entries, infer the SINGLE most likely URL the component affects and visit that.
             2. On each page: load via state, take ONE screenshot, scan console errors, interact briefly.
             3. Do NOT repeat scenarios already covered by qa-plan.md (if present).
-            4. CLASSIFY EVERY ISSUE: 'pr-caused' (file in git diff) or 'pre-existing' (not in diff).
+            4. CLASSIFY EVERY ISSUE 'pr-caused' or 'pre-existing'. A changed/touched file establishes SCOPE
+               (what to inspect), NOT causation. Mark 'pr-caused' ONLY with an observed before/after regression
+               or direct causal evidence; otherwise classify 'pre-existing'.
             5. Do NOT call 'gh issue create'. Write findings to dogfood-findings-\$SHARD_ID.json per the
                skill's CI Pipeline Mode schema (includes fingerprint field).
             6. Also write dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
@@ -1290,7 +1292,10 @@ jobs:
                'scrollintoview @ref', wait for layout to settle, take a fresh snapshot for a current ref, and click that.
                If it still does not navigate, confirm the trusted event targeted the intended element (not <html> or an
                overlay from a layout shift / off-screen coordinate). If the target was wrong, classify it as a driver/harness
-               miss, NOT an app bug."
+               miss, NOT an app bug.
+            11. EVIDENCE — duplicates: repeated labels/titles are NOT duplicate records. Before reporting duplicate or
+               repeated items (cards/rows/list entries), compare a stable identity (href/slug/id). Distinct identities =
+               distinct records (usually seeded data) — no finding. Report a duplicate only when the stable identity itself repeats."
         timeout-minutes: 10
 
       - name: Upload dogfood shard artifacts

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -1280,7 +1280,17 @@ jobs:
             6. Also write dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}
                where critical/high counts = PR-caused only.
             7. Do NOT post a separate PR comment.
-            8. If you hit the 6-min mark with 0 findings, write empty results JSON and exit cleanly — that is success."
+            8. If you hit the 6-min mark with 0 findings, write empty results JSON and exit cleanly — that is success.
+            9. INTERACTION VALIDITY — clearing inputs: never clear a React/controlled input with an empty fill
+               (agent-browser fill @ref with an empty value). An empty fill emits a single untrusted event that
+               React's value-tracker ignores, so the field and any derived URL/results do NOT change — a false
+               stale-state finding. To clear: focus (or click) the field, then 'press Control+a' and 'press Backspace',
+               and wait for the debounce before asserting URL/state/results. Prefer 'type' over 'fill' for entering text.
+            10. INTERACTION VALIDITY — click/navigation: before reporting a click or navigation failure, run
+               'scrollintoview @ref', wait for layout to settle, take a fresh snapshot for a current ref, and click that.
+               If it still does not navigate, confirm the trusted event targeted the intended element (not <html> or an
+               overlay from a layout shift / off-screen coordinate). If the target was wrong, classify it as a driver/harness
+               miss, NOT an app bug."
         timeout-minutes: 10
 
       - name: Upload dogfood shard artifacts

--- a/.github/workflows/qa-pipeline.yml
+++ b/.github/workflows/qa-pipeline.yml
@@ -1274,9 +1274,11 @@ jobs:
                entries, infer the SINGLE most likely URL the component affects and visit that.
             2. On each page: load via state, take ONE screenshot, scan console errors, interact briefly.
             3. Do NOT repeat scenarios already covered by qa-plan.md (if present).
-            4. CLASSIFY EVERY ISSUE 'pr-caused' or 'pre-existing'. A changed/touched file establishes SCOPE
-               (what to inspect), NOT causation. Mark 'pr-caused' ONLY with an observed before/after regression
-               or direct causal evidence; otherwise classify 'pre-existing'.
+            4. CLASSIFY EVERY ISSUE 'pr-caused' or 'pre-existing' — each needs its OWN evidence. A changed/touched
+               file establishes SCOPE (what to inspect), NOT causation. Mark 'pr-caused' ONLY with an observed
+               before/after regression or direct causal evidence. Mark 'pre-existing' ONLY with evidence it predates
+               the PR (baseline/existing behavior). Lack of PR causation does NOT prove pre-existing; if neither is
+               established, gather evidence or do NOT report it (not a blocking finding).
             5. Do NOT call 'gh issue create'. Write findings to dogfood-findings-\$SHARD_ID.json per the
                skill's CI Pipeline Mode schema (includes fingerprint field).
             6. Also write dogfood-results.json: {\"total\":N,\"critical\":N,\"high\":N,\"medium\":N,\"low\":N,\"preexisting\":N,\"blocking\":bool}

--- a/__tests__/app/projects-error.test.tsx
+++ b/__tests__/app/projects-error.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Tests for app/projects/error.tsx — the /projects route client error boundary.
+ *
+ * Covers the shared RouteErrorBoundary contract: accessible recovery UI, error
+ * digest display, a reset action, and a home link.
+ */
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProjectsError from "@/app/projects/error";
+import { renderWithProviders } from "../utils/render";
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <svg data-testid="alert-icon" className={className} />
+  ),
+  RefreshCw: ({ className }: { className?: string }) => (
+    <svg data-testid="refresh-icon" className={className} />
+  ),
+}));
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("ProjectsError boundary", () => {
+  const reset = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders an accessible error heading and recovery message", () => {
+    const error = Object.assign(new Error("boom"), { digest: undefined });
+    renderWithProviders(
+      <ProjectsError error={error as Error & { digest?: string }} reset={reset} />
+    );
+
+    expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeInTheDocument();
+    expect(screen.getByText(/please try again/i)).toBeInTheDocument();
+  });
+
+  it("calls reset when the Try again button is activated", async () => {
+    const user = userEvent.setup();
+    const error = Object.assign(new Error("boom"), { digest: undefined });
+    renderWithProviders(
+      <ProjectsError error={error as Error & { digest?: string }} reset={reset} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the error digest when present and omits it when absent", () => {
+    const withDigest = Object.assign(new Error("boom"), { digest: "ERR_PROJECTS_1" });
+    const { unmount } = renderWithProviders(<ProjectsError error={withDigest} reset={reset} />);
+    expect(screen.getByText(/ERR_PROJECTS_1/)).toBeInTheDocument();
+    unmount();
+
+    const noDigest = Object.assign(new Error("boom"), { digest: undefined });
+    renderWithProviders(
+      <ProjectsError error={noDigest as Error & { digest?: string }} reset={reset} />
+    );
+    expect(screen.queryByText(/Error ID:/)).not.toBeInTheDocument();
+  });
+
+  it("renders a home recovery link", () => {
+    const error = Object.assign(new Error("boom"), { digest: undefined });
+    renderWithProviders(
+      <ProjectsError error={error as Error & { digest?: string }} reset={reset} />
+    );
+
+    expect(screen.getByText(/go home/i).closest("a")).toHaveAttribute("href", "/");
+  });
+});

--- a/__tests__/app/projects-page-orchestration.test.tsx
+++ b/__tests__/app/projects-page-orchestration.test.tsx
@@ -1,0 +1,137 @@
+import { isValidElement, type ReactElement, Suspense } from "react";
+import { createMockProject } from "@/__tests__/factories/project.factory";
+import Projects from "@/app/projects/page";
+import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
+
+/**
+ * SSR /projects orchestration (ADR 0001 + Vercel async-defer). The page awaits
+ * and parses searchParams, renders the static shell immediately, and defers the
+ * single indexer fetch into a Suspense child that seeds ProjectsExplorer. Since
+ * an async server child cannot resume in a client render, the test invokes that
+ * child directly to prove: exactly one service call with the effective request,
+ * the exact seed/state props, and the rejection fallback (no seed).
+ */
+
+const { getExplorerProjectsPaginatedMock } = vi.hoisted(() => ({
+  getExplorerProjectsPaginatedMock: vi.fn(),
+}));
+
+vi.mock("@/services/projects-explorer.service", () => ({
+  getExplorerProjectsPaginated: getExplorerProjectsPaginatedMock,
+}));
+
+// The explorer is a heavy client component; stub the section exports so the
+// deferred child yields an inspectable element without loading them.
+vi.mock("@/components/Pages/Projects", () => ({
+  ProjectsExplorer: () => null,
+  ProjectsHeroSection: () => null,
+  ProjectsLoading: () => null,
+  ProjectsStatsSection: () => null,
+}));
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+const runPage = async (params: SearchParams): Promise<ReactElement> => {
+  const pageFn = Projects as unknown as (props: {
+    searchParams: Promise<SearchParams>;
+  }) => Promise<ReactElement>;
+  return pageFn({ searchParams: Promise.resolve(params) });
+};
+
+// Locate the deferred loader element inside the page's Suspense boundary.
+function findLoaderElement(page: ReactElement): ReactElement {
+  const children = (page.props as { children?: unknown }).children;
+  const list = Array.isArray(children) ? children : [children];
+  const suspense = list.find(
+    (child): child is ReactElement => isValidElement(child) && child.type === Suspense
+  );
+  if (!suspense) {
+    throw new Error("Suspense boundary not found in /projects page");
+  }
+  return (suspense.props as { children: ReactElement }).children;
+}
+
+// Invoke the async server child (the only place data is fetched) and return the
+// ProjectsExplorer element it renders.
+async function resolveExplorer(page: ReactElement): Promise<ReactElement> {
+  const loader = findLoaderElement(page);
+  const loaderFn = loader.type as (props: unknown) => Promise<ReactElement>;
+  return loaderFn(loader.props);
+}
+
+function buildResponse(): PaginatedProjectsResponse {
+  return {
+    payload: [createMockProject({ details: { title: "DAO Tooling", slug: "dao-tooling" } })],
+    pagination: {
+      totalCount: 120,
+      page: 3,
+      limit: PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
+      totalPages: 3,
+      nextPage: null,
+      prevPage: 2,
+      hasNextPage: false,
+      hasPrevPage: true,
+    },
+  };
+}
+
+describe("app/projects/page.tsx server orchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("awaits searchParams, fetches page 3 exactly once in the deferred child, and seeds the explorer", async () => {
+    const response = buildResponse();
+    getExplorerProjectsPaginatedMock.mockResolvedValueOnce(response);
+
+    const page = await runPage({
+      page: "3",
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: "true",
+    });
+    const explorer = await resolveExplorer(page);
+
+    // Exactly one server-side fetch, with the effective first-page request.
+    expect(getExplorerProjectsPaginatedMock).toHaveBeenCalledTimes(1);
+    expect(getExplorerProjectsPaginatedMock).toHaveBeenCalledWith({
+      search: "dao",
+      page: 3,
+      limit: PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
+      sortBy: "title",
+      sortOrder: "asc",
+      includeStats: true,
+      hasPayoutAddress: true,
+    });
+
+    const props = explorer.props as Record<string, unknown>;
+    expect(props.initialData).toEqual(response);
+    expect(props.initialState).toEqual({
+      page: 3,
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: true,
+    });
+  });
+
+  it("resolves the child with no seed but the full state when the deferred fetch rejects", async () => {
+    getExplorerProjectsPaginatedMock.mockRejectedValueOnce(new Error("indexer down"));
+
+    const page = await runPage({ page: "1" });
+    const explorer = await resolveExplorer(page);
+
+    expect(getExplorerProjectsPaginatedMock).toHaveBeenCalledTimes(1);
+    const props = explorer.props as Record<string, unknown>;
+    expect(props.initialData).toBeUndefined();
+    expect(props.initialState).toEqual({
+      page: 1,
+      q: "",
+      sortBy: "updatedAt",
+      sortOrder: "desc",
+      raisingFunds: false,
+    });
+  });
+});

--- a/__tests__/app/projects-page-orchestration.test.tsx
+++ b/__tests__/app/projects-page-orchestration.test.tsx
@@ -13,12 +13,17 @@ import type { PaginatedProjectsResponse } from "@/types/v2/project";
  * the exact seed/state props, and the rejection fallback (no seed).
  */
 
-const { getExplorerProjectsPaginatedMock } = vi.hoisted(() => ({
+const { getExplorerProjectsPaginatedMock, errorManagerMock } = vi.hoisted(() => ({
   getExplorerProjectsPaginatedMock: vi.fn(),
+  errorManagerMock: vi.fn(),
 }));
 
 vi.mock("@/services/projects-explorer.service", () => ({
   getExplorerProjectsPaginated: getExplorerProjectsPaginatedMock,
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: errorManagerMock,
 }));
 
 // The explorer is a heavy client component; stub the section exports so the
@@ -133,5 +138,39 @@ describe("app/projects/page.tsx server orchestration", () => {
       sortOrder: "desc",
       raisingFunds: false,
     });
+  });
+
+  it("reports the seed fetch failure via errorManager without leaking the query/user data", async () => {
+    const failure = new Error("indexer down");
+    getExplorerProjectsPaginatedMock.mockRejectedValueOnce(failure);
+
+    const page = await runPage({ q: "confidential search term", page: "2" });
+    await resolveExplorer(page);
+
+    expect(errorManagerMock).toHaveBeenCalledTimes(1);
+    const [message, error, extra] = errorManagerMock.mock.calls[0];
+    expect(typeof message).toBe("string");
+    expect(error).toBe(failure);
+    // The observability payload must not carry the user's query or request state.
+    const serializedExtra = JSON.stringify(extra ?? {});
+    expect(serializedExtra).not.toContain("confidential search term");
+    expect(extra).not.toHaveProperty("search");
+    expect(extra).not.toHaveProperty("q");
+    expect(extra).not.toHaveProperty("page");
+  });
+
+  it("does not call errorManager when the seed fetch succeeds", async () => {
+    getExplorerProjectsPaginatedMock.mockResolvedValueOnce(buildResponse());
+
+    const page = await runPage({
+      page: "3",
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: "true",
+    });
+    await resolveExplorer(page);
+
+    expect(errorManagerMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/app/route-file-structure.test.ts
+++ b/__tests__/app/route-file-structure.test.ts
@@ -156,7 +156,6 @@ const ERROR_LEGACY_ALLOWLIST: ReadonlySet<string> = new Set([
   "project/[projectId]/(profile)/impact",
   "project/[projectId]/(profile)/team",
   "project/[projectId]/updates",
-  "projects",
   "seeds",
   "seeds/fund",
   "stats",

--- a/__tests__/components/Pages/Projects/ProjectsExplorer-interactions.test.tsx
+++ b/__tests__/components/Pages/Projects/ProjectsExplorer-interactions.test.tsx
@@ -1,0 +1,228 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import { ProjectsExplorer } from "@/components/Pages/Projects/ProjectsExplorer";
+import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
+
+/**
+ * Interaction regressions for the /projects explorer (QA HIGHs):
+ *
+ * 1. Clearing the search input must clear ?q (and the results) immediately —
+ *    it previously stayed stale because the clear went through the same debounce
+ *    that a later render / the debounce-cleanup effect could cancel.
+ * 2. The crawlable "Next" control must be a plain native anchor so its click
+ *    performs a full SSR navigation instead of being client-intercepted once
+ *    hydrated (the observed QA swallow left the URL and cards on page 1).
+ */
+
+// Stateful nuqs mock: a shared store with a STABLE per-key setter (mirroring the
+// real nuqs `useCallback` setter) plus a subscription so setting a value
+// re-renders every consumer — exactly what drives the query to re-run.
+const nuqsStore = vi.hoisted(() => {
+  const values = new Map<string, string>();
+  const listeners = new Set<() => void>();
+  return {
+    values,
+    listeners,
+    notify() {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    reset() {
+      values.clear();
+    },
+  };
+});
+
+vi.mock("nuqs", async () => {
+  const React = await import("react");
+  return {
+    useQueryState: (key: string, options?: { defaultValue?: string }) => {
+      const [, force] = React.useReducer((count: number) => count + 1, 0);
+      React.useEffect(() => {
+        nuqsStore.listeners.add(force);
+        return () => {
+          nuqsStore.listeners.delete(force);
+        };
+      }, []);
+      const setterRef = React.useRef<(next: string | null) => Promise<URLSearchParams>>();
+      if (!setterRef.current) {
+        setterRef.current = (next: string | null) => {
+          if (next === null || next === undefined) {
+            nuqsStore.values.delete(key);
+          } else {
+            nuqsStore.values.set(key, next);
+          }
+          nuqsStore.notify();
+          return Promise.resolve(new URLSearchParams());
+        };
+      }
+      const value = nuqsStore.values.get(key) ?? options?.defaultValue ?? "";
+      return [value, setterRef.current];
+    },
+  };
+});
+
+// Record every hook invocation and return results that reflect the search so the
+// test can assert the query navigated (empty search -> "all", else "filtered").
+const hookMock = vi.hoisted(() => ({ fn: vi.fn() }));
+vi.mock("@/hooks/useProjectsExplorerInfinite", () => ({
+  useProjectsExplorerInfinite: hookMock.fn,
+}));
+
+// ProjectCard drags in heavy editor/image deps — replace with a sentinel.
+vi.mock("@/components/Pages/Projects/ProjectCard", () => ({
+  ProjectCard: ({ project }: { project: { uid: string; details?: { title?: string } } }) => (
+    <div data-testid="project-card">{project.details?.title ?? project.uid}</div>
+  ),
+}));
+
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: { removeQueries: vi.fn() },
+}));
+
+// Model the hydrated App-Router <Link>: once hydrated it intercepts the click
+// (preventDefault) to run a soft client-side navigation, which in the observed
+// QA swallowed pagination. Crawlable pagination must NOT depend on it — a native
+// anchor navigates regardless of hydration state — so the fixed component
+// renders a plain <a> and this mock is never reached.
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} data-nextlink="true" onClick={(event) => event.preventDefault()} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function hookResult(search: string) {
+  const filtered = search.length > 0;
+  return {
+    projects: [
+      {
+        uid: filtered ? "gardens-1" : "all-1",
+        details: {
+          title: filtered ? "Gardens Project" : "All Projects",
+          slug: filtered ? "gardens-1" : "all-1",
+        },
+      },
+    ],
+    totalCount: filtered ? 501 : 999,
+    isLoading: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isError: false,
+    hasNextPage: true,
+    fetchNextPage: vi.fn(),
+  };
+}
+
+function lastSearch(): string | undefined {
+  return hookMock.fn.mock.calls.at(-1)?.[0]?.search;
+}
+
+beforeEach(() => {
+  nuqsStore.reset();
+  vi.clearAllMocks();
+  hookMock.fn.mockImplementation((options: { search?: string }) =>
+    hookResult(options.search ?? "")
+  );
+});
+
+describe("ProjectsExplorer search clearing", () => {
+  it("clears ?q synchronously on empty input and re-runs the query with an empty search", () => {
+    vi.useFakeTimers();
+    try {
+      renderWithProviders(<ProjectsExplorer />);
+      const input = screen.getByRole("textbox", { name: /search projects/i });
+
+      // Type a query — the debounced write lands only after the debounce delay.
+      act(() => {
+        fireEvent.change(input, { target: { value: "gardens" } });
+      });
+      act(() => {
+        vi.advanceTimersByTime(PROJECTS_EXPLORER_CONSTANTS.DEBOUNCE_DELAY_MS + 1);
+      });
+      expect(nuqsStore.values.get("q")).toBe("gardens");
+      expect(lastSearch()).toBe("gardens");
+      expect(screen.getByText("501 projects found")).toBeInTheDocument();
+
+      // Clearing must take effect immediately, WITHOUT advancing timers, so a
+      // re-render or the debounce cleanup cannot cancel the pending clear.
+      act(() => {
+        fireEvent.change(input, { target: { value: "" } });
+      });
+
+      expect((input as HTMLInputElement).value).toBe("");
+      expect(nuqsStore.values.get("q")).toBeUndefined();
+      expect(lastSearch()).toBe("");
+      expect(screen.getByText("999 projects found")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("ProjectsExplorer crawlable Next navigation", () => {
+  const initialState = {
+    q: "",
+    sortBy: "updatedAt" as const,
+    sortOrder: "desc" as const,
+    raisingFunds: false,
+    page: 1,
+  };
+
+  const initialData: PaginatedProjectsResponse = {
+    payload: [],
+    pagination: {
+      totalCount: 999,
+      page: 1,
+      limit: 50,
+      totalPages: 20,
+      nextPage: 2,
+      prevPage: null,
+      hasNextPage: true,
+      hasPrevPage: false,
+    },
+  };
+
+  it("renders Next as a native anchor whose click is not swallowed (full navigation)", () => {
+    renderWithProviders(<ProjectsExplorer initialData={initialData} initialState={initialState} />);
+
+    const next = screen.getByRole("link", { name: /next/i });
+    expect(next).toHaveAttribute("href", "/projects?page=2#browse-projects");
+    expect(next.tagName).toBe("A");
+    // It must be a real native anchor, not the intercepting App-Router <Link>.
+    expect(next).not.toHaveAttribute("data-nextlink");
+
+    // Dispatch a real bubbling click and inspect the default AFTER React's
+    // delegated container listener has run. React attaches its click handler on
+    // the render container, so a one-shot listener on `document` (an ancestor)
+    // bubbles last and observes whether next/link (via React) already cancelled
+    // the default. A native anchor leaves it intact (browser does a full
+    // navigation); the stopper then calls preventDefault purely to suppress the
+    // jsdom navigation so the test stays quiet. Under the intercepting <Link>
+    // mock, React prevents the default before the stopper — so it records true.
+    let defaultPreventedBeforeStopper: boolean | null = null;
+    document.addEventListener(
+      "click",
+      (event) => {
+        defaultPreventedBeforeStopper = event.defaultPrevented;
+        event.preventDefault();
+      },
+      { once: true }
+    );
+    next.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(defaultPreventedBeforeStopper).toBe(false);
+  });
+});

--- a/__tests__/components/Pages/Projects/ProjectsExplorer-ssr.test.tsx
+++ b/__tests__/components/Pages/Projects/ProjectsExplorer-ssr.test.tsx
@@ -1,0 +1,271 @@
+import { screen } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { createMockProject } from "@/__tests__/factories/project.factory";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import { ProjectsExplorer } from "@/components/Pages/Projects/ProjectsExplorer";
+import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
+
+/**
+ * RED (ProjectsExplorer SSR seeding + crawlable pagination, ADR 0001). Pins the
+ * new optional seed/state props: when the live URL state matches initialState
+ * the component seeds the hook with InfiniteData {pages:[response]} + initialPage
+ * and renders the SSR cards synchronously as ordinary /project/<slug> anchors,
+ * plus visible Previous/Next Next.js links (with preserved filters and
+ * #browse-projects) derived from pagination metadata, while keeping Load More as
+ * progressive enhancement. A URL filter change away from initialState must drop
+ * the seed so a page-3 payload cannot bleed into another query.
+ *
+ * The current component takes no props, never seeds the hook, and renders no
+ * Previous/Next links, so these are behavioral REDs.
+ */
+
+interface InfiniteSeed {
+  pages: PaginatedProjectsResponse[];
+  pageParams: number[];
+}
+
+interface HookOptions {
+  search?: string;
+  sortBy?: ExplorerSortByOptions;
+  sortOrder?: ExplorerSortOrder;
+  hasPayoutAddress?: boolean;
+  initialData?: InfiniteSeed;
+  initialPage?: number;
+}
+
+const { useProjectsExplorerInfiniteMock } = vi.hoisted(() => ({
+  useProjectsExplorerInfiniteMock: vi.fn(),
+}));
+
+// The hook derives its output from the InfiniteData seed handed to it, so the
+// component's seeding decision is what drives the rendered projects/pagination.
+vi.mock("@/hooks/useProjectsExplorerInfinite", () => ({
+  useProjectsExplorerInfinite: useProjectsExplorerInfiniteMock,
+}));
+
+// nuqs query state backed by a mutable URL-state map the test can mutate.
+const urlState = new Map<string, string>();
+vi.mock("nuqs", () => ({
+  useQueryState: (key: string, options?: { defaultValue?: string }) => {
+    const value = urlState.get(key) ?? options?.defaultValue ?? "";
+    const setValue = (next: string | null) => {
+      if (next === null) {
+        urlState.delete(key);
+      } else {
+        urlState.set(key, next);
+      }
+      return Promise.resolve(new URLSearchParams());
+    };
+    return [value, setValue];
+  },
+}));
+
+vi.mock("@/components/Utilities/MarkdownPreview", () => ({
+  MarkdownPreview: ({ source }: { source: string }) => (
+    <span data-testid="markdown-preview">{source}</span>
+  ),
+}));
+
+vi.mock("@/components/Utilities/ProfilePicture", () => ({
+  ProfilePicture: ({ name }: { name: string }) => (
+    <span data-testid={`profile-pic-${name}`}>{name}</span>
+  ),
+}));
+
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: { removeQueries: vi.fn() },
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+type ExplorerState = {
+  page: number;
+  q: string;
+  sortBy: ExplorerSortByOptions;
+  sortOrder: ExplorerSortOrder;
+  raisingFunds: boolean;
+};
+
+interface ExplorerProps {
+  initialData?: PaginatedProjectsResponse;
+  initialState?: ExplorerState;
+}
+
+// The production component does not yet accept props — bridge to the seeded
+// signature this slice pins.
+const Explorer = ProjectsExplorer as unknown as ComponentType<ExplorerProps>;
+
+const FILTER_STATE = {
+  q: "dao",
+  sortBy: "title" as ExplorerSortByOptions,
+  sortOrder: "asc" as ExplorerSortOrder,
+  raisingFunds: true,
+};
+
+const FILTERED_QUERY = "q=dao&sortBy=title&sortOrder=asc&raisingFunds=true";
+
+function stateFor(page: number): ExplorerState {
+  return { page, ...FILTER_STATE };
+}
+
+function buildResponse(options: {
+  page: number;
+  totalPages: number;
+  hasNextPage: boolean;
+}): PaginatedProjectsResponse {
+  const { page, totalPages, hasNextPage } = options;
+  return {
+    payload: [
+      createMockProject({ details: { title: "DAO Tooling", slug: "dao-tooling" } }),
+      createMockProject({ details: { title: "DAO Ops", slug: "dao-ops" } }),
+    ],
+    pagination: {
+      totalCount: 250,
+      page,
+      limit: 50,
+      totalPages,
+      nextPage: hasNextPage ? page + 1 : null,
+      prevPage: page > 1 ? page - 1 : null,
+      hasNextPage,
+      hasPrevPage: page > 1,
+    },
+  };
+}
+
+function setMatchingUrl() {
+  urlState.set("q", "dao");
+  urlState.set("sortBy", "title");
+  urlState.set("sortOrder", "asc");
+  urlState.set("raisingFunds", "true");
+}
+
+function lastHookOptions(): HookOptions {
+  return useProjectsExplorerInfiniteMock.mock.calls.at(-1)?.[0] as HookOptions;
+}
+
+beforeEach(() => {
+  urlState.clear();
+  vi.clearAllMocks();
+  useProjectsExplorerInfiniteMock.mockImplementation((options: HookOptions) => {
+    const pages = options.initialData?.pages ?? [];
+    const projects = pages.flatMap((page) => page.payload);
+    const firstPage = pages[0];
+    const lastPage = pages[pages.length - 1];
+    return {
+      projects,
+      totalCount: firstPage?.pagination.totalCount ?? 0,
+      isLoading: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isError: false,
+      error: null,
+      hasNextPage: lastPage?.pagination.hasNextPage ?? false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    };
+  });
+});
+
+describe("ProjectsExplorer SSR seeding and crawlable pagination", () => {
+  it("seeds the hook and renders SSR cards plus filtered Previous/Next links for a matching page-3 state", () => {
+    setMatchingUrl();
+    const response = buildResponse({ page: 3, totalPages: 5, hasNextPage: true });
+
+    renderWithProviders(<Explorer initialData={response} initialState={stateFor(3)} />);
+
+    // Seeded the hook with wrapped InfiniteData and the start page.
+    const options = lastHookOptions();
+    expect(options.initialData).toEqual({ pages: [response], pageParams: [3] });
+    expect(options.initialPage).toBe(3);
+
+    // SSR cards render synchronously as ordinary project anchors.
+    const toolingLink = screen.getByRole("link", { name: /view dao tooling project details/i });
+    expect(toolingLink).toHaveAttribute("href", "/project/dao-tooling");
+    const opsLink = screen.getByRole("link", { name: /view dao ops project details/i });
+    expect(opsLink).toHaveAttribute("href", "/project/dao-ops");
+
+    // Crawlable Previous/Next preserve the effective filters and the anchor.
+    expect(screen.getByRole("link", { name: /previous/i })).toHaveAttribute(
+      "href",
+      `/projects?${FILTERED_QUERY}&page=2#browse-projects`
+    );
+    expect(screen.getByRole("link", { name: /next/i })).toHaveAttribute(
+      "href",
+      `/projects?${FILTERED_QUERY}&page=4#browse-projects`
+    );
+  });
+
+  it("omits Previous on page 1 and keeps Load More when more pages exist", () => {
+    setMatchingUrl();
+    const response = buildResponse({ page: 1, totalPages: 5, hasNextPage: true });
+
+    renderWithProviders(<Explorer initialData={response} initialState={stateFor(1)} />);
+
+    expect(screen.queryByRole("link", { name: /previous/i })).toBeNull();
+    expect(screen.getByRole("link", { name: /next/i })).toHaveAttribute(
+      "href",
+      `/projects?${FILTERED_QUERY}&page=2#browse-projects`
+    );
+    // Progressive enhancement: the Load More control stays.
+    expect(screen.getByRole("button", { name: /load more projects/i })).toBeInTheDocument();
+  });
+
+  it("omits Next on the final page while keeping Previous", () => {
+    setMatchingUrl();
+    const response = buildResponse({ page: 5, totalPages: 5, hasNextPage: false });
+
+    renderWithProviders(<Explorer initialData={response} initialState={stateFor(5)} />);
+
+    expect(screen.queryByRole("link", { name: /next/i })).toBeNull();
+    expect(screen.getByRole("link", { name: /previous/i })).toHaveAttribute(
+      "href",
+      `/projects?${FILTERED_QUERY}&page=4#browse-projects`
+    );
+  });
+
+  it("normalizes an invalid URL sort so neither the service nor the Select label sees it", () => {
+    urlState.set("sortBy", "not-a-sort");
+
+    renderWithProviders(<Explorer />);
+
+    // The service receives the normalized fallback, never the raw invalid value.
+    expect(lastHookOptions().sortBy).toBe("updatedAt");
+    // The Select shows the normalized label rather than an undefined value.
+    expect(screen.getByRole("combobox", { name: /sort projects by/i })).toHaveTextContent(
+      "Recently Updated"
+    );
+  });
+
+  it("drops the seed when the URL filter state changes away from initialState", () => {
+    setMatchingUrl();
+    const response = buildResponse({ page: 3, totalPages: 5, hasNextPage: true });
+
+    const { rerender } = renderWithProviders(
+      <Explorer initialData={response} initialState={stateFor(3)} />
+    );
+
+    // URL query moves away from the seeded state.
+    urlState.set("q", "governance");
+    rerender(<Explorer initialData={response} initialState={stateFor(3)} />);
+
+    const options = lastHookOptions();
+    expect(options.initialData).toBeUndefined();
+    expect(options.initialPage).toBe(1);
+  });
+});

--- a/__tests__/components/Pages/Projects/ProjectsExplorer-ssr.test.tsx
+++ b/__tests__/components/Pages/Projects/ProjectsExplorer-ssr.test.tsx
@@ -7,17 +7,15 @@ import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer"
 import type { PaginatedProjectsResponse } from "@/types/v2/project";
 
 /**
- * RED (ProjectsExplorer SSR seeding + crawlable pagination, ADR 0001). Pins the
- * new optional seed/state props: when the live URL state matches initialState
- * the component seeds the hook with InfiniteData {pages:[response]} + initialPage
- * and renders the SSR cards synchronously as ordinary /project/<slug> anchors,
- * plus visible Previous/Next Next.js links (with preserved filters and
- * #browse-projects) derived from pagination metadata, while keeping Load More as
- * progressive enhancement. A URL filter change away from initialState must drop
- * the seed so a page-3 payload cannot bleed into another query.
- *
- * The current component takes no props, never seeds the hook, and renders no
- * Previous/Next links, so these are behavioral REDs.
+ * ProjectsExplorer SSR seeding + crawlable pagination (ADR 0001). Pins the
+ * optional seed/state props the component accepts: when the live URL state
+ * matches initialState the component seeds the hook with InfiniteData
+ * {pages:[response]} + initialPage and renders the SSR cards synchronously as
+ * ordinary /project/<slug> anchors, plus visible Previous/Next Next.js links
+ * (with preserved filters and #browse-projects) derived from pagination
+ * metadata, while keeping Load More as progressive enhancement. A URL filter
+ * change away from initialState drops the seed so a page-3 payload cannot bleed
+ * into another query.
  */
 
 interface InfiniteSeed {

--- a/__tests__/hooks/useProjectsExplorerInfinite-ssr.test.ts
+++ b/__tests__/hooks/useProjectsExplorerInfinite-ssr.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockProject } from "@/__tests__/factories/project.factory";
+import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
+import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
+
+/**
+ * RED (SSR seeding for useProjectsExplorerInfinite, ADR 0001). Pins the new
+ * optional initialData/initialPage contract: a seed becomes the query's
+ * initialData (InfiniteData), initialPageParam and the query key adopt the start
+ * page, refetchOnMount is disabled so the SSR page is not re-fetched on mount,
+ * and the flattened projects/totalCount come from the seed. Without a seed the
+ * hook keeps its current behavior (page 1, no initialData, refetchOnMount
+ * always) but still keys on the start page so page-1 and page-3 stay distinct.
+ *
+ * useInfiniteQuery is mocked to capture the exact config without a network or a
+ * QueryClient; the hook is invoked directly through a typed compatibility cast.
+ */
+
+const { useInfiniteQueryMock, getExplorerProjectsPaginatedMock } = vi.hoisted(() => ({
+  useInfiniteQueryMock: vi.fn(),
+  getExplorerProjectsPaginatedMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual, useInfiniteQuery: useInfiniteQueryMock };
+});
+
+vi.mock("@/services/projects-explorer.service", () => ({
+  getExplorerProjectsPaginated: getExplorerProjectsPaginatedMock,
+}));
+
+import { useProjectsExplorerInfinite } from "@/hooks/useProjectsExplorerInfinite";
+
+interface ExtendedOptions {
+  search?: string;
+  sortBy?: ExplorerSortByOptions;
+  sortOrder?: ExplorerSortOrder;
+  limit?: number;
+  enabled?: boolean;
+  hasPayoutAddress?: boolean;
+  initialData?: unknown;
+  initialPage?: number;
+}
+
+interface HookResult {
+  projects: unknown[];
+  totalCount: number;
+}
+
+// The production hook does not yet accept initialData/initialPage — bridge to the
+// intended signature this slice pins.
+const callHook = useProjectsExplorerInfinite as unknown as (options: ExtendedOptions) => HookResult;
+
+const ACTIVE_FILTERS = {
+  search: "dao",
+  sortBy: "title" as ExplorerSortByOptions,
+  sortOrder: "asc" as ExplorerSortOrder,
+  hasPayoutAddress: true,
+};
+
+function buildResponse(): PaginatedProjectsResponse {
+  return {
+    payload: [
+      createMockProject({ details: { title: "DAO Tooling", slug: "dao-tooling" } }),
+      createMockProject({ details: { title: "DAO Ops", slug: "dao-ops" } }),
+    ],
+    pagination: {
+      totalCount: 137,
+      page: 3,
+      limit: PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
+      totalPages: 3,
+      nextPage: null,
+      prevPage: 2,
+      hasNextPage: false,
+      hasPrevPage: true,
+    },
+  };
+}
+
+function captureConfig(options: ExtendedOptions): {
+  result: HookResult;
+  config: Record<string, unknown>;
+} {
+  const result = callHook(options);
+  const config = useInfiniteQueryMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+  return { result, config };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // useInfiniteQuery echoes the config's initialData back as the query data, so
+  // the hook's flattening reflects whatever seed the config carries.
+  useInfiniteQueryMock.mockImplementation((config: { initialData?: unknown }) => ({
+    data: config.initialData,
+    isLoading: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+  }));
+});
+
+describe("useProjectsExplorerInfinite SSR seeding", () => {
+  describe("with a page-3 seed", () => {
+    it("adopts the seed as InfiniteData, keys/starts on page 3, and disables refetchOnMount", () => {
+      const response = buildResponse();
+      const { result, config } = captureConfig({
+        ...ACTIVE_FILTERS,
+        initialData: { pages: [response], pageParams: [3] },
+        initialPage: 3,
+      });
+
+      expect(config.initialData).toEqual({ pages: [response], pageParams: [3] });
+      expect(config.initialPageParam).toBe(3);
+      expect(config.refetchOnMount).toBe(false);
+      expect(config.queryKey).toContain(3);
+
+      // Flattened output comes from the seed.
+      expect(result.projects).toEqual(response.payload);
+      expect(result.totalCount).toBe(137);
+    });
+
+    it("still fetches later pages with the active filters through the captured queryFn", async () => {
+      const response = buildResponse();
+      getExplorerProjectsPaginatedMock.mockResolvedValue(response);
+
+      const { config } = captureConfig({
+        ...ACTIVE_FILTERS,
+        initialData: { pages: [response], pageParams: [3] },
+        initialPage: 3,
+      });
+
+      const queryFn = config.queryFn as (ctx: { pageParam: number }) => Promise<unknown>;
+      await queryFn({ pageParam: 4 });
+
+      expect(getExplorerProjectsPaginatedMock).toHaveBeenCalledTimes(1);
+      expect(getExplorerProjectsPaginatedMock).toHaveBeenCalledWith({
+        search: "dao",
+        page: 4,
+        limit: PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
+        sortBy: "title",
+        sortOrder: "asc",
+        includeStats: true,
+        hasPayoutAddress: true,
+      });
+    });
+  });
+
+  describe("without a seed", () => {
+    it("starts at page 1, carries no initialData, and keeps refetchOnMount always", () => {
+      const { config } = captureConfig({ ...ACTIVE_FILTERS });
+
+      expect(config.initialPageParam).toBe(1);
+      expect(config.initialData).toBeUndefined();
+      expect(config.refetchOnMount).toBe("always");
+      expect(config.queryKey).toContain(1);
+    });
+  });
+
+  it("keys page 1 and page 3 distinctly for the same filters", () => {
+    const response = buildResponse();
+
+    const page3 = captureConfig({
+      ...ACTIVE_FILTERS,
+      initialData: { pages: [response], pageParams: [3] },
+      initialPage: 3,
+    }).config.queryKey;
+
+    const page1 = captureConfig({ ...ACTIVE_FILTERS }).config.queryKey;
+
+    expect(page3).not.toEqual(page1);
+    expect(page3).toContain(3);
+    expect(page1).toContain(1);
+  });
+});

--- a/__tests__/hooks/useProjectsExplorerInfinite-ssr.test.ts
+++ b/__tests__/hooks/useProjectsExplorerInfinite-ssr.test.ts
@@ -5,12 +5,12 @@ import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer"
 import type { PaginatedProjectsResponse } from "@/types/v2/project";
 
 /**
- * RED (SSR seeding for useProjectsExplorerInfinite, ADR 0001). Pins the new
- * optional initialData/initialPage contract: a seed becomes the query's
- * initialData (InfiniteData), initialPageParam and the query key adopt the start
- * page, refetchOnMount is disabled so the SSR page is not re-fetched on mount,
- * and the flattened projects/totalCount come from the seed. Without a seed the
- * hook keeps its current behavior (page 1, no initialData, refetchOnMount
+ * SSR seeding for useProjectsExplorerInfinite (ADR 0001). Pins the optional
+ * initialData/initialPage contract now supported by the hook: a seed becomes the
+ * query's initialData (InfiniteData), initialPageParam and the query key adopt
+ * the start page, refetchOnMount is disabled so the SSR page is not re-fetched on
+ * mount, and the flattened projects/totalCount come from the seed. Without a seed
+ * the hook keeps its baseline behavior (page 1, no initialData, refetchOnMount
  * always) but still keys on the start page so page-1 and page-3 stay distinct.
  *
  * useInfiniteQuery is mocked to capture the exact config without a network or a

--- a/__tests__/integration/journeys/project-browsing.test.tsx
+++ b/__tests__/integration/journeys/project-browsing.test.tsx
@@ -290,7 +290,7 @@ describe("ProjectsExplorer - Project browsing & search", () => {
         name: /Search projects/i,
       });
       expect(searchInput).toBeInTheDocument();
-      expect(searchInput).toHaveAttribute("placeholder", "Search projects...");
+      expect(searchInput).toHaveAttribute("placeholder", "Search projects…");
     });
 
     it("allows user to type in search input", async () => {

--- a/__tests__/integration/pages/smoke/marketing-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/marketing-pages.test.tsx
@@ -1,6 +1,13 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
-import { isValidElement, type ReactElement, Suspense } from "react";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+} from "react";
 
 /**
  * Smoke tests for top-level marketing pages (landing pages composed of
@@ -316,24 +323,32 @@ describe("/seeds marketing pages", () => {
 
 describe("/projects explorer page", () => {
   it("renders hero, explorer, stats", async () => {
-    // Async server component that streams: the shell renders immediately while
-    // the explorer is deferred into a Suspense child. Render the shell, then
-    // resolve and render the deferred child (it cannot resume in a client tree).
+    // The page streams: the hero + stats shell render immediately while the
+    // explorer is an async server component deferred behind Suspense. Mounting
+    // that unresolved promise into a client render tree throws (React #482), so
+    // resolve the Suspense child to a concrete element FIRST, substitute it back
+    // into the page's children, and render the fully-synchronous tree exactly
+    // once. This still exercises the real page composition (hero, deferred
+    // explorer, stats) end to end.
     const { default: ProjectsPage } = await import("@/app/projects/page");
     const runAsyncPage = ProjectsPage as unknown as (props: {
       searchParams: Promise<Record<string, string | string[] | undefined>>;
     }) => Promise<ReactElement>;
 
     const page = await runAsyncPage({ searchParams: Promise.resolve({}) });
-    render(page);
 
-    const children = (page.props as { children?: unknown }).children;
-    const list = Array.isArray(children) ? children : [children];
-    const suspense = list.find(
-      (child): child is ReactElement => isValidElement(child) && child.type === Suspense
+    const children = Children.toArray((page.props as { children?: ReactNode }).children);
+    const resolvedChildren = await Promise.all(
+      children.map(async (child) => {
+        if (isValidElement(child) && child.type === Suspense) {
+          const loader = (child.props as { children: ReactElement }).children;
+          return (loader.type as (props: unknown) => Promise<ReactElement>)(loader.props);
+        }
+        return child;
+      })
     );
-    const loader = (suspense?.props as { children: ReactElement }).children;
-    render(await (loader.type as (props: unknown) => Promise<ReactElement>)(loader.props));
+
+    render(cloneElement(page, undefined, ...resolvedChildren));
 
     expect(screen.getByTestId("projects-hero")).toBeInTheDocument();
     expect(screen.getByTestId("projects-explorer")).toBeInTheDocument();

--- a/__tests__/integration/pages/smoke/marketing-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/marketing-pages.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import { isValidElement, type ReactElement, Suspense } from "react";
 
 /**
  * Smoke tests for top-level marketing pages (landing pages composed of
@@ -177,6 +178,24 @@ vi.mock("@/components/Pages/Projects", () => ({
   ProjectsStatsSection: () => <div data-testid="projects-stats" />,
 }));
 
+// The /projects page now fetches its first page server-side; stub the service so
+// the smoke render stays offline and deterministic.
+vi.mock("@/services/projects-explorer.service", () => ({
+  getExplorerProjectsPaginated: vi.fn().mockResolvedValue({
+    payload: [],
+    pagination: {
+      totalCount: 0,
+      page: 1,
+      limit: 50,
+      totalPages: 0,
+      nextPage: null,
+      prevPage: null,
+      hasNextPage: false,
+      hasPrevPage: false,
+    },
+  }),
+}));
+
 const renderPage = async (importer: () => Promise<{ default: React.ComponentType }>) => {
   const { default: Page } = await importer();
   return render(<Page />);
@@ -297,7 +316,25 @@ describe("/seeds marketing pages", () => {
 
 describe("/projects explorer page", () => {
   it("renders hero, explorer, stats", async () => {
-    await renderPage(() => import("@/app/projects/page"));
+    // Async server component that streams: the shell renders immediately while
+    // the explorer is deferred into a Suspense child. Render the shell, then
+    // resolve and render the deferred child (it cannot resume in a client tree).
+    const { default: ProjectsPage } = await import("@/app/projects/page");
+    const runAsyncPage = ProjectsPage as unknown as (props: {
+      searchParams: Promise<Record<string, string | string[] | undefined>>;
+    }) => Promise<ReactElement>;
+
+    const page = await runAsyncPage({ searchParams: Promise.resolve({}) });
+    render(page);
+
+    const children = (page.props as { children?: unknown }).children;
+    const list = Array.isArray(children) ? children : [children];
+    const suspense = list.find(
+      (child): child is ReactElement => isValidElement(child) && child.type === Suspense
+    );
+    const loader = (suspense?.props as { children: ReactElement }).children;
+    render(await (loader.type as (props: unknown) => Promise<ReactElement>)(loader.props));
+
     expect(screen.getByTestId("projects-hero")).toBeInTheDocument();
     expect(screen.getByTestId("projects-explorer")).toBeInTheDocument();
     expect(screen.getByTestId("projects-stats")).toBeInTheDocument();

--- a/__tests__/middleware-dashboard.test.ts
+++ b/__tests__/middleware-dashboard.test.ts
@@ -31,9 +31,11 @@ vi.mock("@/utilities/chosenCommunities", () => ({
   chosenCommunities: () => [],
 }));
 
-// Use a non-whitelabel host for standard middleware tests.
-// "localhost" is a whitelabel domain, so it would be caught by whitelabel logic.
-const STANDARD_HOST = "karmahq.xyz";
+// Use the canonical serving host for standard middleware tests. The apex
+// (karmahq.xyz) and gap.karmahq.xyz are now alias hosts that 308 to www under
+// the ADR 0001 canonical-host policy, so exercising the dashboard/whitelabel
+// behavior requires a request that is already on the canonical host.
+const STANDARD_HOST = "www.karmahq.xyz";
 
 const createRequest = (path: string) => createRequestWithHost(path, STANDARD_HOST);
 const primaryWhitelabel = WHITELABEL_DOMAINS[0];
@@ -106,37 +108,8 @@ describe("middleware dashboard redirects", () => {
   });
 });
 
-describe("middleware project URL-structure redirects", () => {
-  const uid = `0x${"a".repeat(64)}`;
-
-  it("permanently (308) redirects legacy /grants/:uid to /funding/:uid", async () => {
-    const response = await middleware(createRequest(`/project/karma/grants/${uid}`));
-
-    expect(response?.headers.get("location")).toBe(
-      `http://${STANDARD_HOST}/project/karma/funding/${uid}`
-    );
-    expect(response?.status).toBe(308);
-  });
-
-  it("permanently (308) redirects /funding/create-grant to /funding/new", async () => {
-    const response = await middleware(createRequest("/project/karma/funding/create-grant"));
-
-    expect(response?.headers.get("location")).toBe(
-      `http://${STANDARD_HOST}/project/karma/funding/new`
-    );
-    expect(response?.status).toBe(308);
-  });
-
-  it("redirects legacy /roadmap straight to the project overview (no chain) with 308", async () => {
-    const response = await middleware(createRequest("/project/karma/roadmap"));
-
-    expect(response?.headers.get("location")).toBe(`http://${STANDARD_HOST}/project/karma`);
-    expect(response?.status).toBe(308);
-  });
-
-  it("does not redirect a project literally named 'grants'", async () => {
-    const response = await middleware(createRequest("/project/grants"));
-
-    expect(response?.headers.get("location")).toBeNull();
-  });
-});
+// Legacy /project URL-structure normalization (grants → funding,
+// create-grant → new, roadmap collapse) is now driven by the authoritative
+// indexer decision and lives in middleware-indexability.test.ts, which stubs the
+// indexer fetch. The old standalone redirect block was removed so it can no
+// longer create redirect chains.

--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -1,0 +1,334 @@
+import type { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * RED (middleware indexability, ADR 0001, D1/D2/D6). Pins the intended behavior:
+ * apex/gap hosts single-hop 308 to www; project routes on www consult the
+ * indexer and apply the decision (X-Robots-Tag / gone status / redirect);
+ * stateful queries force noindex while tracking-only do not; failures fail
+ * closed. The current middleware has none of this, so these are behavioral REDs.
+ */
+
+// Deterministic next/server mock: returns real Response objects so the suite can
+// assert status + headers uniformly. NextResponse is a constructable subclass of
+// Response (so `new NextResponse(null, { status: 410 })` works for gone) carrying
+// the static redirect/next/rewrite helpers the middleware uses. The class is
+// declared inside the factory because vi.mock is hoisted above the module body.
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  class MockNextResponse extends Response {}
+  return {
+    ...actual,
+    NextResponse: Object.assign(MockNextResponse, {
+      redirect: (url: URL | string, status?: number) => {
+        const response = new Response(null, { status: status ?? 307 });
+        response.headers.set("location", url.toString());
+        return response;
+      },
+      next: (_opts?: unknown) => new Response(null, { status: 200 }),
+      rewrite: (url: URL, _opts?: unknown) => {
+        const response = new Response(null, { status: 200 });
+        response.headers.set("x-middleware-rewrite", url.toString());
+        return response;
+      },
+    }),
+  };
+});
+
+vi.mock("@/utilities/redirectHelpers", () => ({
+  shouldRedirectToGov: vi.fn(() => false),
+  redirectToGov: vi.fn(),
+}));
+
+vi.mock("@/utilities/chosenCommunities", () => ({
+  chosenCommunities: () => [],
+}));
+
+import { middleware } from "@/middleware";
+
+const INDEXER_BASE = "https://indexer.test";
+
+type Fetcher = (url: string, init: RequestInit) => Promise<Response>;
+const fetchMock = vi.fn<Fetcher>();
+
+function createRequest(host: string, path: string, query = ""): NextRequest {
+  const requestUrl = new URL(`https://${host}${path}${query ? `?${query}` : ""}`);
+  return {
+    nextUrl: {
+      pathname: requestUrl.pathname,
+      search: requestUrl.search,
+      searchParams: requestUrl.searchParams,
+      protocol: requestUrl.protocol,
+      host: requestUrl.host,
+      href: requestUrl.href,
+      clone: () => new URL(requestUrl.toString()),
+      toString: () => requestUrl.toString(),
+    },
+    headers: new Headers({ host }),
+    url: requestUrl.toString(),
+  } as unknown as NextRequest;
+}
+
+function decisionResponse(decision: unknown, status = 200): Response {
+  return new Response(JSON.stringify(decision), { status });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubEnv("NEXT_PUBLIC_GAP_INDEXER_URL", INDEXER_BASE);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("middleware indexability", () => {
+  it("308s an apex non-project request to www once, preserving path and query, without fetching", async () => {
+    const response = await middleware(createRequest("karmahq.xyz", "/about", "utm_source=x"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/about?utm_source=x");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("308s a gap.karmahq.xyz non-project request to www, preserving the path", async () => {
+    const response = await middleware(createRequest("gap.karmahq.xyz", "/funding-map"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/funding-map");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a www canonical-indexable project through without an X-Robots-Tag", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "canonical-indexable", url: "/project/paraswap" })
+    );
+
+    const response = await middleware(createRequest("www.karmahq.xyz", "/project/paraswap"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+    // Consulted the indexer exactly once at the canonical-root endpoint, via GET
+    // with an application/json Accept header. objectContaining tolerates the
+    // AbortController signal the client also passes.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://indexer.test/v2/projects/paraswap/indexability?route=root",
+      expect.objectContaining({
+        method: "GET",
+        headers: { Accept: "application/json" },
+      })
+    );
+  });
+
+  it("sets X-Robots-Tag noindex, follow for a noindex-follow decision", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "noindex-follow", url: "/project/paraswap/team" })
+    );
+
+    const response = await middleware(createRequest("www.karmahq.xyz", "/project/paraswap/team"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("forces X-Robots-Tag for a stateful query even when the decision is canonical-indexable", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "canonical-indexable", url: "/project/paraswap" })
+    );
+
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/paraswap", "programId=531")
+    );
+
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("does not set X-Robots-Tag for a tracking-only query on a canonical-indexable decision", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "canonical-indexable", url: "/project/paraswap" })
+    );
+
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/paraswap", "utm_source=x")
+    );
+
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it.each([404, 410])(
+    "returns HTTP %s with a noindex X-Robots-Tag for a gone decision",
+    async (status) => {
+      fetchMock.mockResolvedValue(new Response("gone", { status }));
+
+      const response = await middleware(createRequest("www.karmahq.xyz", "/project/paraswap"));
+
+      expect(response?.status).toBe(status);
+      expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    }
+  );
+
+  it("issues a 308 preserving the query for a redirect decision on www", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({
+        outcome: "redirect",
+        from: "/project/old-paraswap",
+        to: "/project/paraswap",
+      })
+    );
+
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/old-paraswap", "utm_source=x")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.karmahq.xyz/project/paraswap?utm_source=x"
+    );
+  });
+
+  it("collapses an apex old-identifier roadmap request into one 308 to the final www canonical root", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({
+        outcome: "redirect",
+        from: "/project/old-paraswap/roadmap",
+        to: "/project/paraswap",
+      })
+    );
+
+    const response = await middleware(
+      createRequest("karmahq.xyz", "/project/old-paraswap/roadmap")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/project/paraswap");
+  });
+
+  it("collapses a gap old-identifier legacy grants request into one 308 to the final www canonical funding path", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({
+        outcome: "redirect",
+        from: "/project/old-paraswap/funding",
+        to: "/project/paraswap/funding",
+      })
+    );
+
+    const response = await middleware(
+      createRequest("gap.karmahq.xyz", "/project/old-paraswap/grants")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.karmahq.xyz/project/paraswap/funding"
+    );
+  });
+
+  it("normalizes a canonical-host legacy funding/create-grant with a single 308 to www", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({
+        outcome: "noindex-follow",
+        url: "/project/paraswap/funding/new",
+      })
+    );
+
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/paraswap/funding/create-grant")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.karmahq.xyz/project/paraswap/funding/new"
+    );
+  });
+
+  it("keeps a duplicate-alias route usable without a noindex header", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({
+        outcome: "duplicate-alias",
+        url: "/project/paraswap/about",
+        canonicalUrl: "/project/paraswap",
+      })
+    );
+
+    const response = await middleware(createRequest("www.karmahq.xyz", "/project/paraswap/about"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+  });
+
+  it("treats a project literally named 'grants' as the identifier, not a legacy tab", async () => {
+    fetchMock.mockResolvedValue(
+      decisionResponse({ outcome: "canonical-indexable", url: "/project/grants" })
+    );
+
+    const response = await middleware(createRequest("www.karmahq.xyz", "/project/grants"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("location")).toBeNull();
+    // The identifier segment is queried as-is — no grants→funding rewrite.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://indexer.test/v2/projects/grants/indexability?route=root",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("fails closed with a noindex header when the indexer returns 5xx", async () => {
+    fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+
+    const response = await middleware(createRequest("www.karmahq.xyz", "/project/paraswap/team"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("marks the canonical /projects listing noindex, follow for a stateful query without fetching", async () => {
+    const response = await middleware(createRequest("www.karmahq.xyz", "/projects", "page=2"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the canonical /projects listing indexable for a tracking-only query without fetching", async () => {
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/projects", "utm_source=x")
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the clean canonical /projects listing indexable without fetching", async () => {
+    const response = await middleware(createRequest("www.karmahq.xyz", "/projects"));
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without fetching for an unknown project route", async () => {
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/paraswap/unknown-tab")
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("collapses an unknown project route on an alias host into one 308 to www without fetching", async () => {
+    const response = await middleware(
+      createRequest("gap.karmahq.xyz", "/project/paraswap/unknown-tab", "utm_source=x")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.karmahq.xyz/project/paraswap/unknown-tab?utm_source=x"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -332,3 +332,66 @@ describe("middleware indexability", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Canonical-host origin policy (ADR 0001). A normalized/relocated project path
+ * must be redirected on the *right* origin: only the real production alias hosts
+ * (karmahq.xyz / gap.karmahq.xyz) collapse onto https://www.karmahq.xyz; every
+ * other host — Vercel preview, staging, localhost, and the canonical www itself
+ * — keeps the redirect on its own origin so a preview normalization never leaks
+ * a link to production. The roadmap tab is a valid route, so its collapse to the
+ * canonical root comes from an indexer `redirect` decision.
+ */
+describe("middleware canonical-host origin policy", () => {
+  const roadmapCollapse = {
+    outcome: "redirect",
+    from: "/project/abc123-1/roadmap",
+    to: "/project/abc123-1",
+  };
+
+  it("redirects a Vercel-preview roadmap collapse on the request's own origin, not production www", async () => {
+    fetchMock.mockResolvedValue(decisionResponse(roadmapCollapse));
+
+    const response = await middleware(
+      createRequest("gap-app-v2-git-preview.vercel.app", "/project/abc123-1/roadmap")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://gap-app-v2-git-preview.vercel.app/project/abc123-1"
+    );
+  });
+
+  it("redirects a staging roadmap collapse on the staging origin, preserving the query", async () => {
+    fetchMock.mockResolvedValue(decisionResponse(roadmapCollapse));
+
+    const response = await middleware(
+      createRequest("staging.karmahq.xyz", "/project/abc123-1/roadmap", "utm_source=x")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://staging.karmahq.xyz/project/abc123-1?utm_source=x"
+    );
+  });
+
+  it("collapses an alias-host roadmap normalization into one hop to production www", async () => {
+    fetchMock.mockResolvedValue(decisionResponse(roadmapCollapse));
+
+    const response = await middleware(createRequest("karmahq.xyz", "/project/abc123-1/roadmap"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/project/abc123-1");
+  });
+
+  it("keeps a canonical-www roadmap normalization on www", async () => {
+    fetchMock.mockResolvedValue(decisionResponse(roadmapCollapse));
+
+    const response = await middleware(
+      createRequest("www.karmahq.xyz", "/project/abc123-1/roadmap")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/project/abc123-1");
+  });
+});

--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -101,6 +101,22 @@ describe("middleware indexability", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("treats a fully-qualified apex host with a trailing DNS dot (karmahq.xyz.) as an alias", async () => {
+    const response = await middleware(createRequest("karmahq.xyz.", "/about", "utm_source=x"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/about?utm_source=x");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a trailing-dot gap host (gap.karmahq.xyz.) as an alias", async () => {
+    const response = await middleware(createRequest("gap.karmahq.xyz.", "/funding-map"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/funding-map");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("passes a www canonical-indexable project through without an X-Robots-Tag", async () => {
     fetchMock.mockResolvedValue(
       decisionResponse({ outcome: "canonical-indexable", url: "/project/paraswap" })

--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -51,8 +51,8 @@ const INDEXER_BASE = "https://indexer.test";
 type Fetcher = (url: string, init: RequestInit) => Promise<Response>;
 const fetchMock = vi.fn<Fetcher>();
 
-function createRequest(host: string, path: string, query = ""): NextRequest {
-  const requestUrl = new URL(`https://${host}${path}${query ? `?${query}` : ""}`);
+function createRequest(host: string, path: string, query = "", scheme = "https"): NextRequest {
+  const requestUrl = new URL(`${scheme}://${host}${path}${query ? `?${query}` : ""}`);
   return {
     nextUrl: {
       pathname: requestUrl.pathname,
@@ -409,5 +409,18 @@ describe("middleware canonical-host origin policy", () => {
 
     expect(response?.status).toBe(308);
     expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/project/abc123-1");
+  });
+
+  it("normalizes a localhost:port roadmap collapse on its own origin, preserving scheme, host, and port", async () => {
+    fetchMock.mockResolvedValue(decisionResponse(roadmapCollapse));
+
+    const response = await middleware(
+      createRequest("localhost:3000", "/project/abc123-1/roadmap", "utm_source=x", "http")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "http://localhost:3000/project/abc123-1?utm_source=x"
+    );
   });
 });

--- a/__tests__/middleware-indexability.test.ts
+++ b/__tests__/middleware-indexability.test.ts
@@ -186,6 +186,35 @@ describe("middleware indexability", () => {
     }
   );
 
+  it.each([404, 410])(
+    "308s an apex-alias gone route (%s) to www instead of returning the status directly",
+    async (status) => {
+      // Every alias request owes exactly one hop to the canonical host — even a
+      // gone route. The canonical host re-evaluates and returns the 404/410; the
+      // alias host must not answer it directly (that would strand the response on
+      // a duplicate host).
+      fetchMock.mockResolvedValue(new Response("gone", { status }));
+
+      const response = await middleware(createRequest("karmahq.xyz", "/project/paraswap"));
+
+      expect(response?.status).toBe(308);
+      expect(response?.headers.get("location")).toBe("https://www.karmahq.xyz/project/paraswap");
+    }
+  );
+
+  it("308s a gap-alias gone route to www, preserving the path and query", async () => {
+    fetchMock.mockResolvedValue(new Response("gone", { status: 410 }));
+
+    const response = await middleware(
+      createRequest("gap.karmahq.xyz", "/project/paraswap/team", "utm_source=x")
+    );
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.karmahq.xyz/project/paraswap/team?utm_source=x"
+    );
+  });
+
   it("issues a 308 preserving the query for a redirect decision on www", async () => {
     fetchMock.mockResolvedValue(
       decisionResponse({

--- a/__tests__/utilities/project-indexability-client.test.ts
+++ b/__tests__/utilities/project-indexability-client.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildProjectIndexabilityEndpoint } from "@/utilities/project-indexability";
+import {
+  fetchProjectIndexabilityDecision,
+  parseProjectIndexabilityDecision,
+} from "@/utilities/project-indexability-client";
+
+/**
+ * RED (Edge-safe project indexability client, ADR 0001, D5). A strict runtime
+ * parser for the five backend decision outcomes, plus a fail-closed fetcher:
+ * 404/410 map to gone (even for non-JSON bodies); every other failure
+ * (5xx / invalid JSON / invalid shape / missing baseUrl / network / timeout)
+ * degrades to noindex-follow at the parsed normalizedPath. Framework-free so it
+ * runs on the Edge runtime; the fetcher is injected for testability.
+ */
+
+type Fetcher = (url: string, init: RequestInit) => Promise<Response>;
+
+const parsed = {
+  identifier: "paraswap",
+  query: { route: "team" as const },
+  normalizedPath: "/project/paraswap/team",
+};
+
+const BASE_URL = "https://api.example.com";
+const ENDPOINT = buildProjectIndexabilityEndpoint(BASE_URL, parsed);
+
+const FAIL_CLOSED = {
+  outcome: "noindex-follow",
+  url: parsed.normalizedPath,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("parseProjectIndexabilityDecision", () => {
+  const validDecisions: Array<{ name: string; value: unknown }> = [
+    {
+      name: "canonical-indexable",
+      value: { outcome: "canonical-indexable", url: "/project/paraswap" },
+    },
+    {
+      name: "duplicate-alias",
+      value: {
+        outcome: "duplicate-alias",
+        url: "/project/paraswap/about",
+        canonicalUrl: "/project/paraswap",
+      },
+    },
+    {
+      name: "noindex-follow",
+      value: { outcome: "noindex-follow", url: "/project/paraswap/team" },
+    },
+    {
+      name: "redirect",
+      value: {
+        outcome: "redirect",
+        from: "/project/old-paraswap",
+        to: "/project/paraswap",
+      },
+    },
+    { name: "gone 404", value: { outcome: "gone", status: 404 } },
+    { name: "gone 410", value: { outcome: "gone", status: 410 } },
+  ];
+
+  it.each(validDecisions)("parses the $name decision", ({ value }) => {
+    expect(parseProjectIndexabilityDecision(value)).toEqual(value);
+  });
+
+  const invalidDecisions: Array<{ name: string; value: unknown }> = [
+    { name: "unknown outcome", value: { outcome: "mystery", url: "/x" } },
+    {
+      name: "extra field",
+      value: { outcome: "noindex-follow", url: "/x", extra: 1 },
+    },
+    { name: "missing url", value: { outcome: "canonical-indexable" } },
+    {
+      name: "wrong-typed url",
+      value: { outcome: "canonical-indexable", url: 123 },
+    },
+    {
+      name: "duplicate-alias missing canonicalUrl",
+      value: { outcome: "duplicate-alias", url: "/x" },
+    },
+    { name: "redirect missing to", value: { outcome: "redirect", from: "/a" } },
+    { name: "gone bad status", value: { outcome: "gone", status: 200 } },
+    {
+      name: "gone with extra field",
+      value: { outcome: "gone", status: 404, url: "/x" },
+    },
+    { name: "null", value: null },
+    { name: "string", value: "noindex-follow" },
+    { name: "number", value: 42 },
+    { name: "array", value: [] },
+  ];
+
+  it.each(invalidDecisions)("rejects the $name input", ({ value }) => {
+    expect(parseProjectIndexabilityDecision(value)).toBeNull();
+  });
+});
+
+describe("fetchProjectIndexabilityDecision", () => {
+  it("GETs the exact endpoint with an application/json Accept header and returns a valid 200 decision", async () => {
+    const decision = {
+      outcome: "canonical-indexable",
+      url: "/project/paraswap/team",
+    };
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, decision));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(decision);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      ENDPOINT,
+      expect.objectContaining({
+        method: "GET",
+        headers: { Accept: "application/json" },
+      })
+    );
+  });
+
+  it.each([404, 410])(
+    "maps HTTP %s to gone with the same status even for a non-JSON body",
+    async (status) => {
+      const fetcher = vi.fn<Fetcher>(async () => new Response("Not Found", { status }));
+
+      const result = await fetchProjectIndexabilityDecision(parsed, {
+        baseUrl: BASE_URL,
+        fetcher,
+        timeoutMs: 5000,
+      });
+
+      expect(result).toEqual({ outcome: "gone", status });
+    }
+  );
+
+  it("fails closed to noindex-follow on a 5xx", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => new Response("boom", { status: 500 }));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+  });
+
+  it("fails closed when the 200 body is invalid JSON", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => new Response("{not-json", { status: 200 }));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+  });
+
+  it("fails closed when the 200 body has an invalid decision shape", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, { outcome: "mystery" }));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+  });
+
+  it("fails closed without fetching when baseUrl is missing", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, {}));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: "",
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a network error", async () => {
+    const fetcher = vi.fn<Fetcher>(async () => {
+      throw new Error("network down");
+    });
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(FAIL_CLOSED);
+  });
+
+  it("fails closed on timeout/abort", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn<Fetcher>(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        })
+    );
+
+    const promise = fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual(FAIL_CLOSED);
+  });
+
+  it.each<[string, number | undefined]>([
+    ["omitted", undefined],
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["positive Infinity", Number.POSITIVE_INFINITY],
+  ])("aborts at the 2500ms default for a %s timeoutMs", async (_name, timeoutMs) => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn<Fetcher>(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        })
+    );
+
+    const promise = fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs,
+    });
+    await vi.advanceTimersByTimeAsync(2500);
+
+    await expect(promise).resolves.toEqual(FAIL_CLOSED);
+  });
+
+  it("clears the timeout timer on success", async () => {
+    vi.useFakeTimers();
+    const decision = {
+      outcome: "noindex-follow",
+      url: "/project/paraswap/team",
+    };
+    const fetcher = vi.fn<Fetcher>(async () => jsonResponse(200, decision));
+
+    const result = await fetchProjectIndexabilityDecision(parsed, {
+      baseUrl: BASE_URL,
+      fetcher,
+      timeoutMs: 5000,
+    });
+
+    expect(result).toEqual(decision);
+    // A cleared timeout leaves no pending fake timers.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/__tests__/utilities/project-indexability-client.test.ts
+++ b/__tests__/utilities/project-indexability-client.test.ts
@@ -103,6 +103,66 @@ describe("parseProjectIndexabilityDecision", () => {
   it.each(invalidDecisions)("rejects the $name input", ({ value }) => {
     expect(parseProjectIndexabilityDecision(value)).toBeNull();
   });
+
+  // Every URL field is a redirect/canonical target the middleware concatenates
+  // with an origin, so a non-local value could produce a cross-origin 308. The
+  // parser must reject any authority, query, fragment, backslash, control char,
+  // or non-`/project/` path and fail closed.
+  const maliciousDecisions: Array<{ name: string; value: unknown }> = [
+    {
+      name: "redirect to a userinfo authority (@evil)",
+      value: { outcome: "redirect", from: "/project/x", to: "@evil.example/path" },
+    },
+    {
+      name: "redirect to a protocol-relative //host",
+      value: { outcome: "redirect", from: "/project/x", to: "//evil.example/x" },
+    },
+    {
+      name: "absolute http URL",
+      value: { outcome: "canonical-indexable", url: "https://evil.example/project/x" },
+    },
+    {
+      name: "non-project local path",
+      value: { outcome: "canonical-indexable", url: "/about" },
+    },
+    {
+      name: "url carrying a query string",
+      value: { outcome: "canonical-indexable", url: "/project/x?next=//evil" },
+    },
+    {
+      name: "url carrying a fragment",
+      value: { outcome: "noindex-follow", url: "/project/x#@evil" },
+    },
+    {
+      name: "url carrying a backslash",
+      value: { outcome: "canonical-indexable", url: "/project/x\\@evil.example" },
+    },
+    {
+      name: "url carrying an embedded newline",
+      value: { outcome: "canonical-indexable", url: "/project/x\nhttps://evil" },
+    },
+    {
+      name: "bare /project/ with no identifier",
+      value: { outcome: "canonical-indexable", url: "/project/" },
+    },
+    {
+      name: "duplicate-alias with a hostile canonicalUrl",
+      value: {
+        outcome: "duplicate-alias",
+        url: "/project/x/about",
+        canonicalUrl: "https://evil.example/project/x",
+      },
+    },
+  ];
+
+  it.each(maliciousDecisions)("rejects the non-local URL field: $name", ({ value }) => {
+    expect(parseProjectIndexabilityDecision(value)).toBeNull();
+  });
+
+  it("still accepts a well-formed local /project path with a hyphenated slug", () => {
+    const value = { outcome: "redirect", from: "/project/old-slug", to: "/project/new-slug" };
+    expect(parseProjectIndexabilityDecision(value)).toEqual(value);
+  });
 });
 
 describe("fetchProjectIndexabilityDecision", () => {

--- a/__tests__/utilities/project-indexability-client.test.ts
+++ b/__tests__/utilities/project-indexability-client.test.ts
@@ -153,6 +153,37 @@ describe("parseProjectIndexabilityDecision", () => {
         canonicalUrl: "https://evil.example/project/x",
       },
     },
+    // Dot-segment traversal: the `/project/` prefix passes, but resolving the
+    // value against an origin (`new URL`) collapses the `..` and escapes the
+    // route, so these must be rejected.
+    {
+      name: "literal ../ traversal escaping the route",
+      value: { outcome: "redirect", from: "/project/x", to: "/project/x/../../evil" },
+    },
+    {
+      name: "percent-encoded dot traversal (%2e%2e)",
+      value: { outcome: "canonical-indexable", url: "/project/%2e%2e/evil" },
+    },
+    {
+      name: "uppercase percent-encoded dot traversal (%2E%2E)",
+      value: { outcome: "canonical-indexable", url: "/project/x/%2E%2E/evil" },
+    },
+    {
+      name: "bare dot-segment path (/project/..)",
+      value: { outcome: "canonical-indexable", url: "/project/.." },
+    },
+    {
+      name: "encoded forward slash in a segment (%2F)",
+      value: { outcome: "canonical-indexable", url: "/project/a%2Fb" },
+    },
+    {
+      name: "lowercase encoded forward slash in a segment (%2f)",
+      value: { outcome: "redirect", from: "/project/x", to: "/project/a%2fb" },
+    },
+    {
+      name: "encoded backslash in a segment (%5C)",
+      value: { outcome: "canonical-indexable", url: "/project/a%5Cb" },
+    },
   ];
 
   it.each(maliciousDecisions)("rejects the non-local URL field: $name", ({ value }) => {
@@ -161,6 +192,11 @@ describe("parseProjectIndexabilityDecision", () => {
 
   it("still accepts a well-formed local /project path with a hyphenated slug", () => {
     const value = { outcome: "redirect", from: "/project/old-slug", to: "/project/new-slug" };
+    expect(parseProjectIndexabilityDecision(value)).toEqual(value);
+  });
+
+  it("accepts a multi-segment path whose segment carries a legitimate encoded space", () => {
+    const value = { outcome: "canonical-indexable", url: "/project/weird%20slug/about" };
     expect(parseProjectIndexabilityDecision(value)).toEqual(value);
   });
 });

--- a/__tests__/utilities/project-indexability.test.ts
+++ b/__tests__/utilities/project-indexability.test.ts
@@ -240,6 +240,11 @@ describe("parseProjectIndexabilityRequest identifier decoding", () => {
     "/project/a%2Fb", // encoded forward slash would span segments
     "/project/a%2fb", // lowercase encoded forward slash
     "/project/a%5Cb", // encoded backslash the URL parser folds to "/"
+    "/project/.", // literal single dot-segment identifier
+    "/project/..", // literal parent dot-segment identifier
+    "/project/%2e", // percent-encoded single dot
+    "/project/%2e%2e", // percent-encoded parent traversal
+    "/project/%2E%2E", // uppercase percent-encoded parent traversal
   ])("fails closed (null) for the malformed/traversal identifier %s", (pathname) => {
     expect(parseProjectIndexabilityRequest(pathname)).toBeNull();
   });

--- a/__tests__/utilities/project-indexability.test.ts
+++ b/__tests__/utilities/project-indexability.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectIndexabilityEndpoint,
+  classifyProjectQuery,
+  normalizeLegacyProjectPath,
+  parseProjectIndexabilityRequest,
+} from "@/utilities/project-indexability";
+
+/**
+ * RED (Edge-safe project-indexability utility, ADR 0001, D2/D6). Pins the pure
+ * functions the middleware/metadata layer will consume: legacy path
+ * normalization, request parsing into the strict indexer query vocabulary,
+ * query-param classification, and endpoint building. Framework-free so it runs
+ * on the Edge runtime.
+ */
+
+interface ParsedQuery {
+  route: string;
+  grantUid?: string;
+}
+
+interface ParsedRequest {
+  identifier: string;
+  query: ParsedQuery;
+  normalizedPath: string;
+}
+
+describe("normalizeLegacyProjectPath", () => {
+  it.each([
+    ["/project/paraswap/grants", "/project/paraswap/funding"],
+    ["/project/paraswap/grants/0xgrant", "/project/paraswap/funding/0xgrant"],
+    ["/project/paraswap/funding/create-grant", "/project/paraswap/funding/new"],
+    // A project literally named "grants" must not be corrupted: the identifier
+    // segment is left alone; only the tab segment is rewritten.
+    ["/project/grants", "/project/grants"],
+    ["/project/grants/grants", "/project/grants/funding"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizeLegacyProjectPath(input)).toBe(expected);
+  });
+});
+
+describe("parseProjectIndexabilityRequest", () => {
+  const cases: Array<{ pathname: string; expected: ParsedRequest }> = [
+    {
+      pathname: "/project/paraswap",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "root" },
+        normalizedPath: "/project/paraswap",
+      },
+    },
+    {
+      pathname: "/project/paraswap/about",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "about" },
+        normalizedPath: "/project/paraswap/about",
+      },
+    },
+    {
+      pathname: "/project/paraswap/roadmap",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "roadmap" },
+        normalizedPath: "/project/paraswap/roadmap",
+      },
+    },
+    {
+      pathname: "/project/paraswap/team",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "team" },
+        normalizedPath: "/project/paraswap/team",
+      },
+    },
+    {
+      pathname: "/project/paraswap/updates",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "updates" },
+        normalizedPath: "/project/paraswap/updates",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "funding" },
+        normalizedPath: "/project/paraswap/funding",
+      },
+    },
+    {
+      pathname: "/project/paraswap/impact",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "impact" },
+        normalizedPath: "/project/paraswap/impact",
+      },
+    },
+    {
+      pathname: "/project/paraswap/contact-info",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "contact-info" },
+        normalizedPath: "/project/paraswap/contact-info",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/new",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-new" },
+        normalizedPath: "/project/paraswap/funding/new",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/0xgrant",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-detail", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/0xgrant/edit",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-edit", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant/edit",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/0xgrant/complete-grant",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-complete", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant/complete-grant",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/0xgrant/milestones-and-updates",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-milestones-and-updates", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant/milestones-and-updates",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/0xgrant/impact-criteria",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-impact-criteria", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant/impact-criteria",
+      },
+    },
+    // Legacy paths are normalized directly by parse (grants -> funding,
+    // funding/create-grant -> funding/new) and classified accordingly.
+    {
+      pathname: "/project/paraswap/grants/0xgrant",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-detail", grantUid: "0xgrant" },
+        normalizedPath: "/project/paraswap/funding/0xgrant",
+      },
+    },
+    {
+      pathname: "/project/paraswap/funding/create-grant",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "grant-new" },
+        normalizedPath: "/project/paraswap/funding/new",
+      },
+    },
+    // Trailing slashes are stripped in normalizedPath.
+    {
+      pathname: "/project/paraswap/",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "root" },
+        normalizedPath: "/project/paraswap",
+      },
+    },
+    {
+      pathname: "/project/paraswap/team/",
+      expected: {
+        identifier: "paraswap",
+        query: { route: "team" },
+        normalizedPath: "/project/paraswap/team",
+      },
+    },
+  ];
+
+  it.each(cases)("parses $pathname", ({ pathname, expected }) => {
+    expect(parseProjectIndexabilityRequest(pathname)).toEqual(expected);
+  });
+
+  it.each([
+    "/project/paraswap/unknown-tab",
+    "/project/paraswap/funding/0xgrant/unknown-subpage",
+    "/project/paraswap/funding//edit",
+    "/communities/gitcoin",
+    "/project",
+    "/",
+  ])("returns null for the non-project path %s", (pathname) => {
+    expect(parseProjectIndexabilityRequest(pathname)).toBeNull();
+  });
+});
+
+describe("classifyProjectQuery", () => {
+  it("returns clean when there are no query params", () => {
+    expect(classifyProjectQuery(new URLSearchParams(""))).toBe("clean");
+  });
+
+  it("returns tracking-only when every param is a known tracking param", () => {
+    const params = new URLSearchParams(
+      "utm_source=a&utm_medium=b&utm_campaign=c&gclid=d&fbclid=e&msclkid=f&dclid=g"
+    );
+    expect(classifyProjectQuery(params)).toBe("tracking-only");
+  });
+
+  it("returns stateful when a non-tracking param exists", () => {
+    expect(classifyProjectQuery(new URLSearchParams("programId=531"))).toBe("stateful");
+  });
+
+  it("returns stateful when tracking params are mixed with a stateful param", () => {
+    expect(classifyProjectQuery(new URLSearchParams("utm_source=a&programId=1"))).toBe("stateful");
+  });
+});
+
+describe("buildProjectIndexabilityEndpoint", () => {
+  it("builds a root endpoint", () => {
+    const parsed: ParsedRequest = {
+      identifier: "paraswap",
+      query: { route: "root" },
+      normalizedPath: "/project/paraswap",
+    };
+
+    expect(buildProjectIndexabilityEndpoint("https://api.example.com", parsed)).toBe(
+      "https://api.example.com/v2/projects/paraswap/indexability?route=root"
+    );
+  });
+
+  it("builds a grant endpoint carrying grantUid", () => {
+    const parsed: ParsedRequest = {
+      identifier: "paraswap",
+      query: { route: "grant-detail", grantUid: "0xgrant" },
+      normalizedPath: "/project/paraswap/funding/0xgrant",
+    };
+
+    expect(buildProjectIndexabilityEndpoint("https://api.example.com", parsed)).toBe(
+      "https://api.example.com/v2/projects/paraswap/indexability?route=grant-detail&grantUid=0xgrant"
+    );
+  });
+
+  it("percent-encodes the identifier segment", () => {
+    const parsed: ParsedRequest = {
+      identifier: "weird slug",
+      query: { route: "root" },
+      normalizedPath: "/project/weird slug",
+    };
+
+    expect(buildProjectIndexabilityEndpoint("https://api.example.com", parsed)).toBe(
+      "https://api.example.com/v2/projects/weird%20slug/indexability?route=root"
+    );
+  });
+
+  it("does not double the slash when the base URL has a trailing slash", () => {
+    const parsed: ParsedRequest = {
+      identifier: "paraswap",
+      query: { route: "root" },
+      normalizedPath: "/project/paraswap",
+    };
+
+    expect(buildProjectIndexabilityEndpoint("https://api.example.com/", parsed)).toBe(
+      "https://api.example.com/v2/projects/paraswap/indexability?route=root"
+    );
+  });
+});

--- a/__tests__/utilities/project-indexability.test.ts
+++ b/__tests__/utilities/project-indexability.test.ts
@@ -206,6 +206,45 @@ describe("parseProjectIndexabilityRequest", () => {
   });
 });
 
+describe("parseProjectIndexabilityRequest identifier decoding", () => {
+  it("decodes a %20 identifier exactly once and re-encodes it in normalizedPath", () => {
+    expect(parseProjectIndexabilityRequest("/project/weird%20slug")).toEqual({
+      identifier: "weird slug",
+      query: { route: "root" },
+      normalizedPath: "/project/weird%20slug",
+    });
+  });
+
+  it("decodes exactly once — a %2520 identifier yields a literal %20, not a space", () => {
+    const parsed = parseProjectIndexabilityRequest("/project/%2520");
+    expect(parsed).not.toBeNull();
+    if (!parsed) {
+      return;
+    }
+    expect(parsed).toEqual({
+      identifier: "%20",
+      query: { route: "root" },
+      normalizedPath: "/project/%2520",
+    });
+    // Endpoint construction re-encodes the single-decoded identifier exactly
+    // once (no double-decode), so the indexer sees the same %2520 segment.
+    expect(buildProjectIndexabilityEndpoint("https://api.example.com", parsed)).toBe(
+      "https://api.example.com/v2/projects/%2520/indexability?route=root"
+    );
+  });
+
+  it.each([
+    "/project/%", // lone percent
+    "/project/%zz", // non-hex escape
+    "/project/50%", // truncated escape
+    "/project/a%2Fb", // encoded forward slash would span segments
+    "/project/a%2fb", // lowercase encoded forward slash
+    "/project/a%5Cb", // encoded backslash the URL parser folds to "/"
+  ])("fails closed (null) for the malformed/traversal identifier %s", (pathname) => {
+    expect(parseProjectIndexabilityRequest(pathname)).toBeNull();
+  });
+});
+
 describe("classifyProjectQuery", () => {
   it("returns clean when there are no query params", () => {
     expect(classifyProjectQuery(new URLSearchParams(""))).toBe("clean");

--- a/__tests__/utilities/projects-explorer-request.test.ts
+++ b/__tests__/utilities/projects-explorer-request.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+import {
+  buildProjectsPageHref,
+  parseProjectsExplorerRequest,
+} from "@/utilities/projects-explorer-request";
+
+/**
+ * RED (pure projects-explorer request parser + crawlable page href builder,
+ * ADR 0001). Pins the contract for the not-yet-created module
+ * utilities/projects-explorer-request.ts: strict parsing of Next search-param
+ * records into an effective explorer request, and a deterministic href builder
+ * that preserves only non-default filters, encodes values, orders params
+ * predictably, omits page for page 1, and always targets #browse-projects.
+ *
+ * The production module does not exist yet, so importing it fails — the whole
+ * suite is a missing-module RED.
+ */
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+interface ProjectsExplorerState {
+  page: number;
+  q: string;
+  sortBy: ExplorerSortByOptions;
+  sortOrder: ExplorerSortOrder;
+  raisingFunds: boolean;
+}
+
+const DEFAULT_STATE: ProjectsExplorerState = {
+  page: 1,
+  q: "",
+  sortBy: "updatedAt",
+  sortOrder: "desc",
+  raisingFunds: false,
+};
+
+const VALID_SORT_BY: ExplorerSortByOptions[] = [
+  "createdAt",
+  "updatedAt",
+  "title",
+  "noOfGrants",
+  "noOfProjectMilestones",
+  "noOfGrantMilestones",
+];
+
+describe("parseProjectsExplorerRequest", () => {
+  it("returns the default effective state for an empty record", () => {
+    expect(parseProjectsExplorerRequest({})).toEqual(DEFAULT_STATE);
+  });
+
+  it("parses a fully-populated record into its effective state", () => {
+    const input: SearchParams = {
+      page: "3",
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: "true",
+    };
+
+    expect(parseProjectsExplorerRequest(input)).toEqual({
+      page: 3,
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: true,
+    });
+  });
+
+  describe("page", () => {
+    it.each([
+      ["1", 1],
+      ["3", 3],
+      ["42", 42],
+      ["999", 999],
+    ])("accepts digits-only positive integer %s", (raw, expected) => {
+      expect(parseProjectsExplorerRequest({ page: raw }).page).toBe(expected);
+    });
+
+    it.each<[string, SearchParams]>([
+      ["zero", { page: "0" }],
+      ["negative", { page: "-1" }],
+      ["decimal", { page: "1.5" }],
+      ["exponent", { page: "1e3" }],
+      ["leading whitespace", { page: " 2" }],
+      ["surrounding whitespace", { page: " 2 " }],
+      ["empty string", { page: "" }],
+      ["non-numeric", { page: "abc" }],
+      ["above MAX_SAFE_INTEGER", { page: "9007199254740992" }],
+      ["array", { page: ["2"] }],
+      ["undefined", { page: undefined }],
+    ])("falls back to 1 for %s", (_name, input) => {
+      expect(parseProjectsExplorerRequest(input).page).toBe(1);
+    });
+  });
+
+  describe("q", () => {
+    it("keeps a string query", () => {
+      expect(parseProjectsExplorerRequest({ q: "dao" }).q).toBe("dao");
+    });
+
+    it("falls back to empty for an array query", () => {
+      expect(parseProjectsExplorerRequest({ q: ["a", "b"] }).q).toBe("");
+    });
+
+    it("falls back to empty for an undefined query", () => {
+      expect(parseProjectsExplorerRequest({ q: undefined }).q).toBe("");
+    });
+  });
+
+  describe("sortBy", () => {
+    it.each(VALID_SORT_BY)("accepts the valid sortBy %s", (value) => {
+      expect(parseProjectsExplorerRequest({ sortBy: value }).sortBy).toBe(value);
+    });
+
+    it.each<[string, SearchParams]>([
+      ["unknown value", { sortBy: "popularity" }],
+      ["array", { sortBy: ["title"] }],
+      ["undefined", { sortBy: undefined }],
+    ])("defaults to updatedAt for %s", (_name, input) => {
+      expect(parseProjectsExplorerRequest(input).sortBy).toBe("updatedAt");
+    });
+  });
+
+  describe("sortOrder", () => {
+    it.each<[ExplorerSortOrder]>([["asc"], ["desc"]])("accepts %s", (value) => {
+      expect(parseProjectsExplorerRequest({ sortOrder: value }).sortOrder).toBe(value);
+    });
+
+    it.each<[string, SearchParams]>([
+      ["uppercase", { sortOrder: "ASC" }],
+      ["unknown value", { sortOrder: "sideways" }],
+      ["array", { sortOrder: ["asc"] }],
+      ["undefined", { sortOrder: undefined }],
+    ])("defaults to desc for %s", (_name, input) => {
+      expect(parseProjectsExplorerRequest(input).sortOrder).toBe("desc");
+    });
+  });
+
+  describe("raisingFunds", () => {
+    it("is true only for the literal string 'true'", () => {
+      expect(parseProjectsExplorerRequest({ raisingFunds: "true" }).raisingFunds).toBe(true);
+    });
+
+    it.each<[string, SearchParams]>([
+      ["false", { raisingFunds: "false" }],
+      ["one", { raisingFunds: "1" }],
+      ["uppercase TRUE", { raisingFunds: "TRUE" }],
+      ["array", { raisingFunds: ["true"] }],
+      ["undefined", { raisingFunds: undefined }],
+    ])("is false for %s", (_name, input) => {
+      expect(parseProjectsExplorerRequest(input).raisingFunds).toBe(false);
+    });
+  });
+});
+
+describe("buildProjectsPageHref", () => {
+  it("builds the bare canonical href for the default state at page 1", () => {
+    expect(buildProjectsPageHref(DEFAULT_STATE, 1)).toBe("/projects#browse-projects");
+  });
+
+  it("adds only page for a later page when no filters are active", () => {
+    expect(buildProjectsPageHref(DEFAULT_STATE, 2)).toBe("/projects?page=2#browse-projects");
+  });
+
+  it("omits page at target 1 while preserving active filters", () => {
+    const state: ProjectsExplorerState = { ...DEFAULT_STATE, q: "dao" };
+    expect(buildProjectsPageHref(state, 1)).toBe("/projects?q=dao#browse-projects");
+  });
+
+  it("preserves all non-default filters in deterministic order with page last for a later page", () => {
+    const state: ProjectsExplorerState = {
+      page: 1,
+      q: "dao",
+      sortBy: "title",
+      sortOrder: "asc",
+      raisingFunds: true,
+    };
+
+    expect(buildProjectsPageHref(state, 3)).toBe(
+      "/projects?q=dao&sortBy=title&sortOrder=asc&raisingFunds=true&page=3#browse-projects"
+    );
+  });
+
+  it("omits default-valued filters (updatedAt / desc / empty q / raisingFunds false)", () => {
+    const state: ProjectsExplorerState = { ...DEFAULT_STATE, sortBy: "noOfGrants" };
+    expect(buildProjectsPageHref(state, 1)).toBe("/projects?sortBy=noOfGrants#browse-projects");
+  });
+
+  it("URL-encodes filter values", () => {
+    const state: ProjectsExplorerState = { ...DEFAULT_STATE, q: "grant dao" };
+    expect(buildProjectsPageHref(state, 1)).toBe("/projects?q=grant%20dao#browse-projects");
+  });
+});

--- a/app/projects/error.tsx
+++ b/app/projects/error.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { RouteErrorBoundary as default } from "@/src/components/shared/route-error-boundary";

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,6 +6,7 @@ import {
   ProjectsStatsSection,
 } from "@/components/Pages/Projects";
 import { CollectionPageJsonLd } from "@/components/Seo/CollectionPageJsonLd";
+import { errorManager } from "@/components/Utilities/errorManager";
 import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
 import { getExplorerProjectsPaginated } from "@/services/projects-explorer.service";
 import type { PaginatedProjectsResponse } from "@/types/v2/project";
@@ -66,7 +67,15 @@ async function ProjectsExplorerLoader({ initialState }: { initialState: Projects
       includeStats: true,
       hasPayoutAddress: initialState.raisingFunds,
     });
-  } catch {
+  } catch (error) {
+    // Fail closed: degrade to a client-only render (React Query retries with no
+    // seed). Record the failure through the shared Sentry pipeline for
+    // observability, with a route-scoped context that deliberately omits the
+    // request query / user data (transient network/gateway errors are dropped
+    // inside errorManager, so this stays quiet under normal upstream blips).
+    errorManager("SSR /projects seed fetch failed; degrading to client render", error, {
+      context: "app/projects/page",
+    });
     initialData = undefined;
   }
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,7 +6,15 @@ import {
   ProjectsStatsSection,
 } from "@/components/Pages/Projects";
 import { CollectionPageJsonLd } from "@/components/Seo/CollectionPageJsonLd";
+import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
+import { getExplorerProjectsPaginated } from "@/services/projects-explorer.service";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
 import { customMetadata } from "@/utilities/meta";
+import {
+  type ProjectsExplorerSearchParams,
+  type ProjectsExplorerState,
+  parseProjectsExplorerRequest,
+} from "@/utilities/projects-explorer-request";
 
 export const metadata = customMetadata({
   title: "Explore Grant-Funded Projects",
@@ -15,7 +23,16 @@ export const metadata = customMetadata({
   path: "/projects",
 });
 
-export default function Projects() {
+export default async function Projects({
+  searchParams,
+}: {
+  searchParams: Promise<ProjectsExplorerSearchParams>;
+}) {
+  // Parse the request up front, then stream: the hero + JSON-LD render
+  // immediately while the indexer fetch is deferred into the Suspense boundary
+  // below (Vercel async-defer guidance). The route never blocks on the network.
+  const initialState = parseProjectsExplorerRequest(await searchParams);
+
   return (
     <main className="flex flex-col w-full">
       <CollectionPageJsonLd
@@ -25,9 +42,33 @@ export default function Projects() {
       />
       <ProjectsHeroSection />
       <Suspense fallback={<ProjectsLoading />}>
-        <ProjectsExplorer />
+        <ProjectsExplorerLoader initialState={initialState} />
       </Suspense>
       <ProjectsStatsSection />
     </main>
   );
+}
+
+/**
+ * Deferred data boundary: the only place the first page is fetched. A failure
+ * degrades to a client-only render (no seed) so React Query can retry; the
+ * effective request state is always handed to the explorer.
+ */
+async function ProjectsExplorerLoader({ initialState }: { initialState: ProjectsExplorerState }) {
+  let initialData: PaginatedProjectsResponse | undefined;
+  try {
+    initialData = await getExplorerProjectsPaginated({
+      search: initialState.q,
+      page: initialState.page,
+      limit: PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
+      sortBy: initialState.sortBy,
+      sortOrder: initialState.sortOrder,
+      includeStats: true,
+      hasPayoutAddress: initialState.raisingFunds,
+    });
+  } catch {
+    initialData = undefined;
+  }
+
+  return <ProjectsExplorer initialData={initialData} initialState={initialState} />;
 }

--- a/components/Pages/Admin/AllProjects/Contacts.tsx
+++ b/components/Pages/Admin/AllProjects/Contacts.tsx
@@ -71,6 +71,7 @@ export const ProjectContacts: FC<ContactsProps> = ({ contacts }) => {
       {contacts.length > 2 ? (
         <div className="flex w-full justify-start items-start">
           <button
+            type="button"
             onClick={() => setIsContactExpanded(!isContactExpanded)}
             className="rounded-md flex flex-row items-center text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 disabled:opacity-35 hover:opacity-75 transition-all ease-in-out duration-300 px-0 py-0 bg-transparent text-blue-500 underline hover:bg-transparent dark:hover:bg-transparent"
           >

--- a/components/Pages/Admin/MilestonesReview/index.tsx
+++ b/components/Pages/Admin/MilestonesReview/index.tsx
@@ -550,22 +550,24 @@ function MilestonesReviewPageContent({
     return `Program ${parsedProgramId}`;
   }, [data?.grantMilestones, parsedProgramId]);
 
+  // Canonical application detail URL for admins/reviewers (null otherwise)
+  const applicationDetailUrl = useMemo(
+    () =>
+      referenceNumber && (hasAdminAccess || isReviewer)
+        ? PAGES.MANAGE.FUNDING_PLATFORM.APPLICATION_DETAIL(
+            communityId,
+            parsedProgramId,
+            referenceNumber
+          )
+        : null,
+    [referenceNumber, hasAdminAccess, isReviewer, communityId, parsedProgramId]
+  );
+
   // Memoized back button configuration
   const backButtonConfig = useMemo(() => {
     // Only show back to application if came from application page
-    if (referrer === "application" && referenceNumber) {
-      const appUrl =
-        hasAdminAccess || isReviewer
-          ? PAGES.MANAGE.FUNDING_PLATFORM.APPLICATION_DETAIL(
-              communityId,
-              parsedProgramId,
-              referenceNumber
-            )
-          : null;
-
-      if (appUrl) {
-        return { url: appUrl, label: "Back to Application" };
-      }
+    if (referrer === "application" && applicationDetailUrl) {
+      return { url: applicationDetailUrl, label: "Back to Application" };
     }
 
     // Default: back to milestones report
@@ -573,40 +575,13 @@ function MilestonesReviewPageContent({
       url: PAGES.ADMIN.MILESTONES(communityId),
       label: "Back to Milestones Report",
     };
-  }, [
-    referrer,
-    referenceNumber,
-    hasAdminAccess,
-    isReviewer,
-    communityId,
-    programId,
-    parsedProgramId,
-  ]);
+  }, [referrer, applicationDetailUrl, communityId]);
 
   // Memoized milestone review URL - only returns URL if application is approved
-  const milestoneReviewUrl = useMemo(() => {
-    if (fundingApplication?.status?.toLowerCase() === "approved" && referenceNumber) {
-      const appUrl =
-        hasAdminAccess || isReviewer
-          ? PAGES.MANAGE.FUNDING_PLATFORM.APPLICATION_DETAIL(
-              communityId,
-              parsedProgramId,
-              referenceNumber
-            )
-          : null;
-
-      return appUrl;
-    }
-    return null;
-  }, [
-    fundingApplication?.status,
-    referenceNumber,
-    hasAdminAccess,
-    isReviewer,
-    communityId,
-    programId,
-    parsedProgramId,
-  ]);
+  const milestoneReviewUrl = useMemo(
+    () => (fundingApplication?.status?.toLowerCase() === "approved" ? applicationDetailUrl : null),
+    [fundingApplication?.status, applicationDetailUrl]
+  );
 
   const { verifyMilestone, isVerifying, completeMilestone, isCompleting } =
     useMilestoneCompletionVerification({

--- a/components/Pages/MyProjects/EmptyProjectsState.tsx
+++ b/components/Pages/MyProjects/EmptyProjectsState.tsx
@@ -179,5 +179,3 @@ export const EmptyProjectsState: FC<EmptyProjectsStateProps> = ({ onStartWalkthr
     </div>
   );
 };
-
-export default EmptyProjectsState;

--- a/components/Pages/MyProjects/EmptyProjectsState.tsx
+++ b/components/Pages/MyProjects/EmptyProjectsState.tsx
@@ -160,6 +160,7 @@ export const EmptyProjectsState: FC<EmptyProjectsStateProps> = ({ onStartWalkthr
             }}
           />
           <button
+            type="button"
             onClick={onStartWalkthrough}
             className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-transparent border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 font-semibold rounded-md transition-all duration-200 w-full sm:w-auto"
           >

--- a/components/Pages/NewProjects/Loading.tsx
+++ b/components/Pages/NewProjects/Loading.tsx
@@ -54,22 +54,23 @@ const ProjectCardSkeleton = ({ index }: { index: number }) => {
   );
 };
 
+const CARD_SKELETON_KEYS = Array.from({ length: 12 }, (_, i) => `project-card-skeleton-${i}`);
+const PROGRAM_SKELETON_KEYS = Array.from({ length: 6 }, (_, i) => `program-filter-skeleton-${i}`);
+
 export const ProjectCardListSkeleton = () => {
-  const cardArray = Array.from({ length: 12 }, (_, index) => index);
   return (
     <div className="grid grid-cols-4 w-full gap-4 max-[1600px]:grid-cols-4 max-[1500px]:grid-cols-3 max-[1100px]:grid-cols-2 max-sm:grid-cols-1">
-      {cardArray.map((_, index) => (
-        <ProjectCardSkeleton key={index} index={index} />
+      {CARD_SKELETON_KEYS.map((key, index) => (
+        <ProjectCardSkeleton key={key} index={index} />
       ))}
     </div>
   );
 };
 export const FilterByProgramsSkeleton = () => {
-  const programsArray = Array.from({ length: 6 }, (_, index) => index);
   return (
     <div className="flex flex-col gap-2 w-full">
-      {programsArray.map((_, index) => (
-        <Skeleton key={index} className={"h-7 w-full"} />
+      {PROGRAM_SKELETON_KEYS.map((key) => (
+        <Skeleton key={key} className={"h-7 w-full"} />
       ))}
     </div>
   );

--- a/components/Pages/Projects/CrawlablePagination.tsx
+++ b/components/Pages/Projects/CrawlablePagination.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import {
   buildProjectsPageHref,
   type ProjectsExplorerState,
@@ -17,9 +16,14 @@ const LINK_CLASS =
   "px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors";
 
 /**
- * Crawlable pagination — ordinary Next.js `<Link>` anchors bots can follow
- * without JavaScript. Rendered only in SSR mode; the Load More button in
- * ProjectsExplorer remains the progressive-enhancement path for humans.
+ * Crawlable pagination — plain native `<a>` anchors that bots and users can
+ * follow with a full SSR navigation. Once hydrated, a Next.js `<Link>`
+ * client-intercepts the click to do a soft navigation, and in the observed QA
+ * that interception swallowed it (the URL and cards stayed on the current page).
+ * A native anchor guarantees a real full navigation regardless of hydration
+ * state, so we deliberately use ordinary anchors here. Rendered only in SSR
+ * mode; the Load More button in ProjectsExplorer remains the client-side
+ * progressive-enhancement path for humans.
  */
 export const CrawlableProjectsPagination = ({
   hrefState,
@@ -34,22 +38,22 @@ export const CrawlableProjectsPagination = ({
   return (
     <nav aria-label="Pagination" className="flex justify-center items-center gap-4 py-8">
       {hasPrev && (
-        <Link
+        <a
           href={buildProjectsPageHref(hrefState, effectivePage - 1)}
           rel="prev"
           className={LINK_CLASS}
         >
           Previous
-        </Link>
+        </a>
       )}
       {hasNext && (
-        <Link
+        <a
           href={buildProjectsPageHref(hrefState, effectivePage + 1)}
           rel="next"
           className={LINK_CLASS}
         >
           Next
-        </Link>
+        </a>
       )}
     </nav>
   );

--- a/components/Pages/Projects/CrawlablePagination.tsx
+++ b/components/Pages/Projects/CrawlablePagination.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import {
+  buildProjectsPageHref,
+  type ProjectsExplorerState,
+} from "@/utilities/projects-explorer-request";
+
+interface CrawlableProjectsPaginationProps {
+  /** Effective request state used to build the preserved-filter hrefs. */
+  hrefState: ProjectsExplorerState;
+  /** The current SSR page the crawlable links are relative to. */
+  effectivePage: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+const LINK_CLASS =
+  "px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors";
+
+/**
+ * Crawlable pagination — ordinary Next.js `<Link>` anchors bots can follow
+ * without JavaScript. Rendered only in SSR mode; the Load More button in
+ * ProjectsExplorer remains the progressive-enhancement path for humans.
+ */
+export const CrawlableProjectsPagination = ({
+  hrefState,
+  effectivePage,
+  hasPrev,
+  hasNext,
+}: CrawlableProjectsPaginationProps) => {
+  if (!hasPrev && !hasNext) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Pagination" className="flex justify-center items-center gap-4 py-8">
+      {hasPrev && (
+        <Link
+          href={buildProjectsPageHref(hrefState, effectivePage - 1)}
+          rel="prev"
+          className={LINK_CLASS}
+        >
+          Previous
+        </Link>
+      )}
+      {hasNext && (
+        <Link
+          href={buildProjectsPageHref(hrefState, effectivePage + 1)}
+          rel="next"
+          className={LINK_CLASS}
+        >
+          Next
+        </Link>
+      )}
+    </nav>
+  );
+};

--- a/components/Pages/Projects/HeroSection.tsx
+++ b/components/Pages/Projects/HeroSection.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { CreateProjectButton } from "@/src/features/homepage/components/create-project-button";
-import { PAGES } from "@/utilities/pages";
 
 const HERO_ICONS = [
   { emoji: "💖", id: "support", bgColor: "bg-[#FDE3FF]" },
@@ -45,8 +44,8 @@ export const ProjectsHeroSection = () => {
         Discover projects. Evaluate track records and traction. Fund with confidence
       </p>
 
-      {/* Title - Display xl/Bold: 60px, 700, 72px line height, -2% letter spacing */}
-      <h1 className="text-[60px] leading-[72px] font-bold text-center text-black dark:text-white tracking-[-0.02em] mb-5">
+      {/* Title - Display xl: 60px, 72px line height, -2% letter spacing */}
+      <h1 className="text-[60px] leading-[72px] font-semibold text-center text-black dark:text-white tracking-[-0.02em] mb-5">
         Projects on Karma
       </h1>
 
@@ -59,6 +58,7 @@ export const ProjectsHeroSection = () => {
       {/* Buttons */}
       <div className="flex gap-4 mb-4">
         <button
+          type="button"
           onClick={handleScrollToProjects}
           className="px-5 py-2 border border-brand-blue text-brand-blue dark:border-zinc-600 rounded-sm font-medium hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors dark:text-white h-[40px]"
         >

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -117,6 +117,15 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputValue(value);
+    if (value === "") {
+      // Clearing must take effect immediately. Cancel any pending debounced write
+      // and clear the URL synchronously, otherwise the next render or the
+      // debounce-cleanup effect can cancel the queued clear and leave a stale ?q
+      // (and stale results) behind.
+      debouncedSetSearch.cancel();
+      setSearchQuery(null);
+      return;
+    }
     debouncedSetSearch(value);
   };
 

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -4,7 +4,6 @@ import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/24/solid";
 import type { InfiniteData } from "@tanstack/react-query";
 import debounce from "lodash.debounce";
-import Link from "next/link";
 import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -19,11 +18,11 @@ import { useProjectsExplorerInfinite } from "@/hooks/useProjectsExplorerInfinite
 import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
 import type { PaginatedProjectsResponse } from "@/types/v2/project";
 import {
-  buildProjectsPageHref,
   type ProjectsExplorerState,
   parseProjectsExplorerRequest,
 } from "@/utilities/projects-explorer-request";
 import { queryClient } from "@/utilities/query-client";
+import { CrawlableProjectsPagination } from "./CrawlablePagination";
 import { ProjectsLoading } from "./Loading";
 import { ProjectCard } from "./ProjectCard";
 
@@ -198,7 +197,7 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <div>
-          <h2 className="text-2xl font-bold text-black dark:text-white">Projects on Karma</h2>
+          <h2 className="text-2xl font-semibold text-black dark:text-white">Projects on Karma</h2>
           {!isLoading && totalCount > 0 && (
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
               {totalCount.toLocaleString()} {totalCount === 1 ? "project" : "projects"} found
@@ -214,7 +213,7 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
             <input
               type="text"
               aria-label="Search projects"
-              placeholder="Search projects..."
+              placeholder="Search projects…"
               value={inputValue}
               onChange={handleSearchChange}
               className="w-full sm:w-64 pl-10 pr-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
@@ -225,6 +224,7 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
           <label className="flex items-center gap-2 cursor-pointer select-none">
             <input
               type="checkbox"
+              aria-label="Filter to projects raising funds"
               checked={isPayoutAddressFilterActive}
               onChange={() => setHasPayoutAddress(isPayoutAddressFilterActive ? null : "true")}
               className="sr-only peer"
@@ -321,36 +321,18 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
             ))}
           </div>
 
-          {/* Crawlable pagination — ordinary links bots can follow without JS.
-              Rendered only in SSR mode; the Load More button below remains the
-              progressive-enhancement path for humans. */}
-          {(hasCrawlablePrev || hasCrawlableNext) && (
-            <nav aria-label="Pagination" className="flex justify-center items-center gap-4 py-8">
-              {hasCrawlablePrev && (
-                <Link
-                  href={buildProjectsPageHref(hrefState, effectivePage - 1)}
-                  rel="prev"
-                  className="px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
-                >
-                  Previous
-                </Link>
-              )}
-              {hasCrawlableNext && (
-                <Link
-                  href={buildProjectsPageHref(hrefState, effectivePage + 1)}
-                  rel="next"
-                  className="px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
-                >
-                  Next
-                </Link>
-              )}
-            </nav>
-          )}
+          <CrawlableProjectsPagination
+            hrefState={hrefState}
+            effectivePage={effectivePage}
+            hasPrev={hasCrawlablePrev}
+            hasNext={hasCrawlableNext}
+          />
 
           {/* Load More Button */}
           {hasNextPage && (
             <div className="flex justify-center py-8">
               <button
+                type="button"
                 onClick={() => fetchNextPage()}
                 disabled={isFetchingNextPage}
                 className="px-6 py-3 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
@@ -358,7 +340,7 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
                 {isFetchingNextPage ? (
                   <>
                     <div className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                    Loading...
+                    Loading…
                   </>
                 ) : (
                   "Load More Projects"
@@ -380,7 +362,7 @@ export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorer
       {isFetching && !isLoading && !isFetchingNextPage && (
         <div className="fixed bottom-4 right-4 bg-blue-500 text-white px-4 py-2 rounded-lg shadow-lg text-sm flex items-center gap-2">
           <div className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-          Updating...
+          Updating…
         </div>
       )}
     </section>

--- a/components/Pages/Projects/ProjectsExplorer.tsx
+++ b/components/Pages/Projects/ProjectsExplorer.tsx
@@ -2,7 +2,9 @@
 
 import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/24/solid";
+import type { InfiniteData } from "@tanstack/react-query";
 import debounce from "lodash.debounce";
+import Link from "next/link";
 import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -15,6 +17,12 @@ import {
 import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
 import { useProjectsExplorerInfinite } from "@/hooks/useProjectsExplorerInfinite";
 import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+import type { PaginatedProjectsResponse } from "@/types/v2/project";
+import {
+  buildProjectsPageHref,
+  type ProjectsExplorerState,
+  parseProjectsExplorerRequest,
+} from "@/utilities/projects-explorer-request";
 import { queryClient } from "@/utilities/query-client";
 import { ProjectsLoading } from "./Loading";
 import { ProjectCard } from "./ProjectCard";
@@ -28,7 +36,14 @@ const sortOptions: Record<ExplorerSortByOptions, string> = {
   noOfGrantMilestones: "No. of Milestones",
 };
 
-export const ProjectsExplorer = () => {
+interface ProjectsExplorerProps {
+  /** Server-rendered first page for the initial (matching) request. */
+  initialData?: PaginatedProjectsResponse;
+  /** Effective request the server rendered, used to gate the seed. */
+  initialState?: ProjectsExplorerState;
+}
+
+export const ProjectsExplorer = ({ initialData, initialState }: ProjectsExplorerProps = {}) => {
   const sectionRef = useRef<HTMLElement>(null);
   const hasScrolledRef = useRef(false);
 
@@ -106,6 +121,31 @@ export const ProjectsExplorer = () => {
     debouncedSetSearch(value);
   };
 
+  // Normalize the live URL filters with the shared policy so the seed decision
+  // matches exactly what the server parsed.
+  const normalizedState = parseProjectsExplorerRequest({
+    q: searchQuery,
+    sortBy: selectedSort,
+    sortOrder: selectedSortOrder,
+    raisingFunds: hasPayoutAddress,
+  });
+
+  const matchesInitialState =
+    initialState !== undefined &&
+    normalizedState.q === initialState.q &&
+    normalizedState.sortBy === initialState.sortBy &&
+    normalizedState.sortOrder === initialState.sortOrder &&
+    normalizedState.raisingFunds === initialState.raisingFunds;
+
+  // When the live filters still match the server request, start from its page so
+  // even a failed server fetch retries the same page client-side; otherwise
+  // reset to page 1 so a stale seed cannot bleed into a different query.
+  const effectivePage = matchesInitialState && initialState ? initialState.page : 1;
+  const seededData: InfiniteData<PaginatedProjectsResponse, number> | undefined =
+    matchesInitialState && initialData
+      ? { pages: [initialData], pageParams: [effectivePage] }
+      : undefined;
+
   // Infinite query
   const {
     projects,
@@ -117,11 +157,24 @@ export const ProjectsExplorer = () => {
     hasNextPage,
     fetchNextPage,
   } = useProjectsExplorerInfinite({
-    search: searchQuery,
-    sortBy: selectedSort as ExplorerSortByOptions,
-    sortOrder: selectedSortOrder as ExplorerSortOrder,
-    hasPayoutAddress: isPayoutAddressFilterActive,
+    // Feed the service normalized values so an invalid URL param can never reach
+    // the indexer or diverge from the seed decision.
+    search: normalizedState.q,
+    sortBy: normalizedState.sortBy,
+    sortOrder: normalizedState.sortOrder,
+    hasPayoutAddress: normalizedState.raisingFunds,
+    initialData: seededData,
+    initialPage: effectivePage,
   });
+
+  // Crawlable pagination: only meaningful in SSR mode (initialState present).
+  // Derived from the effective page and the total pages so bots can follow
+  // Previous/Next without JavaScript.
+  const totalPages = Math.ceil(totalCount / PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT);
+  const hrefState: ProjectsExplorerState = { ...normalizedState, page: effectivePage };
+  const showCrawlablePagination = initialState !== undefined && projects.length > 0;
+  const hasCrawlablePrev = showCrawlablePagination && effectivePage > 1;
+  const hasCrawlableNext = showCrawlablePagination && effectivePage < totalPages;
 
   // Handle sort change
   const changeSort = async (newValue: ExplorerSortByOptions) => {
@@ -202,7 +255,7 @@ export const ProjectsExplorer = () => {
             </label>
             <div className="flex items-center gap-1">
               <Select
-                value={selectedSort}
+                value={normalizedState.sortBy}
                 onValueChange={(value) => {
                   changeSort(value as ExplorerSortByOptions);
                 }}
@@ -212,7 +265,7 @@ export const ProjectsExplorer = () => {
                   aria-label="Sort projects by"
                   className="w-48 bg-white dark:bg-zinc-800 dark:text-zinc-200 border-gray-300 dark:border-zinc-700"
                 >
-                  <SelectValue>{sortOptions[selectedSort as ExplorerSortByOptions]}</SelectValue>
+                  <SelectValue>{sortOptions[normalizedState.sortBy]}</SelectValue>
                 </SelectTrigger>
                 <SelectContent className="bg-white dark:bg-zinc-800">
                   {Object.keys(sortOptions).map((sortOption) => (
@@ -228,11 +281,13 @@ export const ProjectsExplorer = () => {
               </Select>
               <button
                 type="button"
-                onClick={() => setSelectedSortOrder(selectedSortOrder === "asc" ? "desc" : "asc")}
-                aria-label={`Sort ${selectedSortOrder === "asc" ? "descending" : "ascending"}`}
+                onClick={() =>
+                  setSelectedSortOrder(normalizedState.sortOrder === "asc" ? "desc" : "asc")
+                }
+                aria-label={`Sort ${normalizedState.sortOrder === "asc" ? "descending" : "ascending"}`}
                 className="p-2 rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 hover:bg-gray-50 dark:hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
               >
-                {selectedSortOrder === "asc" ? (
+                {normalizedState.sortOrder === "asc" ? (
                   <ArrowUpIcon className="h-4 w-4 text-gray-600 dark:text-gray-400" />
                 ) : (
                   <ArrowDownIcon className="h-4 w-4 text-gray-600 dark:text-gray-400" />
@@ -265,6 +320,32 @@ export const ProjectsExplorer = () => {
               <ProjectCard key={project.uid} project={project} index={index} />
             ))}
           </div>
+
+          {/* Crawlable pagination — ordinary links bots can follow without JS.
+              Rendered only in SSR mode; the Load More button below remains the
+              progressive-enhancement path for humans. */}
+          {(hasCrawlablePrev || hasCrawlableNext) && (
+            <nav aria-label="Pagination" className="flex justify-center items-center gap-4 py-8">
+              {hasCrawlablePrev && (
+                <Link
+                  href={buildProjectsPageHref(hrefState, effectivePage - 1)}
+                  rel="prev"
+                  className="px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
+                >
+                  Previous
+                </Link>
+              )}
+              {hasCrawlableNext && (
+                <Link
+                  href={buildProjectsPageHref(hrefState, effectivePage + 1)}
+                  rel="next"
+                  className="px-4 py-2 rounded-md border border-gray-300 dark:border-zinc-700 text-sm font-medium text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors"
+                >
+                  Next
+                </Link>
+              )}
+            </nav>
+          )}
 
           {/* Load More Button */}
           {hasNextPage && (

--- a/components/Pages/Projects/SearchBar.tsx
+++ b/components/Pages/Projects/SearchBar.tsx
@@ -33,7 +33,7 @@ export const ProjectsSearchBar = ({
     };
   }, [debouncedSearch]);
 
-  const handleChange = useCallback(
+  const handleSearchInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       setValue(newValue);
@@ -49,7 +49,7 @@ export const ProjectsSearchBar = ({
         type="text"
         aria-label="Search projects"
         value={value}
-        onChange={handleChange}
+        onChange={handleSearchInputChange}
         placeholder={placeholder}
         className="w-full pl-10 pr-4 py-2.5 border border-gray-300 dark:border-zinc-600 rounded-lg bg-white dark:bg-zinc-800 text-gray-900 dark:text-zinc-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
       />

--- a/components/Pages/Projects/StatsSection.tsx
+++ b/components/Pages/Projects/StatsSection.tsx
@@ -82,8 +82,8 @@ export const ProjectsStatsSection = () => {
 
         {/* Stats Grid */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-          {displayStats.map((stat, index) => (
-            <div key={index} className="flex flex-col items-center">
+          {displayStats.map((stat) => (
+            <div key={stat.label} className="flex flex-col items-center">
               <span
                 className={`text-4xl md:text-5xl font-bold text-teal-500 dark:text-teal-400 ${
                   isLoading ? "animate-pulse" : ""

--- a/components/Pages/Projects/index.ts
+++ b/components/Pages/Projects/index.ts
@@ -1,6 +1,5 @@
 export { ProjectsHeroSection } from "./HeroSection";
 export { ProjectsLoading } from "./Loading";
-export { ProjectCard } from "./ProjectCard";
 export { ProjectsExplorer } from "./ProjectsExplorer";
 export { ProjectsSearchBar } from "./SearchBar";
 export { ProjectsStatsSection } from "./StatsSection";

--- a/hooks/useProjectsExplorerInfinite.ts
+++ b/hooks/useProjectsExplorerInfinite.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { type InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
 import { PROJECTS_EXPLORER_CONSTANTS } from "@/constants/projects-explorer";
 import { getExplorerProjectsPaginated } from "@/services/projects-explorer.service";
 import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
@@ -14,6 +14,10 @@ interface UseProjectsExplorerInfiniteOptions {
   limit?: number;
   enabled?: boolean;
   hasPayoutAddress?: boolean;
+  /** SSR seed: the server-rendered first page wrapped as InfiniteData. */
+  initialData?: InfiniteData<PaginatedProjectsResponse, number>;
+  /** Page the seed (or client retry) starts from. Defaults to 1. */
+  initialPage?: number;
 }
 
 /**
@@ -46,20 +50,29 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
     limit = PROJECTS_EXPLORER_CONSTANTS.RESULT_LIMIT,
     enabled = true,
     hasPayoutAddress = false,
+    initialData,
+    initialPage = 1,
   } = options;
 
-  const query = useInfiniteQuery<PaginatedProjectsResponse, Error>({
+  const query = useInfiniteQuery<
+    PaginatedProjectsResponse,
+    Error,
+    InfiniteData<PaginatedProjectsResponse, number>,
+    ReturnType<typeof QUERY_KEYS.PROJECT.EXPLORER_INFINITE>,
+    number
+  >({
     queryKey: QUERY_KEYS.PROJECT.EXPLORER_INFINITE({
       search,
       sortBy,
       sortOrder,
       limit,
       hasPayoutAddress,
+      page: initialPage,
     }),
-    queryFn: async ({ pageParam = 1 }) => {
+    queryFn: async ({ pageParam }) => {
       return getExplorerProjectsPaginated({
         search,
-        page: pageParam as number,
+        page: pageParam,
         limit,
         sortBy,
         sortOrder,
@@ -70,11 +83,14 @@ export const useProjectsExplorerInfinite = (options: UseProjectsExplorerInfinite
     getNextPageParam: (lastPage) => {
       return lastPage.pagination.hasNextPage ? lastPage.pagination.page + 1 : undefined;
     },
-    initialPageParam: 1,
+    initialData,
+    initialPageParam: initialPage,
     enabled,
     staleTime: PROJECTS_EXPLORER_CONSTANTS.STALE_TIME_MS,
     gcTime: 1000 * 60 * 10, // 10 minutes
-    refetchOnMount: "always",
+    // A server seed is already fresh — don't refetch it on mount; without a seed
+    // keep the previous always-refetch behavior.
+    refetchOnMount: initialData ? false : "always",
   });
 
   // Flatten all pages into a single array of projects

--- a/middleware.ts
+++ b/middleware.ts
@@ -296,13 +296,17 @@ async function handleProjectIndexability(
   // the route, otherwise the normalized path parsed from the request.
   const finalPath = decision.outcome === "redirect" ? decision.to : parsed.normalizedPath;
 
-  // One 308 to the canonical host+path whenever we are on an alias host or the
-  // request is not already at its canonical path (legacy/identifier drift).
+  // One 308 whenever we are on an alias host or the request is not already at
+  // its canonical path (legacy/identifier drift). Only the real production alias
+  // hosts (karmahq.xyz / gap.karmahq.xyz) collapse onto the canonical www
+  // origin; every other host (Vercel preview, staging, localhost, canonical www)
+  // keeps the redirect on the request's own origin so a preview/staging
+  // normalization never emits a link to production. Query is preserved either way.
   if (isAliasHost || finalPath !== path) {
-    return NextResponse.redirect(
-      new URL(`${CANONICAL_ORIGIN}${finalPath}${request.nextUrl.search}`),
-      308
-    );
+    const target = isAliasHost
+      ? new URL(`${CANONICAL_ORIGIN}${finalPath}${request.nextUrl.search}`)
+      : new URL(`${finalPath}${request.nextUrl.search}`, request.url);
+    return NextResponse.redirect(target, 308);
   }
 
   // Already canonical: pass through. A noindex-follow decision or any stateful

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,9 +4,32 @@ import { getDomainInfo } from "./src/infrastructure/config/domain-constants";
 import { isKnownTenant } from "./src/infrastructure/types/tenant";
 import { chosenCommunities } from "./utilities/chosenCommunities";
 import { COMMUNITY_SUB_ROUTE_SEGMENTS } from "./utilities/pages";
+import {
+  classifyProjectQuery,
+  parseProjectIndexabilityRequest,
+} from "./utilities/project-indexability";
+import { fetchProjectIndexabilityDecision } from "./utilities/project-indexability-client";
 import { redirectToGov, shouldRedirectToGov } from "./utilities/redirectHelpers";
 import { hasForbiddenChars, sanitizeCommunitySlug } from "./utilities/sanitize";
 import { getWhitelabelByDomain, getWhitelabelDomainForSlug } from "./utilities/whitelabel-config";
+
+// --- Canonical host policy (ADR 0001) ---
+// www.karmahq.xyz is the single canonical serving host. The production apex
+// (karmahq.xyz) and the legacy GAP subdomain (gap.karmahq.xyz) are duplicate
+// hosts; every request on them collapses to www in a single 308 so Google
+// consolidates ranking signals onto one host instead of indexing three.
+const CANONICAL_ORIGIN = "https://www.karmahq.xyz";
+const ALIAS_HOSTS = new Set(["karmahq.xyz", "gap.karmahq.xyz"]);
+const NOINDEX_FOLLOW = "noindex, follow";
+
+function bareHostname(hostname: string): string {
+  return hostname.split(":")[0].toLowerCase();
+}
+
+function withRobots(response: Response, value: string): Response {
+  response.headers.set("X-Robots-Tag", value);
+  return response;
+}
 
 export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname;
@@ -134,6 +157,20 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL(`${protocol}//${mainDomain}${path}`), 301);
   }
 
+  // --- Canonical host policy: collapse alias hosts to www (ADR 0001) ---
+  const isAliasHost = ALIAS_HOSTS.has(bareHostname(hostname));
+
+  // Non-project alias requests take one permanent hop to the canonical host,
+  // preserving the exact path and query — no indexer round-trip needed. Project
+  // requests fall through to the shared handler below so the alias-host switch
+  // and any legacy/identifier normalization collapse into a single 308.
+  if (isAliasHost && !path.startsWith("/project/")) {
+    return NextResponse.redirect(
+      new URL(`${CANONICAL_ORIGIN}${path}${request.nextUrl.search}`),
+      308
+    );
+  }
+
   // --- Standard karmahq.xyz logic below ---
 
   // Redirect frontend-nextjs routes to gov.karmahq.xyz
@@ -195,29 +232,85 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // The explorer listing at exactly /projects (or /projects/) is a static route
+  // — no indexer lookup. A stateful query (filters/pagination) is a duplicate of
+  // the clean listing, so mark it noindex,follow; clean or tracking-only stays
+  // indexable. Alias hosts already 308'd above, so this only runs on www.
+  if (path === "/projects" || path === "/projects/") {
+    const response = NextResponse.next();
+    return classifyProjectQuery(request.nextUrl.searchParams) === "stateful"
+      ? withRobots(response, NOINDEX_FOLLOW)
+      : response;
+  }
+
   if (path.startsWith("/project/")) {
-    // These are permanent URL-structure changes, so emit 308 (not the default
-    // 307). A 307 tells Google the old URL is temporary, so it keeps the
-    // legacy URL in "Page with redirect" instead of consolidating to the new
-    // one; 308 lets it transfer signals to the new URL and drop the old.
-    if (path.includes("/grants") && !path.includes("/project/grants")) {
-      const newPath = path.replace("/grants", "/funding");
-      return NextResponse.redirect(new URL(newPath, request.url), 308);
-    }
-    if (path.includes("/funding/create-grant")) {
-      const newPath = path.replace("/funding/create-grant", "/funding/new");
-      return NextResponse.redirect(new URL(newPath, request.url), 308);
-    }
-    // Send legacy /roadmap straight to the project overview. It used to
-    // redirect to /updates, which then redirects to the overview — a redirect
-    // chain Google has to follow; collapse it to a single hop.
-    if (path.includes("/roadmap") && !path.includes("/project/roadmap")) {
-      const newPath = path.replace(/\/roadmap.*$/, "");
-      return NextResponse.redirect(new URL(newPath, request.url), 308);
-    }
+    return handleProjectIndexability(request, path, isAliasHost);
   }
 
   return NextResponse.next();
+}
+
+/**
+ * Resolve the canonical indexability outcome for a `/project/...` request and
+ * turn it into a single response (ADR 0001). The authoritative decision comes
+ * from the indexer; this collapses the alias-host switch, legacy segment
+ * normalization (grants → funding, create-grant → new), roadmap collapse, and
+ * old-identifier redirects into exactly one 308 hop when the request is not
+ * already at its canonical www URL. Any decision failure fails closed to
+ * noindex,follow via the client.
+ */
+async function handleProjectIndexability(
+  request: NextRequest,
+  path: string,
+  isAliasHost: boolean
+): Promise<Response> {
+  const parsed = parseProjectIndexabilityRequest(path);
+
+  // Unknown project route — we cannot build a trusted indexer query for a route
+  // we do not recognize, so never fetch. On an alias host we still owe the
+  // caller the canonical-host hop (one 308 to www, preserving path + query); on
+  // the canonical host we fail closed to noindex,follow.
+  if (!parsed) {
+    if (isAliasHost) {
+      return NextResponse.redirect(
+        new URL(`${CANONICAL_ORIGIN}${path}${request.nextUrl.search}`),
+        308
+      );
+    }
+    return withRobots(NextResponse.next(), NOINDEX_FOLLOW);
+  }
+
+  const isStatefulQuery = classifyProjectQuery(request.nextUrl.searchParams) === "stateful";
+
+  const decision = await fetchProjectIndexabilityDecision(parsed, {
+    // Read process.env at request time so tests can stub the base URL.
+    baseUrl: process.env.NEXT_PUBLIC_GAP_INDEXER_URL ?? "",
+  });
+
+  // Gone routes answer with their exact status and a noindex header — no hop.
+  if (decision.outcome === "gone") {
+    return withRobots(new NextResponse(null, { status: decision.status }), NOINDEX_FOLLOW);
+  }
+
+  // The final canonical path is the redirect target when the indexer relocates
+  // the route, otherwise the normalized path parsed from the request.
+  const finalPath = decision.outcome === "redirect" ? decision.to : parsed.normalizedPath;
+
+  // One 308 to the canonical host+path whenever we are on an alias host or the
+  // request is not already at its canonical path (legacy/identifier drift).
+  if (isAliasHost || finalPath !== path) {
+    return NextResponse.redirect(
+      new URL(`${CANONICAL_ORIGIN}${finalPath}${request.nextUrl.search}`),
+      308
+    );
+  }
+
+  // Already canonical: pass through. A noindex-follow decision or any stateful
+  // query suppresses indexing; canonical-indexable / duplicate-alias with a
+  // clean or tracking-only query stay indexable.
+  const shouldNoindex = decision.outcome === "noindex-follow" || isStatefulQuery;
+  const response = NextResponse.next();
+  return shouldNoindex ? withRobots(response, NOINDEX_FOLLOW) : response;
 }
 
 export const config = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,10 @@ const ALIAS_HOSTS = new Set(["karmahq.xyz", "gap.karmahq.xyz"]);
 const NOINDEX_FOLLOW = "noindex, follow";
 
 function bareHostname(hostname: string): string {
-  return hostname.split(":")[0].toLowerCase();
+  // Strip the port and lower-case, then drop a single trailing DNS dot:
+  // `karmahq.xyz.` is the fully-qualified form of the same host and must still
+  // match ALIAS_HOSTS, otherwise it would bypass the canonical redirect.
+  return hostname.split(":")[0].toLowerCase().replace(/\.$/, "");
 }
 
 function withRobots(response: Response, value: string): Response {

--- a/middleware.ts
+++ b/middleware.ts
@@ -290,26 +290,39 @@ async function handleProjectIndexability(
     baseUrl: process.env.NEXT_PUBLIC_GAP_INDEXER_URL ?? "",
   });
 
+  // The final canonical path is the redirect target when the indexer relocates
+  // the route, otherwise the normalized path parsed from the request. A gone
+  // route has no relocation target, so it keeps its normalized path and the
+  // canonical host answers the 404/410.
+  const finalPath = decision.outcome === "redirect" ? decision.to : parsed.normalizedPath;
+
+  // Alias hosts (karmahq.xyz / gap.karmahq.xyz) owe exactly ONE 308 to the
+  // canonical www host for EVERY request — including gone routes. Answering the
+  // 404/410 directly here would strand the response on a duplicate host, so we
+  // always hop to www first (folding any normalization/relocation into the same
+  // hop, preserving the query) and let the canonical host re-evaluate and return
+  // the 404/410. This must run before the gone short-circuit below.
+  if (isAliasHost) {
+    return NextResponse.redirect(
+      new URL(`${CANONICAL_ORIGIN}${finalPath}${request.nextUrl.search}`),
+      308
+    );
+  }
+
+  // Canonical / non-alias host (Vercel preview, staging, localhost, www) below.
   // Gone routes answer with their exact status and a noindex header — no hop.
   if (decision.outcome === "gone") {
     return withRobots(new NextResponse(null, { status: decision.status }), NOINDEX_FOLLOW);
   }
 
-  // The final canonical path is the redirect target when the indexer relocates
-  // the route, otherwise the normalized path parsed from the request.
-  const finalPath = decision.outcome === "redirect" ? decision.to : parsed.normalizedPath;
-
-  // One 308 whenever we are on an alias host or the request is not already at
-  // its canonical path (legacy/identifier drift). Only the real production alias
-  // hosts (karmahq.xyz / gap.karmahq.xyz) collapse onto the canonical www
-  // origin; every other host (Vercel preview, staging, localhost, canonical www)
-  // keeps the redirect on the request's own origin so a preview/staging
-  // normalization never emits a link to production. Query is preserved either way.
-  if (isAliasHost || finalPath !== path) {
-    const target = isAliasHost
-      ? new URL(`${CANONICAL_ORIGIN}${finalPath}${request.nextUrl.search}`)
-      : new URL(`${finalPath}${request.nextUrl.search}`, request.url);
-    return NextResponse.redirect(target, 308);
+  // Not already at the canonical path (legacy/identifier drift or an indexer
+  // relocation) — one 308 on the request's own origin so a preview/staging
+  // normalization never emits a link to production. Query is preserved.
+  if (finalPath !== path) {
+    return NextResponse.redirect(
+      new URL(`${finalPath}${request.nextUrl.search}`, request.url),
+      308
+    );
   }
 
   // Already canonical: pass through. A noindex-follow decision or any stateful

--- a/services/projects-explorer.service.ts
+++ b/services/projects-explorer.service.ts
@@ -5,12 +5,12 @@ import type { PaginatedProjectsResponse, Project as ProjectResponse } from "@/ty
 import fetchData from "@/utilities/fetchData";
 import { INDEXER } from "@/utilities/indexer";
 
-export interface ExplorerProjectsParams {
+interface ExplorerProjectsParams {
   search?: string;
   limit?: number;
 }
 
-export interface ExplorerProjectsPaginatedParams {
+interface ExplorerProjectsPaginatedParams {
   search?: string;
   page: number;
   limit?: number;

--- a/utilities/__tests__/queryKeys.test.ts
+++ b/utilities/__tests__/queryKeys.test.ts
@@ -336,7 +336,18 @@ describe("queryKeys", () => {
       it("should return as const tuple", () => {
         const key = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ search: "test" });
         expect(Array.isArray(key)).toBe(true);
-        expect(key.length).toBe(6);
+        expect(key.length).toBe(7);
+      });
+
+      it("should place the page dimension in slot 6 and default it to 1", () => {
+        expect(QUERY_KEYS.PROJECT.EXPLORER_INFINITE({})[6]).toBe(1);
+        expect(QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ page: 3 })[6]).toBe(3);
+      });
+
+      it("should generate different keys for different pages", () => {
+        const key1 = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ page: 1 });
+        const key2 = QUERY_KEYS.PROJECT.EXPLORER_INFINITE({ page: 2 });
+        expect(key1).not.toEqual(key2);
       });
 
       it("should generate different keys for hasPayoutAddress filter", () => {

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure, framework-free (Edge-safe) client for the project indexability decision.
+ * No Node/Next imports — only the sibling path helper, globalThis.fetch,
+ * AbortController, and timers — so it runs on the Edge runtime as well as in
+ * server/metadata code. It is strict on the wire and fails closed: any failure
+ * degrades to noindex,follow at the request's normalized path (ADR 0001, D5/D9).
+ */
+import {
+  buildProjectIndexabilityEndpoint,
+  type ProjectIndexabilityRequest,
+} from "./project-indexability";
+
+/** The exact indexability decision union returned by the backend. */
+export type ProjectIndexabilityDecision =
+  | { outcome: "canonical-indexable"; url: string }
+  | { outcome: "duplicate-alias"; url: string; canonicalUrl: string }
+  | { outcome: "noindex-follow"; url: string }
+  | { outcome: "redirect"; from: string; to: string }
+  | { outcome: "gone"; status: 404 | 410 };
+
+export type ProjectIndexabilityFetcher = (url: string, init: RequestInit) => Promise<Response>;
+
+export interface FetchProjectIndexabilityOptions {
+  baseUrl: string;
+  fetcher?: ProjectIndexabilityFetcher;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 2500;
+
+/**
+ * Strictly parse an unknown value into a ProjectIndexabilityDecision, or null.
+ * Every member must match exactly — the correct outcome, correctly-typed fields,
+ * and no extra keys — so a malformed or partial payload is rejected rather than
+ * trusted.
+ */
+export function parseProjectIndexabilityDecision(
+  value: unknown
+): ProjectIndexabilityDecision | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const outcome = record.outcome;
+
+  switch (outcome) {
+    case "canonical-indexable":
+    case "noindex-follow": {
+      const url = record.url;
+      if (hasExactKeys(record, ["outcome", "url"]) && typeof url === "string") {
+        return { outcome, url };
+      }
+      return null;
+    }
+    case "duplicate-alias": {
+      const url = record.url;
+      const canonicalUrl = record.canonicalUrl;
+      if (
+        hasExactKeys(record, ["outcome", "url", "canonicalUrl"]) &&
+        typeof url === "string" &&
+        typeof canonicalUrl === "string"
+      ) {
+        return { outcome, url, canonicalUrl };
+      }
+      return null;
+    }
+    case "redirect": {
+      const from = record.from;
+      const to = record.to;
+      if (
+        hasExactKeys(record, ["outcome", "from", "to"]) &&
+        typeof from === "string" &&
+        typeof to === "string"
+      ) {
+        return { outcome, from, to };
+      }
+      return null;
+    }
+    case "gone": {
+      const status = record.status;
+      if (hasExactKeys(record, ["outcome", "status"]) && (status === 404 || status === 410)) {
+        return { outcome, status };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fetch the authoritative indexability decision for a parsed request. HTTP
+ * 404/410 map directly to `gone`; a valid 200 body is strictly parsed; every
+ * other case — missing baseUrl, 5xx, invalid JSON/shape, network error, or
+ * timeout/abort — silently fails closed to noindex,follow at normalizedPath.
+ */
+export async function fetchProjectIndexabilityDecision(
+  parsed: ProjectIndexabilityRequest,
+  options: FetchProjectIndexabilityOptions
+): Promise<ProjectIndexabilityDecision> {
+  const failClosed: ProjectIndexabilityDecision = {
+    outcome: "noindex-follow",
+    url: parsed.normalizedPath,
+  };
+
+  const baseUrl = options.baseUrl.trim();
+  if (!baseUrl) {
+    return failClosed;
+  }
+
+  const fetcher: ProjectIndexabilityFetcher = options.fetcher ?? globalThis.fetch;
+  const timeoutMs =
+    typeof options.timeoutMs === "number" &&
+    Number.isFinite(options.timeoutMs) &&
+    options.timeoutMs > 0
+      ? options.timeoutMs
+      : DEFAULT_TIMEOUT_MS;
+
+  const endpoint = buildProjectIndexabilityEndpoint(baseUrl, parsed);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetcher(endpoint, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    if (response.status === 404 || response.status === 410) {
+      return { outcome: "gone", status: response.status };
+    }
+
+    if (response.status !== 200) {
+      return failClosed;
+    }
+
+    const body: unknown = await response.json();
+    return parseProjectIndexabilityDecision(body) ?? failClosed;
+  } catch {
+    return failClosed;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function hasExactKeys(record: Record<string, unknown>, keys: string[]): boolean {
+  return Object.keys(record).length === keys.length && keys.every((key) => key in record);
+}

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -32,7 +32,8 @@ const DEFAULT_TIMEOUT_MS = 2500;
  * Strictly parse an unknown value into a ProjectIndexabilityDecision, or null.
  * Every member must match exactly — the correct outcome, correctly-typed fields,
  * and no extra keys — so a malformed or partial payload is rejected rather than
- * trusted.
+ * trusted. Every URL field is additionally validated as a local `/project/...`
+ * path so a hostile payload cannot drive a cross-origin redirect.
  */
 export function parseProjectIndexabilityDecision(
   value: unknown
@@ -47,7 +48,7 @@ export function parseProjectIndexabilityDecision(
     case "canonical-indexable":
     case "noindex-follow": {
       const url = record.url;
-      if (hasExactKeys(record, ["outcome", "url"]) && typeof url === "string") {
+      if (hasExactKeys(record, ["outcome", "url"]) && isLocalProjectPath(url)) {
         return { outcome, url };
       }
       return null;
@@ -57,8 +58,8 @@ export function parseProjectIndexabilityDecision(
       const canonicalUrl = record.canonicalUrl;
       if (
         hasExactKeys(record, ["outcome", "url", "canonicalUrl"]) &&
-        typeof url === "string" &&
-        typeof canonicalUrl === "string"
+        isLocalProjectPath(url) &&
+        isLocalProjectPath(canonicalUrl)
       ) {
         return { outcome, url, canonicalUrl };
       }
@@ -69,8 +70,8 @@ export function parseProjectIndexabilityDecision(
       const to = record.to;
       if (
         hasExactKeys(record, ["outcome", "from", "to"]) &&
-        typeof from === "string" &&
-        typeof to === "string"
+        isLocalProjectPath(from) &&
+        isLocalProjectPath(to)
       ) {
         return { outcome, from, to };
       }
@@ -150,4 +151,44 @@ export async function fetchProjectIndexabilityDecision(
 
 function hasExactKeys(record: Record<string, unknown>, keys: string[]): boolean {
   return Object.keys(record).length === keys.length && keys.every((key) => key in record);
+}
+
+const PROJECT_PATH_PREFIX = "/project/";
+const MAX_CONTROL_CHAR_CODE = 0x20; // space and everything below (tab, CR, LF, NUL)
+const DEL_CHAR_CODE = 0x7f;
+
+/**
+ * Every URL field in a decision (`url`, `canonicalUrl`, `from`, `to`) is a
+ * redirect/canonical target the middleware concatenates with an origin, so it
+ * must be a root-relative path into a `/project/...` route and nothing else.
+ * Reject anything that could yield a cross-origin URL: an absolute or
+ * protocol-relative form (`//host`), userinfo (`@host`), a query or fragment
+ * (`?` / `#`), a backslash (the URL parser folds `\` to `/`), or any embedded
+ * whitespace/control character. Fails closed for non-strings.
+ */
+function isLocalProjectPath(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (!value.startsWith(PROJECT_PATH_PREFIX) || value.length === PROJECT_PATH_PREFIX.length) {
+    return false;
+  }
+  if (
+    value.includes("//") ||
+    value.includes("@") ||
+    value.includes("?") ||
+    value.includes("#") ||
+    value.includes("\\")
+  ) {
+    return false;
+  }
+  // Reject any ASCII control char, space, or DEL — blocks tab/newline URL
+  // smuggling — using char codes so no literal control byte lives in source.
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= MAX_CONTROL_CHAR_CODE || code === DEL_CHAR_CODE) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -190,5 +190,39 @@ function isLocalProjectPath(value: unknown): value is string {
       return false;
     }
   }
+  // The `/project/` prefix alone is not enough: a dot-segment lets the value
+  // escape the route once the middleware resolves it against an origin — e.g.
+  // `new URL("<origin>/project/x/../../evil")` normalizes to "<origin>/evil".
+  // Validate every segment so no traversal (literal or percent-encoded) or
+  // encoded separator survives.
+  const segments = value.split("/");
+  for (let index = 1; index < segments.length; index += 1) {
+    if (!isSafeProjectPathSegment(segments[index])) {
+      return false;
+    }
+  }
   return true;
+}
+
+/**
+ * A path segment is safe when it is non-empty, is not a literal or
+ * percent-encoded dot-segment ("." / ".." / "%2e%2e"), decodes cleanly (a
+ * malformed escape throws), and carries no encoded path separator once decoded
+ * ("%2F" -> "/", "%5C" -> "\"). Guards against traversal that only appears
+ * after the URL parser resolves the value.
+ */
+function isSafeProjectPathSegment(segment: string): boolean {
+  if (segment.length === 0 || segment === "." || segment === "..") {
+    return false;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return false;
+  }
+  if (decoded === "." || decoded === "..") {
+    return false;
+  }
+  return !decoded.includes("/") && !decoded.includes("\\");
 }

--- a/utilities/project-indexability-client.ts
+++ b/utilities/project-indexability-client.ts
@@ -11,16 +11,16 @@ import {
 } from "./project-indexability";
 
 /** The exact indexability decision union returned by the backend. */
-export type ProjectIndexabilityDecision =
+type ProjectIndexabilityDecision =
   | { outcome: "canonical-indexable"; url: string }
   | { outcome: "duplicate-alias"; url: string; canonicalUrl: string }
   | { outcome: "noindex-follow"; url: string }
   | { outcome: "redirect"; from: string; to: string }
   | { outcome: "gone"; status: 404 | 410 };
 
-export type ProjectIndexabilityFetcher = (url: string, init: RequestInit) => Promise<Response>;
+type ProjectIndexabilityFetcher = (url: string, init: RequestInit) => Promise<Response>;
 
-export interface FetchProjectIndexabilityOptions {
+interface FetchProjectIndexabilityOptions {
   baseUrl: string;
   fetcher?: ProjectIndexabilityFetcher;
   timeoutMs?: number;

--- a/utilities/project-indexability.ts
+++ b/utilities/project-indexability.ts
@@ -23,9 +23,6 @@ type GrantScopedProjectRoute =
   | "grant-milestones-and-updates"
   | "grant-impact-criteria";
 
-/** The closed set of indexer route literals. */
-export type ProjectIndexabilityRoute = SimpleProjectRoute | GrantScopedProjectRoute | "grant-new";
-
 /** The strict indexer query — grant-scoped routes carry a grantUid. */
 export type ProjectIndexabilityQuery =
   | { route: SimpleProjectRoute }
@@ -38,7 +35,7 @@ export interface ProjectIndexabilityRequest {
   normalizedPath: string;
 }
 
-export type ProjectQueryClassification = "clean" | "tracking-only" | "stateful";
+type ProjectQueryClassification = "clean" | "tracking-only" | "stateful";
 
 /**
  * Rewrite legacy route segments that appear AFTER the project identifier —

--- a/utilities/project-indexability.ts
+++ b/utilities/project-indexability.ts
@@ -1,0 +1,205 @@
+/**
+ * Pure, framework-free (Edge-safe) helpers for project indexability. No DOM,
+ * Node, or Next imports — only strings and URLSearchParams — so this can run in
+ * middleware / the Edge runtime as well as in server/metadata code.
+ *
+ * Mirrors the backend's strict indexer route vocabulary (ADR 0001, D2/D6).
+ */
+
+type SimpleProjectRoute =
+  | "root"
+  | "about"
+  | "roadmap"
+  | "team"
+  | "updates"
+  | "funding"
+  | "impact"
+  | "contact-info";
+
+type GrantScopedProjectRoute =
+  | "grant-detail"
+  | "grant-edit"
+  | "grant-complete"
+  | "grant-milestones-and-updates"
+  | "grant-impact-criteria";
+
+/** The closed set of indexer route literals. */
+export type ProjectIndexabilityRoute = SimpleProjectRoute | GrantScopedProjectRoute | "grant-new";
+
+/** The strict indexer query — grant-scoped routes carry a grantUid. */
+export type ProjectIndexabilityQuery =
+  | { route: SimpleProjectRoute }
+  | { route: "grant-new" }
+  | { route: GrantScopedProjectRoute; grantUid: string };
+
+export interface ProjectIndexabilityRequest {
+  identifier: string;
+  query: ProjectIndexabilityQuery;
+  normalizedPath: string;
+}
+
+export type ProjectQueryClassification = "clean" | "tracking-only" | "stateful";
+
+/**
+ * Rewrite legacy route segments that appear AFTER the project identifier —
+ * `grants` → `funding`, and `funding/create-grant` → `funding/new` (applied in
+ * sequence). Operates on path segments, never a substring replace, so a project
+ * literally named `grants` (the identifier segment) is left untouched.
+ */
+export function normalizeLegacyProjectPath(pathname: string): string {
+  const segments = pathname.split("/");
+  // segments[0] is the empty string before the leading slash; segments[1] is
+  // the top-level route, segments[2] the identifier, segments[3+] the route.
+  if (segments[1] !== "project") {
+    return pathname;
+  }
+  if (segments[3] === "grants") {
+    segments[3] = "funding";
+  }
+  if (segments[3] === "funding" && segments[4] === "create-grant") {
+    segments[4] = "new";
+  }
+  return segments.join("/");
+}
+
+/**
+ * Parse a pathname into an indexability request: identifier + strict indexer
+ * query + normalized path. Strips trailing slashes, applies legacy
+ * normalization, matches exact segment shapes only, and fails closed (returns
+ * null) for unknown tabs / non-project paths.
+ */
+export function parseProjectIndexabilityRequest(
+  pathname: string
+): ProjectIndexabilityRequest | null {
+  const withoutTrailingSlash = pathname.replace(/\/+$/, "");
+  const normalized = normalizeLegacyProjectPath(withoutTrailingSlash);
+  // Remove only the single leading slash, then reject any internal empty
+  // segment (e.g. a `//`) instead of silently collapsing it — malformed paths
+  // must fail closed.
+  const withoutLeadingSlash = normalized.startsWith("/") ? normalized.slice(1) : normalized;
+  const segments = withoutLeadingSlash.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    return null;
+  }
+
+  if (segments[0] !== "project") {
+    return null;
+  }
+  const identifier = segments[1];
+  if (!identifier) {
+    return null;
+  }
+
+  const query = parseRouteSegments(segments.slice(2));
+  if (!query) {
+    return null;
+  }
+
+  return {
+    identifier,
+    query,
+    normalizedPath: `/${segments.join("/")}`,
+  };
+}
+
+/**
+ * Classify a query string: `clean` (no params), `tracking-only` (every param is
+ * a known tracking param), else `stateful`. Key comparison is case-insensitive:
+ * any `utm_*` prefix plus exact gclid / fbclid / msclkid / dclid.
+ */
+export function classifyProjectQuery(searchParams: URLSearchParams): ProjectQueryClassification {
+  const keys = Array.from(searchParams.keys());
+  if (keys.length === 0) {
+    return "clean";
+  }
+  return keys.every(isTrackingKey) ? "tracking-only" : "stateful";
+}
+
+/**
+ * Build the indexer endpoint for a parsed request: trims trailing base slashes
+ * and URL-encodes both the identifier segment and the search params.
+ */
+export function buildProjectIndexabilityEndpoint(
+  baseUrl: string,
+  parsed: ProjectIndexabilityRequest
+): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  const identifier = encodeURIComponent(parsed.identifier);
+  const search = new URLSearchParams({ route: parsed.query.route });
+  if ("grantUid" in parsed.query) {
+    search.set("grantUid", parsed.query.grantUid);
+  }
+  return `${base}/v2/projects/${identifier}/indexability?${search.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function parseRouteSegments(rest: string[]): ProjectIndexabilityQuery | null {
+  if (rest.length === 0) {
+    return { route: "root" };
+  }
+
+  if (rest.length === 1) {
+    const route = asSingleSegmentRoute(rest[0]);
+    return route ? { route } : null;
+  }
+
+  // All remaining routes live under the /funding segment.
+  if (rest[0] !== "funding") {
+    return null;
+  }
+
+  if (rest.length === 2) {
+    const grantUid = rest[1];
+    if (grantUid === "new") {
+      return { route: "grant-new" };
+    }
+    return { route: "grant-detail", grantUid };
+  }
+
+  if (rest.length === 3) {
+    const grantUid = rest[1];
+    if (grantUid === "new") {
+      return null;
+    }
+    switch (rest[2]) {
+      case "edit":
+        return { route: "grant-edit", grantUid };
+      case "complete-grant":
+        return { route: "grant-complete", grantUid };
+      case "milestones-and-updates":
+        return { route: "grant-milestones-and-updates", grantUid };
+      case "impact-criteria":
+        return { route: "grant-impact-criteria", grantUid };
+      default:
+        return null;
+    }
+  }
+
+  return null;
+}
+
+function asSingleSegmentRoute(segment: string): SimpleProjectRoute | null {
+  switch (segment) {
+    case "about":
+    case "roadmap":
+    case "team":
+    case "updates":
+    case "funding":
+    case "impact":
+    case "contact-info":
+      return segment;
+    default:
+      return null;
+  }
+}
+
+function isTrackingKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  if (lower.startsWith("utm_")) {
+    return true;
+  }
+  return lower === "gclid" || lower === "fbclid" || lower === "msclkid" || lower === "dclid";
+}

--- a/utilities/project-indexability.ts
+++ b/utilities/project-indexability.ts
@@ -82,8 +82,19 @@ export function parseProjectIndexabilityRequest(
   if (segments[0] !== "project") {
     return null;
   }
-  const identifier = segments[1];
-  if (!identifier) {
+  const rawIdentifier = segments[1];
+  if (!rawIdentifier) {
+    return null;
+  }
+
+  // Decode the identifier segment exactly once. A malformed percent-escape (a
+  // lone or truncated `%`, e.g. `%` or `%zz`) makes decodeURIComponent throw →
+  // fail closed. A decoded path separator (`%2F` → "/", `%5C` → "\") would let a
+  // crafted slug span segments or inject a backslash into the indexer URL, so
+  // reject those too. Everything downstream consumes the decoded identifier and
+  // re-encodes it once, so there is never a double-decode.
+  const identifier = decodeIdentifierSegment(rawIdentifier);
+  if (identifier === null) {
     return null;
   }
 
@@ -92,11 +103,33 @@ export function parseProjectIndexabilityRequest(
     return null;
   }
 
+  // Re-encode the decoded identifier so the canonical path is well-formed and
+  // encoding-stable (a space is always `%20`), independent of how the incoming
+  // request happened to encode it. Route segments are fixed vocabulary and pass
+  // through unchanged.
+  const canonicalSegments = ["project", encodeURIComponent(identifier), ...segments.slice(2)];
   return {
     identifier,
     query,
-    normalizedPath: `/${segments.join("/")}`,
+    normalizedPath: `/${canonicalSegments.join("/")}`,
   };
+}
+
+/**
+ * Decode a project identifier path segment exactly once, failing closed (null)
+ * on a malformed percent-escape or any decoded path separator (`/` or `\`).
+ */
+function decodeIdentifierSegment(segment: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+  if (decoded.includes("/") || decoded.includes("\\")) {
+    return null;
+  }
+  return decoded;
 }
 
 /**
@@ -121,6 +154,8 @@ export function buildProjectIndexabilityEndpoint(
   parsed: ProjectIndexabilityRequest
 ): string {
   const base = baseUrl.replace(/\/+$/, "");
+  // parsed.identifier was decoded exactly once during parsing; encode it exactly
+  // once here so the indexer receives a single, well-formed path segment.
   const identifier = encodeURIComponent(parsed.identifier);
   const search = new URLSearchParams({ route: parsed.query.route });
   if ("grantUid" in parsed.query) {

--- a/utilities/project-indexability.ts
+++ b/utilities/project-indexability.ts
@@ -126,7 +126,10 @@ function decodeIdentifierSegment(segment: string): string | null {
   } catch {
     return null;
   }
-  if (decoded.includes("/") || decoded.includes("\\")) {
+  // Reject a dot-segment identifier (literal or percent-encoded) — `/project/..`
+  // would otherwise be treated as a valid project and, once resolved against an
+  // origin, escape the route — and any decoded path separator.
+  if (decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
     return null;
   }
   return decoded;

--- a/utilities/projects-explorer-request.ts
+++ b/utilities/projects-explorer-request.ts
@@ -5,6 +5,7 @@
  * pagination links all agree on one normalization policy (ADR 0001).
  */
 import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+import { PAGES } from "@/utilities/pages";
 
 /** Shape of Next.js `searchParams` once resolved. */
 export type ProjectsExplorerSearchParams = Record<string, string | string[] | undefined>;
@@ -18,7 +19,7 @@ export interface ProjectsExplorerState {
   raisingFunds: boolean;
 }
 
-const BASE_PATH = "/projects";
+const BASE_PATH = PAGES.PROJECTS_EXPLORER;
 const BROWSE_ANCHOR = "#browse-projects";
 const DEFAULT_SORT_BY: ExplorerSortByOptions = "updatedAt";
 const DEFAULT_SORT_ORDER: ExplorerSortOrder = "desc";

--- a/utilities/projects-explorer-request.ts
+++ b/utilities/projects-explorer-request.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure, framework-free helpers for the /projects explorer. Parses Next.js
+ * search-param records into a strict effective request state and builds
+ * crawlable pagination hrefs, so the server page, the client component, and the
+ * pagination links all agree on one normalization policy (ADR 0001).
+ */
+import type { ExplorerSortByOptions, ExplorerSortOrder } from "@/types/explorer";
+
+/** Shape of Next.js `searchParams` once resolved. */
+export type ProjectsExplorerSearchParams = Record<string, string | string[] | undefined>;
+
+/** The effective, fully-normalized explorer request. */
+export interface ProjectsExplorerState {
+  page: number;
+  q: string;
+  sortBy: ExplorerSortByOptions;
+  sortOrder: ExplorerSortOrder;
+  raisingFunds: boolean;
+}
+
+const BASE_PATH = "/projects";
+const BROWSE_ANCHOR = "#browse-projects";
+const DEFAULT_SORT_BY: ExplorerSortByOptions = "updatedAt";
+const DEFAULT_SORT_ORDER: ExplorerSortOrder = "desc";
+
+const VALID_SORT_BY: readonly ExplorerSortByOptions[] = [
+  "createdAt",
+  "updatedAt",
+  "title",
+  "noOfGrants",
+  "noOfProjectMilestones",
+  "noOfGrantMilestones",
+];
+
+/**
+ * Parse a search-param record into the effective explorer state. Every field
+ * falls back to its default when missing, array-valued, or invalid.
+ */
+export function parseProjectsExplorerRequest(
+  params: ProjectsExplorerSearchParams
+): ProjectsExplorerState {
+  return {
+    page: parsePage(params.page),
+    q: firstString(params.q) ?? "",
+    sortBy: parseSortBy(params.sortBy),
+    sortOrder: parseSortOrder(params.sortOrder),
+    raisingFunds: firstString(params.raisingFunds) === "true",
+  };
+}
+
+/**
+ * Build a crawlable href for a target page: preserve only non-default filters
+ * (deterministic order q, sortBy, sortOrder, raisingFunds, then page), omit
+ * page for page 1, encode values, and always end at #browse-projects.
+ */
+export function buildProjectsPageHref(state: ProjectsExplorerState, targetPage: number): string {
+  const params: string[] = [];
+
+  if (state.q) {
+    params.push(`q=${encode(state.q)}`);
+  }
+  if (state.sortBy !== DEFAULT_SORT_BY) {
+    params.push(`sortBy=${encode(state.sortBy)}`);
+  }
+  if (state.sortOrder !== DEFAULT_SORT_ORDER) {
+    params.push(`sortOrder=${encode(state.sortOrder)}`);
+  }
+  if (state.raisingFunds) {
+    params.push("raisingFunds=true");
+  }
+  if (targetPage > 1) {
+    params.push(`page=${targetPage}`);
+  }
+
+  const query = params.length > 0 ? `?${params.join("&")}` : "";
+  return `${BASE_PATH}${query}${BROWSE_ANCHOR}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function firstString(value: string | string[] | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function parsePage(value: string | string[] | undefined): number {
+  const raw = firstString(value);
+  // Digits-only positive integer within the safe-integer range; everything else
+  // (zero, negative, decimal, exponent, whitespace, empty, oversized, array).
+  if (!raw || !/^\d+$/.test(raw)) {
+    return 1;
+  }
+  const page = Number(raw);
+  if (!Number.isSafeInteger(page) || page < 1) {
+    return 1;
+  }
+  return page;
+}
+
+function parseSortBy(value: string | string[] | undefined): ExplorerSortByOptions {
+  const raw = firstString(value);
+  return raw && (VALID_SORT_BY as readonly string[]).includes(raw)
+    ? (raw as ExplorerSortByOptions)
+    : DEFAULT_SORT_BY;
+}
+
+function parseSortOrder(value: string | string[] | undefined): ExplorerSortOrder {
+  const raw = firstString(value);
+  return raw === "asc" || raw === "desc" ? raw : DEFAULT_SORT_ORDER;
+}
+
+// Encode with encodeURIComponent so spaces become %20 (not +) deterministically.
+function encode(value: string): string {
+  return encodeURIComponent(value);
+}

--- a/utilities/queryKeys.ts
+++ b/utilities/queryKeys.ts
@@ -259,6 +259,7 @@ export const QUERY_KEYS = {
       sortOrder?: string;
       limit?: number;
       hasPayoutAddress?: boolean;
+      page?: number;
     }) =>
       [
         "projects-explorer-infinite",
@@ -267,6 +268,7 @@ export const QUERY_KEYS = {
         params.sortOrder || "desc",
         params.limit ?? 50,
         params.hasPayoutAddress ?? false,
+        params.page ?? 1,
       ] as const,
   },
   INDICATORS: {


### PR DESCRIPTION
## Summary\n\n- enforce the backend indexability decision in middleware with canonical redirects, gone/noindex behavior, query policy, and fail-closed handling\n- make /projects server-rendered with crawlable pagination\n- seed the explorer client to avoid duplicate hydration fetches\n\n## Validation\n\n- 10 focused post-rebase files / 172 tests passed\n- TypeScript passed\n- changed-file Biome passed with no errors\n- git diff --check passed\n\nPart of show-karma/super-gap#55.\n\n## Dependency / rollout\n\nRequires the gap-indexer project indexability endpoint from the backend PR to be deployed first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Projects page now performs server-side seeding for faster, more complete first renders.
  - Added crawlable Previous/Next pagination links that preserve active filters.

- **Bug Fixes**
  - Improved `/projects` error recovery with a working “Try again” flow and optional error digest.
  - Invalid search/sort URL inputs now normalize to safe defaults, and pagination resets when filters change.
  - Search clearing updates the URL immediately (no debounce delay).

- **Accessibility**
  - Improved headings/labels and refined loading/search messaging for clearer UI feedback.

- **SEO**
  - Strengthened canonicalization and indexability behavior for project and projects listing routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->