### PR TITLE
feat(portfolio-reports): derive type filter from configs, not reports

### DIFF
--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportListPage.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { PublicReportListPage } from "@/components/Pages/Community/PortfolioReports/PublicReportListPage";
-import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
+import {
+  usePublishedReports,
+  usePublishedReportTypes,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
 
 // `initialType` seeds the query param, standing in for a URL arriving with
 // `?type=` already set (a shared or reloaded link).
@@ -50,6 +53,7 @@ vi.mock("@/components/ui/select", () => ({
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 
 const mockUsePublishedReports = vi.mocked(usePublishedReports);
+const mockUsePublishedReportTypes = vi.mocked(usePublishedReportTypes);
 
 const community = {
   uid: "community-1",
@@ -132,6 +136,10 @@ describe("PublicReportListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockNuqs.initialType = null;
+    // Default: types endpoint gives nothing, so the dropdown falls back to
+    // deriving from the published reports each test sets up. Tests that
+    // exercise the endpoint override this.
+    mockUsePublishedReportTypes.mockReturnValue({ data: undefined } as any);
   });
 
   describe("loading, error, and empty states", () => {
@@ -349,6 +357,82 @@ describe("PublicReportListPage", () => {
       const links = hrefs();
       expect(links).toContain(`/community/filecoin/reports/${SAME_DATE}/quarterly-review`);
       expect(new Set(links).size).toBe(links.length);
+    });
+  });
+
+  describe("report types from the endpoint", () => {
+    it("lists a report type that has no published reports yet", () => {
+      // The reason this endpoint exists: a config the user just created, with
+      // nothing published, must still be filterable.
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ reportConfigId: "config-pods" })],
+        isLoading: false,
+      } as any);
+      mockUsePublishedReportTypes.mockReturnValue({
+        data: [
+          { id: "config-pods", name: "Monthly Pods Report", slug: "monthly-pods-report" },
+          { id: "config-empty", name: "Brand New Type", slug: "brand-new-type" },
+        ],
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual(["All report types", "Brand New Type", "Monthly Pods Report"]);
+    });
+
+    it("shows the empty state when a report-less type is selected", async () => {
+      const user = userEvent.setup();
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ reportConfigId: "config-pods" })],
+        isLoading: false,
+      } as any);
+      mockUsePublishedReportTypes.mockReturnValue({
+        data: [
+          { id: "config-pods", name: "Monthly Pods Report", slug: "monthly-pods-report" },
+          { id: "config-empty", name: "Brand New Type", slug: "brand-new-type" },
+        ],
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-empty");
+
+      expect(screen.getByText(/no reports of this type/i)).toBeInTheDocument();
+    });
+
+    it("prefers endpoint types over deriving from reports", () => {
+      // Reports carry one config; the endpoint knows two. The endpoint wins.
+      mockUsePublishedReports.mockReturnValue({
+        data: [createReport({ reportConfigId: "config-pods" })],
+        isLoading: false,
+      } as any);
+      mockUsePublishedReportTypes.mockReturnValue({
+        data: [
+          { id: "config-pods", name: "Monthly Pods Report", slug: "monthly-pods-report" },
+          { id: "config-other", name: "Other Type", slug: "other-type" },
+        ],
+      } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+    });
+
+    it("falls back to report-derived types when the endpoint is unavailable", () => {
+      // Deploy-order safety: FE shipped ahead of the backend, so the endpoint
+      // 404s and the hook has no data. The filter still works off the reports.
+      mockUsePublishedReports.mockReturnValue({ data: filecoinReports(), isLoading: false } as any);
+      mockUsePublishedReportTypes.mockReturnValue({ data: undefined } as any);
+
+      render(<PublicReportListPage community={community} />);
+
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual([
+        "All report types",
+        "Bi-Weekly Progress Report",
+        "Filecoin ProPGF Monthly",
+        "Monthly Pods Report",
+      ]);
     });
   });
 

--- a/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportListPage.tsx
@@ -13,8 +13,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { usePublishedReports } from "@/hooks/portfolio-reports/usePortfolioReports";
-import type { PortfolioReport } from "@/types/portfolio-report";
+import {
+  usePublishedReports,
+  usePublishedReportTypes,
+} from "@/hooks/portfolio-reports/usePortfolioReports";
+import type { PortfolioReport, ReportType } from "@/types/portfolio-report";
 import type { Community } from "@/types/v2/community";
 import { PAGES } from "@/utilities/pages";
 import { reportExcerpt } from "@/utilities/portfolio-reports/excerpt";
@@ -31,7 +34,8 @@ interface Props {
  */
 const ALL_TYPES = "all";
 
-interface ReportType {
+/** A single option in the type dropdown. `id` matches `report.reportConfigId`. */
+interface ReportTypeOption {
   id: string;
   label: string;
 }
@@ -102,12 +106,20 @@ function resolveReportTitle(report: PortfolioReport): string {
   );
 }
 
+/** The report types the community exposes, mapped to dropdown options. */
+function toTypeOptions(types: ReportType[]): ReportTypeOption[] {
+  return types
+    .map((type) => ({ id: type.id, label: type.name }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
 /**
- * The report *config* is the closest thing the system has to a "report type" —
- * each one is effectively a template ("Monthly Pods Report", "Bi-Weekly
- * Progress Report"), and every report names its originating config.
+ * Fallback used only when the `/reports/types` endpoint is unavailable (e.g.
+ * deployed ahead of the backend): derive options from the published reports on
+ * hand. Narrower than the endpoint — a config with no published report can't
+ * appear this way — but it keeps the filter working rather than vanishing.
  */
-function deriveReportTypes(reports: PortfolioReport[]): ReportType[] {
+function deriveReportTypesFromReports(reports: PortfolioReport[]): ReportTypeOption[] {
   const byId = new Map<string, string>();
   for (const report of reports) {
     if (!byId.has(report.reportConfigId)) {
@@ -194,7 +206,7 @@ function ReportTypeFilterSelect({
   value,
   onChange,
 }: {
-  types: ReportType[];
+  types: ReportTypeOption[];
   value: string;
   onChange: (next: string) => void;
 }) {
@@ -221,6 +233,7 @@ function ReportTypeFilterSelect({
 export function PublicReportListPage({ community }: Props) {
   const slug = community.details.slug;
   const { data: reports, isLoading, isError, refetch } = usePublishedReports(slug);
+  const { data: reportTypeData } = usePublishedReportTypes(slug);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const sectionsRef = useRef<HTMLDivElement>(null);
   const seededRef = useRef(false);
@@ -231,7 +244,16 @@ export function PublicReportListPage({ community }: Props) {
     [reports]
   );
 
-  const reportTypes = useMemo(() => deriveReportTypes(sortedReports), [sortedReports]);
+  // Prefer the types endpoint — it lists a config as soon as it exists, even
+  // before its first report. Fall back to deriving from the reports on hand
+  // only when the endpoint has nothing to give (unreachable, or still loading).
+  const reportTypes = useMemo(
+    () =>
+      reportTypeData && reportTypeData.length > 0
+        ? toTypeOptions(reportTypeData)
+        : deriveReportTypesFromReports(sortedReports),
+    [reportTypeData, sortedReports]
+  );
 
   const filteredReports = useMemo(
     () =>

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -18,6 +18,7 @@ const QUERY_KEYS = {
   reportCharts: (slug: string, id: string, authenticated: boolean) =>
     ["portfolio-report-charts", slug, id, authenticated ? "auth" : "public"] as const,
   published: (slug: string) => ["portfolio-reports-published", slug] as const,
+  publishedTypes: (slug: string) => ["portfolio-report-types", slug] as const,
   publishedRunDate: (slug: string, runDate: string) =>
     ["portfolio-report-published", slug, runDate] as const,
   /**
@@ -286,6 +287,14 @@ export function usePublishedReports(communitySlug: string) {
   return useQuery({
     queryKey: QUERY_KEYS.published(communitySlug),
     queryFn: () => portfolioService.getPublishedReports(communitySlug),
+    enabled: Boolean(communitySlug),
+  });
+}
+
+export function usePublishedReportTypes(communitySlug: string) {
+  return useQuery({
+    queryKey: QUERY_KEYS.publishedTypes(communitySlug),
+    queryFn: () => portfolioService.getPublishedReportTypes(communitySlug),
     enabled: Boolean(communitySlug),
   });
 }

--- a/services/portfolio-reports.service.ts
+++ b/services/portfolio-reports.service.ts
@@ -7,6 +7,7 @@ import type {
   ReportExportDownload,
   ReportExportManifest,
   ReportSnapshotSource,
+  ReportType,
   UpdateReportConfigRequest,
 } from "@/types/portfolio-report";
 import { createAuthenticatedApiClient } from "@/utilities/auth/api-client";
@@ -163,6 +164,15 @@ export async function unpublishReport(
 
 export async function getPublishedReports(communitySlug: string): Promise<PortfolioReport[]> {
   return fetchPublic<PortfolioReport[]>(`/v2/communities/${communitySlug}/reports/published`);
+}
+
+/**
+ * The selectable report types for a community's public report list — one per
+ * config that is active or has a published report. Drives the type filter, so
+ * a newly-created type is filterable before its first report ships.
+ */
+export async function getPublishedReportTypes(communitySlug: string): Promise<ReportType[]> {
+  return fetchPublic<ReportType[]>(`/v2/communities/${communitySlug}/reports/types`);
 }
 
 /**

--- a/types/portfolio-report/index.ts
+++ b/types/portfolio-report/index.ts
@@ -9,6 +9,18 @@ export interface ReportSchedule {
   ends: ScheduleEnds;
 }
 
+/**
+ * A selectable report type on the public list — the redacted identity of a
+ * report config (no prompt or other internals). Returned by the public
+ * `/reports/types` endpoint: one per config that is active or has a published
+ * report, so a new type is filterable before its first report ships.
+ */
+export interface ReportType {
+  id: string;
+  name: string;
+  slug: string;
+}
+
 export interface ReportConfig {
   id: string;
   communityId: string;


### PR DESCRIPTION
Pairs with **show-karma/gap-indexer#2202** (adds the public `/reports/types` endpoint this consumes). Follow-up to the DEV-520 type filter.

## Problem

The report type dropdown derived its options from the **published reports** on the page. So a report config that hadn't published a report yet never appeared — you had to publish before you could filter by that type. Reported on staging: a second config was added to Filecoin, but the dropdown stayed hidden because that config had no published report.

A report type exists the moment its config does. The filter should reflect that.

## Change

Wires the dropdown to the new public `GET /communities/:slug/reports/types` endpoint (gap-indexer#2202), which returns one entry per config that is **active or has a published report** — so a newly-created type is selectable immediately. Picking a type with no reports shows the existing "No reports of this type" empty state.

The filter predicate is unchanged (`report.reportConfigId === selected`); only the *source* of the options moved from reports to configs.

**Graceful fallback:** if the endpoint is unavailable (e.g. this ships ahead of the backend), the hook has no data and the dropdown falls back to deriving types from the published reports — today's behaviour. So this is deploy-order-safe and can merge before gap-indexer#2202.

## Why a new endpoint (not the existing configs endpoint)

`GET /report-configs` is admin-gated (401 for anon) and its response carries the LLM `prompt`. The public list page has no auth and must not leak that. gap-indexer#2202 adds a redacted, public `{ id, name, slug }` endpoint; archived configs with no reports are omitted server-side so their names never become public.

## Testing

- 26 tests in `PublicReportListPage.test.tsx` (4 new): a report-less type still lists; selecting it shows the empty state; endpoint types win over report-derived; fallback to report-derived when the endpoint has no data.
- Mutation-checked: forcing the component to ignore the endpoint fails exactly the 3 endpoint-path tests, nothing else.
- 67 portfolio tests green; `tsc` clean; Biome clean; `pnpm run build` compiles.

## Smoke results

Deferred to the shared preview — the dropdown lights up with report-less configs only once gap-indexer#2202 is deployed. Until then this renders identically to current `main` (fallback path). The reporter's staging case (2 configs, one report-less) is the exact scenario to verify once both are on the same environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading available public report types for the Type filter.
  - Type options now include available types even when no reports exist for them.
  - Selecting a type without reports displays a clear empty state.

- **Bug Fixes**
  - Improved filter behavior by prioritizing available report types and falling back to types found in published reports when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->