### PR TITLE
feat(portfolio-reports): report type filter on the admin list

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -1,7 +1,48 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { PortfolioReportListPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportListPage";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
+
+// Seeds the `?type=` query param (a reloaded/shared filtered URL).
+const mockNuqs = vi.hoisted(() => ({ initialType: null as string | null }));
+
+vi.mock("nuqs", () => ({
+  useQueryState: (_key: string, options: { defaultValue?: unknown }) => {
+    const [value, setValue] = useState<unknown>(
+      mockNuqs.initialType ?? options?.defaultValue ?? null
+    );
+    return [value, (next: unknown) => setValue(next ?? options?.defaultValue ?? null)] as const;
+  },
+}));
+
+// Radix Select → native <select> for jsdom (same convention as the public list test).
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Filter reports by type"
+      onChange={(e) => onValueChange(e.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
 import {
   useDeleteReport,
   useGenerateReport,
@@ -67,6 +108,7 @@ const filecoinCommunity = {
 describe("PortfolioReportListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNuqs.initialType = null;
 
     mockUseCommunityAdminAccess.mockReturnValue({
       hasAccess: true,
@@ -205,5 +247,136 @@ describe("PortfolioReportListPage", () => {
     render(<PortfolioReportListPage community={filecoinCommunity} />);
 
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  describe("report type filter", () => {
+    function configFixture(id: string, name: string) {
+      return {
+        id,
+        name,
+        isActive: true,
+        modelId: "gpt-5.5",
+        programIds: ["prog-1"],
+        schedule: {
+          intervalUnit: "months",
+          intervalCount: 1,
+          startDate: "2026-01-01",
+          ends: { kind: "never" },
+        },
+      } as any;
+    }
+
+    it("lists a type for a config whose only report is a draft", () => {
+      // The reason the admin filter is broader than the public one: drafts count.
+      mockUseReportConfigs.mockReturnValue({
+        data: [
+          configFixture("config-pods", "Monthly Pods Report"),
+          configFixture("config-bw", "Bi-Weekly"),
+        ],
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReports.mockReturnValue({
+        data: [
+          reportFixture({ id: "r1", reportConfigId: "config-pods", status: "published" }),
+          reportFixture({ id: "r2", reportConfigId: "config-bw", status: "draft" }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual(["All report types", "Bi-Weekly", "Monthly Pods Report"]);
+    });
+
+    it("excludes a config whose only report is still generating or failed", () => {
+      mockUseReportConfigs.mockReturnValue({
+        data: [
+          configFixture("config-pods", "Monthly Pods Report"),
+          configFixture("config-bw", "Bi-Weekly"),
+          configFixture("config-x", "Not Ready"),
+        ],
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReports.mockReturnValue({
+        data: [
+          reportFixture({ id: "r1", reportConfigId: "config-pods", status: "published" }),
+          reportFixture({ id: "r2", reportConfigId: "config-bw", status: "draft" }),
+          reportFixture({ id: "r3", reportConfigId: "config-x", status: "generating" }),
+          reportFixture({ id: "r4", reportConfigId: "config-x", status: "failed" }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+      const options = screen.getAllByRole("option").map((o) => o.textContent);
+      expect(options).toEqual(["All report types", "Bi-Weekly", "Monthly Pods Report"]);
+      expect(options).not.toContain("Not Ready");
+    });
+
+    it("hides the filter when only one type has generated a report", () => {
+      mockUseReportConfigs.mockReturnValue({
+        data: [configFixture("config-pods", "Monthly Pods Report")],
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReports.mockReturnValue({
+        data: [reportFixture({ id: "r1", reportConfigId: "config-pods", status: "published" })],
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+      expect(screen.queryByLabelText(/filter reports by type/i)).not.toBeInTheDocument();
+    });
+
+    it("narrows the table to the selected type", async () => {
+      const user = userEvent.setup();
+      mockUseReportConfigs.mockReturnValue({
+        data: [
+          configFixture("config-pods", "Monthly Pods Report"),
+          configFixture("config-bw", "Bi-Weekly"),
+        ],
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReports.mockReturnValue({
+        data: [
+          reportFixture({ id: "r1", reportConfigId: "config-pods", status: "published" }),
+          reportFixture({ id: "r2", reportConfigId: "config-bw", status: "draft" }),
+          reportFixture({ id: "r3", reportConfigId: "config-bw", status: "published" }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportListPage community={filecoinCommunity} />);
+      await user.selectOptions(screen.getByLabelText(/filter reports by type/i), "config-bw");
+
+      // 3 report rows total, 2 belong to config-bw → table shows 2 "Bi-Weekly" cells.
+      expect(screen.getAllByRole("cell", { name: "Bi-Weekly" })).toHaveLength(2);
+      expect(screen.queryByRole("cell", { name: "Monthly Pods Report" })).not.toBeInTheDocument();
+    });
+
+    it("shows the filtered empty state and resets from a stale type param", () => {
+      mockNuqs.initialType = "config-deleted-since-shared";
+      mockUseReportConfigs.mockReturnValue({
+        data: [
+          configFixture("config-pods", "Monthly Pods Report"),
+          configFixture("config-bw", "Bi-Weekly"),
+        ],
+        isLoading: false,
+      } as any);
+      mockUsePortfolioReports.mockReturnValue({
+        data: [
+          reportFixture({ id: "r1", reportConfigId: "config-pods", status: "published" }),
+          reportFixture({ id: "r2", reportConfigId: "config-bw", status: "published" }),
+        ],
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+      expect(screen.getByText(/no reports of this type/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /show all reports/i })).toBeInTheDocument();
+    });
   });
 });

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -13,11 +13,20 @@ import {
   Trash2,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useQueryState } from "nuqs";
+import pluralize from "pluralize";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useCommunityAdminAccess } from "@/hooks/communities/useCommunityAdminAccess";
 import {
   useDeleteReport,
@@ -41,6 +50,68 @@ import { GenerationStatusBadge } from "./GenerationStatusBadge";
 
 interface Props {
   community: Community;
+}
+
+/** Sentinel for "no type filter"; also the value the URL param is cleared to. */
+const ALL_TYPES = "all";
+
+interface ReportTypeOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * Report types for the admin filter: one per config that has a *generated*
+ * report — draft or published. A report mid-generation (`generating`) or one
+ * whose generation `failed` hasn't produced anything to review, so its config
+ * doesn't count until it does. This is why the admin filter is broader than the
+ * public one (published-only): the admin table shows drafts too.
+ */
+function deriveGeneratedTypes(
+  reports: PortfolioReport[],
+  configById: Map<string, ReportConfig>
+): ReportTypeOption[] {
+  const byId = new Map<string, string>();
+  for (const report of reports) {
+    if (report.status !== "draft" && report.status !== "published") continue;
+    if (byId.has(report.reportConfigId)) continue;
+    byId.set(
+      report.reportConfigId,
+      configById.get(report.reportConfigId)?.name ?? "(deleted config)"
+    );
+  }
+  return Array.from(byId, ([id, label]) => ({ id, label })).sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
+function ReportTypeFilterSelect({
+  types,
+  value,
+  onChange,
+}: {
+  types: ReportTypeOption[];
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+      <span className="font-medium uppercase tracking-wider">Type</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger aria-label="Filter reports by type" className="h-8 max-w-[16rem] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_TYPES}>All report types</SelectItem>
+          {types.map((type) => (
+            <SelectItem key={type.id} value={type.id}>
+              {type.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
 }
 
 interface ReportTableRowProps {
@@ -170,6 +241,18 @@ export function PortfolioReportListPage({ community }: Props) {
 
   const activeConfigs = useMemo(() => (configs ?? []).filter((c) => c.isActive), [configs]);
 
+  const [typeFilter, setTypeFilter] = useQueryState("type", { defaultValue: ALL_TYPES });
+
+  const reportTypes = useMemo(
+    () => deriveGeneratedTypes(reports ?? [], configById),
+    [reports, configById]
+  );
+
+  // Clearing to null (not the sentinel) drops `?type=` from the URL.
+  const handleTypeChange = (next: string) => {
+    setTypeFilter(next === ALL_TYPES ? null : next);
+  };
+
   const generatingConfigIds = useMemo(() => {
     const ids = new Set<string>();
     for (const r of reports ?? []) {
@@ -296,6 +379,10 @@ export function PortfolioReportListPage({ community }: Props) {
       deleteMutation.isPending);
 
   const sortedReports = (reports ?? []).slice().sort((a, b) => b.runDate.localeCompare(a.runDate));
+  const visibleReports =
+    typeFilter === ALL_TYPES
+      ? sortedReports
+      : sortedReports.filter((report) => report.reportConfigId === typeFilter);
 
   return (
     <div className="space-y-6">
@@ -421,41 +508,76 @@ export function PortfolioReportListPage({ community }: Props) {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
-          <table className="w-full text-sm">
-            <thead className="bg-zinc-50 dark:bg-zinc-800">
-              <tr>
-                <th className="px-4 py-3 text-left font-medium text-zinc-500">Report</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-500">Run date</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-500">Status</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-500">Model</th>
-                <th className="px-4 py-3 text-left font-medium text-zinc-500">Generated</th>
-                <th className="px-4 py-3 text-right font-medium text-zinc-500">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-200 dark:divide-zinc-700">
-              {sortedReports.map((report: PortfolioReport) => (
-                <ReportTableRow
-                  key={report.id}
-                  slug={slug}
-                  report={report}
-                  configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
-                  rowPending={isRowPending(report.id)}
-                  activeMutationType={activeMutationType}
-                  onEdit={() => router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)}
-                  onPreview={() =>
-                    router.push(
-                      PAGES.COMMUNITY.REPORT_DETAIL(slug, report.runDate, report.reportConfigSlug)
-                    )
-                  }
-                  onPublish={() => handlePublish(report.id)}
-                  onUnpublish={() => handleUnpublish(report.id)}
-                  onRegenerate={() => setRegenerateTargetId(report.id)}
-                  onDelete={() => setDeleteTargetId(report.id)}
-                />
-              ))}
-            </tbody>
-          </table>
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              {visibleReports.length} {pluralize("report", visibleReports.length)}
+            </p>
+            {reportTypes.length > 1 && (
+              <ReportTypeFilterSelect
+                types={reportTypes}
+                value={typeFilter}
+                onChange={handleTypeChange}
+              />
+            )}
+          </div>
+
+          {visibleReports.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-zinc-300 p-12 text-center dark:border-zinc-600">
+              <FileText className="mb-3 h-8 w-8 text-zinc-400" />
+              <p className="text-sm text-zinc-500">No reports of this type.</p>
+              <button
+                type="button"
+                onClick={() => handleTypeChange(ALL_TYPES)}
+                className="mt-4 text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+              >
+                Show all reports
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+              <table className="w-full text-sm">
+                <thead className="bg-zinc-50 dark:bg-zinc-800">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-500">Report</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-500">Run date</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-500">Status</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-500">Model</th>
+                    <th className="px-4 py-3 text-left font-medium text-zinc-500">Generated</th>
+                    <th className="px-4 py-3 text-right font-medium text-zinc-500">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-200 dark:divide-zinc-700">
+                  {visibleReports.map((report: PortfolioReport) => (
+                    <ReportTableRow
+                      key={report.id}
+                      slug={slug}
+                      report={report}
+                      configName={configById.get(report.reportConfigId)?.name ?? "(deleted config)"}
+                      rowPending={isRowPending(report.id)}
+                      activeMutationType={activeMutationType}
+                      onEdit={() =>
+                        router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)
+                      }
+                      onPreview={() =>
+                        router.push(
+                          PAGES.COMMUNITY.REPORT_DETAIL(
+                            slug,
+                            report.runDate,
+                            report.reportConfigSlug
+                          )
+                        )
+                      }
+                      onPublish={() => handlePublish(report.id)}
+                      onUnpublish={() => handleUnpublish(report.id)}
+                      onRegenerate={() => setRegenerateTargetId(report.id)}
+                      onDelete={() => setDeleteTargetId(report.id)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Follow-up to the DEV-520 type filter, from staging feedback.

## Context

The public report list already has a type filter that derives from **published** reports (correct for a public page — it only shows published). But on the admin report management list, you wanted to filter by type too, and the right source there is **generated** reports (draft *or* published), not published-only and not configs-with-no-reports. Each page's filter now matches what that page displays:

- **Public list**: published-only types (unchanged — already on `main`)
- **Admin list**: draft-or-published types (this PR)

No backend change: the admin list already loads every report via `usePortfolioReports`, so the types are derived client-side.

## Change

Adds a report-type dropdown to `PortfolioReportListPage`. A type appears when its config has at least one report with status `draft` or `published` — i.e. something was actually generated. A config whose only reports are `generating` (in flight) or `failed` (produced nothing) doesn't appear until it has a real report. The table filters to the selected type; URL-synced via nuqs; filtered empty state with a reset; hidden when only one type qualifies.

## Testing

- `PortfolioReportListPage.test.tsx` +5: a draft-only config lists; generating/failed-only configs are excluded; filter hidden at one type; table narrows to the selection; stale `?type=` shows the empty state + reset.
- Mutation-checked: dropping the `draft|published` guard fails the exclusion test, nothing else.
- 38 admin portfolio tests green; `tsc` clean; Biome clean; `pnpm run build` compiles.

## Notes

Independent of the title work (gap-indexer#2202) and the earlier public filter — no shared files, merges on its own. The new endpoint I briefly opened (gap-app-v2#1857) was closed; this approach needs no endpoint.