### PR TITLE
fix(portfolio-reports): persist draft title edits to the manage list and restore the dedicated preview

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.test.tsx
@@ -125,7 +125,7 @@ describe("PortfolioReportListPage", () => {
     mockUseReportRowSync.mockImplementation((_slug, initialReport) => initialReport);
   });
 
-  it("shows a Preview action for draft reports and navigates to the unified public report URL", async () => {
+  it("shows a Preview action for draft reports and navigates to the manage preview page", async () => {
     const user = userEvent.setup();
 
     mockUsePortfolioReports.mockReturnValue({
@@ -159,7 +159,42 @@ describe("PortfolioReportListPage", () => {
 
     await user.click(screen.getByRole("button", { name: /preview/i }));
 
-    expect(mockPush).toHaveBeenCalledWith("/community/filecoin/reports/2026-03-15");
+    expect(mockPush).toHaveBeenCalledWith(
+      "/community/filecoin/manage/portfolio-reports/draft-report/preview"
+    );
+  });
+
+  it("shows the report's custom title with the config name as secondary context", () => {
+    mockUseReportConfigs.mockReturnValue({
+      data: [{ id: "config-1", name: "Monthly Pods Report", isActive: false, programIds: [] }],
+      isLoading: false,
+    } as any);
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "titled-report", title: "Pods Report — June 2026" })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    expect(screen.getByText("Pods Report — June 2026")).toBeInTheDocument();
+    // Config name stays visible as secondary context so admins know its source.
+    expect(screen.getByText("Monthly Pods Report")).toBeInTheDocument();
+  });
+
+  it("falls back to the config name when a report has no custom title", () => {
+    mockUseReportConfigs.mockReturnValue({
+      data: [{ id: "config-1", name: "Monthly Pods Report", isActive: false, programIds: [] }],
+      isLoading: false,
+    } as any);
+    mockUsePortfolioReports.mockReturnValue({
+      data: [reportFixture({ id: "untitled-report", title: null })],
+      isLoading: false,
+    } as any);
+
+    render(<PortfolioReportListPage community={filecoinCommunity} />);
+
+    // Only one occurrence — the config name stands in for the missing title.
+    expect(screen.getAllByText("Monthly Pods Report")).toHaveLength(1);
   });
 
   it("does not show a Preview action for published reports", () => {

--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.test.tsx
@@ -3,13 +3,18 @@ import userEvent from "@testing-library/user-event";
 import { PortfolioReportPreviewPage } from "@/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 
-// DEV-496: the preview route is now a redirect shim to the unified public URL
-// (/community/:slug/reports/:runDate), where a community admin sees the draft.
-const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace, push: vi.fn() }),
-}));
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
+vi.mock("@/components/Pages/Community/PortfolioReports/HtmlReportFrame", () => ({
+  HtmlReportFrame: ({ html }: { html?: string }) => (
+    <div data-testid="markdown-preview">{html}</div>
+  ),
+}));
+vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () => ({
+  ReportChartsSection: () => <div data-testid="report-charts-section" />,
+}));
+vi.mock("@/components/Pages/Community/PortfolioReports/ExportDataMenu", () => ({
+  ExportDataMenu: () => <div data-testid="export-data-menu" />,
+}));
 
 const mockUsePortfolioReport = vi.mocked(usePortfolioReport);
 
@@ -20,69 +25,124 @@ const community = {
 
 const draftReport = {
   id: "draft-report",
+  reportConfigId: "config-1",
+  communityId: "community-1",
   runDate: "2026-03-15",
   status: "draft",
+  content: "# Draft report body",
+  dataSnapshot: {},
+  modelId: "gpt-4.1",
+  tokenUsage: null,
+  generatedAt: "2026-04-01T00:00:00.000Z",
+  generationError: null,
   publishedAt: null,
-} as any;
+  publishedBy: null,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+};
 
-describe("PortfolioReportPreviewPage (redirect shim)", () => {
+const publishedReport = {
+  ...draftReport,
+  id: "published-report",
+  status: "published",
+  publishedAt: "2026-04-02T00:00:00.000Z",
+  publishedBy: "user-1",
+};
+
+describe("PortfolioReportPreviewPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders a spinner while the report is loading and does not redirect yet", () => {
-    mockUsePortfolioReport.mockReturnValue({ data: undefined, isLoading: true } as any);
+  describe("loading state", () => {
+    it("renders a spinner while the report is loading", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      } as any);
 
-    const { container } = render(
-      <PortfolioReportPreviewPage community={community} reportId="draft-report" />
-    );
+      const { container } = render(
+        <PortfolioReportPreviewPage community={community} reportId="draft-report" />
+      );
 
-    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalled();
+      expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    });
   });
 
-  it("redirects to the unified public report URL once the report resolves", () => {
-    mockUsePortfolioReport.mockReturnValue({ data: draftReport, isLoading: false } as any);
+  describe("error state", () => {
+    it("renders a retry button that re-fetches the report", async () => {
+      const user = userEvent.setup();
+      const refetch = vi.fn();
+      mockUsePortfolioReport.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        refetch,
+      } as any);
 
-    render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
 
-    expect(replace).toHaveBeenCalledWith("/community/filecoin/reports/2026-03-15");
+      expect(screen.getByText(/failed to load the report preview/i)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("renders a retry button that re-fetches on error and does not redirect", async () => {
-    const user = userEvent.setup();
-    const refetch = vi.fn();
-    mockUsePortfolioReport.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      refetch,
-    } as any);
+  describe("not found state", () => {
+    it("shows a not-found message with a back link when the report does not exist", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+      } as any);
 
-    render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
+      render(<PortfolioReportPreviewPage community={community} reportId="missing-report" />);
 
-    expect(screen.getByText(/failed to load the report/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
-      "href",
-      "/community/filecoin/manage/portfolio-reports"
-    );
-
-    await user.click(screen.getByRole("button", { name: /retry/i }));
-
-    expect(refetch).toHaveBeenCalledTimes(1);
-    expect(replace).not.toHaveBeenCalled();
+      expect(screen.getByText(/report not found/i)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+    });
   });
 
-  it("shows a not-found message when the report does not exist", () => {
-    mockUsePortfolioReport.mockReturnValue({
-      data: null,
-      isLoading: false,
-      isError: false,
-    } as any);
+  describe("success state", () => {
+    it("renders the draft report in preview mode with a back link to admin portfolio reports", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: draftReport,
+        isLoading: false,
+      } as any);
 
-    render(<PortfolioReportPreviewPage community={community} reportId="missing-report" />);
+      render(<PortfolioReportPreviewPage community={community} reportId="draft-report" />);
 
-    expect(screen.getByText(/report not found/i)).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalled();
+      expect(
+        screen.getByText(/preview mode — this draft is only visible to community admins\./i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /back to portfolio reports/i })).toHaveAttribute(
+        "href",
+        "/community/filecoin/manage/portfolio-reports"
+      );
+      expect(screen.getByTestId("markdown-preview")).toHaveTextContent("# Draft report body");
+    });
+
+    it("uses a neutral preview banner for already-published reports", () => {
+      mockUsePortfolioReport.mockReturnValue({
+        data: publishedReport,
+        isLoading: false,
+      } as any);
+
+      render(<PortfolioReportPreviewPage community={community} reportId="published-report" />);
+
+      expect(screen.getByText(/preview mode — admin view of this report\./i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/this draft is only visible to community admins/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/hooks/portfolio-reports/useUpdateReportContent.test.tsx
+++ b/__tests__/hooks/portfolio-reports/useUpdateReportContent.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @file Regression tests for useUpdateReportContent cache reconciliation.
+ * @description Saving a title/content edit on an *unpublished* (draft) report
+ * used to update only the single-report cache — the admin list cache was left
+ * stale, so the change never appeared on the manage list ("the title didn't
+ * save"). These tests lock the list-cache patch for both draft and published
+ * reports.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { useUpdateReportContent } from "@/hooks/portfolio-reports/usePortfolioReports";
+import * as portfolioService from "@/services/portfolio-reports.service";
+
+vi.mock("@/services/portfolio-reports.service");
+
+const mockUpdateReportContent = vi.mocked(portfolioService.updateReportContent);
+
+const SLUG = "filecoin";
+// Mirror usePortfolioReports' key: [...reports(slug), status] with status undefined.
+const LIST_KEY = ["portfolio-reports", SLUG, undefined];
+
+function reportFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "report-1",
+    reportConfigId: "config-1",
+    communityId: "community-1",
+    runDate: "2026-03-15",
+    status: "draft",
+    title: null,
+    content: "# Report",
+    dataSnapshot: {},
+    modelId: "gpt-4.1",
+    tokenUsage: null,
+    generatedAt: "2026-04-01T00:00:00.000Z",
+    generationError: null,
+    publishedAt: null,
+    publishedBy: null,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+describe("useUpdateReportContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("patches the saved title into the admin list cache for an unpublished draft", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const draft = reportFixture({ id: "draft-1", status: "draft", title: null });
+    queryClient.setQueryData(LIST_KEY, [draft]);
+
+    const updated = {
+      ...draft,
+      title: "Pods Report — June 2026",
+      updatedAt: "2026-04-02T00:00:00.000Z",
+    };
+    mockUpdateReportContent.mockResolvedValue(updated as any);
+
+    const { result } = renderHook(() => useUpdateReportContent(SLUG), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({
+        reportId: "draft-1",
+        content: draft.content,
+        title: "Pods Report — June 2026",
+      });
+    });
+
+    const list = queryClient.getQueryData<any[]>(LIST_KEY);
+    expect(list?.[0].title).toBe("Pods Report — June 2026");
+    // Still a draft — no publish happened.
+    expect(list?.[0].status).toBe("draft");
+    // Single-report cache is updated too (drives the editor's own view).
+    expect(queryClient.getQueryData<any>(["portfolio-report", SLUG, "draft-1"])?.title).toBe(
+      "Pods Report — June 2026"
+    );
+  });
+
+  it("leaves unrelated reports in the list untouched", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const target = reportFixture({ id: "r1", title: null });
+    const other = reportFixture({ id: "r2", reportConfigId: "config-2", title: "Untouched" });
+    queryClient.setQueryData(LIST_KEY, [target, other]);
+
+    mockUpdateReportContent.mockResolvedValue({ ...target, title: "New" } as any);
+
+    const { result } = renderHook(() => useUpdateReportContent(SLUG), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ reportId: "r1", content: target.content, title: "New" });
+    });
+
+    const list = queryClient.getQueryData<any[]>(LIST_KEY);
+    expect(list?.find((r) => r.id === "r1").title).toBe("New");
+    expect(list?.find((r) => r.id === "r2").title).toBe("Untouched");
+  });
+});

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx
@@ -114,6 +114,22 @@ function ReportTypeFilterSelect({
   );
 }
 
+/**
+ * Report name cell: the admin-authored title when set, otherwise the report
+ * config's name. When a title is set the config name still shows underneath so
+ * admins can tell which config produced the report.
+ */
+function ReportNameCell({ title, configName }: { title?: string | null; configName: string }) {
+  return (
+    <td className="px-4 py-3">
+      <span className="font-medium text-zinc-900 dark:text-zinc-100">{title ?? configName}</span>
+      {title ? (
+        <span className="mt-0.5 block text-xs font-normal text-zinc-500">{configName}</span>
+      ) : null}
+    </td>
+  );
+}
+
 interface ReportTableRowProps {
   slug: string;
   report: PortfolioReport;
@@ -151,7 +167,7 @@ function ReportTableRow({
   const deletable = report.status === "draft" || failed;
   return (
     <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-      <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-100">{configName}</td>
+      <ReportNameCell title={report.title} configName={configName} />
       <td className="px-4 py-3 text-zinc-500">{fmt.shortLabel}</td>
       <td className="px-4 py-3">
         <GenerationStatusBadge status={report.status} />
@@ -560,13 +576,7 @@ export function PortfolioReportListPage({ community }: Props) {
                         router.push(`${PAGES.ADMIN.PORTFOLIO_REPORTS(slug)}/${report.id}`)
                       }
                       onPreview={() =>
-                        router.push(
-                          PAGES.COMMUNITY.REPORT_DETAIL(
-                            slug,
-                            report.runDate,
-                            report.reportConfigSlug
-                          )
-                        )
+                        router.push(PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW(slug, report.id))
                       }
                       onPublish={() => handlePublish(report.id)}
                       onUnpublish={() => handleUnpublish(report.id)}

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx
@@ -2,8 +2,7 @@
 
 import { AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { PortfolioReportDocumentView } from "@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView";
 import { Spinner } from "@/components/Utilities/Spinner";
 import { usePortfolioReport } from "@/hooks/portfolio-reports/usePortfolioReports";
 import type { Community } from "@/types/v2/community";
@@ -15,33 +14,29 @@ interface Props {
 }
 
 /**
- * DEV-496: the admin preview and the public report now share one URL. This
- * legacy `/manage/.../preview` route redirects to `/reports/:runDate`, where a
- * community admin sees the draft preview inline (public sees published only).
+ * Admin preview of a single report, addressed by report id. Renders the report
+ * document inline (drafts included — the report is fetched from the auth-gated
+ * admin endpoint), so it stays reachable regardless of publish status.
  */
 export function PortfolioReportPreviewPage({ community, reportId }: Props) {
   const slug = community.details.slug;
   const { data: report, isLoading, isError, refetch } = usePortfolioReport(slug, reportId);
-  const { replace } = useRouter();
   const backHref = PAGES.ADMIN.PORTFOLIO_REPORTS(slug);
 
-  const runDate = report?.runDate;
-  // Carry the config slug through: this route knows exactly which report was
-  // requested, and a run-date-only redirect would drop that and land on
-  // whichever report is newest when two configs ran the same day.
-  const configSlug = report?.reportConfigSlug ?? null;
-  useEffect(() => {
-    if (runDate) {
-      replace(PAGES.COMMUNITY.REPORT_DETAIL(slug, runDate, configSlug));
-    }
-  }, [runDate, configSlug, slug, replace]);
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (isError) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
         <div className="flex flex-col items-center gap-4">
           <AlertTriangle className="h-8 w-8 text-red-400" />
-          <p className="text-zinc-500">Failed to load the report. Please try again.</p>
+          <p className="text-zinc-500">Failed to load the report preview. Please try again.</p>
           <button
             type="button"
             onClick={() => refetch()}
@@ -62,7 +57,7 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
     );
   }
 
-  if (!isLoading && !report) {
+  if (!report) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-12 text-center">
         <p className="text-zinc-500">Report not found.</p>
@@ -77,10 +72,19 @@ export function PortfolioReportPreviewPage({ community, reportId }: Props) {
     );
   }
 
-  // Loading the report, or redirecting once its run date resolves.
+  const bannerText = report.publishedAt
+    ? "Preview mode — admin view of this report."
+    : "Preview mode — this draft is only visible to community admins.";
+
   return (
-    <div className="flex items-center justify-center p-12">
-      <Spinner />
-    </div>
+    <PortfolioReportDocumentView
+      community={community}
+      runDate={report.runDate}
+      report={report}
+      backHref={backHref}
+      backLabel="Back to portfolio reports"
+      bannerText={bannerText}
+      isAdmin
+    />
   );
 }

--- a/hooks/portfolio-reports/usePortfolioReports.ts
+++ b/hooks/portfolio-reports/usePortfolioReports.ts
@@ -155,6 +155,7 @@ export function useReportRowSync(
           if (r.id !== data.id || r === data) return r;
           if (
             r.status === data.status &&
+            r.title === data.title &&
             r.content === data.content &&
             r.generationError === data.generationError &&
             r.updatedAt === data.updatedAt
@@ -268,6 +269,14 @@ export function useUpdateReportContent(communitySlug: string) {
     }) => portfolioService.updateReportContent(communitySlug, reportId, content, title),
     onSuccess: (data: PortfolioReport) => {
       queryClient.setQueryData(QUERY_KEYS.report(communitySlug, data.id), data);
+      // Reflect the edit on the admin list right away. A draft has no public
+      // surface, so without this a title/content change wouldn't show on the
+      // manage list until the list happened to refetch — reading as "the title
+      // didn't save" for unpublished reports.
+      queryClient.setQueriesData<PortfolioReport[] | undefined>(
+        { queryKey: QUERY_KEYS.reports(communitySlug) },
+        (old) => old?.map((report) => (report.id === data.id ? data : report))
+      );
       if (data.status === "published") {
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.published(communitySlug),


### PR DESCRIPTION
## Overview

Three frontend-only fixes to the portfolio report admin surface, all around the recently-added editable report title and the report preview flow:

1. A draft report's title/content edit now reflects on the manage list.
2. The manage report list shows the admin-authored title.
3. Report previews are reachable again via the dedicated manage preview link.

No backend changes — the indexer already persists the title correctly for drafts.

## Problem

- **Title "doesn't save" for unpublished reports.** Editing a draft's title appeared to do nothing outside the editor. The backend was storing it fine; the issue was purely client cache: `useUpdateReportContent.onSuccess` updated the single-report cache and — *only when published* — the public caches, but it never touched the admin list cache (`QUERY_KEYS.reports`). A draft has no public surface, so the saved title never reappeared on the manage list.
- **The manage list never showed the title.** The "Report" column rendered only the report config name, so admins couldn't tell a title had been set/changed.
- **Report previews were unreachable.** The DEV-496 "unify preview + public URL" change turned the admin `/manage/.../preview` route into a redirect to the public `/reports/:runDate` page and repointed the list Preview button there. Drafts only render on that public URL through a fragile admin-only fallback, so previews frequently landed on "not found".

## Solution

- `useUpdateReportContent.onSuccess` now patches the returned report into the admin list cache with `setQueriesData`, so a title/content edit shows on the manage list regardless of publish status. `useReportRowSync`'s row-reconciliation compare now also includes `title` so a title-only change propagates.
- New `ReportNameCell` renders `title ?? configName` as the primary line, with the config name as muted secondary context when a title is set (extracted as its own component to keep `ReportTableRow`'s cognitive complexity at its existing baseline).
- Reverted the DEV-496 unification on the admin surface: `PortfolioReportPreviewPage` renders the report inline again (`PortfolioReportDocumentView`), and the list Preview button points back at `PAGES.ADMIN.PORTFOLIO_REPORTS_PREVIEW`. This preview is addressed by report id, so it resolves the exact report and stays reachable for drafts.

## Why This Approach

The preview page fetches by report id (auth-gated admin endpoint), which is unambiguous and works for drafts — unlike run-date resolution on the public URL, which needs a config-slug fallback and an admin-draft branch that were the source of the unreachable previews. The public report page keeps its existing admin-draft fallback in place (now dormant), so nothing on the public/filpgf side changes — matching the "keep the manage preview link for now" intent while leaving the split-URL cleanup for a follow-up.

## Testing Steps

1. As a community admin, open **Manage → Portfolio Reports** for a community with a generated report.
2. Click **Edit** on a **draft** report, set a **Title**, and Save.
3. Go back to the report list — the row now shows the new title, with the config name underneath. (Previously the row still showed the config name only.)
4. Click **Preview** on a draft — it opens the report inline at `/manage/.../preview` with the "draft is only visible to community admins" banner, instead of redirecting to an unreachable public URL.
5. Clear the title (empty the field) and Save — the row falls back to the config name.
6. Repeat for a published report — the title still shows on both the manage list and the public list.

## Technical Details

- `hooks/portfolio-reports/usePortfolioReports.ts` — list-cache patch in `useUpdateReportContent`; `title` added to `useReportRowSync` compare.
- `components/Pages/Admin/PortfolioReports/PortfolioReportListPage.tsx` — `ReportNameCell`; Preview button repointed.
- `components/Pages/Admin/PortfolioReports/PortfolioReportPreviewPage.tsx` — restored inline render (reverts the redirect shim).
- Tests: restored the inline-render preview page test, updated the list preview assertion, added title-column tests, and added a `useUpdateReportContent` cache regression test. 107 portfolio-report tests pass; `pnpm run build` is green.

## Follow-up (not in this PR)

If the split preview/public-URL model is kept permanently, the now-dormant `useAdminReportByRunDate` hook and the `PublicReportViewPage` admin-draft branch can be removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin preview pages for draft and published reports, with clear loading, error, retry, and not-found states.
  - Draft and published previews now display appropriate visibility banners.
  - Report lists show custom titles with the configuration name as context, or fall back to the configuration name.

- **Bug Fixes**
  - Preview actions now open the correct admin preview view.
  - Edited report titles and content appear immediately in report lists without requiring a refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->