### PR TITLE
fix(sitemap): version the indexer fetch cache key

### DIFF
--- a/__tests__/utilities/sitemap.test.ts
+++ b/__tests__/utilities/sitemap.test.ts
@@ -7,9 +7,11 @@ import {
   chunkCountFromTotal,
   countForKind,
   fetchAllSitemapKindUrls,
+  fetchSitemapCounts,
   fetchSitemapKindPage,
   formatSitemapLastmod,
   INDEXER_FETCH_PAGE_SIZE,
+  SITEMAP_FETCH_CACHE_VERSION,
   type SitemapCounts,
 } from "@/utilities/sitemap";
 
@@ -138,7 +140,7 @@ describe("countForKind", () => {
 });
 
 describe("fetchSitemapKindPage", () => {
-  it("requests the right kind/page and canonicalizes the returned URLs", async () => {
+  it("requests the right kind/page/version and canonicalizes the returned URLs", async () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse({ urls: ["https://staging.karmahq.xyz/project/a"] })
     );
@@ -148,7 +150,7 @@ describe("fetchSitemapKindPage", () => {
 
     expect(urls).toEqual([`${SITE}/project/a`]);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:4000/v2/sitemap?kind=projects&page=2&pageSize=1000",
+      `http://localhost:4000/v2/sitemap?kind=projects&page=2&pageSize=1000&v=${SITEMAP_FETCH_CACHE_VERSION}`,
       expect.objectContaining({ next: { revalidate: 86400 } })
     );
   });
@@ -159,6 +161,36 @@ describe("fetchSitemapKindPage", () => {
       vi.fn(async () => jsonResponse({}, false, 503))
     );
     await expect(fetchSitemapKindPage("grants", 1)).rejects.toThrow("HTTP 503");
+  });
+});
+
+describe("fetchSitemapCounts", () => {
+  it("requests the counts endpoint with the sitemap data-cache version and the 24h revalidate policy unchanged", async () => {
+    const counts: SitemapCounts = {
+      projects: 1,
+      impacts: 2,
+      grants: 3,
+      milestones: 4,
+      fundingPrograms: 5,
+    };
+    const fetchMock = vi.fn(async () => jsonResponse(counts));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchSitemapCounts();
+
+    expect(result).toEqual(counts);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://localhost:4000/v2/sitemap/counts?v=${SITEMAP_FETCH_CACHE_VERSION}`,
+      expect.objectContaining({ next: { revalidate: 86400 } })
+    );
+  });
+
+  it("throws on a non-ok response so SWR keeps the last good counts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({}, false, 500))
+    );
+    await expect(fetchSitemapCounts()).rejects.toThrow("HTTP 500");
   });
 });
 

--- a/utilities/sitemap.ts
+++ b/utilities/sitemap.ts
@@ -37,6 +37,16 @@ export const MAX_SITEMAP_CHUNK = 100_000;
 // instead of an empty one.
 export const SITEMAP_REVALIDATE_SECONDS = 60 * 60 * 24; // 24h
 
+// Next's Data Cache persists across deployments (unlike the CDN edge cache,
+// which is purged on every deploy), so a redeploy alone never forces a fresh
+// fetch of these two indexer URLs — the 24h SWR window is the only thing that
+// ever refreshes them. Embedding this version in the request URL changes the
+// Data Cache key: bump it whenever an indexer-side sitemap contract change
+// (e.g. a project-slug indexability rule) must be visible sooner than the SWR
+// window allows. Does not change SITEMAP_REVALIDATE_SECONDS or the CDN policy
+// below — only which cache entry a deploy starts reading from.
+export const SITEMAP_FETCH_CACHE_VERSION = "v1";
+
 // Crawlers get an instant edge hit for a day, then Vercel's CDN serves the
 // stale copy for up to a week while it revalidates in the background — a slow
 // function or indexer never makes Googlebot wait or time out. max-age=0 keeps
@@ -162,9 +172,12 @@ const INDEXER_BASE_URL = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
 // last good counts rather than collapsing the index. Throws only on a true cold
 // miss (e.g. first request after a deploy) when the indexer is also unreachable.
 export async function fetchSitemapCounts(): Promise<SitemapCounts> {
-  const res = await fetch(`${INDEXER_BASE_URL}/v2/sitemap/counts`, {
-    next: { revalidate: SITEMAP_REVALIDATE_SECONDS },
-  });
+  const res = await fetch(
+    `${INDEXER_BASE_URL}/v2/sitemap/counts?v=${SITEMAP_FETCH_CACHE_VERSION}`,
+    {
+      next: { revalidate: SITEMAP_REVALIDATE_SECONDS },
+    }
+  );
   if (!res.ok) {
     throw new Error(`sitemap counts fetch failed: HTTP ${res.status}`);
   }
@@ -179,7 +192,7 @@ export async function fetchSitemapKindPage(
   pageSize: number = SITEMAP_PAGE_SIZE
 ): Promise<string[]> {
   const res = await fetch(
-    `${INDEXER_BASE_URL}/v2/sitemap?kind=${kind}&page=${page}&pageSize=${pageSize}`,
+    `${INDEXER_BASE_URL}/v2/sitemap?kind=${kind}&page=${page}&pageSize=${pageSize}&v=${SITEMAP_FETCH_CACHE_VERSION}`,
     { next: { revalidate: SITEMAP_REVALIDATE_SECONDS } }
   );
   if (!res.ok) {


### PR DESCRIPTION
## Summary

Add `SITEMAP_FETCH_CACHE_VERSION` and embed it in the two upstream indexer fetch URLs (`fetchSitemapCounts`, `fetchSitemapKindPage`), so a version bump forces exactly one fresh fetch through Next's Data Cache on the next deploy.

Relates to show-karma/super-gap#55.

## Production evidence / rationale

Diagnosed live while monitoring the `gap-indexer` production release (`production-1.47.51`, commit `c6bc52f3f`) that retires the `delete_test` / `qa-bug-sweep-project-1752` fixture slugs from the sitemap: once that release deployed, per-project page checks on `www.karmahq.xyz` immediately reflected the fix (`/project/delete_test` and `/project/qa-bug-sweep-project-1752` → 404 + `noindex, follow`), but `https://www.karmahq.xyz/sitemaps/projects/sitemap.xml` kept listing both slugs unchanged across ~10 minutes of polling.

Root cause, confirmed by reading `utilities/sitemap.ts` and `app/api/cron/warm-sitemaps/route.ts`:
- `fetchSitemapCounts()` and `fetchSitemapKindPage()` cache their upstream indexer fetch in Next's Data Cache with `next: { revalidate: 60 * 60 * 24 }` (24h) and no `tags`.
- The `warm-sitemaps` cron route's own comment states the reason this matters: "...the CDN cache is cold but the Data Cache (**which persists across deployments**) is not."
- Grepped `app/` and `utilities/` for `revalidateTag|revalidatePath|unstable_cache|cacheTag|cacheLife` — zero hits. No on-demand invalidation and no cache-key version existed before this change.
- Net effect: a `gap-app-v2` redeploy purges the CDN edge cache (forcing the sitemap route to re-execute) but *not* the underlying Data Cache, so the freshly-purged CDN edge re-caches the same stale indexer response for another 24h. A routine frontend deploy cannot make an indexer-side sitemap fix visible sooner than the 24h SWR window.

**Compatibility check against production**, performed independently against `gapapi.karmahq.xyz` before merge:
- `GET /v2/sitemap/counts?v=v1` → `200`
- `GET /v2/sitemap?kind=projects&page=1&pageSize=1&v=v1` → `200`

Confirms the added `v` query parameter is accepted by the production indexer today (ignored as an unrecognized param, not rejected), so this change is safe to ship without any coordinated indexer-side change.

## Scope

- `utilities/sitemap.ts` — add `SITEMAP_FETCH_CACHE_VERSION = "v1"`; append `?v=${SITEMAP_FETCH_CACHE_VERSION}` / `&v=${SITEMAP_FETCH_CACHE_VERSION}` to the two upstream indexer fetch URLs. `SITEMAP_REVALIDATE_SECONDS` (24h) and `SITEMAP_CACHE_CONTROL` (CDN policy) are **unchanged** — this only changes which Data Cache entry a deploy starts reading from, not steady-state caching behavior.
- `__tests__/utilities/sitemap.test.ts` — updated the existing `fetchSitemapKindPage` URL assertion and added a new `fetchSitemapCounts` test asserting the same version param and unchanged `revalidate: 86400`.

Out of scope: no domain/DNS/alias/redirect changes, no AWS, no `gov.karmahq.xyz`, no umbrella (`super-gap`) repo changes, no `gap-indexer` changes.

## Tests / gates (red-green)

RED: 2 failing assertions before the source change — `fetchSitemapKindPage`'s URL assertion (missing `&v=v1`) and a new `fetchSitemapCounts` test (missing `?v=v1`, importing the not-yet-existing `SITEMAP_FETCH_CACHE_VERSION`).

GREEN: `__tests__/utilities/sitemap.test.ts` — 30/30 passing. Regression check on dependent suites `__tests__/app/sitemap-routes.test.ts` + `__tests__/app/sitemaps/**` — 33/33 passing (63/63 combined), confirming no other test hardcoded the old URL shape.

`tsc --noEmit` — clean. `biome check` on the two changed files — clean (one formatting reflow auto-applied via `--write` to my own added line, no logic change).

## Rollout / verification

Ordinary next `gap-app-v2` release — no special sequencing needed; the version-const bump itself is what forces freshness, not deploy timing relative to the indexer release. Post-deploy, one hit to `/sitemaps/projects/sitemap.xml` (or the existing `warm-sitemaps` cron) is expected to show `delete_test` / `qa-bug-sweep-project-1752` absent, closing the gap this PR fixes. No GSC action is taken as part of this PR.

## Explicitly not included

No domain, DNS, alias, redirect, AWS, `gov.karmahq.xyz`, umbrella (`super-gap`), or `gap-indexer` changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sitemap data freshness by adding cache-version tracking to sitemap requests.
  - Ensured sitemap count retrieval reports HTTP errors instead of serving stale results.
  - Preserved canonical sitemap URLs and the existing 24-hour revalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->