### PR TITLE
DEV-496: unify report URL + consolidate milestones-report links (rows 5 & 7)

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -83,7 +83,7 @@ describe("PortfolioReportListPage", () => {
     mockUseReportRowSync.mockImplementation((_slug, initialReport) => initialReport);
   });
 
-  it("shows a Preview action for draft reports and navigates to the admin preview page", async () => {
+  it("shows a Preview action for draft reports and navigates to the unified public report URL", async () => {
     const user = userEvent.setup();
 
     mockUsePortfolioReports.mockReturnValue({
@@ -117,9 +117,7 @@ describe("PortfolioReportListPage", () => {
 
     await user.click(screen.getByRole("button", { name: /preview/i }));
 
-    expect(mockPush).toHaveBeenCalledWith(
-      "/community/filecoin/manage/portfolio-reports/draft-report/preview"
-    );
+    expect(mockPush).toHaveBeenCalledWith("/community/filecoin/reports/2026-03-15");
   });
 
   it("does not show a Preview action for published reports", () => {

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -3,18 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 
+// DEV-496: the preview route is now a redirect shim to the unified public URL
+// (/community/:slug/reports/:runDate), where a community admin sees the draft.
+const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn() }),
+}));
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
-vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => ({
-  HtmlReportFrame: ({ html }: { html?: string }) => (
-    <div data-testid="markdown-preview">{html}</div>
-  ),
-}));
-vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () => ({
-  ReportChartsSection: () => <div data-testid="report-charts-section" />,
-}));
-vi.mock("@/components/Pages/Community/PortfolioReports/ExportDataMenu", () => ({
-  ExportDataMenu: () => <div data-testid="export-data-menu" />,
-}));
 
 const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
 
@@ -25,124 +20,69 @@ const community = {
 
 const draftReport = {
   id: "draft-report",
-  reportConfigId: "config-1",
-  communityId: "community-1",
   runDate: "2026-03-15",
   status: "draft",
-  content: "# Draft report body",
-  dataSnapshot: {},
-  modelId: "gpt-4.1",
-  tokenUsage: null,
-  generatedAt: "2026-04-01T00:00:00.000Z",
-  generationError: null,
   publishedAt: null,
-  publishedBy: null,
-  createdAt: "2026-04-01T00:00:00.000Z",
-  updatedAt: "2026-04-01T00:00:00.000Z",
-};
+} as any;
 
-const publishedReport = {
-  ...draftReport,
-  id: "published-report",
-  status: "published",
-  publishedAt: "2026-04-02T00:00:00.000Z",
-  publishedBy: "user-1",
-};
-
-describe("PortfolioReportPreviewPage", () => {
+describe("PortfolioReportPreviewPage (redirect shim)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe("loading state", () => {
-    it("renders a spinner while the report is loading", () => {
-      mockUsePortfolioReport.mockReturnValue({
-        data: undefined,
-        isLoading: true,
-      } as any);
+  it("renders a spinner while the report is loading and does not redirect yet", () => {
+    mockUsePortfolioReport.mockReturnValue({ data: undefined, isLoading: true } as any);
 
-      const { container } = render(
-        <PortfolioReportPreviewPage community={community} reportId="draft-report" />
-      );
+    const { container } = render(
+      <PortfolioReportPreviewPage community={community} reportId="draft-report" />
+    );
 
-      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
-    });
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
   });
 
-  describe("error state", () => {
-    it("renders a retry button that re-fetches the report", async () => {
-      const user = userEvent.setup();
-      const refetch = vi.fn();
-      mockUsePortfolioReport.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        isError: true,
-        refetch,
-      } as any);
+  it("redirects to the unified public report URL once the report resolves", () => {
+    mockUsePortfolioReport.mockReturnValue({ data: draftReport, isLoading: false } as any);
 
-      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+    render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
 
-      expect(screen.getByText(/failed to load the report preview/i)).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
-        "href",
-        "/community/filecoin/manage/portfolio-reports"
-      );
-
-      await user.click(screen.getByRole("button", { name: /retry/i }));
-
-      expect(refetch).toHaveBeenCalledTimes(1);
-    });
+    expect(replace).toHaveBeenCalledWith("/community/filecoin/reports/2026-03-15");
   });
 
-  describe("not found state", () => {
-    it("shows a not-found message with a back link when the report does not exist", () => {
-      mockUsePortfolioReport.mockReturnValue({
-        data: null,
-        isLoading: false,
-        isError: false,
-      } as any);
+  it("renders a retry button that re-fetches on error and does not redirect", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    mockUsePortfolioReport.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    } as any);
 
-      render(<PortfolioReportPreviewPage community={community} reportId="missing-report" />);
+    render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
 
-      expect(screen.getByText(/report not found/i)).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
-        "href",
-        "/community/filecoin/manage/portfolio-reports"
-      );
-    });
+    expect(screen.getByText(/failed to load the report/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+      "href",
+      "/community/filecoin/manage/portfolio-reports"
+    );
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(replace).not.toHaveBeenCalled();
   });
 
-  describe("success state", () => {
-    it("renders the draft report in preview mode with a back link to admin portfolio reports", () => {
-      mockUsePortfolioReport.mockReturnValue({
-        data: draftReport,
-        isLoading: false,
-      } as any);
+  it("shows a not-found message when the report does not exist", () => {
+    mockUsePortfolioReport.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    } as any);
 
-      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+    render(<PortfolioReportPreviewPage community={community} reportId="missing-report" />);
 
-      expect(
-        screen.getByText(/preview mode — this draft is only visible to community admins\./i)
-      ).toBeInTheDocument();
-      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
-        "href",
-        "/community/filecoin/manage/portfolio-reports"
-      );
-      expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
-    });
-
-    it("uses a neutral preview banner for already-published reports", () => {
-      mockUsePortfolioReport.mockReturnValue({
-        data: publishedReport,
-        isLoading: false,
-      } as any);
-
-      render(<PortfolioReportPreviewPage community={community} reportId="published-report" />);
-
-      expect(screen.getByText(/preview mode — admin view of this report\./i)).toBeInTheDocument();
-      expect(
-        screen.queryByText(/this draft is only visible to community admins/i)
-      ).not.toBeInTheDocument();
-    });
+    expect(screen.getByText(/report not found/i)).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/Pages/Admin/StatsTable.test.tsx
+++ b/__tests__/components/Pages/Admin/StatsTable.test.tsx
@@ -141,6 +141,31 @@ describe("StatsTable", () => {
       expect(pastDueCell).toHaveClass("text-red-600");
     });
 
+    it("links milestone counts to the canonical manage review page (DEV-496)", () => {
+      render(
+        <StatsTable
+          {...baseProps}
+          reports={[makeReport({ pastDueMilestones: 1 })]}
+          isLoading={false}
+          error={null}
+          onSort={vi.fn()}
+          onPageChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByRole("row", { name: /Grant Alpha/i });
+      const pastDueCell = within(row).getByRole("link", {
+        name: "1 past due milestones for Grant Alpha",
+      });
+
+      // DEV-496: one canonical milestone link — the manage review page, not the
+      // public project page with a status anchor.
+      expect(pastDueCell).toHaveAttribute(
+        "href",
+        "/community/community-1/manage/funding-platform/program-1/milestones/project-1"
+      );
+    });
+
     it("renders zero past-due counts in gray", () => {
       render(
         <StatsTable

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
@@ -40,9 +40,19 @@ const RUN_DATE = "2026-03-15";
 describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPublished.mockReturnValue({ data: null, isLoading: false, isError: false } as any);
+    mockPublished.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
     mockAdmin.mockReturnValue({ isCommunityAdmin: false, isLoading: false } as any);
-    mockDraft.mockReturnValue({ data: null, isLoading: false } as any);
+    mockDraft.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
   });
 
   it("renders a published report as the public view, with no admin banner", () => {
@@ -85,5 +95,37 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
     expect(screen.queryByTestId("doc-view")).not.toBeInTheDocument();
     // The draft lookup is gated off for non-admins.
     expect(mockDraft).toHaveBeenCalledWith("filecoin", RUN_DATE, false);
+  });
+
+  it("surfaces the error state (not 'no report') when the admin draft lookup fails", () => {
+    const refetchDraft = vi.fn();
+    mockAdmin.mockReturnValue({ isCommunityAdmin: true, isLoading: false } as any);
+    mockDraft.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: true,
+      refetch: refetchDraft,
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    expect(screen.getByText(/failed to load the report/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no published report found/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render a cached draft to a non-admin (selection is gated, not just the fetch)", () => {
+    // Query is disabled for non-admins but React Query still returns the last
+    // cached draft — the page must not surface it.
+    mockDraft.mockReturnValue({
+      data: { id: "stale-draft", publishedAt: null },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    expect(screen.getByText(/no published report found/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("doc-view")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { PublicReportViewPage } from "@/components/Pages/Community/PortfolioReports/PublicReportViewPage";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+import {
+  useAdminReportByRunDate,
+  usePublishedReport,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
+
+// DEV-496: /reports/:runDate is the single report URL. Public sees published;
+// a community admin previews the draft at the same URL when nothing is published.
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+vi.mock("@/hooks/communities/useIsCommunityAdmin");
+vi.mock("@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView", () => ({
+  PortfolioReportDocumentView: ({
+    report,
+    bannerText,
+    isAdmin,
+  }: {
+    report: { id: string };
+    bannerText?: string;
+    isAdmin?: boolean;
+  }) => (
+    <div data-testid="doc-view" data-banner={bannerText ?? ""} data-admin={String(isAdmin)}>
+      report:{report?.id}
+    </div>
+  ),
+}));
+
+const mockPublished = vi.mocked(usePublishedReport);
+const mockAdmin = vi.mocked(useIsCommunityAdmin);
+const mockDraft = vi.mocked(useAdminReportByRunDate);
+
+const community = {
+  uid: "c-1",
+  details: { slug: "filecoin", name: "Filecoin" },
+} as any;
+
+const RUN_DATE = "2026-03-15";
+
+describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPublished.mockReturnValue({ data: null, isLoading: false, isError: false } as any);
+    mockAdmin.mockReturnValue({ isCommunityAdmin: false, isLoading: false } as any);
+    mockDraft.mockReturnValue({ data: null, isLoading: false } as any);
+  });
+
+  it("renders a published report as the public view, with no admin banner", () => {
+    mockPublished.mockReturnValue({
+      data: { id: "pub-1", publishedAt: "2026-01-01T00:00:00Z" },
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    const doc = screen.getByTestId("doc-view");
+    expect(doc).toHaveTextContent("report:pub-1");
+    expect(doc).toHaveAttribute("data-banner", "");
+    expect(doc).toHaveAttribute("data-admin", "false");
+  });
+
+  it("previews the draft to a community admin, with the admin-only banner", () => {
+    mockAdmin.mockReturnValue({ isCommunityAdmin: true, isLoading: false } as any);
+    mockDraft.mockReturnValue({
+      data: { id: "draft-1", publishedAt: null },
+      isLoading: false,
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    const doc = screen.getByTestId("doc-view");
+    expect(doc).toHaveTextContent("report:draft-1");
+    expect(doc).toHaveAttribute(
+      "data-banner",
+      "Preview mode — this draft is only visible to community admins."
+    );
+    expect(doc).toHaveAttribute("data-admin", "true");
+  });
+
+  it("shows a not-found message to a non-admin and never fetches the draft", () => {
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    expect(screen.getByText(/no published report found/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("doc-view")).not.toBeInTheDocument();
+    // The draft lookup is gated off for non-admins.
+    expect(mockDraft).toHaveBeenCalledWith("filecoin", RUN_DATE, false);
+  });
+});

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -443,9 +443,7 @@ export function PortfolioReportListPage({ community }: Props) {
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
                   onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
-                  onPreview={() =>
-                    router.push(PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW(slug, report.id))
-                  }
+                  onPreview={() => router.push(PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate))}
                   onPublish={() => handlePublish(report.id)}
                   onUnpublish={() => handleUnpublish(report.id)}
                   onRegenerate={() => setRegenerateTargetId(report.id)}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -2,7 +2,8 @@
 
 import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
 import Link from "next/link";
-import { PortfolioReportDocumentView } from "@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
@@ -13,25 +14,30 @@ interface Props {
   reportId: string;
 }
 
+/**
+ * DEV-496: the admin preview and the public report now share one URL. This
+ * legacy `/manage/.../preview` route redirects to `/reports/:runDate`, where a
+ * community admin sees the draft preview inline (public sees published only).
+ */
 export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const slug = community.details.slug;
   const { data: report, isLoading, isError, refetch } = usePortfolioReport(slug, reportId);
+  const { replace } = useRouter();
   const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center p-12">
-        <Spinner />
-      </div>
-    );
-  }
+  const runDate = report?.runDate;
+  useEffect(() => {
+    if (runDate) {
+      replace(PAGES.COMMUNITY.REPORT_DETAIL(slug, runDate));
+    }
+  }, [runDate, slug, replace]);
 
   if (isError) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
         <div className="flex flex-col items-center gap-4">
           <AlertTriangle className="h-8 w-8 text-red-400" />
-          <p className="text-zinc-500">Failed to load the report preview. Please try again.</p>
+          <p className="text-zinc-500">Failed to load the report. Please try again.</p>
           <button
             type="button"
             onClick={() => refetch()}
@@ -52,7 +58,7 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
     );
   }
 
-  if (!report) {
+  if (!isLoading && !report) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
         <p className="text-zinc-500">Report not found.</p>
@@ -67,19 +73,10 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
     );
   }
 
-  const bannerText = report.publishedAt
-    ? "Preview mode — admin view of this report."
-    : "Preview mode — this draft is only visible to community admins.";
-
+  // Loading the report, or redirecting once its run date resolves.
   return (
-    <PortfolioReportDocumentView
-      community={community}
-      runDate={report.runDate}
-      report={report}
-      backHref={backHref}
-      backLabel="Back to portfolio reports"
-      bannerText={bannerText}
-      isAdmin
-    />
+    <div className="flex items-center justify-center p-12">
+      <Spinner />
+    </div>
   );
 }

--- a/components/Pages/Admin/StatsTable.tsx
+++ b/components/Pages/Admin/StatsTable.tsx
@@ -234,6 +234,16 @@ export function StatsTable({
             ) : (
               reports?.map((report) => {
                 const completed = isFullyCompleted(report);
+                // DEV-496: one canonical milestone link per row. On this reviewer
+                // surface that's the manage review page; fall back to the public
+                // grant page only when the row has no programId to review against.
+                const milestoneHref = report.programId
+                  ? PAGES.MANAGE.FUNDING_PLATFORM.MILESTONES(
+                      communityId,
+                      normalizeProgramId(report.programId),
+                      report.projectUid
+                    )
+                  : PAGES.PROJECT.MILESTONES_AND_UPDATES(report.projectSlug, report.grantUid);
                 return (
                   <tr
                     key={`${report.grantUid}-${report.programId ?? ""}`}
@@ -278,10 +288,7 @@ export function StatsTable({
                     </td>
                     <td className="px-4 py-3">
                       <Link
-                        href={`${PAGES.PROJECT.GRANT(
-                          report.projectSlug,
-                          report.grantUid
-                        )}/milestones-and-updates#all`}
+                        href={milestoneHref}
                         className="text-sm text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400 tabular-nums transition-colors"
                         target="_blank"
                         rel="noopener noreferrer"
@@ -291,10 +298,7 @@ export function StatsTable({
                     </td>
                     <td className="px-4 py-3">
                       <Link
-                        href={`${PAGES.PROJECT.GRANT(
-                          report.projectSlug,
-                          report.grantUid
-                        )}/milestones-and-updates#pending`}
+                        href={milestoneHref}
                         className={cn(
                           "text-sm tabular-nums transition-colors",
                           report.pendingMilestones > 0
@@ -312,10 +316,7 @@ export function StatsTable({
                         const pastDueCount = report.pastDueMilestones ?? 0;
                         return (
                           <Link
-                            href={`${PAGES.PROJECT.GRANT(
-                              report.projectSlug,
-                              report.grantUid
-                            )}/milestones-and-updates#past-due`}
+                            href={milestoneHref}
                             aria-label={`${pastDueCount} past due milestones for ${report.grantTitle}`}
                             className={cn(
                               "text-sm tabular-nums transition-colors",
@@ -334,10 +335,7 @@ export function StatsTable({
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-3">
                         <Link
-                          href={`${PAGES.PROJECT.GRANT(
-                            report.projectSlug,
-                            report.grantUid
-                          )}/milestones-and-updates#completed`}
+                          href={milestoneHref}
                           className="text-sm text-gray-900 dark:text-white tabular-nums hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
                           target="_blank"
                           rel="noopener noreferrer"

--- a/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
@@ -4,7 +4,11 @@ import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { PortfolioReportDocumentView } from "@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView";
 import { Spinner } from "@/components/Utilities/Spinner";
-import { usePublishedReport } from "@/hooks/portfolio-reports/usePortfolioReports";
+import { useIsCommunityAdmin } from "@/hooks/communities/useIsCommunityAdmin";
+import {
+  useAdminReportByRunDate,
+  usePublishedReport,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
 import { formatRunDate } from "@/utilities/portfolio-reports/period";
 
@@ -15,9 +19,29 @@ interface Props {
 
 export function PublicReportViewPage({ community, runDate }: Props) {
   const slug = community.details.slug;
-  const { data: report, isLoading, isError, refetch } = usePublishedReport(slug, runDate);
+  const {
+    data: published,
+    isLoading: publishedLoading,
+    isError,
+    refetch,
+  } = usePublishedReport(slug, runDate);
 
-  if (isLoading) {
+  // DEV-496: the admin "preview" and the public report share this one URL. When
+  // there's no published report, a community admin can still see the draft here
+  // (the list endpoint is auth-gated, so non-admins never receive it).
+  const publishedMissing = !publishedLoading && !published;
+  const { isCommunityAdmin, isLoading: adminLoading } = useIsCommunityAdmin(slug);
+  const { data: draft, isLoading: draftLoading } = useAdminReportByRunDate(
+    slug,
+    runDate,
+    publishedMissing && isCommunityAdmin
+  );
+
+  const report = published ?? draft ?? null;
+  const resolving =
+    publishedLoading || (publishedMissing && (adminLoading || (isCommunityAdmin && draftLoading)));
+
+  if (resolving) {
     return (
       <div className="flex items-center justify-center p-12">
         <Spinner />
@@ -68,6 +92,13 @@ export function PublicReportViewPage({ community, runDate }: Props) {
     );
   }
 
+  // Published reports render as the public view for everyone. An unpublished
+  // draft only reaches here for a community admin — badge it as an admin preview.
+  const isDraftPreview = !report.publishedAt;
+  const bannerText = isDraftPreview
+    ? "Preview mode — this draft is only visible to community admins."
+    : undefined;
+
   return (
     <PortfolioReportDocumentView
       community={community}
@@ -75,6 +106,8 @@ export function PublicReportViewPage({ community, runDate }: Props) {
       report={report}
       backHref={`/community/${slug}/reports`}
       backLabel="Reports"
+      bannerText={bannerText}
+      isAdmin={isDraftPreview}
     />
   );
 }

--- a/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
@@ -22,24 +22,36 @@ export function PublicReportViewPage({ community, runDate }: Props) {
   const {
     data: published,
     isLoading: publishedLoading,
-    isError,
-    refetch,
+    isError: publishedError,
+    refetch: refetchPublished,
   } = usePublishedReport(slug, runDate);
 
   // DEV-496: the admin "preview" and the public report share this one URL. When
-  // there's no published report, a community admin can still see the draft here
-  // (the list endpoint is auth-gated, so non-admins never receive it).
+  // there's no published report, a resolved community admin can still see the
+  // draft here (the list endpoint is auth-gated, so non-admins never receive it).
   const publishedMissing = !publishedLoading && !published;
   const { isCommunityAdmin, isLoading: adminLoading } = useIsCommunityAdmin(slug);
-  const { data: draft, isLoading: draftLoading } = useAdminReportByRunDate(
-    slug,
-    runDate,
-    publishedMissing && isCommunityAdmin
-  );
+  const canPreviewDraft = publishedMissing && isCommunityAdmin;
+  const {
+    data: draft,
+    isLoading: draftLoading,
+    isError: draftError,
+    refetch: refetchDraft,
+  } = useAdminReportByRunDate(slug, runDate, canPreviewDraft);
 
-  const report = published ?? draft ?? null;
+  // A disabled React Query still holds its last cached value, so gate the
+  // selection (not just the fetch) on the resolved admin state — a stale draft
+  // must not linger after the admin signs out or the report gets published.
+  const report = published ?? (canPreviewDraft ? (draft ?? null) : null);
   const resolving =
     publishedLoading || (publishedMissing && (adminLoading || (isCommunityAdmin && draftLoading)));
+  // Surface a failed admin draft lookup instead of falling through to the
+  // "no published report" empty state.
+  const isError = publishedError || (canPreviewDraft && draftError);
+  const handleRetry = () => {
+    refetchPublished();
+    if (canPreviewDraft) refetchDraft();
+  };
 
   if (resolving) {
     return (
@@ -57,7 +69,7 @@ export function PublicReportViewPage({ community, runDate }: Props) {
           <p className="text-zinc-500">Failed to load the report. Please try again.</p>
           <button
             type="button"
-            onClick={() => refetch()}
+            onClick={handleRetry}
             className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             <RefreshCw className="h-4 w-4" />

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -7,7 +7,6 @@ import {
   type CreateReportConfigRequest,
   type GenerateReportRequest,
   type PortfolioReport,
-  type ReportConfig,
   reportPollIntervalMs,
   type UpdateReportConfigRequest,
 } from "@/types/portfolio-report";
@@ -283,6 +282,25 @@ export function usePublishedReport(communitySlug: string, runDate: string) {
     queryKey: QUERY_KEYS.publishedRunDate(communitySlug, runDate),
     queryFn: () => portfolioService.getPublishedReportByRunDate(communitySlug, runDate),
     enabled: Boolean(communitySlug && runDate),
+  });
+}
+
+/**
+ * Admin-only fallback for the unified report URL (DEV-496): when the public
+ * `/reports/:runDate` page finds no published report, a community admin can
+ * still preview the draft at the same URL. Resolves the report for the run date
+ * from the admin list (auth-gated server-side, so non-admins never see drafts).
+ * Only fires when `enabled` — i.e. published lookup came back empty AND the
+ * viewer is a resolved community admin.
+ */
+export function useAdminReportByRunDate(communitySlug: string, runDate: string, enabled: boolean) {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.reports(communitySlug), "by-run-date", runDate],
+    queryFn: async () => {
+      const reports = await portfolioService.listReports(communitySlug);
+      return reports.find((report) => report.runDate === runDate) ?? null;
+    },
+    enabled: Boolean(communitySlug && runDate) && enabled,
   });
 }
 

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -292,13 +292,19 @@ export function usePublishedReport(communitySlug: string, runDate: string) {
  * from the admin list (auth-gated server-side, so non-admins never see drafts).
  * Only fires when `enabled` — i.e. published lookup came back empty AND the
  * viewer is a resolved community admin.
+ *
+ * Restricted to `draft` reports: matching only on `runDate` could otherwise
+ * surface a failed/generating/published row and expose it to the document view
+ * as a draft preview.
  */
 export function useAdminReportByRunDate(communitySlug: string, runDate: string, enabled: boolean) {
   return useQuery({
     queryKey: [...QUERY_KEYS.reports(communitySlug), "by-run-date", runDate],
     queryFn: async () => {
       const reports = await portfolioService.listReports(communitySlug);
-      return reports.find((report) => report.runDate === runDate) ?? null;
+      return (
+        reports.find((report) => report.runDate === runDate && report.status === "draft") ?? null
+      );
     },
     enabled: Boolean(communitySlug && runDate) && enabled,
   });


### PR DESCRIPTION
## Overview

**DEV-496** — the last two "Clean up URL" rows from the disparate-links sheet that were deferred out of the main consolidation PR (which is now merged). Both are frontend-only.

## Row 5 — Unify the report preview + public URL

Admins previewed a report at `/community/:slug/manage/portfolio-reports/:reportId/preview` while the public viewed the same document at `/community/:slug/reports/:runDate` — two URLs for one report. Mahesh: *"there shouldn't be a public url and a different preview url — combine them."*

Now there's **one URL** (`/reports/:runDate`):
- The public report page serves an **unpublished draft to a community admin** (with a "draft — admin only" banner), gated by `useIsCommunityAdmin`. The draft comes from the **auth-gated** list endpoint, so non-admins never receive it even if the client gate is bypassed (double-gated).
- The admin **"Preview"** button now navigates to `/reports/:runDate`.
- The legacy `/manage/.../preview` route is a thin **redirect** to `/reports/:runDate`.

Published reports render as the public view for everyone (no admin banner).

## Row 7 — One canonical milestone link on the milestones-report

The admin milestones-report emitted **two milestone "doors"** per row — the count cells (e.g. "3 pending") linked to the public `/project/.../milestones-and-updates` page with status anchors, while the **Review** button linked to the manage review page.

Consolidated: it's a reviewer surface, so the **count cells now route to the same manage review page** as the Review button (falling back to the public grant page only when a row has no `programId`). 

**Trade-off:** the per-status anchor jump (`#pending`/`#completed`) is dropped — the manage review page doesn't support status anchors. Clicking a count now lands on that project's review page. If you'd rather preserve the status filter, I can add status-anchor support to the manage page instead — flag it and I'll follow up.

## Testing

22 unit tests green across the touched components:
- **New** `PublicReportViewPage` test: published → public view (no banner); no-published + admin → draft preview with banner; non-admin → not-found, draft lookup gated off.
- Rewrote `PortfolioReportPreviewPage` test for the redirect-shim behavior; updated the list-page Preview assertion.
- Added a StatsTable assertion that count cells link to the canonical manage URL.

Biome + `tsc` clean on all changed files. **Pre-merge gate:** walk the report flow on a preview (admin sees the draft at `/reports/:runDate`; a logged-out user does not).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified portfolio report URLs now support published reports and administrator previews.
  * Community administrators can preview draft reports at the same report URL, while other viewers see only published reports.
  * Portfolio milestone counts now link consistently to the appropriate milestone management page.

* **Bug Fixes**
  * Updated report preview navigation and loading behavior to redirect reliably and avoid displaying unavailable drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->