### PR TITLE
chore(sentry): filter browser-extension injected-script noise

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -21,6 +21,15 @@ Sentry.init({
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production",
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   ignoreErrors: sentryIgnoreErrors,
+  // Browser-extension content scripts (wallet extensions and similar) inject
+  // `injectedScript.bundle.js` into every page and throw against it — most
+  // commonly `Cannot read properties of undefined (reading 'sendMessage')`
+  // when their `chrome.runtime` handle is invalidated. We never ship a file by
+  // that name, so drop any event whose crash frame is that injected bundle.
+  // Sibling to the chrome.runtime.sendMessage signature already in
+  // utilities/sentry/ignoreErrors.ts (browserExtensionErrors).
+  // See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-257
+  denyUrls: [/injectedScript\.bundle\.js/],
   integrations: [],
   // Defence in depth for transient Axios "Network Error" events that
   // bubble through code paths bypassing `errorManager` (raw React errors,

--- a/utilities/sentry/__tests__/ignoreErrors.test.ts
+++ b/utilities/sentry/__tests__/ignoreErrors.test.ts
@@ -37,3 +37,18 @@ describe("sentryIgnoreErrors — chunk load errors", () => {
     expect(isIgnored("Cannot read property 'map' of undefined")).toBe(false);
   });
 });
+
+describe("sentryIgnoreErrors — obfuscated injected-script errors", () => {
+  it("ignores Safari's 'Can't find variable: _0x…' ReferenceError", () => {
+    expect(isIgnored("ReferenceError: Can't find variable: _0x4761")).toBe(true);
+  });
+
+  it("ignores V8's '_0x… is not defined' ReferenceError", () => {
+    expect(isIgnored("_0x1ad251 is not defined")).toBe(true);
+  });
+
+  it("does NOT ignore a genuine application ReferenceError", () => {
+    expect(isIgnored("Can't find variable: fetchApplication")).toBe(false);
+    expect(isIgnored("myLocalVar is not defined")).toBe(false);
+  });
+});

--- a/utilities/sentry/ignoreErrors.ts
+++ b/utilities/sentry/ignoreErrors.ts
@@ -107,6 +107,22 @@ const reconciliationDomMutationErrors = [
   /null is not an object \(evaluating '.*\.(parentNode|removeChild)/,
 ];
 
+// Browser extensions and injected third-party scripts ship JavaScript minified
+// with `javascript-obfuscator`, whose identifiers are hex-mangled like `_0x4761`.
+// When such a script (injected via DOM `insertBefore`) references a variable its
+// own obfuscated bundle never defined, Safari throws
+// `ReferenceError: Can't find variable: _0x4761` and V8 throws
+// `_0x4761 is not defined` at global scope (`mechanism: onerror`). The frames are
+// all `webkit-masked-url://hidden/` with obfuscated names — none of it is our
+// code (this repo contains zero `_0x*` identifiers), and an error boundary can't
+// catch a global-scope onerror. Filter the whole class; the hex-identifier shape
+// guarantees we never mask a genuine application ReferenceError.
+// See https://karma-crypto-inc.sentry.io/issues/GAP-FRONTEND-25E
+const obfuscatedInjectedScriptErrors = [
+  /Can't find variable: _0x[0-9a-f]+/i,
+  /_0x[0-9a-f]+ is not defined/i,
+];
+
 export const sentryIgnoreErrors = [
   // user rejected a confirmation in the wallet
   "rejected the request",
@@ -127,4 +143,5 @@ export const sentryIgnoreErrors = [
   ...streamingAbortErrors,
   ...anonymousAuthErrors,
   ...reconciliationDomMutationErrors,
+  ...obfuscatedInjectedScriptErrors,
 ];


### PR DESCRIPTION
## Root cause

Two issues in the frontend Sentry feed are third-party browser-extension noise, not bugs in our code. Both come from scripts an extension injects into the page; neither originates from our bundle.

### GAP-FRONTEND-25E — `ReferenceError: Can't find variable: _0x4761`

`_0x4761` is a `javascript-obfuscator` hex-mangled identifier. The script is injected via a DOM `insertBefore` (a `[native code]` frame in the trace) and the whole stack is `webkit-masked-url://hidden/` frames with obfuscated names, thrown at global scope (`mechanism: onerror`, `handled: no`) so no error boundary can catch it. Grepping the entire repo for `_0x` and for any obfuscation config (`javascript-obfuscator`/`webpack-obfuscator`/`obfuscat`) returns **zero** matches — we do not emit hex-mangled symbols, so this signature cannot come from our bundle. 1 occurrence / 1 user confirms a single client's extension.

### GAP-FRONTEND-257 — `Cannot read properties of undefined (reading 'sendMessage')`

The crash frame is `app:///injectedScript.bundle.js`. `find -name "*.bundle.js"` and `grep injectedScript` over the repo return nothing — we ship no file by that name. It is an extension content script calling `chrome.runtime.sendMessage` on an invalidated `chrome.runtime` handle (extension context invalidated), surfacing as an unhandled promise rejection at global scope on whatever page the user was on. Our only `.sendMessage` in source is a defined function on the agent/widget stream hooks — not this call path. Sibling to the `chrome.runtime.sendMessage() called from a webpage must specify an Extension ID` entry already in `browserExtensionErrors`.

## Fix

Both fixes are inbound Sentry filters, consistent with the repo's existing curated `sentryIgnoreErrors` / `browserExtensionErrors` / `reconciliationDomMutationErrors` lists. No runtime behavior changes.

- **`utilities/sentry/ignoreErrors.ts`**: add an `obfuscatedInjectedScriptErrors` regex group (`/Can't find variable: _0x[0-9a-f]+/i` and `/_0x[0-9a-f]+ is not defined/i`) covering both engine phrasings, spread into `sentryIgnoreErrors`. The required hex `_0x…` token means a genuine application ReferenceError is never masked.
- **`instrumentation-client.ts`**: add `denyUrls: [/injectedScript\.bundle\.js/]`. `denyUrls` matches the crash-site stack frame, dropping only events thrown from the injected extension bundle. Chosen over a `/sendMessage/` message regex because we have a legitimate `sendMessage` hook that such a regex could suppress.

## Test plan

- `pnpm test utilities/sentry/__tests__/ignoreErrors.test.ts` — new cases assert both obfuscated phrasings are ignored and that a genuine app ReferenceError (`fetchApplication`, `myLocalVar is not defined`) is **not** ignored. Green (7 passed).
- `pnpm lint:fix` clean on all three files.
- `pnpm run build` succeeds (Next strict type-check passes).

Fixes GAP-FRONTEND-25E
Fixes GAP-FRONTEND-257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false-positive error reports caused by browser extensions and injected scripts.
  * Improved filtering for obfuscated third-party `ReferenceError` messages while preserving genuine application errors.

* **Tests**
  * Added coverage to verify injected-script errors are ignored and legitimate application errors continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->