### PR TITLE
feat(portfolio-reports): editable report titles + type filter (DEV-520)

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -48,6 +48,8 @@ const baseReport = {
   communityId: "community-1",
   runDate: "2026-03-15",
   status: "draft",
+  title: null,
+  reportConfigName: "Monthly Pods Report",
   content: "<p>Server content</p>",
   dataSnapshot: {},
   modelId: "gpt-4.1",
@@ -230,6 +232,86 @@ describe("PortfolioReportEditorPage", () => {
         screen.queryByRole("heading", { name: /discard unsaved edits/i })
       ).not.toBeInTheDocument();
       expect(screen.getByRole("heading", { name: /^regenerate report/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("report title", () => {
+    it("should_seed_title_input_with_stored_title_when_dialog_opens", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "Monthly Pods Report — June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect((screen.getByLabelText(/^title$/i) as HTMLInputElement).value).toBe(
+        "Monthly Pods Report — June 2026"
+      );
+    });
+
+    it("should_seed_title_input_empty_when_report_is_untitled", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect((screen.getByLabelText(/^title$/i) as HTMLInputElement).value).toBe("");
+    });
+
+    it("should_send_the_typed_title_when_saved", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ reportId: "report-1", title: "June 2026" })
+      );
+    });
+
+    it("should_send_null_title_when_the_field_is_emptied", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.clear(screen.getByLabelText(/^title$/i));
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
+    });
+
+    it("should_enable_save_when_only_the_title_changed", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+
+      expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled();
     });
   });
 });

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -300,6 +300,25 @@ describe("PortfolioReportEditorPage", () => {
       expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
     });
 
+    it("should_not_treat_a_stored_title_as_unsaved_edits_before_the_dialog_opens", async () => {
+      // The title draft is empty until the dialog seeds it, so comparing it to
+      // a stored title without gating on the dialog being open would report
+      // unsaved edits on every titled report and wrongly warn here.
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "Monthly Pods Report — June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /discard unsaved edits/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /^regenerate report/i })).toBeInTheDocument();
+    });
+
     it("should_enable_save_when_only_the_title_changed", async () => {
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -300,10 +300,87 @@ describe("PortfolioReportEditorPage", () => {
       expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
     });
 
+    it("should_not_overwrite_refreshed_content_when_only_the_title_changed", async () => {
+      // The dialog seeds its draft from the report on open. If the body then
+      // refreshes underneath it, a title-only save must not push the stale
+      // seeded copy back over the newer content.
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      const { rerender } = render(
+        <PortfolioReportEditorPage community={community} reportId="report-1" />
+      );
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      // A background refetch lands while the dialog is open.
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, content: "<p>Refreshed by someone else</p>" },
+        isLoading: false,
+      } as any);
+      rerender(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "June 2026",
+          content: "<p>Refreshed by someone else</p>",
+        })
+      );
+    });
+
+    it("should_leave_title_untouched_when_only_the_content_changed", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i);
+      await user.clear(textarea);
+      await user.type(textarea, "<p>Body only</p>");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      // undefined preserves the stored title rather than rewriting it.
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "<p>Body only</p>", title: undefined })
+      );
+    });
+
+    it("should_send_emptied_content_rather_than_silently_restoring_it", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.clear(screen.getByLabelText(/report html content/i));
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ content: "" }));
+    });
+
     it("should_not_treat_a_stored_title_as_unsaved_edits_before_the_dialog_opens", async () => {
       // The title draft is empty until the dialog seeds it, so comparing it to
-      // a stored title without gating on the dialog being open would report
-      // unsaved edits on every titled report and wrongly warn here.
+      // the live stored title would report unsaved edits on every titled
+      // report and wrongly warn here. Baselines start empty alongside it.
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({
         data: { ...baseReport, title: "Monthly Pods Report — June 2026" },

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -1,37 +1,125 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
 
+vi.mock("nuqs", () => ({
+  useQueryState: (_key: string, options: { defaultValue?: unknown }) => {
+    const [value, setValue] = useState<unknown>(options?.defaultValue ?? null);
+    // Mirrors nuqs: setting null drops the param, so the hook falls back to
+    // the default value rather than storing a literal null.
+    return [value, (next: unknown) => setValue(next ?? options?.defaultValue ?? null)] as const;
+  },
+}));
+
+// Radix Select is portal/pointer-driven and awkward in jsdom; mock it to a
+// native <select> (the same convention used by ApplicationsFullView's tests).
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Filter reports by type"
+      onChange={(e) => onValueChange(e.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 
-const mockReports = vi.mocked(usePublishedReports);
+const mockUsePublishedReports = vi.mocked(usePublishedReports);
 
 const community = {
-  uid: "c-1",
-  details: { slug: "filpgf", name: "FIL PGF" },
+  uid: "community-1",
+  details: { slug: "filecoin", name: "Filecoin" },
 } as any;
 
-const SAME_DATE = "2026-07-06";
-
-function makeReport(overrides: Record<string, unknown>) {
+function createReport(overrides: Record<string, unknown> = {}) {
   return {
-    id: "r-1",
-    reportConfigId: "cfg-1",
-    runDate: SAME_DATE,
+    id: "report-1",
+    reportConfigId: "config-pods",
+    reportConfigName: "Monthly Pods Report",
+    reportConfigSlug: "monthly-pods-report",
+    communityId: "community-1",
+    runDate: "2026-07-06",
     status: "published",
-    content: "<h1>Report</h1><p>Body text.</p>",
-    publishedAt: "2026-07-06T10:00:00.000Z",
-    reportConfigName: "Quarterly Review",
-    reportConfigSlug: "quarterly-review",
+    title: null,
+    content: "<h1>Monthly Pods Report</h1>",
+    dataSnapshot: {},
+    modelId: "gpt-5.5",
+    tokenUsage: null,
+    generatedAt: "2026-07-06T00:00:00.000Z",
+    generationError: null,
+    publishedAt: "2026-07-06T00:00:00.000Z",
+    publishedBy: "0xadmin",
+    createdAt: "2026-07-06T00:00:00.000Z",
+    updatedAt: "2026-07-06T00:00:00.000Z",
     ...overrides,
   };
 }
 
-function hrefs(): string[] {
-  return screen
-    .getAllByRole("link")
-    .map((a) => a.getAttribute("href") ?? "")
-    .filter((h) => h.includes("/reports/"));
+/** Mirrors the live Filecoin shape: 3 configs, 2 runs each, titles repeated. */
+function filecoinReports() {
+  return [
+    createReport({
+      id: "r1",
+      reportConfigId: "config-biweekly",
+      reportConfigName: "Bi-Weekly Progress Report",
+      reportConfigSlug: "bi-weekly-progress-report",
+      runDate: "2026-07-09",
+    }),
+    createReport({
+      id: "r2",
+      reportConfigId: "config-pods",
+      reportConfigName: "Monthly Pods Report",
+      reportConfigSlug: "monthly-pods-report",
+      runDate: "2026-07-06",
+    }),
+    createReport({
+      id: "r3",
+      reportConfigId: "config-propgf",
+      reportConfigName: "Filecoin ProPGF Monthly",
+      reportConfigSlug: "filecoin-propgf-monthly",
+      runDate: "2026-06-30",
+    }),
+    createReport({
+      id: "r4",
+      reportConfigId: "config-biweekly",
+      reportConfigName: "Bi-Weekly Progress Report",
+      reportConfigSlug: "bi-weekly-progress-report",
+      runDate: "2026-06-22",
+    }),
+    createReport({
+      id: "r5",
+      reportConfigId: "config-pods",
+      reportConfigName: "Monthly Pods Report",
+      reportConfigSlug: "monthly-pods-report",
+      runDate: "2026-06-17",
+    }),
+    createReport({
+      id: "r6",
+      reportConfigId: "config-propgf",
+      reportConfigName: "Filecoin ProPGF Monthly",
+      reportConfigSlug: "filecoin-propgf-monthly",
+      runDate: "2026-06-03",
+    }),
+  ];
 }
 
 describe("PublicReportListPage", () => {
@@ -39,117 +127,302 @@ describe("PublicReportListPage", () => {
     vi.clearAllMocks();
   });
 
-  it("gives two reports published on the same date distinct links", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-quarterly",
-          reportConfigId: "cfg-quarterly",
-          reportConfigName: "Quarterly Review",
-          reportConfigSlug: "quarterly-review",
-        }),
-        makeReport({
-          id: "r-health",
-          reportConfigId: "cfg-health",
-          reportConfigName: "Portfolio Health",
-          reportConfigSlug: "portfolio-health",
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("loading, error, and empty states", () => {
+    it("should_render_spinner_when_reports_are_loading", () => {
+      mockUsePublishedReports.mockReturnValue({ isLoading: true } as any);
 
-    render(<PublicReportListPage community={community} />);
+      const { container } = render(<PublicReportListPage community={community} />);
 
-    const links = hrefs();
-    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/quarterly-review`);
-    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/portfolio-health`);
-    expect(new Set(links).size).toBe(links.length);
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    it("should_render_retry_when_the_fetch_fails", () => {
+      mockUsePublishedReports.mockReturnValue({ isError: true, refetch: vi.fn() } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByText(/failed to load reports/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it("should_render_empty_state_when_there_are_no_published_reports", () => {
+      mockUsePublishedReports.mockReturnValue({ data: [], isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByText(/no published reports yet/i)).toBeInTheDocument();
+    });
   });
 
-  it("falls back to the run-date-only link when the config slug is missing", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-orphan",
-          reportConfigName: null,
-          reportConfigSlug: null,
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("report title resolution", () => {
+    it("should_prefer_the_admin_authored_title_over_the_config_name", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: "Monthly Pods Report — June 2026" })],
+        isLoading: false,
+      } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(hrefs()).toContain(`/community/filpgf/reports/${SAME_DATE}`);
+      expect(
+        screen.getByRole("heading", { name: "Monthly Pods Report — June 2026" })
+      ).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_the_config_name_when_untitled", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: null })],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_a_content_heading_when_untitled_and_the_config_is_deleted", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            title: null,
+            reportConfigName: null,
+            content: "<h1>Scraped From Content</h1>",
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Scraped From Content" })).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_the_run_date_when_no_other_source_names_the_report", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: null, reportConfigName: null, content: "" })],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "July 6, 2026" })).toBeInTheDocument();
+    });
   });
 
-  it("renders both same-date reports rather than collapsing them", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-quarterly",
-          reportConfigName: "Quarterly Review",
-          reportConfigSlug: "quarterly-review",
-        }),
-        makeReport({
-          id: "r-health",
-          reportConfigName: "Portfolio Health",
-          reportConfigSlug: "portfolio-health",
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  // Carried over from the same-date-collision work (#1855), which this branch
+  // is stacked on: two configs can publish on one day, so a run-date-only link
+  // cannot address a report. Kept here because both PRs touch this list.
+  describe("same-date report links", () => {
+    const SAME_DATE = "2026-07-06";
 
-    render(<PublicReportListPage community={community} />);
+    function hrefs(): string[] {
+      return screen
+        .getAllByRole("link")
+        .map((a) => a.getAttribute("href") ?? "")
+        .filter((h) => h.includes("/reports/"));
+    }
 
-    expect(screen.getByText("Quarterly Review")).toBeInTheDocument();
-    expect(screen.getByText("Portfolio Health")).toBeInTheDocument();
-    expect(screen.getByText(/2 reports/i)).toBeInTheDocument();
+    it("gives two reports published on the same date distinct links", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      const links = hrefs();
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/quarterly-review`);
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/portfolio-health`);
+      expect(new Set(links).size).toBe(links.length);
+    });
+
+    it("falls back to the run-date-only link when the config slug is missing", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-orphan",
+            reportConfigName: null,
+            reportConfigSlug: null,
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(hrefs()).toContain(`/community/filecoin/reports/${SAME_DATE}`);
+    });
+
+    it("renders both same-date reports rather than collapsing them", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      // Scoped to headings: each config name now also appears as an option in
+      // the type filter this branch adds, so a bare text match is ambiguous.
+      expect(screen.getByRole("heading", { name: "Quarterly Review" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Portfolio Health" })).toBeInTheDocument();
+      expect(screen.getByText(/2 reports/i)).toBeInTheDocument();
+    });
+
+    it("keeps same-date links distinct when a title is set on one of them", () => {
+      // The two features interact here: a title changes what the card *reads*,
+      // never where it *points* — the link still keys off runDate + configSlug.
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            title: "Quarterly Review — Q2 2026",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Quarterly Review — Q2 2026" })
+      ).toBeInTheDocument();
+      const links = hrefs();
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/quarterly-review`);
+      expect(new Set(links).size).toBe(links.length);
+    });
   });
 
-  it("renders a spinner while loading", () => {
-    mockReports.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("report type filter", () => {
+    it("should_list_each_config_once_as_a_type_option", () => {
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual([
+        "All report types",
+        "Bi-Weekly Progress Report",
+        "Filecoin ProPGF Monthly",
+        "Monthly Pods Report",
+      ]);
+    });
 
-  it("renders an empty state when there are no reports", () => {
-    mockReports.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+    it("should_hide_the_filter_when_only_one_type_exists", () => {
+      mockUsePublishedReports.mockReturnValue({ data: [createReport()], isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.getByText(/no published reports yet/i)).toBeInTheDocument();
-  });
+      expect(screen.queryByLabelText(/filter reports by type/i)).not.toBeInTheDocument();
+    });
 
-  it("renders a retry affordance on error", () => {
-    mockReports.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      refetch: vi.fn(),
-    } as any);
+    it("should_show_every_report_before_a_type_is_picked", () => {
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.getByText(/failed to load reports/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+      expect(screen.getByText(/^6 reports/)).toBeInTheDocument();
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
+
+    it("should_narrow_the_list_to_the_picked_type", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+
+      const headings = screen.getAllByRole("heading", { level: 2 });
+      expect(headings).toHaveLength(2);
+      for (const heading of headings) {
+        expect(heading).toHaveTextContent("Monthly Pods Report");
+      }
+    });
+
+    it("should_pluralize_the_count_for_a_single_matching_report", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({ id: "r1", reportConfigId: "config-pods" }),
+          createReport({
+            id: "r2",
+            reportConfigId: "config-biweekly",
+            reportConfigName: "Bi-Weekly Progress Report",
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+
+      expect(screen.getByText(/^1 report /)).toBeInTheDocument();
+    });
+
+    it("should_restore_every_report_when_the_filter_is_reset", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      const select = screen.getByLabelText(/filter reports by type/i);
+      await user.selectOptions(select, "config-pods");
+      await user.selectOptions(select, "all");
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
+
+    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      // A shared link whose config has since been deleted.
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-propgf");
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "all");
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
   });
 });

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -179,6 +179,18 @@ describe("PublicReportListPage", () => {
       expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
     });
 
+    it("should_fall_back_to_the_config_name_when_the_api_omits_title_entirely", () => {
+      // Deploy-order safety: if this ships before the indexer adds `title`,
+      // the field is absent rather than null and every report must render
+      // exactly as it does today.
+      const { title: _omitted, ...withoutTitle } = createReport();
+      mockUsePublishedReports.mockReturnValue({ data: [withoutTitle], isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
+    });
+
     it("should_fall_back_to_a_content_heading_when_untitled_and_the_config_is_deleted", () => {
       mockUsePublishedReports.mockReturnValue({
         data: [

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -4,9 +4,15 @@ import { useState } from "react";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
 
+// `initialType` seeds the query param, standing in for a URL arriving with
+// `?type=` already set (a shared or reloaded link).
+const mockNuqs = vi.hoisted(() => ({ initialType: null as string | null }));
+
 vi.mock("nuqs", () => ({
   useQueryState: (_key: string, options: { defaultValue?: unknown }) => {
-    const [value, setValue] = useState<unknown>(options?.defaultValue ?? null);
+    const [value, setValue] = useState<unknown>(
+      mockNuqs.initialType ?? options?.defaultValue ?? null
+    );
     // Mirrors nuqs: setting null drops the param, so the hook falls back to
     // the default value rather than storing a literal null.
     return [value, (next: unknown) => setValue(next ?? options?.defaultValue ?? null)] as const;
@@ -125,6 +131,7 @@ function filecoinReports() {
 describe("PublicReportListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNuqs.initialType = null;
   });
 
   describe("loading, error, and empty states", () => {
@@ -411,6 +418,22 @@ describe("PublicReportListPage", () => {
       expect(screen.getByText(/^1 report /)).toBeInTheDocument();
     });
 
+    it("should_keep_the_filter_applied_across_a_background_refetch", async () => {
+      // React Query hands back a new array identity on every refetch; the
+      // filtered view must survive that rather than snapping back.
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      const { rerender } = render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+      rerender(<PublicReportListPage community={community} />);
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+    });
+
     it("should_restore_every_report_when_the_filter_is_reset", async () => {
       const user = userEvent.setup();
       mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
@@ -423,16 +446,34 @@ describe("PublicReportListPage", () => {
       expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
     });
 
-    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
-      const user = userEvent.setup();
+    it("should_render_the_empty_state_when_a_stale_type_param_matches_nothing", () => {
+      // A shared or bookmarked link whose config has since been deleted, so the
+      // `?type=` value matches no report.
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
       mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
       render(<PublicReportListPage community={community} />);
-      // A shared link whose config has since been deleted.
-      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-propgf");
-      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
 
-      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "all");
+      expect(screen.getByText(/no reports of this type/i)).toBeInTheDocument();
+      expect(screen.queryAllByRole("heading", { level: 2 })).toHaveLength(0);
+    });
+
+    it("should_not_render_a_zero_count_in_the_filtered_empty_state", () => {
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.queryByText(/0 reports/i)).not.toBeInTheDocument();
+    });
+
+    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
+      const user = userEvent.setup();
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.click(screen.getByRole("button", { name: /show all reports/i }));
 
       expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
     });

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -41,6 +41,24 @@ const TITLE_INPUT_ID = "portfolio-report-title";
 /** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
 const TITLE_MAX_LENGTH = 200;
 
+interface EditState {
+  open: boolean;
+  draft: string;
+  titleDraft: string;
+  /** Server content when the dialog opened. */
+  baseContent: string;
+  /** Server title when the dialog opened, "" for untitled. */
+  baseTitle: string;
+}
+
+const CLOSED_EDIT_STATE: EditState = {
+  open: false,
+  draft: "",
+  titleDraft: "",
+  baseContent: "",
+  baseTitle: "",
+};
+
 /**
  * Admin preview + actions page.
  *
@@ -65,15 +83,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   // Edit-dialog state lives in one object so we can update {open, draft}
   // atomically in event handlers. Avoids a chain of setState updates
   // across useState + useEffect.
-  const [editState, setEditState] = useState<{
-    open: boolean;
-    draft: string;
-    titleDraft: string;
-  }>({
-    open: false,
-    draft: "",
-    titleDraft: "",
-  });
+  //
+  // `base*` snapshot what the server held when the dialog opened. Dirty checks
+  // compare drafts against those snapshots rather than against live `report`,
+  // which can refresh underneath an open dialog — otherwise a title-only save
+  // would write the stale seeded content back over the newer body.
+  const [editState, setEditState] = useState<EditState>(CLOSED_EDIT_STATE);
 
   const isReportRegenerating = report ? isReportGenerating(report) : false;
   // Edit dialog hides automatically while a regenerate is in flight — the
@@ -119,6 +134,8 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       open: true,
       draft: report.content ?? "",
       titleDraft: report.title ?? "",
+      baseContent: report.content ?? "",
+      baseTitle: report.title ?? "",
     });
   };
 
@@ -153,7 +170,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       // stale draft would surface a misleading "unsaved edits" warning
       // on the next Regenerate click.
       if (editState.open) {
-        setEditState({ open: false, draft: "", titleDraft: "" });
+        setEditState(CLOSED_EDIT_STATE);
         toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
           icon: "ℹ️",
         });
@@ -168,14 +185,18 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     try {
       await updateContentMutation.mutateAsync({
         reportId,
-        content: editState.draft,
-        // An emptied field clears the title (null) rather than sending "",
-        // which the API rejects. Null restores the config-name fallback.
-        title: editState.titleDraft.trim() || null,
+        // Send the draft only when the user actually edited the body. Otherwise
+        // send the server's current content, so saving a title alone can't push
+        // stale seeded content over a body that refreshed while we were open.
+        content: hasContentEdits ? editState.draft : (report.content ?? ""),
+        // `undefined` leaves the stored title untouched; an emptied field sends
+        // null to clear it (the API rejects ""), restoring the config-name
+        // fallback.
+        title: hasTitleEdits ? editState.titleDraft.trim() || null : undefined,
       });
       // Atomically close + clear so the brief window before React Query's
       // cache update propagates doesn't make `hasUnsavedEdits` falsely true.
-      setEditState({ open: false, draft: "", titleDraft: "" });
+      setEditState(CLOSED_EDIT_STATE);
       toast.success("Report saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
@@ -184,11 +205,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // True when the user has typed in the Edit dialog and their local draft
-  // diverges from the server's saved state. We only warn about *user* edits,
-  // not the initial empty state before the dialog has ever been opened.
-  const hasContentEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
-  const hasTitleEdits = editState.open && editState.titleDraft.trim() !== (report.title ?? "");
+  // Drafts are compared against the snapshot taken when the dialog opened, not
+  // against live `report` — so a background refresh is never mistaken for a
+  // user edit. Before the dialog has ever opened both sides are "", so a
+  // titled report doesn't read as dirty.
+  const hasContentEdits = editState.draft !== editState.baseContent;
+  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
   const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
 
   return (

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -40,6 +40,10 @@ interface Props {
 const TITLE_INPUT_ID = "portfolio-report-title";
 /** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
 const TITLE_MAX_LENGTH = 200;
+// Static example rather than the config's name: this page loads the report from
+// the admin endpoint, whose response has no `reportConfigName` — only the public
+// list projects it.
+const TITLE_PLACEHOLDER = "e.g. Monthly Pods Report — June 2026";
 
 interface EditState {
   open: boolean;
@@ -125,6 +129,14 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const generating = isReportGenerating(report);
   const failed = report.status === "failed";
 
+  // Drafts are compared against the snapshot taken when the dialog opened, not
+  // against live `report` — so a background refresh is never mistaken for a
+  // user edit. Before the dialog has ever opened both sides are "", so a
+  // titled report doesn't read as dirty.
+  const hasContentEdits = editState.draft !== editState.baseContent;
+  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
+  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
+
   const navigateBack = () => {
     routerPush(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
   };
@@ -205,14 +217,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // Drafts are compared against the snapshot taken when the dialog opened, not
-  // against live `report` — so a background refresh is never mistaken for a
-  // user edit. Before the dialog has ever opened both sides are "", so a
-  // titled report doesn't read as dirty.
-  const hasContentEdits = editState.draft !== editState.baseContent;
-  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
-  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
-
   return (
     <div className="flex h-full flex-col">
       <Dialog open={showRegenerateDialog} onOpenChange={setShowRegenerateDialog}>
@@ -280,7 +284,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
                 setEditState((prev) => ({ ...prev, titleDraft: event.target.value }))
               }
               maxLength={TITLE_MAX_LENGTH}
-              placeholder={report.reportConfigName ?? "e.g. Monthly Pods Report — June 2026"}
+              placeholder={TITLE_PLACEHOLDER}
             />
             <p className="text-xs text-zinc-500 dark:text-zinc-400">
               Name the period this report covers — it&apos;s what readers see in the public list.

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -37,6 +37,10 @@ interface Props {
   reportId: string;
 }
 
+const TITLE_INPUT_ID = "portfolio-report-title";
+/** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
+const TITLE_MAX_LENGTH = 200;
+
 /**
  * Admin preview + actions page.
  *
@@ -61,9 +65,14 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   // Edit-dialog state lives in one object so we can update {open, draft}
   // atomically in event handlers. Avoids a chain of setState updates
   // across useState + useEffect.
-  const [editState, setEditState] = useState<{ open: boolean; draft: string }>({
+  const [editState, setEditState] = useState<{
+    open: boolean;
+    draft: string;
+    titleDraft: string;
+  }>({
     open: false,
     draft: "",
+    titleDraft: "",
   });
 
   const isReportRegenerating = report ? isReportGenerating(report) : false;
@@ -106,7 +115,11 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   };
 
   const openEditDialog = () => {
-    setEditState({ open: true, draft: report.content ?? "" });
+    setEditState({
+      open: true,
+      draft: report.content ?? "",
+      titleDraft: report.title ?? "",
+    });
   };
 
   const closeEditDialog = () => {
@@ -140,7 +153,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       // stale draft would surface a misleading "unsaved edits" warning
       // on the next Regenerate click.
       if (editState.open) {
-        setEditState({ open: false, draft: "" });
+        setEditState({ open: false, draft: "", titleDraft: "" });
         toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
           icon: "ℹ️",
         });
@@ -153,11 +166,17 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const handleSaveEdit = async () => {
     try {
-      await updateContentMutation.mutateAsync({ reportId, content: editState.draft });
+      await updateContentMutation.mutateAsync({
+        reportId,
+        content: editState.draft,
+        // An emptied field clears the title (null) rather than sending "",
+        // which the API rejects. Null restores the config-name fallback.
+        title: editState.titleDraft.trim() || null,
+      });
       // Atomically close + clear so the brief window before React Query's
       // cache update propagates doesn't make `hasUnsavedEdits` falsely true.
-      setEditState({ open: false, draft: "" });
-      toast.success("Report content saved");
+      setEditState({ open: false, draft: "", titleDraft: "" });
+      toast.success("Report saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
     }
@@ -165,10 +184,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // True when the user has typed in the Edit textarea and their local draft
-  // diverges from the server's saved content. We only warn about *user* edits,
+  // True when the user has typed in the Edit dialog and their local draft
+  // diverges from the server's saved state. We only warn about *user* edits,
   // not the initial empty state before the dialog has ever been opened.
-  const hasUnsavedEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
+  const hasContentEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
+  const hasTitleEdits = editState.open && editState.titleDraft.trim() !== (report.title ?? "");
+  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
 
   return (
     <div className="flex h-full flex-col">
@@ -215,14 +236,37 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       >
         <DialogContent className="max-w-4xl">
           <DialogHeader>
-            <DialogTitle>Edit report content</DialogTitle>
+            <DialogTitle>Edit report</DialogTitle>
             <DialogDescription>
-              Edits the rendered HTML directly. Regenerating the report will overwrite these
-              changes.
+              Edits the rendered HTML directly. Regenerating the report will overwrite the content,
+              but keeps the title.
             </DialogDescription>
           </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={TITLE_INPUT_ID}
+              className="text-xs font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Title
+            </label>
+            <input
+              id={TITLE_INPUT_ID}
+              type="text"
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+              value={editState.titleDraft}
+              onChange={(event) =>
+                setEditState((prev) => ({ ...prev, titleDraft: event.target.value }))
+              }
+              maxLength={TITLE_MAX_LENGTH}
+              placeholder={report.reportConfigName ?? "e.g. Monthly Pods Report — June 2026"}
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Name the period this report covers — it&apos;s what readers see in the public list.
+              Leave empty to fall back to the report config&apos;s name.
+            </p>
+          </div>
           <textarea
-            className="h-[60vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            className="h-[50vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
             value={editState.draft}
             onChange={(event) => setEditState((prev) => ({ ...prev, draft: event.target.value }))}
             spellCheck={false}
@@ -238,9 +282,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
             </Button>
             <Button
               onClick={handleSaveEdit}
-              disabled={
-                updateContentMutation.isPending || editState.draft === (report.content ?? "")
-              }
+              disabled={updateContentMutation.isPending || !hasUnsavedEdits}
             >
               {updateContentMutation.isPending ? "Saving…" : "Save"}
             </Button>
@@ -261,10 +303,11 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           </Button>
           <div>
             <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              {runDateLabel}
+              {report.title ?? runDateLabel}
             </h1>
             <div className="flex items-center gap-2 text-xs text-zinc-500">
               <GenerationStatusBadge status={report.status} />
+              {report.title && <span>{runDateLabel}</span>}
               <span>Model: {report.modelId}</span>
               {report.tokenUsage && (
                 <span>{report.tokenUsage.totalTokens.toLocaleString()} tokens</span>

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -2,9 +2,19 @@
 
 import { AlertTriangle, ArrowUpRight, FileText, RefreshCw } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryState } from "nuqs";
+import pluralize from "pluralize";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Spinner } from "@/components/Utilities/Spinner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
+import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { reportExcerpt } from "@/utilities/portfolio-reports/excerpt";
@@ -13,6 +23,17 @@ import { ReportTimelineScrubber, type TimelineEntry } from "./ReportTimelineScru
 
 interface Props {
   community: Community;
+}
+
+/**
+ * Sentinel for "no type filter". Radix `SelectItem` rejects an empty string
+ * value, and the URL param is dropped entirely (set to null) at this value.
+ */
+const ALL_TYPES = "all";
+
+interface ReportType {
+  id: string;
+  label: string;
 }
 
 function formatPublished(iso: string): string {
@@ -63,6 +84,42 @@ const MONTH_ABBR = [
 ];
 
 /**
+ * What a reader sees as the report's name, most-specific first:
+ *
+ * 1. `title` — admin-authored, the only source that can name the period the
+ *    report covers (nothing else records it).
+ * 2. `reportConfigName` — shared by every run of that config, so a year of
+ *    monthly reports all read identically. This is the pre-DEV-520 behaviour
+ *    and remains the fallback for untitled reports.
+ * 3. a heading scraped from the rendered content, then the run date.
+ */
+function resolveReportTitle(report: PortfolioReport): string {
+  return (
+    report.title ??
+    report.reportConfigName ??
+    extractTitle(report.content) ??
+    formatRunDate(report.runDate).label
+  );
+}
+
+/**
+ * The report *config* is the closest thing the system has to a "report type" —
+ * each one is effectively a template ("Monthly Pods Report", "Bi-Weekly
+ * Progress Report"), and every report names its originating config.
+ */
+function deriveReportTypes(reports: PortfolioReport[]): ReportType[] {
+  const byId = new Map<string, string>();
+  for (const report of reports) {
+    if (!byId.has(report.reportConfigId)) {
+      byId.set(report.reportConfigId, report.reportConfigName ?? "Untitled report type");
+    }
+  }
+  return Array.from(byId, ([id, label]) => ({ id, label })).sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
+/**
  * One timeline dot per actual published report. The previous biweekly
  * implementation gap-filled missing months — the new model has arbitrary
  * `runDate`s (any day, any cadence) so gap-fill no longer makes sense; we
@@ -84,26 +141,121 @@ function deriveTimeline(sortedReports: Array<{ id: string; runDate: string }>): 
   });
 }
 
+const ReportListItem = memo(function ReportListItem({
+  report,
+  slug,
+  isFirst,
+}: {
+  report: PortfolioReport;
+  slug: string;
+  isFirst: boolean;
+}) {
+  const excerpt = reportExcerpt(report, 280);
+  const fmt = formatRunDate(report.runDate);
+  return (
+    <article
+      data-report-key={report.id}
+      className={`py-8 ${isFirst ? "" : "border-t border-zinc-200 dark:border-zinc-800"}`}
+    >
+      <Link
+        href={PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate, report.reportConfigSlug)}
+        className="group/link flex items-start gap-8"
+      >
+        <div className="min-w-0 flex-1">
+          <p className="mb-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {fmt.badge}
+          </p>
+          <h2 className="text-xl font-semibold tracking-tight text-zinc-900 transition-colors group-hover/link:text-blue-600 sm:text-2xl dark:text-zinc-100 dark:group-hover/link:text-blue-400">
+            {resolveReportTitle(report)}
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">{excerpt}</p>
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {report.publishedAt && <span>Published {formatPublished(report.publishedAt)}</span>}
+            <span className="inline-flex items-center gap-1 text-blue-500 opacity-0 transition-all duration-200 group-hover/link:opacity-100 dark:text-blue-400">
+              Read report
+              <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
+            </span>
+          </div>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="hidden self-center text-zinc-300 transition-all duration-200 group-hover/link:translate-x-1 group-hover/link:text-blue-500 sm:block dark:text-zinc-700 dark:group-hover/link:text-blue-400"
+        >
+          →
+        </div>
+      </Link>
+    </article>
+  );
+});
+
+function ReportTypeFilterSelect({
+  types,
+  value,
+  onChange,
+}: {
+  types: ReportType[];
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+      <span className="font-mono uppercase tracking-wider">Type</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger aria-label="Filter reports by type" className="h-8 max-w-[16rem] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_TYPES}>All report types</SelectItem>
+          {types.map((type) => (
+            <SelectItem key={type.id} value={type.id}>
+              {type.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 export function PublicReportListPage({ community }: Props) {
   const slug = community.details.slug;
   const { data: reports, isLoading, isError, refetch } = usePublishedReports(slug);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const sectionsRef = useRef<HTMLDivElement>(null);
   const seededRef = useRef(false);
+  const [typeFilter, setTypeFilter] = useQueryState("type", { defaultValue: ALL_TYPES });
 
   const sortedReports = useMemo(
     () => (reports ? [...reports].sort((a, b) => b.runDate.localeCompare(a.runDate)) : []),
     [reports]
   );
 
-  const timeline = useMemo(() => deriveTimeline(sortedReports), [sortedReports]);
+  const reportTypes = useMemo(() => deriveReportTypes(sortedReports), [sortedReports]);
+
+  const filteredReports = useMemo(
+    () =>
+      typeFilter === ALL_TYPES
+        ? sortedReports
+        : sortedReports.filter((report) => report.reportConfigId === typeFilter),
+    [sortedReports, typeFilter]
+  );
+
+  // Setting null (rather than the sentinel) drops `?type=` from the URL.
+  const handleTypeChange = (next: string) => {
+    setTypeFilter(next === ALL_TYPES ? null : next);
+  };
+
+  const timeline = useMemo(() => deriveTimeline(filteredReports), [filteredReports]);
 
   useEffect(() => {
     seededRef.current = false;
-  }, [sortedReports]);
+    // The active dot must not survive a filter change that removed it.
+    setActiveKey(null);
+  }, [filteredReports]);
 
   useEffect(() => {
-    if (sortedReports.length === 0) return;
+    if (filteredReports.length === 0) return;
     const root = sectionsRef.current;
     if (!root) return;
     const nodes = root.querySelectorAll<HTMLElement>("[data-report-key]");
@@ -127,7 +279,7 @@ export function PublicReportListPage({ community }: Props) {
       setActiveKey((current) => current ?? nodes[0].dataset.reportKey ?? null);
     }
     return () => observer.disconnect();
-  }, [sortedReports]);
+  }, [filteredReports]);
 
   const handleJumpTo = (key: string) => {
     const target = sectionsRef.current?.querySelector<HTMLElement>(`[data-report-key="${key}"]`);
@@ -181,77 +333,57 @@ export function PublicReportListPage({ community }: Props) {
     );
   }
 
-  const count = sortedReports.length;
-  const latest = sortedReports[0];
+  const count = filteredReports.length;
+  const latest = filteredReports[0];
 
   return (
     <div className="w-full max-w-full -my-4 py-2 animate-fade-in-up">
-      <header className="mb-10">
-        <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
-          Portfolio Reports
-        </h1>
-        <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-          {count} {count === 1 ? "report" : "reports"} · Latest{" "}
-          {formatRunDate(latest.runDate).label}
-        </p>
+      <header className="mb-10 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
+            Portfolio Reports
+          </h1>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {count} {pluralize("report", count)}
+            {latest ? ` · Latest ${formatRunDate(latest.runDate).label}` : ""}
+          </p>
+        </div>
+        {reportTypes.length > 1 && (
+          <ReportTypeFilterSelect
+            types={reportTypes}
+            value={typeFilter}
+            onChange={handleTypeChange}
+          />
+        )}
       </header>
 
-      <div className="grid grid-cols-1 gap-x-10 lg:grid-cols-[160px_1fr]">
-        <ReportTimelineScrubber entries={timeline} activeKey={activeKey} onJumpTo={handleJumpTo} />
-
-        <div ref={sectionsRef} className="min-w-0">
-          {sortedReports.map((report, index) => {
-            const excerpt = reportExcerpt(report, 280);
-            const fmt = formatRunDate(report.runDate);
-            return (
-              <article
-                key={report.id}
-                data-report-key={report.id}
-                className={`py-8 ${
-                  index !== 0 ? "border-t border-zinc-200 dark:border-zinc-800" : ""
-                }`}
-              >
-                <Link
-                  href={PAGES.COMMUNITY.REPORT_DETAIL(
-                    slug,
-                    report.runDate,
-                    report.reportConfigSlug
-                  )}
-                  className="group/link flex items-start gap-8"
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="mb-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                      {fmt.badge}
-                    </p>
-                    <h2 className="text-xl font-semibold tracking-tight text-zinc-900 transition-colors group-hover/link:text-blue-600 sm:text-2xl dark:text-zinc-100 dark:group-hover/link:text-blue-400">
-                      {report.reportConfigName ?? extractTitle(report.content) ?? fmt.label}
-                    </h2>
-                    <p className="mt-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-                      {excerpt}
-                    </p>
-                    <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                      {report.publishedAt && (
-                        <span>Published {formatPublished(report.publishedAt)}</span>
-                      )}
-                      <span className="inline-flex items-center gap-1 text-blue-500 opacity-0 transition-all duration-200 group-hover/link:opacity-100 dark:text-blue-400">
-                        Read report
-                        <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
-                      </span>
-                    </div>
-                  </div>
-
-                  <div
-                    aria-hidden="true"
-                    className="hidden self-center text-zinc-300 transition-all duration-200 group-hover/link:translate-x-1 group-hover/link:text-blue-500 sm:block dark:text-zinc-700 dark:group-hover/link:text-blue-400"
-                  >
-                    →
-                  </div>
-                </Link>
-              </article>
-            );
-          })}
+      {filteredReports.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-600">
+          <FileText className="mb-3 h-8 w-8 text-zinc-400" />
+          <p className="text-sm text-zinc-500">No reports of this type.</p>
+          <button
+            type="button"
+            onClick={() => handleTypeChange(ALL_TYPES)}
+            className="mt-4 text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            Show all reports
+          </button>
         </div>
-      </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-x-10 lg:grid-cols-[160px_1fr]">
+          <ReportTimelineScrubber
+            entries={timeline}
+            activeKey={activeKey}
+            onJumpTo={handleJumpTo}
+          />
+
+          <div ref={sectionsRef} className="min-w-0">
+            {filteredReports.map((report, index) => (
+              <ReportListItem key={report.id} report={report} slug={slug} isFirst={index === 0} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -249,10 +249,14 @@ export function PublicReportListPage({ community }: Props) {
   const timeline = useMemo(() => deriveTimeline(filteredReports), [filteredReports]);
 
   useEffect(() => {
+    // The active dot must not survive a filter change that removed it. Keyed on
+    // the filter rather than on `filteredReports`, whose identity changes on
+    // every refetch — clearing it there would jump the timeline to the top each
+    // time data refreshed. Re-observing below on refetch is harmless: seeding
+    // keeps any dot already set.
     seededRef.current = false;
-    // The active dot must not survive a filter change that removed it.
     setActiveKey(null);
-  }, [filteredReports]);
+  }, [typeFilter]);
 
   useEffect(() => {
     if (filteredReports.length === 0) return;
@@ -343,10 +347,11 @@ export function PublicReportListPage({ community }: Props) {
           <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
             Portfolio Reports
           </h1>
-          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-            {count} {pluralize("report", count)}
-            {latest ? ` · Latest ${formatRunDate(latest.runDate).label}` : ""}
-          </p>
+          {count > 0 && (
+            <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+              {count} {pluralize("report", count)} · Latest {formatRunDate(latest.runDate).label}
+            </p>
+          )}
         </div>
         {reportTypes.length > 1 && (
           <ReportTypeFilterSelect

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -257,8 +257,15 @@ export function useUnpublishReport(communitySlug: string) {
 export function useUpdateReportContent(communitySlug: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ reportId, content }: { reportId: string; content: string }) =>
-      portfolioService.updateReportContent(communitySlug, reportId, content),
+    mutationFn: ({
+      reportId,
+      content,
+      title,
+    }: {
+      reportId: string;
+      content: string;
+      title?: string | null;
+    }) => portfolioService.updateReportContent(communitySlug, reportId, content, title),
     onSuccess: (data: PortfolioReport) => {
       queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
       if (data.status === "published") {

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -100,13 +100,19 @@ export async function getReportCharts(
   return data;
 }
 
+/**
+ * `title` is tri-state: omit it to preserve the stored title, pass a string to
+ * set it, or pass `null` to clear it back to the report config's name.
+ */
 export async function updateReportContent(
   communitySlug: string,
   reportId: string,
-  content: string
+  content: string,
+  title?: string | null
 ): Promise<PortfolioReport> {
   const { data } = await apiClient.put(`/v2/communities/${communitySlug}/reports/${reportId}`, {
     content,
+    ...(title !== undefined && { title }),
   });
   return data;
 }

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -82,6 +82,14 @@ export interface PortfolioReport {
   runDate: string;
   status: PortfolioReportStatus;
   /**
+   * Admin-authored title for this specific report (e.g. "Monthly Pods Report
+   * — June 2026"). `null` when untitled, which is every report generated
+   * before DEV-520 — readers fall back to `reportConfigName`. Exists because
+   * the period a report covers is recorded nowhere: `runDate` is the
+   * generation date, not the covered range.
+   */
+  title: string | null;
+  /**
    * Rendered report body. New reports are full `<!DOCTYPE html>`
    * documents emitted by the agentic generator's structured-document
    * pipeline. Pre-migration rows carry markdown text (one-time


### PR DESCRIPTION
Pairs with **show-karma/gap-indexer#2202** (adds the `title` field this reads). Closes [DEV-520](https://linear.app/showkarma/issue/DEV-520/erin-oconnor-edit-sorting-options-for-report-titles-represented-on).

## Problem

`app.filpgf.io` → `communitySlug: "filecoin"` (`whitelabel-config.ts:49`) → this list page. Live prod data is 6 published reports across 3 configs, and the card title was `reportConfigName`, shared by every run of that config — so readers saw:

```
07/09/26   Bi-Weekly Progress Report      Published Jul 15, 2026
07/06/26   Monthly Pods Report            Published Jul 6, 2026
06/30/26   Filecoin ProPGF Monthly        Published Jul 8, 2026
06/22/26   Bi-Weekly Progress Report      Published Jun 24, 2026
06/17/26   Monthly Pods Report            Published Jun 25, 2026
06/03/26   Filecoin ProPGF Monthly        Published Jun 3, 2026
```

Every title twice, nothing naming the period, and no way to narrow to one kind of report. Erin: *"Identifying which monthly report aligns with which month is not super intuitive without clicking into each report."*

## Change

**Editable titles.** Renders the new per-report `title`, falling back through the existing chain:

```
title  ??  reportConfigName  ??  extractTitle(content)  ??  runDate label
 ↑ new       ↑ today's behaviour — untitled reports are unchanged
```

Admins author it in the report editor (title input beside the content textarea). An emptied field sends `null`, restoring the config-name fallback. The editor header now leads with the title when set. The covered period is knowable only to a human — `runDate` is the generation date and nothing records the range — so this is authored, not derived. Rationale in gap-indexer#2202.

**Type filter.** The report *config* is effectively the report type, and both `reportConfigId` and `reportConfigName` already ship on the published payload — so this filters **client-side with zero API change**. URL-synced with nuqs (`?type=<configId>`), so a filtered view is shareable and survives reload. Hidden when a community has only one config.

Also: list item extracted into a `React.memo` component; the count now uses `pluralize` (was a manual ternary) and moves with the filter; the timeline scrubber and scroll-spy track the filtered list.

## Testing

- New `PublicReportListPage.test.tsx` (14 tests, none existed before): all 4 title-fallback tiers, filter narrowing/reset, options deduped per config, filter hidden at one type, pluralized count, stale-filter reset, plus loading/error/empty states.
- `PortfolioReportEditorPage.test.tsx` +5: title seeding (set and untitled), save sends typed title, emptied field sends `null`, Save enables on title-only change.
- Deploy-order safety is pinned by a test: with `title` **absent** (not null), as it would be
  if this ships before gap-indexer#2202, every report still renders the config name.
- Fixtures mirror the real Filecoin shape (3 configs × 2 runs).
- Mutation-checked: removing `report.title ??` from the resolver fails the title test and nothing else, so the coverage is real rather than vacuous.
- 88 portfolio-report tests green; `tsc --noEmit` clean; `pnpm run build` succeeds; Biome clean on changed files.

## Notes for review

- `PortfolioReportEditorPage` trips Biome's complexity warning — but it already did on `main` (34 → 39, limit 20). Advisory, pre-existing; extracting the edit dialog felt like scope creep here. Happy to split it out if preferred.
- No Next.js proxy sits in this seam (the browser calls the indexer directly via `NEXT_PUBLIC_GAP_INDEXER_URL`), so the proxy-contract-test guardrail doesn't apply; the wire contract is covered by controller tests in gap-indexer#2202.

## Smoke results

Not yet run — cross-service gate pending. This must not merge until both branches are on the same preview and the DEV-520 flows are walked end-to-end. Deploying this ahead of gap-indexer#2202 is safe but inert: `title` is `undefined`, so every report falls back to the config name exactly as today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom report titles (editing, saving, clearing) with title-aware unsaved-change detection and save behavior.
  * Updated report headers and public listings to prefer the custom title with fallback labels.
  * Added URL-backed filtering of public reports by report type, including type-aware empty states and restore-to-all.
* **Bug Fixes**
  * Prevented title-only updates from overwriting refreshed report content while the editor is open.
  * Ensured regeneration and type changes don’t leave stale dirty/active timeline state.
* **Tests**
  * Expanded coverage for title editing behavior and type filtering UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
