### PR TITLE
fix(reports): make report title optional to match its wire contract

### DIFF
--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -87,8 +87,11 @@ export interface PortfolioReport {
    * before DEV-520 — readers fall back to `reportConfigName`. Exists because
    * the period a report covers is recorded nowhere: `runDate` is the
    * generation date, not the covered range.
+   *
+   * Optional, not just nullable: until the indexer ships the field, responses
+   * omit it entirely rather than sending `null`, and readers must handle both.
    */
-  title: string | null;
+  title?: string | null;
   /**
    * Rendered report body. New reports are full `<!DOCTYPE html>`
    * documents emitted by the agentic generator's structured-document


### PR DESCRIPTION
## Summary

`PortfolioReport.title` is declared required-but-nullable, but the API omits the key entirely until the indexer ships the field. This makes the type match reality.

Follow-up to #1855 — CodeRabbit raised this after that PR had already merged, so it lands separately.

## Problem

```ts
reportConfigName?: string | null;   // optional — may be absent by endpoint/deploy state
reportConfigSlug?: string | null;   // optional — same reason
title: string | null;               // required — but faces the identical hazard
```

`title` has exactly the same deploy-order hazard as its two siblings: until the indexer ships it, responses omit the key rather than sending `null`.

The list page's own test already asserts that case — `should_fall_back_to_the_config_name_when_the_api_omits_title_entirely` constructs a payload with `title` stripped — so the type and the test directly contradicted each other.

Nothing caught it because **`__tests__/**` is excluded from `tsconfig.json`**, so test files are never typechecked, and the mock is cast to `any`. The type was free to disagree with the payload the test builds.

Verified against staging: `GET /v2/communities/filecoin/reports/published` currently returns rows with **no `title` key at all**.

## Solution

Make `title` optional (`title?: string | null`). Type-only — every reader already handles the absent case via `report.title ?? …`, so behaviour is unchanged.

## Testing steps

1. `npx vitest run __tests__/components/Pages/Community/PortfolioReports __tests__/components/Pages/Admin/PortfolioReports` — 63 pass.
2. `pnpm run build` — compiles (Next strict typecheck).
3. Existing coverage for the omitted-`title` payload continues to pass.

## Risk

None. Widening a required field to optional is safe for readers, all of which already use `?? `.

## Note for reviewers

Worth knowing more broadly: `__tests__/**` being excluded from tsconfig means **no test file in this repo is typechecked**. That's what allowed this drift, and it's the same gap that let a related field silently serialize as `undefined` against a nullable-only response schema on the indexer side. Might be worth a separate look.