### PR TITLE
refactor(mcp): point MCP discovery at /mcp, drop /v2/mcp

### DIFF
--- a/__tests__/app/well-known.test.ts
+++ b/__tests__/app/well-known.test.ts
@@ -364,4 +364,24 @@ describe("normalizeBaseUrl helper", () => {
     const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
     expect(() => normalizeBaseUrl(undefined as unknown as string)).not.toThrow();
   });
+
+  it("strips trailing whitespace", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz ")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("strips trailing whitespace after a trailing slash", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/ ")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("strips a trailing slash-then-whitespace-then-slash mix", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz// ")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("strips repeated whitespace/slash combinations", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz /  / ")).toBe("https://gapapi.karmahq.xyz");
+  });
 });

--- a/__tests__/app/well-known.test.ts
+++ b/__tests__/app/well-known.test.ts
@@ -82,7 +82,7 @@ describe("/.well-known/mcp.json route handler", () => {
     const res = GET();
     const body = await res.json();
     expect(body.mcpServers.karma.transport).toBe("http");
-    expect(body.mcpServers.karma.url).toBe(`${INDEXER_URL}/v2/mcp`);
+    expect(body.mcpServers.karma.url).toBe(`${INDEXER_URL}/mcp`);
   });
 
   it("advertises oauth2 auth with the indexer's protected-resource metadata", async () => {
@@ -91,7 +91,7 @@ describe("/.well-known/mcp.json route handler", () => {
     const body = await res.json();
     expect(body.mcpServers.karma.auth.type).toBe("oauth2");
     expect(body.mcpServers.karma.auth.metadata).toBe(
-      `${INDEXER_URL}/.well-known/oauth-protected-resource/v2/mcp`
+      `${INDEXER_URL}/.well-known/oauth-protected-resource/mcp`
     );
   });
 
@@ -130,7 +130,7 @@ describe("/.well-known/mcp-tools.json route handler", () => {
     vi.clearAllMocks();
   });
 
-  it("proxies the upstream /v2/mcp/tools response when it succeeds", async () => {
+  it("proxies the upstream /mcp/tools response when it succeeds", async () => {
     const upstream = { tools: [{ name: "get_project_details" }] };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => upstream }));
 
@@ -217,7 +217,7 @@ describe("/.well-known/mcp-tools.json route handler", () => {
     await GET();
 
     expect(Sentry.captureException).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Upstream /v2/mcp/tools returned 503" }),
+      expect.objectContaining({ message: "Upstream /mcp/tools returned 503" }),
       expect.objectContaining({
         tags: { route: "well-known/mcp-tools" },
         extra: { status: 503 },

--- a/__tests__/app/well-known.test.ts
+++ b/__tests__/app/well-known.test.ts
@@ -292,4 +292,76 @@ describe("getIndexerBaseUrl helper", () => {
     const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
     expect(() => getIndexerBaseUrl()).toThrow(/is not a valid URL/);
   });
+
+  it("strips a trailing slash so downstream /mcp URLs don't get a double slash", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/" },
+    }));
+    const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
+    expect(getIndexerBaseUrl()).toBe("https://gapapi.karmahq.xyz");
+    expect(`${getIndexerBaseUrl()}/mcp`).toBe("https://gapapi.karmahq.xyz/mcp");
+  });
+
+  it("strips multiple trailing slashes", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz///" },
+    }));
+    const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
+    expect(getIndexerBaseUrl()).toBe("https://gapapi.karmahq.xyz");
+  });
+});
+
+describe("/.well-known/mcp.json route handler with a trailing slash in the env var", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/utilities/enviromentVars");
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("normalizes NEXT_PUBLIC_GAP_INDEXER_URL to a single slash before /mcp", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/" },
+    }));
+    const { GET } = await import("@/app/.well-known/mcp.json/route");
+    const res = GET();
+    const body = await res.json();
+    expect(body.mcpServers.karma.url).toBe("https://gapapi.karmahq.xyz/mcp");
+    expect(body.mcpServers.karma.url).not.toContain("//mcp");
+  });
+});
+
+describe("normalizeBaseUrl helper", () => {
+  it("strips a single trailing slash", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("strips multiple trailing slashes", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz///")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("leaves a URL with no trailing slash unchanged", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("does not strip an internal slash, only trailing ones", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/mcp/")).toBe(
+      "https://gapapi.karmahq.xyz/mcp"
+    );
+  });
+
+  it("does not throw on a non-string input", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(() => normalizeBaseUrl(undefined as unknown as string)).not.toThrow();
+  });
 });

--- a/__tests__/app/well-known.test.ts
+++ b/__tests__/app/well-known.test.ts
@@ -309,6 +309,22 @@ describe("getIndexerBaseUrl helper", () => {
     const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
     expect(getIndexerBaseUrl()).toBe("https://gapapi.karmahq.xyz");
   });
+
+  it("throws when NEXT_PUBLIC_GAP_INDEXER_URL carries a query string", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/?tenant=x" },
+    }));
+    const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
+    expect(() => getIndexerBaseUrl()).toThrow(/must not contain a query string or fragment/);
+  });
+
+  it("throws when NEXT_PUBLIC_GAP_INDEXER_URL carries a fragment", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/#preview" },
+    }));
+    const { getIndexerBaseUrl } = await import("@/utilities/wellKnown");
+    expect(() => getIndexerBaseUrl()).toThrow(/must not contain a query string or fragment/);
+  });
 });
 
 describe("/.well-known/mcp.json route handler with a trailing slash in the env var", () => {
@@ -383,5 +399,40 @@ describe("normalizeBaseUrl helper", () => {
   it("strips repeated whitespace/slash combinations", async () => {
     const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
     expect(normalizeBaseUrl("https://gapapi.karmahq.xyz /  / ")).toBe("https://gapapi.karmahq.xyz");
+  });
+
+  it("strips a trailing query string", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/?tenant=x")).toBe(
+      "https://gapapi.karmahq.xyz"
+    );
+  });
+
+  it("strips a trailing fragment", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/#preview")).toBe(
+      "https://gapapi.karmahq.xyz"
+    );
+  });
+
+  it("strips a combined query string and fragment", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz/?tenant=x#preview")).toBe(
+      "https://gapapi.karmahq.xyz"
+    );
+  });
+
+  it("strips a query string with trailing whitespace/slashes after it", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz?tenant=x// ")).toBe(
+      "https://gapapi.karmahq.xyz"
+    );
+  });
+
+  it("strips a fragment with trailing whitespace/slashes after it", async () => {
+    const { normalizeBaseUrl } = await import("@/utilities/wellKnown");
+    expect(normalizeBaseUrl("https://gapapi.karmahq.xyz#preview// ")).toBe(
+      "https://gapapi.karmahq.xyz"
+    );
   });
 });

--- a/__tests__/app/well-known/mcp-server-card.test.ts
+++ b/__tests__/app/well-known/mcp-server-card.test.ts
@@ -20,7 +20,7 @@ describe("/.well-known/mcp/server-card.json route handler", () => {
     expect(body.name).toBe("gap-tools");
     expect(body.alternateNames).toEqual(expect.arrayContaining(["karma-gap-tools"]));
     expect(body.transport).toBe("http");
-    expect(body.url).toBe(`${INDEXER_URL}/v2/mcp`);
+    expect(body.url).toBe(`${INDEXER_URL}/mcp`);
     expect(body.protocolVersion).toBe("2025-11-25");
     expect(body.version).toBe("1.0.0");
   });

--- a/__tests__/app/well-known/oauth-protected-resource.test.ts
+++ b/__tests__/app/well-known/oauth-protected-resource.test.ts
@@ -20,7 +20,7 @@ describe("/.well-known/oauth-protected-resource route handler", () => {
     const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
     const res = GET();
     const body = await res.json();
-    expect(body.resource).toBe(`${INDEXER_URL}/v2/mcp`);
+    expect(body.resource).toBe(`${INDEXER_URL}/mcp`);
   });
 
   it("advertises NEXT_PUBLIC_GAP_OAUTH_URL as the authorization server", async () => {

--- a/__tests__/components/Pages/ForAgents/fetchToolCatalog.test.ts
+++ b/__tests__/components/Pages/ForAgents/fetchToolCatalog.test.ts
@@ -118,7 +118,7 @@ describe("fetchToolCatalog", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toMatch(/\/v2\/mcp\/tools$/);
+    expect(url).toMatch(/\/mcp\/tools$/);
     expect(init).toMatchObject({ next: { revalidate: 3600 } });
     expect(init.signal).toBeDefined();
   });

--- a/__tests__/components/Pages/McpConnect.render.test.tsx
+++ b/__tests__/components/Pages/McpConnect.render.test.tsx
@@ -1,0 +1,38 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+describe("McpConnectPage mcpUrl construction", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/utilities/enviromentVars");
+    vi.resetModules();
+  });
+
+  it("renders the MCP server URL without a double slash when the indexer URL has a trailing slash", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/" },
+    }));
+
+    const { McpConnectPage } = await import("@/components/Pages/McpConnect/McpConnectPage");
+    render(<McpConnectPage />);
+
+    const mcpUrl = screen.getByText("https://gapapi.karmahq.xyz/mcp");
+    expect(mcpUrl).toBeInTheDocument();
+    expect(mcpUrl.textContent).not.toContain("//mcp");
+    expect(mcpUrl.textContent).toBe("https://gapapi.karmahq.xyz/mcp");
+  });
+
+  it("renders the MCP server URL without a double slash when the indexer URL has no trailing slash", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz" },
+    }));
+
+    const { McpConnectPage } = await import("@/components/Pages/McpConnect/McpConnectPage");
+    render(<McpConnectPage />);
+
+    expect(screen.getByText("https://gapapi.karmahq.xyz/mcp")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Pages/McpConnect.render.test.tsx
+++ b/__tests__/components/Pages/McpConnect.render.test.tsx
@@ -35,4 +35,17 @@ describe("McpConnectPage mcpUrl construction", () => {
 
     expect(screen.getByText("https://gapapi.karmahq.xyz/mcp")).toBeInTheDocument();
   });
+
+  it("renders the MCP server URL without the query string when the indexer URL carries one", async () => {
+    vi.doMock("@/utilities/enviromentVars", () => ({
+      envVars: { NEXT_PUBLIC_GAP_INDEXER_URL: "https://gapapi.karmahq.xyz/?tenant=x" },
+    }));
+
+    const { McpConnectPage } = await import("@/components/Pages/McpConnect/McpConnectPage");
+    render(<McpConnectPage />);
+
+    const mcpUrl = screen.getByText("https://gapapi.karmahq.xyz/mcp");
+    expect(mcpUrl).toBeInTheDocument();
+    expect(mcpUrl.textContent).not.toContain("tenant=x");
+  });
 });

--- a/__tests__/public/agents.test.ts
+++ b/__tests__/public/agents.test.ts
@@ -57,6 +57,6 @@ describe("public/agents.md", () => {
 
   it("points at the canonical MCP endpoint on the indexer", () => {
     const contents = fs.readFileSync(AGENTS_MD_PATH, "utf-8");
-    expect(contents).toContain("https://gapapi.karmahq.xyz/v2/mcp");
+    expect(contents).toContain("https://gapapi.karmahq.xyz/mcp");
   });
 });

--- a/__tests__/public/pricing.test.ts
+++ b/__tests__/public/pricing.test.ts
@@ -29,7 +29,7 @@ describe("public/pricing.md", () => {
     const contents = fs.readFileSync(PRICING_MD_PATH, "utf-8");
     expect(contents).toContain("## API access");
     expect(contents).toContain("fair-use rate limits");
-    expect(contents).toContain("https://gapapi.karmahq.xyz/v2/mcp");
+    expect(contents).toContain("https://gapapi.karmahq.xyz/mcp");
   });
 
   it("includes a Last updated section pointing back to the apex marketing URL", () => {

--- a/app/.well-known/mcp-tools.json/route.ts
+++ b/app/.well-known/mcp-tools.json/route.ts
@@ -15,13 +15,13 @@ const UPSTREAM_TIMEOUT_MS = 5000;
 
 export async function GET() {
   try {
-    const res = await fetch(`${getIndexerBaseUrl()}/v2/mcp/tools`, {
+    const res = await fetch(`${getIndexerBaseUrl()}/mcp/tools`, {
       next: { revalidate: 3600 },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
 
     if (!res.ok) {
-      Sentry.captureException(new Error(`Upstream /v2/mcp/tools returned ${res.status}`), {
+      Sentry.captureException(new Error(`Upstream /mcp/tools returned ${res.status}`), {
         tags: { route: "well-known/mcp-tools" },
         extra: { status: res.status },
       });

--- a/app/.well-known/mcp.json/route.ts
+++ b/app/.well-known/mcp.json/route.ts
@@ -15,12 +15,12 @@ export function GET() {
   const body = {
     mcpServers: {
       karma: {
-        url: `${apiUrl}/v2/mcp`,
+        url: `${apiUrl}/mcp`,
         transport: "http",
         description: "Karma — funding programs, projects, milestones, and impact data.",
         auth: {
           type: "oauth2",
-          metadata: `${apiUrl}/.well-known/oauth-protected-resource/v2/mcp`,
+          metadata: `${apiUrl}/.well-known/oauth-protected-resource/mcp`,
         },
         documentation: `${SITE_URL}/mcp/connect`,
       },

--- a/app/.well-known/mcp/server-card.json/route.ts
+++ b/app/.well-known/mcp/server-card.json/route.ts
@@ -42,7 +42,7 @@ export function GET() {
     version: "1.0.0",
     protocolVersion: MCP_PROTOCOL_VERSION,
     transport: "http",
-    url: `${apiUrl}/v2/mcp`,
+    url: `${apiUrl}/mcp`,
     documentation: `${SITE_URL}/mcp/connect`,
     openapi: `${SITE_URL}/openapi.json`,
     authentication: {

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -41,7 +41,7 @@ export function GET() {
     });
     throw err;
   }
-  const resource = `${getIndexerBaseUrl()}/v2/mcp`;
+  const resource = `${getIndexerBaseUrl()}/mcp`;
 
   const body = {
     resource,

--- a/components/Pages/ForAgents/content.ts
+++ b/components/Pages/ForAgents/content.ts
@@ -3,7 +3,7 @@
  * structured data (FAQPage). Co-located with the page sections so the
  * schema and the page never drift apart.
  *
- * The tool catalog is fetched live from gap-indexer's `/v2/mcp/tools`
+ * The tool catalog is fetched live from gap-indexer's `/mcp/tools`
  * endpoint at request time (1h ISR). `STATIC_FALLBACK_TOOLS` below is the
  * fallback the page renders only when that upstream is down at build or
  * revalidation time.
@@ -70,7 +70,7 @@ export const USE_CASES: UseCaseCard[] = [
 ];
 
 /**
- * Fallback only — rendered when the live `/v2/mcp/tools` fetch fails at
+ * Fallback only — rendered when the live `/mcp/tools` fetch fails at
  * build or revalidation time. Keep small and representative across the
  * main categories. The full live list comes from the indexer.
  */

--- a/components/Pages/ForAgents/fetchToolCatalog.ts
+++ b/components/Pages/ForAgents/fetchToolCatalog.ts
@@ -7,7 +7,7 @@ const UPSTREAM_TIMEOUT_MS = 5000;
 const REVALIDATE_SECONDS = 3600;
 
 /**
- * Fetches the live MCP tool catalog from gap-indexer's `/v2/mcp/tools`
+ * Fetches the live MCP tool catalog from gap-indexer's `/mcp/tools`
  * discovery endpoint. Cached at the Next.js data layer for one hour so
  * the build never blocks on a slow indexer and cold renders are cheap.
  *
@@ -28,7 +28,7 @@ const REVALIDATE_SECONDS = 3600;
  */
 export async function fetchToolCatalog(): Promise<PublicToolMetadata[]> {
   try {
-    const res = await fetch(`${getIndexerBaseUrl()}/v2/mcp/tools`, {
+    const res = await fetch(`${getIndexerBaseUrl()}/mcp/tools`, {
       next: { revalidate: REVALIDATE_SECONDS },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });

--- a/components/Pages/ForAgents/types.ts
+++ b/components/Pages/ForAgents/types.ts
@@ -1,6 +1,6 @@
 /**
  * Mirrors the `PublicToolMetadata` shape exposed by gap-indexer's
- * `/v2/mcp/tools` discovery endpoint. The frontend re-declares the type
+ * `/mcp/tools` discovery endpoint. The frontend re-declares the type
  * (rather than depending on @show-karma/shared-types) because the catalog
  * is a fully decoupled, fetch-with-fallback surface — the indexer is the
  * source of truth at runtime, not at build time.

--- a/components/Pages/McpConnect/McpConnectPage.tsx
+++ b/components/Pages/McpConnect/McpConnectPage.tsx
@@ -68,7 +68,7 @@ const SUPPORTED_CLIENTS: SupportedClient[] = [
 
 export function McpConnectPage() {
   const [, copy] = useCopyToClipboard();
-  const mcpUrl = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/v2/mcp`;
+  const mcpUrl = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/mcp`;
 
   return (
     <main className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-4 py-12">

--- a/components/Pages/McpConnect/McpConnectPage.tsx
+++ b/components/Pages/McpConnect/McpConnectPage.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { envVars } from "@/utilities/enviromentVars";
+import { normalizeBaseUrl } from "@/utilities/wellKnown";
 import { CONNECT_STEPS, MCP_FAQS } from "./content";
 
 interface SupportedClient {
@@ -68,7 +69,7 @@ const SUPPORTED_CLIENTS: SupportedClient[] = [
 
 export function McpConnectPage() {
   const [, copy] = useCopyToClipboard();
-  const mcpUrl = `${envVars.NEXT_PUBLIC_GAP_INDEXER_URL}/mcp`;
+  const mcpUrl = `${normalizeBaseUrl(envVars.NEXT_PUBLIC_GAP_INDEXER_URL)}/mcp`;
 
   return (
     <main className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-4 py-12">

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,6 +1,6 @@
 # Karma — agent instructions
 
-Karma is a platform for funding programs: ecosystems run grants, builders apply, milestones get tracked, and impact gets measured on-chain. Connect via MCP at https://gapapi.karmahq.xyz/v2/mcp.
+Karma is a platform for funding programs: ecosystems run grants, builders apply, milestones get tracked, and impact gets measured on-chain. Connect via MCP at https://gapapi.karmahq.xyz/mcp.
 
 ## When to use Karma tools
 

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -26,7 +26,7 @@ Contact info@karmahq.xyz for ecosystem pricing.
 
 ## API access
 
-All API endpoints under https://gapapi.karmahq.xyz/v2/* and the MCP server at https://gapapi.karmahq.xyz/v2/mcp are free to use under fair-use rate limits. Rate limit headers are returned on every response. Heavy programmatic access should contact info@karmahq.xyz for a dedicated tier.
+All API endpoints under https://gapapi.karmahq.xyz/v2/* and the MCP server at https://gapapi.karmahq.xyz/mcp are free to use under fair-use rate limits. Rate limit headers are returned on every response. Heavy programmatic access should contact info@karmahq.xyz for a dedicated tier.
 
 ## Last updated
 

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -59,6 +59,21 @@ export const WELL_KNOWN_PREFLIGHT_HEADERS = {
 export const MCP_PROTOCOL_VERSION = "2025-11-25";
 
 /**
+ * Strips trailing slash(es) from a URL string. Pure and non-throwing, so it
+ * is safe to call on client components that must degrade gracefully when
+ * the env var is missing (e.g. `McpConnectPage`), not just from
+ * `getIndexerBaseUrl()`.
+ *
+ * RFC 8707 resource indicators are exact-match: a trailing slash on the
+ * indexer base URL would produce `.../mcp/` where `.../mcp` is expected,
+ * recreating the OAuth audience mismatch this module exists to prevent.
+ */
+export function normalizeBaseUrl(url: string): string {
+  if (typeof url !== "string") return url;
+  return url.replace(/\/+$/, "");
+}
+
+/**
  * Returns the indexer base URL or throws if it is unset or malformed.
  *
  * The /.well-known/* route handlers depend on this URL at build time
@@ -81,5 +96,5 @@ export function getIndexerBaseUrl(): string {
       `NEXT_PUBLIC_GAP_INDEXER_URL is not a valid URL: "${url}". Expected a fully-qualified URL like https://gapapi.karmahq.xyz.`
     );
   }
-  return url;
+  return normalizeBaseUrl(url);
 }

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -78,7 +78,7 @@ export function normalizeBaseUrl(url: string): string {
  *
  * The /.well-known/* route handlers depend on this URL at build time
  * (`force-static` + ISR). A misconfigured deploy without
- * NEXT_PUBLIC_GAP_INDEXER_URL would otherwise ship `undefined/v2/...` to
+ * NEXT_PUBLIC_GAP_INDEXER_URL would otherwise ship `undefined/mcp` to
  * production. This helper makes that fail loudly during `next build`.
  *
  * Format validation via `URL.canParse` catches missing schemes

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -59,27 +59,39 @@ export const WELL_KNOWN_PREFLIGHT_HEADERS = {
 export const MCP_PROTOCOL_VERSION = "2025-11-25";
 
 /**
- * Strips trailing whitespace and slash(es) from a URL string. Pure and
- * non-throwing, so it is safe to call on client components that must
- * degrade gracefully when the env var is missing (e.g. `McpConnectPage`),
- * not just from `getIndexerBaseUrl()`.
+ * Strips a trailing query string and/or fragment, then trailing whitespace
+ * and slash(es), from a URL string. Pure and non-throwing, so it is safe to
+ * call on client components that must degrade gracefully when the env var
+ * is missing or malformed (e.g. `McpConnectPage`), not just from
+ * `getIndexerBaseUrl()`.
  *
  * RFC 8707 resource indicators are exact-match: a trailing slash on the
  * indexer base URL would produce `.../mcp/` where `.../mcp` is expected,
- * recreating the OAuth audience mismatch this module exists to prevent.
+ * recreating the OAuth audience mismatch this module exists to prevent. A
+ * query string or fragment is worse — interpolating `${base}/mcp` into
+ * `https://host/?tenant=x` yields `https://host/?tenant=x/mcp`, landing
+ * `/mcp` inside the query component instead of the path.
  *
- * Whitespace is trimmed first, then any trailing run of whitespace and/or
- * slashes is stripped in a single pass — a misconfigured env var like
- * `"https://host// "` (slash, then space, then nothing after) would
+ * The query/fragment is cut first (everything from the first `?` or `#`
+ * onward), then whitespace is trimmed, then any trailing run of whitespace
+ * and/or slashes is stripped in a single pass — a misconfigured env var
+ * like `"https://host// "` (slash, then space, then nothing after) would
  * otherwise leave a dangling space or slash behind a naive single-pass
  * trim/replace. `URL.canParse` in `getIndexerBaseUrl()` tolerates
- * leading/trailing whitespace (the `URL` constructor trims before parsing),
- * so a value can pass validation while still carrying whitespace this
- * function must remove before the string is used to build a `/mcp` URL.
+ * leading/trailing whitespace (the `URL` constructor trims before parsing)
+ * and does not reject a query string or fragment, so a value can pass
+ * validation while still carrying content this function must remove before
+ * the string is used to build a `/mcp` URL. `getIndexerBaseUrl()` itself
+ * throws on a query/fragment-bearing value (fail loud, server-side); this
+ * function's stripping keeps client-side normalization coherent with that
+ * same value even when no exception can be raised (fail safe, client-side).
  */
 export function normalizeBaseUrl(url: string): string {
   if (typeof url !== "string") return url;
-  return url.trim().replace(/[\s/]+$/, "");
+  return url
+    .split(/[?#]/)[0]
+    .trim()
+    .replace(/[\s/]+$/, "");
 }
 
 /**
@@ -94,6 +106,12 @@ export function normalizeBaseUrl(url: string): string {
  * (`gapapi.karmahq.xyz` instead of `https://gapapi.karmahq.xyz`) and
  * structurally invalid URLs. It does NOT catch typos with a valid scheme
  * (e.g. `https://gapap.karmahq.xyz`) — those still ship.
+ *
+ * A query string or fragment also passes `URL.canParse` (it's a valid URL),
+ * but a base URL must not carry one: interpolating `${base}/mcp` into
+ * `https://host/?tenant=x` lands `/mcp` inside the query component instead
+ * of the path, silently corrupting every downstream MCP URL. This is
+ * checked explicitly and rejected below.
  */
 export function getIndexerBaseUrl(): string {
   const url = envVars.NEXT_PUBLIC_GAP_INDEXER_URL;
@@ -103,6 +121,12 @@ export function getIndexerBaseUrl(): string {
   if (!URL.canParse(url)) {
     throw new Error(
       `NEXT_PUBLIC_GAP_INDEXER_URL is not a valid URL: "${url}". Expected a fully-qualified URL like https://gapapi.karmahq.xyz.`
+    );
+  }
+  const parsed = new URL(url);
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      `NEXT_PUBLIC_GAP_INDEXER_URL must not contain a query string or fragment: "${url}". Expected a bare base URL like https://gapapi.karmahq.xyz.`
     );
   }
   return normalizeBaseUrl(url);

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -59,18 +59,33 @@ export const WELL_KNOWN_PREFLIGHT_HEADERS = {
 export const MCP_PROTOCOL_VERSION = "2025-11-25";
 
 /**
- * Strips trailing slash(es) from a URL string. Pure and non-throwing, so it
- * is safe to call on client components that must degrade gracefully when
- * the env var is missing (e.g. `McpConnectPage`), not just from
- * `getIndexerBaseUrl()`.
+ * Strips trailing whitespace and slash(es) from a URL string. Pure and
+ * non-throwing, so it is safe to call on client components that must
+ * degrade gracefully when the env var is missing (e.g. `McpConnectPage`),
+ * not just from `getIndexerBaseUrl()`.
  *
  * RFC 8707 resource indicators are exact-match: a trailing slash on the
  * indexer base URL would produce `.../mcp/` where `.../mcp` is expected,
  * recreating the OAuth audience mismatch this module exists to prevent.
+ *
+ * Whitespace is trimmed first, then trailing slashes are stripped, in a
+ * loop — a misconfigured env var like `"https://host// "` (slash, then
+ * space, then nothing after) would otherwise leave a dangling space or
+ * slash behind a single-pass trim/replace. `URL.canParse` in
+ * `getIndexerBaseUrl()` tolerates leading/trailing whitespace (the `URL`
+ * constructor trims before parsing), so a value can pass validation while
+ * still carrying whitespace this function must remove before the string is
+ * used to build a `/mcp` URL.
  */
 export function normalizeBaseUrl(url: string): string {
   if (typeof url !== "string") return url;
-  return url.replace(/\/+$/, "");
+  let result = url;
+  let previous: string;
+  do {
+    previous = result;
+    result = result.trim().replace(/\/+$/, "");
+  } while (result !== previous);
+  return result;
 }
 
 /**

--- a/utilities/wellKnown.ts
+++ b/utilities/wellKnown.ts
@@ -68,24 +68,18 @@ export const MCP_PROTOCOL_VERSION = "2025-11-25";
  * indexer base URL would produce `.../mcp/` where `.../mcp` is expected,
  * recreating the OAuth audience mismatch this module exists to prevent.
  *
- * Whitespace is trimmed first, then trailing slashes are stripped, in a
- * loop — a misconfigured env var like `"https://host// "` (slash, then
- * space, then nothing after) would otherwise leave a dangling space or
- * slash behind a single-pass trim/replace. `URL.canParse` in
- * `getIndexerBaseUrl()` tolerates leading/trailing whitespace (the `URL`
- * constructor trims before parsing), so a value can pass validation while
- * still carrying whitespace this function must remove before the string is
- * used to build a `/mcp` URL.
+ * Whitespace is trimmed first, then any trailing run of whitespace and/or
+ * slashes is stripped in a single pass — a misconfigured env var like
+ * `"https://host// "` (slash, then space, then nothing after) would
+ * otherwise leave a dangling space or slash behind a naive single-pass
+ * trim/replace. `URL.canParse` in `getIndexerBaseUrl()` tolerates
+ * leading/trailing whitespace (the `URL` constructor trims before parsing),
+ * so a value can pass validation while still carrying whitespace this
+ * function must remove before the string is used to build a `/mcp` URL.
  */
 export function normalizeBaseUrl(url: string): string {
   if (typeof url !== "string") return url;
-  let result = url;
-  let previous: string;
-  do {
-    previous = result;
-    result = result.trim().replace(/\/+$/, "");
-  } while (result !== previous);
-  return result;
+  return url.trim().replace(/[\s/]+$/, "");
 }
 
 /**


### PR DESCRIPTION
## Why

gap-indexer is collapsing the MCP server onto a single canonical endpoint at `/mcp` and removing the `/v2/mcp` alias (see **show-karma/gap-indexer#2259**). A client connecting to `/v2/mcp` sent `resource=/v2/mcp` in its OAuth authorize request, which gap-oauth (audience `/mcp`) rejected with a 500 — the Codex login failure. Pointing everything at `/mcp` makes clients send `resource=/mcp`, which matches the token audience, with no gap-oauth change.

This PR updates every frontend surface that advertises the MCP URL.

## Changes

- **Connect page** (`McpConnectPage`): the copyable URL and the `codex mcp add karma --url …` command now use `/mcp`.
- **`.well-known` discovery docs**: `mcp.json`, `mcp/server-card.json`, `oauth-protected-resource`, and `mcp-tools.json` advertise `/mcp` and fetch `/mcp/tools`.
- **ForAgents**: the live tool-catalog fetch hits `/mcp/tools`.
- **Static agent docs**: `public/agents.md` and `public/pricing.md` document the MCP URL as `https://gapapi.karmahq.xyz/mcp`.
- **Base-URL normalization**: added `normalizeBaseUrl()` in `utilities/wellKnown.ts`, which strips trailing whitespace and slash(es) from `NEXT_PUBLIC_GAP_INDEXER_URL` before it's used to build a `/mcp` URL, and also strips everything from the first `?` or `#` onward. Applied at `getIndexerBaseUrl()` and at the `McpConnectPage` call site, so a misconfigured env var (trailing slash, trailing whitespace, or both) can no longer ship a double slash or a stray space into the advertised MCP URL. `getIndexerBaseUrl()` also now throws if `NEXT_PUBLIC_GAP_INDEXER_URL` carries a query string or fragment, since interpolating it into `${base}/mcp` would otherwise land `/mcp` inside the query or fragment instead of the path — **this is a behavior change that will fail `next build`** on a deploy with a misconfigured env var, so double-check `NEXT_PUBLIC_GAP_INDEXER_URL` before merging/deploying.
- Tests updated to assert `/mcp`.

## Coordination ⚠️

**show-karma/gap-indexer#2259 is merged** (expand-phase alias): `/mcp`, `/mcp/info`, and `/mcp/tools` are served alongside their `/v2/mcp` equivalents, and both sets verify 200 in prod. Deploy order is safe in either direction — there is no tools-route 404 window to worry about.

Prod OAuth discovery is currently **broken**, though: gap-indexer already dropped `/.well-known/oauth-protected-resource/v2/mcp` (404 in prod), but the currently-deployed FE `mcp.json` still advertises that path (`https://gapapi.karmahq.xyz/v2/mcp` / `.../oauth-protected-resource/v2/mcp`), so MCP clients discovering Karma today hit a dead metadata URL. This PR is what fixes that — merge and deploy promptly.

## Tests

`vitest` green, including `__tests__/components/Pages/ForAgents/fetchToolCatalog.test.ts` — whose `/\/v2\/mcp\/tools$/` assertion the initial grep-driven rename missed (the regex-escaped path didn't match a literal `v2/mcp` search); fixed in this branch.

Added regression coverage for the trailing-slash normalization: `__tests__/app/well-known.test.ts` now covers `normalizeBaseUrl()` against trailing whitespace and mixed whitespace/slash combinations (e.g. `"https://host// "`), and `__tests__/components/Pages/McpConnect.render.test.tsx` renders `McpConnectPage` with a trailing-slash `NEXT_PUBLIC_GAP_INDEXER_URL` and asserts the displayed MCP URL is exactly `.../mcp` with no `//mcp` — closing the gap where only `content.ts` had test coverage, not the rendered URL at the connect-page call site. A follow-up commit closes the query/fragment gap: 8 new cases cover `getIndexerBaseUrl()` throwing on a query- or fragment-bearing `NEXT_PUBLIC_GAP_INDEXER_URL`, `normalizeBaseUrl()` stripping a trailing `?query`, `#fragment`, a combined query+fragment, and query/fragment mixed with trailing slash/whitespace, plus one more `McpConnectPage` render case asserting the displayed URL drops the query string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated agents/pricing guidance and related text to use the canonical `/mcp` endpoint and `/mcp/tools` for tool discovery.
- **Bug Fixes**
  - Updated `.well-known` discovery responses (including server-card, OAuth protected-resource, and MCP config) to advertise `/mcp` instead of `/v2/mcp`.
  - Updated tool catalog live fetching to use `/mcp/tools`, with improved base-URL normalization to prevent malformed URLs.
- **Tests**
  - Adjusted endpoint and error expectations to match `/mcp` and `/mcp/tools`, and added coverage for trailing-slash normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

