### PR TITLE
Improve application status clarity and tenant button contrast

### DIFF
--- a/__tests__/components/FundingPlatform/ApplicationView/ApplicationHeader.test.tsx
+++ b/__tests__/components/FundingPlatform/ApplicationView/ApplicationHeader.test.tsx
@@ -142,7 +142,7 @@ describe("ApplicationHeader", () => {
       const application = createMockApplication({ status: "rejected" });
       renderWithProviders(<ApplicationHeader application={application} />);
 
-      expect(screen.getByText("Rejected")).toBeInTheDocument();
+      expect(screen.getByText("Declined")).toBeInTheDocument();
       expect(screen.getByTestId("x-icon")).toBeInTheDocument();
     });
 

--- a/__tests__/components/ui/ApplicationStatusChip.test.tsx
+++ b/__tests__/components/ui/ApplicationStatusChip.test.tsx
@@ -41,9 +41,9 @@ describe("ApplicationStatusChip", () => {
       expect(screen.getByText("Approved")).toBeInTheDocument();
     });
 
-    it("renders 'Rejected' for status='rejected'", () => {
+    it("renders 'Declined' for status='rejected'", () => {
       render(<ApplicationStatusChip status="rejected" />);
-      expect(screen.getByText("Rejected")).toBeInTheDocument();
+      expect(screen.getByText("Declined")).toBeInTheDocument();
     });
 
     it("renders 'Cancelled' for status='canceled'", () => {

--- a/__tests__/performance/bundle-constants.perf.test.ts
+++ b/__tests__/performance/bundle-constants.perf.test.ts
@@ -158,17 +158,19 @@ describe("Bundle constants -- module-level extraction", () => {
     expect(statusColorsIndex).toBeLessThan(componentIndex);
   });
 
-  it("ApplicationStatusBadge defines the status formatter at module level", () => {
-    // The snake_case -> Title Case status formatter was extracted out of
-    // ApplicationTableRow into the shared ApplicationStatusBadge component and
-    // must stay module-level so it is not re-created on every render.
+  it("ApplicationStatusBadge imports the shared status formatter at module level", () => {
+    // Application status labels are centralized so every application surface
+    // uses the same user-facing terminology. The formatter must remain a
+    // module-level import so it is not re-created on every render.
     const file = path.join(
       ROOT,
       "components/FundingPlatform/ApplicationList/applicationStatusBadge.tsx"
     );
     const content = fs.readFileSync(file, "utf-8");
 
-    const formatStatusIndex = content.indexOf("const formatApplicationStatus");
+    const formatStatusIndex = content.indexOf(
+      'import { formatApplicationStatus } from "@/utilities/application-status"'
+    );
     const componentIndex = content.indexOf("export const ApplicationStatusBadge");
 
     expect(formatStatusIndex).toBeGreaterThan(-1);

--- a/__tests__/utilities/whitelabel-config.test.ts
+++ b/__tests__/utilities/whitelabel-config.test.ts
@@ -21,6 +21,14 @@ describe("whitelabel-config", () => {
     it("returns null for unknown domains", () => {
       expect(getWhitelabelByDomain("example.com")).toBeNull();
     });
+
+    it("configures button foreground colors independently from primary colors", () => {
+      const optimism = getWhitelabelByDomain("app.opgrants.io");
+      const filecoin = getWhitelabelByDomain("app.filpgf.io");
+
+      expect(optimism?.theme?.buttonTextColor).toBe("#FFFFFF");
+      expect(filecoin?.theme?.buttonTextColor).toBe("#FFFFFF");
+    });
   });
 
   describe("toHslToken", () => {

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/ApplicationPageClient.tsx
@@ -253,7 +253,6 @@ export function ApplicationPageClient({
 
       <ApplicationHeader
         programName={programName}
-        status={application.status}
         showEditButton={showEditButton}
         editHref={editHref}
         publicHref={PAGES.COMMUNITY.BROWSE_APPLICATIONS(communityId)}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationHeader.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationHeader.tsx
@@ -10,13 +10,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { Link } from "@/src/components/navigation/Link";
-import type { ApplicationStatus } from "@/types/whitelabel-entities";
-import { cn } from "@/utilities/tailwind";
-import { getStatusVisual } from "./application-status-ui";
 
 interface ApplicationHeaderProps {
   programName: string;
-  status: ApplicationStatus;
   showEditButton: boolean;
   editHref: string;
   publicHref: string;
@@ -27,14 +23,12 @@ interface ApplicationHeaderProps {
 
 export function ApplicationHeader({
   programName,
-  status,
   showEditButton,
   editHref,
   publicHref,
   canReviewInAdmin,
   reviewHref,
 }: ApplicationHeaderProps) {
-  const visual = getStatusVisual(status);
   const [, copy] = useCopyToClipboard();
 
   const handleCopyLink = () => {
@@ -50,16 +44,6 @@ export function ApplicationHeader({
       </h1>
 
       <div className="flex items-center gap-2.5">
-        <span
-          className={cn(
-            "inline-flex h-9 items-center gap-2 rounded-full px-4 text-sm font-semibold",
-            visual.pillClass
-          )}
-        >
-          <span className={cn("h-2 w-2 rounded-full", visual.dotClass)} />
-          {visual.label}
-        </span>
-
         {showEditButton && (
           <Link
             href={editHref}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationSidebar.tsx
@@ -58,7 +58,11 @@ export function ApplicationSidebar({
         onViewActivity={onViewActivity}
       />
 
-      <ApplicationStatusStepper status={application.status} statusHistory={statusHistory || []} />
+      <ApplicationStatusStepper
+        status={application.status}
+        statusHistory={statusHistory || []}
+        currentStatusDate={application.updatedAt}
+      />
 
       <ApplicationInfoCard
         referenceNumber={application.referenceNumber}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationStatusStepper.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationStatusStepper.tsx
@@ -15,6 +15,7 @@ interface StatusHistoryItem {
 interface ApplicationStatusStepperProps {
   status: ApplicationStatus;
   statusHistory: StatusHistoryItem[];
+  currentStatusDate?: string;
 }
 
 const STATUS_SUBTITLES: Record<string, string> = {
@@ -27,21 +28,47 @@ const STATUS_SUBTITLES: Record<string, string> = {
   rejected: "Not approved this round",
 };
 
-export function ApplicationStatusStepper({ status, statusHistory }: ApplicationStatusStepperProps) {
+export function ApplicationStatusStepper({
+  status,
+  statusHistory,
+  currentStatusDate,
+}: ApplicationStatusStepperProps) {
   const heroVisual = getStatusVisual(status);
 
-  // Oldest → newest so the timeline reads top-to-bottom chronologically.
-  const sortedHistory = useMemo(
-    () =>
-      [...(statusHistory ?? [])].sort(
-        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-      ),
-    [statusHistory]
-  );
+  const { currentHistoryItem, priorHistory } = useMemo(() => {
+    const sortedHistory = [...(statusHistory ?? [])].sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const normalizedStatus = status.toLowerCase().replace(/-/g, "_");
+    let currentIndex = -1;
+
+    for (let index = sortedHistory.length - 1; index >= 0; index -= 1) {
+      const itemStatus = sortedHistory[index]?.status.toLowerCase().replace(/-/g, "_");
+      if (itemStatus === normalizedStatus) {
+        currentIndex = index;
+        break;
+      }
+    }
+
+    return {
+      currentHistoryItem: currentIndex >= 0 ? sortedHistory[currentIndex] : undefined,
+      priorHistory:
+        currentIndex >= 0
+          ? sortedHistory.filter((_, index) => index !== currentIndex)
+          : sortedHistory,
+    };
+  }, [status, statusHistory]);
+
+  const statusDate = currentHistoryItem?.timestamp ?? currentStatusDate;
 
   return (
     <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-      <div className="mb-5 flex items-center gap-3">
+      <div
+        className={cn(
+          "flex items-center gap-3",
+          (currentHistoryItem?.reason || priorHistory.length > 0) && "mb-5"
+        )}
+      >
         <div
           className={cn(
             "flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full",
@@ -54,17 +81,29 @@ export function ApplicationStatusStepper({ status, statusHistory }: ApplicationS
           <div className="text-lg font-semibold tracking-tight text-foreground">
             {heroVisual.label}
           </div>
-          <div className="text-[13px] text-muted-foreground">
-            {STATUS_SUBTITLES[status] ?? "Application status"}
+          <div className="flex flex-wrap items-center gap-x-1.5 text-[13px] text-muted-foreground">
+            <span>{STATUS_SUBTITLES[status] ?? "Application status"}</span>
+            {statusDate && (
+              <>
+                <span aria-hidden>·</span>
+                <time dateTime={statusDate}>{formatDate(statusDate)}</time>
+              </>
+            )}
           </div>
         </div>
       </div>
 
-      {sortedHistory.length > 0 && (
+      {currentHistoryItem?.reason && (
+        <p className="mb-4 rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          {currentHistoryItem.reason}
+        </p>
+      )}
+
+      {priorHistory.length > 0 && (
         <ol className="relative">
-          {sortedHistory.map((item, index) => {
+          {priorHistory.map((item, index) => {
             const visual = getStatusVisual(item.status);
-            const isLast = index === sortedHistory.length - 1;
+            const isLast = index === priorHistory.length - 1;
             return (
               <li key={`${item.timestamp}-${index}`} className="relative flex gap-3 pb-4 last:pb-0">
                 {!isLast && (

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationTabBar.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/ApplicationTabBar.tsx
@@ -37,7 +37,7 @@ export function ApplicationTabBar({ tabs, activeTab, onTabChange }: ApplicationT
             className={cn(
               "inline-flex items-center gap-2 whitespace-nowrap rounded-lg px-3.5 py-2 text-sm font-medium transition-colors",
               isActive
-                ? "bg-[rgb(var(--color-primary))] text-brand-950 shadow-sm"
+                ? "bg-primary text-primary-foreground shadow-sm"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
             )}
           >
@@ -47,7 +47,9 @@ export function ApplicationTabBar({ tabs, activeTab, onTabChange }: ApplicationT
               <span
                 className={cn(
                   "rounded-full px-1.5 py-px text-[11px] font-semibold",
-                  isActive ? "bg-brand-950/15 text-brand-950" : "bg-muted text-muted-foreground"
+                  isActive
+                    ? "bg-primary-foreground/15 text-primary-foreground"
+                    : "bg-muted text-muted-foreground"
                 )}
               >
                 {count}

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/NextStepCard.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/NextStepCard.tsx
@@ -134,7 +134,7 @@ export function NextStepCard(props: NextStepCardProps) {
   const { title, copy, cta } = descriptor;
 
   const ctaClassName =
-    "flex w-full items-center justify-center gap-2 rounded-lg bg-[rgb(var(--color-primary))] px-4 py-2.5 text-sm font-semibold text-brand-950 shadow-sm transition-opacity hover:opacity-90";
+    "flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition-opacity hover:opacity-90";
 
   let ctaNode: ReactNode = null;
   if (cta?.kind === "link") {

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationStatusStepper.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationStatusStepper.test.tsx
@@ -10,21 +10,29 @@ const history = [
 describe("ApplicationStatusStepper", () => {
   it("renders the hero for the current status with its subtitle", () => {
     render(<ApplicationStatusStepper status="approved" statusHistory={history} />);
-    // Hero label + each timeline node label both read "Approved"; at least one exists.
-    expect(screen.getAllByText("Approved").length).toBeGreaterThan(0);
+    expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Funded & ready to build")).toBeInTheDocument();
+    expect(screen.getByText("Mar 27, 2026", { selector: "time" })).toBeInTheDocument();
   });
 
-  it("renders every history entry chronologically with reasons", () => {
+  it("renders prior history chronologically without repeating the current status", () => {
     render(<ApplicationStatusStepper status="approved" statusHistory={history} />);
     expect(screen.getByText("Pending")).toBeInTheDocument();
     expect(screen.getByText("Under Review")).toBeInTheDocument();
     expect(screen.getByText("Looks great")).toBeInTheDocument();
+    expect(screen.getAllByText("Approved")).toHaveLength(1);
   });
 
   it("still renders the hero when there is no history", () => {
-    render(<ApplicationStatusStepper status="pending" statusHistory={[]} />);
+    render(
+      <ApplicationStatusStepper
+        status="pending"
+        statusHistory={[]}
+        currentStatusDate="2026-06-18T12:00:00Z"
+      />
+    );
     expect(screen.getByText("Pending")).toBeInTheDocument();
     expect(screen.getByText("Awaiting a reviewer")).toBeInTheDocument();
+    expect(screen.getByText("Jun 18, 2026")).toBeInTheDocument();
   });
 });

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationTabBar.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/ApplicationTabBar.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ApplicationTabBar, TAB_ICONS } from "../ApplicationTabBar";
+
+const tabs = [
+  { key: "details" as const, label: "Application Details", Icon: TAB_ICONS.details },
+  { key: "comments" as const, label: "Comments", Icon: TAB_ICONS.comments, count: 2 },
+];
+
+describe("ApplicationTabBar", () => {
+  it("uses the customizable primary foreground for the active tab", () => {
+    render(<ApplicationTabBar tabs={tabs} activeTab="comments" onTabChange={vi.fn()} />);
+
+    const activeTab = screen.getByRole("tab", { name: /comments/i });
+    expect(activeTab).toHaveClass("bg-primary", "text-primary-foreground");
+    expect(activeTab.querySelector("span")).toHaveClass(
+      "bg-primary-foreground/15",
+      "text-primary-foreground"
+    );
+  });
+
+  it("changes tabs when selected", () => {
+    const onTabChange = vi.fn();
+    render(<ApplicationTabBar tabs={tabs} activeTab="details" onTabChange={onTabChange} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /comments/i }));
+    expect(onTabChange).toHaveBeenCalledWith("comments");
+  });
+});

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/NextStepCard.test.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/__tests__/NextStepCard.test.tsx
@@ -1,12 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ComponentProps } from "react";
 import type { ApplicationStatus } from "@/types/whitelabel-entities";
 import { type ApplicationViewerRole, NextStepCard } from "../NextStepCard";
 
 vi.mock("@/src/components/navigation/Link", () => ({
-  Link: ({ href, children }: { href: string; children: ReactNode }) => (
-    <a href={href}>{children}</a>
-  ),
+  Link: ({ children, ...props }: ComponentProps<"a">) => <a {...props}>{children}</a>,
 }));
 
 interface Overrides {
@@ -46,6 +44,7 @@ describe("NextStepCard", () => {
     expect(screen.getByText("Review this application")).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /go to admin panel/i });
     expect(link).toHaveAttribute("href", "/review");
+    expect(link).toHaveClass("bg-primary", "text-primary-foreground");
   });
 
   it.each<[ApplicationStatus, string]>([

--- a/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/application-status-ui.tsx
+++ b/app/community/[communityId]/(whitelabel)/applications/[applicationId]/components/application-status-ui.tsx
@@ -8,6 +8,7 @@ import {
   RefreshCw,
   XCircle,
 } from "lucide-react";
+import { formatApplicationStatus } from "@/utilities/application-status";
 
 /**
  * Single source of truth for how an application status is rendered across the
@@ -73,20 +74,19 @@ const STATUS_VISUALS: Record<string, StatusVisual> = {
     dotClass: "bg-green-500",
   },
   rejected: {
-    label: "Rejected",
+    label: "Declined",
     Icon: XCircle,
     pillClass: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
     dotClass: "bg-red-500",
   },
 };
 
-function formatStatusLabel(status: string): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 export function getStatusVisual(status: string): StatusVisual {
   const normalized = status?.toLowerCase().replace(/-/g, "_");
   const visual = STATUS_VISUALS[normalized];
   if (visual) return visual;
-  return { ...DEFAULT_VISUAL, label: formatStatusLabel(status ?? "") || DEFAULT_VISUAL.label };
+  return {
+    ...DEFAULT_VISUAL,
+    label: formatApplicationStatus(status ?? "") || DEFAULT_VISUAL.label,
+  };
 }

--- a/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
+++ b/app/community/[communityId]/(with-header)/browse-applications/BrowseApplicationsClient.tsx
@@ -25,7 +25,7 @@ const statusOptions: Array<{
   { value: "under_review", label: "Under review" },
   { value: "revision_requested", label: "Needs info" },
   { value: "approved", label: "Approved" },
-  { value: "rejected", label: "Rejected" },
+  { value: "rejected", label: "Declined" },
 ];
 
 interface StatusStyle {
@@ -63,7 +63,7 @@ const STATUS_STYLES: Record<ApplicationStatus, StatusStyle> = {
   rejected: {
     pill: "bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300",
     dot: "bg-red-600",
-    label: "Rejected",
+    label: "Declined",
   },
   draft: {
     pill: "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",

--- a/app/community/[communityId]/manage/funding-platform/page.tsx
+++ b/app/community/[communityId]/manage/funding-platform/page.tsx
@@ -243,7 +243,7 @@ function FundingPlatformContent() {
       alwaysShow: false,
     },
     {
-      title: "Rejected",
+      title: "Declined",
       value: formatCurrency(statistics.rejected),
       rawValue: statistics.rejected,
       color: "text-red-600",
@@ -304,7 +304,7 @@ function FundingPlatformContent() {
         bgColor: "bg-green-500",
       },
       {
-        title: "Rejected",
+        title: "Declined",
         value: rejectedApplications,
         color: "text-red-600",
         bgColor: "bg-red-500",

--- a/app/community/[communityId]/manage/send-email/SendEmailComposer.tsx
+++ b/app/community/[communityId]/manage/send-email/SendEmailComposer.tsx
@@ -33,7 +33,7 @@ const APPLICATION_STATUS_ITEMS: DropdownItem[] = [
   { id: "under_review", label: "Under Review", color: "#3b82f6" },
   { id: "approved", label: "Approved", color: "#22c55e" },
   { id: "in_progress", label: "In Progress", color: "#8b5cf6" },
-  { id: "rejected", label: "Rejected", color: "#ef4444" },
+  { id: "rejected", label: "Declined", color: "#ef4444" },
   { id: "revision_requested", label: "Revision Requested", color: "#f97316" },
   { id: "resubmitted", label: "Resubmitted", color: "#06b6d4" },
   { id: "withdrawn", label: "Withdrawn", color: "#6b7280" },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,8 @@ import { TenantStoreInitializer } from "@/components/Utilities/TenantStoreInitia
 import { FooterSwitcher } from "@/src/components/footer/footer-switcher";
 import { GlobalNavbarSlot } from "@/src/components/navbar/global-navbar-slot";
 import { WhitelabelNavbar } from "@/src/components/navbar/whitelabel-navbar";
-import { toHslToken } from "@/utilities/whitelabel-config";
+import type { TenantConfig } from "@/src/infrastructure/types/tenant";
+import { toHslToken, type WhitelabelDomain } from "@/utilities/whitelabel-config";
 import { WhitelabelProvider } from "@/utilities/whitelabel-context";
 import { getWhitelabelContext } from "@/utilities/whitelabel-server";
 
@@ -118,21 +119,36 @@ const toasterConfig = {
   containerStyle: { top: 20, right: 20 },
 };
 
-export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const { isWhitelabel, communitySlug, config, tenantConfig } = await getWhitelabelContext();
-
+function getWhitelabelThemeStyle(
+  config: WhitelabelDomain | null,
+  tenantConfig: TenantConfig | null
+): React.CSSProperties | undefined {
   const tenantPrimaryToken = tenantConfig?.theme?.colors?.primary
     ? (toHslToken(tenantConfig.theme.colors.primary) ?? tenantConfig.theme.colors.primary)
     : null;
   const configPrimaryToken = config?.theme?.primaryColor
     ? toHslToken(config.theme.primaryColor)
     : null;
-  const primaryToken = tenantPrimaryToken ?? configPrimaryToken;
+  const primaryToken = configPrimaryToken ?? tenantPrimaryToken;
+  const tenantPrimaryForegroundToken = tenantConfig?.theme?.colors?.buttontext
+    ? toHslToken(tenantConfig.theme.colors.buttontext)
+    : null;
+  const configPrimaryForegroundToken = config?.theme?.buttonTextColor
+    ? toHslToken(config.theme.buttonTextColor)
+    : null;
+  const primaryForegroundToken = configPrimaryForegroundToken ?? tenantPrimaryForegroundToken;
 
-  const themeStyle =
-    isWhitelabel && primaryToken
-      ? ({ "--primary": primaryToken } as React.CSSProperties)
-      : undefined;
+  if (!primaryToken && !primaryForegroundToken) return undefined;
+
+  return {
+    ...(primaryToken ? { "--primary": primaryToken } : {}),
+    ...(primaryForegroundToken ? { "--primary-foreground": primaryForegroundToken } : {}),
+  } as React.CSSProperties;
+}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const { isWhitelabel, communitySlug, config, tenantConfig } = await getWhitelabelContext();
+  const themeStyle = isWhitelabel ? getWhitelabelThemeStyle(config, tenantConfig) : undefined;
 
   return (
     <html

--- a/components/FundingPlatform/ApplicationList/ApplicationListFilterBar.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListFilterBar.tsx
@@ -74,7 +74,7 @@ export const ApplicationListFilterBar: FC<ApplicationListFilterBarProps> = ({
           <option value="under_review">Under Review</option>
           <option value="revision_requested">Revision Requested</option>
           <option value="approved">Approved</option>
-          <option value="rejected">Rejected</option>
+          <option value="rejected">Declined</option>
         </select>
       </div>
 

--- a/components/FundingPlatform/ApplicationList/ApplicationListStatsBar.tsx
+++ b/components/FundingPlatform/ApplicationList/ApplicationListStatsBar.tsx
@@ -16,7 +16,7 @@ export const ApplicationListStatsBar: FC<ApplicationListStatsBarProps> = ({ stat
     { title: "Revision Requested", value: stats.revisionRequestedApplications || 0 },
     { title: "Under Review", value: stats.underReviewApplications || 0 },
     { title: "Approved", value: stats.approvedApplications || 0 },
-    { title: "Rejected", value: stats.rejectedApplications || 0 },
+    { title: "Declined", value: stats.rejectedApplications || 0 },
   ];
 
   return (

--- a/components/FundingPlatform/ApplicationList/applicationStatusBadge.tsx
+++ b/components/FundingPlatform/ApplicationList/applicationStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { cn } from "@/utilities/tailwind";
 
 /**
@@ -12,13 +13,6 @@ const applicationStatusColors: Record<string, string> = {
   approved: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
   rejected: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
 };
-
-/** Humanize a snake_case status (e.g. `under_review` -> `Under Review`). */
-const formatApplicationStatus = (status: string): string =>
-  status
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 
 /** Rounded status pill used in the applications table and inbox. */
 export const ApplicationStatusBadge = ({

--- a/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationContent.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/src/features/applications/lib/milestone-status";
 import { useApplicationVersionsStore } from "@/store/applicationVersions";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { createFieldLabelsMap, createFieldTypeMap } from "@/utilities/form-schema-helpers";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
@@ -72,13 +73,6 @@ const statusIcons = {
   revision_requested: ExclamationTriangleIcon,
   approved: CheckCircleIcon,
   rejected: XMarkIcon,
-};
-
-const formatStatus = (status: string): string => {
-  return status
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 };
 
 const ApplicationContent: FC<ApplicationContentProps> = ({
@@ -162,7 +156,7 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
         if (pendingStatus === "approved") {
           toast.success("Application approved successfully!");
         } else {
-          toast.success(`Application status updated to ${formatStatus(pendingStatus)}`);
+          toast.success(`Application status updated to ${formatApplicationStatus(pendingStatus)}`);
         }
       } catch (error) {
         console.error("Failed to update status:", error);
@@ -485,7 +479,7 @@ const ApplicationContent: FC<ApplicationContentProps> = ({
                 )}
               >
                 <StatusIcon className="w-4 h-4" />
-                <span>{formatStatus(application.status)}</span>
+                <span>{formatApplicationStatus(application.status)}</span>
               </div>
               <div className="flex flex-col gap-1">
                 <h2 className="text-xl font-semibold text-gray-900 dark:text-white">

--- a/components/FundingPlatform/ApplicationView/ApplicationHeader.tsx
+++ b/components/FundingPlatform/ApplicationView/ApplicationHeader.tsx
@@ -10,6 +10,7 @@ import type { FC, ReactNode } from "react";
 import { KycStatusBadge } from "@/components/KycStatusIcon";
 import type { IFundingApplication, ProgramWithFormSchema } from "@/types/funding-platform";
 import type { KycStatusResponse } from "@/types/kyc";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import { getProjectTitle } from "../helper/getProjectTitle";
@@ -36,13 +37,6 @@ const statusIcons: Record<string, typeof ClockIcon> = {
   approved: CheckCircleIcon,
   rejected: XMarkIcon,
   resubmitted: ClockIcon,
-};
-
-const formatStatus = (status: string): string => {
-  return status
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 };
 
 export interface ApplicationHeaderProps {
@@ -99,10 +93,10 @@ export const ApplicationHeader: FC<ApplicationHeaderProps> = ({
                 "flex items-center gap-2 px-3 py-1.5 rounded-full border text-xs sm:text-sm font-medium whitespace-nowrap",
                 statusColors[application.status] || "bg-gray-100 text-gray-800 border-gray-200"
               )}
-              aria-label={`Application status: ${formatStatus(application.status)}`}
+              aria-label={`Application status: ${formatApplicationStatus(application.status)}`}
             >
               <StatusIcon className="w-4 h-4" aria-hidden="true" />
-              <span>{formatStatus(application.status)}</span>
+              <span>{formatApplicationStatus(application.status)}</span>
             </output>
 
             {/* More Actions - always visible */}

--- a/components/FundingPlatform/ApplicationView/CommentsTimeline.tsx
+++ b/components/FundingPlatform/ApplicationView/CommentsTimeline.tsx
@@ -82,7 +82,7 @@ const statusConfig = {
   rejected: {
     icon: XCircleIcon,
     color: "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900",
-    label: "Rejected",
+    label: "Declined",
   },
 };
 const labelMap = {
@@ -90,7 +90,7 @@ const labelMap = {
   under_review: "Under Review",
   revision_requested: "Revision Requested",
   approved: "Approved",
-  rejected: "Rejected",
+  rejected: "Declined",
 };
 
 // Helper function to determine edit type

--- a/components/FundingPlatform/ApplicationView/DiscussionTab/TimelineContainer.tsx
+++ b/components/FundingPlatform/ApplicationView/DiscussionTab/TimelineContainer.tsx
@@ -83,7 +83,7 @@ const statusConfig = {
   rejected: {
     icon: XCircleIcon,
     color: "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900",
-    label: "Rejected",
+    label: "Declined",
   },
   resubmitted: {
     icon: ArrowPathIcon,
@@ -97,7 +97,7 @@ const labelMap = {
   under_review: "Under Review",
   revision_requested: "Revision Requested",
   approved: "Approved",
-  rejected: "Rejected",
+  rejected: "Declined",
   resubmitted: "Resubmitted",
 };
 

--- a/components/FundingPlatform/ApplicationView/StatusHistoryTimeline.tsx
+++ b/components/FundingPlatform/ApplicationView/StatusHistoryTimeline.tsx
@@ -35,7 +35,7 @@ const statusConfig = {
   rejected: {
     icon: XCircleIcon,
     color: "text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900",
-    label: "Rejected",
+    label: "Declined",
   },
 };
 

--- a/components/FundingPlatform/__tests__/resubmitted-status.test.tsx
+++ b/components/FundingPlatform/__tests__/resubmitted-status.test.tsx
@@ -86,7 +86,7 @@ describe("Resubmitted Status in Admin UI", () => {
         { value: "under_review", label: "Under Review" },
         { value: "revision_requested", label: "Revision Requested" },
         { value: "approved", label: "Approved" },
-        { value: "rejected", label: "Rejected" },
+        { value: "rejected", label: "Declined" },
       ];
 
       const resubmittedOption = filterOptions.find((opt) => opt.value === "resubmitted");
@@ -102,7 +102,7 @@ describe("Resubmitted Status in Admin UI", () => {
         { value: "under_review", label: "Under Review" },
         { value: "revision_requested", label: "Revision Requested" },
         { value: "approved", label: "Approved" },
-        { value: "rejected", label: "Rejected" },
+        { value: "rejected", label: "Declined" },
       ];
 
       const pendingIndex = filterOptions.findIndex((opt) => opt.value === "pending");

--- a/components/Inbox/InboxBadges.tsx
+++ b/components/Inbox/InboxBadges.tsx
@@ -59,7 +59,7 @@ const STATUS_LABEL: Record<string, string> = {
   under_review: "Under review",
   revision_requested: "Revision requested",
   approved: "Approved",
-  rejected: "Rejected",
+  rejected: "Declined",
   withdrawn: "Withdrawn",
   completed: "Pending Verification",
   pending_verification: "Pending Verification",

--- a/components/Pages/Dashboard/v3/ApplicationsFullView.tsx
+++ b/components/Pages/Dashboard/v3/ApplicationsFullView.tsx
@@ -65,7 +65,7 @@ const STATUS_OPTIONS: Array<{ value: ApplicationStatus | "all"; label: string }>
   { value: "under_review", label: "Under review" },
   { value: "revision_requested", label: "Revision requested" },
   { value: "approved", label: "Approved" },
-  { value: "rejected", label: "Rejected" },
+  { value: "rejected", label: "Declined" },
 ];
 
 const FIELD_CLASS =

--- a/components/Pages/Dashboard/v3/summaries.ts
+++ b/components/Pages/Dashboard/v3/summaries.ts
@@ -78,7 +78,7 @@ const APPLICATION_BADGE: Partial<Record<ApplicationStatus, { tone: BadgeTone; la
   under_review: { tone: "amber", label: "Under review" },
   revision_requested: { tone: "amber", label: "Revision" },
   approved: { tone: "green", label: "Approved" },
-  rejected: { tone: "red", label: "Rejected" },
+  rejected: { tone: "red", label: "Declined" },
 };
 
 /**

--- a/src/components/ui/ApplicationStatusChip.tsx
+++ b/src/components/ui/ApplicationStatusChip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { cn } from "@/utilities/tailwind";
 
 interface ApplicationStatusChipProps {
@@ -36,30 +37,6 @@ function getStatusStyle(status: string): string {
   return STATUS_STYLES[normalized] ?? "bg-muted text-muted-foreground";
 }
 
-function formatStatus(status: string): string {
-  const lower = status.toLowerCase();
-  const labels: Record<string, string> = {
-    pending: "Pending",
-    resubmitted: "Resubmitted",
-    approved: "Approved",
-    accepted: "Accepted",
-    rejected: "Rejected",
-    canceled: "Cancelled",
-    cancelled: "Cancelled",
-    submitted: "Submitted",
-    under_review: "Under Review",
-    revision_requested: "Revision Requested",
-    draft: "Draft",
-  };
-  return (
-    labels[lower] ??
-    status
-      .split("_")
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-      .join(" ")
-  );
-}
-
 export function ApplicationStatusChip({
   status,
   size = "md",
@@ -89,7 +66,7 @@ export function ApplicationStatusChip({
         className
       )}
     >
-      {formatStatus(status)}
+      {formatApplicationStatus(status)}
     </Badge>
   );
 }

--- a/src/features/application-comments/components/StatusChangeItem.tsx
+++ b/src/features/application-comments/components/StatusChangeItem.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Calendar, CheckCircle, Clock, Eye, FileQuestion, XCircle } from "lucide-react";
-import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { formatDate } from "@/utilities/formatDate";
 import type { StatusHistoryItem } from "../types";
 
@@ -28,13 +28,6 @@ function getStatusIcon(status: string) {
   }
 }
 
-function formatStatusLabel(status: string): string {
-  return status
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
 export function StatusChangeItem({ status }: StatusChangeItemProps) {
   return (
     <Card className="rounded-none bg-gray-50 dark:bg-zinc-900/50 border-l-4 border-l-primary">
@@ -48,7 +41,7 @@ export function StatusChangeItem({ status }: StatusChangeItemProps) {
 
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
-              <Badge variant="outline">{formatStatusLabel(status.status)}</Badge>
+              <Badge variant="outline">{formatApplicationStatus(status.status)}</Badge>
               <span className="text-xs text-muted-foreground">Status Changed</span>
             </div>
 

--- a/src/features/user-applications/components/ApplicationCard.tsx
+++ b/src/features/user-applications/components/ApplicationCard.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { getProjectTitle } from "@/components/FundingPlatform/helper/getProjectTitle";
 import { Link } from "@/src/components/navigation/Link";
 import type { Application, ApplicationStatus } from "@/types/whitelabel-entities";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 
@@ -26,10 +27,6 @@ function getStatusColor(status: ApplicationStatus): string {
     default:
       return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
   }
-}
-
-function formatStatusLabel(status: ApplicationStatus): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
 }
 
 interface ApplicationCardProps {
@@ -89,7 +86,7 @@ export function ApplicationCard({
               getStatusColor(application.status)
             )}
           >
-            {formatStatusLabel(application.status)}
+            {formatApplicationStatus(application.status)}
           </span>
         </div>
 

--- a/src/features/user-applications/components/ApplicationsFilters.tsx
+++ b/src/features/user-applications/components/ApplicationsFilters.tsx
@@ -20,7 +20,7 @@ const statusOptions: Array<{
   { value: "pending", label: "Pending" },
   { value: "resubmitted", label: "Resubmitted" },
   { value: "approved", label: "Approved" },
-  { value: "rejected", label: "Rejected" },
+  { value: "rejected", label: "Declined" },
   { value: "revision_requested", label: "Revision Requested" },
 ];
 

--- a/src/features/user-applications/components/ApplicationsTable.tsx
+++ b/src/features/user-applications/components/ApplicationsTable.tsx
@@ -3,6 +3,7 @@
 import { Edit, Eye, FileText } from "lucide-react";
 import { Link } from "@/src/components/navigation/Link";
 import type { Application, ApplicationStatus } from "@/types/whitelabel-entities";
+import { formatApplicationStatus } from "@/utilities/application-status";
 import { formatDate } from "@/utilities/formatDate";
 import { cn } from "@/utilities/tailwind";
 import type { UserApplicationsSortBy } from "../types";
@@ -34,10 +35,6 @@ function getStatusColor(status: ApplicationStatus): string {
     default:
       return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
   }
-}
-
-function formatStatusLabel(status: ApplicationStatus): string {
-  return status.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
 }
 
 const columns: Array<{
@@ -119,7 +116,7 @@ export function ApplicationsTable({
                     getStatusColor(app.status)
                   )}
                 >
-                  {formatStatusLabel(app.status)}
+                  {formatApplicationStatus(app.status)}
                 </span>
               </td>
               <td className="px-4 py-3 text-muted-foreground">{formatDate(app.createdAt)}</td>

--- a/utilities/__tests__/application-status.test.ts
+++ b/utilities/__tests__/application-status.test.ts
@@ -1,0 +1,12 @@
+import { formatApplicationStatus } from "@/utilities/application-status";
+
+describe("formatApplicationStatus", () => {
+  it("uses Declined as the user-facing label for rejected applications", () => {
+    expect(formatApplicationStatus("rejected")).toBe("Declined");
+  });
+
+  it("formats other application statuses", () => {
+    expect(formatApplicationStatus("under_review")).toBe("Under Review");
+    expect(formatApplicationStatus("custom_status")).toBe("Custom Status");
+  });
+});

--- a/utilities/application-status.ts
+++ b/utilities/application-status.ts
@@ -1,0 +1,25 @@
+const APPLICATION_STATUS_LABELS: Record<string, string> = {
+  draft: "Draft",
+  pending: "Pending",
+  resubmitted: "Resubmitted",
+  under_review: "Under Review",
+  revision_requested: "Revision Requested",
+  approved: "Approved",
+  accepted: "Accepted",
+  rejected: "Declined",
+  canceled: "Cancelled",
+  cancelled: "Cancelled",
+  submitted: "Submitted",
+};
+
+export function formatApplicationStatus(status: string): string {
+  const normalized = status.toLowerCase().replace(/-/g, "_");
+
+  return (
+    APPLICATION_STATUS_LABELS[normalized] ??
+    normalized
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ")
+  );
+}

--- a/utilities/whitelabel-config.ts
+++ b/utilities/whitelabel-config.ts
@@ -5,6 +5,7 @@ export interface WhitelabelDomain {
   name: string;
   theme?: {
     primaryColor?: string;
+    buttonTextColor?: string;
     logoBackground?: string;
   };
 }
@@ -15,49 +16,57 @@ const DEFAULT_WHITELABEL_DOMAINS: WhitelabelDomain[] = [
     communitySlug: "optimism",
     tenantId: "optimism",
     name: "Optimism",
-    theme: { primaryColor: "#FF0420", logoBackground: "#FF0420" },
+    theme: {
+      primaryColor: "#FF0420",
+      buttonTextColor: "#FFFFFF",
+      logoBackground: "#FF0420",
+    },
   },
   {
     domain: "testapp.opgrants.io",
     communitySlug: "optimism",
     tenantId: "optimism",
     name: "Optimism (Test)",
-    theme: { primaryColor: "#FF0420", logoBackground: "#FF0420" },
+    theme: {
+      primaryColor: "#FF0420",
+      buttonTextColor: "#FFFFFF",
+      logoBackground: "#FF0420",
+    },
   },
   {
     domain: "founders.polygon.technology",
     communitySlug: "polygon",
     tenantId: "polygon",
     name: "Polygon",
-    theme: { primaryColor: "#8247E5" },
+    theme: { primaryColor: "#8247E5", buttonTextColor: "#FFFFFF" },
   },
   {
     domain: "foundersapp.polygon.technology",
     communitySlug: "polygon",
     tenantId: "polygon",
     name: "Polygon (Test)",
-    theme: { primaryColor: "#8247E5" },
+    theme: { primaryColor: "#8247E5", buttonTextColor: "#FFFFFF" },
   },
   {
     domain: "grantsapp.scroll.io",
     communitySlug: "scroll",
     tenantId: "scroll",
     name: "Scroll",
-    theme: { primaryColor: "#EBC28E" },
+    theme: { primaryColor: "#EBC28E", buttonTextColor: "#190602" },
   },
   {
     domain: "app.filpgf.io",
     communitySlug: "filecoin",
     tenantId: "filecoin",
     name: "Filecoin",
-    theme: { primaryColor: "#0090ff" },
+    theme: { primaryColor: "#0090ff", buttonTextColor: "#FFFFFF" },
   },
   {
     domain: "grants.filecoin.io",
     communitySlug: "filecoin",
     tenantId: "filecoin",
     name: "Filecoin (Legacy)",
-    theme: { primaryColor: "#0090ff" },
+    theme: { primaryColor: "#0090ff", buttonTextColor: "#FFFFFF" },
   },
 ];
 
@@ -96,6 +105,8 @@ function parseExtraWhitelabelDomainsFromEnv(): WhitelabelDomain[] {
 
       const primaryColor =
         typeof themeRecord?.primaryColor === "string" ? themeRecord.primaryColor : undefined;
+      const buttonTextColor =
+        typeof themeRecord?.buttonTextColor === "string" ? themeRecord.buttonTextColor : undefined;
       const logoBackground =
         typeof themeRecord?.logoBackground === "string" ? themeRecord.logoBackground : undefined;
 
@@ -106,9 +117,10 @@ function parseExtraWhitelabelDomainsFromEnv(): WhitelabelDomain[] {
           tenantId,
           name,
           theme:
-            primaryColor || logoBackground
+            primaryColor || buttonTextColor || logoBackground
               ? {
                   primaryColor,
+                  buttonTextColor,
                   logoBackground,
                 }
               : undefined,


### PR DESCRIPTION
## Summary

Improves application-page status clarity and whitelabel accessibility. Tenant primary buttons now use a configurable foreground token, pending applications show the current status and date once in the sidebar while preserving prior history, and user-facing application status copy consistently uses “Declined” instead of “Rejected” without changing API values.

## User flows verified

- [x] Filecoin whitelabel application page renders tenant-blue tabs and actions with white text — verified locally against a real application route.
- [x] Pending application status appears once in the sidebar with its date — verified locally across application routes and with focused component tests.
- [x] Application status copy displays “Declined” while internal status remains `rejected` — verified with formatter and component tests.
- [x] Optimism and Filecoin application routes load successfully in local development.

## Cross-service (FE + BE)?

- [x] N/A — frontend-only
- [ ] Yes — paired with show-karma/gap-indexer#____

## Smoke results

Local whitelabel walkthrough completed for Filecoin and Optimism application pages. The requester reviewed the Filecoin tenant-color preview and confirmed the result.

## Review waivers

- [x] No HIGH findings, OR all HIGH findings fixed
- [ ] HIGH findings waived (listed below with reasons)

## Pre-PR checklist (super-gap CLAUDE.md)

- [x] Every touched data-fetching component preserves loading, empty, and error behavior
- [x] No new `any` / `as any` casts
- [x] No mutation flow changed
- [x] Routes use existing route structure; colors are tenant configuration values exposed through theme tokens
- [x] No dynamic count behavior changed
- [x] No empty-state behavior changed
- [x] No list rendering behavior changed
- [x] No new Radix imports
- [x] No `useParams()` / `useRouter()` dependency changes
- [x] No heavy libraries added
- [x] `pnpm lint:fix` completed

## Validation

- `pnpm typecheck`
- 93 relevant Vitest tests passed across application status, whitelabel configuration, tabs, sidebar status, CTA, header, and layout coverage
- `git diff --check`
- Pre-commit Biome checks and pre-push TypeScript checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application status labels are now standardized across the platform, with “Rejected” displayed as “Declined.”
  * Application status timelines show clearer current-status dates, reasons, and historical steps.
  * Whitelabel themes now support customizable button text colors.

* **UI Improvements**
  * Updated application navigation tabs and action buttons to use theme-aware colors.
  * Improved application header actions and review/edit navigation.

* **Bug Fixes**
  * Improved consistency and accessibility of status labels across application lists, dashboards, filters, timelines, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->