### PR TITLE
fix(funding-platform): repair the /manage → public applicant redirect

### DIFF
--- a/__tests__/integration/pages/smoke/remaining-pages.test.tsx
+++ b/__tests__/integration/pages/smoke/remaining-pages.test.tsx
@@ -285,6 +285,8 @@ vi.mock("@/utilities/fundingPlatformUrls", () => ({
   getApplicationDetailUrl: (cId: string, ref: string) => `/community/${cId}/applications/${ref}`,
   getBrowseApplicationsUrl: (cId: string, pId: string) =>
     `/community/${cId}/browse-applications?programId=${pId}`,
+  getBrowseApplicationsRedirectUrl: (cId: string, pId: string) =>
+    `/community/${cId}/browse-applications?programId=${pId}`,
 }));
 
 vi.mock("@/utilities/formatCurrency", () => ({

--- a/__tests__/utilities/fundingPlatformUrls.test.ts
+++ b/__tests__/utilities/fundingPlatformUrls.test.ts
@@ -34,6 +34,8 @@ function setHostname(hostname: string) {
 
 // Import after the mock is registered.
 import {
+  getApplicationDetailUrl,
+  getBrowseApplicationsRedirectUrl,
   getBrowseApplicationsUrl,
   getDomainForCommunity,
   getGatedApplyUrl,
@@ -148,6 +150,73 @@ describe("getBrowseApplicationsUrl", () => {
     setHostname("gap.karmahq.xyz");
     expect(getBrowseApplicationsUrl("optimism", "123")).toBe(
       "https://app.opgrants.io/browse-applications?programId=123"
+    );
+  });
+});
+
+describe("getApplicationDetailUrl (in-app redirect target — always same-origin)", () => {
+  it("emits a same-origin path on localhost", () => {
+    setHostname("localhost");
+    expect(getApplicationDetailUrl("optimism", "REF-1")).toBe(
+      "/community/optimism/applications/REF-1"
+    );
+  });
+
+  it("stays same-origin on a deployed host instead of jumping to the tenant domain", () => {
+    // Regression (DEV-496): a redirect must keep the visitor on the current
+    // deployment. A reviewer link opened on the standard (non-whitelabel) host
+    // must resolve to /community/:slug/applications/:ref, never app.opgrants.io.
+    setHostname("gap.karmahq.xyz");
+    expect(getApplicationDetailUrl("optimism", "REF-1")).toBe(
+      "/community/optimism/applications/REF-1"
+    );
+  });
+
+  it("stays same-origin on staging even for tenants whose dev domain equals prod", () => {
+    // Regression (DEV-496): filecoin's dev domain === its prod domain
+    // (app.filpgf.io), so the old external-domain path bounced staging → prod.
+    setHostname("staging.karmahq.xyz");
+    mockEnv.isDev = true;
+    expect(getApplicationDetailUrl("filecoin", "REF-9")).toBe(
+      "/community/filecoin/applications/REF-9"
+    );
+  });
+
+  it("prefers the whitelabel origin (bare path on the current host)", () => {
+    setHostname("gap.karmahq.xyz");
+    expect(getApplicationDetailUrl("filecoin", "REF-1", "https://app.filpgf.io")).toBe(
+      "https://app.filpgf.io/applications/REF-1"
+    );
+  });
+
+  it("appends the tab query when provided", () => {
+    setHostname("localhost");
+    expect(getApplicationDetailUrl("optimism", "REF-1", undefined, { tab: "milestones" })).toBe(
+      "/community/optimism/applications/REF-1?tab=milestones"
+    );
+  });
+});
+
+describe("getBrowseApplicationsRedirectUrl (in-app redirect target — always same-origin)", () => {
+  it("stays same-origin on a deployed host instead of jumping to the tenant domain", () => {
+    setHostname("gap.karmahq.xyz");
+    expect(getBrowseApplicationsRedirectUrl("optimism", "123")).toBe(
+      "/community/optimism/browse-applications?programId=123"
+    );
+  });
+
+  it("stays same-origin on staging even for tenants whose dev domain equals prod", () => {
+    setHostname("staging.karmahq.xyz");
+    mockEnv.isDev = true;
+    expect(getBrowseApplicationsRedirectUrl("filecoin", "123")).toBe(
+      "/community/filecoin/browse-applications?programId=123"
+    );
+  });
+
+  it("prefers the whitelabel origin (bare path on the current host)", () => {
+    setHostname("gap.karmahq.xyz");
+    expect(getBrowseApplicationsRedirectUrl("filecoin", "123", "https://app.filpgf.io")).toBe(
+      "https://app.filpgf.io/browse-applications?programId=123"
     );
   });
 });

--- a/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/[programId]/applications/page.tsx
@@ -19,7 +19,7 @@ import { Link } from "@/src/components/navigation/Link";
 import { AdminOnly, FundingPlatformGuard, useIsFundingPlatformAdmin } from "@/src/core/rbac";
 import { usePermissionContext } from "@/src/core/rbac/context/permission-context";
 import type { IFundingApplication } from "@/types/funding-platform";
-import { getBrowseApplicationsUrl } from "@/utilities/fundingPlatformUrls";
+import { getBrowseApplicationsRedirectUrl } from "@/utilities/fundingPlatformUrls";
 import { PAGES } from "@/utilities/pages";
 import { useWhitelabel } from "@/utilities/whitelabel-context";
 
@@ -72,7 +72,13 @@ export default function ApplicationsPage() {
 
   // DEV-496: a non-reviewer handed the review-queue link is sent to the public
   // browse-applications list for the program rather than an "Access Denied" box.
-  const applicantRedirect = getBrowseApplicationsUrl(communityId, programId, whitelabelOrigin);
+  // Same-origin so the redirect stays on the current deployment (staging must not
+  // bounce to the production tenant domain).
+  const applicantRedirect = getBrowseApplicationsRedirectUrl(
+    communityId,
+    programId,
+    whitelabelOrigin
+  );
 
   const { data: programConfig } = useProgramConfig(programId);
   const { applications: _applications } = useFundingApplications(programId, initialFilters);

--- a/utilities/fundingPlatformUrls.ts
+++ b/utilities/fundingPlatformUrls.ts
@@ -145,6 +145,33 @@ export function getBrowseApplicationsUrl(
 }
 
 /**
+ * Same-origin browse-applications URL, for use as an in-app **redirect** target
+ * (a non-reviewer handed a `/manage` review-queue link is sent to the public
+ * browse list for the same program).
+ *
+ * Unlike {@link getBrowseApplicationsUrl} — which intentionally emits the external
+ * tenant domain so admins can copy a shareable public link — a redirect must keep
+ * the visitor on the current deployment. Emitting the external domain here would
+ * bounce staging → production for tenants whose dev domain equals their prod
+ * domain (e.g. filecoin, scroll).
+ *
+ * @param communityId - The community slug
+ * @param programId - The program ID
+ * @param whitelabelOrigin - Current origin when running in whitelabel mode
+ * @returns The same-origin URL to the browse-applications list
+ */
+export function getBrowseApplicationsRedirectUrl(
+  communityId: string,
+  programId: string,
+  whitelabelOrigin?: string
+): string {
+  if (whitelabelOrigin) {
+    return `${whitelabelOrigin}/browse-applications?programId=${programId}`;
+  }
+  return `${PAGES.COMMUNITY.BROWSE_APPLICATIONS(communityId)}?programId=${programId}`;
+}
+
+/**
  * Optional context appended to an application detail URL.
  *
  * The reference number alone identifies the application (globally unique —
@@ -168,11 +195,18 @@ function buildApplicationDetailQuery(context?: ApplicationDetailUrlContext): str
  * authenticated grantee lands on their private view. The route is keyed by
  * `referenceNumber`, not the application's internal id.
  *
+ * Always resolves to a **same-origin** target: this URL is only ever used as an
+ * in-app redirect destination (a visitor handed a `/manage` reviewer link is sent
+ * here), so it must keep them on the current deployment. Emitting the external
+ * tenant domain would bounce staging → production for tenants whose dev domain
+ * equals their prod domain (e.g. filecoin `app.filpgf.io`, scroll
+ * `grantsapp.scroll.io`), which is why the external-domain branch is not used here.
+ *
  * @param communityId - The community slug
  * @param referenceNumber - The application's reference number
  * @param whitelabelOrigin - Current origin when running in whitelabel mode
- * @param context - Optional `programId`/`tab` query context (DEV-496)
- * @returns The full URL to the application detail page
+ * @param context - Optional `tab` query context (DEV-496)
+ * @returns The same-origin URL to the application detail page
  */
 export function getApplicationDetailUrl(
   communityId: string,
@@ -181,11 +215,10 @@ export function getApplicationDetailUrl(
   context?: ApplicationDetailUrlContext
 ): string {
   const query = buildApplicationDetailQuery(context);
-  if (usesSameOriginLinks(whitelabelOrigin)) {
-    return `${PAGES.COMMUNITY.APPLICATION_DETAIL(communityId, referenceNumber)}${query}`;
+  if (whitelabelOrigin) {
+    return `${whitelabelOrigin}/applications/${referenceNumber}${query}`;
   }
-  const domain = getDomainForCommunity(communityId, whitelabelOrigin);
-  return `${domain}/applications/${referenceNumber}${query}`;
+  return `${PAGES.COMMUNITY.APPLICATION_DETAIL(communityId, referenceNumber)}${query}`;
 }
 
 export type GranteeRedirect = { kind: "application" | "dashboard"; url: string };


### PR DESCRIPTION
## Summary

Two fixes that make the DEV-496 `/manage → /applications/:ref` applicant redirect actually work. A visitor handed a reviewer/manage link should land on the canonical **public** page — on the **current deployment**, and for the **applicants it targets**.

## 1. Redirect stayed on the wrong domain (staging → production)

When the redirect fired, `getApplicationDetailUrl` / the list redirect resolved the base via `getDomainForCommunity`, which on any deployed host returns the external tenant domain (`.dev`/`.prod` by `envVars.isDev`). For tenants whose dev domain equals their prod domain — filecoin (`app.filpgf.io`), scroll (`grantsapp.scroll.io`) — a visitor on `staging.karmahq.xyz` was bounced to **production**.

**Fix:** both redirect targets resolve **same-origin** — the whitelabel origin in whitelabel mode, otherwise the relative `/community/:slug/...` route. `getApplicationDetailUrl` is now same-origin-only (it's redirect-only); the list route uses a dedicated `getBrowseApplicationsRedirectUrl`. The dual-use `getBrowseApplicationsUrl` (question-builder "share" link) is left external on purpose.

## 2. Redirect never fired for the applicants it targets (shadowed by the layout gate)

The page-level `FundingPlatformGuard onDeniedRedirectTo` is **shadowed** by `ManageLayoutShell`: anyone without community manage access gets `ManageDeniedView` **before** the guarded page mounts. So a logged-out applicant or authenticated non-reviewer handed a reviewer link hit a wall with the reviewer URL stuck in the address bar — the redirect never ran. (Surfaced by this PR's QA run; pre-existing since #1836.)

**Fix (at the denial boundary):**
- **Authenticated** visitor without manage access on a funding-platform application-detail or review-queue route → redirected to the canonical public page (same-origin, via `getManageFundingPlatformPublicRedirect`), regardless of ownership.
- **Logged-out** visitor → keeps the access-denied wall (must sign in first).
- Transient permission-lookup failure (`isGuestDueToError`) → undetermined, never redirects; auth resolves behind a spinner so the denial never flashes.

## Testing

- `getApplicationDetailUrl` / `getBrowseApplicationsRedirectUrl` / `getManageFundingPlatformPublicRedirect` unit cases: same-origin on a deployed host **and** on staging for a `dev === prod` tenant (filecoin), whitelabel-origin honored, milestones/non-redirect routes → null.
- `ManageDeniedView` component cases: authenticated → redirect + spinner; logged-out → access-denied; auth-not-ready → spinner (no flash); `isGuestDueToError` → no redirect; non-redirect route → access-denied.
- 38 targeted tests + 294 related RBAC/smoke tests green; `biome`, `tsc --noEmit`, and `next build` all clean.

## Risk

Low. Whitelabel and localhost behavior is unchanged. The domain change only affects the deployed non-whitelabel redirect path (external absolute → same-origin relative). The denial-boundary change only adds a redirect for **authenticated** users on two specific funding-platform routes; logged-out users and every other manage route keep the existing access-denied view.

Linear: DEV-496