### PR TITLE
chore(ci): run indexability monitor weekly

### DIFF
--- a/.github/workflows/indexability-monitor.yml
+++ b/.github/workflows/indexability-monitor.yml
@@ -2,8 +2,8 @@ name: Indexability Monitor
 
 on:
   schedule:
-    # Daily at 07:15 UTC.
-    - cron: "15 7 * * *"
+    # Every Wednesday at 12:00 UTC.
+    - cron: "0 12 * * 3"
   workflow_dispatch:
     inputs:
       min_leaf_count:


### PR DESCRIPTION
## Summary

- run the Indexability Monitor every Wednesday at 12:00 UTC
- keep manual `workflow_dispatch` support unchanged

## Why

The monitor no longer needs to run daily. A weekly Wednesday schedule keeps automated production coverage while reducing unnecessary workflow runs.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/indexability-monitor.yml`
- repository pre-commit checks
- pre-push TypeScript check (`tsc --noEmit`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the indexability monitoring schedule to run every Wednesday at 12:00 UTC instead of daily at 07:15 UTC.
  * Manual execution and monitoring behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->