### PR TITLE
chore(indexability): add production indexability monitor

### DIFF
--- a/.github/workflows/indexability-monitor.yml
+++ b/.github/workflows/indexability-monitor.yml
@@ -43,11 +43,17 @@ jobs:
       - name: Run indexability verification
         id: verify
         continue-on-error: true
+        # Pass workflow_dispatch inputs through the environment and reference them
+        # as quoted shell variables — never interpolate ${{ }} directly into the
+        # run script, which would let a crafted manual input escape the quotes.
+        env:
+          MIN_LEAF_COUNT: ${{ github.event.inputs.min_leaf_count || '3800' }}
+          TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '15000' }}
         run: >
           node scripts/verify-indexability.mjs
           --output artifacts/indexability-report.json
-          --min-leaf-count "${{ github.event.inputs.min_leaf_count || '3800' }}"
-          --timeout-ms "${{ github.event.inputs.timeout_ms || '15000' }}"
+          --min-leaf-count "$MIN_LEAF_COUNT"
+          --timeout-ms "$TIMEOUT_MS"
 
       - name: Append report summary
         if: always()

--- a/.github/workflows/indexability-monitor.yml
+++ b/.github/workflows/indexability-monitor.yml
@@ -1,0 +1,94 @@
+name: Indexability Monitor
+
+on:
+  schedule:
+    # Daily at 07:15 UTC.
+    - cron: "15 7 * * *"
+  workflow_dispatch:
+    inputs:
+      min_leaf_count:
+        # Floor recalibrated 4000 -> 3800 after gap-indexer #2195 (production-1.47.49)
+        # projects=v4 content-gate dropped the accepted projects baseline (~4087 ->
+        # ~3992 total leaves). 3800 is ~95% of the new 3992 baseline.
+        description: "Minimum sitemap leaf count"
+        required: false
+        default: "3800"
+      timeout_ms:
+        description: "Per-request timeout in milliseconds"
+        required: false
+        default: "15000"
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run Node test suites
+        run: >
+          node --test
+          scripts/indexability/__tests__/audit-sitemaps.test.mjs
+          scripts/indexability/__tests__/verify-indexability.test.mjs
+          scripts/indexability/__tests__/cli.test.mjs
+
+      - name: Run indexability verification
+        id: verify
+        continue-on-error: true
+        run: >
+          node scripts/verify-indexability.mjs
+          --output artifacts/indexability-report.json
+          --min-leaf-count "${{ github.event.inputs.min_leaf_count || '3800' }}"
+          --timeout-ms "${{ github.event.inputs.timeout_ms || '15000' }}"
+
+      - name: Append report summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/indexability-report.json ]; then
+            node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+              const r = JSON.parse(readFileSync("artifacts/indexability-report.json", "utf8"));
+              const failing = (r.checks ?? []).filter((c) => !c.ok).map((c) => c.name);
+              const passed = (r.checks ?? []).filter((c) => c.ok).length;
+              const lines = [
+                "## Indexability monitor",
+                "",
+                `- Overall: ${r.ok ? "PASS" : "FAIL"}`,
+                `- Timestamp: ${r.timestamp ?? "unknown"}`,
+                `- Canonical: ${r.origins?.canonical ?? "unknown"}`,
+                `- Sitemaps: ${r.sitemap?.sitemapCount ?? 0} docs, ${r.sitemap?.leafCount ?? 0} leaves`,
+                `- Representative: ${r.representativeProject ?? "none"}`,
+                `- Checks: ${passed}/${(r.checks ?? []).length} passed`,
+                `- Failing: ${failing.length ? failing.join(", ") : "none"}`,
+              ];
+              process.stdout.write(lines.join("\n") + "\n");
+            ' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No indexability report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: indexability-report
+          path: artifacts/indexability-report.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail job if verification failed
+        if: always()
+        run: |
+          if [ "${{ steps.verify.outcome }}" != "success" ]; then
+            echo "Indexability verification failed."
+            exit 1
+          fi

--- a/scripts/indexability/__tests__/audit-sitemaps.test.mjs
+++ b/scripts/indexability/__tests__/audit-sitemaps.test.mjs
@@ -49,12 +49,7 @@ describe("auditSitemaps", () => {
   it("recursively traverses to urlset leaves and reports counts", async () => {
     const fetchImpl = makeFetch({
       [ROOT]: () =>
-        xml(
-          sitemapIndex([
-            `${CANONICAL}/sitemap-projects.xml`,
-            `${CANONICAL}/sitemap-pages.xml`,
-          ])
-        ),
+        xml(sitemapIndex([`${CANONICAL}/sitemap-projects.xml`, `${CANONICAL}/sitemap-pages.xml`])),
       [`${CANONICAL}/sitemap-projects.xml`]: () =>
         xml(urlSet([`${CANONICAL}/project/paraswap`, `${CANONICAL}/project/gitcoin`])),
       [`${CANONICAL}/sitemap-pages.xml`]: () =>
@@ -103,8 +98,7 @@ describe("auditSitemaps", () => {
 
   it("rejects leaves that carry a query or hash", async () => {
     const fetchImpl = makeFetch({
-      [ROOT]: () =>
-        xml(urlSet([`${CANONICAL}/project/a?tab=1`, `${CANONICAL}/project/b#frag`])),
+      [ROOT]: () => xml(urlSet([`${CANONICAL}/project/a?tab=1`, `${CANONICAL}/project/b#frag`])),
     });
 
     const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
@@ -281,4 +275,31 @@ describe("auditSitemaps", () => {
     assert.equal(report.ok, false);
     assert.ok(report.errors.some((e) => /minimum|min leaf|too few/i.test(e)));
   });
+});
+
+describe("body-read timeout", () => {
+  it(
+    "aborts a stalled sitemap body read via the timeout and still returns",
+    { timeout: 3000 },
+    async () => {
+      const fetchImpl = async (_url, options) => ({
+        status: 200,
+        headers: {
+          get: (name) => (name.toLowerCase() === "content-type" ? "application/xml" : null),
+        },
+        text: () =>
+          new Promise((_, reject) => {
+            options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      });
+      const report = await auditSitemaps({
+        fetch: fetchImpl,
+        rootSitemapUrl: ROOT,
+        minLeafCount: 0,
+        timeoutMs: 20,
+      });
+      assert.equal(report.leafCount, 0);
+      assert.ok(report.errors.some((e) => /sitemap fetch failed/.test(e)));
+    }
+  );
 });

--- a/scripts/indexability/__tests__/audit-sitemaps.test.mjs
+++ b/scripts/indexability/__tests__/audit-sitemaps.test.mjs
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+// RED: the production module does not exist yet — this import fails until the
+// dependency-free ESM verifier is implemented. Pins the auditSitemaps contract.
+import { auditSitemaps } from "../verify-indexability.mjs";
+
+// ---------------------------------------------------------------------------
+// Small dependency-free response helpers (no real network).
+// ---------------------------------------------------------------------------
+
+const CANONICAL = "https://www.karmahq.xyz";
+const ROOT = `${CANONICAL}/sitemap.xml`;
+const NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
+
+function xml(body, { status = 200, contentType = "application/xml" } = {}) {
+  return new Response(body, { status, headers: { "content-type": contentType } });
+}
+
+const sitemapIndex = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><sitemapindex ${NS}>${locs
+    .map((loc) => `<sitemap><loc>${loc}</loc></sitemap>`)
+    .join("")}</sitemapindex>`;
+
+const urlSet = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><urlset ${NS}>${locs
+    .map((loc) => `<url><loc>${loc}</loc></url>`)
+    .join("")}</urlset>`;
+
+function makeFetch(routes) {
+  const calls = [];
+  const callDetails = [];
+  const fetchImpl = async (url, options) => {
+    const key = String(url);
+    calls.push(key);
+    callDetails.push({ url: key, options });
+    const entry = routes[key];
+    if (entry === undefined) {
+      return new Response("missing", { status: 404, headers: { "content-type": "text/plain" } });
+    }
+    // Pass options through so handlers can observe redirect + abort signal.
+    return typeof entry === "function" ? entry(options) : entry;
+  };
+  fetchImpl.calls = calls;
+  fetchImpl.callDetails = callDetails;
+  return fetchImpl;
+}
+
+describe("auditSitemaps", () => {
+  it("recursively traverses to urlset leaves and reports counts", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        xml(
+          sitemapIndex([
+            `${CANONICAL}/sitemap-projects.xml`,
+            `${CANONICAL}/sitemap-pages.xml`,
+          ])
+        ),
+      [`${CANONICAL}/sitemap-projects.xml`]: () =>
+        xml(urlSet([`${CANONICAL}/project/paraswap`, `${CANONICAL}/project/gitcoin`])),
+      [`${CANONICAL}/sitemap-pages.xml`]: () =>
+        xml(urlSet([`${CANONICAL}/projects`, `${CANONICAL}/about`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 3 });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.sitemapCount, 3); // index + 2 children
+    assert.equal(report.leafCount, 4);
+    assert.ok(report.leaves.includes(`${CANONICAL}/project/paraswap`));
+    assert.deepEqual(report.errors, []);
+  });
+
+  it("dedupes repeated child sitemap references and fetches each once", async () => {
+    const child = `${CANONICAL}/sitemap-projects.xml`;
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([child, child])),
+      [child]: () => xml(urlSet([`${CANONICAL}/project/paraswap`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 1 });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.sitemapCount, 2); // index + one unique child
+    assert.equal(report.leafCount, 1);
+    assert.equal(
+      fetchImpl.calls.filter((u) => u === child).length,
+      1,
+      "duplicate child sitemap must be fetched only once"
+    );
+  });
+
+  it("rejects leaves whose origin is not the canonical host", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(urlSet([`${CANONICAL}/project/ok`, "https://evil.example.com/project/x"])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 1 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.leafCount, 1);
+    assert.ok(report.errors.some((e) => e.includes("evil.example.com")));
+  });
+
+  it("rejects leaves that carry a query or hash", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        xml(urlSet([`${CANONICAL}/project/a?tab=1`, `${CANONICAL}/project/b#frag`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.leafCount, 0);
+    assert.ok(report.errors.length >= 2);
+  });
+
+  it("rejects duplicate leaves across sitemaps", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([`${CANONICAL}/a.xml`, `${CANONICAL}/b.xml`])),
+      [`${CANONICAL}/a.xml`]: () => xml(urlSet([`${CANONICAL}/project/dup`])),
+      [`${CANONICAL}/b.xml`]: () => xml(urlSet([`${CANONICAL}/project/dup`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 1 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /duplicate/i.test(e)));
+  });
+
+  it("rejects malformed loc URLs", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(urlSet(["https:// not a url", "::::"])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.leafCount, 0);
+  });
+
+  it("rejects an off-origin child sitemap and never fetches it, even with canonical leaves", async () => {
+    const offOrigin = "https://evil.example.com/sitemap-projects.xml";
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([offOrigin])),
+      // Its leaves would be canonical, but the child itself must never be loaded.
+      [offOrigin]: () => xml(urlSet([`${CANONICAL}/project/canonical-but-unreachable`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => e.includes("evil.example.com")));
+    assert.ok(
+      !fetchImpl.calls.includes(offOrigin),
+      "off-origin child sitemap must never be fetched"
+    );
+    assert.equal(report.leafCount, 0);
+  });
+
+  it("detects cycles between sitemapindex files without looping forever", async () => {
+    const a = `${CANONICAL}/a.xml`;
+    const b = `${CANONICAL}/b.xml`;
+    const fetchImpl = makeFetch({
+      [a]: () => xml(sitemapIndex([b])),
+      [b]: () => xml(sitemapIndex([a])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: a, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /cycle/i.test(e)));
+  });
+
+  it("rejects a non-200 sitemap response", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([`${CANONICAL}/child.xml`])),
+      [`${CANONICAL}/child.xml`]: () => xml("", { status: 500 }),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /500|status/i.test(e)));
+  });
+
+  it("rejects a non-XML content type", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /xml|content-type/i.test(e)));
+  });
+
+  it("rejects banned exact project slugs (-1, ---, -nan, test)", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        xml(
+          urlSet([
+            `${CANONICAL}/project/-1`,
+            `${CANONICAL}/project/---`,
+            `${CANONICAL}/project/-nan`,
+            `${CANONICAL}/project/test`,
+            `${CANONICAL}/project/valid`,
+          ])
+        ),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 1 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.leafCount, 1); // only /project/valid survives
+    for (const banned of ["-1", "---", "-nan", "test"]) {
+      assert.ok(
+        report.errors.some((e) => e.includes(`/project/${banned}`)),
+        `banned slug ${banned} must be reported`
+      );
+    }
+  });
+
+  it("fetches root and child sitemaps with redirect: manual", async () => {
+    const child = `${CANONICAL}/child.xml`;
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(sitemapIndex([child])),
+      [child]: () => xml(urlSet([`${CANONICAL}/project/ok`])),
+    });
+
+    await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    for (const url of [ROOT, child]) {
+      const call = fetchImpl.callDetails.find((c) => c.url === url);
+      assert.ok(call, `expected a fetch for ${url}`);
+      assert.equal(call.options?.redirect, "manual");
+    }
+  });
+
+  it("applies the configurable timeout to a pending sitemap fetch via options.signal", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: (options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted.", "AbortError"))
+          );
+        }),
+    });
+
+    const report = await auditSitemaps({
+      fetch: fetchImpl,
+      rootSitemapUrl: ROOT,
+      minLeafCount: 0,
+      timeoutMs: 20,
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /fetch failed|abort/i.test(e)));
+  });
+
+  it("rejects XML whose root is neither sitemapindex nor urlset", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        xml(`<?xml version="1.0" encoding="UTF-8"?><foo><loc>${CANONICAL}/project/x</loc></foo>`),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 0 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.leafCount, 0);
+    assert.ok(report.errors.some((e) => /unrecognized|sitemapindex|urlset|root/i.test(e)));
+  });
+
+  it("enforces the configurable minimum leaf count", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () => xml(urlSet([`${CANONICAL}/project/a`, `${CANONICAL}/project/b`])),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 5 });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.errors.some((e) => /minimum|min leaf|too few/i.test(e)));
+  });
+});

--- a/scripts/indexability/__tests__/cli.test.mjs
+++ b/scripts/indexability/__tests__/cli.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+// Importing the CLI must not execute it (import-safe guard).
+import { main, parseArgs } from "../../verify-indexability.mjs";
+
+function fakeStream() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(chunk);
+      return true;
+    },
+    text() {
+      return chunks.join("");
+    },
+  };
+}
+
+function makeReport(ok) {
+  return {
+    timestamp: "2026-07-14T00:00:00.000Z",
+    origins: { canonical: "C", apex: "A", gap: "G", indexer: "I" },
+    sitemap: { sitemapCount: 3, leafCount: 4200 },
+    representativeProject: "/project/x",
+    checks: [
+      { name: "root", ok: true },
+      { name: "indexer-decision", ok },
+    ],
+    errors: ok ? [] : ["indexer-decision: check failed"],
+    ok,
+  };
+}
+
+function captureVerify(report) {
+  const calls = [];
+  const verify = async (options) => {
+    calls.push(options);
+    return report;
+  };
+  verify.calls = calls;
+  return verify;
+}
+
+async function withTempDir(run) {
+  const dir = await mkdtemp(join(tmpdir(), "indexability-cli-"));
+  try {
+    return await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("parseArgs", () => {
+  it("parses known flags in both --flag value and --flag=value forms", () => {
+    const flags = parseArgs(["--canonical-origin=https://x", "--timeout-ms", "5", "--output", "/tmp/r.json"]);
+    assert.equal(flags.canonicalOrigin, "https://x");
+    assert.equal(flags.timeoutMs, "5");
+    assert.equal(flags.output, "/tmp/r.json");
+  });
+
+  it("rejects unknown flags", () => {
+    assert.throws(() => parseArgs(["--nope", "x"]), /Unknown argument/);
+  });
+
+  it("rejects a missing value", () => {
+    assert.throws(() => parseArgs(["--min-leaf-count"]), /Missing value/);
+    assert.throws(() => parseArgs(["--min-leaf-count", "--output", "x"]), /Missing value/);
+  });
+});
+
+describe("main configuration", () => {
+  it("applies production defaults", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({ argv: [], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+
+    assert.equal(code, 0);
+    const options = verify.calls[0];
+    assert.equal(options.canonicalOrigin, "https://www.karmahq.xyz");
+    assert.equal(options.apexOrigin, "https://karmahq.xyz");
+    assert.equal(options.gapOrigin, "https://gap.karmahq.xyz");
+    assert.equal(options.indexerBaseUrl, "https://gapapi.karmahq.xyz");
+    assert.equal(options.rootSitemapUrl, "https://www.karmahq.xyz/sitemap_index.xml");
+    assert.equal(options.minLeafCount, 3800);
+    assert.equal(options.timeoutMs, 15000);
+  });
+
+  it("applies INDEXABILITY_ env overrides and derives the root from the canonical", async () => {
+    const verify = captureVerify(makeReport(true));
+    await main({
+      argv: [],
+      env: {
+        INDEXABILITY_CANONICAL_ORIGIN: "https://c.example",
+        INDEXABILITY_MIN_LEAF_COUNT: "10",
+        INDEXABILITY_TIMEOUT_MS: "500",
+      },
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+
+    const options = verify.calls[0];
+    assert.equal(options.canonicalOrigin, "https://c.example");
+    assert.equal(options.minLeafCount, 10);
+    assert.equal(options.timeoutMs, 500);
+    assert.equal(options.rootSitemapUrl, "https://c.example/sitemap_index.xml");
+  });
+
+  it("lets flags win over env and derives the root from the flag canonical", async () => {
+    const verify = captureVerify(makeReport(true));
+    await main({
+      argv: ["--canonical-origin=https://flag.example", "--min-leaf-count", "20"],
+      env: {
+        INDEXABILITY_CANONICAL_ORIGIN: "https://env.example",
+        INDEXABILITY_MIN_LEAF_COUNT: "10",
+      },
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+
+    const options = verify.calls[0];
+    assert.equal(options.canonicalOrigin, "https://flag.example");
+    assert.equal(options.minLeafCount, 20);
+    assert.equal(options.rootSitemapUrl, "https://flag.example/sitemap_index.xml");
+  });
+
+  it("uses an explicit root sitemap url verbatim even when canonical changes", async () => {
+    const verify = captureVerify(makeReport(true));
+    await main({
+      argv: ["--root-sitemap-url", "https://c.example/custom.xml", "--canonical-origin", "https://other.example"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+
+    assert.equal(verify.calls[0].rootSitemapUrl, "https://c.example/custom.xml");
+  });
+
+  it("returns 1 without running verify on invalid numeric args", async () => {
+    const verify = captureVerify(makeReport(true));
+    const stderr = fakeStream();
+    const code = await main({ argv: ["--min-leaf-count", "abc"], env: {}, verify, stdout: fakeStream(), stderr });
+
+    assert.equal(code, 1);
+    assert.equal(verify.calls.length, 0);
+    assert.match(stderr.text(), /Invalid numeric value for --min-leaf-count/);
+  });
+
+  it("returns 1 without running verify on unknown flags", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({ argv: ["--bogus"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+
+    assert.equal(code, 1);
+    assert.equal(verify.calls.length, 0);
+  });
+});
+
+describe("main output + exit codes", () => {
+  it("writes pretty JSON (creating parent dirs) and exits 0 on success", async () => {
+    await withTempDir(async (dir) => {
+      const outputPath = join(dir, "nested", "report.json");
+      const stdout = fakeStream();
+      const verify = captureVerify(makeReport(true));
+
+      const code = await main({ argv: ["--output", outputPath], env: {}, verify, stdout, stderr: fakeStream() });
+
+      assert.equal(code, 0);
+      const content = await readFile(outputPath, "utf8");
+      const parsed = JSON.parse(content);
+      assert.equal(parsed.ok, true);
+      assert.match(content, /\n {2}"ok": true/); // pretty-printed, 2-space indent
+      assert.match(stdout.text(), /Overall: PASS/);
+      assert.match(stdout.text(), /PASS root/);
+    });
+  });
+
+  it("still writes the report and exits 1 on failure", async () => {
+    await withTempDir(async (dir) => {
+      const outputPath = join(dir, "report.json");
+      const stdout = fakeStream();
+      const verify = captureVerify(makeReport(false));
+
+      const code = await main({ argv: ["--output", outputPath], env: {}, verify, stdout, stderr: fakeStream() });
+
+      assert.equal(code, 1);
+      const parsed = JSON.parse(await readFile(outputPath, "utf8"));
+      assert.equal(parsed.ok, false);
+      assert.match(stdout.text(), /Overall: FAIL/);
+    });
+  });
+
+  it("exits 1 without an output file when the report is not ok and no output is set", async () => {
+    const verify = captureVerify(makeReport(false));
+    const code = await main({ argv: [], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    assert.equal(code, 1);
+  });
+});
+
+describe("main failure handling", () => {
+  it("writes a structured failure report and exits 1 when the verifier throws with --output set", async () => {
+    await withTempDir(async (dir) => {
+      const outputPath = join(dir, "nested", "report.json");
+      const stderr = fakeStream();
+      const verify = async () => {
+        throw new Error("boom-verifier");
+      };
+
+      const code = await main({
+        argv: ["--output", outputPath, "--canonical-origin", "https://c.example"],
+        env: {},
+        verify,
+        stdout: fakeStream(),
+        stderr,
+      });
+
+      assert.equal(code, 1);
+      assert.match(stderr.text(), /boom-verifier/);
+
+      const parsed = JSON.parse(await readFile(outputPath, "utf8"));
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.sitemap.sitemapCount, 0);
+      assert.equal(parsed.sitemap.leafCount, 0);
+      assert.deepEqual(parsed.checks, []);
+      assert.ok(parsed.errors.some((error) => error.includes("boom-verifier")));
+      assert.equal(parsed.origins.canonical, "https://c.example");
+      assert.equal(parsed.origins.indexer, "https://gapapi.karmahq.xyz");
+      assert.equal(typeof parsed.timestamp, "string");
+      assert.ok(parsed.timestamp.length > 0);
+    });
+  });
+
+  it("returns 1 and reports both errors when the verifier throws and the failure-report write also fails", async () => {
+    const stderr = fakeStream();
+    const verify = async () => {
+      throw new Error("boom-verifier");
+    };
+    const writeFile = async () => {
+      throw new Error("disk-full");
+    };
+
+    const code = await main({
+      argv: ["--output", "/some/report.json"],
+      env: {},
+      verify,
+      writeFile,
+      mkdir: async () => {},
+      stdout: fakeStream(),
+      stderr,
+    });
+
+    assert.equal(code, 1);
+    assert.match(stderr.text(), /boom-verifier/);
+    assert.match(stderr.text(), /disk-full/);
+  });
+});
+
+describe("strict numeric validation", () => {
+  it("accepts --min-leaf-count 0 (nonnegative)", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({ argv: ["--min-leaf-count", "0"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    assert.equal(code, 0);
+    assert.equal(verify.calls[0].minLeafCount, 0);
+  });
+
+  for (const bad of ["-1", "1.5", "1e3", "9007199254740992"]) {
+    it(`rejects --min-leaf-count ${bad} before running verify`, async () => {
+      const verify = captureVerify(makeReport(true));
+      const stderr = fakeStream();
+      const code = await main({ argv: ["--min-leaf-count", bad], env: {}, verify, stdout: fakeStream(), stderr });
+      assert.equal(code, 1);
+      assert.equal(verify.calls.length, 0);
+      assert.match(stderr.text(), /--min-leaf-count/);
+    });
+  }
+
+  for (const bad of ["0", "-1", "1.5", "1e3", "9007199254740992"]) {
+    it(`rejects --timeout-ms ${bad} before running verify`, async () => {
+      const verify = captureVerify(makeReport(true));
+      const stderr = fakeStream();
+      const code = await main({ argv: ["--timeout-ms", bad], env: {}, verify, stdout: fakeStream(), stderr });
+      assert.equal(code, 1);
+      assert.equal(verify.calls.length, 0);
+      assert.match(stderr.text(), /--timeout-ms/);
+    });
+  }
+
+  it("accepts a positive safe --timeout-ms", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({ argv: ["--timeout-ms", "500"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    assert.equal(code, 0);
+    assert.equal(verify.calls[0].timeoutMs, 500);
+  });
+});

--- a/scripts/indexability/__tests__/cli.test.mjs
+++ b/scripts/indexability/__tests__/cli.test.mjs
@@ -55,7 +55,13 @@ async function withTempDir(run) {
 
 describe("parseArgs", () => {
   it("parses known flags in both --flag value and --flag=value forms", () => {
-    const flags = parseArgs(["--canonical-origin=https://x", "--timeout-ms", "5", "--output", "/tmp/r.json"]);
+    const flags = parseArgs([
+      "--canonical-origin=https://x",
+      "--timeout-ms",
+      "5",
+      "--output",
+      "/tmp/r.json",
+    ]);
     assert.equal(flags.canonicalOrigin, "https://x");
     assert.equal(flags.timeoutMs, "5");
     assert.equal(flags.output, "/tmp/r.json");
@@ -74,7 +80,13 @@ describe("parseArgs", () => {
 describe("main configuration", () => {
   it("applies production defaults", async () => {
     const verify = captureVerify(makeReport(true));
-    const code = await main({ argv: [], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    const code = await main({
+      argv: [],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
 
     assert.equal(code, 0);
     const options = verify.calls[0];
@@ -130,7 +142,12 @@ describe("main configuration", () => {
   it("uses an explicit root sitemap url verbatim even when canonical changes", async () => {
     const verify = captureVerify(makeReport(true));
     await main({
-      argv: ["--root-sitemap-url", "https://c.example/custom.xml", "--canonical-origin", "https://other.example"],
+      argv: [
+        "--root-sitemap-url",
+        "https://c.example/custom.xml",
+        "--canonical-origin",
+        "https://other.example",
+      ],
       env: {},
       verify,
       stdout: fakeStream(),
@@ -143,7 +160,13 @@ describe("main configuration", () => {
   it("returns 1 without running verify on invalid numeric args", async () => {
     const verify = captureVerify(makeReport(true));
     const stderr = fakeStream();
-    const code = await main({ argv: ["--min-leaf-count", "abc"], env: {}, verify, stdout: fakeStream(), stderr });
+    const code = await main({
+      argv: ["--min-leaf-count", "abc"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr,
+    });
 
     assert.equal(code, 1);
     assert.equal(verify.calls.length, 0);
@@ -152,7 +175,13 @@ describe("main configuration", () => {
 
   it("returns 1 without running verify on unknown flags", async () => {
     const verify = captureVerify(makeReport(true));
-    const code = await main({ argv: ["--bogus"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    const code = await main({
+      argv: ["--bogus"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
 
     assert.equal(code, 1);
     assert.equal(verify.calls.length, 0);
@@ -166,7 +195,13 @@ describe("main output + exit codes", () => {
       const stdout = fakeStream();
       const verify = captureVerify(makeReport(true));
 
-      const code = await main({ argv: ["--output", outputPath], env: {}, verify, stdout, stderr: fakeStream() });
+      const code = await main({
+        argv: ["--output", outputPath],
+        env: {},
+        verify,
+        stdout,
+        stderr: fakeStream(),
+      });
 
       assert.equal(code, 0);
       const content = await readFile(outputPath, "utf8");
@@ -184,7 +219,13 @@ describe("main output + exit codes", () => {
       const stdout = fakeStream();
       const verify = captureVerify(makeReport(false));
 
-      const code = await main({ argv: ["--output", outputPath], env: {}, verify, stdout, stderr: fakeStream() });
+      const code = await main({
+        argv: ["--output", outputPath],
+        env: {},
+        verify,
+        stdout,
+        stderr: fakeStream(),
+      });
 
       assert.equal(code, 1);
       const parsed = JSON.parse(await readFile(outputPath, "utf8"));
@@ -195,7 +236,13 @@ describe("main output + exit codes", () => {
 
   it("exits 1 without an output file when the report is not ok and no output is set", async () => {
     const verify = captureVerify(makeReport(false));
-    const code = await main({ argv: [], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    const code = await main({
+      argv: [],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
     assert.equal(code, 1);
   });
 });
@@ -261,7 +308,13 @@ describe("main failure handling", () => {
 describe("strict numeric validation", () => {
   it("accepts --min-leaf-count 0 (nonnegative)", async () => {
     const verify = captureVerify(makeReport(true));
-    const code = await main({ argv: ["--min-leaf-count", "0"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    const code = await main({
+      argv: ["--min-leaf-count", "0"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
     assert.equal(code, 0);
     assert.equal(verify.calls[0].minLeafCount, 0);
   });
@@ -270,7 +323,13 @@ describe("strict numeric validation", () => {
     it(`rejects --min-leaf-count ${bad} before running verify`, async () => {
       const verify = captureVerify(makeReport(true));
       const stderr = fakeStream();
-      const code = await main({ argv: ["--min-leaf-count", bad], env: {}, verify, stdout: fakeStream(), stderr });
+      const code = await main({
+        argv: ["--min-leaf-count", bad],
+        env: {},
+        verify,
+        stdout: fakeStream(),
+        stderr,
+      });
       assert.equal(code, 1);
       assert.equal(verify.calls.length, 0);
       assert.match(stderr.text(), /--min-leaf-count/);
@@ -281,7 +340,13 @@ describe("strict numeric validation", () => {
     it(`rejects --timeout-ms ${bad} before running verify`, async () => {
       const verify = captureVerify(makeReport(true));
       const stderr = fakeStream();
-      const code = await main({ argv: ["--timeout-ms", bad], env: {}, verify, stdout: fakeStream(), stderr });
+      const code = await main({
+        argv: ["--timeout-ms", bad],
+        env: {},
+        verify,
+        stdout: fakeStream(),
+        stderr,
+      });
       assert.equal(code, 1);
       assert.equal(verify.calls.length, 0);
       assert.match(stderr.text(), /--timeout-ms/);
@@ -290,8 +355,56 @@ describe("strict numeric validation", () => {
 
   it("accepts a positive safe --timeout-ms", async () => {
     const verify = captureVerify(makeReport(true));
-    const code = await main({ argv: ["--timeout-ms", "500"], env: {}, verify, stdout: fakeStream(), stderr: fakeStream() });
+    const code = await main({
+      argv: ["--timeout-ms", "500"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
     assert.equal(code, 0);
     assert.equal(verify.calls[0].timeoutMs, 500);
+  });
+});
+
+describe("origin normalization and validation", () => {
+  it("normalizes a trailing-slash canonical origin and derives a single-slash root sitemap", async () => {
+    const verify = captureVerify(makeReport(true));
+    await main({
+      argv: [],
+      env: { INDEXABILITY_CANONICAL_ORIGIN: "https://c.example/" },
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+    const options = verify.calls[0];
+    assert.equal(options.canonicalOrigin, "https://c.example");
+    assert.equal(options.rootSitemapUrl, "https://c.example/sitemap_index.xml");
+  });
+
+  it("rejects a path-bearing canonical origin without running verify", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({
+      argv: ["--canonical-origin=https://c.example/foo"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+    assert.equal(code, 1);
+    assert.equal(verify.calls.length, 0);
+  });
+
+  it("rejects a non-http origin scheme without running verify", async () => {
+    const verify = captureVerify(makeReport(true));
+    const code = await main({
+      argv: ["--apex-origin=ftp://c.example"],
+      env: {},
+      verify,
+      stdout: fakeStream(),
+      stderr: fakeStream(),
+    });
+    assert.equal(code, 1);
+    assert.equal(verify.calls.length, 0);
   });
 });

--- a/scripts/indexability/__tests__/verify-indexability.test.mjs
+++ b/scripts/indexability/__tests__/verify-indexability.test.mjs
@@ -59,8 +59,7 @@ function healthyRoutes() {
     // Listing + home.
     [`${CANONICAL}/`]: () => htmlPage({ status: 200, canonical: `${CANONICAL}/` }),
     [`${CANONICAL}/projects`]: () => htmlPage({ status: 200, canonical: `${CANONICAL}/projects` }),
-    [`${CANONICAL}/projects?page=2`]: () =>
-      htmlPage({ status: 200, robots: "noindex, follow" }),
+    [`${CANONICAL}/projects?page=2`]: () => htmlPage({ status: 200, robots: "noindex, follow" }),
     [`${CANONICAL}/projects?utm_source=x`]: () => htmlPage({ status: 200 }),
 
     // Alias hosts: exact one-hop 308 to www, preserving path + query.
@@ -77,8 +76,7 @@ function healthyRoutes() {
       htmlPage({ status: 200, robots: "noindex, follow" }),
 
     // Compound gap legacy grants route → one 308 to final www funding.
-    [`${GAP}/project/${SLUG}/grants`]: () =>
-      redirectTo(`${CANONICAL}/project/${SLUG}/funding`),
+    [`${GAP}/project/${SLUG}/grants`]: () => redirectTo(`${CANONICAL}/project/${SLUG}/funding`),
 
     // Invalid slug → gone with noindex.
     [`${CANONICAL}/project/this-project-does-not-exist`]: () =>
@@ -386,4 +384,62 @@ describe("verifyIndexability permanent-redirect handling", () => {
     assert.equal(legacy.ok, false);
     assert.equal(legacy.resolved, `${CANONICAL}/project/${SLUG}/grants`);
   });
+});
+
+describe("origin normalization and validation", () => {
+  it("normalizes a trailing-slash canonical origin so same-origin leaves are accepted", async () => {
+    const CANON2 = "https://c.example";
+    const root2 = `${CANON2}/sitemap_index.xml`;
+    const fetchImpl = makeFetch({
+      [root2]: () => xml(urlSet([`${CANON2}/project/foo`])),
+    });
+    const report = await verifyIndexability({
+      fetch: fetchImpl,
+      canonicalOrigin: "https://c.example/",
+      apexOrigin: APEX,
+      gapOrigin: GAP,
+      indexerBaseUrl: INDEXER,
+      rootSitemapUrl: root2,
+      minLeafCount: 1,
+      now: NOW,
+    });
+    assert.equal(report.origins.canonical, CANON2);
+    assert.equal(report.sitemap.leafCount, 1);
+  });
+
+  it("rejects a path-bearing canonical origin by throwing", async () => {
+    await assert.rejects(
+      () =>
+        verifyIndexability({
+          fetch: makeFetch({}),
+          canonicalOrigin: "https://c.example/path",
+          apexOrigin: APEX,
+          gapOrigin: GAP,
+          indexerBaseUrl: INDEXER,
+          now: NOW,
+        }),
+      /origin/i
+    );
+  });
+});
+
+describe("body-read timeout (page probes)", () => {
+  it(
+    "aborts a stalled page body read via the timeout and still runs later checks",
+    { timeout: 3000 },
+    async () => {
+      const routes = healthyRoutes();
+      routes[`${CANONICAL}/`] = (options) => ({
+        status: 200,
+        headers: { get: () => null },
+        text: () =>
+          new Promise((_, reject) => {
+            options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      });
+      const report = await runVerify(makeFetch(routes), { timeoutMs: 20 });
+      assert.equal(byName(report, "root").ok, false);
+      assert.equal(byName(report, "projects-listing").ok, true);
+    }
+  );
 });

--- a/scripts/indexability/__tests__/verify-indexability.test.mjs
+++ b/scripts/indexability/__tests__/verify-indexability.test.mjs
@@ -1,0 +1,389 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+// RED: the production module does not exist yet — this import fails until the
+// dependency-free ESM verifier is implemented. Pins the verifyIndexability
+// contract (verification matrix + resilient report).
+import { verifyIndexability } from "../verify-indexability.mjs";
+
+// ---------------------------------------------------------------------------
+// Origins + representative fixtures.
+// ---------------------------------------------------------------------------
+
+const CANONICAL = "https://www.karmahq.xyz";
+const APEX = "https://karmahq.xyz";
+const GAP = "https://gap.karmahq.xyz";
+const INDEXER = "https://indexer.test";
+const SITEMAP = `${CANONICAL}/sitemap.xml`;
+const SLUG = "paraswap";
+const NOW = "2026-07-14T00:00:00.000Z";
+const NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
+
+// ---------------------------------------------------------------------------
+// Small dependency-free response helpers (no real network).
+// ---------------------------------------------------------------------------
+
+function xml(body) {
+  return new Response(body, { status: 200, headers: { "content-type": "application/xml" } });
+}
+
+function htmlPage({ status = 200, robots, canonical } = {}) {
+  const headers = { "content-type": "text/html" };
+  if (robots) headers["x-robots-tag"] = robots;
+  const body = canonical
+    ? `<!doctype html><html><head><link rel="canonical" href="${canonical}"/></head><body></body></html>`
+    : "<!doctype html><html><head></head><body></body></html>";
+  return new Response(body, { status, headers });
+}
+
+function redirectTo(location, status = 308) {
+  return new Response(null, { status, headers: { location } });
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const urlSet = (locs) =>
+  `<?xml version="1.0" encoding="UTF-8"?><urlset ${NS}>${locs
+    .map((loc) => `<url><loc>${loc}</loc></url>`)
+    .join("")}</urlset>`;
+
+function healthyRoutes() {
+  return {
+    // Sitemap for auto-discovery of a representative /project/<slug> leaf.
+    [SITEMAP]: () => xml(urlSet([`${CANONICAL}/project/${SLUG}`, `${CANONICAL}/projects`])),
+
+    // Listing + home.
+    [`${CANONICAL}/`]: () => htmlPage({ status: 200, canonical: `${CANONICAL}/` }),
+    [`${CANONICAL}/projects`]: () => htmlPage({ status: 200, canonical: `${CANONICAL}/projects` }),
+    [`${CANONICAL}/projects?page=2`]: () =>
+      htmlPage({ status: 200, robots: "noindex, follow" }),
+    [`${CANONICAL}/projects?utm_source=x`]: () => htmlPage({ status: 200 }),
+
+    // Alias hosts: exact one-hop 308 to www, preserving path + query.
+    [`${APEX}/funding-map?ref=1`]: () => redirectTo(`${CANONICAL}/funding-map?ref=1`),
+    [`${GAP}/funding-map`]: () => redirectTo(`${CANONICAL}/funding-map`),
+
+    // Canonical project routes.
+    [`${CANONICAL}/project/${SLUG}`]: () =>
+      htmlPage({ status: 200, canonical: `${CANONICAL}/project/${SLUG}` }),
+    [`${CANONICAL}/project/${SLUG}/about`]: () =>
+      htmlPage({ status: 200, canonical: `${CANONICAL}/project/${SLUG}` }),
+    [`${CANONICAL}/project/${SLUG}/roadmap`]: () => redirectTo(`${CANONICAL}/project/${SLUG}`),
+    [`${CANONICAL}/project/${SLUG}/impact`]: () =>
+      htmlPage({ status: 200, robots: "noindex, follow" }),
+
+    // Compound gap legacy grants route → one 308 to final www funding.
+    [`${GAP}/project/${SLUG}/grants`]: () =>
+      redirectTo(`${CANONICAL}/project/${SLUG}/funding`),
+
+    // Invalid slug → gone with noindex.
+    [`${CANONICAL}/project/this-project-does-not-exist`]: () =>
+      htmlPage({ status: 404, robots: "noindex, follow" }),
+
+    // Each exact banned slug must be gone (404/410) + noindex at the canonical
+    // project path (mix of 404 and 410 to prove either is accepted).
+    [`${CANONICAL}/project/-1`]: () => htmlPage({ status: 404, robots: "noindex, follow" }),
+    [`${CANONICAL}/project/---`]: () => htmlPage({ status: 410, robots: "noindex, follow" }),
+    [`${CANONICAL}/project/-nan`]: () => htmlPage({ status: 404, robots: "noindex, follow" }),
+    [`${CANONICAL}/project/test`]: () => htmlPage({ status: 410, robots: "noindex, follow" }),
+
+    // Indexer decision endpoint → strict canonical-indexable root decision.
+    [`${INDEXER}/v2/projects/${SLUG}/indexability?route=root`]: () =>
+      jsonResponse({ outcome: "canonical-indexable", url: `/project/${SLUG}` }),
+  };
+}
+
+function makeFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    const key = String(url);
+    calls.push({ url: key, options });
+    const entry = routes[key];
+    if (typeof entry === "function") {
+      // Pass options through so route handlers can react to the abort signal.
+      return entry(options);
+    }
+    return new Response("missing", { status: 404, headers: { "content-type": "text/plain" } });
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+function runVerify(fetchImpl, extra = {}) {
+  return verifyIndexability({
+    fetch: fetchImpl,
+    canonicalOrigin: CANONICAL,
+    apexOrigin: APEX,
+    gapOrigin: GAP,
+    indexerBaseUrl: INDEXER,
+    rootSitemapUrl: SITEMAP,
+    minLeafCount: 1,
+    now: NOW,
+    ...extra,
+  });
+}
+
+const byName = (report, name) => report.checks.find((check) => check.name === name);
+
+describe("verifyIndexability", () => {
+  it("passes the full matrix and produces a complete report", async () => {
+    const report = await runVerify(makeFetch(healthyRoutes()));
+
+    assert.equal(report.ok, true);
+    assert.equal(report.timestamp, NOW);
+    assert.deepEqual(report.origins, {
+      canonical: CANONICAL,
+      apex: APEX,
+      gap: GAP,
+      indexer: INDEXER,
+    });
+    assert.ok(report.sitemap.sitemapCount >= 1);
+    assert.ok(report.sitemap.leafCount >= 1);
+    assert.equal(report.representativeProject, `/project/${SLUG}`);
+    assert.deepEqual(report.errors, []);
+
+    // Listing behaviors.
+    assert.equal(byName(report, "root").ok, true);
+    assert.equal(byName(report, "projects-listing").ok, true);
+    const paginated = byName(report, "projects-paginated");
+    assert.equal(paginated.ok, true);
+    assert.equal(paginated.robots, "noindex, follow");
+    const tracking = byName(report, "projects-tracking-only");
+    assert.equal(tracking.ok, true);
+    assert.ok(!tracking.robots, "tracking-only listing must not carry a robots header");
+
+    // Alias one-hop 308 preserving path + query.
+    const apex = byName(report, "apex-alias");
+    assert.equal(apex.ok, true);
+    assert.equal(apex.status, 308);
+    assert.equal(apex.location, `${CANONICAL}/funding-map?ref=1`);
+    assert.equal(byName(report, "gap-alias").ok, true);
+
+    // Project routes.
+    const projectRoot = byName(report, "project-root-canonical");
+    assert.equal(projectRoot.ok, true);
+    assert.equal(projectRoot.canonical, `${CANONICAL}/project/${SLUG}`);
+    const about = byName(report, "project-about-canonical");
+    assert.equal(about.ok, true);
+    assert.equal(about.canonical, `${CANONICAL}/project/${SLUG}`);
+    const roadmap = byName(report, "project-roadmap-redirect");
+    assert.equal(roadmap.ok, true);
+    assert.equal(roadmap.status, 308);
+    assert.equal(roadmap.location, `${CANONICAL}/project/${SLUG}`);
+    assert.equal(byName(report, "project-impact-noindex").ok, true);
+
+    // Compound gap legacy grants → one 308 to final www funding.
+    const legacy = byName(report, "gap-legacy-grants-redirect");
+    assert.equal(legacy.ok, true);
+    assert.equal(legacy.location, `${CANONICAL}/project/${SLUG}/funding`);
+
+    // Invalid slug → 404/410 with noindex.
+    const invalid = byName(report, "invalid-slug-gone");
+    assert.equal(invalid.ok, true);
+    assert.ok(invalid.status === 404 || invalid.status === 410);
+
+    // Indexer strict canonical-indexable root decision.
+    assert.equal(byName(report, "indexer-decision").ok, true);
+  });
+
+  it("does not hang the report when the root sitemap is pending; non-project checks still run", async () => {
+    const routes = healthyRoutes();
+    // Root sitemap never resolves until the audit's timeout aborts it.
+    routes[SITEMAP] = (options) =>
+      new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        );
+      });
+
+    const report = await runVerify(makeFetch(routes), { timeoutMs: 20 });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.representativeProject, null);
+    // Independent, non-project checks still executed.
+    assert.equal(byName(report, "root").ok, true);
+    assert.equal(byName(report, "projects-listing").ok, true);
+    assert.equal(byName(report, "apex-alias").ok, true);
+    assert.equal(byName(report, "gap-alias").ok, true);
+  });
+
+  it("extracts canonical when href precedes rel and rel carries multiple tokens", async () => {
+    const routes = healthyRoutes();
+    routes[`${CANONICAL}/project/${SLUG}`] = () =>
+      new Response(
+        `<!doctype html><html><head><link href="${CANONICAL}/project/${SLUG}" rel="canonical alternate"/></head><body></body></html>`,
+        { status: 200, headers: { "content-type": "text/html" } }
+      );
+
+    const report = await runVerify(makeFetch(routes));
+
+    const check = byName(report, "project-root-canonical");
+    assert.equal(check.ok, true);
+    assert.equal(check.canonical, `${CANONICAL}/project/${SLUG}`);
+  });
+
+  it("requests redirecting checks with redirect: manual", async () => {
+    const fetchImpl = makeFetch(healthyRoutes());
+    await runVerify(fetchImpl);
+
+    const roadmapCall = fetchImpl.calls.find(
+      (call) => call.url === `${CANONICAL}/project/${SLUG}/roadmap`
+    );
+    assert.ok(roadmapCall, "roadmap URL must be fetched");
+    assert.equal(roadmapCall.options?.redirect, "manual");
+  });
+
+  it("marks ok false on a 5xx but still runs the remaining independent checks", async () => {
+    const routes = healthyRoutes();
+    routes[`${CANONICAL}/project/${SLUG}`] = () => htmlPage({ status: 500 });
+
+    const report = await runVerify(makeFetch(routes));
+
+    assert.equal(report.ok, false);
+    assert.equal(byName(report, "project-root-canonical").ok, false);
+    // An independent check still executed and passed.
+    assert.equal(byName(report, "root").ok, true);
+    assert.equal(byName(report, "indexer-decision").ok, true);
+    assert.ok(report.errors.length >= 1);
+  });
+
+  it("catches a network throw on one check without aborting the rest", async () => {
+    const routes = healthyRoutes();
+    routes[`${CANONICAL}/project/${SLUG}/impact`] = () => {
+      throw new Error("ECONNRESET");
+    };
+
+    const report = await runVerify(makeFetch(routes));
+
+    assert.equal(report.ok, false);
+    assert.equal(byName(report, "project-impact-noindex").ok, false);
+    // Checks after the failing one still ran.
+    assert.equal(byName(report, "indexer-decision").ok, true);
+    assert.equal(report.checks.length, byName(report, "root") ? report.checks.length : 0);
+    assert.ok(report.checks.length >= 12);
+  });
+
+  it("probes each exact banned slug at canonical /project/{slug}, requiring 404/410 + noindex", async () => {
+    const report = await runVerify(makeFetch(healthyRoutes()));
+
+    for (const slug of ["-1", "---", "-nan", "test"]) {
+      const check = byName(report, `banned-slug:${slug}`);
+      assert.ok(check, `expected a per-slug check for banned slug ${slug}`);
+      assert.equal(check.slug, slug);
+      assert.equal(check.ok, true);
+      assert.ok(
+        check.status === 404 || check.status === 410,
+        `banned slug ${slug} must be 404 or 410`
+      );
+      assert.equal(check.robots, "noindex, follow");
+    }
+  });
+
+  it("fails the per-slug banned check when a banned slug is unexpectedly indexable", async () => {
+    const routes = healthyRoutes();
+    routes[`${CANONICAL}/project/test`] = () =>
+      htmlPage({ status: 200, canonical: `${CANONICAL}/project/test` });
+
+    const report = await runVerify(makeFetch(routes));
+
+    assert.equal(report.ok, false);
+    assert.equal(byName(report, "banned-slug:test").ok, false);
+    // A sibling banned slug is unaffected.
+    assert.equal(byName(report, "banned-slug:-1").ok, true);
+  });
+
+  it("times out a pending check via options.signal and still runs later independent checks", async () => {
+    const routes = healthyRoutes();
+    // Stays pending until the verifier's timeout aborts the request signal.
+    routes[`${CANONICAL}/project/${SLUG}/impact`] = (options) =>
+      new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        );
+      });
+
+    const report = await runVerify(makeFetch(routes), { timeoutMs: 20 });
+
+    assert.equal(report.ok, false);
+    assert.equal(byName(report, "project-impact-noindex").ok, false);
+    // A check sequenced after the timed-out one still executed.
+    assert.equal(byName(report, "indexer-decision").ok, true);
+  });
+
+  it("fails only the indexer check when the decision is not a strict canonical-indexable root", async () => {
+    const routes = healthyRoutes();
+    routes[`${INDEXER}/v2/projects/${SLUG}/indexability?route=root`] = () =>
+      jsonResponse({ outcome: "noindex-follow", url: `/project/${SLUG}` });
+
+    const report = await runVerify(makeFetch(routes));
+
+    assert.equal(report.ok, false);
+    assert.equal(byName(report, "indexer-decision").ok, false);
+    assert.equal(byName(report, "project-root-canonical").ok, true);
+  });
+});
+
+// A permanent redirect is 301 OR 308, and the Location header may be
+// absolute or root-relative (resolve it against the request URL before
+// comparing). Production serves the apex/gap alias hop as a 301 (a Vercel
+// platform redirect) and the same-origin roadmap hop as a 308 with a relative
+// Location — both are compliant and must PASS. The gap-legacy-grants check stays
+// strict about the one-hop FINAL target, so the real 2-hop live chain still
+// fails.
+describe("verifyIndexability permanent-redirect handling", () => {
+  it("accepts a 301 (not only 308) permanent redirect for apex/gap alias hosts", async () => {
+    const routes = healthyRoutes();
+    routes[`${APEX}/funding-map?ref=1`] = () => redirectTo(`${CANONICAL}/funding-map?ref=1`, 301);
+    routes[`${GAP}/funding-map`] = () => redirectTo(`${CANONICAL}/funding-map`, 301);
+
+    const report = await runVerify(makeFetch(routes));
+
+    const apex = byName(report, "apex-alias");
+    assert.equal(apex.ok, true);
+    assert.equal(apex.status, 301);
+    assert.equal(apex.resolved, `${CANONICAL}/funding-map?ref=1`);
+    assert.equal(byName(report, "gap-alias").ok, true);
+  });
+
+  it("accepts a relative Location on a permanent roadmap redirect (resolved against the request URL)", async () => {
+    const routes = healthyRoutes();
+    // Same-origin hop with a root-relative Location, as Next/Vercel may emit.
+    routes[`${CANONICAL}/project/${SLUG}/roadmap`] = () => redirectTo(`/project/${SLUG}`, 308);
+
+    const report = await runVerify(makeFetch(routes));
+
+    const roadmap = byName(report, "project-roadmap-redirect");
+    assert.equal(roadmap.ok, true);
+    assert.equal(roadmap.status, 308);
+    assert.equal(roadmap.location, `/project/${SLUG}`);
+    assert.equal(roadmap.resolved, `${CANONICAL}/project/${SLUG}`);
+  });
+
+  it("accepts a 301 one-hop gap-legacy-grants redirect to the final www funding target", async () => {
+    const routes = healthyRoutes();
+    routes[`${GAP}/project/${SLUG}/grants`] = () =>
+      redirectTo(`${CANONICAL}/project/${SLUG}/funding`, 301);
+
+    const report = await runVerify(makeFetch(routes));
+
+    assert.equal(byName(report, "gap-legacy-grants-redirect").ok, true);
+  });
+
+  it("keeps gap-legacy-grants strict: a one-hop redirect to www /grants (real 2-hop chain) fails", async () => {
+    const routes = healthyRoutes();
+    // The live chain: gap → www/.../grants (alias hop only), NOT the final
+    // funding target in a single hop. redirect: "manual" sees just this first hop.
+    routes[`${GAP}/project/${SLUG}/grants`] = () =>
+      redirectTo(`${CANONICAL}/project/${SLUG}/grants`, 301);
+
+    const report = await runVerify(makeFetch(routes));
+
+    const legacy = byName(report, "gap-legacy-grants-redirect");
+    assert.equal(legacy.ok, false);
+    assert.equal(legacy.resolved, `${CANONICAL}/project/${SLUG}/grants`);
+  });
+});

--- a/scripts/indexability/verify-indexability.mjs
+++ b/scripts/indexability/verify-indexability.mjs
@@ -89,26 +89,36 @@ export async function auditSitemaps({
     visited.add(url);
     stack.add(url);
     try {
-      let response;
+      let fetched;
       try {
-        // Timeout + redirect: manual apply to root and child sitemap fetches.
-        response = await timedFetch(fetch, url, { timeoutMs, redirect: "manual" });
+        // Timeout + redirect: manual apply to root and child sitemap fetches. The
+        // body is read inside `consume`, so it stays under the same timeout — a
+        // stalled sitemap body aborts instead of hanging after the timer is cleared.
+        fetched = await timedFetch(fetch, url, {
+          timeoutMs,
+          redirect: "manual",
+          consume: async (response) => {
+            const status = response?.status;
+            const contentType = headerValue(response, "content-type");
+            const body = status === 200 && /xml/i.test(contentType) ? await response.text() : null;
+            return { status, contentType, body };
+          },
+        });
       } catch (err) {
         errors.push(`sitemap fetch failed for ${url}: ${errMsg(err)}`);
         return;
       }
 
-      if (!response || response.status !== 200) {
-        errors.push(`sitemap ${url} returned status ${response?.status ?? "unknown"}`);
+      if (!fetched || fetched.status !== 200) {
+        errors.push(`sitemap ${url} returned status ${fetched?.status ?? "unknown"}`);
         return;
       }
-      const contentType = headerValue(response, "content-type");
-      if (!/xml/i.test(contentType)) {
-        errors.push(`sitemap ${url} has non-XML content-type "${contentType}"`);
+      if (!/xml/i.test(fetched.contentType)) {
+        errors.push(`sitemap ${url} has non-XML content-type "${fetched.contentType}"`);
         return;
       }
 
-      const body = await response.text();
+      const body = fetched.body;
       sitemapCount += 1;
       const locs = extractLocs(body);
 
@@ -167,12 +177,22 @@ export async function verifyIndexability({
   apexOrigin = APEX_DEFAULT,
   gapOrigin = GAP_DEFAULT,
   indexerBaseUrl = INDEXER_DEFAULT,
-  // Default to the sitemap INDEX — the sole GSC-submitted entry point.
-  rootSitemapUrl = `${canonicalOrigin}/sitemap_index.xml`,
+  rootSitemapUrl,
   minLeafCount = 0,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   now,
 } = {}) {
+  // Normalize + validate every origin before constructing URLs so a trailing
+  // slash or stray path can never corrupt them (e.g. `https://c.example/` must
+  // not yield `https://c.example//sitemap_index.xml`). The default root sitemap
+  // follows the normalized canonical origin — the sitemap INDEX is the sole
+  // GSC-submitted entry point; an explicit rootSitemapUrl override is verbatim.
+  canonicalOrigin = normalizeOrigin(canonicalOrigin, "canonicalOrigin");
+  apexOrigin = normalizeOrigin(apexOrigin, "apexOrigin");
+  gapOrigin = normalizeOrigin(gapOrigin, "gapOrigin");
+  indexerBaseUrl = normalizeOrigin(indexerBaseUrl, "indexerBaseUrl");
+  rootSitemapUrl = rootSitemapUrl ?? new URL("/sitemap_index.xml", canonicalOrigin).href;
+
   const errors = [];
   const checks = [];
 
@@ -193,28 +213,28 @@ export async function verifyIndexability({
   const slug = representativeProject ? representativeProject.split("/")[2] : null;
 
   const probe = async (url) => {
-    let response;
     try {
-      response = await timedFetch(fetch, url, { timeoutMs, redirect: "manual" });
+      // Read the body inside `consume`, so a 2xx body stays under the same
+      // timeout as the fetch — a stalled page body aborts and fails this check
+      // instead of hanging the whole run after the timer would have been cleared.
+      const result = await timedFetch(fetch, url, {
+        timeoutMs,
+        redirect: "manual",
+        consume: async (response) => {
+          const status = response.status;
+          const body = status >= 200 && status < 300 ? await response.text() : "";
+          return {
+            status,
+            robots: headerValue(response, "x-robots-tag") || null,
+            location: headerValue(response, "location") || null,
+            body,
+          };
+        },
+      });
+      return { ...result, error: null };
     } catch (err) {
       return { status: 0, robots: null, location: null, body: "", error: errMsg(err) };
     }
-    const status = response.status;
-    let body = "";
-    if (status >= 200 && status < 300) {
-      try {
-        body = await response.text();
-      } catch {
-        body = "";
-      }
-    }
-    return {
-      status,
-      robots: headerValue(response, "x-robots-tag") || null,
-      location: headerValue(response, "location") || null,
-      body,
-      error: null,
-    };
   };
 
   const addCheck = async (name, url, evaluate, extra = {}) => {
@@ -236,7 +256,9 @@ export async function verifyIndexability({
     return check;
   };
 
-  const projectRootUrl = slug ? `${canonicalOrigin}/project/${slug}` : `${canonicalOrigin}/project/`;
+  const projectRootUrl = slug
+    ? `${canonicalOrigin}/project/${slug}`
+    : `${canonicalOrigin}/project/`;
 
   // --- Listing routes ---
   await addCheck("root", `${canonicalOrigin}/`, (r) => ({
@@ -318,9 +340,7 @@ export async function verifyIndexability({
   // --- Compound gap legacy grants → ONE permanent hop to the FINAL www funding
   // target. Deliberately strict about the one-hop final target: a live 2-hop
   // chain (gap → www/.../grants, then a second hop to funding) fails here. ---
-  const legacyUrl = slug
-    ? `${gapOrigin}/project/${slug}/grants`
-    : `${gapOrigin}/project//grants`;
+  const legacyUrl = slug ? `${gapOrigin}/project/${slug}/grants` : `${gapOrigin}/project//grants`;
   const legacyExpected = `${projectRootUrl}/funding`;
   await addCheck("gap-legacy-grants-redirect", legacyUrl, (r) => {
     const match = permanentRedirectMatch(r.status, r.location, legacyUrl, legacyExpected);
@@ -388,7 +408,10 @@ export async function verifyIndexability({
 
 // Single timed fetch: one AbortController + one timer per request (no double
 // timers). Timeout aborts the signal; redirect is passed through when given.
-async function timedFetch(fetch, url, { timeoutMs, redirect } = {}) {
+// An optional `consume` callback reads the response (e.g. body) WHILE the timer
+// is still armed, so a stalled body aborts under the same timeout instead of
+// hanging after the timer would otherwise have been cleared.
+async function timedFetch(fetch, url, { timeoutMs, redirect, consume } = {}) {
   const controller = new AbortController();
   const timer =
     typeof timeoutMs === "number" && timeoutMs > 0
@@ -399,12 +422,37 @@ async function timedFetch(fetch, url, { timeoutMs, redirect } = {}) {
     if (redirect) {
       options.redirect = redirect;
     }
-    return await fetch(url, options);
+    const response = await fetch(url, options);
+    return consume ? await consume(response) : response;
   } finally {
     if (timer) {
       clearTimeout(timer);
     }
   }
+}
+
+/**
+ * Normalize + validate an origin override. Accepts only an http(s), origin-only
+ * URL (an optional single trailing slash is allowed) and returns its canonical
+ * `URL.origin` with no trailing slash — so `https://c.example/` can never yield
+ * `https://c.example//sitemap_index.xml`. Rejects any path, query, hash, embedded
+ * credentials, or non-http(s) scheme.
+ */
+export function normalizeOrigin(value, label = "origin") {
+  const url = safeUrl(value);
+  if (!url) {
+    throw new Error(`Invalid ${label}: "${value}" is not a valid URL`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Invalid ${label}: "${value}" must use http(s)`);
+  }
+  if (url.username || url.password) {
+    throw new Error(`Invalid ${label}: "${value}" must not embed credentials`);
+  }
+  if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+    throw new Error(`Invalid ${label}: "${value}" must be origin-only (no path, query, or hash)`);
+  }
+  return url.origin;
 }
 
 function safeUrl(value, base) {
@@ -459,15 +507,17 @@ function extractLocs(xml) {
 }
 
 function decodeXmlEntities(value) {
-  return value
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => codePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => codePoint(Number(dec)))
-    // Decode &amp; last so it does not double-decode the entities above.
-    .replace(/&amp;/g, "&");
+  return (
+    value
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => codePoint(parseInt(hex, 16)))
+      .replace(/&#(\d+);/g, (_, dec) => codePoint(Number(dec)))
+      // Decode &amp; last so it does not double-decode the entities above.
+      .replace(/&amp;/g, "&")
+  );
 }
 
 function codePoint(value) {

--- a/scripts/indexability/verify-indexability.mjs
+++ b/scripts/indexability/verify-indexability.mjs
@@ -1,0 +1,561 @@
+/**
+ * Dependency-free ESM verifier for the Karma canonical-indexability policy.
+ * Two entry points, both taking an injected `fetch`:
+ *
+ *  - auditSitemaps: bounded recursive traversal of sitemapindex → urlset,
+ *    validating canonical origin before any child fetch, distinguishing
+ *    harmless repeated references (dedupe) from true recursion-stack cycles,
+ *    and rejecting off-origin/query/hash/duplicate/malformed/banned leaves.
+ *  - verifyIndexability: auto-discovers a representative /project/<slug> from
+ *    the sitemap and runs an independent, named check matrix (all requests use
+ *    redirect: "manual" with a per-request AbortController timeout), always
+ *    accumulating failures and continuing.
+ *
+ * No Node-only APIs beyond the global URL / Response / AbortController and
+ * Date; safe to import without side effects.
+ */
+
+const CANONICAL_DEFAULT = "https://www.karmahq.xyz";
+const APEX_DEFAULT = "https://karmahq.xyz";
+const GAP_DEFAULT = "https://gap.karmahq.xyz";
+const INDEXER_DEFAULT = "https://gapapi.karmahq.xyz";
+
+const BANNED_PROJECT_SLUGS = Object.freeze(["-1", "---", "-nan", "test"]);
+const INVALID_PROBE_SLUG = "this-project-does-not-exist";
+const DEFAULT_TIMEOUT_MS = 15000;
+const MAX_SITEMAP_DEPTH = 12;
+// 301 and 308 are treated as equivalent permanent redirects.
+const PERMANENT_REDIRECT_STATUSES = new Set([301, 308]);
+
+// ---------------------------------------------------------------------------
+// auditSitemaps
+// ---------------------------------------------------------------------------
+
+export async function auditSitemaps({
+  fetch,
+  rootSitemapUrl,
+  minLeafCount = 0,
+  canonicalOrigin = safeUrl(rootSitemapUrl)?.origin ?? CANONICAL_DEFAULT,
+  bannedSlugs = BANNED_PROJECT_SLUGS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const errors = [];
+  const visited = new Set(); // globally fetched sitemap URLs (dedupe)
+  const leafKeys = new Set(); // canonicalized leaf keys (duplicate detection)
+  const leaves = [];
+  let sitemapCount = 0;
+
+  const collectLeaf = (loc) => {
+    const parsed = safeUrl(loc);
+    if (!parsed) {
+      errors.push(`malformed leaf loc: ${loc}`);
+      return;
+    }
+    if (parsed.origin !== canonicalOrigin) {
+      errors.push(`off-origin leaf rejected: ${loc}`);
+      return;
+    }
+    if (parsed.search || parsed.hash) {
+      errors.push(`leaf has query or hash: ${loc}`);
+      return;
+    }
+    const banned = bannedProjectSlug(parsed.pathname, bannedSlugs);
+    if (banned) {
+      errors.push(`banned project slug rejected: /project/${banned}`);
+      return;
+    }
+    const key = `${parsed.origin}${parsed.pathname}`;
+    if (leafKeys.has(key)) {
+      errors.push(`duplicate leaf rejected: ${key}`);
+      return;
+    }
+    leafKeys.add(key);
+    leaves.push(key);
+  };
+
+  const traverse = async (url, stack) => {
+    if (stack.has(url)) {
+      errors.push(`cycle detected in sitemap graph at ${url}`);
+      return;
+    }
+    if (visited.has(url)) {
+      return; // harmless repeated reference — already processed
+    }
+    if (stack.size >= MAX_SITEMAP_DEPTH) {
+      errors.push(`maximum sitemap depth exceeded at ${url}`);
+      return;
+    }
+
+    visited.add(url);
+    stack.add(url);
+    try {
+      let response;
+      try {
+        // Timeout + redirect: manual apply to root and child sitemap fetches.
+        response = await timedFetch(fetch, url, { timeoutMs, redirect: "manual" });
+      } catch (err) {
+        errors.push(`sitemap fetch failed for ${url}: ${errMsg(err)}`);
+        return;
+      }
+
+      if (!response || response.status !== 200) {
+        errors.push(`sitemap ${url} returned status ${response?.status ?? "unknown"}`);
+        return;
+      }
+      const contentType = headerValue(response, "content-type");
+      if (!/xml/i.test(contentType)) {
+        errors.push(`sitemap ${url} has non-XML content-type "${contentType}"`);
+        return;
+      }
+
+      const body = await response.text();
+      sitemapCount += 1;
+      const locs = extractLocs(body);
+
+      if (isSitemapIndex(body)) {
+        for (const loc of locs) {
+          const parsed = safeUrl(loc);
+          if (!parsed) {
+            errors.push(`malformed child sitemap loc: ${loc}`);
+            continue;
+          }
+          // Canonical-origin validation BEFORE fetching the child.
+          if (parsed.origin !== canonicalOrigin) {
+            errors.push(`off-origin child sitemap rejected (not fetched): ${loc}`);
+            continue;
+          }
+          await traverse(parsed.href, stack);
+        }
+      } else if (isUrlSet(body)) {
+        for (const loc of locs) {
+          collectLeaf(loc);
+        }
+      } else {
+        // Never treat arbitrary XML <loc> tags as leaves.
+        errors.push(
+          `sitemap ${url} has an unrecognized root element (neither sitemapindex nor urlset)`
+        );
+      }
+    } finally {
+      stack.delete(url);
+    }
+  };
+
+  const start = safeUrl(rootSitemapUrl)?.href ?? String(rootSitemapUrl);
+  await traverse(start, new Set());
+
+  if (leaves.length < minLeafCount) {
+    errors.push(`leaf count ${leaves.length} below minimum ${minLeafCount}`);
+  }
+
+  return {
+    ok: errors.length === 0,
+    sitemapCount,
+    leafCount: leaves.length,
+    leaves,
+    errors,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// verifyIndexability
+// ---------------------------------------------------------------------------
+
+export async function verifyIndexability({
+  fetch,
+  canonicalOrigin = CANONICAL_DEFAULT,
+  apexOrigin = APEX_DEFAULT,
+  gapOrigin = GAP_DEFAULT,
+  indexerBaseUrl = INDEXER_DEFAULT,
+  // Default to the sitemap INDEX — the sole GSC-submitted entry point.
+  rootSitemapUrl = `${canonicalOrigin}/sitemap_index.xml`,
+  minLeafCount = 0,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  now,
+} = {}) {
+  const errors = [];
+  const checks = [];
+
+  // Pass the timeout into the audit so a hung root/child sitemap cannot hang
+  // the whole report.
+  const audit = await auditSitemaps({
+    fetch,
+    rootSitemapUrl,
+    minLeafCount,
+    canonicalOrigin,
+    timeoutMs,
+  });
+  for (const auditError of audit.errors) {
+    errors.push(`sitemap: ${auditError}`);
+  }
+
+  const representativeProject = firstProjectPath(audit.leaves);
+  const slug = representativeProject ? representativeProject.split("/")[2] : null;
+
+  const probe = async (url) => {
+    let response;
+    try {
+      response = await timedFetch(fetch, url, { timeoutMs, redirect: "manual" });
+    } catch (err) {
+      return { status: 0, robots: null, location: null, body: "", error: errMsg(err) };
+    }
+    const status = response.status;
+    let body = "";
+    if (status >= 200 && status < 300) {
+      try {
+        body = await response.text();
+      } catch {
+        body = "";
+      }
+    }
+    return {
+      status,
+      robots: headerValue(response, "x-robots-tag") || null,
+      location: headerValue(response, "location") || null,
+      body,
+      error: null,
+    };
+  };
+
+  const addCheck = async (name, url, evaluate, extra = {}) => {
+    const result = await probe(url);
+    let ok = false;
+    let fields = {};
+    if (result.error) {
+      fields = { status: 0, error: result.error };
+    } else {
+      const evaluation = evaluate(result);
+      ok = Boolean(evaluation.ok);
+      fields = evaluation.fields ?? {};
+    }
+    const check = { name, url, ok, ...extra, ...fields };
+    checks.push(check);
+    if (!ok) {
+      errors.push(`${name}: ${result.error ?? "check failed"}`);
+    }
+    return check;
+  };
+
+  const projectRootUrl = slug ? `${canonicalOrigin}/project/${slug}` : `${canonicalOrigin}/project/`;
+
+  // --- Listing routes ---
+  await addCheck("root", `${canonicalOrigin}/`, (r) => ({
+    ok: r.status === 200,
+    fields: { status: r.status },
+  }));
+  await addCheck("projects-listing", `${canonicalOrigin}/projects`, (r) => ({
+    ok: r.status === 200,
+    fields: { status: r.status },
+  }));
+  await addCheck("projects-paginated", `${canonicalOrigin}/projects?page=2`, (r) => ({
+    ok: r.status === 200 && r.robots === "noindex, follow",
+    fields: { status: r.status, robots: r.robots },
+  }));
+  await addCheck("projects-tracking-only", `${canonicalOrigin}/projects?utm_source=x`, (r) => ({
+    ok: r.status === 200 && !r.robots,
+    fields: { status: r.status, robots: r.robots },
+  }));
+
+  // --- Alias hosts: one permanent hop (301/308) to www preserving path + query.
+  // The Location is resolved against the request URL before comparison. ---
+  const apexUrl = `${apexOrigin}/funding-map?ref=1`;
+  const apexExpected = `${canonicalOrigin}${pathAndQuery(apexUrl)}`;
+  await addCheck("apex-alias", apexUrl, (r) => {
+    const match = permanentRedirectMatch(r.status, r.location, apexUrl, apexExpected);
+    return {
+      ok: match.ok,
+      fields: {
+        status: r.status,
+        location: r.location,
+        resolved: match.resolved,
+        expected: apexExpected,
+      },
+    };
+  });
+  const gapUrl = `${gapOrigin}/funding-map`;
+  const gapExpected = `${canonicalOrigin}${pathAndQuery(gapUrl)}`;
+  await addCheck("gap-alias", gapUrl, (r) => {
+    const match = permanentRedirectMatch(r.status, r.location, gapUrl, gapExpected);
+    return {
+      ok: match.ok,
+      fields: {
+        status: r.status,
+        location: r.location,
+        resolved: match.resolved,
+        expected: gapExpected,
+      },
+    };
+  });
+
+  // --- Canonical project routes ---
+  await addCheck("project-root-canonical", projectRootUrl, (r) => {
+    const canonical = extractCanonical(r.body);
+    return {
+      ok: r.status === 200 && canonical === projectRootUrl,
+      fields: { status: r.status, canonical },
+    };
+  });
+  await addCheck("project-about-canonical", `${projectRootUrl}/about`, (r) => {
+    const canonical = extractCanonical(r.body);
+    return {
+      ok: r.status === 200 && canonical === projectRootUrl,
+      fields: { status: r.status, canonical },
+    };
+  });
+  const roadmapUrl = `${projectRootUrl}/roadmap`;
+  await addCheck("project-roadmap-redirect", roadmapUrl, (r) => {
+    const match = permanentRedirectMatch(r.status, r.location, roadmapUrl, projectRootUrl);
+    return {
+      ok: match.ok,
+      fields: { status: r.status, location: r.location, resolved: match.resolved },
+    };
+  });
+  await addCheck("project-impact-noindex", `${projectRootUrl}/impact`, (r) => ({
+    ok: r.status === 200 && r.robots === "noindex, follow",
+    fields: { status: r.status, robots: r.robots },
+  }));
+
+  // --- Compound gap legacy grants → ONE permanent hop to the FINAL www funding
+  // target. Deliberately strict about the one-hop final target: a live 2-hop
+  // chain (gap → www/.../grants, then a second hop to funding) fails here. ---
+  const legacyUrl = slug
+    ? `${gapOrigin}/project/${slug}/grants`
+    : `${gapOrigin}/project//grants`;
+  const legacyExpected = `${projectRootUrl}/funding`;
+  await addCheck("gap-legacy-grants-redirect", legacyUrl, (r) => {
+    const match = permanentRedirectMatch(r.status, r.location, legacyUrl, legacyExpected);
+    return {
+      ok: match.ok,
+      fields: {
+        status: r.status,
+        location: r.location,
+        resolved: match.resolved,
+        expected: legacyExpected,
+      },
+    };
+  });
+
+  // --- Invalid slug → gone (404/410) with noindex ---
+  await addCheck("invalid-slug-gone", `${canonicalOrigin}/project/${INVALID_PROBE_SLUG}`, (r) => ({
+    ok: (r.status === 404 || r.status === 410) && Boolean(r.robots) && /noindex/i.test(r.robots),
+    fields: { status: r.status, robots: r.robots },
+  }));
+
+  // --- Each exact banned slug: gone (404/410) + noindex, follow ---
+  for (const banned of BANNED_PROJECT_SLUGS) {
+    await addCheck(
+      `banned-slug:${banned}`,
+      `${canonicalOrigin}/project/${banned}`,
+      (r) => ({
+        ok: (r.status === 404 || r.status === 410) && r.robots === "noindex, follow",
+        fields: { status: r.status, robots: r.robots },
+      }),
+      { slug: banned }
+    );
+  }
+
+  // --- Indexer decision endpoint: strict canonical-indexable root ---
+  const indexerUrl = slug
+    ? `${indexerBaseUrl}/v2/projects/${slug}/indexability?route=root`
+    : `${indexerBaseUrl}/v2/projects//indexability?route=root`;
+  await addCheck("indexer-decision", indexerUrl, (r) => {
+    const decision = parseJson(r.body);
+    const valid = isStrictCanonicalIndexableRoot(decision, `/project/${slug}`);
+    return { ok: r.status === 200 && valid, fields: { status: r.status } };
+  });
+
+  const ok = audit.ok && checks.every((check) => check.ok);
+
+  return {
+    timestamp: now ?? new Date().toISOString(),
+    origins: {
+      canonical: canonicalOrigin,
+      apex: apexOrigin,
+      gap: gapOrigin,
+      indexer: indexerBaseUrl,
+    },
+    sitemap: { sitemapCount: audit.sitemapCount, leafCount: audit.leafCount },
+    representativeProject,
+    checks,
+    errors,
+    ok,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Single timed fetch: one AbortController + one timer per request (no double
+// timers). Timeout aborts the signal; redirect is passed through when given.
+async function timedFetch(fetch, url, { timeoutMs, redirect } = {}) {
+  const controller = new AbortController();
+  const timer =
+    typeof timeoutMs === "number" && timeoutMs > 0
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+  try {
+    const options = { signal: controller.signal };
+    if (redirect) {
+      options.redirect = redirect;
+    }
+    return await fetch(url, options);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function safeUrl(value, base) {
+  try {
+    return base === undefined ? new URL(String(value)) : new URL(String(value), String(base));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A permanent redirect is 301 OR 308, and its Location may be absolute
+ * or root-relative. Resolve the Location against the request URL, then compare to
+ * the expected absolute target. Returns the resolved href (or null) so checks can
+ * report it. A relative same-origin hop resolves to the canonical URL; an
+ * absolute Location resolves to itself; a cross-origin relative Location cannot
+ * match a different-origin target — correct, since alias hops must be absolute.
+ */
+function permanentRedirectMatch(status, location, requestUrl, expectedUrl) {
+  if (!PERMANENT_REDIRECT_STATUSES.has(status) || !location) {
+    return { ok: false, resolved: null };
+  }
+  const resolved = safeUrl(location, requestUrl)?.href ?? null;
+  return { ok: resolved === expectedUrl, resolved };
+}
+
+function headerValue(response, name) {
+  const getter = response?.headers?.get;
+  if (typeof getter !== "function") {
+    return "";
+  }
+  return response.headers.get(name) ?? "";
+}
+
+function isSitemapIndex(xml) {
+  return /<sitemapindex[\s>]/i.test(xml);
+}
+
+function isUrlSet(xml) {
+  return /<urlset[\s>]/i.test(xml);
+}
+
+function extractLocs(xml) {
+  const locs = [];
+  const pattern = /<loc>\s*([\s\S]*?)\s*<\/loc>/gi;
+  let match = pattern.exec(xml);
+  while (match !== null) {
+    locs.push(decodeXmlEntities(match[1].trim()));
+    match = pattern.exec(xml);
+  }
+  return locs;
+}
+
+function decodeXmlEntities(value) {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => codePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => codePoint(Number(dec)))
+    // Decode &amp; last so it does not double-decode the entities above.
+    .replace(/&amp;/g, "&");
+}
+
+function codePoint(value) {
+  try {
+    return String.fromCodePoint(value);
+  } catch {
+    return "";
+  }
+}
+
+function bannedProjectSlug(pathname, bannedSlugs) {
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts.length === 2 && parts[0] === "project" && bannedSlugs.includes(parts[1])) {
+    return parts[1];
+  }
+  return null;
+}
+
+function firstProjectPath(leaves) {
+  for (const leaf of leaves) {
+    const parsed = safeUrl(leaf);
+    if (!parsed) {
+      continue;
+    }
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parts.length === 2 && parts[0] === "project") {
+      return parsed.pathname;
+    }
+  }
+  return null;
+}
+
+function pathAndQuery(url) {
+  const parsed = safeUrl(url);
+  return parsed ? `${parsed.pathname}${parsed.search}` : "";
+}
+
+// Attribute-order independent: scan every <link> tag, treat rel as a
+// space-separated token list, and return the href of the first tag whose rel
+// tokens include an exact "canonical" token.
+function extractCanonical(html) {
+  if (!html) {
+    return null;
+  }
+  const linkPattern = /<link\b[^>]*>/gi;
+  let match = linkPattern.exec(html);
+  while (match !== null) {
+    const tag = match[0];
+    const rel = attributeValue(tag, "rel");
+    if (rel && rel.trim().split(/\s+/).includes("canonical")) {
+      const href = attributeValue(tag, "href");
+      if (href) {
+        return href;
+      }
+    }
+    match = linkPattern.exec(html);
+  }
+  return null;
+}
+
+function attributeValue(tag, name) {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i");
+  const match = tag.match(pattern);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? match[2] ?? match[3] ?? null;
+}
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function isStrictCanonicalIndexableRoot(value, expectedUrl) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 2 || !keys.includes("outcome") || !keys.includes("url")) {
+    return false;
+  }
+  return value.outcome === "canonical-indexable" && value.url === expectedUrl;
+}
+
+function errMsg(err) {
+  return err && err.message ? err.message : String(err);
+}

--- a/scripts/verify-indexability.mjs
+++ b/scripts/verify-indexability.mjs
@@ -1,0 +1,303 @@
+/**
+ * Import-safe, dependency-free CLI around verifyIndexability. Running the file
+ * directly executes the verification; importing it (e.g. from tests) only
+ * exposes parseArgs/main without side effects.
+ *
+ * Precedence: flags > INDEXABILITY_* env > built-in defaults. The root sitemap
+ * URL follows the (possibly overridden) canonical origin unless it is set
+ * explicitly.
+ */
+import { mkdir as fsMkdir, writeFile as fsWriteFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { verifyIndexability } from "./indexability/verify-indexability.mjs";
+
+const DEFAULTS = Object.freeze({
+  canonicalOrigin: "https://www.karmahq.xyz",
+  apexOrigin: "https://karmahq.xyz",
+  gapOrigin: "https://gap.karmahq.xyz",
+  indexerOrigin: "https://gapapi.karmahq.xyz",
+  // Leaf-count floor. Recalibrated 4000 -> 3800 after gap-indexer PR #2195
+  // (production-1.47.49) shipped the projects=v4 content-gate: a project root now
+  // requires the project's OWN substantive description; grant text alone no longer
+  // qualifies. That dropped the accepted projects baseline ~3845 -> 3750 (total
+  // leaves ~4087 -> ~3992). 3800 is ~95% of the new 3992 baseline: it still
+  // catches a real regression (a large, unexpected drop) without flapping on the
+  // expected v4 contract propagation or normal project churn.
+  minLeafCount: "3800",
+  timeoutMs: "15000",
+});
+
+const FLAG_TO_KEY = Object.freeze({
+  "--canonical-origin": "canonicalOrigin",
+  "--apex-origin": "apexOrigin",
+  "--gap-origin": "gapOrigin",
+  "--indexer-origin": "indexerOrigin",
+  "--root-sitemap-url": "rootSitemapUrl",
+  "--min-leaf-count": "minLeafCount",
+  "--timeout-ms": "timeoutMs",
+  "--output": "output",
+});
+
+const ENV_NAMES = Object.freeze({
+  canonicalOrigin: "INDEXABILITY_CANONICAL_ORIGIN",
+  apexOrigin: "INDEXABILITY_APEX_ORIGIN",
+  gapOrigin: "INDEXABILITY_GAP_ORIGIN",
+  indexerOrigin: "INDEXABILITY_INDEXER_ORIGIN",
+  rootSitemapUrl: "INDEXABILITY_ROOT_SITEMAP_URL",
+  minLeafCount: "INDEXABILITY_MIN_LEAF_COUNT",
+  timeoutMs: "INDEXABILITY_TIMEOUT_MS",
+  output: "INDEXABILITY_OUTPUT",
+});
+
+/**
+ * Parse argv into a flags object. Throws on unknown flags and missing values.
+ * Accepts both `--flag value` and `--flag=value` forms.
+ */
+export function parseArgs(argv) {
+  const flags = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    let name = token;
+    let value;
+
+    const eq = token.startsWith("--") ? token.indexOf("=") : -1;
+    if (eq !== -1) {
+      name = token.slice(0, eq);
+      value = token.slice(eq + 1);
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(FLAG_TO_KEY, name)) {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+
+    if (value === undefined) {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(`Missing value for ${name}`);
+      }
+      value = next;
+      index += 1;
+    }
+
+    if (value === "") {
+      throw new Error(`Missing value for ${name}`);
+    }
+
+    flags[FLAG_TO_KEY[name]] = value;
+  }
+  return flags;
+}
+
+function resolveConfig(flags, env) {
+  const pick = (key, fallback) => {
+    if (flags[key] !== undefined) {
+      return flags[key];
+    }
+    const envValue = env[ENV_NAMES[key]];
+    if (envValue !== undefined && envValue !== "") {
+      return envValue;
+    }
+    return fallback;
+  };
+
+  const canonicalOrigin = pick("canonicalOrigin", DEFAULTS.canonicalOrigin);
+  const apexOrigin = pick("apexOrigin", DEFAULTS.apexOrigin);
+  const gapOrigin = pick("gapOrigin", DEFAULTS.gapOrigin);
+  const indexerOrigin = pick("indexerOrigin", DEFAULTS.indexerOrigin);
+
+  // Derived root follows canonical unless set explicitly (flag or env).
+  // Default to /sitemap_index.xml — the sitemap INDEX is the sole URL currently
+  // submitted to Google Search Console, so the monitor must audit that entry
+  // point by default (override with --root-sitemap-url / INDEXABILITY_ROOT_SITEMAP_URL).
+  const explicitRoot = pick("rootSitemapUrl", undefined);
+  const rootSitemapUrl = explicitRoot ?? `${canonicalOrigin}/sitemap_index.xml`;
+
+  // minLeafCount: nonnegative safe integer; timeoutMs: positive safe integer.
+  const minLeafCount = parseBoundedInt(pick("minLeafCount", DEFAULTS.minLeafCount), "--min-leaf-count", 0);
+  const timeoutMs = parseBoundedInt(pick("timeoutMs", DEFAULTS.timeoutMs), "--timeout-ms", 1);
+
+  const output = pick("output", undefined);
+
+  return {
+    canonicalOrigin,
+    apexOrigin,
+    gapOrigin,
+    indexerOrigin,
+    rootSitemapUrl,
+    minLeafCount,
+    timeoutMs,
+    output,
+  };
+}
+
+/**
+ * Run the CLI. Injectable (fetch/verify/stdout/stderr/writeFile/mkdir) for
+ * tests. Returns 0 on a passing report, 1 otherwise — never calls process.exit.
+ */
+export async function main({
+  argv = [],
+  env = {},
+  fetch = globalThis.fetch,
+  verify = verifyIndexability,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  writeFile = fsWriteFile,
+  mkdir = fsMkdir,
+} = {}) {
+  let config;
+  try {
+    config = resolveConfig(parseArgs(argv), env);
+  } catch (err) {
+    writeLine(stderr, `Error: ${errMsg(err)}`);
+    return 1;
+  }
+
+  let report;
+  try {
+    report = await verify({
+      fetch,
+      canonicalOrigin: config.canonicalOrigin,
+      apexOrigin: config.apexOrigin,
+      gapOrigin: config.gapOrigin,
+      indexerBaseUrl: config.indexerOrigin,
+      rootSitemapUrl: config.rootSitemapUrl,
+      minLeafCount: config.minLeafCount,
+      timeoutMs: config.timeoutMs,
+    });
+  } catch (err) {
+    // Even on an unexpected verifier failure, still emit a structured failure
+    // report so the monitoring artifact exists.
+    writeLine(stderr, `Verification failed to run: ${errMsg(err)}`);
+    if (config.output) {
+      try {
+        await writeReport(config.output, buildFailureReport(config, errMsg(err)), {
+          writeFile,
+          mkdir,
+        });
+        writeLine(stdout, `Failure report written to ${config.output}`);
+      } catch (writeErr) {
+        writeLine(
+          stderr,
+          `Failed to write failure report to ${config.output}: ${errMsg(writeErr)}`
+        );
+      }
+    }
+    return 1;
+  }
+
+  printSummary(report, stdout);
+
+  if (config.output) {
+    try {
+      await writeReport(config.output, report, { writeFile, mkdir });
+      writeLine(stdout, `Report written to ${config.output}`);
+    } catch (err) {
+      writeLine(stderr, `Failed to write report to ${config.output}: ${errMsg(err)}`);
+      return 1;
+    }
+  }
+
+  return report.ok ? 0 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Accept only a plain digits string that parses to a safe integer >= min.
+// Rejects decimals, exponents, negatives, and unsafe (>= 2^53) integers.
+function parseBoundedInt(value, label, min) {
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    throw new Error(`Invalid numeric value for ${label}: "${value}"`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < min) {
+    throw new Error(`Invalid numeric value for ${label}: "${value}"`);
+  }
+  return parsed;
+}
+
+function buildFailureReport(config, message) {
+  return {
+    timestamp: new Date().toISOString(),
+    origins: {
+      canonical: config.canonicalOrigin,
+      apex: config.apexOrigin,
+      gap: config.gapOrigin,
+      indexer: config.indexerOrigin,
+    },
+    sitemap: { sitemapCount: 0, leafCount: 0 },
+    representativeProject: null,
+    checks: [],
+    errors: [message],
+    ok: false,
+  };
+}
+
+async function writeReport(outputPath, report, { writeFile = fsWriteFile, mkdir = fsMkdir } = {}) {
+  const dir = dirname(outputPath);
+  if (dir && dir !== "." && dir !== "/") {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+function printSummary(report, out) {
+  writeLine(out, `Indexability check @ ${report.timestamp}`);
+  writeLine(
+    out,
+    `Origins: canonical=${report.origins.canonical} apex=${report.origins.apex} ` +
+      `gap=${report.origins.gap} indexer=${report.origins.indexer}`
+  );
+  writeLine(
+    out,
+    `Sitemaps: ${report.sitemap.sitemapCount} docs, ${report.sitemap.leafCount} leaves; ` +
+      `representative=${report.representativeProject ?? "none"}`
+  );
+  const passed = report.checks.filter((check) => check.ok).length;
+  writeLine(out, `Checks: ${passed}/${report.checks.length} passed`);
+  for (const check of report.checks) {
+    writeLine(out, `  ${check.ok ? "PASS" : "FAIL"} ${check.name}`);
+  }
+  if (report.errors.length > 0) {
+    writeLine(out, `Errors (${report.errors.length}):`);
+    for (const error of report.errors) {
+      writeLine(out, `  - ${error}`);
+    }
+  }
+  writeLine(out, `Overall: ${report.ok ? "PASS" : "FAIL"}`);
+}
+
+function writeLine(stream, line) {
+  stream.write(`${line}\n`);
+}
+
+function errMsg(err) {
+  return err && err.message ? err.message : String(err);
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+if (isDirectRun()) {
+  main({ argv: process.argv.slice(2), env: process.env })
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch(async (err) => {
+      process.exitCode = 1;
+      process.stderr.write(`Unexpected error: ${errMsg(err)}\n`);
+      // Best-effort failure report if an output path can be resolved.
+      try {
+        const config = resolveConfig(parseArgs(process.argv.slice(2)), process.env);
+        if (config.output) {
+          await writeReport(config.output, buildFailureReport(config, errMsg(err)));
+        }
+      } catch {
+        // Ignore secondary failures while handling the primary error.
+      }
+    });
+}

--- a/scripts/verify-indexability.mjs
+++ b/scripts/verify-indexability.mjs
@@ -10,7 +10,7 @@
 import { mkdir as fsMkdir, writeFile as fsWriteFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { pathToFileURL } from "node:url";
-import { verifyIndexability } from "./indexability/verify-indexability.mjs";
+import { normalizeOrigin, verifyIndexability } from "./indexability/verify-indexability.mjs";
 
 const DEFAULTS = Object.freeze({
   canonicalOrigin: "https://www.karmahq.xyz",
@@ -101,20 +101,33 @@ function resolveConfig(flags, env) {
     return fallback;
   };
 
-  const canonicalOrigin = pick("canonicalOrigin", DEFAULTS.canonicalOrigin);
-  const apexOrigin = pick("apexOrigin", DEFAULTS.apexOrigin);
-  const gapOrigin = pick("gapOrigin", DEFAULTS.gapOrigin);
-  const indexerOrigin = pick("indexerOrigin", DEFAULTS.indexerOrigin);
+  // Normalize + validate every origin before building URLs downstream: reject
+  // path/query/hash/credentials/non-http and collapse a trailing slash to
+  // URL.origin (shared with the direct verifier via normalizeOrigin).
+  const canonicalOrigin = normalizeOrigin(
+    pick("canonicalOrigin", DEFAULTS.canonicalOrigin),
+    "--canonical-origin"
+  );
+  const apexOrigin = normalizeOrigin(pick("apexOrigin", DEFAULTS.apexOrigin), "--apex-origin");
+  const gapOrigin = normalizeOrigin(pick("gapOrigin", DEFAULTS.gapOrigin), "--gap-origin");
+  const indexerOrigin = normalizeOrigin(
+    pick("indexerOrigin", DEFAULTS.indexerOrigin),
+    "--indexer-origin"
+  );
 
-  // Derived root follows canonical unless set explicitly (flag or env).
-  // Default to /sitemap_index.xml — the sitemap INDEX is the sole URL currently
-  // submitted to Google Search Console, so the monitor must audit that entry
-  // point by default (override with --root-sitemap-url / INDEXABILITY_ROOT_SITEMAP_URL).
+  // Derived root follows the normalized canonical unless set explicitly (flag or
+  // env). Default to /sitemap_index.xml — the sitemap INDEX is the sole URL
+  // submitted to Google Search Console, so the monitor audits that entry point by
+  // default (override with --root-sitemap-url / INDEXABILITY_ROOT_SITEMAP_URL).
   const explicitRoot = pick("rootSitemapUrl", undefined);
-  const rootSitemapUrl = explicitRoot ?? `${canonicalOrigin}/sitemap_index.xml`;
+  const rootSitemapUrl = explicitRoot ?? new URL("/sitemap_index.xml", canonicalOrigin).href;
 
   // minLeafCount: nonnegative safe integer; timeoutMs: positive safe integer.
-  const minLeafCount = parseBoundedInt(pick("minLeafCount", DEFAULTS.minLeafCount), "--min-leaf-count", 0);
+  const minLeafCount = parseBoundedInt(
+    pick("minLeafCount", DEFAULTS.minLeafCount),
+    "--min-leaf-count",
+    0
+  );
   const timeoutMs = parseBoundedInt(pick("timeoutMs", DEFAULTS.timeoutMs), "--timeout-ms", 1);
 
   const output = pick("output", undefined);


### PR DESCRIPTION
## What & why

Adds a **dependency-free Node 20 indexability monitor** to gap-app-v2, plus a scheduled/manual GitHub Actions workflow that runs it. It recursively audits the production sitemaps and verifies the canonical-indexability of the `karmahq.xyz` routes (root, projects listing/pagination, apex/gap alias redirects, project root/about/roadmap/impact, banned/invalid slugs, and the indexer decision).

**Ownership moved into gap-app-v2.** The monitor was prototyped in the super-gap umbrella; it belongs here, in the repo that owns the sitemap generation and the routes being verified. This PR carries only the monitor implementation — no ADR doc, no umbrella coupling.

**Files (6, all new):**
- `.github/workflows/indexability-monitor.yml` — scheduled + `workflow_dispatch` runner (Node 20, dependency-free)
- `scripts/verify-indexability.mjs` — CLI wrapper (flags + `INDEXABILITY_` env, JSON report)
- `scripts/indexability/verify-indexability.mjs` — `auditSitemaps` + `verifyIndexability` (injected `fetch`)
- `scripts/indexability/__tests__/{audit-sitemaps,verify-indexability,cli}.test.mjs`

## Authoritative default root sitemap: `/sitemap_index.xml`

The default root the monitor audits is now `${canonicalOrigin}/sitemap_index.xml` (previously `/sitemap.xml`), in the CLI derivation and the verifier default alike. **The sitemap index is the sole entry point currently submitted to Google Search Console**, so the monitor must audit that by default. It remains overridable via `--root-sitemap-url` / `INDEXABILITY_ROOT_SITEMAP_URL` (an explicit override is honored verbatim).

## Tests

`node --test` over the three files: **54 passed / 54 total / 0 failed**. TDD for the default correction: the CLI default-derivation assertions were flipped to `sitemap_index.xml` first (RED against the old `/sitemap.xml` source — 3 failures), then both source defaults were corrected (GREEN). `git diff --cached --check`: clean.

## Live run (production, this branch)

`node scripts/verify-indexability.mjs --timeout-ms 20000` (default root `https://www.karmahq.xyz/sitemap_index.xml`):

- Sitemaps: **5 docs, 3992 leaves** (the index correctly fans out to the child sitemaps)
- **15 of 17 checks passed**; overall FAIL on exactly the two **known** production items:
  - `banned-slug:test` — `/project/test` is still live in the projects sitemap
  - `gap-legacy-grants-redirect` — the real 2-hop `gap → www/grants` chain

These are expected findings, not monitor defects, and the tests are not weakened to hide them.

## Dependencies / remaining work

- `/project/test` is remediated by **show-karma/gap-indexer#2200** (reserve the `test` project slug + v5 sitemap cache bump); the `banned-slug:test` check will pass once that ships and the projects sitemap cache repopulates.
- The `gap-legacy-grants-redirect` 2-hop chain is a **Vercel platform domain/redirect** configuration item (external to this repo).

## Tracking

Part of show-karma/super-gap#55 (indexability remediation). Referenced, not closed — this slice adds the monitor only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated indexability monitoring that runs daily or on demand.
  * Added comprehensive checks for sitemaps, canonical URLs, redirects, project pages, metadata, and indexer behavior.
  * Added configurable thresholds, timeouts, origins, and optional JSON report output.
  * Monitoring summaries and downloadable reports are now available for each run.

* **Tests**
  * Added extensive coverage for sitemap auditing, verification logic, CLI options, failures, timeouts, redirects, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review findings resolved (commit d2b22fc2; branch merged with latest main)

Three karma-coding-ai findings (all Major) addressed on this branch:

1. **Shell-safe workflow inputs** (`.github/workflows/indexability-monitor.yml`) — `min_leaf_count` / `timeout_ms` now enter the shell through step `env:` and are referenced as quoted shell variables (`"$MIN_LEAF_COUNT"`, `"$TIMEOUT_MS"`); no `${{ }}` expression is interpolated into the `run` script. Defaults (`3800` / `15000`) preserved.
2. **Origin normalization/validation** — a shared `normalizeOrigin`, used by both the CLI config and the direct `verifyIndexability`, accepts only http(s) origin-only URLs, collapses a trailing slash to `URL.origin` (so `https://c.example/` no longer produces `https://c.example//sitemap_index.xml`), and rejects path/query/hash/credentials/non-http. The default root sitemap is derived with `new URL("/sitemap_index.xml", canonicalOrigin).href`; an explicit `--root-sitemap-url` override stays verbatim.
3. **Timeout across body reads** — the `AbortController` timeout now stays armed through `response.text()` for both the sitemap audit and the page probes (via a `consume` callback), so a stalled body aborts and fails its check instead of hanging. `redirect: "manual"` and report semantics unchanged.

### Evidence
- Monitor tests: **61 passed / 61 total** (`node --test`), including new regressions for trailing-slash / path-bearing / invalid origins and for stalled sitemap and page bodies.
- `biome check` on the five `.mjs` files: format-clean, exit 0 (4 pre-existing lint warnings only, unchanged from the prior PR head).
- Workflow YAML parses; the `run` step uses `"$MIN_LEAF_COUNT"` / `"$TIMEOUT_MS"` with no direct interpolation.
- `git diff --check`: clean.
- Live CLI (production): **5 docs / 3992 leaves / 15 of 17 checks** — only the known `gap-legacy-grants-redirect` (Vercel two-hop) and `banned-slug:test` (`/project/test`, pending gap-indexer #2200) failures remain.
