### PR TITLE
fix(reports): give same-date reports their own URLs

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -48,6 +48,8 @@ const baseReport = {
   communityId: "community-1",
   runDate: "2026-03-15",
   status: "draft",
+  title: null,
+  reportConfigName: "Monthly Pods Report",
   content: "<p>Server content</p>",
   dataSnapshot: {},
   modelId: "gpt-4.1",
@@ -230,6 +232,86 @@ describe("PortfolioReportEditorPage", () => {
         screen.queryByRole("heading", { name: /discard unsaved edits/i })
       ).not.toBeInTheDocument();
       expect(screen.getByRole("heading", { name: /^regenerate report/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("report title", () => {
+    it("should_seed_title_input_with_stored_title_when_dialog_opens", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "Monthly Pods Report — June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect((screen.getByLabelText(/^title$/i) as HTMLInputElement).value).toBe(
+        "Monthly Pods Report — June 2026"
+      );
+    });
+
+    it("should_seed_title_input_empty_when_report_is_untitled", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect((screen.getByLabelText(/^title$/i) as HTMLInputElement).value).toBe("");
+    });
+
+    it("should_send_the_typed_title_when_saved", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ reportId: "report-1", title: "June 2026" })
+      );
+    });
+
+    it("should_send_null_title_when_the_field_is_emptied", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.clear(screen.getByLabelText(/^title$/i));
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
+    });
+
+    it("should_enable_save_when_only_the_title_changed", async () => {
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+
+      expect(screen.getByRole("button", { name: /^save$/i })).toBeEnabled();
     });
   });
 });

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -300,6 +300,25 @@ describe("PortfolioReportEditorPage", () => {
       expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
     });
 
+    it("should_not_treat_a_stored_title_as_unsaved_edits_before_the_dialog_opens", async () => {
+      // The title draft is empty until the dialog seeds it, so comparing it to
+      // a stored title without gating on the dialog being open would report
+      // unsaved edits on every titled report and wrongly warn here.
+      const user = userEvent.setup();
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "Monthly Pods Report — June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^regenerate$/i }));
+
+      expect(
+        screen.queryByRole("heading", { name: /discard unsaved edits/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /^regenerate report/i })).toBeInTheDocument();
+    });
+
     it("should_enable_save_when_only_the_title_changed", async () => {
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -300,10 +300,87 @@ describe("PortfolioReportEditorPage", () => {
       expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ title: null }));
     });
 
+    it("should_not_overwrite_refreshed_content_when_only_the_title_changed", async () => {
+      // The dialog seeds its draft from the report on open. If the body then
+      // refreshes underneath it, a title-only save must not push the stale
+      // seeded copy back over the newer content.
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      const { rerender } = render(
+        <PortfolioReportEditorPage community={community} reportId="report-1" />
+      );
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      // A background refetch lands while the dialog is open.
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, content: "<p>Refreshed by someone else</p>" },
+        isLoading: false,
+      } as any);
+      rerender(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      await user.type(screen.getByLabelText(/^title$/i), "June 2026");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "June 2026",
+          content: "<p>Refreshed by someone else</p>",
+        })
+      );
+    });
+
+    it("should_leave_title_untouched_when_only_the_content_changed", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({
+        data: { ...baseReport, title: "June 2026" },
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      const textarea = screen.getByLabelText(/report html content/i);
+      await user.clear(textarea);
+      await user.type(textarea, "<p>Body only</p>");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      // undefined preserves the stored title rather than rewriting it.
+      expect(updateMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "<p>Body only</p>", title: undefined })
+      );
+    });
+
+    it("should_send_emptied_content_rather_than_silently_restoring_it", async () => {
+      const user = userEvent.setup();
+      const updateMutate = vi.fn().mockResolvedValue(baseReport);
+      mockUseUpdateReportContent.mockReturnValue({
+        isPending: false,
+        mutateAsync: updateMutate,
+      } as any);
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+      await user.clear(screen.getByLabelText(/report html content/i));
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(updateMutate).toHaveBeenCalledWith(expect.objectContaining({ content: "" }));
+    });
+
     it("should_not_treat_a_stored_title_as_unsaved_edits_before_the_dialog_opens", async () => {
       // The title draft is empty until the dialog seeds it, so comparing it to
-      // a stored title without gating on the dialog being open would report
-      // unsaved edits on every titled report and wrongly warn here.
+      // the live stored title would report unsaved edits on every titled
+      // report and wrongly warn here. Baselines start empty alongside it.
       const user = userEvent.setup();
       mockUsePortfolioReport.mockReturnValue({
         data: { ...baseReport, title: "Monthly Pods Report — June 2026" },

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -1,37 +1,125 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
 
+vi.mock("nuqs", () => ({
+  useQueryState: (_key: string, options: { defaultValue?: unknown }) => {
+    const [value, setValue] = useState<unknown>(options?.defaultValue ?? null);
+    // Mirrors nuqs: setting null drops the param, so the hook falls back to
+    // the default value rather than storing a literal null.
+    return [value, (next: unknown) => setValue(next ?? options?.defaultValue ?? null)] as const;
+  },
+}));
+
+// Radix Select is portal/pointer-driven and awkward in jsdom; mock it to a
+// native <select> (the same convention used by ApplicationsFullView's tests).
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Filter reports by type"
+      onChange={(e) => onValueChange(e.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 
-const mockReports = vi.mocked(usePublishedReports);
+const mockUsePublishedReports = vi.mocked(usePublishedReports);
 
 const community = {
-  uid: "c-1",
-  details: { slug: "filpgf", name: "FIL PGF" },
+  uid: "community-1",
+  details: { slug: "filecoin", name: "Filecoin" },
 } as any;
 
-const SAME_DATE = "2026-07-06";
-
-function makeReport(overrides: Record<string, unknown>) {
+function createReport(overrides: Record<string, unknown> = {}) {
   return {
-    id: "r-1",
-    reportConfigId: "cfg-1",
-    runDate: SAME_DATE,
+    id: "report-1",
+    reportConfigId: "config-pods",
+    reportConfigName: "Monthly Pods Report",
+    reportConfigSlug: "monthly-pods-report",
+    communityId: "community-1",
+    runDate: "2026-07-06",
     status: "published",
-    content: "<h1>Report</h1><p>Body text.</p>",
-    publishedAt: "2026-07-06T10:00:00.000Z",
-    reportConfigName: "Quarterly Review",
-    reportConfigSlug: "quarterly-review",
+    title: null,
+    content: "<h1>Monthly Pods Report</h1>",
+    dataSnapshot: {},
+    modelId: "gpt-5.5",
+    tokenUsage: null,
+    generatedAt: "2026-07-06T00:00:00.000Z",
+    generationError: null,
+    publishedAt: "2026-07-06T00:00:00.000Z",
+    publishedBy: "0xadmin",
+    createdAt: "2026-07-06T00:00:00.000Z",
+    updatedAt: "2026-07-06T00:00:00.000Z",
     ...overrides,
   };
 }
 
-function hrefs(): string[] {
-  return screen
-    .getAllByRole("link")
-    .map((a) => a.getAttribute("href") ?? "")
-    .filter((h) => h.includes("/reports/"));
+/** Mirrors the live Filecoin shape: 3 configs, 2 runs each, titles repeated. */
+function filecoinReports() {
+  return [
+    createReport({
+      id: "r1",
+      reportConfigId: "config-biweekly",
+      reportConfigName: "Bi-Weekly Progress Report",
+      reportConfigSlug: "bi-weekly-progress-report",
+      runDate: "2026-07-09",
+    }),
+    createReport({
+      id: "r2",
+      reportConfigId: "config-pods",
+      reportConfigName: "Monthly Pods Report",
+      reportConfigSlug: "monthly-pods-report",
+      runDate: "2026-07-06",
+    }),
+    createReport({
+      id: "r3",
+      reportConfigId: "config-propgf",
+      reportConfigName: "Filecoin ProPGF Monthly",
+      reportConfigSlug: "filecoin-propgf-monthly",
+      runDate: "2026-06-30",
+    }),
+    createReport({
+      id: "r4",
+      reportConfigId: "config-biweekly",
+      reportConfigName: "Bi-Weekly Progress Report",
+      reportConfigSlug: "bi-weekly-progress-report",
+      runDate: "2026-06-22",
+    }),
+    createReport({
+      id: "r5",
+      reportConfigId: "config-pods",
+      reportConfigName: "Monthly Pods Report",
+      reportConfigSlug: "monthly-pods-report",
+      runDate: "2026-06-17",
+    }),
+    createReport({
+      id: "r6",
+      reportConfigId: "config-propgf",
+      reportConfigName: "Filecoin ProPGF Monthly",
+      reportConfigSlug: "filecoin-propgf-monthly",
+      runDate: "2026-06-03",
+    }),
+  ];
 }
 
 describe("PublicReportListPage", () => {
@@ -39,117 +127,302 @@ describe("PublicReportListPage", () => {
     vi.clearAllMocks();
   });
 
-  it("gives two reports published on the same date distinct links", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-quarterly",
-          reportConfigId: "cfg-quarterly",
-          reportConfigName: "Quarterly Review",
-          reportConfigSlug: "quarterly-review",
-        }),
-        makeReport({
-          id: "r-health",
-          reportConfigId: "cfg-health",
-          reportConfigName: "Portfolio Health",
-          reportConfigSlug: "portfolio-health",
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("loading, error, and empty states", () => {
+    it("should_render_spinner_when_reports_are_loading", () => {
+      mockUsePublishedReports.mockReturnValue({ isLoading: true } as any);
 
-    render(<PublicReportListPage community={community} />);
+      const { container } = render(<PublicReportListPage community={community} />);
 
-    const links = hrefs();
-    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/quarterly-review`);
-    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/portfolio-health`);
-    expect(new Set(links).size).toBe(links.length);
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    it("should_render_retry_when_the_fetch_fails", () => {
+      mockUsePublishedReports.mockReturnValue({ isError: true, refetch: vi.fn() } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByText(/failed to load reports/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it("should_render_empty_state_when_there_are_no_published_reports", () => {
+      mockUsePublishedReports.mockReturnValue({ data: [], isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByText(/no published reports yet/i)).toBeInTheDocument();
+    });
   });
 
-  it("falls back to the run-date-only link when the config slug is missing", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-orphan",
-          reportConfigName: null,
-          reportConfigSlug: null,
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("report title resolution", () => {
+    it("should_prefer_the_admin_authored_title_over_the_config_name", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: "Monthly Pods Report — June 2026" })],
+        isLoading: false,
+      } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(hrefs()).toContain(`/community/filpgf/reports/${SAME_DATE}`);
+      expect(
+        screen.getByRole("heading", { name: "Monthly Pods Report — June 2026" })
+      ).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_the_config_name_when_untitled", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: null })],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_a_content_heading_when_untitled_and_the_config_is_deleted", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            title: null,
+            reportConfigName: null,
+            content: "<h1>Scraped From Content</h1>",
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Scraped From Content" })).toBeInTheDocument();
+    });
+
+    it("should_fall_back_to_the_run_date_when_no_other_source_names_the_report", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ title: null, reportConfigName: null, content: "" })],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "July 6, 2026" })).toBeInTheDocument();
+    });
   });
 
-  it("renders both same-date reports rather than collapsing them", () => {
-    mockReports.mockReturnValue({
-      data: [
-        makeReport({
-          id: "r-quarterly",
-          reportConfigName: "Quarterly Review",
-          reportConfigSlug: "quarterly-review",
-        }),
-        makeReport({
-          id: "r-health",
-          reportConfigName: "Portfolio Health",
-          reportConfigSlug: "portfolio-health",
-        }),
-      ],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  // Carried over from the same-date-collision work (#1855), which this branch
+  // is stacked on: two configs can publish on one day, so a run-date-only link
+  // cannot address a report. Kept here because both PRs touch this list.
+  describe("same-date report links", () => {
+    const SAME_DATE = "2026-07-06";
 
-    render(<PublicReportListPage community={community} />);
+    function hrefs(): string[] {
+      return screen
+        .getAllByRole("link")
+        .map((a) => a.getAttribute("href") ?? "")
+        .filter((h) => h.includes("/reports/"));
+    }
 
-    expect(screen.getByText("Quarterly Review")).toBeInTheDocument();
-    expect(screen.getByText("Portfolio Health")).toBeInTheDocument();
-    expect(screen.getByText(/2 reports/i)).toBeInTheDocument();
+    it("gives two reports published on the same date distinct links", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      const links = hrefs();
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/quarterly-review`);
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/portfolio-health`);
+      expect(new Set(links).size).toBe(links.length);
+    });
+
+    it("falls back to the run-date-only link when the config slug is missing", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-orphan",
+            reportConfigName: null,
+            reportConfigSlug: null,
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(hrefs()).toContain(`/community/filecoin/reports/${SAME_DATE}`);
+    });
+
+    it("renders both same-date reports rather than collapsing them", () => {
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      // Scoped to headings: each config name now also appears as an option in
+      // the type filter this branch adds, so a bare text match is ambiguous.
+      expect(screen.getByRole("heading", { name: "Quarterly Review" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Portfolio Health" })).toBeInTheDocument();
+      expect(screen.getByText(/2 reports/i)).toBeInTheDocument();
+    });
+
+    it("keeps same-date links distinct when a title is set on one of them", () => {
+      // The two features interact here: a title changes what the card *reads*,
+      // never where it *points* — the link still keys off runDate + configSlug.
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({
+            id: "r-quarterly",
+            reportConfigId: "cfg-quarterly",
+            reportConfigName: "Quarterly Review",
+            reportConfigSlug: "quarterly-review",
+            title: "Quarterly Review — Q2 2026",
+            runDate: SAME_DATE,
+          }),
+          createReport({
+            id: "r-health",
+            reportConfigId: "cfg-health",
+            reportConfigName: "Portfolio Health",
+            reportConfigSlug: "portfolio-health",
+            runDate: SAME_DATE,
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Quarterly Review — Q2 2026" })
+      ).toBeInTheDocument();
+      const links = hrefs();
+      expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/quarterly-review`);
+      expect(new Set(links).size).toBe(links.length);
+    });
   });
 
-  it("renders a spinner while loading", () => {
-    mockReports.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+  describe("report type filter", () => {
+    it("should_list_each_config_once_as_a_type_option", () => {
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual([
+        "All report types",
+        "Bi-Weekly Progress Report",
+        "Filecoin ProPGF Monthly",
+        "Monthly Pods Report",
+      ]);
+    });
 
-  it("renders an empty state when there are no reports", () => {
-    mockReports.mockReturnValue({
-      data: [],
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as any);
+    it("should_hide_the_filter_when_only_one_type_exists", () => {
+      mockUsePublishedReports.mockReturnValue({ data: [createReport()], isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.getByText(/no published reports yet/i)).toBeInTheDocument();
-  });
+      expect(screen.queryByLabelText(/filter reports by type/i)).not.toBeInTheDocument();
+    });
 
-  it("renders a retry affordance on error", () => {
-    mockReports.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      refetch: vi.fn(),
-    } as any);
+    it("should_show_every_report_before_a_type_is_picked", () => {
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
-    render(<PublicReportListPage community={community} />);
+      render(<PublicReportListPage community={community} />);
 
-    expect(screen.getByText(/failed to load reports/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+      expect(screen.getByText(/^6 reports/)).toBeInTheDocument();
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
+
+    it("should_narrow_the_list_to_the_picked_type", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+
+      const headings = screen.getAllByRole("heading", { level: 2 });
+      expect(headings).toHaveLength(2);
+      for (const heading of headings) {
+        expect(heading).toHaveTextContent("Monthly Pods Report");
+      }
+    });
+
+    it("should_pluralize_the_count_for_a_single_matching_report", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({
+        data: [
+          createReport({ id: "r1", reportConfigId: "config-pods" }),
+          createReport({
+            id: "r2",
+            reportConfigId: "config-biweekly",
+            reportConfigName: "Bi-Weekly Progress Report",
+          }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+
+      expect(screen.getByText(/^1 report /)).toBeInTheDocument();
+    });
+
+    it("should_restore_every_report_when_the_filter_is_reset", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      const select = screen.getByLabelText(/filter reports by type/i);
+      await user.selectOptions(select, "config-pods");
+      await user.selectOptions(select, "all");
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
+
+    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      // A shared link whose config has since been deleted.
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-propgf");
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "all");
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
+    });
   });
 });

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
+import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
+
+vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+
+const mockReports = vi.mocked(usePublishedReports);
+
+const community = {
+  uid: "c-1",
+  details: { slug: "filpgf", name: "FIL PGF" },
+} as any;
+
+const SAME_DATE = "2026-07-06";
+
+function makeReport(overrides: Record<string, unknown>) {
+  return {
+    id: "r-1",
+    reportConfigId: "cfg-1",
+    runDate: SAME_DATE,
+    status: "published",
+    content: "<h1>Report</h1><p>Body text.</p>",
+    publishedAt: "2026-07-06T10:00:00.000Z",
+    reportConfigName: "Quarterly Review",
+    reportConfigSlug: "quarterly-review",
+    ...overrides,
+  };
+}
+
+function hrefs(): string[] {
+  return screen
+    .getAllByRole("link")
+    .map((a) => a.getAttribute("href") ?? "")
+    .filter((h) => h.includes("/reports/"));
+}
+
+describe("PublicReportListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("gives two reports published on the same date distinct links", () => {
+    mockReports.mockReturnValue({
+      data: [
+        makeReport({
+          id: "r-quarterly",
+          reportConfigId: "cfg-quarterly",
+          reportConfigName: "Quarterly Review",
+          reportConfigSlug: "quarterly-review",
+        }),
+        makeReport({
+          id: "r-health",
+          reportConfigId: "cfg-health",
+          reportConfigName: "Portfolio Health",
+          reportConfigSlug: "portfolio-health",
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    const links = hrefs();
+    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/quarterly-review`);
+    expect(links).toContain(`/community/filpgf/reports/${SAME_DATE}/portfolio-health`);
+    expect(new Set(links).size).toBe(links.length);
+  });
+
+  it("falls back to the run-date-only link when the config slug is missing", () => {
+    mockReports.mockReturnValue({
+      data: [
+        makeReport({
+          id: "r-orphan",
+          reportConfigName: null,
+          reportConfigSlug: null,
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    expect(hrefs()).toContain(`/community/filpgf/reports/${SAME_DATE}`);
+  });
+
+  it("renders both same-date reports rather than collapsing them", () => {
+    mockReports.mockReturnValue({
+      data: [
+        makeReport({
+          id: "r-quarterly",
+          reportConfigName: "Quarterly Review",
+          reportConfigSlug: "quarterly-review",
+        }),
+        makeReport({
+          id: "r-health",
+          reportConfigName: "Portfolio Health",
+          reportConfigSlug: "portfolio-health",
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    expect(screen.getByText("Quarterly Review")).toBeInTheDocument();
+    expect(screen.getByText("Portfolio Health")).toBeInTheDocument();
+    expect(screen.getByText(/2 reports/i)).toBeInTheDocument();
+  });
+
+  it("renders a spinner while loading", () => {
+    mockReports.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no reports", () => {
+    mockReports.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    expect(screen.getByText(/no published reports yet/i)).toBeInTheDocument();
+  });
+
+  it("renders a retry affordance on error", () => {
+    mockReports.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportListPage community={community} />);
+
+    expect(screen.getByText(/failed to load reports/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -179,6 +179,18 @@ describe("PublicReportListPage", () => {
       expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
     });
 
+    it("should_fall_back_to_the_config_name_when_the_api_omits_title_entirely", () => {
+      // Deploy-order safety: if this ships before the indexer adds `title`,
+      // the field is absent rather than null and every report must render
+      // exactly as it does today.
+      const { title: _omitted, ...withoutTitle } = createReport();
+      mockUsePublishedReports.mockReturnValue({ data: [withoutTitle], isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getByRole("heading", { name: "Monthly Pods Report" })).toBeInTheDocument();
+    });
+
     it("should_fall_back_to_a_content_heading_when_untitled_and_the_config_is_deleted", () => {
       mockUsePublishedReports.mockReturnValue({
         data: [

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -4,9 +4,15 @@ import { useState } from "react";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
 
+// `initialType` seeds the query param, standing in for a URL arriving with
+// `?type=` already set (a shared or reloaded link).
+const mockNuqs = vi.hoisted(() => ({ initialType: null as string | null }));
+
 vi.mock("nuqs", () => ({
   useQueryState: (_key: string, options: { defaultValue?: unknown }) => {
-    const [value, setValue] = useState<unknown>(options?.defaultValue ?? null);
+    const [value, setValue] = useState<unknown>(
+      mockNuqs.initialType ?? options?.defaultValue ?? null
+    );
     // Mirrors nuqs: setting null drops the param, so the hook falls back to
     // the default value rather than storing a literal null.
     return [value, (next: unknown) => setValue(next ?? options?.defaultValue ?? null)] as const;
@@ -125,6 +131,7 @@ function filecoinReports() {
 describe("PublicReportListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNuqs.initialType = null;
   });
 
   describe("loading, error, and empty states", () => {
@@ -411,6 +418,22 @@ describe("PublicReportListPage", () => {
       expect(screen.getByText(/^1 report /)).toBeInTheDocument();
     });
 
+    it("should_keep_the_filter_applied_across_a_background_refetch", async () => {
+      // React Query hands back a new array identity on every refetch; the
+      // filtered view must survive that rather than snapping back.
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      const { rerender } = render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-pods");
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+      rerender(<PublicReportListPage community={community} />);
+
+      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
+    });
+
     it("should_restore_every_report_when_the_filter_is_reset", async () => {
       const user = userEvent.setup();
       mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
@@ -423,16 +446,34 @@ describe("PublicReportListPage", () => {
       expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
     });
 
-    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
-      const user = userEvent.setup();
+    it("should_render_the_empty_state_when_a_stale_type_param_matches_nothing", () => {
+      // A shared or bookmarked link whose config has since been deleted, so the
+      // `?type=` value matches no report.
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
       mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
 
       render(<PublicReportListPage community={community} />);
-      // A shared link whose config has since been deleted.
-      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-propgf");
-      expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(2);
 
-      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "all");
+      expect(screen.getByText(/no reports of this type/i)).toBeInTheDocument();
+      expect(screen.queryAllByRole("heading", { level: 2 })).toHaveLength(0);
+    });
+
+    it("should_not_render_a_zero_count_in_the_filtered_empty_state", () => {
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.queryByText(/0 reports/i)).not.toBeInTheDocument();
+    });
+
+    it("should_offer_a_reset_when_a_stale_type_param_matches_nothing", async () => {
+      const user = userEvent.setup();
+      mockNuqs.initialType = "config-deleted-since-the-link-was-shared";
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.click(screen.getByRole("button", { name: /show all reports/i }));
 
       expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(6);
     });

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
@@ -128,4 +128,37 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
     expect(screen.getByText(/no published report found/i)).toBeInTheDocument();
     expect(screen.queryByTestId("doc-view")).not.toBeInTheDocument();
   });
+
+  it("passes the config slug through so the right same-date report is fetched", () => {
+    mockPublished.mockReturnValue({
+      data: { id: "r-health", publishedAt: "2026-03-15T00:00:00.000Z" },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(
+      <PublicReportViewPage
+        community={community}
+        runDate={RUN_DATE}
+        configSlug="portfolio-health"
+      />
+    );
+
+    expect(mockPublished).toHaveBeenCalledWith("filecoin", RUN_DATE, "portfolio-health");
+    expect(screen.getByTestId("doc-view")).toHaveTextContent("report:r-health");
+  });
+
+  it("omits the config slug on the legacy run-date-only URL", () => {
+    mockPublished.mockReturnValue({
+      data: { id: "r-newest", publishedAt: "2026-03-15T00:00:00.000Z" },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    expect(mockPublished).toHaveBeenCalledWith("filecoin", RUN_DATE, undefined);
+  });
 });

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
@@ -94,7 +94,7 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
     expect(screen.getByText(/no published report found/i)).toBeInTheDocument();
     expect(screen.queryByTestId("doc-view")).not.toBeInTheDocument();
     // The draft lookup is gated off for non-admins.
-    expect(mockDraft).toHaveBeenCalledWith("filecoin", RUN_DATE, false);
+    expect(mockDraft).toHaveBeenCalledWith("filecoin", RUN_DATE, false, undefined);
   });
 
   it("surfaces the error state (not 'no report') when the admin draft lookup fails", () => {
@@ -147,6 +147,34 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
 
     expect(mockPublished).toHaveBeenCalledWith("filecoin", RUN_DATE, "portfolio-health");
     expect(screen.getByTestId("doc-view")).toHaveTextContent("report:r-health");
+  });
+
+  it("scopes the admin draft preview to the config in the URL", () => {
+    // Two configs can have a draft on one date; the draft shown must be the
+    // one the URL names, not whichever comes back first.
+    mockPublished.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+    mockAdmin.mockReturnValue({ isCommunityAdmin: true, isLoading: false } as any);
+    mockDraft.mockReturnValue({
+      data: { id: "draft-health", publishedAt: null },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(
+      <PublicReportViewPage
+        community={community}
+        runDate={RUN_DATE}
+        configSlug="portfolio-health"
+      />
+    );
+
+    expect(mockDraft).toHaveBeenCalledWith("filecoin", RUN_DATE, true, "portfolio-health");
   });
 
   it("omits the config slug on the legacy run-date-only URL", () => {

--- a/__tests__/utilities/pages.test.ts
+++ b/__tests__/utilities/pages.test.ts
@@ -1,6 +1,26 @@
 import { PAGES } from "@/utilities/pages";
 
 describe("PAGES constants", () => {
+  describe("COMMUNITY.REPORT_DETAIL", () => {
+    it("appends the config slug so same-date reports get distinct URLs", () => {
+      const quarterly = PAGES.COMMUNITY.REPORT_DETAIL("filpgf", "2026-07-06", "quarterly-review");
+      const health = PAGES.COMMUNITY.REPORT_DETAIL("filpgf", "2026-07-06", "portfolio-health");
+
+      expect(quarterly).toBe("/community/filpgf/reports/2026-07-06/quarterly-review");
+      expect(health).toBe("/community/filpgf/reports/2026-07-06/portfolio-health");
+      expect(quarterly).not.toBe(health);
+    });
+
+    it("falls back to the run-date-only URL when no slug is available", () => {
+      expect(PAGES.COMMUNITY.REPORT_DETAIL("filpgf", "2026-07-06")).toBe(
+        "/community/filpgf/reports/2026-07-06"
+      );
+      expect(PAGES.COMMUNITY.REPORT_DETAIL("filpgf", "2026-07-06", null)).toBe(
+        "/community/filpgf/reports/2026-07-06"
+      );
+    });
+  });
+
   describe("COMMUNITY.APPLICATION_SUCCESS", () => {
     it("returns correct path format", () => {
       const result = PAGES.COMMUNITY.APPLICATION_SUCCESS("optimism", "app-123");

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/error.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Link } from "@/src/components/navigation/Link";
+
+export default function ReportMonthError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          We encountered an error loading this report. Please try again.
+        </p>
+        {error.digest ? (
+          <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+        ) : null}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/error.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/error.tsx
@@ -3,7 +3,7 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Link } from "@/src/components/navigation/Link";
 
-export default function ReportMonthError({
+export default function ReportError({
   error,
   reset,
 }: {

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/loading.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/loading.tsx
@@ -1,0 +1,12 @@
+import { Spinner } from "@/components/Utilities/Spinner";
+
+export default function Loading() {
+  return (
+    <output
+      aria-label="Loading"
+      className="flex w-full items-center min-h-screen h-full justify-center"
+    >
+      <Spinner />
+    </output>
+  );
+}

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/not-found.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/not-found.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { FileX } from "lucide-react";
+import { useParams } from "next/navigation";
+import { Link } from "@/src/components/navigation/Link";
+import { PAGES } from "@/utilities/pages";
+
+export default function ReportMonthNotFound() {
+  const params = useParams<{ communityId: string }>();
+  const communityId = params?.communityId ?? "";
+
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
+          <FileX className="h-6 w-6 text-zinc-500 dark:text-zinc-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">Report not found</h1>
+        <p className="text-sm text-muted-foreground">
+          We couldn&apos;t find a report at this URL. It may have been removed, or the month format
+          is invalid.
+        </p>
+        {communityId ? (
+          <Link
+            href={PAGES.COMMUNITY.REPORTS(communityId)}
+            className="mt-2 flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            ← Back to reports
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/not-found.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/not-found.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { Link } from "@/src/components/navigation/Link";
 import { PAGES } from "@/utilities/pages";
 
-export default function ReportMonthNotFound() {
+export default function ReportNotFound() {
   const params = useParams<{ communityId: string }>();
   const communityId = params?.communityId ?? "";
 
@@ -17,8 +17,8 @@ export default function ReportMonthNotFound() {
         </div>
         <h1 className="text-xl font-semibold text-foreground">Report not found</h1>
         <p className="text-sm text-muted-foreground">
-          We couldn&apos;t find a report at this URL. It may have been removed, or the month format
-          is invalid.
+          We couldn&apos;t find a report at this URL. It may have been removed, or the report may
+          have been renamed.
         </p>
         {communityId ? (
           <Link

--- a/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/page.tsx
+++ b/app/community/[communityId]/(with-header)/reports/[runDate]/[configSlug]/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { PublicReportViewPage } from "@/components/Pages/Community/PortfolioReports/PublicReportViewPage";
+import { communitySubpageMetadata } from "@/utilities/metadata/communityCanonical";
+import { CONFIG_SLUG_REGEX, RUN_DATE_REGEX } from "@/utilities/portfolio-reports/period";
+import { getCommunityDetails } from "@/utilities/queries/v2/community";
+
+interface Props {
+  params: Promise<{ communityId: string; runDate: string; configSlug: string }>;
+}
+
+// Self-canonical per (run-date, config): a community running two configs on the
+// same day has two distinct reports, and each needs its own canonical URL.
+// Mirrors the page's validation so an invalid segment never emits a canonical
+// for a URL the page 404s.
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { communityId, runDate, configSlug } = await params;
+  if (!RUN_DATE_REGEX.test(runDate) || !CONFIG_SLUG_REGEX.test(configSlug)) {
+    return {};
+  }
+  return communitySubpageMetadata(communityId, `reports/${runDate}/${configSlug}`);
+}
+
+export default async function Page(props: Props) {
+  const { communityId, runDate, configSlug } = await props.params;
+
+  if (!RUN_DATE_REGEX.test(runDate) || !CONFIG_SLUG_REGEX.test(configSlug)) {
+    notFound();
+  }
+
+  const community = await getCommunityDetails(communityId);
+
+  if (!community) {
+    notFound();
+  }
+
+  return <PublicReportViewPage community={community} runDate={runDate} configSlug={configSlug} />;
+}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -41,6 +41,24 @@ const TITLE_INPUT_ID = "portfolio-report-title";
 /** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
 const TITLE_MAX_LENGTH = 200;
 
+interface EditState {
+  open: boolean;
+  draft: string;
+  titleDraft: string;
+  /** Server content when the dialog opened. */
+  baseContent: string;
+  /** Server title when the dialog opened, "" for untitled. */
+  baseTitle: string;
+}
+
+const CLOSED_EDIT_STATE: EditState = {
+  open: false,
+  draft: "",
+  titleDraft: "",
+  baseContent: "",
+  baseTitle: "",
+};
+
 /**
  * Admin preview + actions page.
  *
@@ -65,15 +83,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   // Edit-dialog state lives in one object so we can update {open, draft}
   // atomically in event handlers. Avoids a chain of setState updates
   // across useState + useEffect.
-  const [editState, setEditState] = useState<{
-    open: boolean;
-    draft: string;
-    titleDraft: string;
-  }>({
-    open: false,
-    draft: "",
-    titleDraft: "",
-  });
+  //
+  // `base*` snapshot what the server held when the dialog opened. Dirty checks
+  // compare drafts against those snapshots rather than against live `report`,
+  // which can refresh underneath an open dialog — otherwise a title-only save
+  // would write the stale seeded content back over the newer body.
+  const [editState, setEditState] = useState<EditState>(CLOSED_EDIT_STATE);
 
   const isReportRegenerating = report ? isReportGenerating(report) : false;
   // Edit dialog hides automatically while a regenerate is in flight — the
@@ -119,6 +134,8 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       open: true,
       draft: report.content ?? "",
       titleDraft: report.title ?? "",
+      baseContent: report.content ?? "",
+      baseTitle: report.title ?? "",
     });
   };
 
@@ -153,7 +170,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       // stale draft would surface a misleading "unsaved edits" warning
       // on the next Regenerate click.
       if (editState.open) {
-        setEditState({ open: false, draft: "", titleDraft: "" });
+        setEditState(CLOSED_EDIT_STATE);
         toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
           icon: "ℹ️",
         });
@@ -168,14 +185,18 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
     try {
       await updateContentMutation.mutateAsync({
         reportId,
-        content: editState.draft,
-        // An emptied field clears the title (null) rather than sending "",
-        // which the API rejects. Null restores the config-name fallback.
-        title: editState.titleDraft.trim() || null,
+        // Send the draft only when the user actually edited the body. Otherwise
+        // send the server's current content, so saving a title alone can't push
+        // stale seeded content over a body that refreshed while we were open.
+        content: hasContentEdits ? editState.draft : (report.content ?? ""),
+        // `undefined` leaves the stored title untouched; an emptied field sends
+        // null to clear it (the API rejects ""), restoring the config-name
+        // fallback.
+        title: hasTitleEdits ? editState.titleDraft.trim() || null : undefined,
       });
       // Atomically close + clear so the brief window before React Query's
       // cache update propagates doesn't make `hasUnsavedEdits` falsely true.
-      setEditState({ open: false, draft: "", titleDraft: "" });
+      setEditState(CLOSED_EDIT_STATE);
       toast.success("Report saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
@@ -184,11 +205,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // True when the user has typed in the Edit dialog and their local draft
-  // diverges from the server's saved state. We only warn about *user* edits,
-  // not the initial empty state before the dialog has ever been opened.
-  const hasContentEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
-  const hasTitleEdits = editState.open && editState.titleDraft.trim() !== (report.title ?? "");
+  // Drafts are compared against the snapshot taken when the dialog opened, not
+  // against live `report` — so a background refresh is never mistaken for a
+  // user edit. Before the dialog has ever opened both sides are "", so a
+  // titled report doesn't read as dirty.
+  const hasContentEdits = editState.draft !== editState.baseContent;
+  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
   const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
 
   return (

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -40,6 +40,10 @@ interface Props {
 const TITLE_INPUT_ID = "portfolio-report-title";
 /** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
 const TITLE_MAX_LENGTH = 200;
+// Static example rather than the config's name: this page loads the report from
+// the admin endpoint, whose response has no `reportConfigName` — only the public
+// list projects it.
+const TITLE_PLACEHOLDER = "e.g. Monthly Pods Report — June 2026";
 
 interface EditState {
   open: boolean;
@@ -125,6 +129,14 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   const generating = isReportGenerating(report);
   const failed = report.status === "failed";
 
+  // Drafts are compared against the snapshot taken when the dialog opened, not
+  // against live `report` — so a background refresh is never mistaken for a
+  // user edit. Before the dialog has ever opened both sides are "", so a
+  // titled report doesn't read as dirty.
+  const hasContentEdits = editState.draft !== editState.baseContent;
+  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
+  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
+
   const navigateBack = () => {
     routerPush(PAGES.ADMIN.PORTFOLIO_REPORTS(slug));
   };
@@ -205,14 +217,6 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // Drafts are compared against the snapshot taken when the dialog opened, not
-  // against live `report` — so a background refresh is never mistaken for a
-  // user edit. Before the dialog has ever opened both sides are "", so a
-  // titled report doesn't read as dirty.
-  const hasContentEdits = editState.draft !== editState.baseContent;
-  const hasTitleEdits = editState.titleDraft.trim() !== editState.baseTitle;
-  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
-
   return (
     <div className="flex h-full flex-col">
       <Dialog open={showRegenerateDialog} onOpenChange={setShowRegenerateDialog}>
@@ -280,7 +284,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
                 setEditState((prev) => ({ ...prev, titleDraft: event.target.value }))
               }
               maxLength={TITLE_MAX_LENGTH}
-              placeholder={report.reportConfigName ?? "e.g. Monthly Pods Report — June 2026"}
+              placeholder={TITLE_PLACEHOLDER}
             />
             <p className="text-xs text-zinc-500 dark:text-zinc-400">
               Name the period this report covers — it&apos;s what readers see in the public list.

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -37,6 +37,10 @@ interface Props {
   reportId: string;
 }
 
+const TITLE_INPUT_ID = "portfolio-report-title";
+/** Mirrors `UpdateReportContentBodySchema.title` max on the indexer. */
+const TITLE_MAX_LENGTH = 200;
+
 /**
  * Admin preview + actions page.
  *
@@ -61,9 +65,14 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   // Edit-dialog state lives in one object so we can update {open, draft}
   // atomically in event handlers. Avoids a chain of setState updates
   // across useState + useEffect.
-  const [editState, setEditState] = useState<{ open: boolean; draft: string }>({
+  const [editState, setEditState] = useState<{
+    open: boolean;
+    draft: string;
+    titleDraft: string;
+  }>({
     open: false,
     draft: "",
+    titleDraft: "",
   });
 
   const isReportRegenerating = report ? isReportGenerating(report) : false;
@@ -106,7 +115,11 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
   };
 
   const openEditDialog = () => {
-    setEditState({ open: true, draft: report.content ?? "" });
+    setEditState({
+      open: true,
+      draft: report.content ?? "",
+      titleDraft: report.title ?? "",
+    });
   };
 
   const closeEditDialog = () => {
@@ -140,7 +153,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       // stale draft would surface a misleading "unsaved edits" warning
       // on the next Regenerate click.
       if (editState.open) {
-        setEditState({ open: false, draft: "" });
+        setEditState({ open: false, draft: "", titleDraft: "" });
         toast("Closed Edit — report is regenerating. Reopen when it finishes.", {
           icon: "ℹ️",
         });
@@ -153,11 +166,17 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const handleSaveEdit = async () => {
     try {
-      await updateContentMutation.mutateAsync({ reportId, content: editState.draft });
+      await updateContentMutation.mutateAsync({
+        reportId,
+        content: editState.draft,
+        // An emptied field clears the title (null) rather than sending "",
+        // which the API rejects. Null restores the config-name fallback.
+        title: editState.titleDraft.trim() || null,
+      });
       // Atomically close + clear so the brief window before React Query's
       // cache update propagates doesn't make `hasUnsavedEdits` falsely true.
-      setEditState({ open: false, draft: "" });
-      toast.success("Report content saved");
+      setEditState({ open: false, draft: "", titleDraft: "" });
+      toast.success("Report saved");
     } catch (err) {
       toast.error(`Failed to save: ${err instanceof Error ? err.message : "Unknown error"}`);
     }
@@ -165,10 +184,12 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
 
   const runDateLabel = formatRunDate(report.runDate).label;
 
-  // True when the user has typed in the Edit textarea and their local draft
-  // diverges from the server's saved content. We only warn about *user* edits,
+  // True when the user has typed in the Edit dialog and their local draft
+  // diverges from the server's saved state. We only warn about *user* edits,
   // not the initial empty state before the dialog has ever been opened.
-  const hasUnsavedEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
+  const hasContentEdits = editState.draft !== "" && editState.draft !== (report.content ?? "");
+  const hasTitleEdits = editState.open && editState.titleDraft.trim() !== (report.title ?? "");
+  const hasUnsavedEdits = hasContentEdits || hasTitleEdits;
 
   return (
     <div className="flex h-full flex-col">
@@ -215,14 +236,37 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
       >
         <DialogContent className="max-w-4xl">
           <DialogHeader>
-            <DialogTitle>Edit report content</DialogTitle>
+            <DialogTitle>Edit report</DialogTitle>
             <DialogDescription>
-              Edits the rendered HTML directly. Regenerating the report will overwrite these
-              changes.
+              Edits the rendered HTML directly. Regenerating the report will overwrite the content,
+              but keeps the title.
             </DialogDescription>
           </DialogHeader>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={TITLE_INPUT_ID}
+              className="text-xs font-medium text-zinc-700 dark:text-zinc-300"
+            >
+              Title
+            </label>
+            <input
+              id={TITLE_INPUT_ID}
+              type="text"
+              className="w-full rounded border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+              value={editState.titleDraft}
+              onChange={(event) =>
+                setEditState((prev) => ({ ...prev, titleDraft: event.target.value }))
+              }
+              maxLength={TITLE_MAX_LENGTH}
+              placeholder={report.reportConfigName ?? "e.g. Monthly Pods Report — June 2026"}
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Name the period this report covers — it&apos;s what readers see in the public list.
+              Leave empty to fall back to the report config&apos;s name.
+            </p>
+          </div>
           <textarea
-            className="h-[60vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+            className="h-[50vh] w-full resize-none rounded border border-zinc-300 bg-white p-3 font-mono text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
             value={editState.draft}
             onChange={(event) => setEditState((prev) => ({ ...prev, draft: event.target.value }))}
             spellCheck={false}
@@ -238,9 +282,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
             </Button>
             <Button
               onClick={handleSaveEdit}
-              disabled={
-                updateContentMutation.isPending || editState.draft === (report.content ?? "")
-              }
+              disabled={updateContentMutation.isPending || !hasUnsavedEdits}
             >
               {updateContentMutation.isPending ? "Saving…" : "Save"}
             </Button>
@@ -261,10 +303,11 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
           </Button>
           <div>
             <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              {runDateLabel}
+              {report.title ?? runDateLabel}
             </h1>
             <div className="flex items-center gap-2 text-xs text-zinc-500">
               <GenerationStatusBadge status={report.status} />
+              {report.title && <span>{runDateLabel}</span>}
               <span>Model: {report.modelId}</span>
               {report.tokenUsage && (
                 <span>{report.tokenUsage.totalTokens.toLocaleString()} tokens</span>

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -443,7 +443,11 @@ export function PortfolioReportListPage({ community }: Props) {
                   rowPending={isRowPending(report.id)}
                   activeMutationType={activeMutationType}
                   onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
-                  onPreview={() => router.push(PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate))}
+                  onPreview={() =>
+                    router.push(
+                      PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate, report.reportConfigSlug)
+                    )
+                  }
                   onPublish={() => handlePublish(report.id)}
                   onUnpublish={() => handleUnpublish(report.id)}
                   onRegenerate={() => setRegenerateTargetId(report.id)}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -26,11 +26,15 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
   const runDate = report?.runDate;
+  // Carry the config slug through: this route knows exactly which report was
+  // requested, and a run-date-only redirect would drop that and land on
+  // whichever report is newest when two configs ran the same day.
+  const configSlug = report?.reportConfigSlug ?? null;
   useEffect(() => {
     if (runDate) {
-      replace(PAGES.COMMUNITY.REPORT_DETAIL(slug, runDate));
+      replace(PAGES.COMMUNITY.REPORT_DETAIL(slug, runDate, configSlug));
     }
-  }, [runDate, slug, replace]);
+  }, [runDate, configSlug, slug, replace]);
 
   if (isError) {
     return (

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -2,9 +2,19 @@
 
 import { AlertTriangle, ArrowUpRight, FileText, RefreshCw } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryState } from "nuqs";
+import pluralize from "pluralize";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Spinner } from "@/components/Utilities/Spinner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
+import type { PortfolioReport } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { reportExcerpt } from "@/utilities/portfolio-reports/excerpt";
@@ -13,6 +23,17 @@ import { ReportTimelineScrubber, type TimelineEntry } from "./ReportTimelineScru
 
 interface Props {
   community: Community;
+}
+
+/**
+ * Sentinel for "no type filter". Radix `SelectItem` rejects an empty string
+ * value, and the URL param is dropped entirely (set to null) at this value.
+ */
+const ALL_TYPES = "all";
+
+interface ReportType {
+  id: string;
+  label: string;
 }
 
 function formatPublished(iso: string): string {
@@ -63,6 +84,42 @@ const MONTH_ABBR = [
 ];
 
 /**
+ * What a reader sees as the report's name, most-specific first:
+ *
+ * 1. `title` — admin-authored, the only source that can name the period the
+ *    report covers (nothing else records it).
+ * 2. `reportConfigName` — shared by every run of that config, so a year of
+ *    monthly reports all read identically. This is the pre-DEV-520 behaviour
+ *    and remains the fallback for untitled reports.
+ * 3. a heading scraped from the rendered content, then the run date.
+ */
+function resolveReportTitle(report: PortfolioReport): string {
+  return (
+    report.title ??
+    report.reportConfigName ??
+    extractTitle(report.content) ??
+    formatRunDate(report.runDate).label
+  );
+}
+
+/**
+ * The report *config* is the closest thing the system has to a "report type" —
+ * each one is effectively a template ("Monthly Pods Report", "Bi-Weekly
+ * Progress Report"), and every report names its originating config.
+ */
+function deriveReportTypes(reports: PortfolioReport[]): ReportType[] {
+  const byId = new Map<string, string>();
+  for (const report of reports) {
+    if (!byId.has(report.reportConfigId)) {
+      byId.set(report.reportConfigId, report.reportConfigName ?? "Untitled report type");
+    }
+  }
+  return Array.from(byId, ([id, label]) => ({ id, label })).sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
+/**
  * One timeline dot per actual published report. The previous biweekly
  * implementation gap-filled missing months — the new model has arbitrary
  * `runDate`s (any day, any cadence) so gap-fill no longer makes sense; we
@@ -84,26 +141,121 @@ function deriveTimeline(sortedReports: Array<{ id: string; runDate: string }>): 
   });
 }
 
+const ReportListItem = memo(function ReportListItem({
+  report,
+  slug,
+  isFirst,
+}: {
+  report: PortfolioReport;
+  slug: string;
+  isFirst: boolean;
+}) {
+  const excerpt = reportExcerpt(report, 280);
+  const fmt = formatRunDate(report.runDate);
+  return (
+    <article
+      data-report-key={report.id}
+      className={`py-8 ${isFirst ? "" : "border-t border-zinc-200 dark:border-zinc-800"}`}
+    >
+      <Link
+        href={PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate, report.reportConfigSlug)}
+        className="group/link flex items-start gap-8"
+      >
+        <div className="min-w-0 flex-1">
+          <p className="mb-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {fmt.badge}
+          </p>
+          <h2 className="text-xl font-semibold tracking-tight text-zinc-900 transition-colors group-hover/link:text-blue-600 sm:text-2xl dark:text-zinc-100 dark:group-hover/link:text-blue-400">
+            {resolveReportTitle(report)}
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">{excerpt}</p>
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {report.publishedAt && <span>Published {formatPublished(report.publishedAt)}</span>}
+            <span className="inline-flex items-center gap-1 text-blue-500 opacity-0 transition-all duration-200 group-hover/link:opacity-100 dark:text-blue-400">
+              Read report
+              <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
+            </span>
+          </div>
+        </div>
+
+        <div
+          aria-hidden="true"
+          className="hidden self-center text-zinc-300 transition-all duration-200 group-hover/link:translate-x-1 group-hover/link:text-blue-500 sm:block dark:text-zinc-700 dark:group-hover/link:text-blue-400"
+        >
+          →
+        </div>
+      </Link>
+    </article>
+  );
+});
+
+function ReportTypeFilterSelect({
+  types,
+  value,
+  onChange,
+}: {
+  types: ReportType[];
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+      <span className="font-mono uppercase tracking-wider">Type</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger aria-label="Filter reports by type" className="h-8 max-w-[16rem] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_TYPES}>All report types</SelectItem>
+          {types.map((type) => (
+            <SelectItem key={type.id} value={type.id}>
+              {type.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 export function PublicReportListPage({ community }: Props) {
   const slug = community.details.slug;
   const { data: reports, isLoading, isError, refetch } = usePublishedReports(slug);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const sectionsRef = useRef<HTMLDivElement>(null);
   const seededRef = useRef(false);
+  const [typeFilter, setTypeFilter] = useQueryState("type", { defaultValue: ALL_TYPES });
 
   const sortedReports = useMemo(
     () => (reports ? [...reports].sort((a, b) => b.runDate.localeCompare(a.runDate)) : []),
     [reports]
   );
 
-  const timeline = useMemo(() => deriveTimeline(sortedReports), [sortedReports]);
+  const reportTypes = useMemo(() => deriveReportTypes(sortedReports), [sortedReports]);
+
+  const filteredReports = useMemo(
+    () =>
+      typeFilter === ALL_TYPES
+        ? sortedReports
+        : sortedReports.filter((report) => report.reportConfigId === typeFilter),
+    [sortedReports, typeFilter]
+  );
+
+  // Setting null (rather than the sentinel) drops `?type=` from the URL.
+  const handleTypeChange = (next: string) => {
+    setTypeFilter(next === ALL_TYPES ? null : next);
+  };
+
+  const timeline = useMemo(() => deriveTimeline(filteredReports), [filteredReports]);
 
   useEffect(() => {
     seededRef.current = false;
-  }, [sortedReports]);
+    // The active dot must not survive a filter change that removed it.
+    setActiveKey(null);
+  }, [filteredReports]);
 
   useEffect(() => {
-    if (sortedReports.length === 0) return;
+    if (filteredReports.length === 0) return;
     const root = sectionsRef.current;
     if (!root) return;
     const nodes = root.querySelectorAll<HTMLElement>("[data-report-key]");
@@ -127,7 +279,7 @@ export function PublicReportListPage({ community }: Props) {
       setActiveKey((current) => current ?? nodes[0].dataset.reportKey ?? null);
     }
     return () => observer.disconnect();
-  }, [sortedReports]);
+  }, [filteredReports]);
 
   const handleJumpTo = (key: string) => {
     const target = sectionsRef.current?.querySelector<HTMLElement>(`[data-report-key="${key}"]`);
@@ -181,77 +333,57 @@ export function PublicReportListPage({ community }: Props) {
     );
   }
 
-  const count = sortedReports.length;
-  const latest = sortedReports[0];
+  const count = filteredReports.length;
+  const latest = filteredReports[0];
 
   return (
     <div className="w-full max-w-full -my-4 py-2 animate-fade-in-up">
-      <header className="mb-10">
-        <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
-          Portfolio Reports
-        </h1>
-        <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-          {count} {count === 1 ? "report" : "reports"} · Latest{" "}
-          {formatRunDate(latest.runDate).label}
-        </p>
+      <header className="mb-10 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
+            Portfolio Reports
+          </h1>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {count} {pluralize("report", count)}
+            {latest ? ` · Latest ${formatRunDate(latest.runDate).label}` : ""}
+          </p>
+        </div>
+        {reportTypes.length > 1 && (
+          <ReportTypeFilterSelect
+            types={reportTypes}
+            value={typeFilter}
+            onChange={handleTypeChange}
+          />
+        )}
       </header>
 
-      <div className="grid grid-cols-1 gap-x-10 lg:grid-cols-[160px_1fr]">
-        <ReportTimelineScrubber entries={timeline} activeKey={activeKey} onJumpTo={handleJumpTo} />
-
-        <div ref={sectionsRef} className="min-w-0">
-          {sortedReports.map((report, index) => {
-            const excerpt = reportExcerpt(report, 280);
-            const fmt = formatRunDate(report.runDate);
-            return (
-              <article
-                key={report.id}
-                data-report-key={report.id}
-                className={`py-8 ${
-                  index !== 0 ? "border-t border-zinc-200 dark:border-zinc-800" : ""
-                }`}
-              >
-                <Link
-                  href={PAGES.COMMUNITY.REPORT_DETAIL(
-                    slug,
-                    report.runDate,
-                    report.reportConfigSlug
-                  )}
-                  className="group/link flex items-start gap-8"
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="mb-1.5 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                      {fmt.badge}
-                    </p>
-                    <h2 className="text-xl font-semibold tracking-tight text-zinc-900 transition-colors group-hover/link:text-blue-600 sm:text-2xl dark:text-zinc-100 dark:group-hover/link:text-blue-400">
-                      {report.reportConfigName ?? extractTitle(report.content) ?? fmt.label}
-                    </h2>
-                    <p className="mt-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-                      {excerpt}
-                    </p>
-                    <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                      {report.publishedAt && (
-                        <span>Published {formatPublished(report.publishedAt)}</span>
-                      )}
-                      <span className="inline-flex items-center gap-1 text-blue-500 opacity-0 transition-all duration-200 group-hover/link:opacity-100 dark:text-blue-400">
-                        Read report
-                        <ArrowUpRight className="h-3 w-3 transition-transform duration-200 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
-                      </span>
-                    </div>
-                  </div>
-
-                  <div
-                    aria-hidden="true"
-                    className="hidden self-center text-zinc-300 transition-all duration-200 group-hover/link:translate-x-1 group-hover/link:text-blue-500 sm:block dark:text-zinc-700 dark:group-hover/link:text-blue-400"
-                  >
-                    →
-                  </div>
-                </Link>
-              </article>
-            );
-          })}
+      {filteredReports.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-600">
+          <FileText className="mb-3 h-8 w-8 text-zinc-400" />
+          <p className="text-sm text-zinc-500">No reports of this type.</p>
+          <button
+            type="button"
+            onClick={() => handleTypeChange(ALL_TYPES)}
+            className="mt-4 text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            Show all reports
+          </button>
         </div>
-      </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-x-10 lg:grid-cols-[160px_1fr]">
+          <ReportTimelineScrubber
+            entries={timeline}
+            activeKey={activeKey}
+            onJumpTo={handleJumpTo}
+          />
+
+          <div ref={sectionsRef} className="min-w-0">
+            {filteredReports.map((report, index) => (
+              <ReportListItem key={report.id} report={report} slug={slug} isFirst={index === 0} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -249,10 +249,14 @@ export function PublicReportListPage({ community }: Props) {
   const timeline = useMemo(() => deriveTimeline(filteredReports), [filteredReports]);
 
   useEffect(() => {
+    // The active dot must not survive a filter change that removed it. Keyed on
+    // the filter rather than on `filteredReports`, whose identity changes on
+    // every refetch — clearing it there would jump the timeline to the top each
+    // time data refreshed. Re-observing below on refetch is harmless: seeding
+    // keeps any dot already set.
     seededRef.current = false;
-    // The active dot must not survive a filter change that removed it.
     setActiveKey(null);
-  }, [filteredReports]);
+  }, [typeFilter]);
 
   useEffect(() => {
     if (filteredReports.length === 0) return;
@@ -343,10 +347,11 @@ export function PublicReportListPage({ community }: Props) {
           <h1 className="text-2xl font-bold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-100">
             Portfolio Reports
           </h1>
-          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-            {count} {pluralize("report", count)}
-            {latest ? ` · Latest ${formatRunDate(latest.runDate).label}` : ""}
-          </p>
+          {count > 0 && (
+            <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+              {count} {pluralize("report", count)} · Latest {formatRunDate(latest.runDate).label}
+            </p>
+          )}
         </div>
         {reportTypes.length > 1 && (
           <ReportTypeFilterSelect

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -74,7 +74,9 @@ function deriveTimeline(sortedReports: Array<{ id: string; runDate: string }>): 
     const monthIdx = Number(monthStr) - 1;
     const monthAbbr = MONTH_ABBR[monthIdx] ?? monthStr;
     return {
-      key: r.runDate,
+      // Keyed by report id, not runDate: two configs can publish on the same
+      // day, and a runDate key would collide and scrub to the wrong report.
+      key: r.id,
       year: Number(yearStr),
       label: `${monthAbbr} ${Number(dayStr)}`,
       hasReport: true,
@@ -204,13 +206,17 @@ export function PublicReportListPage({ community }: Props) {
             return (
               <article
                 key={report.id}
-                data-report-key={report.runDate}
+                data-report-key={report.id}
                 className={`py-8 ${
                   index !== 0 ? "border-t border-zinc-200 dark:border-zinc-800" : ""
                 }`}
               >
                 <Link
-                  href={PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate)}
+                  href={PAGES.COMMUNITY.REPORT_DETAIL(
+                    slug,
+                    report.runDate,
+                    report.reportConfigSlug
+                  )}
                   className="group/link flex items-start gap-8"
                 >
                   <div className="min-w-0 flex-1">

--- a/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
@@ -15,16 +15,21 @@ import { formatRunDate } from "@/utilities/portfolio-reports/period";
 interface Props {
   community: Community;
   runDate: string;
+  /**
+   * Identifies which config's report to show. Absent on the legacy
+   * run-date-only URL, which resolves to the newest report for that date.
+   */
+  configSlug?: string;
 }
 
-export function PublicReportViewPage({ community, runDate }: Props) {
+export function PublicReportViewPage({ community, runDate, configSlug }: Props) {
   const slug = community.details.slug;
   const {
     data: published,
     isLoading: publishedLoading,
     isError: publishedError,
     refetch: refetchPublished,
-  } = usePublishedReport(slug, runDate);
+  } = usePublishedReport(slug, runDate, configSlug);
 
   // DEV-496: the admin "preview" and the public report share this one URL. When
   // there's no published report, a resolved community admin can still see the

--- a/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
@@ -42,7 +42,7 @@ export function PublicReportViewPage({ community, runDate, configSlug }: Props) 
     isLoading: draftLoading,
     isError: draftError,
     refetch: refetchDraft,
-  } = useAdminReportByRunDate(slug, runDate, canPreviewDraft);
+  } = useAdminReportByRunDate(slug, runDate, canPreviewDraft, configSlug);
 
   // A disabled React Query still holds its last cached value, so gate the
   // selection (not just the fetch) on the resolved admin state — a stale draft

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -321,14 +321,27 @@ export function usePublishedReport(
  * surface a failed/generating/published row and expose it to the document view
  * as a draft preview.
  */
-export function useAdminReportByRunDate(communitySlug: string, runDate: string, enabled: boolean) {
+/**
+ * Finds the draft an admin can preview at a report URL. `configSlug` narrows to
+ * a specific config: matching on `runDate` alone returns whichever draft comes
+ * first when two configs ran the same day, which is not necessarily the one the
+ * URL points at.
+ */
+export function useAdminReportByRunDate(
+  communitySlug: string,
+  runDate: string,
+  enabled: boolean,
+  configSlug?: string
+) {
   return useQuery({
-    queryKey: [...QUERY_KEYS.reports(communitySlug), "by-run-date", runDate],
+    queryKey: [...QUERY_KEYS.reports(communitySlug), "by-run-date", runDate, configSlug ?? null],
     queryFn: async () => {
       const reports = await portfolioService.listReports(communitySlug);
-      return (
-        reports.find((report) => report.runDate === runDate && report.status === "draft") ?? null
+      const drafts = reports.filter(
+        (report) => report.runDate === runDate && report.status === "draft"
       );
+      if (!configSlug) return drafts[0] ?? null;
+      return drafts.find((report) => report.reportConfigSlug === configSlug) ?? null;
     },
     enabled: Boolean(communitySlug && runDate) && enabled,
   });

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -20,6 +20,12 @@ const QUERY_KEYS = {
   published: (slug: string) => ["portfolio-reports-published", slug] as const,
   publishedRunDate: (slug: string, runDate: string) =>
     ["portfolio-report-published", slug, runDate] as const,
+  /**
+   * Deliberately nested under `publishedRunDate` so the existing
+   * publish/unpublish invalidations prefix-match and clear this too.
+   */
+  publishedRunDateConfig: (slug: string, runDate: string, configSlug: string) =>
+    ["portfolio-report-published", slug, runDate, configSlug] as const,
 };
 
 // ── Config queries ───────────────────────────────────────────
@@ -277,10 +283,28 @@ export function usePublishedReports(communitySlug: string) {
   });
 }
 
-export function usePublishedReport(communitySlug: string, runDate: string) {
+/**
+ * Fetches the published report for a run date. Pass `configSlug` to address a
+ * specific report — without it, a date shared by two configs resolves to the
+ * most recently published one.
+ */
+export function usePublishedReport(
+  communitySlug: string,
+  runDate: string,
+  configSlug?: string | null
+) {
   return useQuery({
-    queryKey: QUERY_KEYS.publishedRunDate(communitySlug, runDate),
-    queryFn: () => portfolioService.getPublishedReportByRunDate(communitySlug, runDate),
+    queryKey: configSlug
+      ? QUERY_KEYS.publishedRunDateConfig(communitySlug, runDate, configSlug)
+      : QUERY_KEYS.publishedRunDate(communitySlug, runDate),
+    queryFn: () =>
+      configSlug
+        ? portfolioService.getPublishedReportByRunDateAndConfigSlug(
+            communitySlug,
+            runDate,
+            configSlug
+          )
+        : portfolioService.getPublishedReportByRunDate(communitySlug, runDate),
     enabled: Boolean(communitySlug && runDate),
   });
 }

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -257,8 +257,15 @@ export function useUnpublishReport(communitySlug: string) {
 export function useUpdateReportContent(communitySlug: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ reportId, content }: { reportId: string; content: string }) =>
-      portfolioService.updateReportContent(communitySlug, reportId, content),
+    mutationFn: ({
+      reportId,
+      content,
+      title,
+    }: {
+      reportId: string;
+      content: string;
+      title?: string | null;
+    }) => portfolioService.updateReportContent(communitySlug, reportId, content, title),
     onSuccess: (data: PortfolioReport) => {
       queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
       if (data.status === "published") {

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -100,13 +100,19 @@ export async function getReportCharts(
   return data;
 }
 
+/**
+ * `title` is tri-state: omit it to preserve the stored title, pass a string to
+ * set it, or pass `null` to clear it back to the report config's name.
+ */
 export async function updateReportContent(
   communitySlug: string,
   reportId: string,
-  content: string
+  content: string,
+  title?: string | null
 ): Promise<PortfolioReport> {
   const { data } = await apiClient.put(`/v2/communities/${communitySlug}/reports/${reportId}`, {
     content,
+    ...(title !== undefined && { title }),
   });
   return data;
 }

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -175,6 +175,27 @@ export async function getPublishedReportByRunDate(
   return res.json() as Promise<PortfolioReport>;
 }
 
+/**
+ * Fetch the report a specific config published on `runDate`. Preferred over
+ * {@link getPublishedReportByRunDate}: a run date identifies at most one report
+ * *per config*, so the date alone cannot address a report when a community runs
+ * two configs on the same day.
+ */
+export async function getPublishedReportByRunDateAndConfigSlug(
+  communitySlug: string,
+  runDate: string,
+  configSlug: string
+): Promise<PortfolioReport | null> {
+  const res = await fetch(
+    `${API_URL}/v2/communities/${communitySlug}/reports/published/${encodeURIComponent(
+      runDate
+    )}/${encodeURIComponent(configSlug)}`
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`API error: ${res.status} ${res.statusText}`);
+  return res.json() as Promise<PortfolioReport>;
+}
+
 // ── Data export (admin-only) ─────────────────────────────────
 
 function parseFilename(contentDisposition: string | undefined, fallback: string): string {

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -71,6 +71,13 @@ export interface PortfolioReport {
    * has been deleted.
    */
   reportConfigName?: string | null;
+  /**
+   * URL segment identifying the originating ReportConfig. Needed because
+   * `runDate` alone is ambiguous — two configs can publish on the same day.
+   * Populated by the public list endpoint only; `null` when the config has
+   * been deleted, in which case callers fall back to the run-date-only URL.
+   */
+  reportConfigSlug?: string | null;
   communityId: string;
   runDate: string;
   status: PortfolioReportStatus;

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -82,6 +82,14 @@ export interface PortfolioReport {
   runDate: string;
   status: PortfolioReportStatus;
   /**
+   * Admin-authored title for this specific report (e.g. "Monthly Pods Report
+   * — June 2026"). `null` when untitled, which is every report generated
+   * before DEV-520 — readers fall back to `reportConfigName`. Exists because
+   * the period a report covers is recorded nowhere: `runDate` is the
+   * generation date, not the covered range.
+   */
+  title: string | null;
+  /**
    * Rendered report body. New reports are full `<!DOCTYPE html>`
    * documents emitted by the agentic generator's structured-document
    * pipeline. Pre-migration rows carry markdown text (one-time

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -38,8 +38,15 @@ export const PAGES = {
     BROWSE_APPLICATIONS: (community: string) => `/community/${community}/browse-applications`,
     CLAIM_FUNDS: (community: string) => `/community/${community}/claim-funds`,
     REPORTS: (community: string) => `/community/${community}/reports`,
-    REPORT_DETAIL: (community: string, runDate: string) =>
-      `/community/${community}/reports/${encodeURIComponent(runDate)}`,
+    /**
+     * `configSlug` disambiguates reports sharing a run date. Omit it only when
+     * the slug is unavailable (deleted config) — the run-date-only URL cannot
+     * address a specific report and resolves to the newest one for that date.
+     */
+    REPORT_DETAIL: (community: string, runDate: string, configSlug?: string | null) =>
+      configSlug
+        ? `/community/${community}/reports/${encodeURIComponent(runDate)}/${encodeURIComponent(configSlug)}`
+        : `/community/${community}/reports/${encodeURIComponent(runDate)}`,
     ASK_KARMA: (community: string) => `/community/${community}/ask-karma`,
   },
   MY_PROJECTS: `/my-projects`,

--- a/utilities/portfolio-reports/period.ts
+++ b/utilities/portfolio-reports/period.ts
@@ -2,6 +2,13 @@ import type { ReportSchedule, ScheduleIntervalUnit } from "@/types/portfolio-rep
 
 export const RUN_DATE_REGEX = /^(19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
+/**
+ * Report-config slug segment. Must stay in sync with the backend's
+ * `configSlugSchema` (portfolio-report.schemas.ts) — a slug the FE accepts but
+ * the API rejects would 400 instead of rendering a not-found.
+ */
+export const CONFIG_SLUG_REGEX = /^[a-z0-9][a-z0-9-]*$/;
+
 export function isRunDate(value: string): boolean {
   return RUN_DATE_REGEX.test(value);
 }


### PR DESCRIPTION
## Summary

Publishing two reports on the same date left only the first one reachable — both list entries linked to the same URL. This adds a config-slug segment so each report has its own address.

Reported against https://app.filpgf.io/reports/2026-07-06.

Pairs with gap-indexer#2203 (required — this consumes the new endpoint and the `reportConfigSlug` field).

## Problem

A report's run date is unique per report **config**, not per community, so a community running two configs on the same day has two reports for one date. The URL carried only the date:

```ts
REPORT_DETAIL: (community, runDate) => `/community/${community}/reports/${runDate}`
```

Two reports, one URL. The backend returned whichever row the database listed first, so the second report was unreachable and its list entry pointed at the first.

Changing a report's published date didn't help — the lookup keys on run date, never on `publishedAt`.

## Solution

New route `/community/:slug/reports/:runDate/:configSlug`, self-canonical per report. `REPORT_DETAIL` takes an optional `configSlug` and falls back to the run-date-only URL when it's unavailable (deleted config).

Also fixes two same-cause bugs in the list page: the timeline scrubber keyed on `runDate` (`key`, `data-report-key`), so same-date reports produced duplicate React keys and the scrubber jumped to the wrong report.

The legacy `/reports/:runDate` route still renders for links shared before the slug existed; it now resolves to the most recently published report for that date.

## Testing steps

1. `pnpm run build` — compiles; both routes registered:
   - `/community/[communityId]/reports/[runDate]`
   - `/community/[communityId]/reports/[runDate]/[configSlug]`
2. `npx vitest run __tests__/components/Pages/Community/PortfolioReports __tests__/utilities/pages.test.ts` — passes.
3. Publish two reports on one date → the list shows both with distinct links; each opens its own report.
4. Open a legacy `/reports/<date>` link → still renders (newest for that date).

The list-page regression test was verified to **fail** against the old run-date-only URL builder, so it genuinely pins the reported bug.

## Risk

Low. Additive route; the legacy URL keeps working. Slugs derive from config names, so renaming a config changes its URL — accepted tradeoff (it's what avoids a schema migration and makes existing reports addressable immediately). The not-found copy on the detail route names this as the likely cause.

## Notes for reviewers

- `CONFIG_SLUG_REGEX` must stay in sync with the backend's `configSlugSchema`, or a slug the FE accepts would 400 instead of rendering not-found.
- Conflicts likely with #1854 (DEV-520): it touches `PublicReportListPage.tsx`, `usePortfolioReports.ts`, `portfolio-reports.service.ts`, `types/portfolio-report/index.ts`, and adds a `PublicReportListPage.test.tsx` that this PR also adds. Worth deciding merge order.
- The admin preview is covered too: the report list, the legacy `/preview` redirect, and `useAdminReportByRunDate` all carry the config slug now, so previewing the older of two same-date reports no longer lands on the newer. The draft lookup only falls back to first-match when no slug is given (legacy URL).
- Cross-service E2E against a shared preview has **not** run yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added report-specific URLs so multiple configurations can be viewed separately.
  * Added report type filtering with URL-synced selections and reset options.
  * Added report title editing, including clearing titles and improved title fallbacks.
  * Added loading, error recovery, and not-found states for report pages.

* **Bug Fixes**
  * Preserved report titles and body content during partial edits and refreshes.
  * Improved report links and handling of reports sharing the same run date.
  * Added validation for report URL parameters and configuration slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->