### PR TITLE
fix(nonprofit-research): donor terminology, section copy, full-width footer

### DIFF
--- a/__tests__/features/donor-research/AdvancedDisclosure.repro.test.tsx
+++ b/__tests__/features/donor-research/AdvancedDisclosure.repro.test.tsx
@@ -64,7 +64,7 @@ function advancedTrigger() {
 }
 
 async function selectPersona(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByRole("combobox", { name: /persona/i }));
+  await user.click(screen.getByRole("combobox", { name: /donor/i }));
   await user.click(await screen.findByRole("option", { name: "Hartwell" }));
 }
 

--- a/__tests__/features/donor-research/CriteriaInputPanel.prefill.test.tsx
+++ b/__tests__/features/donor-research/CriteriaInputPanel.prefill.test.tsx
@@ -89,10 +89,10 @@ beforeEach(() => {
   mockUseDonorPersona.mockReturnValue(personaResult());
 });
 
-const badges = () => screen.queryAllByText("Prefilled from persona");
+const badges = () => screen.queryAllByText("Prefilled from donor profile");
 
 async function selectPersona(user: ReturnType<typeof userEvent.setup>, name: string) {
-  await user.click(screen.getByRole("combobox", { name: "Persona" }));
+  await user.click(screen.getByRole("combobox", { name: "Donor" }));
   await user.click(await screen.findByRole("option", { name }));
 }
 

--- a/__tests__/features/donor-research/DonorResearchHome.test.tsx
+++ b/__tests__/features/donor-research/DonorResearchHome.test.tsx
@@ -76,7 +76,7 @@ describe("DonorResearchHome", () => {
     expect(within(overview).getByText("Reports")).toBeVisible();
     expect(within(overview).getByText("Completed")).toBeVisible();
     expect(within(overview).getByText("Shared")).toBeVisible();
-    expect(within(overview).getByText("Personas")).toBeVisible();
+    expect(within(overview).getByText("Donors")).toBeVisible();
     expect(overview.querySelectorAll(":scope > div")).toHaveLength(4);
     expect(overview.querySelectorAll("svg")).toHaveLength(4);
     expect(overview.querySelector(".lucide-file-text")).toBeInTheDocument();

--- a/__tests__/features/donor-research/DonorResearchShell.test.tsx
+++ b/__tests__/features/donor-research/DonorResearchShell.test.tsx
@@ -123,11 +123,26 @@ describe("DonorResearchShell", () => {
       "href",
       PAGES.DONOR_RESEARCH.INDEX
     );
-    expect(within(breadcrumb).getByRole("link", { name: "Personas" })).toHaveAttribute(
+    expect(within(breadcrumb).getByRole("link", { name: "Donors" })).toHaveAttribute(
       "href",
       PAGES.DONOR_RESEARCH.PERSONAS
     );
     expect(within(breadcrumb).getByText("Q1")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("scopes the sidebar rail to the shell so the body-level footer is never overlaid", () => {
+    // The rail is absolute within the (relative) provider rather than fixed
+    // to the viewport — the platform footer rendered below the shell by the
+    // root layout must stay clear of it.
+    renderWithProviders(
+      <DonorResearchShell>
+        <div>Report content</div>
+      </DonorResearchShell>
+    );
+
+    const rail = document.querySelector('[data-sidebar="sidebar"]')?.parentElement;
+    expect(rail?.className).toContain("md:!absolute");
+    expect(screen.queryByText(/All rights reserved/)).not.toBeInTheDocument();
   });
 
   it("shows the report number as the current shell breadcrumb", () => {

--- a/__tests__/features/donor-research/NewDonorHandleModal.test.tsx
+++ b/__tests__/features/donor-research/NewDonorHandleModal.test.tsx
@@ -52,14 +52,14 @@ async function renderAtProfileStep() {
   renderWithProviders(
     <NewDonorHandleModal onCreated={onCreated} onOpenChange={onOpenChange} open />
   );
-  await user.type(screen.getByLabelText("New persona name"), "Smith Family Q3");
+  await user.type(screen.getByLabelText("New donor name"), "Smith Family Q3");
   await user.click(screen.getByRole("button", { name: /continue to profile/i }));
   await screen.findByText("Set up Smith Family Q3's profile");
   return { user, onCreated, onOpenChange };
 }
 
 describe("NewDonorHandleModal", () => {
-  it("gates both create actions until a persona name is entered", () => {
+  it("gates both create actions until a donor name is entered", () => {
     renderWithProviders(<NewDonorHandleModal onOpenChange={vi.fn()} open />);
     expect(screen.getByRole("button", { name: /continue to profile/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /save without profile/i })).toBeDisabled();
@@ -74,7 +74,7 @@ describe("NewDonorHandleModal", () => {
       <NewDonorHandleModal onCreated={onCreated} onOpenChange={onOpenChange} open />
     );
 
-    await user.type(screen.getByLabelText("New persona name"), "Smith Family Q3");
+    await user.type(screen.getByLabelText("New donor name"), "Smith Family Q3");
     await user.click(screen.getByRole("button", { name: /save without profile/i }));
 
     await waitFor(() => expect(onCreated).toHaveBeenCalledWith("h-new"));
@@ -96,7 +96,7 @@ describe("NewDonorHandleModal", () => {
       <NewDonorHandleModal editHandle={NEW_HANDLE} editPersonaExists onOpenChange={vi.fn()} open />
     );
 
-    expect(screen.queryByLabelText("New persona name")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("New donor name")).not.toBeInTheDocument();
     expect(await screen.findByText("Change profile")).toBeInTheDocument();
     expect(screen.getByText("Change Smith Family Q3's profile")).toBeInTheDocument();
   });

--- a/__tests__/features/donor-research/PersonaEditor.test.tsx
+++ b/__tests__/features/donor-research/PersonaEditor.test.tsx
@@ -89,7 +89,7 @@ beforeEach(() => vi.clearAllMocks());
 
 const NARRATIVE = "An established local funder with a multi-decade focus on education access.";
 
-const saveButton = () => screen.getByRole("button", { name: /save persona/i });
+const saveButton = () => screen.getByRole("button", { name: /save profile/i });
 // The Accept button only exists while a refine suggestion awaits a decision.
 const acceptButton = () => screen.queryByRole("button", { name: /^accept$/i });
 
@@ -98,7 +98,7 @@ describe("PersonaEditor cold-mount states", () => {
     setup({ persona: null });
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    expect(screen.getByLabelText("Persona source")).toHaveValue("");
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue("");
     expect(acceptButton()).not.toBeInTheDocument();
     expect(saveButton()).toBeDisabled();
   });
@@ -113,7 +113,9 @@ describe("PersonaEditor cold-mount states", () => {
     });
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    expect(screen.getByLabelText("Persona source")).toHaveValue("kickoff notes about this donor");
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(
+      "kickoff notes about this donor"
+    );
     expect(saveButton()).toBeDisabled();
   });
 
@@ -121,7 +123,7 @@ describe("PersonaEditor cold-mount states", () => {
     setup({ persona: makeDonorPersona() });
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
     expect(acceptButton()).not.toBeInTheDocument();
     expect(saveButton()).toBeDisabled();
   });
@@ -160,18 +162,18 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
     const refineBtn = screen.getByRole("button", { name: /^refine$/i });
     expect(refineBtn).toBeDisabled(); // empty source < 10 chars
 
-    await user.type(screen.getByLabelText("Persona source"), "Donor funds local education");
+    await user.type(screen.getByLabelText("Donor preferences"), "Donor funds local education");
     expect(refineBtn).toBeEnabled();
 
     await user.click(refineBtn);
 
     // Refine writes the suggestion straight into the (still editable) field;
     // chips/scalars wait for the Accept decision.
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
-    expect(screen.getByLabelText("Persona source")).not.toHaveAttribute("readonly");
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).not.toHaveAttribute("readonly");
     expect(acceptButton()).toBeInTheDocument();
     expect(
-      screen.getByText("Recommended persona written to the input — accept or reject below")
+      screen.getByText("Recommended profile written to the input — accept or reject below")
     ).toBeInTheDocument();
     const chipsBefore = JSON.parse(screen.getByTestId("chips-json").textContent ?? "{}");
     expect(chipsBefore.orgMaturity.value).toBeNull();
@@ -183,7 +185,7 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
 
     // Accept keeps the field text, applies chips, enables Save.
     expect(acceptButton()).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
     const chipsAfter = JSON.parse(screen.getByTestId("chips-json").textContent ?? "{}");
     expect(chipsAfter.orgMaturity).toEqual({ value: "established", source: "extracted" });
     expect(saveButton()).toBeEnabled();
@@ -215,7 +217,7 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
     expect(input.amountMax).toBe(20000);
     expect(input.cause).toBe("education");
     expect(input.geography).toBe("Greater Boston");
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Persona saved"));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Profile saved"));
   });
 
   it("restores the pre-refine text on Reject and leaves the chips untouched", async () => {
@@ -226,16 +228,16 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
     );
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    await user.type(screen.getByLabelText("Persona source"), "Donor funds local education");
+    await user.type(screen.getByLabelText("Donor preferences"), "Donor funds local education");
     await user.click(screen.getByRole("button", { name: /^refine$/i }));
     // The suggestion replaced the field text…
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
 
     await user.click(screen.getByRole("button", { name: /^reject$/i }));
 
     // …and Reject puts the original text back.
     expect(acceptButton()).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Persona source")).toHaveValue("Donor funds local education");
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue("Donor funds local education");
     const chips = JSON.parse(screen.getByTestId("chips-json").textContent ?? "{}");
     expect(chips.orgMaturity.value).toBeNull();
     // Back to the input state: Refine returns, ready to try again.
@@ -277,10 +279,10 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
     );
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    await user.type(screen.getByLabelText("Persona source"), "Donor funds local education");
+    await user.type(screen.getByLabelText("Donor preferences"), "Donor funds local education");
     await user.click(screen.getByRole("button", { name: /^refine$/i }));
     // The suggestion is editable in place — tweak it before accepting.
-    await user.type(screen.getByLabelText("Persona source"), " Prefers spring grants.");
+    await user.type(screen.getByLabelText("Donor preferences"), " Prefers spring grants.");
     await user.click(screen.getByRole("button", { name: /^accept$/i }));
     await user.click(saveButton());
 
@@ -300,7 +302,7 @@ describe("PersonaEditor refine → accept → save round-trip", () => {
     );
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
-    await user.type(screen.getByLabelText("Persona source"), "Raw notes, never refined");
+    await user.type(screen.getByLabelText("Donor preferences"), "Raw notes, never refined");
     await user.click(saveButton());
 
     const input = updateMutate.mock.calls[0][0] as {
@@ -322,7 +324,7 @@ describe("PersonaEditor save omits unset chips (S-001 regression)", () => {
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
     // Typing source makes the editor dirty without touching any chip.
-    await user.type(screen.getByLabelText("Persona source"), "Donor notes with no chips set");
+    await user.type(screen.getByLabelText("Donor preferences"), "Donor notes with no chips set");
     await user.click(saveButton());
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
@@ -354,7 +356,7 @@ describe("PersonaEditor error & empty-refine feedback (S-003)", () => {
   it("renders an error state with Retry when the persona fetch fails (e.g. 429)", () => {
     setup({ isError: true });
     renderWithProviders(<PersonaEditor handleId="h1" />);
-    expect(screen.getByText("Couldn't load the persona.")).toBeInTheDocument();
+    expect(screen.getByText("Couldn't load the profile.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
@@ -376,7 +378,7 @@ describe("PersonaEditor error & empty-refine feedback (S-003)", () => {
     renderWithProviders(<PersonaEditor handleId="h1" />);
 
     // The existing persona shows in the field before refine.
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
 
     await user.click(screen.getByRole("button", { name: /^refine$/i }));
 
@@ -385,10 +387,10 @@ describe("PersonaEditor error & empty-refine feedback (S-003)", () => {
     expect(screen.getByText(/add more detail and try again/i)).toBeInTheDocument();
     // The empty result must NOT open a review card or touch the field.
     expect(acceptButton()).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Persona source")).toHaveValue(NARRATIVE);
+    expect(screen.getByLabelText("Donor preferences")).toHaveValue(NARRATIVE);
 
     // Typing clears the notice.
-    await user.type(screen.getByLabelText("Persona source"), " more detail");
+    await user.type(screen.getByLabelText("Donor preferences"), " more detail");
     expect(screen.queryByText(/add more detail and try again/i)).not.toBeInTheDocument();
   });
 
@@ -407,7 +409,7 @@ describe("PersonaEditor error & empty-refine feedback (S-003)", () => {
     await user.click(screen.getByText("edit-chip")); // dirty → enable Save
     await user.click(saveButton());
 
-    expect(toast.error).toHaveBeenCalledWith("Couldn't save the persona. Try again.");
+    expect(toast.error).toHaveBeenCalledWith("Couldn't save the profile. Try again.");
     expect(toast.error).not.toHaveBeenCalledWith(expect.stringMatching(/allowed values/i));
   });
 });

--- a/__tests__/features/donor-research/personas/PersonaDetailView.test.tsx
+++ b/__tests__/features/donor-research/personas/PersonaDetailView.test.tsx
@@ -108,7 +108,7 @@ describe("PersonaDetailView", () => {
     // The persona editor is dynamic()-imported (ssr:false) — its stub resolves
     // asynchronously, after the wrapper's own loading fallback paints once.
     expect(await screen.findByTestId("persona-editor")).toHaveTextContent("persona editor for h1");
-    expect(screen.getByLabelText("Private handle notes")).toHaveValue("Met at gala");
+    expect(screen.getByLabelText("Donor description")).toHaveValue("Met at gala");
     expect(container.querySelector("[data-persona-detail-columns]")).toHaveClass(
       "lg:[grid-template-columns:minmax(0,3fr)_minmax(18rem,2fr)]"
     );
@@ -133,7 +133,7 @@ describe("PersonaDetailView", () => {
   it("Reports card: shows an empty state with a New report link when there are none", () => {
     renderWithProviders(<PersonaDetailView handleId="h1" />);
 
-    expect(screen.getByText("No reports for this persona yet")).toBeInTheDocument();
+    expect(screen.getByText("No reports for this donor yet")).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /new report/i })[0]).toHaveAttribute(
       "href",
       "/nonprofit-research/new?handle=h1"
@@ -208,7 +208,7 @@ describe("PersonaDetailView", () => {
     try {
       // Edit ONLY the notes field (the persona editor stays clean) — an unsaved
       // note must still block navigation.
-      const notes = await screen.findByLabelText("Private handle notes");
+      const notes = await screen.findByLabelText("Donor description");
       await user.type(notes, " and follow up in Q3");
       await user.click(shellLink);
 
@@ -224,7 +224,7 @@ describe("PersonaDetailView", () => {
     renderWithProviders(<PersonaDetailView handleId="h1" />);
 
     await user.click(await screen.findByRole("button", { name: /simulate unsaved edit/i }));
-    await user.click(screen.getByRole("link", { name: /new report for this persona/i }));
+    await user.click(screen.getByRole("link", { name: /new report for this donor/i }));
     await user.click(await screen.findByRole("button", { name: /^discard$/i }));
 
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/nonprofit-research/new?handle=h1"));
@@ -235,7 +235,7 @@ describe("PersonaDetailView", () => {
     renderWithProviders(<PersonaDetailView handleId="h1" />);
 
     await user.click(await screen.findByRole("button", { name: /simulate unsaved edit/i }));
-    await user.click(screen.getByRole("link", { name: /new report for this persona/i }));
+    await user.click(screen.getByRole("link", { name: /new report for this donor/i }));
 
     expect(await screen.findByText("Discard unsaved changes?")).toBeInTheDocument();
   });
@@ -331,7 +331,7 @@ describe("PersonaDetailView", () => {
     expect(addSpy).toHaveBeenCalledWith("beforeunload", expect.any(Function));
 
     // Discarding clears the dirty flag, which tears the listener back down.
-    await user.click(screen.getByRole("link", { name: /new report for this persona/i }));
+    await user.click(screen.getByRole("link", { name: /new report for this donor/i }));
     await user.click(await screen.findByRole("button", { name: /^discard$/i }));
     await waitFor(() =>
       expect(removeSpy).toHaveBeenCalledWith("beforeunload", expect.any(Function))

--- a/__tests__/features/donor-research/personas/PersonasListView.test.tsx
+++ b/__tests__/features/donor-research/personas/PersonasListView.test.tsx
@@ -2,7 +2,7 @@
  * Personas list (redesign P2, spec 2.3 "Personas list"). Verifies the three
  * states, the per-row persona chip driven by `useDonorPersona`, the
  * per-row "New report" link (`/new?handle=<id>` preselect), and the
- * header "New persona" quick-create flow.
+ * header "New donor" quick-create flow.
  */
 
 import { fireEvent, screen } from "@testing-library/react";
@@ -108,11 +108,9 @@ describe("PersonasListView", () => {
     );
     renderWithProviders(<PersonasListView />);
 
-    expect(screen.getByText("No personas yet")).toBeInTheDocument();
-    // Two "New persona" triggers exist (header + empty-state CTA).
-    expect(screen.getAllByRole("button", { name: /new persona/i }).length).toBeGreaterThanOrEqual(
-      2
-    );
+    expect(screen.getByText("No donors yet")).toBeInTheDocument();
+    // Two "New donor" triggers exist (header + empty-state CTA).
+    expect(screen.getAllByRole("button", { name: /new donor/i }).length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders persona rows with the profile chip, notes preview, and a per-row New report link", () => {
@@ -163,8 +161,8 @@ describe("PersonasListView", () => {
 
     renderWithProviders(<PersonasListView />);
 
-    await user.click(screen.getAllByRole("button", { name: /new persona/i })[0]);
-    await user.type(screen.getByLabelText("New persona name"), "New Fund");
+    await user.click(screen.getAllByRole("button", { name: /new donor/i })[0]);
+    await user.type(screen.getByLabelText("New donor name"), "New Fund");
     expect(screen.getByRole("button", { name: /continue to profile/i })).toBeVisible();
     await user.click(screen.getByRole("button", { name: /save without profile/i }));
 

--- a/app/nonprofit-research/layout.tsx
+++ b/app/nonprofit-research/layout.tsx
@@ -129,7 +129,7 @@ function DonorResearchSessionBoundary({
       <AccessDenied
         compactTitle
         title="Sign in to access nonprofit research"
-        message="Sign in to create research reports, build donor personas, and return to your saved work."
+        message="Sign in to create research reports, build donor profiles, and return to your saved work."
       />
     );
   }

--- a/app/nonprofit-research/new/page.tsx
+++ b/app/nonprofit-research/new/page.tsx
@@ -8,7 +8,7 @@ interface PageProps {
 
 export const metadata: Metadata = customMetadata({
   title: "Nonprofit Research — New Report",
-  description: "Start a new ranked nonprofit research report for a donor persona.",
+  description: "Start a new ranked nonprofit research report for a donor.",
   path: "/nonprofit-research/new",
   robots: { index: false, follow: false },
 });

--- a/app/nonprofit-research/page.tsx
+++ b/app/nonprofit-research/page.tsx
@@ -5,7 +5,7 @@ import { customMetadata } from "@/utilities/meta";
 export const metadata: Metadata = customMetadata({
   title: "Nonprofit Research",
   description:
-    "Research current, ranked nonprofit recommendations for donor personas with compliance verification and live activity signals.",
+    "Research current, ranked nonprofit recommendations for donors with compliance verification and live activity signals.",
   path: "/nonprofit-research",
   robots: { index: false, follow: true },
 });

--- a/app/nonprofit-research/personas/[handleId]/loading.tsx
+++ b/app/nonprofit-research/personas/[handleId]/loading.tsx
@@ -1,5 +1,5 @@
 import { DonorResearchLoading } from "@/src/features/donor-research/components/common/DonorResearchLoading";
 
 export default function Loading() {
-  return <DonorResearchLoading label="Loading persona…" variant="report" />;
+  return <DonorResearchLoading label="Loading donor…" variant="report" />;
 }

--- a/app/nonprofit-research/personas/[handleId]/page.tsx
+++ b/app/nonprofit-research/personas/[handleId]/page.tsx
@@ -10,8 +10,8 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { handleId } = await params;
   return customMetadata({
-    title: "Nonprofit Research — Persona",
-    description: "Research profile, private notes, and reports for a donor persona.",
+    title: "Nonprofit Research — Donor",
+    description: "Research profile, description, and reports for a donor.",
     path: PAGES.DONOR_RESEARCH.PERSONA(handleId),
     robots: { index: false, follow: false },
   });

--- a/app/nonprofit-research/personas/loading.tsx
+++ b/app/nonprofit-research/personas/loading.tsx
@@ -1,5 +1,5 @@
 import { DonorResearchLoading } from "@/src/features/donor-research/components/common/DonorResearchLoading";
 
 export default function Loading() {
-  return <DonorResearchLoading label="Loading your personas…" variant="list" />;
+  return <DonorResearchLoading label="Loading your donors…" variant="list" />;
 }

--- a/app/nonprofit-research/personas/page.tsx
+++ b/app/nonprofit-research/personas/page.tsx
@@ -4,8 +4,8 @@ import { customMetadata } from "@/utilities/meta";
 import { PAGES } from "@/utilities/pages";
 
 export const metadata: Metadata = customMetadata({
-  title: "Nonprofit Research — Personas",
-  description: "Manage the anonymous donor personas you research on behalf of.",
+  title: "Nonprofit Research — Donors",
+  description: "Manage the anonymous donors you research on behalf of.",
   path: PAGES.DONOR_RESEARCH.PERSONAS,
   robots: { index: false, follow: false },
 });

--- a/components/Manage/ManageLayoutShell.tsx
+++ b/components/Manage/ManageLayoutShell.tsx
@@ -89,7 +89,9 @@ export function ManageLayoutShell({ children }: { children: React.ReactNode }) {
   const slug = community.details?.slug || communityId;
 
   return (
-    <SidebarProvider>
+    // `relative` anchors the rail's absolute positioning (see
+    // SIDEBAR_BELOW_NAVBAR_CLASSES) so the body-level footer stays clear.
+    <SidebarProvider className="relative">
       <ManageSidebar communityId={communityId} community={community} />
       <SidebarInset>
         <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">

--- a/components/Manage/ManageSidebar.tsx
+++ b/components/Manage/ManageSidebar.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -349,7 +350,7 @@ export function ManageSidebar({ communityId, community }: ManageSidebarProps) {
   const isDashboard = isDashboardRoute(pathname, slug);
 
   return (
-    <Sidebar collapsible="icon" style={{ top: "var(--navbar-height)", bottom: 0, height: "auto" }}>
+    <Sidebar collapsible="icon" className={SIDEBAR_BELOW_NAVBAR_CLASSES}>
       {/* Community identity + switcher */}
       <SidebarHeader className="pt-3">
         <CommunitySwitcher

--- a/components/Manage/ManageSidebar.tsx
+++ b/components/Manage/ManageSidebar.tsx
@@ -31,7 +31,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -45,6 +44,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@/components/ui/sidebar";
+import { SIDEBAR_BELOW_NAVBAR_CLASSES } from "@/components/ui/sidebar-below-navbar";
 import { useDashboardAdmin } from "@/hooks/useDashboardAdmin";
 import { useFundingPrograms } from "@/hooks/useFundingPlatform";
 import { Link } from "@/src/components/navigation/Link";

--- a/components/ui/sidebar-below-navbar.ts
+++ b/components/ui/sidebar-below-navbar.ts
@@ -1,0 +1,16 @@
+import { cn } from "@/utilities/tailwind";
+
+/**
+ * Sidebar `className` for app shells that sit below the global navbar AND have
+ * a body-level footer after the shell. The default rail is `position: fixed`
+ * to the viewport, so it would paint over that footer once scrolled into view.
+ * These overrides scope the rail to the shell instead (`absolute` in a
+ * `relative` SidebarProvider — the provider MUST get a `relative` class), and
+ * make the inner column sticky so the nav stays in view while scrolling.
+ * Mobile (the Sheet drawer) only gets the below-navbar offset.
+ */
+export const SIDEBAR_BELOW_NAVBAR_CLASSES = cn(
+  "!bottom-0 !h-auto !top-[var(--navbar-height,64px)]",
+  "md:!absolute md:!top-0",
+  "md:[&>[data-sidebar=sidebar]]:sticky md:[&>[data-sidebar=sidebar]]:top-[var(--navbar-height,64px)] md:[&>[data-sidebar=sidebar]]:!h-[calc(100svh-var(--navbar-height,64px))]"
+);

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -733,7 +733,23 @@ const SidebarMenuSubButton = React.forwardRef<
 });
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
 
+/**
+ * Sidebar `className` for app shells that sit below the global navbar AND have
+ * a body-level footer after the shell. The default rail is `position: fixed`
+ * to the viewport, so it would paint over that footer once scrolled into view.
+ * These overrides scope the rail to the shell instead (`absolute` in a
+ * `relative` SidebarProvider — the provider MUST get a `relative` class), and
+ * make the inner column sticky so the nav stays in view while scrolling.
+ * Mobile (the Sheet drawer) only gets the below-navbar offset.
+ */
+const SIDEBAR_BELOW_NAVBAR_CLASSES = cn(
+  "!bottom-0 !h-auto !top-[var(--navbar-height,64px)]",
+  "md:!absolute md:!top-0",
+  "md:[&>[data-sidebar=sidebar]]:sticky md:[&>[data-sidebar=sidebar]]:top-[var(--navbar-height,64px)] md:[&>[data-sidebar=sidebar]]:!h-[calc(100svh-var(--navbar-height,64px))]"
+);
+
 export {
+  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -733,23 +733,7 @@ const SidebarMenuSubButton = React.forwardRef<
 });
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
 
-/**
- * Sidebar `className` for app shells that sit below the global navbar AND have
- * a body-level footer after the shell. The default rail is `position: fixed`
- * to the viewport, so it would paint over that footer once scrolled into view.
- * These overrides scope the rail to the shell instead (`absolute` in a
- * `relative` SidebarProvider — the provider MUST get a `relative` class), and
- * make the inner column sticky so the nav stays in view while scrolling.
- * Mobile (the Sheet drawer) only gets the below-navbar offset.
- */
-const SIDEBAR_BELOW_NAVBAR_CLASSES = cn(
-  "!bottom-0 !h-auto !top-[var(--navbar-height,64px)]",
-  "md:!absolute md:!top-0",
-  "md:[&>[data-sidebar=sidebar]]:sticky md:[&>[data-sidebar=sidebar]]:top-[var(--navbar-height,64px)] md:[&>[data-sidebar=sidebar]]:!h-[calc(100svh-var(--navbar-height,64px))]"
-);
-
 export {
-  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,

--- a/src/components/footer/footer-switcher.tsx
+++ b/src/components/footer/footer-switcher.tsx
@@ -1,45 +1,9 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { isDonorResearchTokenRoute, NON_PROFITS_PAGES, PAGES } from "@/utilities/pages";
+import { isDonorResearchTokenRoute, NON_PROFITS_PAGES } from "@/utilities/pages";
 import { Footer } from "./footer";
 import { WhitelabelFooter } from "./whitelabel-footer";
-
-/** Routes that use the in-app sidebar layout — suppress the marketing footer.
- * Matches /community/<slug>/manage and /community/<slug>/manage/... */
-const MANAGE_ROUTE_RE = /^\/community\/[^/]+\/manage(\/|$)/;
-
-function isAppRoute(pathname: string): boolean {
-  return MANAGE_ROUTE_RE.test(pathname);
-}
-
-function MinimalFooter() {
-  return (
-    <footer className="border-t border-border bg-background">
-      <div className="flex items-center justify-between px-6 py-3 text-xs text-muted-foreground max-w-[1920px] mx-auto">
-        <span>© {new Date().getFullYear()} Karma. All rights reserved.</span>
-        <div className="flex items-center gap-4">
-          <a
-            href={PAGES.TERMS_AND_CONDITIONS}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
-          >
-            Terms
-          </a>
-          <a
-            href={PAGES.PRIVACY_POLICY}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
-          >
-            Privacy
-          </a>
-        </div>
-      </div>
-    </footer>
-  );
-}
 
 export function FooterSwitcher({ isWhitelabel }: { isWhitelabel: boolean }) {
   const pathname = usePathname();
@@ -48,6 +12,8 @@ export function FooterSwitcher({ isWhitelabel }: { isWhitelabel: boolean }) {
   if (pathname.startsWith(NON_PROFITS_PAGES.HOME)) return null;
   // Anonymous donor-research token pages carry their own slim chrome.
   if (isDonorResearchTokenRoute(pathname)) return null;
-  if (isAppRoute(pathname)) return <MinimalFooter />;
+  // In-app sidebar layouts (community manage, nonprofit research) also get the
+  // platform footer: their rails are shell-scoped (SIDEBAR_BELOW_NAVBAR_CLASSES),
+  // not viewport-fixed, so the footer renders full-width below them.
   return <Footer />;
 }

--- a/src/features/donor-research/components/common/DonorResearchHome.tsx
+++ b/src/features/donor-research/components/common/DonorResearchHome.tsx
@@ -92,7 +92,7 @@ function ReportsStats() {
     (r) => r.status === "complete" || r.status === "fast_complete"
   ).length;
   const shared = reports.filter((r) => r.hasShareToken).length;
-  // Handles ("Personas" in the UI) degrade to "—" rather than blocking the
+  // Handles ("Donors" in the UI) degrade to "—" rather than blocking the
   // whole stat strip — the same graceful-degrade posture as RateLimitCounter.
   const personas = handlesQuery.isSuccess ? (handlesQuery.data?.items.length ?? 0) : null;
 
@@ -121,7 +121,7 @@ function ReportsStats() {
       iconClassName: "bg-violet-50 text-violet-600 dark:bg-violet-500/[.14] dark:text-violet-300",
     },
     {
-      label: "Personas",
+      label: "Donors",
       value: personas ?? "—",
       icon: <Users className="h-5 w-5" />,
       iconClassName: "bg-brand-50 text-brand-700 dark:bg-brand-500/[.14] dark:text-brand-300",

--- a/src/features/donor-research/components/common/DonorResearchShell.tsx
+++ b/src/features/donor-research/components/common/DonorResearchShell.tsx
@@ -17,7 +17,6 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import {
-  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -33,6 +32,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { SIDEBAR_BELOW_NAVBAR_CLASSES } from "@/components/ui/sidebar-below-navbar";
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorHandle } from "@/hooks/useDonorHandles";
 import { Link } from "@/src/components/navigation/Link";

--- a/src/features/donor-research/components/common/DonorResearchShell.tsx
+++ b/src/features/donor-research/components/common/DonorResearchShell.tsx
@@ -17,6 +17,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import {
+  SIDEBAR_BELOW_NAVBAR_CLASSES,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -50,7 +51,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { href: PAGES.DONOR_RESEARCH.NEW, label: "New report", icon: Plus },
   { href: PAGES.DONOR_RESEARCH.INDEX, label: "Reports", icon: FileText },
-  { href: PAGES.DONOR_RESEARCH.PERSONAS, label: "Personas", icon: UsersRound },
+  { href: PAGES.DONOR_RESEARCH.PERSONAS, label: "Donors", icon: UsersRound },
   {
     href: PAGES.DONOR_RESEARCH.DILIGENCE_TEMPLATE,
     label: "Diligence questions",
@@ -111,7 +112,7 @@ function DonorResearchSidebar({
   pathname: string;
 }) {
   return (
-    <Sidebar collapsible="icon" style={{ top: "var(--navbar-height)", bottom: 0, height: "auto" }}>
+    <Sidebar collapsible="icon" className={SIDEBAR_BELOW_NAVBAR_CLASSES}>
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel>Research</SidebarGroupLabel>
@@ -183,9 +184,9 @@ function DonorResearchBreadcrumbs({ pathname }: { pathname: string }) {
   let detailLabel: ReactNode = null;
   if (personaId) {
     if (personaQuery.isLoading) {
-      detailLabel = <output aria-label="Loading persona" className={cn(SK, "h-4 w-10 rounded")} />;
+      detailLabel = <output aria-label="Loading donor" className={cn(SK, "h-4 w-10 rounded")} />;
     } else if (personaQuery.isError || !personaQuery.data) {
-      detailLabel = "Persona";
+      detailLabel = "Donor";
     } else {
       detailLabel = personaQuery.data.opaqueLabel;
     }
@@ -248,7 +249,7 @@ function DonorResearchAppShell({
   pathname: string;
 }) {
   return (
-    <SidebarProvider className="dashv3 min-h-[calc(100vh-var(--navbar-height,64px))] bg-sf-panel">
+    <SidebarProvider className="dashv3 relative min-h-[calc(100vh-var(--navbar-height,64px))] bg-sf-panel">
       <DonorResearchSidebar advisor={advisor} pathname={pathname} />
       <SidebarInset className="bg-sf-panel">
         <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background px-4">

--- a/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
+++ b/src/features/donor-research/components/criteria-input/CriteriaForm.test.tsx
@@ -68,7 +68,7 @@ function Harness({
 // `handleSubmit` runs its `onInvalid` branch (the toast under test). Mirrors the
 // real panel's required-criteria rule without importing the full schema.
 const ValidatedSchema = z.object({
-  donorHandleId: z.string().min(1, "Pick or create a persona"),
+  donorHandleId: z.string().min(1, "Pick or create a donor"),
   criteriaText: z.string().min(1, "Describe what you're researching"),
   cause: z.string().optional(),
   geography: z.string().optional(),
@@ -134,17 +134,17 @@ describe("CriteriaForm weights", () => {
   it("uses the shadcn persona picker and keeps adjacent actions on the same control height", () => {
     render(withQueryClient(<Harness onSubmit={() => {}} />));
 
-    const picker = screen.getByRole("combobox", { name: "Persona" });
+    const picker = screen.getByRole("combobox", { name: "Donor" });
     expect(picker).toHaveClass("h-[42px]");
     expect(picker.tagName).toBe("BUTTON");
-    expect(screen.getByRole("button", { name: /new persona/i })).toHaveClass("h-[42px]");
+    expect(screen.getByRole("button", { name: /new donor/i })).toHaveClass("h-[42px]");
     expect(screen.getByRole("button", { name: /add profile/i })).toHaveClass("h-[42px]");
   });
 
   it("keeps the persona options inside the themed picker row", async () => {
     render(withQueryClient(<Harness onSubmit={() => {}} />));
 
-    const picker = screen.getByRole("combobox", { name: "Persona" });
+    const picker = screen.getByRole("combobox", { name: "Donor" });
     fireEvent.keyDown(picker, { key: "ArrowDown" });
 
     expect(picker.parentElement).toContainElement(await screen.findByRole("listbox"));
@@ -157,7 +157,7 @@ describe("CriteriaForm weights", () => {
     );
 
     const action = screen.getByRole("button", { name: "Change profile for Smith Family" });
-    const newPersona = screen.getByRole("button", { name: /new persona/i });
+    const newPersona = screen.getByRole("button", { name: /new donor/i });
     expect(action).toHaveClass("h-[42px]", "w-[42px]", "px-0");
     expect(action).toHaveTextContent("");
     expect(action.querySelector("svg")).toBeInTheDocument();

--- a/src/features/donor-research/components/criteria-input/CriteriaForm.tsx
+++ b/src/features/donor-research/components/criteria-input/CriteriaForm.tsx
@@ -235,7 +235,7 @@ export function CriteriaForm({
 
   return (
     <form className="flex flex-col gap-5" onSubmit={handleSubmit(onSubmit, onInvalid)}>
-      <FormSection description="Who is this research for?" title="Persona">
+      <FormSection description="Who is this research for?" title="Donor">
         <DonorHandlePicker
           error={errors.donorHandleId?.message}
           handles={handles}

--- a/src/features/donor-research/components/criteria-input/CriteriaInputPanel.tsx
+++ b/src/features/donor-research/components/criteria-input/CriteriaInputPanel.tsx
@@ -53,7 +53,7 @@ function composeCriteriaText(personaCriteriaText?: string, criteriaText?: string
 
 const CriteriaSchema = z
   .object({
-    donorHandleId: z.string().min(1, "Pick or create a persona"),
+    donorHandleId: z.string().min(1, "Pick or create a donor"),
     /** Hidden persona narrative, combined with the report-specific criteria on submit. */
     personaCriteriaText: z.string().max(5000).optional(),
     criteriaText: z.string().max(5000),
@@ -75,7 +75,7 @@ const CriteriaSchema = z
     } else if (combinedCriteria.length > 5000) {
       context.addIssue({
         code: "custom",
-        message: "Persona and additional criteria must be 5,000 characters or fewer",
+        message: "Donor preferences and additional criteria must be 5,000 characters or fewer",
         path: ["criteriaText"],
       });
     }
@@ -117,8 +117,8 @@ function prefilledFieldsOf(prefill: PersonaPrefill | null): Set<PersonaPrefillFi
 
 interface CriteriaInputPanelProps {
   /**
-   * Preselects a donor handle from `/new?handle=<id>` (the Personas-list
-   * "New report for this persona" link, and the report-list empty state).
+   * Preselects a donor handle from `/new?handle=<id>` (the Donors-list
+   * "New report for this donor" link, and the report-list empty state).
    * Read server-side from `searchParams` by the page — never mirrored back
    * to the URL.
    */

--- a/src/features/donor-research/components/criteria-input/DonorHandlePicker.tsx
+++ b/src/features/donor-research/components/criteria-input/DonorHandlePicker.tsx
@@ -21,7 +21,7 @@ interface DonorHandlePickerProps {
   onChange: (handleId: string) => void;
   /**
    * Opens the create flow (the quick-create dialog, owned by the parent).
-   * Both the first-run CTA and the "+ New persona" shortcut delegate here so
+   * Both the first-run CTA and the "+ New donor" shortcut delegate here so
    * creation lives in one place and the new handle can be auto-selected.
    */
   onRequestCreate: () => void;
@@ -39,7 +39,7 @@ interface DonorHandlePickerProps {
  *
  * Three states honored:
  *  - loading: skeleton
- *  - empty: explicit "create your first persona" CTA → opens the dialog
+ *  - empty: explicit "create your first donor" CTA → opens the dialog
  *  - error: surfaced inline via the parent's `error` prop
  */
 export function DonorHandlePicker({
@@ -65,10 +65,10 @@ export function DonorHandlePicker({
       ) : empty ? (
         <div className="rounded-md border border-dashed border-border p-4 text-center">
           <p className="mb-2 text-sm text-muted-foreground">
-            No personas yet. Create one to scope your research.
+            No donors yet. Create one to scope your research.
           </p>
           <Button size="sm" onClick={onRequestCreate} type="button">
-            Create your first persona
+            Create your first donor
           </Button>
         </div>
       ) : (
@@ -97,7 +97,7 @@ interface ExistingHandlesRowProps {
 }
 
 /**
- * The populated-state row: a shadcn/Radix Select, a "+ New persona" shortcut,
+ * The populated-state row: a shadcn/Radix Select, a "+ New donor" shortcut,
  * and (when a handle is selected) an in-place profile action. Every control
  * shares the Soft dashboard's 42px control height.
  */
@@ -111,16 +111,16 @@ function ExistingHandlesRow({
 }: ExistingHandlesRowProps) {
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
   const selectedLabel =
-    handles.find((handle) => handle.id === value)?.opaqueLabel ?? "selected persona";
+    handles.find((handle) => handle.id === value)?.opaqueLabel ?? "selected donor";
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row" ref={setPortalContainer}>
       <Select onValueChange={onChange} value={value}>
         <SelectTrigger
-          aria-label="Persona"
+          aria-label="Donor"
           className="h-[42px] min-w-0 flex-1 rounded-sf-tile border-sf-line-strong bg-sf-elev px-3 text-[13.5px] text-sf-heading shadow-none focus:ring-brand-500/20"
         >
-          <SelectValue placeholder="Select a persona…" />
+          <SelectValue placeholder="Select a donor…" />
         </SelectTrigger>
         <SelectContent
           className="rounded-sf-tile border-sf-line bg-sf-card text-sf-heading shadow-sf-card"
@@ -158,7 +158,7 @@ function ExistingHandlesRow({
         onClick={onCreate}
         type="button"
       >
-        + New persona
+        + New donor
       </button>
     </div>
   );

--- a/src/features/donor-research/components/criteria-input/NewDonorHandleModal.tsx
+++ b/src/features/donor-research/components/criteria-input/NewDonorHandleModal.tsx
@@ -75,19 +75,19 @@ function PersonaNameStep({
       }}
     >
       <DialogHeader>
-        <DialogTitle>New persona</DialogTitle>
+        <DialogTitle>New donor</DialogTitle>
         <DialogDescription>
-          Add an anonymous persona label, then optionally create the profile that will prefill
-          future research.
+          Add an anonymous donor label, then optionally create the profile that will prefill future
+          research.
         </DialogDescription>
       </DialogHeader>
 
       <div className="flex flex-col gap-1.5">
         <label className="text-sm font-medium" htmlFor="new-handle-label">
-          Persona name
+          Donor name
         </label>
         <input
-          aria-label="New persona name"
+          aria-label="New donor name"
           className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm"
           id="new-handle-label"
           maxLength={MAX_LABEL_LENGTH}
@@ -212,8 +212,8 @@ function DiscardPersonaDialog({
         <DialogHeader>
           <DialogTitle>Discard profile changes?</DialogTitle>
           <DialogDescription>
-            Your unsaved changes to {personaName ?? "this persona"} will be lost. You can edit them
-            again from this report or the persona page.
+            Your unsaved changes to {personaName ?? "this donor"} will be lost. You can edit them
+            again from this report or the donor page.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -232,7 +232,7 @@ function DiscardPersonaDialog({
 /**
  * Persona creation and profile authoring in one dialog.
  *
- * Create mode starts with the anonymous persona label, then lets the advisor
+ * Create mode starts with the anonymous donor label, then lets the advisor
  * either finish immediately or continue into the optional profile editor.
  * Edit mode opens the same editor in place, preserving report-form progress.
  */
@@ -291,7 +291,7 @@ export function NewDonorHandleModal({
       }
     } catch (error) {
       setCreateError(
-        error instanceof Error ? error.message : "Couldn't create the persona. Try again."
+        error instanceof Error ? error.message : "Couldn't create the donor. Try again."
       );
     }
   };

--- a/src/features/donor-research/components/criteria-input/PrefilledFromPersonaBadge.tsx
+++ b/src/features/donor-research/components/criteria-input/PrefilledFromPersonaBadge.tsx
@@ -30,7 +30,7 @@ export function PrefilledFromPersonaBadge({ control, name }: PrefilledFromPerson
 
   return (
     <span className="inline-flex items-center rounded-full border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-      Prefilled from persona
+      Prefilled from donor profile
     </span>
   );
 }

--- a/src/features/donor-research/components/donor-detail/HandleNotesSection.tsx
+++ b/src/features/donor-research/components/donor-detail/HandleNotesSection.tsx
@@ -37,16 +37,18 @@ export function HandleNotesSection({ handle, onDirtyChange }: HandleNotesSection
     update.mutate(
       { notes: notes.length ? notes : null },
       {
-        onSuccess: () => toast.success("Notes saved"),
+        onSuccess: () => toast.success("Description saved"),
         onError: (err) =>
-          toast.error(err instanceof Error ? err.message : "Couldn't save notes. Try again."),
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't save the description. Try again."
+          ),
       }
     );
   };
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-base font-semibold">Notes: private, not used by research</h2>
+      <h2 className="text-base font-semibold">Description</h2>
       <p className="text-xs text-muted-foreground">
         Your own reminders about this donor. Never sent to the research model.
       </p>
@@ -54,7 +56,7 @@ export function HandleNotesSection({ handle, onDirtyChange }: HandleNotesSection
         value={notes}
         onChange={(e) => setNotes(e.target.value)}
         rows={4}
-        aria-label="Private handle notes"
+        aria-label="Donor description"
         placeholder="e.g. Prefers email; introduced by the board chair."
         className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm"
       />
@@ -66,7 +68,7 @@ export function HandleNotesSection({ handle, onDirtyChange }: HandleNotesSection
         disabled={!isDirty || update.isPending}
         className="self-start"
       >
-        {update.isPending ? "Saving…" : "Save notes"}
+        {update.isPending ? "Saving…" : "Save description"}
       </Button>
     </section>
   );

--- a/src/features/donor-research/components/donor-detail/PersonaEditor.tsx
+++ b/src/features/donor-research/components/donor-detail/PersonaEditor.tsx
@@ -190,9 +190,9 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
         // effect from clobbering the in-field suggestion on a background
         // refetch, and arms the host's discard guard against dismissal.
         setIsDirty(true);
-        setAnnouncement("Recommended persona written to the input — accept or reject below");
+        setAnnouncement("Recommended profile written to the input — accept or reject below");
       },
-      onError: (err) => toastError(err, "Couldn't refine the persona. Try again."),
+      onError: (err) => toastError(err, "Couldn't refine the profile. Try again."),
     });
   };
 
@@ -209,7 +209,7 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
     setGeography(recommendation.geography ?? null);
     setRecommendation(null);
     setIsDirty(true);
-    setAnnouncement("Recommended persona accepted");
+    setAnnouncement("Recommended profile accepted");
   };
 
   const onRejectRecommendation = () => {
@@ -263,12 +263,12 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
       onSuccess: (saved) => {
         hydrate(saved);
         setIsDirty(false);
-        toast.success("Persona saved");
+        toast.success("Profile saved");
         onSaved?.();
       },
       // Rollback is handled by the mutation hook; isDirty stays true so the
       // Save button remains an actionable retry.
-      onError: (err) => toastError(err, "Couldn't save the persona. Try again."),
+      onError: (err) => toastError(err, "Couldn't save the profile. Try again."),
     });
   };
 
@@ -285,7 +285,7 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
   if (personaQuery.isError) {
     return (
       <div className="rounded-md border border-border p-4 text-sm">
-        <p className="mb-2 text-red-600 dark:text-red-400">Couldn't load the persona.</p>
+        <p className="mb-2 text-red-600 dark:text-red-400">Couldn't load the profile.</p>
         <Button type="button" variant="outline" size="sm" onClick={() => personaQuery.refetch()}>
           Retry
         </Button>
@@ -300,11 +300,11 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
       {/* Persona text — the one input. Locked while a recommendation awaits a decision. */}
       <div className="flex flex-col gap-1.5">
         <label htmlFor="persona-source" className="text-sm font-medium">
-          Persona source
+          Donor preferences
         </label>
         <p className="text-xs text-muted-foreground">
           Paste donor letters, kickoff notes, anything that describes this donor, then click Refine
-          to get a recommended persona.
+          to get a recommended profile.
         </p>
         <div className="relative">
           <textarea
@@ -332,7 +332,7 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
             <div className="absolute inset-x-px bottom-px flex flex-wrap items-center justify-between gap-2 rounded-b-md bg-background/90 px-3 py-2">
               <span className="text-xs font-medium text-primary">
                 {recommendation.narrative
-                  ? "Recommended persona"
+                  ? "Recommended profile"
                   : "No narrative was generated, but donor details were extracted"}
               </span>
               <div className="flex gap-2">
@@ -403,7 +403,7 @@ export function PersonaEditor({ handleId, onDirtyChange, onSkip, onSaved }: Pers
           disabled={!isDirty || isReviewing || update.isPending}
           className="order-1 w-full sm:order-2 sm:w-auto"
         >
-          {update.isPending ? "Saving persona…" : "Save persona"}
+          {update.isPending ? "Saving profile…" : "Save profile"}
         </Button>
       </div>
     </div>

--- a/src/features/donor-research/components/personas/PersonaDetailView.tsx
+++ b/src/features/donor-research/components/personas/PersonaDetailView.tsx
@@ -44,22 +44,17 @@ const PersonaEditor = dynamic(
 
 function DetailCard({
   title,
-  description,
   action,
   children,
 }: {
   title: string;
-  description?: string;
   action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
     <section className="flex flex-col gap-4 rounded-sf-card border border-sf-line bg-sf-card p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-col gap-[3px]">
-          <h2 className="m-0 text-[15px] font-[650] tracking-[-0.01em] text-sf-heading">{title}</h2>
-          {description ? <p className="m-0 text-[13px] text-sf-muted">{description}</p> : null}
-        </div>
+        <h2 className="m-0 text-[15px] font-[650] tracking-[-0.01em] text-sf-heading">{title}</h2>
         {action ?? null}
       </div>
       {children}
@@ -123,9 +118,7 @@ function ReportsCard({ handleId, onGuardedPush }: ReportsCardProps) {
   } else if (reportsQuery.isError) {
     body = (
       <ErrorState
-        message={
-          (reportsQuery.error as Error)?.message || "Couldn't load reports for this persona."
-        }
+        message={(reportsQuery.error as Error)?.message || "Couldn't load reports for this donor."}
         onRetry={() => reportsQuery.refetch()}
       />
     );
@@ -134,14 +127,14 @@ function ReportsCard({ handleId, onGuardedPush }: ReportsCardProps) {
     if (reports.length === 0) {
       body = (
         <EmptyState
-          body="Start a research report scoped to this persona."
+          body="Start a research report scoped to this donor."
           icon="compass"
           primary={{
             label: "New report",
             icon: "plus",
             onClick: () => onGuardedPush(newReportHref),
           }}
-          title="No reports for this persona yet"
+          title="No reports for this donor yet"
         />
       );
     } else {
@@ -174,7 +167,7 @@ function ReportsCard({ handleId, onGuardedPush }: ReportsCardProps) {
           className="text-[12.5px] font-medium text-sf-heading underline underline-offset-2 hover:no-underline"
           href={newReportHref}
         >
-          New report for this persona
+          New report for this donor
         </Link>
       }
       title="Reports"
@@ -353,19 +346,18 @@ export function PersonaDetailView({ handleId }: PersonaDetailViewProps) {
         <h1 className="text-2xl font-semibold tracking-[-0.02em] text-sf-heading">
           {handle.opaqueLabel}
         </h1>
-        <p className="mt-1 text-[13.5px] text-sf-muted">Persona profile</p>
+        <p className="mt-1 text-[13.5px] text-sf-muted">Donor profile</p>
       </div>
 
       <div
         className="grid gap-6 lg:[grid-template-columns:minmax(0,3fr)_minmax(18rem,2fr)]"
         data-persona-detail-columns
       >
-        <DetailCard
-          description="Refine writes a recommended persona into the field below — accept or reject it, then save."
-          title="Research profile"
-        >
+        {/* No card header here (design request) — the editor's own "Donor
+            preferences" label leads the card. */}
+        <section className="rounded-sf-card border border-sf-line bg-sf-card p-6">
           <PersonaEditor handleId={handleId} onDirtyChange={onPersonaDirtyChange} />
-        </DetailCard>
+        </section>
 
         <div className="flex flex-col gap-6">
           {/* HandleNotesSection renders its own heading — no DetailCard title

--- a/src/features/donor-research/components/personas/PersonasListView.tsx
+++ b/src/features/donor-research/components/personas/PersonasListView.tsx
@@ -19,7 +19,7 @@ import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { NewDonorHandleModal } from "../criteria-input/NewDonorHandleModal";
 
-/** Header "New persona" trigger — opens the quick-create dialog. */
+/** Header "New donor" trigger — opens the quick-create dialog. */
 function NewPersonaButton({ onClick, className }: { onClick: () => void; className?: string }) {
   return (
     <button
@@ -28,7 +28,7 @@ function NewPersonaButton({ onClick, className }: { onClick: () => void; classNa
       type="button"
     >
       <SoftIcon className="h-4 w-4" name="plus" />
-      New persona
+      New donor
     </button>
   );
 }
@@ -132,9 +132,7 @@ function PersonaListBody({ handlesQuery, onRequestCreate }: PersonaListBodyProps
   if (handlesQuery.isError) {
     return (
       <ErrorState
-        message={
-          (handlesQuery.error as Error)?.message || "Couldn't load your personas. Try again."
-        }
+        message={(handlesQuery.error as Error)?.message || "Couldn't load your donors. Try again."}
         onRetry={() => handlesQuery.refetch()}
       />
     );
@@ -145,9 +143,9 @@ function PersonaListBody({ handlesQuery, onRequestCreate }: PersonaListBodyProps
     return (
       <EmptyState
         action={<NewPersonaButton onClick={onRequestCreate} />}
-        body="Create a persona to research on a donor's behalf. Each persona can hold a profile, private notes, and its own reports."
+        body="Create a donor to research on their behalf. Each donor can hold a profile, a description, and their own reports."
         icon="users"
-        title="No personas yet"
+        title="No donors yet"
       />
     );
   }
@@ -174,9 +172,9 @@ export function PersonasListView() {
     <div className="flex flex-col gap-6">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="max-w-xl">
-          <h1 className="text-2xl font-semibold tracking-[-0.02em] text-sf-heading">Personas</h1>
+          <h1 className="text-2xl font-semibold tracking-[-0.02em] text-sf-heading">Donors</h1>
           <p className="mt-1 text-[13.5px] text-sf-muted">
-            Anonymous profiles for the donors you advise. Each one can hold private notes and its
+            Anonymous profiles for the donors you advise. Each one can hold a description and its
             own research reports.
           </p>
         </div>

--- a/src/features/donor-research/components/report-list/ReportListPanel.tsx
+++ b/src/features/donor-research/components/report-list/ReportListPanel.tsx
@@ -219,10 +219,10 @@ function DonorFilterSelect({ handles, value, onChange }: DonorFilterSelectProps)
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
   return (
     <div className="flex items-center gap-2 text-[12px] text-sf-muted" ref={setPortalContainer}>
-      <span className="font-medium uppercase tracking-[0.1em]">Persona</span>
+      <span className="font-medium uppercase tracking-[0.1em]">Donor</span>
       <Select disabled={disabled} onValueChange={onChange} value={value}>
         <SelectTrigger
-          aria-label="Filter reports by persona"
+          aria-label="Filter reports by donor"
           className="h-8 max-w-[14rem] rounded-full border-sf-line-strong bg-sf-card text-[12.5px] text-sf-heading"
         >
           <SelectValue />
@@ -232,7 +232,7 @@ function DonorFilterSelect({ handles, value, onChange }: DonorFilterSelectProps)
           container={portalContainer}
         >
           <SelectItem className="rounded-md text-[13px] focus:bg-sf-elev" value={ALL_DONORS}>
-            All personas
+            All donors
           </SelectItem>
           {handles.map((h) => (
             <SelectItem className="rounded-md text-[13px] focus:bg-sf-elev" key={h.id} value={h.id}>


### PR DESCRIPTION
## Summary

Copy and layout pass on the nonprofit research section, plus a shared sidebar/footer layout fix that also applies to community manage pages.

## Problem

- The research UI called donors "Personas" — indirect and inconsistent ("Persona source", "Persona profile", "New persona").
- The donor detail page had a redundant "Research profile" card header, and the notes card was titled "Notes: private, not used by research".
- The sidebar rail on `/nonprofit-research` and `/community/<slug>/manage` is `position: fixed` to the viewport, so scrolling to the bottom painted the empty rail over the body-level footer (clipped links, stray vertical border). Manage pages also only got a stripped-down `MinimalFooter` instead of the platform footer.

## Solution

- Rename user-facing "Persona" → "Donor" everywhere in the research section (nav, breadcrumbs, headings, dialogs, pickers, toasts, page metadata). Narrative-text actions use "profile" ("Save profile", "Recommended profile"). Routes and code identifiers unchanged.
- Drop the "Research profile" card header; the editor leads with a "Donor preferences" label (was "Persona source").
- Rename the notes card to "Description" (button "Save description", matching toasts and aria-label).
- Add `SIDEBAR_BELOW_NAVBAR_CLASSES` (components/ui/sidebar.tsx): scopes the rail to the shell (`absolute` inside a `relative` SidebarProvider) with a sticky inner column so the nav stays visible while scrolling; mobile sheet only gets the below-navbar offset. Applied to both `DonorResearchShell` and `ManageSidebar`.
- Simplify `FooterSwitcher`: manage routes now render the standard platform footer; `MinimalFooter` and the manage-route matcher are removed.

## Testing Steps

1. `pnpm vitest run __tests__/features/donor-research src/features/donor-research __tests__/components/Footer.test.tsx` — 409 tests pass.
2. Signed in, open `/nonprofit-research`: sidebar reads Donors; donors list/detail use the new copy; scroll to the bottom — the full platform footer spans edge to edge below the rail.
3. Open `/community/filecoin/manage`, scroll to the bottom: same full-width platform footer, rail stops above it, nav column stays pinned while scrolling.
4. Narrow viewport (<768px): sidebar still opens as a drawer below the navbar.

## Risk

Low — copy strings, test updates, and CSS positioning overrides. No data flow, routing, or API changes. Main visual risk is the rail behavior in the two shells, both covered by the manual steps above.