### PR TITLE
chore(indexability): monitor delete_test and qa-bug-sweep-project-1752

### DIFF
--- a/scripts/indexability/__tests__/audit-sitemaps.test.mjs
+++ b/scripts/indexability/__tests__/audit-sitemaps.test.mjs
@@ -189,7 +189,7 @@ describe("auditSitemaps", () => {
     assert.ok(report.errors.some((e) => /xml|content-type/i.test(e)));
   });
 
-  it("rejects banned exact project slugs (-1, ---, -nan, test)", async () => {
+  it("rejects banned exact project slugs (-1, ---, -nan, test, delete_test, qa-bug-sweep-project-1752)", async () => {
     const fetchImpl = makeFetch({
       [ROOT]: () =>
         xml(
@@ -198,6 +198,8 @@ describe("auditSitemaps", () => {
             `${CANONICAL}/project/---`,
             `${CANONICAL}/project/-nan`,
             `${CANONICAL}/project/test`,
+            `${CANONICAL}/project/delete_test`,
+            `${CANONICAL}/project/qa-bug-sweep-project-1752`,
             `${CANONICAL}/project/valid`,
           ])
         ),
@@ -207,12 +209,38 @@ describe("auditSitemaps", () => {
 
     assert.equal(report.ok, false);
     assert.equal(report.leafCount, 1); // only /project/valid survives
-    for (const banned of ["-1", "---", "-nan", "test"]) {
+    for (const banned of [
+      "-1",
+      "---",
+      "-nan",
+      "test",
+      "delete_test",
+      "qa-bug-sweep-project-1752",
+    ]) {
       assert.ok(
         report.errors.some((e) => e.includes(`/project/${banned}`)),
         `banned slug ${banned} must be reported`
       );
     }
+  });
+
+  it("does not reject near-miss leaves that merely contain a reserved token but are not the exact banned slug", async () => {
+    const fetchImpl = makeFetch({
+      [ROOT]: () =>
+        xml(
+          urlSet([
+            `${CANONICAL}/project/delete_test_project`,
+            `${CANONICAL}/project/qa-bug-sweep-project-1753`,
+            `${CANONICAL}/project/test-project`,
+          ])
+        ),
+    });
+
+    const report = await auditSitemaps({ fetch: fetchImpl, rootSitemapUrl: ROOT, minLeafCount: 3 });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.leafCount, 3);
+    assert.deepEqual(report.errors, []);
   });
 
   it("fetches root and child sitemaps with redirect: manual", async () => {

--- a/scripts/indexability/__tests__/verify-indexability.test.mjs
+++ b/scripts/indexability/__tests__/verify-indexability.test.mjs
@@ -88,6 +88,10 @@ function healthyRoutes() {
     [`${CANONICAL}/project/---`]: () => htmlPage({ status: 410, robots: "noindex, follow" }),
     [`${CANONICAL}/project/-nan`]: () => htmlPage({ status: 404, robots: "noindex, follow" }),
     [`${CANONICAL}/project/test`]: () => htmlPage({ status: 410, robots: "noindex, follow" }),
+    [`${CANONICAL}/project/delete_test`]: () =>
+      htmlPage({ status: 404, robots: "noindex, follow" }),
+    [`${CANONICAL}/project/qa-bug-sweep-project-1752`]: () =>
+      htmlPage({ status: 410, robots: "noindex, follow" }),
 
     // Indexer decision endpoint → strict canonical-indexable root decision.
     [`${INDEXER}/v2/projects/${SLUG}/indexability?route=root`]: () =>
@@ -268,7 +272,7 @@ describe("verifyIndexability", () => {
   it("probes each exact banned slug at canonical /project/{slug}, requiring 404/410 + noindex", async () => {
     const report = await runVerify(makeFetch(healthyRoutes()));
 
-    for (const slug of ["-1", "---", "-nan", "test"]) {
+    for (const slug of ["-1", "---", "-nan", "test", "delete_test", "qa-bug-sweep-project-1752"]) {
       const check = byName(report, `banned-slug:${slug}`);
       assert.ok(check, `expected a per-slug check for banned slug ${slug}`);
       assert.equal(check.slug, slug);

--- a/scripts/indexability/verify-indexability.mjs
+++ b/scripts/indexability/verify-indexability.mjs
@@ -20,7 +20,14 @@ const APEX_DEFAULT = "https://karmahq.xyz";
 const GAP_DEFAULT = "https://gap.karmahq.xyz";
 const INDEXER_DEFAULT = "https://gapapi.karmahq.xyz";
 
-const BANNED_PROJECT_SLUGS = Object.freeze(["-1", "---", "-nan", "test"]);
+const BANNED_PROJECT_SLUGS = Object.freeze([
+  "-1",
+  "---",
+  "-nan",
+  "test",
+  "delete_test",
+  "qa-bug-sweep-project-1752",
+]);
 const INVALID_PROBE_SLUG = "this-project-does-not-exist";
 const DEFAULT_TIMEOUT_MS = 15000;
 const MAX_SITEMAP_DEPTH = 12;


### PR DESCRIPTION
## Summary

Add `delete_test` and `qa-bug-sweep-project-1752` to the production indexability monitor's `BANNED_PROJECT_SLUGS`, alongside the existing `-1`, `---`, `-nan`, and `test` entries.

Relates to show-karma/super-gap#55.

## Production / GSC evidence

Search Console `sc-domain:karmahq.xyz` Page Indexing report (fresh authenticated read-only audit; report last updated 2026-07-09): **12,200 indexed** vs **32,345 not indexed** domain-wide.

Filtered to the `sitemap_index.xml` cohort: **1,860 indexed** vs **2,180 not indexed**, of which **1,654** are "Crawled – currently not indexed". The only submitted sitemap is `https://www.karmahq.xyz/sitemap_index.xml` — status Processed, **4,042** pages found, last read **2026-07-11**.

Within the domain-wide "Crawled – currently not indexed" examples, the exact observed rows for these two fixtures were subpaths, not the bare project roots:

- `https://www.karmahq.xyz/project/delete_test/about` (last crawled 2026-07-11)
- a `qa-bug-sweep-project-1752` `/funding/.../milestones-and-updates` subpath (last crawled 2026-07-10)

Separately, live re-verification on 2026-07-15 confirmed both **project roots** are a live production defect, unrelated to any code in this PR and to the GSC sample rows above (this PR only extends what the *monitor* watches for — the sitemap/indexer-side fix is a separate `gap-indexer` PR):

- `https://www.karmahq.xyz/project/delete_test` -> HTTP 200, self-canonical, no noindex.
- `https://www.karmahq.xyz/project/qa-bug-sweep-project-1752` -> HTTP 200, self-canonical, no noindex.
- Both were present as `<loc>` entries in the live `sitemaps/projects/sitemap.xml` child of `sitemap_index.xml` (cohort size at audit time: 3,749 project leaves / 3,992 total `sitemap_index.xml` leaves).

Until now, the indexability monitor (`indexability-monitor.yml` / `verify-indexability.mjs`) had no check for either fixture, so a regression on these two specific slugs would not have been caught by the scheduled run.

## Scope

- `scripts/indexability/verify-indexability.mjs` — add `delete_test` and `qa-bug-sweep-project-1752` to `BANNED_PROJECT_SLUGS` (exact match, same mechanism as the existing four entries — no new substring/regex matching).
- `scripts/indexability/__tests__/audit-sitemaps.test.mjs` — extend the existing banned-slug test to cover both new slugs, plus a new test proving near-miss slugs (`delete_test_project`, `qa-bug-sweep-project-1753`, `test-project`) remain allowed.
- `scripts/indexability/__tests__/verify-indexability.test.mjs` — add fixture routes for both slugs and extend the per-slug `banned-slug:<slug>` check assertions.

Out of scope, unchanged: `apex-alias`, `gap-alias`, `project-roadmap-redirect`, `gap-legacy-grants-redirect`, and every other existing check. No AWS, DNS, Vercel, domain/alias/redirect, `gov.karmahq.xyz`, or umbrella (`super-gap`) changes are included in this PR. No UI work.

## Tests / gates (red-green)

RED (before the source change): 2 failing tests — `audit-sitemaps.test.mjs` (`3 !== 1` leaf count, since the two new leaves weren't yet banned) and `verify-indexability.test.mjs` (`expected a per-slug check for banned slug delete_test`).

GREEN (after): `node --test scripts/indexability/__tests__/audit-sitemaps.test.mjs scripts/indexability/__tests__/verify-indexability.test.mjs scripts/indexability/__tests__/cli.test.mjs` — 62/62 passing.

`biome check` scoped to the three changed files — 0 errors (2 pre-existing `useOptionalChain` warnings on untouched lines, left alone). `tsc --noEmit` does not cover these `.mjs` scripts (outside `tsconfig.json`'s include globs) and no Vitest-run app code imports this module, so the full `pnpm test` / `typecheck` gates are not applicable to this change.

## Rollout / verification

Standard deploy once merged. After release, the next scheduled `indexability-monitor.yml` run (or a manual `workflow_dispatch`) will evaluate `banned-slug:delete_test` and `banned-slug:qa-bug-sweep-project-1752` against production and fail loudly if either slug is still indexable — which, as of this PR, it currently is, pending the paired `gap-indexer` fix. No GSC action (validation request, resubmission) is taken as part of this PR.

## Explicitly not included

No AWS, DNS, Vercel, domain/alias/redirect configuration, `gov.karmahq.xyz`, umbrella (`super-gap`) repo changes, or UI work.

