### PR TITLE
feat(portfolio-report): export data from the editor + gate report-view export on admin

### DIFF
--- a/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
+++ b/__tests__/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.test.tsx
@@ -27,6 +27,12 @@ vi.mock("@/components/Pages/Community/PortfolioReports/ReportChartsSection", () 
   ReportChartsSection: () => <div data-testid="report-charts-section" />,
 }));
 
+vi.mock("@/components/Pages/Community/PortfolioReports/ExportDataMenu", () => ({
+  ExportDataMenu: ({ communitySlug, reportId }: { communitySlug: string; reportId: string }) => (
+    <div data-testid="export-data-menu" data-slug={communitySlug} data-report={reportId} />
+  ),
+}));
+
 vi.mock("@/hooks/communities/useCommunityAdminAccess");
 vi.mock("@/hooks/portfolio-reports/usePortfolioReports");
 
@@ -73,6 +79,18 @@ describe("PortfolioReportEditorPage", () => {
     mockUseUnpublishReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
     mockUseRegenerateReport.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
     mockUseUpdateReportContent.mockReturnValue({ isPending: false, mutateAsync: vi.fn() } as any);
+  });
+
+  describe("data export", () => {
+    it("renders the export-data menu in the toolbar, wired to this community and report", () => {
+      mockUsePortfolioReport.mockReturnValue({ data: baseReport, isLoading: false } as any);
+
+      render(<PortfolioReportEditorPage community={community} reportId="report-1" />);
+
+      const menu = screen.getByTestId("export-data-menu");
+      expect(menu).toHaveAttribute("data-slug", "filecoin");
+      expect(menu).toHaveAttribute("data-report", "report-1");
+    });
   });
 
   describe("edit textarea seeding", () => {

--- a/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
+++ b/__tests__/components/Pages/Community/PortfolioReports/PublicReportViewPage.test.tsx
@@ -15,12 +15,19 @@ vi.mock("@/components/Pages/Community/PortfolioReports/PortfolioReportDocumentVi
     report,
     bannerText,
     isAdmin,
+    canExportData,
   }: {
     report: { id: string };
     bannerText?: string;
     isAdmin?: boolean;
+    canExportData?: boolean;
   }) => (
-    <div data-testid="doc-view" data-banner={bannerText ?? ""} data-admin={String(isAdmin)}>
+    <div
+      data-testid="doc-view"
+      data-banner={bannerText ?? ""}
+      data-admin={String(isAdmin)}
+      data-can-export={String(canExportData)}
+    >
       report:{report?.id}
     </div>
   ),
@@ -68,6 +75,25 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
     expect(doc).toHaveTextContent("report:pub-1");
     expect(doc).toHaveAttribute("data-banner", "");
     expect(doc).toHaveAttribute("data-admin", "false");
+    // The public must never get the raw-data export.
+    expect(doc).toHaveAttribute("data-can-export", "false");
+  });
+
+  it("gives a community admin the export affordance on a published report", () => {
+    // Regression: export must reach admins on published reports too, where
+    // `isAdmin` (draft-preview) is false. It is gated on admin status, not draft.
+    mockAdmin.mockReturnValue({ isCommunityAdmin: true, isLoading: false } as any);
+    mockPublished.mockReturnValue({
+      data: { id: "pub-1", publishedAt: "2026-01-01T00:00:00Z" },
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    render(<PublicReportViewPage community={community} runDate={RUN_DATE} />);
+
+    const doc = screen.getByTestId("doc-view");
+    expect(doc).toHaveAttribute("data-admin", "false");
+    expect(doc).toHaveAttribute("data-can-export", "true");
   });
 
   it("previews the draft to a community admin, with the admin-only banner", () => {
@@ -86,6 +112,7 @@ describe("PublicReportViewPage (DEV-496 unified report URL)", () => {
       "Preview mode — this draft is only visible to community admins."
     );
     expect(doc).toHaveAttribute("data-admin", "true");
+    expect(doc).toHaveAttribute("data-can-export", "true");
   });
 
   it("shows a not-found message to a non-admin and never fetches the draft", () => {

--- a/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
+++ b/components/Pages/Admin/PortfolioReports/PortfolioReportEditorPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Download, Eye, EyeOff, Pencil, RefreshCw } from "lucide-reac
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
+import { ExportDataMenu } from "@/components/Pages/Community/PortfolioReports/ExportDataMenu";
 import { HtmlReportFrame } from "@/components/Pages/Community/PortfolioReports/HtmlReportFrame";
 import { ReportChartsSection } from "@/components/Pages/Community/PortfolioReports/ReportChartsSection";
 import { Spinner } from "@/components/Utilities/Spinner";
@@ -351,6 +352,7 @@ export function PortfolioReportEditorPage({ community, reportId }: Props) {
             <Pencil className="mr-1 h-3 w-3" />
             Edit
           </Button>
+          <ExportDataMenu communitySlug={community.details.slug} reportId={reportId} />
           <Button
             variant="outline"
             size="sm"

--- a/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
+++ b/components/Pages/Community/PortfolioReports/PortfolioReportDocumentView.tsx
@@ -26,6 +26,12 @@ interface Props {
    * reports require community-admin auth.
    */
   isAdmin?: boolean;
+  /**
+   * `true` when the viewer is a resolved community admin. Gates the raw-data
+   * export affordance, which must never be exposed to the public — including
+   * on published reports, where `isAdmin` (draft-preview) is `false`.
+   */
+  canExportData?: boolean;
 }
 
 function formatDate(iso: string): string {
@@ -44,6 +50,7 @@ export function PortfolioReportDocumentView({
   backLabel = "Reports",
   bannerText,
   isAdmin = false,
+  canExportData = false,
 }: Props) {
   const runDateLabel = formatRunDate(runDate).label;
 
@@ -77,7 +84,7 @@ export function PortfolioReportDocumentView({
             </ol>
           </nav>
           <div className="flex flex-wrap items-center gap-2">
-            {isAdmin ? (
+            {canExportData ? (
               <ExportDataMenu communitySlug={community.details.slug} reportId={report.id} />
             ) : null}
             <Button

--- a/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
+++ b/components/Pages/Community/PortfolioReports/PublicReportViewPage.tsx
@@ -125,6 +125,7 @@ export function PublicReportViewPage({ community, runDate, configSlug }: Props) 
       backLabel="Reports"
       bannerText={bannerText}
       isAdmin={isDraftPreview}
+      canExportData={isCommunityAdmin}
     />
   );
 }


### PR DESCRIPTION
## Overview

Makes the portfolio-report raw-data export reachable in the two places it was missing: the **admin editor toolbar**, and **published reports for admins** on the report view.

## Problem

The Export Data menu shipped in `v1.7.95` but only rendered on the public report **document view**, and there only when the report was an **unpublished draft**. Two consequences:

1. **Not in the editor.** Admins working on a report at `/manage/portfolio-reports/[reportId]` (`PortfolioReportEditorPage`) never saw an Export Data affordance — that page only has "Export PDF". This is where an admin naturally is when working with a report, so the feature appeared missing.
2. **Hidden from admins on published reports.** On the report view, export was gated on the `isAdmin` prop, which is actually **draft-preview** (`!report.publishedAt`). Once a report was published, `isAdmin` became `false`, so the button disappeared for everyone — including admins. An admin could never export a live report. The prop also double-duty gated the charts auth flag, coupling two unrelated concerns.

## Solution

- **Editor:** add `<ExportDataMenu>` to the editor toolbar beside "Export PDF". The page is already community-admin gated (`useCommunityAdminAccess` → `AccessDenied` before the toolbar renders), so no extra guard is needed.
- **Report view:** introduce a dedicated `canExportData` prop on `PortfolioReportDocumentView`, gated on **resolved** `isCommunityAdmin` (from `useIsCommunityAdmin`). `isAdmin` stays as-is for the charts auth flag. `PublicReportViewPage` now passes `canExportData={isCommunityAdmin}`.

Resulting visibility:

| Viewer | Draft | Published |
|---|---|---|
| Community admin | shows | **shows (was hidden)** |
| Public / guest | never reaches the view | hidden |

## Why This Approach

- Decoupling `canExportData` from `isAdmin` keeps the charts auth behavior unchanged (published reports still use the public client) while fixing export visibility — one prop, one concern.
- Gating on `isCommunityAdmin` **fails closed**: the flag is `false` while admin status resolves, so the button never flashes for guests and only appears once admin is confirmed. The BE export endpoints remain the real authorization boundary.
- The editor is route-level admin gated, so the menu can be added directly without a redundant client check.

## Testing Steps

1. As a community admin, open `/manage/portfolio-reports/[reportId]` → **Export Data** appears in the toolbar next to Export PDF; opening it lists the report's sections.
2. As a community admin, open a **published** report at `/community/[slug]/reports/[runDate]` → **Export Data** is present.
3. As a community admin, open an unpublished **draft** at the same URL → **Export Data** is present (unchanged).
4. As a **signed-out / non-admin** user, open a published report → **Export Data** is absent, and never flashes during load.

## Technical Details

- `PortfolioReportDocumentView.tsx`: new optional `canExportData?: boolean` (default `false`); export menu now gated on it instead of `isAdmin`.
- `PublicReportViewPage.tsx`: passes `canExportData={isCommunityAdmin}`.
- `PortfolioReportEditorPage.tsx`: imports and renders `ExportDataMenu` in the toolbar.

## Tests

- `PublicReportViewPage.test.tsx`: asserts `canExportData` is `false` for the public, `true` for an admin on a **published** report (regression), and `true` on a draft preview.
- `PortfolioReportEditorPage.test.tsx`: asserts the editor renders the export menu wired to the community slug + report id.
- All touched suites pass (32 unit + 16 integration smoke); `tsc` clean on touched files; Biome clean (pre-existing complexity warning on the editor is unchanged).

## Checklist

- [x] Tests added/updated
- [x] Loading/empty/error states handled (export menu handles loading, empty, error, legacy-report notice)
- [x] No hardcoded colors/URLs introduced
- [x] Linting passes on changed files
- [ ] Screenshots (UI change — reviewer can verify via steps above)
