### PR TITLE
fix(milestones): check cancelled before completed in badge styling (DEV-523)

### DIFF
--- a/components/Milestone/MilestoneCard.tsx
+++ b/components/Milestone/MilestoneCard.tsx
@@ -146,17 +146,20 @@ export const MilestoneCard = ({ milestone, isAuthorized, canEdit }: MilestoneCar
 
   const isCancelled = effectiveStatus === MilestoneLifecycleStatus.CANCELLED;
 
+  // Cancelled is terminal and wins over completed — mirror the precedence in
+  // getEffectiveMilestoneStatus so the badge color matches the label when a
+  // milestone is both cancelled and completed.
   const getStatusColor = () => {
-    if (completed) return "bg-brand-blue text-white";
     if (isCancelled)
       return "bg-gray-100 text-gray-600 line-through dark:bg-zinc-800 dark:text-gray-400";
+    if (completed) return "bg-brand-blue text-white";
     if (isPastDue) return "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300";
     return "bg-[#FFFAEB] text-[#B54708] dark:bg-[#FFFAEB]/10 dark:text-orange-100";
   };
 
   const getStatusBorder = () => {
-    if (completed) return "";
     if (isCancelled) return "border border-gray-200 dark:border-zinc-700";
+    if (completed) return "";
     if (isPastDue) return "border border-red-200 dark:border-red-900";
     return "border border-[#FEDF89]";
   };


### PR DESCRIPTION
## Summary

Small follow-up to #1877 (already merged). Addresses the one CodeRabbit finding on that PR, which was authored after #1877 had merged and so didn't make it in.

## Problem

`getEffectiveMilestoneStatus` resolves cancellation **before** completion (cancelled is terminal), so the milestone label reads "Cancelled" for a milestone that is both cancelled and completed. But `getStatusColor`/`getStatusBorder` in `components/Milestone/MilestoneCard.tsx` checked `completed` first — so that same milestone rendered the blue "completed" badge, disagreeing with its own "Cancelled" label.

## Solution

Reorder both style helpers to check `isCancelled` before `completed`, mirroring `getEffectiveMilestoneStatus` precedence. Now the badge color/border match the label in the cancelled+completed case.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm biome check` — clean
- Non-cancelled and cancelled-only rendering unchanged; only the cancelled+completed edge case is corrected.

## Risk

Very low — a 5-line reorder of two style helpers, no behavior change outside the cancelled+completed edge case.