### PR TITLE
fix(milestones): exclude cancelled from pending count & roadmap filter (DEV-523)

### DIFF
--- a/__tests__/components/Pages/Dashboard/utils/pending-actions.test.ts
+++ b/__tests__/components/Pages/Dashboard/utils/pending-actions.test.ts
@@ -60,6 +60,45 @@ describe("computeProjectPendingActions", () => {
     expect(result.grantsInProgress).toBe(1);
   });
 
+  it("does not count cancelled milestones as needing submission", () => {
+    // A cancelled milestone is terminal — it must not inflate the pending
+    // badge/count or flag the grant as having pending work (DEV-523).
+    const project = {
+      grants: [
+        {
+          uid: "0xg",
+          completed: null,
+          milestones: [
+            { completed: null, currentStatus: "cancelled", verified: [] },
+            { completed: null, currentStatus: "pending", verified: [] },
+          ],
+        },
+      ],
+    } as ProjectWithGrantsResponse;
+
+    const result = computeProjectPendingActions(project);
+
+    expect(result.milestonesNeedingSubmission).toBe(1);
+    expect(result.grantsWithPendingMilestones).toEqual(["0xg"]);
+  });
+
+  it("does not flag a grant whose only outstanding milestone is cancelled", () => {
+    const project = {
+      grants: [
+        {
+          uid: "0xg",
+          completed: null,
+          milestones: [{ completed: null, currentStatus: "cancelled", verified: [] }],
+        },
+      ],
+    } as ProjectWithGrantsResponse;
+
+    const result = computeProjectPendingActions(project);
+
+    expect(result.milestonesNeedingSubmission).toBe(0);
+    expect(result.grantsWithPendingMilestones).toEqual([]);
+  });
+
   it("does not count incomplete milestones from completed grants", () => {
     const project = {
       grants: [

--- a/components/Pages/Dashboard/utils/pending-actions.ts
+++ b/components/Pages/Dashboard/utils/pending-actions.ts
@@ -1,4 +1,5 @@
 import type { ProjectWithGrantsResponse } from "@/types/v2/project";
+import { isCancelledMilestoneStatus } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { PAGES } from "@/utilities/pages";
 
 export interface PendingActions {
@@ -25,6 +26,9 @@ export function computeProjectPendingActions(project: ProjectWithGrantsResponse)
 
     let grantHasPendingMilestone = false;
     for (const milestone of grant.milestones ?? []) {
+      // A cancelled milestone is terminal — it needs no submission and must not
+      // inflate the "pending" count/badge or the dashboard sort (DEV-523).
+      if (isCancelledMilestoneStatus(milestone.currentStatus)) continue;
       if (!milestone.completed) {
         milestonesNeedingSubmission += 1;
         grantHasPendingMilestone = true;

--- a/components/Pages/Dashboard/utils/pending-actions.ts
+++ b/components/Pages/Dashboard/utils/pending-actions.ts
@@ -2,7 +2,7 @@ import type { ProjectWithGrantsResponse } from "@/types/v2/project";
 import { isCancelledMilestoneStatus } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { PAGES } from "@/utilities/pages";
 
-export interface PendingActions {
+interface PendingActions {
   milestonesNeedingSubmission: number;
   grantsInProgress: number;
   /** uids of incomplete grants that have ≥1 milestone still needing submission. */

--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -26,6 +26,21 @@ const isItemCompleted = (item: UnifiedMilestone): boolean =>
   item.completed === true ||
   (typeof item.completed === "object" && item.completed !== null && "createdAt" in item.completed);
 
+const isMilestoneTypeItem = (item: UnifiedMilestone): boolean =>
+  item.type === "milestone" || item.type === "grant" || item.type === "project";
+
+// A milestone counts as pending only when it is not delivered AND not cancelled
+// (cancelled is terminal, not pending — DEV-523).
+const isPendingMilestoneItem = (item: UnifiedMilestone): boolean =>
+  item.completed === false &&
+  !isCancelledMilestoneStatus(item.currentStatus) &&
+  isMilestoneTypeItem(item);
+
+// Both boolean `true` and a completion object count as completed.
+const isCompletedMilestoneItem = (item: UnifiedMilestone): boolean =>
+  (item.completed === true || (typeof item.completed === "object" && item.completed !== null)) &&
+  isMilestoneTypeItem(item);
+
 const getSortTimestamp = (item: UnifiedMilestone): number => {
   if (item.completed && typeof item.completed === "object" && "createdAt" in item.completed) {
     return Math.floor(new Date(item.completed.createdAt).getTime() / 1000);
@@ -81,62 +96,23 @@ export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) =>
       return combinedUpdatesAndMilestones;
     }
 
-    // Core filtering function
+    // Core filtering function — each selected filter matches the item against
+    // its own predicate; the item is kept if any active filter matches.
     return combinedUpdatesAndMilestones.filter((item) => {
-      // We'll thoroughly examine each item and check against all selected filters
-
-      // ===== PENDING MILESTONES =====
-      if (activeFilters.includes("pending")) {
-        // Using a direct approach - looking at the 'completed' flag directly.
-        // A cancelled milestone is terminal, not pending — exclude it (DEV-523).
-        if (item.completed === false && !isCancelledMilestoneStatus(item.currentStatus)) {
-          // For pending, check the underlying schema matches a milestone type
-          const isMilestoneType =
-            item.type === "milestone" || item.type === "grant" || item.type === "project";
-
-          if (isMilestoneType) {
-            return true;
-          }
-        }
+      if (activeFilters.includes("pending") && isPendingMilestoneItem(item)) {
+        return true;
       }
-
-      // ===== COMPLETED MILESTONES =====
-      if (activeFilters.includes("completed")) {
-        // Both boolean true and object {"createdAt": ...} should be treated as completed
-        const isItemCompleted =
-          item.completed === true || (item.completed && typeof item.completed === "object");
-
-        // Check if it's a milestone or grant type
-        const isMilestoneType =
-          item.type === "milestone" || item.type === "grant" || item.type === "project";
-
-        if (isItemCompleted && isMilestoneType) {
-          return true;
-        }
+      if (activeFilters.includes("completed") && isCompletedMilestoneItem(item)) {
+        return true;
       }
-
-      // ===== IMPACT FILTER =====
-      if (activeFilters.includes("impacts")) {
-        // Simply check the type - we've improved the type detection
-        if (item.type === "impact") {
-          return true;
-        }
+      if (activeFilters.includes("impacts") && item.type === "impact") {
+        return true;
       }
-
-      // ===== ACTIVITIES FILTER =====
-      if (activeFilters.includes("activities")) {
-        // Activities should only be items explicitly marked as activities
-        if (item.type === "activity") {
-          return true;
-        }
+      if (activeFilters.includes("activities") && item.type === "activity") {
+        return true;
       }
-
-      // ===== GRANT UPDATES FILTER =====
-      if (activeFilters.includes("updates")) {
-        // Simply check the type - we've improved the type detection
-        if (item.type === "grant_update") {
-          return true;
-        }
+      if (activeFilters.includes("updates") && item.type === "grant_update") {
+        return true;
       }
 
       // If none of the filters matched, don't include this item

--- a/components/Pages/Project/Roadmap/index.tsx
+++ b/components/Pages/Project/Roadmap/index.tsx
@@ -13,6 +13,7 @@ import { useProgressModalStore } from "@/store/modals/progress";
 import type { Project as ProjectResponse } from "@/types/v2/project";
 import type { UnifiedMilestone } from "@/types/v2/roadmap";
 import { MESSAGES } from "@/utilities/messages";
+import { isCancelledMilestoneStatus } from "@/utilities/milestones/getEffectiveMilestoneStatus";
 import { RoadmapListLoading } from "../Loading/Roadmap";
 
 interface ProjectRoadmapProps {
@@ -86,8 +87,9 @@ export const ProjectRoadmap = ({ project: propProject }: ProjectRoadmapProps) =>
 
       // ===== PENDING MILESTONES =====
       if (activeFilters.includes("pending")) {
-        // Using a direct approach - looking at the 'completed' flag directly
-        if (item.completed === false) {
+        // Using a direct approach - looking at the 'completed' flag directly.
+        // A cancelled milestone is terminal, not pending — exclude it (DEV-523).
+        if (item.completed === false && !isCancelledMilestoneStatus(item.currentStatus)) {
           // For pending, check the underlying schema matches a milestone type
           const isMilestoneType =
             item.type === "milestone" || item.type === "grant" || item.type === "project";


### PR DESCRIPTION
## Summary

Two more surfaces (found in a cancelled-milestone sweep) still treated a **cancelled** milestone as **pending**.

## Problems

1. **Dashboard pending count** (`components/Pages/Dashboard/utils/pending-actions.ts`) counted any non-completed milestone as "needing submission". A cancelled milestone therefore: inflated the "N milestone pending" badge, bumped the project up the dashboard sort (projects are ordered by pending count), and prevented the "All caught up" state.
2. **Project Roadmap "Pending" filter** (`components/Pages/Project/Roadmap/index.tsx`) matched on `completed === false`, so cancelled milestones appeared in the Pending bucket.

## Fix

Both now skip cancelled via `isCancelledMilestoneStatus(...currentStatus)` — the same guard the sibling `components/Milestone/MilestonesList.tsx` pending bucket already applies.

## Testing

- Added two cases to `pending-actions.test.ts` (cancelled not counted as pending; a grant whose only outstanding milestone is cancelled isn't flagged). 12 tests pass.
- `pnpm exec tsc --noEmit`, `pnpm biome check`, `pnpm run build` — all clean.

## Risk

Low — adds a terminal-state guard to two pending filters; completed/verified/past-due handling is unchanged.

## Related

Part of the DEV-523 cancelled-milestone sweep. A companion indexer PR covers the server-side community-stat total and makes the AI agent tools cancelled-aware (their pre-computed completion counts currently fold cancelled into the denominator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled milestones are no longer counted as pending actions or milestones requiring submission.
  * Grants with only cancelled outstanding milestones no longer appear to have pending work.
  * The project roadmap’s Pending filter now excludes cancelled milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->