### PR TITLE
fix(milestones): correct cancelled-milestone display on project pages (DEV-523)

### DIFF
--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -117,8 +117,14 @@ export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCar
   // "Due by" line so they cannot disagree, and corrupted endsAt degrades to
   // no due date rather than a 1970 date plus a spurious past-due badge.
   const dueMs = normalizeMilestoneDueDateMs(endsAt);
+  // currentStatus lives on the unified milestone (useProjectUpdates path) OR
+  // only on the raw source milestone (grant-store path this page uses), so
+  // check both — otherwise a cancelled milestone falls through to a past-due
+  // badge when the unified field isn't threaded.
+  const rawStatus =
+    milestone.currentStatus ?? milestone.source.grantMilestone?.milestone?.currentStatus;
   const effectiveStatus = getEffectiveMilestoneStatus(
-    isCancelledMilestoneStatus(milestone.currentStatus)
+    isCancelledMilestoneStatus(rawStatus)
       ? MilestoneLifecycleStatus.CANCELLED
       : completed
         ? MilestoneLifecycleStatus.COMPLETED
@@ -138,14 +144,19 @@ export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCar
     return "#FDB022";
   };
 
+  const isCancelled = effectiveStatus === MilestoneLifecycleStatus.CANCELLED;
+
   const getStatusColor = () => {
     if (completed) return "bg-brand-blue text-white";
+    if (isCancelled)
+      return "bg-gray-100 text-gray-600 line-through dark:bg-zinc-800 dark:text-gray-400";
     if (isPastDue) return "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300";
     return "bg-[#FFFAEB] text-[#B54708] dark:bg-[#FFFAEB]/10 dark:text-orange-100";
   };
 
   const getStatusBorder = () => {
     if (completed) return "";
+    if (isCancelled) return "border border-gray-200 dark:border-zinc-700";
     if (isPastDue) return "border border-red-200 dark:border-red-900";
     return "border border-[#FEDF89]";
   };

--- a/components/Shared/ActivityCard/MilestoneCard.tsx
+++ b/components/Shared/ActivityCard/MilestoneCard.tsx
@@ -589,7 +589,7 @@ export const MilestoneCard: FC<MilestoneCardProps> = ({
   const milestoneActions =
     isAuthorized && (type === "milestone" || type === "grant") ? (
       <>
-        {!completed && (
+        {!completed && effectiveStatus !== MilestoneLifecycleStatus.CANCELLED && (
           <Button
             className="flex flex-row gap-1 border border-brand-blue text-brand-blue text-sm font-semibold bg-white hover:bg-white dark:bg-transparent dark:hover:bg-transparent p-3 rounded-md max-sm:px-2 max-sm:py-1"
             onClick={() => handleCompleting(true)}


### PR DESCRIPTION
## Summary

Two follow-up display fixes for on-chain cancelled milestones (DEV-523, follow-up to #1837, now merged). Surfaced while QAing cancellation on staging.

## Problems

1. **Grant milestones-and-updates page showed a red "Past Due" badge for a cancelled milestone.** `components/Milestone/MilestoneCard.tsx` derived its lifecycle status from the unified `currentStatus`, but the grant-store data path this page uses (unlike the `useProjectUpdates` path) does not thread that field. The milestone fell through to `PENDING`, and being past its due date, rendered as `PAST_DUE`.
2. **The "Mark Milestone Complete" action still rendered for a cancelled milestone** on the project activity card (`components/Shared/ActivityCard/MilestoneCard.tsx`) — it was gated only on `!completed`, and cancellation is a separate terminal state.

## Solution

- `Milestone/MilestoneCard.tsx`: fall back to the raw source milestone's `currentStatus` (`milestone.source.grantMilestone?.milestone?.currentStatus`) when the unified field isn't populated, so cancellation is detected on every data path. Added a neutral gray Cancelled badge/border (matching the shared `MILESTONE_STATUS_BADGE_CLASS[CANCELLED]`) so it no longer borrows the past-due red.
- `Shared/ActivityCard/MilestoneCard.tsx`: also gate the Mark Complete button on `effectiveStatus !== CANCELLED`.

Both changes are display-only; no data-fetch or mutation paths touched.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm biome check` — clean on both files
- `pnpm run build` — succeeds
- Manual: on staging, a cancelled milestone now shows the gray "Cancelled" badge (not "Past Due") on the grant page, and the Mark Complete button is hidden on the activity card.

## Risk

Low. Two small, display-only conditionals scoped to the cancelled state; pending/completed/past-due rendering is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected milestone status handling when status information comes from different sources.
  * Cancelled milestones now display the appropriate badge styling, including gray borders and strikethrough text.
  * Prevented cancelled milestones from being incorrectly marked as past due.
  * Removed the “Mark Milestone Complete” action for cancelled milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->