### PR TITLE
feat(seo): add gap.karmahq.xyz domain-redirect management tool

### DIFF
--- a/.github/workflows/gap-domain-redirect.yml
+++ b/.github/workflows/gap-domain-redirect.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # This job only reads the repo (tests + CLI) and needs no git-authenticated
+          # writes; don't persist GITHUB_TOKEN into .git/config where an uploaded
+          # artifact could leak it (zizmor artipacked).
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/gap-domain-redirect.yml
+++ b/.github/workflows/gap-domain-redirect.yml
@@ -1,0 +1,68 @@
+name: Gap domain redirect (manual)
+
+# Manually inspect / clear / restore the Vercel project-domain redirect on
+# gap.karmahq.xyz. Clearing the redirect lets the app serve gap.karmahq.xyz so
+# the middleware collapses the host-swap + grants->funding normalization into a
+# single 308 (see scripts/vercel-domain-redirect/manage-gap-redirect.mjs).
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Action to perform"
+        type: choice
+        required: true
+        options:
+          - inspect
+          - apply
+          - rollback
+      confirmation:
+        description: "apply: CLEAR gap.karmahq.xyz | rollback: RESTORE gap.karmahq.xyz -> www.karmahq.xyz"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Focused tests run BEFORE any live CLI invocation.
+      - name: Run focused tests
+        run: node --test scripts/vercel-domain-redirect/__tests__/manage-gap-redirect.test.mjs
+
+      - name: Manage gap.karmahq.xyz domain redirect
+        # All inputs + secrets enter through the environment and are referenced
+        # as quoted shell variables — never interpolate ${{ }} directly into run.
+        env:
+          MODE: ${{ inputs.mode }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        run: |
+          mkdir -p artifacts
+          node scripts/vercel-domain-redirect/manage-gap-redirect.mjs \
+            --mode "$MODE" \
+            --confirm "$CONFIRMATION" \
+            --report artifacts/gap-domain-report.json \
+            --rollback-state artifacts/gap-domain-rollback-state.json
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gap-domain-redirect
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/gap-domain-redirect.yml
+++ b/.github/workflows/gap-domain-redirect.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # This job only reads the repo (tests + CLI) and needs no git-authenticated
-          # writes; don't persist GITHUB_TOKEN into .git/config where an uploaded
-          # artifact could leak it (zizmor artipacked).
+          # Avoid persisting the token before uploading workspace artifacts.
           persist-credentials: false
 
       - name: Set up Node

--- a/scripts/vercel-domain-redirect/__tests__/manage-gap-redirect.test.mjs
+++ b/scripts/vercel-domain-redirect/__tests__/manage-gap-redirect.test.mjs
@@ -1,0 +1,670 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+// Pins the CLI contract for inspecting / clearing / restoring the Vercel
+// project-domain redirect on gap.karmahq.xyz via the v9 project-domain GET/PATCH
+// endpoints, with identity/verified guards, exact state validation, a real
+// request timeout, auto-rollback, and absolute token redaction.
+import { main, makeRedactor, parseArgs } from "../manage-gap-redirect.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures + injectable seams (no real network / fs).
+// ---------------------------------------------------------------------------
+
+const ENV = Object.freeze({
+  VERCEL_TOKEN: "tok_secret_ABC123",
+  VERCEL_PROJECT_ID: "prj_abc",
+  VERCEL_ORG_ID: "team_xyz",
+});
+
+const API = "https://api.vercel.com/";
+const ENDPOINT =
+  "https://api.vercel.com/v9/projects/prj_abc/domains/gap.karmahq.xyz?teamId=team_xyz";
+const PROBE_URL = "https://gap.karmahq.xyz/project/paraswap/grants";
+const EXPECTED_LOCATION = "https://www.karmahq.xyz/project/paraswap/funding";
+const WRONG_LOCATION = "https://www.karmahq.xyz/project/paraswap/grants"; // the 2-hop first stop
+
+const REDIRECTING = Object.freeze({
+  name: "gap.karmahq.xyz",
+  apexName: "karmahq.xyz",
+  projectId: "prj_abc",
+  redirect: "www.karmahq.xyz",
+  redirectStatusCode: 301,
+  gitBranch: null,
+  verified: true,
+});
+const CLEARED = Object.freeze({ ...REDIRECTING, redirect: null, redirectStatusCode: null });
+
+function apiResponse(body, { status = 200, malformed = false } = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (n) => (n.toLowerCase() === "content-type" ? "application/json" : null) },
+    json: async () => {
+      if (malformed) throw new Error("Unexpected token < in JSON");
+      return body;
+    },
+    text: async () => (malformed ? "<html>" : JSON.stringify(body)),
+  };
+}
+
+function redirectResponse(location, status = 308) {
+  return {
+    status,
+    ok: false,
+    headers: { get: (n) => (n.toLowerCase() === "location" ? location : null) },
+    json: async () => {
+      throw new Error("no json on redirect");
+    },
+    text: async () => "",
+  };
+}
+
+// A response whose body read (.json) never settles until the request is aborted.
+function stalledJson(signal) {
+  return {
+    status: 200,
+    ok: true,
+    headers: { get: (n) => (n.toLowerCase() === "content-type" ? "application/json" : null) },
+    json: () =>
+      new Promise((_, reject) =>
+        signal?.addEventListener("abort", () => reject(new Error("aborted")))
+      ),
+    text: async () => "",
+  };
+}
+
+// Records every call; dispatches to a per-test responder that receives a
+// normalized call object { url, method, headers, redirect, body, signal }.
+function recordingFetch(responder) {
+  const calls = [];
+  const impl = async (url, options = {}) => {
+    const method = (options.method || "GET").toUpperCase();
+    const call = {
+      url: String(url),
+      method,
+      headers: options.headers || {},
+      redirect: options.redirect,
+      body: typeof options.body === "string" ? JSON.parse(options.body) : undefined,
+      signal: options.signal,
+    };
+    calls.push(call);
+    return responder(call);
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+// Sequenced API responder: one GET body, successive PATCH responses, a probe.
+function apiFetch({ get = REDIRECTING, patches = [apiResponse(CLEARED)], probe } = {}) {
+  let patchIndex = 0;
+  return recordingFetch((call) => {
+    if (call.url.startsWith(API)) {
+      if (call.method === "GET") return typeof get === "function" ? get(call) : apiResponse(get);
+      const response = patches[patchIndex] ?? patches[patches.length - 1];
+      patchIndex += 1;
+      return response;
+    }
+    return probe ?? redirectResponse(EXPECTED_LOCATION, 308);
+  });
+}
+
+function fakeStream() {
+  const chunks = [];
+  return {
+    write: (str) => {
+      chunks.push(String(str));
+      return true;
+    },
+    text: () => chunks.join(""),
+  };
+}
+
+function fakeWriteFile() {
+  const files = {};
+  const fn = async (path, data) => {
+    files[String(path)] = String(data);
+  };
+  fn.files = files;
+  return fn;
+}
+
+function run(argv, { env = ENV, fetch, writeFile = fakeWriteFile(), timeoutMs } = {}) {
+  const stdout = fakeStream();
+  const stderr = fakeStream();
+  const mkdir = async () => {};
+  return main({ argv, env, fetch, writeFile, mkdir, stdout, stderr, timeoutMs }).then((code) => ({
+    code,
+    out: stdout.text(),
+    err: stderr.text(),
+    files: writeFile.files,
+    calls: fetch?.calls ?? [],
+  }));
+}
+
+const patchCalls = (calls) => calls.filter((c) => c.method === "PATCH");
+const getCalls = (calls) => calls.filter((c) => c.method === "GET" && c.url.startsWith(API));
+const authOf = (call) => call.headers.authorization ?? call.headers.Authorization;
+const APPLY_OK = ["--mode", "apply", "--confirm", "CLEAR gap.karmahq.xyz"];
+const ROLLBACK_OK = [
+  "--mode",
+  "rollback",
+  "--confirm",
+  "RESTORE gap.karmahq.xyz -> www.karmahq.xyz",
+];
+
+// ---------------------------------------------------------------------------
+// parseArgs + redactor
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("parses mode, confirm, and artifact paths", () => {
+    const flags = parseArgs([
+      "--mode",
+      "apply",
+      "--confirm",
+      "CLEAR gap.karmahq.xyz",
+      "--report",
+      "/art/r.json",
+      "--rollback-state",
+      "/art/s.json",
+    ]);
+    assert.deepEqual(flags, {
+      mode: "apply",
+      confirm: "CLEAR gap.karmahq.xyz",
+      report: "/art/r.json",
+      rollbackState: "/art/s.json",
+    });
+  });
+  it("rejects an unknown flag", () => {
+    assert.throws(() => parseArgs(["--nope", "x"]), /unknown/i);
+  });
+});
+
+describe("makeRedactor", () => {
+  it("masks the token wherever it appears", () => {
+    assert.equal(makeRedactor("tok_secret_ABC123")("a tok_secret_ABC123 b"), "a [REDACTED] b");
+  });
+  it("is a no-op passthrough when no token is set", () => {
+    assert.equal(makeRedactor(undefined)("plain text"), "plain text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inspect
+// ---------------------------------------------------------------------------
+
+describe("inspect", () => {
+  it("reports the current domain config and never mutates", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "inspect", "--report", "/art/report.json"], { fetch });
+    assert.equal(r.code, 0);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.out, /gap\.karmahq\.xyz/);
+    assert.match(r.out, /www\.karmahq\.xyz/);
+    assert.match(r.out, /301/);
+    assert.ok(r.files["/art/report.json"]);
+  });
+
+  it("targets the exact v9 endpoint with an encoded teamId and a Bearer token", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "inspect"], { fetch });
+    const get = getCalls(r.calls)[0];
+    assert.equal(get.url, ENDPOINT);
+    assert.equal(authOf(get), "Bearer tok_secret_ABC123");
+  });
+
+  it("percent-encodes project id and team id that contain special characters", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "inspect"], {
+      env: { ...ENV, VERCEL_PROJECT_ID: "prj/a b#c", VERCEL_ORG_ID: "team x/y?z" },
+      fetch,
+    });
+    const get = getCalls(r.calls)[0];
+    assert.equal(
+      get.url,
+      "https://api.vercel.com/v9/projects/prj%2Fa%20b%23c/domains/gap.karmahq.xyz?teamId=team%20x%2Fy%3Fz"
+    );
+  });
+
+  it("fails on a domain/project identity mismatch", async () => {
+    const fetch = apiFetch({ get: { ...REDIRECTING, projectId: "prj_other" } });
+    const r = await run(["--mode", "inspect"], { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+
+  it("fails without required secrets and makes no request", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "inspect"], {
+      env: { VERCEL_PROJECT_ID: "prj_abc", VERCEL_ORG_ID: "team_xyz" },
+      fetch,
+    });
+    assert.equal(r.code, 1);
+    assert.equal(r.calls.length, 0);
+    assert.match(r.err, /VERCEL_TOKEN/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — guards (no mutation)
+// ---------------------------------------------------------------------------
+
+describe("apply — guards (no mutation)", () => {
+  it("refuses without the exact confirmation and makes no request", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "apply", "--confirm", "clear gap"], { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(r.calls.length, 0);
+    assert.match(r.err, /confirm/i);
+  });
+
+  it("writes a failure report on a wrong confirmation when --report is supplied", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(["--mode", "apply", "--confirm", "nope", "--report", "/art/report.json"], {
+      fetch,
+    });
+    assert.equal(r.code, 1);
+    assert.equal(r.calls.length, 0);
+    const report = JSON.parse(r.files["/art/report.json"]);
+    assert.equal(report.ok, false);
+  });
+
+  it("refuses when the current redirect is not the expected www 301 — no PATCH", async () => {
+    const fetch = apiFetch({
+      get: { ...REDIRECTING, redirect: "other.example", redirectStatusCode: 302 },
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.err, /precondition|unexpected/i);
+  });
+
+  it("refuses on a domain/project identity mismatch — no PATCH", async () => {
+    const fetch = apiFetch({ get: { ...REDIRECTING, projectId: "prj_other" } });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+
+  it("refuses to mutate an unverified domain — no PATCH", async () => {
+    const fetch = apiFetch({ get: { ...REDIRECTING, verified: false } });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.err, /verified/i);
+  });
+
+  it("refuses on a malformed GET response — no PATCH", async () => {
+    const fetch = recordingFetch((call) =>
+      call.method === "GET" ? apiResponse(null, { malformed: true }) : apiResponse(CLEARED)
+    );
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — success + PATCH request shape
+// ---------------------------------------------------------------------------
+
+describe("apply — success", () => {
+  it("clears the redirect, captures rollback state, and validates a single-hop probe", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(
+      [...APPLY_OK, "--report", "/art/report.json", "--rollback-state", "/art/rollback.json"],
+      { fetch }
+    );
+
+    assert.equal(r.code, 0);
+    const patch = patchCalls(r.calls);
+    assert.equal(patch.length, 1);
+    assert.equal(patch[0].url, ENDPOINT);
+    assert.equal(authOf(patch[0]), "Bearer tok_secret_ABC123");
+    assert.equal(
+      patch[0].headers["content-type"] ?? patch[0].headers["Content-Type"],
+      "application/json"
+    );
+    assert.deepEqual(patch[0].body, { redirect: null, redirectStatusCode: null });
+    assert.deepEqual(JSON.parse(r.files["/art/rollback.json"]), {
+      redirect: "www.karmahq.xyz",
+      redirectStatusCode: 301,
+      gitBranch: null,
+    });
+    assert.ok(r.files["/art/report.json"]);
+  });
+
+  it("sends the probe with manual redirect handling to the grants URL", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED)],
+      probe: redirectResponse(EXPECTED_LOCATION, 301),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 0);
+    const probe = r.calls.find((c) => c.url === PROBE_URL);
+    assert.equal(probe.redirect, "manual");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — auto-rollback on any post-mutation failure
+// ---------------------------------------------------------------------------
+
+describe("apply — auto-rollback", () => {
+  it("rolls back when the probe is a wrong-target single hop (2-hop chain)", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED), apiResponse(REDIRECTING)],
+      probe: redirectResponse(WRONG_LOCATION, 301),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    const patch = patchCalls(r.calls);
+    assert.equal(patch.length, 2);
+    assert.deepEqual(patch[0].body, { redirect: null, redirectStatusCode: null });
+    assert.deepEqual(patch[1].body, {
+      redirect: "www.karmahq.xyz",
+      redirectStatusCode: 301,
+      gitBranch: null,
+    });
+    assert.equal(authOf(patch[1]), "Bearer tok_secret_ABC123");
+    assert.match(r.err, /rolled back/i);
+  });
+
+  it("rolls back when the clear PATCH response is not actually cleared", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(REDIRECTING), apiResponse(REDIRECTING)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+  });
+
+  it("rolls back when the clear PATCH response is for the wrong project", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse({ ...CLEARED, projectId: "prj_other" }), apiResponse(REDIRECTING)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rolled back/i);
+  });
+
+  it("rolls back when the clear PATCH response changed gitBranch", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse({ ...CLEARED, gitBranch: "surprise" }), apiResponse(REDIRECTING)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+  });
+
+  it("reports rollback failure when a 200 rollback response did not restore the captured state", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED), apiResponse(CLEARED)],
+      probe: redirectResponse(WRONG_LOCATION, 301),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rollback (also )?failed|did not restore/i);
+  });
+
+  it("reports both primary and rollback errors when the rollback PATCH errors (500)", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED), apiResponse({ error: { message: "boom" } }, { status: 500 })],
+      probe: redirectResponse(WRONG_LOCATION, 301),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rollback (also )?failed|failed to roll back/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — already-clear idempotency
+// ---------------------------------------------------------------------------
+
+describe("apply — already clear", () => {
+  it("succeeds idempotently without mutating when already clear and the probe passes", async () => {
+    const fetch = apiFetch({ get: CLEARED, probe: redirectResponse(EXPECTED_LOCATION, 308) });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 0);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.out, /idempotent|already/i);
+  });
+
+  it("fails without mutating when already clear but the probe does not single-hop", async () => {
+    const fetch = apiFetch({ get: CLEARED, probe: redirectResponse(WRONG_LOCATION, 301) });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply — request timeout (real timer, injectable for fast tests)
+// ---------------------------------------------------------------------------
+
+describe("timeout", () => {
+  it(
+    "aborts a stalled Vercel response body and exits 1 without hanging",
+    { timeout: 3000 },
+    async () => {
+      const fetch = recordingFetch((call) =>
+        call.url.startsWith(API)
+          ? stalledJson(call.signal)
+          : redirectResponse(EXPECTED_LOCATION, 308)
+      );
+      const r = await run(["--mode", "inspect"], { fetch, timeoutMs: 25 });
+      assert.equal(r.code, 1);
+    }
+  );
+
+  it(
+    "aborts a stalled probe after clearing and auto-rolls back without hanging",
+    { timeout: 3000 },
+    async () => {
+      let patchN = 0;
+      const fetch = recordingFetch((call) => {
+        if (call.url.startsWith(API)) {
+          if (call.method === "GET") return apiResponse(REDIRECTING);
+          patchN += 1;
+          return apiResponse(patchN === 1 ? CLEARED : REDIRECTING);
+        }
+        // probe never settles until aborted
+        return new Promise((_, reject) =>
+          call.signal?.addEventListener("abort", () => reject(new Error("aborted")))
+        );
+      });
+      const r = await run(APPLY_OK, { fetch, timeoutMs: 25 });
+      assert.equal(r.code, 1);
+      assert.equal(patchCalls(r.calls).length, 2);
+      assert.match(r.err, /rolled back/i);
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// rollback (manual) — GET-first, only from the exact cleared state
+// ---------------------------------------------------------------------------
+
+describe("rollback", () => {
+  it("refuses without the exact confirmation — no PATCH", async () => {
+    const fetch = apiFetch({ get: CLEARED });
+    const r = await run(["--mode", "rollback", "--confirm", "RESTORE gap"], { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(r.calls.length, 0);
+  });
+
+  it("writes a failure report on a wrong confirmation when --report is supplied", async () => {
+    const fetch = apiFetch({ get: CLEARED });
+    const r = await run(["--mode", "rollback", "--confirm", "no", "--report", "/art/report.json"], {
+      fetch,
+    });
+    assert.equal(r.code, 1);
+    assert.equal(JSON.parse(r.files["/art/report.json"]).ok, false);
+  });
+
+  it("restores www 301 from the cleared state and validates the PATCH response", async () => {
+    const fetch = apiFetch({ get: CLEARED, patches: [apiResponse(REDIRECTING)] });
+    const r = await run([...ROLLBACK_OK, "--report", "/art/report.json"], { fetch });
+    assert.equal(r.code, 0);
+    const patch = patchCalls(r.calls);
+    assert.equal(patch.length, 1);
+    assert.equal(patch[0].url, ENDPOINT);
+    assert.equal(authOf(patch[0]), "Bearer tok_secret_ABC123");
+    assert.deepEqual(patch[0].body, { redirect: "www.karmahq.xyz", redirectStatusCode: 301 });
+  });
+
+  it("succeeds idempotently with no PATCH when already restored to www 301", async () => {
+    const fetch = apiFetch({ get: REDIRECTING });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 0);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.out, /already|idempotent/i);
+  });
+
+  it("refuses to restore from an unexpected (non-cleared) state — no PATCH", async () => {
+    const fetch = apiFetch({
+      get: { ...REDIRECTING, redirect: "other.example", redirectStatusCode: 302 },
+    });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+
+  it("refuses on identity mismatch — no PATCH", async () => {
+    const fetch = apiFetch({ get: { ...CLEARED, projectId: "prj_other" } });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+  });
+
+  it("refuses to mutate an unverified domain — no PATCH", async () => {
+    const fetch = apiFetch({ get: { ...CLEARED, verified: false } });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.err, /verified/i);
+  });
+
+  it("fails when the restore PATCH response did not restore www 301", async () => {
+    const fetch = apiFetch({ get: CLEARED, patches: [apiResponse(CLEARED)] });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// token redaction
+// ---------------------------------------------------------------------------
+
+describe("token redaction", () => {
+  it("never prints the token, even when an underlying error message contains it", async () => {
+    const fetch = recordingFetch(() => {
+      throw new Error(`network exploded for Bearer ${ENV.VERCEL_TOKEN}`);
+    });
+    const r = await run(["--mode", "inspect"], { fetch });
+    assert.equal(r.code, 1);
+    assert.ok(!r.out.includes(ENV.VERCEL_TOKEN));
+    assert.ok(!r.err.includes(ENV.VERCEL_TOKEN));
+  });
+
+  it("does not leak the token across a full successful apply run (logs + artifacts)", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(
+      [...APPLY_OK, "--report", "/art/report.json", "--rollback-state", "/art/rollback.json"],
+      { fetch }
+    );
+    assert.equal(r.code, 0);
+    const everything = r.out + r.err + Object.values(r.files).join("");
+    assert.ok(!everything.includes(ENV.VERCEL_TOKEN));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mutation PATCH responses must be identity- AND verified-checked
+// ---------------------------------------------------------------------------
+
+describe("mutation PATCH verified guard", () => {
+  it("(a) rolls back when the clear PATCH response is not verified", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse({ ...CLEARED, verified: false }), apiResponse(REDIRECTING)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rolled back/i);
+  });
+
+  it("(b) reports rollback failure when the rollback response matches captured state but is not verified", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse(CLEARED), apiResponse({ ...REDIRECTING, verified: false })],
+      probe: redirectResponse(WRONG_LOCATION, 301),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rollback (also )?failed|not verified/i);
+  });
+
+  it("(c) fails when the manual restore PATCH response is not verified", async () => {
+    const fetch = apiFetch({
+      get: CLEARED,
+      patches: [apiResponse({ ...REDIRECTING, verified: false })],
+    });
+    const r = await run(ROLLBACK_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 1);
+    assert.match(r.err, /verified/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verified must be the literal boolean true (fail closed on non-boolean)
+// ---------------------------------------------------------------------------
+
+describe("strict verified boolean", () => {
+  it("refuses to mutate when the GET payload verified is the string 'false' — no PATCH", async () => {
+    const fetch = apiFetch({ get: { ...REDIRECTING, verified: "false" } });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 0);
+    assert.match(r.err, /verified/i);
+  });
+
+  it("rolls back when the clear PATCH response verified is the string 'true'", async () => {
+    const fetch = apiFetch({
+      get: REDIRECTING,
+      patches: [apiResponse({ ...CLEARED, verified: "true" }), apiResponse(REDIRECTING)],
+      probe: redirectResponse(EXPECTED_LOCATION, 308),
+    });
+    const r = await run(APPLY_OK, { fetch });
+    assert.equal(r.code, 1);
+    assert.equal(patchCalls(r.calls).length, 2);
+    assert.match(r.err, /rolled back/i);
+  });
+});

--- a/scripts/vercel-domain-redirect/manage-gap-redirect.mjs
+++ b/scripts/vercel-domain-redirect/manage-gap-redirect.mjs
@@ -1,0 +1,568 @@
+/**
+ * Import-safe, dependency-free CLI to inspect / clear / restore the Vercel
+ * project-domain redirect on gap.karmahq.xyz. Running the file directly executes
+ * the requested mode; importing it (e.g. from tests) only exposes
+ * parseArgs/makeRedactor/main without side effects.
+ *
+ * Why this exists: gap.karmahq.xyz currently carries a Vercel project-domain
+ * redirect (301 -> www.karmahq.xyz) that fires at the edge BEFORE the Next.js
+ * middleware runs. For /project/<slug>/grants that produces a two-hop chain
+ * (301 host-swap, then a 308 grants->funding). Clearing the domain redirect lets
+ * the app serve gap.karmahq.xyz, and the middleware collapses host-swap +
+ * grants->funding into a single 308 to www/.../funding. This tool performs that
+ * change safely, with strict identity/verified guards, exact state validation, a
+ * real request timeout, a live single-hop postcondition, and automatic rollback.
+ *
+ * Every API response (inspect, apply, auto-rollback, manual rollback) is checked
+ * for the exact domain + project identity; the mutating modes additionally
+ * require verified=true. The Vercel API token is never printed: all
+ * stdout/stderr/artifact writes pass through a redactor that masks the token.
+ */
+import { mkdir as fsMkdir, writeFile as fsWriteFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const API_BASE = "https://api.vercel.com";
+const DOMAIN = "gap.karmahq.xyz";
+const TARGET_HOST = "www.karmahq.xyz";
+const RESTORE_STATUS = 301;
+const PROBE_URL = "https://gap.karmahq.xyz/project/paraswap/grants";
+const EXPECTED_LOCATION = "https://www.karmahq.xyz/project/paraswap/funding";
+const CONFIRM_APPLY = "CLEAR gap.karmahq.xyz";
+const CONFIRM_ROLLBACK = "RESTORE gap.karmahq.xyz -> www.karmahq.xyz";
+const PERMANENT_REDIRECT_STATUSES = new Set([301, 308]);
+const MODES = new Set(["inspect", "apply", "rollback"]);
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const FLAG_TO_KEY = Object.freeze({
+  "--mode": "mode",
+  "--confirm": "confirm",
+  "--report": "report",
+  "--rollback-state": "rollbackState",
+});
+
+/** Build a function that masks the Vercel token anywhere it appears. */
+export function makeRedactor(token) {
+  return (value) => (token ? String(value).split(token).join("[REDACTED]") : String(value));
+}
+
+/**
+ * Parse argv into a flags object. Throws on unknown flags and missing values.
+ * Accepts both `--flag value` and `--flag=value` forms.
+ */
+export function parseArgs(argv) {
+  const flags = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    let name = token;
+    let value;
+
+    const eq = token.startsWith("--") ? token.indexOf("=") : -1;
+    if (eq !== -1) {
+      name = token.slice(0, eq);
+      value = token.slice(eq + 1);
+    }
+
+    if (!Object.hasOwn(FLAG_TO_KEY, name)) {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+
+    if (value === undefined) {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(`Missing value for ${name}`);
+      }
+      value = next;
+      index += 1;
+    }
+
+    flags[FLAG_TO_KEY[name]] = value;
+  }
+  return flags;
+}
+
+/**
+ * Run the CLI. Injectable (fetch/writeFile/mkdir/stdout/stderr/timeoutMs) for
+ * tests. Returns 0 on success, 1 otherwise — never calls process.exit.
+ */
+export async function main({
+  argv = [],
+  env = {},
+  fetch = globalThis.fetch,
+  writeFile = fsWriteFile,
+  mkdir = fsMkdir,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  let flags;
+  try {
+    flags = parseArgs(argv);
+  } catch (err) {
+    stderr.write(`Error: ${errMsg(err)}\n`);
+    return 1;
+  }
+
+  const token = env.VERCEL_TOKEN;
+  const projectId = env.VERCEL_PROJECT_ID;
+  const teamId = env.VERCEL_ORG_ID;
+
+  const redact = makeRedactor(token);
+  const log = (line) => stdout.write(`${redact(line)}\n`);
+  const error = (line) => stderr.write(`Error: ${redact(line)}\n`);
+
+  const missing = [];
+  if (!token) missing.push("VERCEL_TOKEN");
+  if (!projectId) missing.push("VERCEL_PROJECT_ID");
+  if (!teamId) missing.push("VERCEL_ORG_ID");
+  if (missing.length > 0) {
+    error(`missing required environment: ${missing.join(", ")}`);
+    return 1;
+  }
+
+  if (!MODES.has(flags.mode)) {
+    error(`unknown mode: ${flags.mode ?? "(none)"} (expected inspect|apply|rollback)`);
+    return 1;
+  }
+
+  const ctx = {
+    fetch,
+    writeFile,
+    mkdir,
+    token,
+    projectId,
+    teamId,
+    endpoint: domainEndpoint(projectId, teamId),
+    confirm: flags.confirm,
+    flags,
+    timeoutMs,
+    log,
+    error,
+    redact,
+  };
+
+  try {
+    if (flags.mode === "inspect") return await runInspect(ctx);
+    if (flags.mode === "apply") return await runApply(ctx);
+    return await runRollback(ctx);
+  } catch (err) {
+    error(errMsg(err));
+    try {
+      await writeReport(ctx, { mode: flags.mode, ok: false, error: errMsg(err) });
+    } catch {
+      // Ignore secondary failures while handling the primary error.
+    }
+    return 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Modes
+// ---------------------------------------------------------------------------
+
+async function runInspect(ctx) {
+  const summary = pickSummary(assertIdentity(await apiGet(ctx), ctx));
+  ctx.log(`Domain: ${summary.name} (project ${summary.projectId})`);
+  ctx.log(
+    `Redirect: ${summary.redirect ?? "(none)"} status ${summary.redirectStatusCode ?? "(none)"}`
+  );
+  ctx.log(`gitBranch: ${summary.gitBranch ?? "(none)"} | verified: ${summary.verified}`);
+  await writeReport(ctx, { mode: "inspect", ok: true, domain: summary });
+  return 0;
+}
+
+async function runApply(ctx) {
+  if (ctx.confirm !== CONFIRM_APPLY) {
+    ctx.error(`apply requires the exact confirmation "${CONFIRM_APPLY}"`);
+    await writeReport(ctx, { mode: "apply", ok: false, error: "invalid or missing confirmation" });
+    return 1;
+  }
+
+  const current = pickSummary(assertIdentity(await apiGet(ctx), ctx));
+  if (current.verified !== true) {
+    ctx.error("domain is not verified (verified=false); refusing to mutate");
+    await writeReport(ctx, { mode: "apply", ok: false, mutated: false, current });
+    return 1;
+  }
+
+  const alreadyClear = current.redirect == null && current.redirectStatusCode == null;
+  if (alreadyClear) {
+    const probe = await probeSingleHop(ctx);
+    if (probe.ok) {
+      ctx.log(
+        "Redirect already cleared and the probe confirms a single hop to funding — idempotent, no mutation."
+      );
+      await writeReport(ctx, { mode: "apply", ok: true, mutated: false, idempotent: true, probe });
+      return 0;
+    }
+    ctx.error(`redirect already cleared but the probe did not single-hop: ${probe.reason}`);
+    await writeReport(ctx, { mode: "apply", ok: false, mutated: false, probe });
+    return 1;
+  }
+
+  if (current.redirect !== TARGET_HOST || current.redirectStatusCode !== RESTORE_STATUS) {
+    ctx.error(
+      `precondition failed: expected redirect ${TARGET_HOST} status ${RESTORE_STATUS}, ` +
+        `found ${current.redirect} status ${current.redirectStatusCode} — no mutation`
+    );
+    await writeReport(ctx, { mode: "apply", ok: false, mutated: false, current });
+    return 1;
+  }
+
+  // Capture rollback state BEFORE any mutation.
+  const rollbackState = {
+    redirect: current.redirect,
+    redirectStatusCode: current.redirectStatusCode,
+    gitBranch: current.gitBranch,
+  };
+  await writeRollbackState(ctx, rollbackState);
+
+  let primaryError = null;
+  try {
+    const patched = pickSummary(
+      assertMutationResult(await apiPatch(ctx, { redirect: null, redirectStatusCode: null }), ctx)
+    );
+    if (patched.redirect != null || patched.redirectStatusCode != null) {
+      primaryError = `clear PATCH response still shows redirect ${patched.redirect} status ${patched.redirectStatusCode}`;
+    } else if (patched.gitBranch !== rollbackState.gitBranch) {
+      primaryError = `clear PATCH changed gitBranch from ${rollbackState.gitBranch} to ${patched.gitBranch}`;
+    } else {
+      const probe = await probeSingleHop(ctx);
+      if (probe.ok) {
+        ctx.log(
+          "Redirect cleared; probe confirms a single 30x hop to www/project/paraswap/funding."
+        );
+        await writeReport(ctx, { mode: "apply", ok: true, mutated: true, probe });
+        return 0;
+      }
+      primaryError = probe.reason;
+    }
+  } catch (err) {
+    primaryError = errMsg(err);
+  }
+
+  return autoRollback(ctx, rollbackState, primaryError);
+}
+
+async function autoRollback(ctx, rollbackState, primaryError) {
+  ctx.error(`apply failed after mutation: ${primaryError}`);
+  try {
+    const restored = pickSummary(
+      assertMutationResult(
+        await apiPatch(ctx, {
+          redirect: rollbackState.redirect,
+          redirectStatusCode: rollbackState.redirectStatusCode,
+          gitBranch: rollbackState.gitBranch,
+        }),
+        ctx
+      )
+    );
+    if (
+      restored.redirect !== rollbackState.redirect ||
+      restored.redirectStatusCode !== rollbackState.redirectStatusCode ||
+      restored.gitBranch !== rollbackState.gitBranch
+    ) {
+      throw new Error(
+        `rollback PATCH response did not restore the captured state ` +
+          `(redirect ${restored.redirect}, status ${restored.redirectStatusCode}, gitBranch ${restored.gitBranch})`
+      );
+    }
+    ctx.error("Rolled back to the previous redirect state.");
+    await writeReport(ctx, {
+      mode: "apply",
+      ok: false,
+      mutated: true,
+      rolledBack: true,
+      primaryError,
+    });
+    return 1;
+  } catch (rollbackErr) {
+    const rollbackError = errMsg(rollbackErr);
+    ctx.error(`Rollback also failed: ${rollbackError}. Manual intervention required.`);
+    await writeReport(ctx, {
+      mode: "apply",
+      ok: false,
+      mutated: true,
+      rolledBack: false,
+      primaryError,
+      rollbackError,
+    });
+    return 1;
+  }
+}
+
+async function runRollback(ctx) {
+  if (ctx.confirm !== CONFIRM_ROLLBACK) {
+    ctx.error(`rollback requires the exact confirmation "${CONFIRM_ROLLBACK}"`);
+    await writeReport(ctx, {
+      mode: "rollback",
+      ok: false,
+      error: "invalid or missing confirmation",
+    });
+    return 1;
+  }
+
+  const current = pickSummary(assertIdentity(await apiGet(ctx), ctx));
+
+  // Already restored — idempotent success, no mutation.
+  if (current.redirect === TARGET_HOST && current.redirectStatusCode === RESTORE_STATUS) {
+    if (current.verified !== true) {
+      ctx.error("domain is not verified (verified=false); refusing");
+      await writeReport(ctx, { mode: "rollback", ok: false, mutated: false, current });
+      return 1;
+    }
+    ctx.log(
+      `Redirect already restored to ${TARGET_HOST} ${RESTORE_STATUS} — idempotent, no mutation.`
+    );
+    await writeReport(ctx, { mode: "rollback", ok: true, mutated: false, idempotent: true });
+    return 0;
+  }
+
+  // Only restore from the exact cleared state.
+  const cleared = current.redirect == null && current.redirectStatusCode == null;
+  if (!cleared) {
+    ctx.error(
+      `refusing to restore from an unexpected state: redirect ${current.redirect} status ${current.redirectStatusCode} — no mutation`
+    );
+    await writeReport(ctx, { mode: "rollback", ok: false, mutated: false, current });
+    return 1;
+  }
+  if (current.verified !== true) {
+    ctx.error("domain is not verified (verified=false); refusing to mutate");
+    await writeReport(ctx, { mode: "rollback", ok: false, mutated: false, current });
+    return 1;
+  }
+
+  const restored = pickSummary(
+    assertMutationResult(
+      await apiPatch(ctx, { redirect: TARGET_HOST, redirectStatusCode: RESTORE_STATUS }),
+      ctx
+    )
+  );
+  if (restored.redirect !== TARGET_HOST || restored.redirectStatusCode !== RESTORE_STATUS) {
+    ctx.error(
+      `rollback PATCH did not restore ${TARGET_HOST} ${RESTORE_STATUS}: ${restored.redirect} ${restored.redirectStatusCode}`
+    );
+    await writeReport(ctx, { mode: "rollback", ok: false, mutated: true, restored });
+    return 1;
+  }
+  ctx.log(`Restored the ${TARGET_HOST} ${RESTORE_STATUS} redirect on ${DOMAIN}.`);
+  await writeReport(ctx, { mode: "rollback", ok: true, mutated: true, restored });
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Vercel v9 project-domain API (timeout stays armed through body consumption)
+// ---------------------------------------------------------------------------
+
+function domainEndpoint(projectId, teamId) {
+  return (
+    `${API_BASE}/v9/projects/${encodeURIComponent(projectId)}` +
+    `/domains/${encodeURIComponent(DOMAIN)}?teamId=${encodeURIComponent(teamId)}`
+  );
+}
+
+async function apiGet(ctx) {
+  return timedFetch(ctx.fetch, ctx.endpoint, {
+    timeoutMs: ctx.timeoutMs,
+    init: { method: "GET", headers: { authorization: `Bearer ${ctx.token}` } },
+    consume: parseApiDomain,
+  });
+}
+
+async function apiPatch(ctx, body) {
+  return timedFetch(ctx.fetch, ctx.endpoint, {
+    timeoutMs: ctx.timeoutMs,
+    init: {
+      method: "PATCH",
+      headers: { authorization: `Bearer ${ctx.token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    consume: parseApiDomain,
+  });
+}
+
+/**
+ * One AbortController + one timer per request. The optional `consume` callback
+ * reads the response body WHILE the timer is still armed, so a stalled body
+ * aborts under the same timeout instead of hanging after the timer is cleared.
+ */
+async function timedFetch(fetch, url, { timeoutMs, init = {}, consume } = {}) {
+  const controller = new AbortController();
+  const timer =
+    typeof timeoutMs === "number" && timeoutMs > 0
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    return consume ? await consume(response) : response;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function parseApiDomain(response) {
+  if (!response || typeof response.status !== "number") {
+    throw new Error("no response from the Vercel API");
+  }
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error(`malformed or unreadable body from the Vercel API (status ${response.status})`);
+  }
+  if (response.status < 200 || response.status >= 300) {
+    const detail = data?.error?.message ? `: ${data.error.message}` : "";
+    throw new Error(`Vercel API returned status ${response.status}${detail}`);
+  }
+  if (
+    !data ||
+    typeof data !== "object" ||
+    typeof data.name !== "string" ||
+    typeof data.projectId !== "string"
+  ) {
+    throw new Error("unexpected domain payload from the Vercel API");
+  }
+  return data;
+}
+
+function assertIdentity(domain, ctx) {
+  if (domain.name !== DOMAIN) {
+    throw new Error(`domain identity mismatch: expected ${DOMAIN}, got ${domain.name}`);
+  }
+  if (domain.projectId !== ctx.projectId) {
+    throw new Error(
+      `project mismatch: domain belongs to ${domain.projectId}, expected ${ctx.projectId}`
+    );
+  }
+  return domain;
+}
+
+/**
+ * The single gate every mutation PATCH response passes before any success /
+ * rolledBack result: exact domain + project identity AND verified===true. A
+ * PATCH that lands the domain in an unverified state is a failed mutation even
+ * if the redirect fields look right.
+ */
+function assertMutationResult(domain, ctx) {
+  assertIdentity(domain, ctx);
+  if (domain.verified !== true) {
+    throw new Error("mutation PATCH response is not verified (verified !== true)");
+  }
+  return domain;
+}
+
+function pickSummary(domain) {
+  return {
+    name: domain.name,
+    apexName: domain.apexName ?? null,
+    projectId: domain.projectId,
+    redirect: domain.redirect ?? null,
+    redirectStatusCode: domain.redirectStatusCode ?? null,
+    gitBranch: domain.gitBranch ?? null,
+    // Strict: only the literal boolean true counts as verified — a non-boolean
+    // (e.g. the string "false" or "true") fails closed.
+    verified: domain.verified === true,
+  };
+}
+
+async function probeSingleHop(ctx) {
+  let response;
+  try {
+    response = await timedFetch(ctx.fetch, PROBE_URL, {
+      timeoutMs: ctx.timeoutMs,
+      init: { method: "GET", redirect: "manual" },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      location: null,
+      resolved: null,
+      reason: `probe request failed: ${errMsg(err)}`,
+    };
+  }
+  const status = response?.status;
+  const location =
+    typeof response?.headers?.get === "function" ? response.headers.get("location") : null;
+  if (!PERMANENT_REDIRECT_STATUSES.has(status)) {
+    return {
+      ok: false,
+      status,
+      location,
+      resolved: null,
+      reason: `probe status ${status} is not a 301/308 permanent redirect`,
+    };
+  }
+  if (!location) {
+    return {
+      ok: false,
+      status,
+      location,
+      resolved: null,
+      reason: "probe response has no Location header",
+    };
+  }
+  let resolved = null;
+  try {
+    resolved = new URL(location, PROBE_URL).href;
+  } catch {
+    resolved = null;
+  }
+  if (resolved !== EXPECTED_LOCATION) {
+    return {
+      ok: false,
+      status,
+      location,
+      resolved,
+      reason: `probe resolved to ${resolved}, expected ${EXPECTED_LOCATION}`,
+    };
+  }
+  return { ok: true, status, location, resolved, reason: null };
+}
+
+// ---------------------------------------------------------------------------
+// Artifacts
+// ---------------------------------------------------------------------------
+
+async function writeReport(ctx, report) {
+  if (!ctx.flags.report) return;
+  await writeJson(ctx, ctx.flags.report, { timestamp: new Date().toISOString(), ...report });
+}
+
+async function writeRollbackState(ctx, state) {
+  if (!ctx.flags.rollbackState) return;
+  await writeJson(ctx, ctx.flags.rollbackState, state);
+}
+
+async function writeJson(ctx, path, obj) {
+  const dir = dirname(path);
+  if (dir && dir !== "." && dir !== "/") {
+    try {
+      await ctx.mkdir(dir, { recursive: true });
+    } catch {
+      // Best-effort: the directory may already exist or be provided by CI.
+    }
+  }
+  await ctx.writeFile(path, ctx.redact(`${JSON.stringify(obj, null, 2)}\n`));
+}
+
+function errMsg(err) {
+  return err?.message ? err.message : String(err);
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+if (isDirectRun()) {
+  const redact = makeRedactor(process.env.VERCEL_TOKEN);
+  main({ argv: process.argv.slice(2), env: process.env })
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      process.exitCode = 1;
+      process.stderr.write(`${redact(`Unexpected error: ${errMsg(err)}`)}\n`);
+    });
+}


### PR DESCRIPTION
## Root cause: edge redirect preempts the middleware

`gap.karmahq.xyz` carries a **Vercel project-domain redirect** (301 → `www.karmahq.xyz`) that fires **at the edge, before** the Next.js middleware runs. For `/project/<slug>/grants` that means **two hops**:

1. `gap/project/<slug>/grants` → **301** (Vercel host-swap) → `www/project/<slug>/grants`
2. `www/project/<slug>/grants` → **308** (middleware `grants`→`funding`) → `www/project/<slug>/funding`

The middleware **already** collapses host-swap + `grants`→`funding` into a **single 308** to `www/project/<slug>/funding` (pinned by `__tests__/middleware-indexability.test.ts`). It just never gets the chance, because the edge redirect answers first. Clearing the Vercel domain redirect lets the app serve `gap.karmahq.xyz`, so the middleware produces the one-hop result the indexability monitor expects.

## What this PR adds (no live change)

A dependency-free Node 20 CLI + a **manual-only** workflow to make that Vercel change safely. **It performs no mutation until manually dispatched** (`workflow_dispatch`): the workflow's GitHub token is scoped `contents: read`, and the Vercel project-domain mutation itself stays confirmation-gated and manual (nothing runs automatically).

- `scripts/vercel-domain-redirect/manage-gap-redirect.mjs` — CLI with three modes.
- `scripts/vercel-domain-redirect/__tests__/manage-gap-redirect.test.mjs` — 42 focused tests (injected `fetch`/`fs`, no network).
- `.github/workflows/gap-domain-redirect.yml` — `workflow_dispatch` (choice `inspect|apply|rollback` + confirmation), `permissions: contents: read`, `timeout-minutes: 5`, Node 20, focused tests run before the CLI, all inputs/secrets passed via `env` (no `${{ }}` in `run`), artifacts uploaded always.

## Modes & safety

- **inspect** — GET the Vercel v9 project-domain config and print it. Read-only.
- **apply** (exact confirmation `CLEAR gap.karmahq.xyz`) — validate domain+project **identity** and `verified === true`; require the current state to be the expected `redirect: www.karmahq.xyz` / `301`; capture a rollback-state artifact; `PATCH {redirect:null,redirectStatusCode:null}`; validate the PATCH response (identity, `verified===true`, cleared, unchanged `gitBranch`); then **probe** `https://gap.karmahq.xyz/project/paraswap/grants` with `redirect: manual` and require exactly one **301/308** hop resolving to `https://www.karmahq.xyz/project/paraswap/funding`. **Any post-mutation failure auto-rolls back** the captured state (validated identity + `verified===true` + exact `redirect/status/gitBranch`), reporting both primary and rollback errors. Already-cleared state is idempotent **only if the live probe passes**.
- **rollback** (exact confirmation `RESTORE gap.karmahq.xyz -> www.karmahq.xyz`) — GET first; idempotent no-op if already `www/301`; refuse any non-cleared state with no PATCH; otherwise restore `www/301` and validate the response.

Additional guards: a real **15s request timeout** that stays armed through Vercel response-body consumption and the live probe (injectable for fast tests); the API **token is never printed** (all logs + artifacts pass through a redactor, exercised even when an error message contains the token); `verified` is checked as the **literal boolean `true`** (non-boolean values fail closed); the v9 endpoint encodes `projectId`/`teamId` (tested with special characters) and every API call uses `Authorization: Bearer`.

## Tests

`node --test` over the suite: **42 passed / 42 total**. Covers inspect/apply/rollback happy paths, confirmations, precondition/identity/verified refusals with no mutation, PATCH request URL/auth/body, malformed API bodies, single-hop resolution, already-clear/already-restored idempotency, auto-rollback success/failure, stalled API body + stalled probe timeouts, strict-boolean `verified`, and token redaction. Biome clean; `node --check` OK; workflow YAML validated.

## Tracking

Part of show-karma/super-gap#55 (indexability remediation) — this resolves the `gap-legacy-grants-redirect` two-hop finding, pending a manual dispatch of the workflow. Referenced, not closed.
