### PR TITLE
fix(milestones): render cancelled status on application-detail & grant pages (DEV-523)

### DIFF
--- a/__tests__/components/GrantMilestonesAndUpdates/MilestoneDetails.test.tsx
+++ b/__tests__/components/GrantMilestonesAndUpdates/MilestoneDetails.test.tsx
@@ -8,10 +8,15 @@ vi.mock("@show-karma/karma-gap-sdk", () => ({
   GapSchema: vi.fn(),
 }));
 
-// Mock the ActivityCard component to avoid SDK dependency chain
+// Mock the ActivityCard component to avoid SDK dependency chain. Expose the
+// unified milestone's currentStatus so we can assert it is threaded through
+// (the card itself derives the Cancelled badge from this field).
 vi.mock("@/components/Shared/ActivityCard", () => ({
   ActivityCard: ({ activity }: any) => (
-    <div data-testid="activity-card">{activity?.data?.title || "Activity"}</div>
+    <div data-testid="activity-card">
+      {activity?.data?.title || "Activity"}
+      <span data-testid="unified-current-status">{activity?.data?.currentStatus ?? ""}</span>
+    </div>
   ),
 }));
 
@@ -77,5 +82,14 @@ describe("MilestoneDetails", () => {
   it("does not render amount badge when allocationAmount is empty string", () => {
     render(<MilestoneDetails milestone={baseMilestone} index={1} allocationAmount="" />);
     expect(screen.queryByTestId("milestone-allocation-amount")).not.toBeInTheDocument();
+  });
+
+  it("threads the raw currentStatus onto the unified milestone (DEV-523 cancelled)", () => {
+    // Without this the grant-store data path never sets currentStatus, so a
+    // cancelled milestone falls through to a pending/past-due badge.
+    render(
+      <MilestoneDetails milestone={{ ...baseMilestone, currentStatus: "cancelled" }} index={1} />
+    );
+    expect(screen.getByTestId("unified-current-status")).toHaveTextContent("cancelled");
   });
 });

--- a/__tests__/features/applications/MilestoneStatusBadge.test.tsx
+++ b/__tests__/features/applications/MilestoneStatusBadge.test.tsx
@@ -90,6 +90,23 @@ describe("MilestoneStatusBadge", () => {
     expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
   });
 
+  it("should_render_Cancelled_when_currentStatus_is_cancelled", () => {
+    render(<MilestoneStatusBadge entry={makeEntry({ currentStatus: "cancelled" })} />);
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+  });
+
+  it("should_render_Cancelled_over_PastDue_when_cancelled_and_dueDate_is_past", () => {
+    // Cancelled is terminal and wins over every other state — a cancelled
+    // milestone past its due date must read "Cancelled", not "Past Due".
+    render(
+      <MilestoneStatusBadge
+        entry={makeEntry({ currentStatus: "cancelled", dueDate: "2020-01-01" })}
+      />
+    );
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.queryByText("Past Due")).not.toBeInTheDocument();
+  });
+
   it("should_render_Pending_when_entry_is_undefined", () => {
     // Missing entry means the milestone hasn't been linked on-chain
     // yet — treat as Pending (the indexer's default).

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestoneDetails.tsx
@@ -80,6 +80,11 @@ function toUnifiedMilestone(milestone: GrantMilestone, grant: GrantContext): Uni
     title: milestone.title,
     description: milestone.description,
     completed,
+    // Thread the raw on-chain status so the card can detect a terminal
+    // cancelled milestone (DEV-523) — `completed` is a delivered-only boolean
+    // and can't represent cancellation, and this grant-store data path (unlike
+    // useProjectUpdates) is the only place currentStatus gets set.
+    currentStatus: milestone.currentStatus,
     createdAt: (milestone as any).createdAt || "",
     startsAt: milestone.startsAt,
     endsAt: milestone.endsAt,

--- a/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
+++ b/components/Pages/GrantMilestonesAndUpdates/screens/MilestonesAndUpdates/MilestonesList.tsx
@@ -163,7 +163,8 @@ export const MilestonesList: FC<MilestonesListProps> = ({ grant }) => {
       (item) =>
         !isCompleted(item) &&
         item.type !== "update" &&
-        !isCancelledMilestoneStatus(item.currentStatus)
+        // status lives on the wrapped milestone (item.object), not the item
+        !isCancelledMilestoneStatus(item.object?.currentStatus)
     );
 
     // For completed items: use completion date or creation date, descending (newest first)

--- a/src/features/applications/components/MilestoneStatusBadge.tsx
+++ b/src/features/applications/components/MilestoneStatusBadge.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import {
+  isMilestoneCancelled,
   isMilestoneCompleted,
   isMilestoneLate,
   isMilestoneVerified,
@@ -23,6 +24,7 @@ type Tone = "success" | "warning" | "danger" | "neutral";
 interface BadgeSpec {
   label: string;
   tone: Tone;
+  strikethrough?: boolean;
 }
 
 const TONE_CLASSES: Record<Tone, string> = {
@@ -41,9 +43,11 @@ const TONE_CLASSES: Record<Tone, string> = {
 };
 
 function resolveSpec(entry?: MilestoneStatusEntry): BadgeSpec {
-  // Order matters: Verified wins over Completed (a verified milestone
-  // is by definition also completed); Late only applies when not yet
-  // completed/verified.
+  // Order matters: Cancelled is terminal and wins over everything; Verified
+  // wins over Completed (a verified milestone is by definition also
+  // completed); Late only applies when not yet completed/verified.
+  if (isMilestoneCancelled(entry))
+    return { label: "Cancelled", tone: "neutral", strikethrough: true };
   if (isMilestoneVerified(entry)) return { label: "Verified", tone: "success" };
   if (isMilestoneCompleted(entry)) return { label: "Pending Verification", tone: "warning" };
   if (isMilestoneLate(entry)) return { label: "Past Due", tone: "danger" };
@@ -72,12 +76,13 @@ export const MilestoneStatusBadge = memo(function MilestoneStatusBadge({
   entry,
   className,
 }: MilestoneStatusBadgeProps) {
-  const { label, tone } = resolveSpec(entry);
+  const { label, tone, strikethrough } = resolveSpec(entry);
   return (
     <span
       className={cn(
         "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
         TONE_CLASSES[tone],
+        strikethrough && "line-through",
         className
       )}
     >

--- a/src/features/applications/components/OffChainMilestoneRow.tsx
+++ b/src/features/applications/components/OffChainMilestoneRow.tsx
@@ -14,6 +14,7 @@ import { formatDate } from "@/utilities/formatDate";
 import { INDEXER } from "@/utilities/indexer";
 import { useSubmitMilestoneCompletion } from "../hooks/use-submit-milestone-completion";
 import {
+  isMilestoneCancelled,
   isMilestoneCompleted,
   isMilestoneLate,
   isMilestoneVerified,
@@ -76,12 +77,14 @@ export function OffChainMilestoneRow({
   const [isUploading, setIsUploading] = useState(false);
   const pendingFileNameRef = useRef<string | undefined>(undefined);
 
+  const isCancelled = isMilestoneCancelled(entry);
   const isCompletionVerified = isMilestoneVerified(entry);
   const isCompletionSubmitted = isMilestoneCompleted(entry) && !isCompletionVerified;
   const isLate = isMilestoneLate(entry);
   // Submission requires a milestoneUID (refUID for the on-chain attestation).
-  // Slots that haven't been anchored on-chain yet stay read-only.
-  const canEdit = isEditable && !isCompletionVerified && !!entry.milestoneUID;
+  // Slots that haven't been anchored on-chain yet stay read-only. A cancelled
+  // milestone is terminal — no completion can be submitted against it.
+  const canEdit = isEditable && !isCompletionVerified && !isCancelled && !!entry.milestoneUID;
   const isWaitingForIndexer = isSubmittingTitle(entry.milestoneUID, entry.title);
 
   const completionEntry = entry.completed ?? null;
@@ -174,7 +177,11 @@ export function OffChainMilestoneRow({
         <div className="flex justify-between items-start">
           <h4 className="font-medium">{entry.title}</h4>
           <div className="flex items-center gap-2">
-            {isCompletionVerified ? (
+            {isCancelled ? (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-zinc-100 text-zinc-600 line-through dark:bg-zinc-700 dark:text-zinc-400">
+                Cancelled
+              </span>
+            ) : isCompletionVerified ? (
               <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">
                 Verified
               </span>

--- a/src/features/applications/components/OnChainMilestoneRow.tsx
+++ b/src/features/applications/components/OnChainMilestoneRow.tsx
@@ -14,6 +14,7 @@ import { formatDate } from "@/utilities/formatDate";
 import { PAGES } from "@/utilities/pages";
 import { useSubmitMilestoneCompletion } from "../hooks/use-submit-milestone-completion";
 import {
+  isMilestoneCancelled,
   isMilestoneCompleted,
   isMilestoneLate,
   isMilestoneVerified,
@@ -61,12 +62,14 @@ export function OnChainMilestoneRow({
   const [isEditing, setIsEditing] = useState(false);
   const [editedText, setEditedText] = useState("");
 
+  const isCancelled = isMilestoneCancelled(entry);
   const isVerified = isMilestoneVerified(entry);
   const isCompleted = isMilestoneCompleted(entry) && !isVerified;
   const isLate = isMilestoneLate(entry);
   // Project-source rows always have a milestoneUID (the indexer only
   // emits them from grant.milestones[], which by construction has UIDs).
-  const canEdit = isEditable && !isVerified && !!entry.milestoneUID;
+  // A cancelled milestone is terminal — no completion can be submitted.
+  const canEdit = isEditable && !isVerified && !isCancelled && !!entry.milestoneUID;
   const isWaitingForIndexer = isSubmittingTitle(entry.milestoneUID, entry.title);
 
   const completionEntry = entry.completed ?? null;
@@ -134,7 +137,11 @@ export function OnChainMilestoneRow({
             </Popover>
           </div>
           <div className="flex items-center gap-2">
-            {isVerified ? (
+            {isCancelled ? (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-zinc-100 text-zinc-600 line-through dark:bg-zinc-700 dark:text-zinc-400">
+                Cancelled
+              </span>
+            ) : isVerified ? (
               <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700">
                 Verified
               </span>

--- a/src/features/applications/lib/milestone-status.ts
+++ b/src/features/applications/lib/milestone-status.ts
@@ -74,6 +74,17 @@ export function lookupMilestoneStatus(
  * on-chain yet — treat as Pending.
  */
 
+/**
+ * A milestone is Cancelled when the on-chain status was set to `cancelled`
+ * (DEV-523). Cancelled is terminal — it takes precedence over every other
+ * display state (completed, verified, late, pending), so callers must check
+ * this first.
+ */
+export function isMilestoneCancelled(statusEntry?: MilestoneStatusEntry): boolean {
+  if (!statusEntry) return false;
+  return statusEntry.currentStatus === "cancelled";
+}
+
 export function isMilestoneVerified(statusEntry?: MilestoneStatusEntry): boolean {
   if (!statusEntry) return false;
   return statusEntry.currentStatus === "verified" || !!statusEntry.verified;
@@ -92,7 +103,12 @@ export function isMilestoneCompleted(statusEntry?: MilestoneStatusEntry): boolea
  */
 export function isMilestoneLate(statusEntry?: MilestoneStatusEntry): boolean {
   if (!statusEntry) return false;
-  if (isMilestoneCompleted(statusEntry) || isMilestoneVerified(statusEntry)) return false;
+  if (
+    isMilestoneCompleted(statusEntry) ||
+    isMilestoneVerified(statusEntry) ||
+    isMilestoneCancelled(statusEntry)
+  )
+    return false;
   if (!statusEntry.dueDate) return false;
   const dueMs = new Date(statusEntry.dueDate).getTime();
   return Number.isFinite(dueMs) && dueMs < Date.now();


### PR DESCRIPTION
## Summary

Follow-up to #1877. Cancelled milestones were still rendering as **Pending** / **Past Due** on two surfaces that #1877 didn't actually cover. Surfaced during staging QA of an on-chain cancel.

## What was wrong

1. **`components/Milestone/MilestoneCard.tsx` (the file #1877 edited for the grant page) is dead code** — it's imported by nothing in the app. So #1877's "Past Due → Cancelled" change had no effect. The grant milestones-and-updates page actually renders through `MilestonesList → MilestoneDetails → ActivityCard`.
   - `MilestoneDetails.toUnifiedMilestone` built the unified milestone but never set the top-level `currentStatus`, so the card read `undefined` → fell through to pending/past-due.
   - `MilestonesList` read `item.currentStatus` in the pending-bucket filter, but status lives on `item.object` — so cancelled milestones were never excluded from the Pending tab.

2. **Funding-platform application detail** (`community/.../funding-platform/.../applications/...`, both the Application-tab badge and the Milestones-tab rows, plus the whitelabel applicant page) resolves status through `src/features/applications/lib/milestone-status.ts`, whose predicates never checked `currentStatus === "cancelled"` → default "Pending".

## Fix

- Thread `currentStatus` onto the unified milestone in `MilestoneDetails`; fix the `MilestonesList` pending filter (`item.object.currentStatus`).
- Add `isMilestoneCancelled` (terminal — checked first) to the applications lib; add a "Cancelled" branch to `MilestoneStatusBadge`, `OnChainMilestoneRow`, and `OffChainMilestoneRow`; treat cancelled as terminal in `isMilestoneLate`; gate completion editing off for cancelled milestones.

## Not fixed here (separate backend issue)

The same application also shows the **same "Upgrade" milestone twice**. EAS-verified root cause: the milestone was **edited** on-chain (edit = revoke old UID `0xa3c76e…` + create new UID `0x52d166…`), then the new one was cancelled. The application's form data still points to the **revoked predecessor UID**, so the indexer's `milestoneStatuses` builder emits both rows and can't dedup (different UIDs). This needs an indexer fix (reconcile a revoked application-source milestone to its successor via `findRevokedMilestonePredecessor`) — filing separately.

## Testing

- `pnpm exec tsc --noEmit`, `pnpm biome check`, `pnpm run build` — all clean
- 126 tests across the applications + grant-milestones suites pass; added cancelled coverage (badge terminal-precedence, `MilestoneDetails` currentStatus threading)

## Risk

Low. Adds a terminal "cancelled" branch (checked first) to display-only status resolution; pending/completed/verified/past-due paths are unchanged.