### PR TITLE
feat(funding-platform): use markdown editor for reviewer private notes

### DIFF
--- a/__tests__/features/application-notes/PrivateNotesTab.test.tsx
+++ b/__tests__/features/application-notes/PrivateNotesTab.test.tsx
@@ -19,6 +19,28 @@ vi.mock("@/components/EthereumAddressToProfileName", () => ({
   default: ({ address }: { address: string }) => <span>{address}</span>,
 }));
 
+// The markdown editor lazy-loads md-editor-rt via next/dynamic (ssr: false), which
+// never resolves synchronously under jsdom. Stub it to a controlled textarea that
+// preserves the value/onChange/placeholder contract this suite exercises.
+vi.mock("@/components/Utilities/MarkdownEditor", () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="markdown-editor"
+      value={value ?? ""}
+      placeholder={placeholder}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
 const mockHook = vi.mocked(useApplicationNote);
 
 type HookReturn = ReturnType<typeof useApplicationNote>;
@@ -118,7 +140,7 @@ describe("PrivateNotesTab", () => {
     render(<PrivateNotesTab referenceNumber="APP-1" canViewNotes />);
 
     // Make the editor dirty so Save is enabled, then click it.
-    fireEvent.change(screen.getByLabelText("Private note"), {
+    fireEvent.change(screen.getByTestId("markdown-editor"), {
       target: { value: "updated note" },
     });
     fireEvent.click(screen.getByRole("button", { name: /save/i }));

--- a/src/features/application-notes/components/PrivateNotesTab.tsx
+++ b/src/features/application-notes/components/PrivateNotesTab.tsx
@@ -4,10 +4,10 @@ import { AlertCircle, Lock, RefreshCw, Save } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
+import { MarkdownEditor } from "@/components/Utilities/MarkdownEditor";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { Textarea } from "@/components/ui/textarea";
 import { useApplicationNote } from "../hooks/use-application-note";
 import type { ApplicationNote } from "../types";
 
@@ -18,6 +18,8 @@ interface PrivateNotesTabProps {
 }
 
 const MAX_NOTE_LENGTH = 10000;
+// Only surface the character counter as the note nears the limit — short notes stay clean.
+const NOTE_COUNTER_THRESHOLD = 8000;
 
 // Deterministic date display from the ISO timestamp — no locale/timezone
 // formatting APIs, so it is hydration-safe and renders identically everywhere.
@@ -133,14 +135,14 @@ function NoteEditor({
       </div>
 
       <div className="space-y-3 px-5 py-4">
-        <Textarea
-          aria-label="Private note"
+        <MarkdownEditor
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={setDraft}
           placeholder="Add a private note visible only to reviewers…"
-          rows={8}
           maxLength={MAX_NOTE_LENGTH}
-          disabled={isSaving}
+          isDisabled={isSaving}
+          showCharacterCount
+          characterCountThreshold={NOTE_COUNTER_THRESHOLD}
         />
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[12.5px] text-muted-foreground">{metaLine}</p>


### PR DESCRIPTION
## Overview

Replaces the raw `<textarea>` in the reviewer-only **Private Notes** tab (DEV-515) with the shared `MarkdownEditor` we use everywhere else in the app (project creation, project/grant updates, milestones, application comments).

## Problem

The private notes input was a plain shadcn `<Textarea>` — no formatting, no preview, inconsistent with every other long-form text field in the product. Reviewers writing structured notes (lists, headings, links) got no markdown affordances and a different editing experience than they see when creating a project.

## Solution

`NoteEditor` now renders `<MarkdownEditor>` (`@/components/Utilities/MarkdownEditor`), preserving the existing behavior contract:

- `value` / `onChange` drive the same `draft` state and dirty-check → Save flow.
- `maxLength={10000}` cap is kept and enforced by the editor.
- `disabled` → `isDisabled` while saving.
- Added `showCharacterCount` with an `8000` threshold so the counter only appears as the note approaches the limit — mirroring the project-creation editor (which caps at 15k with a 10k threshold).

Reviewers now get markdown formatting, an edit/preview toggle, and the same editing surface as the rest of the app. Both surfaces that render this tab — the admin funding-platform view (`ApplicationDetailView`) and the whitelabel applicant page (`ApplicationPageClient`) — pick up the change since they share this one component.

## Why This Approach

`MarkdownEditor` is the established, single shared editor. It internally lazy-loads the heavy `md-editor-rt` via `next/dynamic({ ssr: false })`, XSS-sanitizes content, is theme-aware, and enforces `maxLength` — so reusing it keeps the notes field consistent and avoids reinventing any of that. The permission gate, data hook, save/attribution logic, and empty/loading/error states are untouched.

## Testing Steps

1. Open a funding application as a reviewer/admin → **Notes** tab.
2. Confirm the editor renders with a toolbar and an **Edit/Preview** toggle (instead of a plain textarea).
3. Type markdown (e.g. `**bold**`, a `- list`), toggle **Preview**, confirm it renders.
4. Save; reload; confirm the note persists and the "Last edited by … · UTC" byline updates.
5. Paste a long note (>8000 chars) and confirm the character counter appears and caps at 10,000.
6. As a non-reviewer, confirm the Notes tab is not shown at all (unchanged gate).

## Technical Details

- Component: `src/features/application-notes/components/PrivateNotesTab.tsx`
- Test: `__tests__/features/application-notes/PrivateNotesTab.test.tsx` — `MarkdownEditor` is stubbed to a controlled `<textarea>` (the editor's `next/dynamic({ ssr: false })` load never resolves synchronously under jsdom), matching the pattern used across ~18 other suites.

**Verification:** all 17 application-notes tests pass (7 in `PrivateNotesTab`), `tsc --noEmit` clean for the edited files, Biome clean.

## Related Issues

DEV-515
