### PR TITLE
test(smoke): use staging sitemap slug for project-page smoke tests

### DIFF
--- a/e2e/tests/smoke/project-pages.smoke.spec.ts
+++ b/e2e/tests/smoke/project-pages.smoke.spec.ts
@@ -2,17 +2,16 @@ import { expect, test } from "../../fixtures";
 import { assertNoJsErrors, collectJsErrors } from "../../helpers/assertions";
 import { GOTO_OPTIONS, waitForPageReady } from "../../helpers/navigation";
 
-// The project pages use async server components that fetch data via SSR.
-// Playwright route mocks only intercept browser requests, not server-side fetches.
-// We use a real project ID that exists in the production indexer API.
-const REAL_PROJECT_ID = "0x26c473b456ff3de304120b5928603b88bfae6562577a328a49e61f4e429a518a";
+// SSR fetches bypass browser mocks, and smoke CI targets the staging app/indexer.
+// Use a stable staging sitemap slug whose four tested tabs return 200.
+const STAGING_PROJECT_SLUG = "buidlguidl";
 
 test.describe("Smoke Tests — Project Pages", () => {
   test("T-PROJ-01: project about page loads with project name", async ({ page, withApiMocks }) => {
     const jsErrors = collectJsErrors(page);
 
     await withApiMocks();
-    await page.goto(`/project/${REAL_PROJECT_ID}/about`, GOTO_OPTIONS);
+    await page.goto(`/project/${STAGING_PROJECT_SLUG}/about`, GOTO_OPTIONS);
     await waitForPageReady(page);
 
     const hasContent = await Promise.race([
@@ -38,7 +37,7 @@ test.describe("Smoke Tests — Project Pages", () => {
     const jsErrors = collectJsErrors(page);
 
     await withApiMocks();
-    await page.goto(`/project/${REAL_PROJECT_ID}/funding`, GOTO_OPTIONS);
+    await page.goto(`/project/${STAGING_PROJECT_SLUG}/funding`, GOTO_OPTIONS);
     await waitForPageReady(page);
 
     const hasTabContent = await Promise.race([
@@ -64,7 +63,7 @@ test.describe("Smoke Tests — Project Pages", () => {
     const jsErrors = collectJsErrors(page);
 
     await withApiMocks();
-    await page.goto(`/project/${REAL_PROJECT_ID}/impact`, GOTO_OPTIONS);
+    await page.goto(`/project/${STAGING_PROJECT_SLUG}/impact`, GOTO_OPTIONS);
     await waitForPageReady(page);
 
     const hasTabContent = await Promise.race([
@@ -90,7 +89,7 @@ test.describe("Smoke Tests — Project Pages", () => {
     const jsErrors = collectJsErrors(page);
 
     await withApiMocks();
-    await page.goto(`/project/${REAL_PROJECT_ID}/team`, GOTO_OPTIONS);
+    await page.goto(`/project/${STAGING_PROJECT_SLUG}/team`, GOTO_OPTIONS);
     await waitForPageReady(page);
 
     const hasTabContent = await Promise.race([


### PR DESCRIPTION
## Problem

The project-page smoke tests hardcoded a **production-only** project UID (`0x26c4…518a`). Smoke CI runs against the **staging** deployment (`BASE_URL=https://staging.karmahq.xyz`), which is backed by the staging indexer — the production UID does not exist there, so all four SSR routes 404 and every T-PROJ test fails on all retries.

**Deterministic RED evidence (not flake):**
- PR #1849 smoke run **29426692626** — the four T-PROJ tests failed on all retries.
- Unrelated run **29400445168** — same four deterministic failures.
- Staging route confirmation: `GET https://staging.karmahq.xyz/project/0x26c4…518a/{about,funding,impact,team}` → **404** on all four.

## Fix

Point the fixture at **`buidlguidl`**, a stable project in the staging project sitemap.

- Staging preflight: `GET https://staging.karmahq.xyz/project/buidlguidl/{about,funding,impact,team}` → **200** on all four.
- Targeted Playwright against staging (`--grep "T-PROJ"`, chromium): **4/4 green** (T-PROJ-01/02/03/04).

Renamed the misleading `REAL_PROJECT_ID` constant to `STAGING_PROJECT_SLUG` and corrected the comment to state that SSR fetches bypass browser mocks and smoke CI targets the staging app/indexer.

## Scope

Touches only `e2e/tests/smoke/project-pages.smoke.spec.ts`. **No change to assertions, timeouts, retries, helpers, or app code** — only the fixture value/name and its comment. Biome clean; `git diff --check` clean.

Unblocks the smoke check on PR #1849 (the indexability monitor slice), whose only red check was this pre-existing, unrelated smoke failure.
