### PR TITLE
fix(funding-platform): show orphan reviewer addresses in assignment chips

### DIFF
--- a/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
+++ b/components/FundingPlatform/ApplicationList/ReviewerAssignmentDropdown.tsx
@@ -10,6 +10,7 @@ import { type DropdownItem, MultiSelectDropdown } from "@/components/Utilities/M
 import { ReviewerType, useReviewerAssignment } from "@/hooks/useReviewerAssignment";
 import type { AddMilestoneReviewerRequest } from "@/services/milestone-reviewers.service";
 import type { AddReviewerRequest } from "@/services/program-reviewers.service";
+import { shortAddress } from "@/utilities/shortAddress";
 
 const ReviewerPickerModal = dynamic(
   () => import("@/components/FundingPlatform/ReviewerPicker/ReviewerPickerModal"),
@@ -147,6 +148,9 @@ export const ReviewerAssignmentDropdown: FC<ReviewerAssignmentDropdownProps> = (
         isLoading={isLoading}
         emptyActionLabel={reviewerActionLabel}
         onEmptyAction={handleEmptyAction}
+        showUnknownSelections
+        formatUnknownLabel={shortAddress}
+        unknownSelectionHint={`Not configured as a ${reviewerType} reviewer for this program`}
       />
       {communityUID ? (
         <ReviewerPickerModal

--- a/components/Utilities/MultiSelectDropdown.tsx
+++ b/components/Utilities/MultiSelectDropdown.tsx
@@ -2,11 +2,12 @@
 import {
   CheckIcon,
   ChevronDownIcon,
+  ExclamationTriangleIcon,
   MagnifyingGlassIcon,
   PlusIcon,
   XMarkIcon,
 } from "@heroicons/react/24/solid";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { cn } from "@/utilities/tailwind";
 
 export interface DropdownItem {
@@ -15,6 +16,67 @@ export interface DropdownItem {
   value?: unknown;
   color?: string;
 }
+
+interface SelectedChipProps {
+  id: string;
+  label: string;
+  color?: string;
+  isUnknown?: boolean;
+  unknownHint?: string;
+  disabled: boolean;
+  onRemove: (id: string) => void;
+}
+
+/**
+ * A single selected-value chip. Rendered for every selected id — including
+ * "unknown" ids that have no matching item in the available list (see
+ * `showUnknownSelections`). Unknown chips get a distinct warning treatment and
+ * remain removable so stale/orphaned selections can always be cleared.
+ */
+const SelectedChip = memo(function SelectedChip({
+  id,
+  label,
+  color,
+  isUnknown = false,
+  unknownHint,
+  disabled,
+  onRemove,
+}: SelectedChipProps) {
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!disabled) onRemove(id);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-md px-2 py-1 text-xs",
+        isUnknown
+          ? "border border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700/60 dark:bg-amber-900/30 dark:text-amber-300"
+          : "bg-gray-100 dark:bg-zinc-700"
+      )}
+      title={isUnknown ? `${unknownHint ?? "Not in the available list"}: ${id}` : undefined}
+    >
+      {isUnknown && (
+        <ExclamationTriangleIcon className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+      )}
+      {color && (
+        <span className="h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+      )}
+      <span className="truncate max-w-[200px]">{label}</span>
+      <XMarkIcon
+        className={cn(
+          "h-3 w-3 flex-shrink-0",
+          isUnknown ? "text-amber-600 dark:text-amber-300" : "text-gray-500 dark:text-zinc-400",
+          disabled
+            ? "cursor-not-allowed opacity-50"
+            : "cursor-pointer hover:text-gray-700 dark:hover:text-zinc-200"
+        )}
+        onClick={handleRemove}
+      />
+    </div>
+  );
+});
 
 interface MultiSelectDropdownProps {
   items: DropdownItem[];
@@ -30,6 +92,15 @@ interface MultiSelectDropdownProps {
   isLoading?: boolean; // Optional loading state prop
   emptyActionLabel?: string;
   onEmptyAction?: () => void;
+  /** When true, a selected id with no matching item is still rendered as a
+   *  (removable) "unknown" chip instead of being silently hidden. Defaults to
+   *  false to preserve behaviour for existing consumers. */
+  showUnknownSelections?: boolean;
+  /** Formats the label of an unknown selection chip (e.g. shorten a wallet
+   *  address). Defaults to showing the raw id. */
+  formatUnknownLabel?: (id: string) => string;
+  /** Hint shown on hover for unknown selection chips. */
+  unknownSelectionHint?: string;
 }
 
 export const MultiSelectDropdown = ({
@@ -46,6 +117,9 @@ export const MultiSelectDropdown = ({
   isLoading = false,
   emptyActionLabel,
   onEmptyAction,
+  showUnknownSelections = false,
+  formatUnknownLabel,
+  unknownSelectionHint,
 }: MultiSelectDropdownProps) => {
   const isDisabled = disabled || isLoading;
   const [isOpen, setIsOpen] = useState(false);
@@ -107,14 +181,12 @@ export const MultiSelectDropdown = ({
     onChange(newSelectedIds);
   };
 
-  // Remove a selected item
-  const removeItem = (id: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!isDisabled) {
-      const newSelectedIds = localSelectedIds.filter((selectedId) => selectedId !== id);
-      setLocalSelectedIds(newSelectedIds);
-      onChange(newSelectedIds);
-    }
+  // Remove a selected item (works for known items and unknown/orphan ids alike)
+  const handleRemoveSelection = (id: string) => {
+    if (isDisabled) return;
+    const newSelectedIds = localSelectedIds.filter((selectedId) => selectedId !== id);
+    setLocalSelectedIds(newSelectedIds);
+    onChange(newSelectedIds);
   };
 
   // Clear all selected items
@@ -128,6 +200,15 @@ export const MultiSelectDropdown = ({
 
   // Get selected item labels for display
   const selectedItems = items.filter((item) => localSelectedIds.includes(item.id));
+
+  // Selected ids that have no matching item — these are "orphan"/unknown
+  // selections. They are only surfaced when the consumer opts in, so they're
+  // never silently dropped (which would leave them invisible and unremovable).
+  const unknownSelectedIds = showUnknownSelections
+    ? localSelectedIds.filter((id) => !items.some((item) => item.id === id))
+    : [];
+
+  const hasSelections = selectedItems.length > 0 || unknownSelectedIds.length > 0;
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: This div only stops event propagation, it's not interactive
@@ -166,37 +247,37 @@ export const MultiSelectDropdown = ({
         }}
       >
         <div className="flex flex-1 min-w-0 flex-wrap gap-1">
-          {selectedItems.length > 0 ? (
-            selectedItems.map((item) => (
-              <div
-                key={item.id}
-                className="flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-zinc-700"
-              >
-                {item.color && (
-                  <span
-                    className="h-2 w-2 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: item.color }}
-                  />
-                )}
-                <span className="truncate max-w-[200px]">{item.label}</span>
-                <XMarkIcon
-                  className={cn(
-                    "h-3 w-3 flex-shrink-0 text-gray-500 dark:text-zinc-400",
-                    isDisabled
-                      ? "cursor-not-allowed opacity-50"
-                      : "cursor-pointer hover:text-gray-700 dark:hover:text-zinc-200"
-                  )}
-                  onClick={(e) => removeItem(item.id, e)}
+          {hasSelections ? (
+            <>
+              {selectedItems.map((item) => (
+                <SelectedChip
+                  key={item.id}
+                  id={item.id}
+                  label={item.label}
+                  color={item.color}
+                  disabled={isDisabled}
+                  onRemove={handleRemoveSelection}
                 />
-              </div>
-            ))
+              ))}
+              {unknownSelectedIds.map((id) => (
+                <SelectedChip
+                  key={id}
+                  id={id}
+                  label={formatUnknownLabel ? formatUnknownLabel(id) : id}
+                  isUnknown
+                  unknownHint={unknownSelectionHint}
+                  disabled={isDisabled}
+                  onRemove={handleRemoveSelection}
+                />
+              ))}
+            </>
           ) : (
             <span className="text-gray-500 dark:text-zinc-400">{placeholder}</span>
           )}
         </div>
 
         <div className="flex flex-shrink-0 items-center gap-2">
-          {selectedItems.length > 0 && (
+          {hasSelections && (
             <button
               type="button"
               onClick={clearAll}

--- a/components/Utilities/MultiSelectDropdown.tsx
+++ b/components/Utilities/MultiSelectDropdown.tsx
@@ -64,16 +64,22 @@ const SelectedChip = memo(function SelectedChip({
         <span className="h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
       )}
       <span className="truncate max-w-[200px]">{label}</span>
-      <XMarkIcon
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        disabled={disabled}
+        onClick={handleRemove}
+        onKeyDown={(e) => e.stopPropagation()}
         className={cn(
-          "h-3 w-3 flex-shrink-0",
+          "flex flex-shrink-0 items-center rounded",
           isUnknown ? "text-amber-600 dark:text-amber-300" : "text-gray-500 dark:text-zinc-400",
           disabled
             ? "cursor-not-allowed opacity-50"
             : "cursor-pointer hover:text-gray-700 dark:hover:text-zinc-200"
         )}
-        onClick={handleRemove}
-      />
+      >
+        <XMarkIcon className="h-3 w-3" aria-hidden="true" />
+      </button>
     </div>
   );
 });

--- a/components/Utilities/__tests__/MultiSelectDropdown.test.tsx
+++ b/components/Utilities/__tests__/MultiSelectDropdown.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { type DropdownItem, MultiSelectDropdown } from "../MultiSelectDropdown";
+
+describe("MultiSelectDropdown", () => {
+  const items: DropdownItem[] = [
+    { id: "0x1111", label: "John Doe" },
+    { id: "0x2222", label: "Jane Smith" },
+  ];
+
+  const orphanId = "0xa97bcd2f7e40daa8218f94f55b57ab09ec24cde0";
+
+  describe("known selections", () => {
+    it("renders a chip for each selected id that matches an item", () => {
+      render(<MultiSelectDropdown items={items} selectedIds={["0x1111"]} onChange={vi.fn()} />);
+
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+  });
+
+  describe("unknown/orphan selections", () => {
+    it("hides a selected id with no matching item by default", () => {
+      render(
+        <MultiSelectDropdown
+          items={items}
+          selectedIds={[orphanId]}
+          onChange={vi.fn()}
+          placeholder="Select items"
+        />
+      );
+
+      // No chip and no truncated address — falls back to placeholder.
+      expect(screen.queryByText(orphanId)).not.toBeInTheDocument();
+      expect(screen.getByText("Select items")).toBeInTheDocument();
+    });
+
+    it("renders an orphan selection as a chip when showUnknownSelections is on", () => {
+      render(
+        <MultiSelectDropdown
+          items={items}
+          selectedIds={[orphanId]}
+          onChange={vi.fn()}
+          showUnknownSelections
+        />
+      );
+
+      // Raw id is shown when no label formatter is provided.
+      expect(screen.getByText(orphanId)).toBeInTheDocument();
+    });
+
+    it("applies the label formatter to orphan chips", () => {
+      const formatUnknownLabel = (id: string) => `${id.slice(0, 6)}...${id.slice(-6)}`;
+      render(
+        <MultiSelectDropdown
+          items={items}
+          selectedIds={[orphanId]}
+          onChange={vi.fn()}
+          showUnknownSelections
+          formatUnknownLabel={formatUnknownLabel}
+        />
+      );
+
+      expect(screen.getByText("0xa97b...24cde0")).toBeInTheDocument();
+      expect(screen.queryByText(orphanId)).not.toBeInTheDocument();
+    });
+
+    it("keeps orphan chips removable and reports the remaining ids", () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectDropdown
+          items={items}
+          selectedIds={["0x1111", orphanId]}
+          onChange={onChange}
+          showUnknownSelections
+        />
+      );
+
+      const orphanChip = screen.getByText(orphanId).closest("div");
+      expect(orphanChip).not.toBeNull();
+      // The chip renders a leading warning icon and a trailing remove (X) icon;
+      // the remove control is the last svg.
+      const icons = orphanChip?.querySelectorAll("svg");
+      const removeIcon = icons?.[icons.length - 1];
+      expect(removeIcon).not.toBeUndefined();
+
+      fireEvent.click(removeIcon as SVGElement);
+
+      expect(onChange).toHaveBeenCalledWith(["0x1111"]);
+    });
+
+    it("renders both known and orphan chips together", () => {
+      render(
+        <MultiSelectDropdown
+          items={items}
+          selectedIds={["0x1111", orphanId]}
+          onChange={vi.fn()}
+          showUnknownSelections
+        />
+      );
+
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+      expect(screen.getByText(orphanId)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/Utilities/__tests__/MultiSelectDropdown.test.tsx
+++ b/components/Utilities/__tests__/MultiSelectDropdown.test.tsx
@@ -75,15 +75,11 @@ describe("MultiSelectDropdown", () => {
         />
       );
 
-      const orphanChip = screen.getByText(orphanId).closest("div");
-      expect(orphanChip).not.toBeNull();
-      // The chip renders a leading warning icon and a trailing remove (X) icon;
-      // the remove control is the last svg.
-      const icons = orphanChip?.querySelectorAll("svg");
-      const removeIcon = icons?.[icons.length - 1];
-      expect(removeIcon).not.toBeUndefined();
+      const removeButton = screen.getByRole("button", {
+        name: `Remove ${orphanId}`,
+      });
 
-      fireEvent.click(removeIcon as SVGElement);
+      fireEvent.click(removeButton);
 
       expect(onChange).toHaveBeenCalledWith(["0x1111"]);
     });


### PR DESCRIPTION
## Bug

On the Funding Platform, an application's assigned reviewer chips (**app reviewers** and **milestone reviewers**) resolved each stored wallet address against the program's *configured* reviewer list. Any stored address that did **not** match a configured reviewer (an "orphan") was silently hidden — no chip, no way to remove it.

This caused a production incident: an application's `milestoneReviewers` contained a stale/orphaned wallet (`0xa97bcd2f7e40daa8218f94f55b57ab09ec24cde0`) that was not a configured reviewer for program 992. Because the UI hid it, admins couldn't see or remove it, and every save re-validated the whole array and failed with `Reviewer 0xa97bcd… is not configured as a milestone reviewer for program 992`. Admins were stuck.

## Root cause

`components/Utilities/MultiSelectDropdown.tsx` derived the displayed chips by **intersecting** the available items with the selected ids:

```ts
const selectedItems = items.filter((item) => localSelectedIds.includes(item.id));
```

`ReviewerAssignmentDropdown` passes `items` = configured/available reviewers and `selectedIds` = the stored assigned addresses. Any assigned address with no matching available reviewer was dropped from `selectedItems`, so it was never rendered and never removable.

## Fix (frontend display only)

- **`MultiSelectDropdown`**: add an opt-in `showUnknownSelections` mode. When enabled, the component renders **one removable chip per selected id** — iterating the selected ids as the source of truth rather than intersecting with `items`. Ids that resolve to an item render as today; ids that don't ("unknown"/orphan) render as a distinct chip. New optional props `formatUnknownLabel` (label formatter, e.g. shorten a wallet) and `unknownSelectionHint` (hover title). Selected chips were extracted into a memoized `SelectedChip` component. **Default behaviour is unchanged** (`showUnknownSelections` defaults to `false`), so the other three consumers — `SendEmailComposer`, `WorkBoard`, `WorkTaskDrawer` — are unaffected.
- **`ReviewerAssignmentDropdown`**: enables `showUnknownSelections`, formats orphan ids with the existing `shortAddress` helper, and passes a hint like `Not configured as a milestone reviewer for this program`.

### How orphans now render
An orphan address renders as a chip showing the truncated wallet (e.g. `0xa97b...24cde0`) with an amber "warning" treatment (leading `ExclamationTriangleIcon`, amber background/border/text via Tailwind theme classes — no hardcoded colors) and a hover tooltip explaining it isn't a configured reviewer. The chip keeps its `×` remove control, so admins can delete stale entries; removing it sends the remaining addresses to the existing assignment mutation.

No backend, validation, or assignment-API changes. The stored data is not modified — this only stops the UI from hiding it.

## Testing

- New `components/Utilities/__tests__/MultiSelectDropdown.test.tsx`: covers default hiding (off), orphan chip rendering (on), label formatter, removability (reports remaining ids), and mixed known+orphan rendering.
- Existing `ReviewerAssignmentDropdown.test.tsx` still green. **37/37 tests pass** across both files.
- `tsc --noEmit` clean, `pnpm run build` succeeds, `biome check` clean.

> Note: verified via unit tests + typecheck + build. Not exercised against a live deployed preview with the real orphaned program-992 record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select dropdowns can now display selections that are no longer available in the configured options.
  * Unknown selections include shortened labels, warning styling, contextual hints, and can be removed individually.
  * Known and unavailable selections can be displayed together.

* **Bug Fixes**
  * Preserved selected values instead of hiding them when their corresponding options are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->