### PR TITLE
feat(community): poll indexer before navigating after pending on-chain create

### DIFF
--- a/components/Dialogs/CommunityDialog.tsx
+++ b/components/Dialogs/CommunityDialog.tsx
@@ -15,6 +15,7 @@ import { MESSAGES } from "@/utilities/messages";
 import { gapSupportedNetworks } from "@/utilities/network";
 import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
+import { waitForCommunityIndexed } from "@/utilities/waitForCommunityIndexed";
 import { errorManager } from "../Utilities/errorManager";
 import { MarkdownEditor } from "../Utilities/MarkdownEditor";
 import { Button } from "../ui/button";
@@ -41,22 +42,6 @@ interface CreateCommunityResponse {
 }
 
 const sanitizeSlug = (slug: string) => slug.toLowerCase().replace(/[^a-z0-9-]/g, "-");
-
-export const COMMUNITY_INDEX_POLL_ATTEMPTS = 12;
-export const COMMUNITY_INDEX_POLL_DELAY_MS = 2500;
-
-// After an on-chain community create returns `status: "pending"` (BE PR #2232),
-// the community is attested but not yet indexed. Poll the read endpoint until it
-// appears so we don't navigate to a not-yet-indexed page. Resolves true once found,
-// false if it never appears within the window (caller navigates anyway).
-export const waitForCommunityIndexed = async (idOrSlug: string): Promise<boolean> => {
-  for (let attempt = 0; attempt < COMMUNITY_INDEX_POLL_ATTEMPTS; attempt++) {
-    const [community] = await fetchData(INDEXER.COMMUNITY.V2.GET(idOrSlug), "GET");
-    if (community?.uid) return true;
-    await new Promise((resolve) => setTimeout(resolve, COMMUNITY_INDEX_POLL_DELAY_MS));
-  }
-  return false;
-};
 
 type ProjectDialogProps = {
   buttonElement?: {

--- a/components/Dialogs/CommunityDialog.tsx
+++ b/components/Dialogs/CommunityDialog.tsx
@@ -36,9 +36,27 @@ type SchemaType = z.infer<typeof schema>;
 interface CreateCommunityResponse {
   slug: string;
   uid: string;
+  status?: "pending" | "indexed";
+  message?: string;
 }
 
 const sanitizeSlug = (slug: string) => slug.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+
+export const COMMUNITY_INDEX_POLL_ATTEMPTS = 12;
+export const COMMUNITY_INDEX_POLL_DELAY_MS = 2500;
+
+// After an on-chain community create returns `status: "pending"` (BE PR #2232),
+// the community is attested but not yet indexed. Poll the read endpoint until it
+// appears so we don't navigate to a not-yet-indexed page. Resolves true once found,
+// false if it never appears within the window (caller navigates anyway).
+export const waitForCommunityIndexed = async (idOrSlug: string): Promise<boolean> => {
+  for (let attempt = 0; attempt < COMMUNITY_INDEX_POLL_ATTEMPTS; attempt++) {
+    const [community] = await fetchData(INDEXER.COMMUNITY.V2.GET(idOrSlug), "GET");
+    if (community?.uid) return true;
+    await new Promise((resolve) => setTimeout(resolve, COMMUNITY_INDEX_POLL_DELAY_MS));
+  }
+  return false;
+};
 
 type ProjectDialogProps = {
   buttonElement?: {
@@ -167,12 +185,20 @@ export const CommunityDialog: FC<ProjectDialogProps> = ({
         toast.error("Community created but could not determine its URL. Check your dashboard.");
         return;
       }
-      toast.success("Community created successfully!");
+      const isPending = result?.status === "pending";
+      toast.success(
+        isPending
+          ? "Community created on-chain — finalizing indexing, this can take a moment…"
+          : "Community created successfully!"
+      );
       closeModal();
       try {
         await refreshCommunities();
       } catch {
         // Non-critical — community was already created
+      }
+      if (isPending) {
+        await waitForCommunityIndexed(communitySlug);
       }
       router.push(PAGES.COMMUNITY.ALL_GRANTS(communitySlug));
     } catch (error: unknown) {

--- a/components/Dialogs/__tests__/CommunityDialog.test.tsx
+++ b/components/Dialogs/__tests__/CommunityDialog.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+import {
+  COMMUNITY_INDEX_POLL_ATTEMPTS,
+  COMMUNITY_INDEX_POLL_DELAY_MS,
+  waitForCommunityIndexed,
+} from "../CommunityDialog";
+
+vi.mock("@/utilities/fetchData");
+// The dialog imports the markdown editor eagerly; stub it so the unit test for
+// the polling helper doesn't drag in the md-editor-rt/CSS chain.
+vi.mock("@/components/Utilities/MarkdownEditor", () => ({
+  MarkdownEditor: () => null,
+}));
+
+const mockFetchData = fetchData as unknown as ReturnType<typeof vi.fn>;
+
+describe("waitForCommunityIndexed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true and stops polling once the community is indexed", async () => {
+    mockFetchData
+      .mockResolvedValueOnce([null, null, null, 200])
+      .mockResolvedValueOnce([null, null, null, 200])
+      .mockResolvedValueOnce([{ uid: "0xabc" }, null, null, 200]);
+
+    const promise = waitForCommunityIndexed("my-community");
+    await vi.advanceTimersByTimeAsync(COMMUNITY_INDEX_POLL_DELAY_MS * 2);
+
+    await expect(promise).resolves.toBe(true);
+    expect(mockFetchData).toHaveBeenCalledTimes(3);
+    expect(mockFetchData).toHaveBeenCalledWith(INDEXER.COMMUNITY.V2.GET("my-community"), "GET");
+    // Stopped early rather than exhausting the full window.
+    expect(mockFetchData.mock.calls.length).toBeLessThan(COMMUNITY_INDEX_POLL_ATTEMPTS);
+  });
+
+  it("returns false after exhausting all attempts when the community never appears", async () => {
+    // fetchData treats a 404 as an error, so `community` stays null and polling continues.
+    mockFetchData.mockResolvedValue([null, "Not Found", null, 404]);
+
+    const promise = waitForCommunityIndexed("ghost-community");
+    await vi.advanceTimersByTimeAsync(
+      COMMUNITY_INDEX_POLL_DELAY_MS * COMMUNITY_INDEX_POLL_ATTEMPTS
+    );
+
+    await expect(promise).resolves.toBe(false);
+    expect(mockFetchData).toHaveBeenCalledTimes(COMMUNITY_INDEX_POLL_ATTEMPTS);
+  });
+});

--- a/utilities/__tests__/waitForCommunityIndexed.test.ts
+++ b/utilities/__tests__/waitForCommunityIndexed.test.ts
@@ -5,14 +5,9 @@ import {
   COMMUNITY_INDEX_POLL_ATTEMPTS,
   COMMUNITY_INDEX_POLL_DELAY_MS,
   waitForCommunityIndexed,
-} from "../CommunityDialog";
+} from "../waitForCommunityIndexed";
 
 vi.mock("@/utilities/fetchData");
-// The dialog imports the markdown editor eagerly; stub it so the unit test for
-// the polling helper doesn't drag in the md-editor-rt/CSS chain.
-vi.mock("@/components/Utilities/MarkdownEditor", () => ({
-  MarkdownEditor: () => null,
-}));
 
 const mockFetchData = fetchData as unknown as ReturnType<typeof vi.fn>;
 

--- a/utilities/waitForCommunityIndexed.ts
+++ b/utilities/waitForCommunityIndexed.ts
@@ -1,0 +1,18 @@
+import fetchData from "@/utilities/fetchData";
+import { INDEXER } from "@/utilities/indexer";
+
+export const COMMUNITY_INDEX_POLL_ATTEMPTS = 12;
+export const COMMUNITY_INDEX_POLL_DELAY_MS = 2500;
+
+// After an on-chain community create returns `status: "pending"` (BE PR #2232),
+// the community is attested but not yet indexed. Poll the read endpoint until it
+// appears so we don't navigate to a not-yet-indexed page. Resolves true once found,
+// false if it never appears within the window (caller navigates anyway).
+export const waitForCommunityIndexed = async (idOrSlug: string): Promise<boolean> => {
+  for (let attempt = 0; attempt < COMMUNITY_INDEX_POLL_ATTEMPTS; attempt++) {
+    const [community] = await fetchData(INDEXER.COMMUNITY.V2.GET(idOrSlug), "GET");
+    if (community?.uid) return true;
+    await new Promise((resolve) => setTimeout(resolve, COMMUNITY_INDEX_POLL_DELAY_MS));
+  }
+  return false;
+};


### PR DESCRIPTION
## Root cause / contract

`POST /v2/communities` used to return **500** when the community was attested on-chain but the indexer DB read-back timed out under eventual consistency (Sentry **GAP-INDEXER-XB**). Backend PR **show-karma/gap-indexer#2232** changes that path: instead of a 500 it now returns **HTTP 202** with a lightweight body:

```json
{ "uid", "chainID", "name", "slug", "status": "pending", "message" }
```

On full success it still returns **201** with the community object (also carries `uid` + `slug`).

The frontend (`CommunityDialog.tsx` → `createCommunity`) treats any 2xx as success: it read `result.slug`, toasted "Community created successfully!", and immediately `router.push`ed to the community page by slug. On a `status: "pending"` response the community is attested but **not yet indexed**, so that destination page can briefly 404 / render empty until indexing catches up.

## Change

- Extend the create response type with the new optional `status`/`message` fields.
- Add a small, module-level, exported polling helper `waitForCommunityIndexed(idOrSlug)` that hits the community read endpoint (`INDEXER.COMMUNITY.V2.GET`) up to `COMMUNITY_INDEX_POLL_ATTEMPTS` (12) times, `COMMUNITY_INDEX_POLL_DELAY_MS` (2500ms) apart, resolving `true` once the community appears and `false` if the window elapses (caller navigates anyway so we never trap the user).
- In `createCommunity`, when the response is `status: "pending"`: show accurate "Community created on-chain — finalizing indexing…" messaging and poll before navigating. The non-pending 201 path keeps its exact ordering and behavior.

Diff is intentionally minimal — the existing imperative handler is **not** refactored to `useMutation` (out of scope for this follow-up).

## Safe to merge independently

This FE PR handles **both** contracts and requires no coordinated deploy:

- **Old behavior** (BE 500): still lands in the `error` branch → error toast, unchanged.
- **New behavior** (BE 202 `status: "pending"`): pending messaging + poll-before-navigate.

Because the extra 201-body fields are simply absent on today's indexed path, `result?.status === "pending"` is `false` and the new branch is **inert until #2232 ships**. Merging this first is harmless; merging #2232 first is harmless. The two only combine to produce the improved UX — a coordinated *benefit*, not a coordinated *deploy*.

## Test plan

- **Unit** (`components/Dialogs/__tests__/CommunityDialog.test.tsx`, Vitest + fake timers): `waitForCommunityIndexed` returns `true` and stops polling early once the read endpoint returns a community with a `uid` (asserts the endpoint + that it did not exhaust the window); returns `false` after exhausting all `COMMUNITY_INDEX_POLL_ATTEMPTS` when the community never appears. Passing.
- `pnpm lint:fix` — clean (only a pre-existing `createCommunity` cognitive-complexity warning, unrelated to this diff).
- `pnpm run build` — `✓ Compiled successfully`.

Related: gap-indexer#2232 / GAP-INDEXER-XB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved community creation handling for communities that are still being set up.
  * Added automatic waiting for community availability before navigating to the grants page.
  * Added clearer status messages during community creation and indexing.

* **Bug Fixes**
  * Community refresh failures no longer interrupt the creation flow.

* **Tests**
  * Added coverage for successful indexing and polling timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->