### PR TITLE
fix(milestones): completion spins for minutes then reports nothing useful

### DIFF
--- a/__tests__/unit/hooks/useMilestoneCompletionIndexingTimeout.test.ts
+++ b/__tests__/unit/hooks/useMilestoneCompletionIndexingTimeout.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Regression tests for the milestone-completion indexing wait.
+ *
+ * The completion flow signed on-chain, POSTed to the attestation listener, then
+ * polled `retryUntilConditionMet` on the DEFAULT budget (200 x 1500ms, plus a
+ * full project-query invalidation + refetch per iteration) waiting for
+ * `milestone.completed` to appear. When the indexer REFUSES a completion
+ * attestation — which it does silently, and which
+ * `POST /attestations/index-by-transaction` reports as 200 either way — that
+ * condition can never be satisfied, so the stepper spun for minutes and then
+ * showed a generic "There was an error completing the milestone" to a user who
+ * had already signed and paid gas.
+ *
+ * These lock in: the INTERACTIVE budget (~60s, as the undo flow already uses)
+ * and an actionable, cause-naming message on exhaustion.
+ */
+import { act, renderHook } from "@testing-library/react";
+
+const mockGetProjectById = vi.fn();
+const mockGetProjectObjectives = vi.fn();
+const mockRetryUntilConditionMet = vi.fn();
+const mockRefetchUpdates = vi.fn();
+const mockRefetchGrants = vi.fn();
+const mockShowError = vi.fn();
+const mockShowSuccess = vi.fn();
+const mockStartAttestation = vi.fn();
+const mockChangeStepperStep = vi.fn();
+const mockDismiss = vi.fn();
+const mockShowChainProgress = vi.fn();
+const mockUseAccount = vi.fn();
+const mockSwitchChainAsync = vi.fn();
+const mockSetupChainAndWallet = vi.fn();
+const mockApiPost = vi.fn();
+const mockOpenShareDialog = vi.fn();
+const mockErrorManager = vi.fn();
+const mockComplete = vi.fn();
+
+vi.mock("@show-karma/karma-gap-sdk/core/class/entities/ProjectMilestone", () => ({
+  ProjectMilestone: { from: vi.fn(() => []) },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(() => ({ projectId: "project-slug" })),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+  usePathname: vi.fn(() => "/"),
+}));
+
+vi.mock("wagmi", () => ({
+  useAccount: (...args: unknown[]) => mockUseAccount(...args),
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: (...args: unknown[]) => mockErrorManager(...args),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: vi.fn(() => ({ switchChainAsync: mockSwitchChainAsync })),
+}));
+
+vi.mock("@/hooks/useAttestationToast", () => ({
+  useAttestationToast: vi.fn(() => ({
+    startAttestation: mockStartAttestation,
+    showLoading: vi.fn(),
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    changeStepperStep: mockChangeStepperStep,
+    dismiss: mockDismiss,
+    showChainProgress: mockShowChainProgress,
+  })),
+}));
+
+vi.mock("@/hooks/useOffChainRevoke", () => ({
+  useOffChainRevoke: vi.fn(() => ({ performOffChainRevoke: vi.fn() })),
+}));
+
+// useMilestone imports this relatively; alias and relative specifiers resolve
+// to distinct module ids under vitest, so every variant must be mocked or the
+// real hook pulls in wagmi's createConfig through useZeroDevSigner.
+vi.mock("@/hooks/useSetupChainAndWallet", () => ({
+  useSetupChainAndWallet: vi.fn(() => ({ setupChainAndWallet: mockSetupChainAndWallet })),
+}));
+vi.mock("hooks/useSetupChainAndWallet", () => ({
+  useSetupChainAndWallet: vi.fn(() => ({ setupChainAndWallet: mockSetupChainAndWallet })),
+}));
+vi.mock("../../../hooks/useSetupChainAndWallet", () => ({
+  useSetupChainAndWallet: vi.fn(() => ({ setupChainAndWallet: mockSetupChainAndWallet })),
+}));
+
+vi.mock("@/hooks/v2/useProjectUpdates", () => ({
+  useProjectUpdates: vi.fn(() => ({ refetch: mockRefetchUpdates })),
+}));
+
+vi.mock("@/hooks/v2/useProjectGrants", () => ({
+  useProjectGrants: vi.fn(() => ({ refetch: mockRefetchGrants })),
+}));
+
+vi.mock("@/utilities/sdk", () => ({
+  getProjectById: (...args: unknown[]) => mockGetProjectById(...args),
+}));
+
+vi.mock("@/utilities/gapIndexerApi/getProjectObjectives", () => ({
+  getProjectObjectives: (...args: unknown[]) => mockGetProjectObjectives(...args),
+}));
+
+vi.mock("@/utilities/api/client", () => ({
+  api: { post: (...args: unknown[]) => mockApiPost(...args) },
+}));
+
+vi.mock("@/store/modals/shareDialog", () => ({
+  useShareDialogStore: vi.fn((selector?: any) => {
+    const state = { openShareDialog: mockOpenShareDialog };
+    return selector ? selector(state) : state;
+  }),
+}));
+
+vi.mock("@/utilities/retries", async () => {
+  const actual = await vi.importActual<typeof import("@/utilities/retries")>("@/utilities/retries");
+  return {
+    ...actual,
+    retryUntilConditionMet: (...args: unknown[]) => mockRetryUntilConditionMet(...args),
+  };
+});
+
+vi.mock("@/store", () => {
+  const state = {
+    project: { uid: "0xproject", details: { slug: "project-slug" } },
+    isProjectOwner: true,
+    isOwner: false,
+  };
+  return {
+    useProjectStore: vi.fn((selector?: any) => (selector ? selector(state) : state)),
+    useOwnerStore: vi.fn((selector?: any) => {
+      const ownerState = { isOwner: state.isOwner };
+      return selector ? selector(ownerState) : ownerState;
+    }),
+  };
+});
+
+import { useMilestone } from "@/hooks/useMilestone";
+import {
+  COMPLETION_INDEXING_TIMEOUT_MESSAGE,
+  IndexingTimeoutError,
+  isSurfacedError,
+} from "@/utilities/errors";
+import { INTERACTIVE_INDEXING_POLL, RetryConditionNotMetError } from "@/utilities/retries";
+
+const milestone = {
+  uid: "0xmilestone",
+  type: "grant",
+  chainID: 8453,
+  refUID: "0xgrant",
+  title: "Systems Boundary Mapping",
+  mergedGrants: undefined,
+  source: {},
+} as any;
+
+const completionForm = {
+  description: "done",
+  completionPercentage: "25",
+  outputs: [],
+  deliverables: [],
+  noProofCheckbox: true,
+};
+
+function wireHappyChainAndProject() {
+  mockComplete.mockResolvedValue({ tx: [{ hash: "0xtx" }] });
+  mockSetupChainAndWallet.mockResolvedValue({
+    gapClient: {
+      fetch: {
+        projectById: vi.fn().mockResolvedValue({
+          uid: "0xproject",
+          grants: [
+            {
+              uid: "0xgrant",
+              details: { title: "Filecoin ProPGF Batch 2" },
+              milestones: [{ uid: "0xmilestone", chainID: 8453, complete: mockComplete }],
+            },
+          ],
+        }),
+      },
+    },
+    walletSigner: {},
+  });
+}
+
+describe("useMilestone - completion indexing wait", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAccount.mockReturnValue({ chain: { id: 8453 }, address: "0xsigner" });
+    mockApiPost.mockResolvedValue(undefined);
+    mockRefetchUpdates.mockResolvedValue(undefined);
+    mockRefetchGrants.mockResolvedValue({ data: [] });
+    wireHappyChainAndProject();
+  });
+
+  it("polls the indexer on the interactive budget, not the multi-minute default", async () => {
+    mockRetryUntilConditionMet.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useMilestone());
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone, completionForm as any);
+    });
+
+    expect(mockRetryUntilConditionMet).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      INTERACTIVE_INDEXING_POLL.maxRetries,
+      INTERACTIVE_INDEXING_POLL.delay
+    );
+  });
+
+  it("throws an IndexingTimeoutError when the completion is never indexed", async () => {
+    mockRetryUntilConditionMet.mockRejectedValue(new RetryConditionNotMetError());
+
+    const { result } = renderHook(() => useMilestone());
+
+    let caught: unknown;
+    await act(async () => {
+      await result.current
+        .completeMilestone(milestone, completionForm as any)
+        .catch((error: unknown) => {
+          caught = error;
+        });
+    });
+
+    expect(caught).toBeInstanceOf(IndexingTimeoutError);
+    expect((caught as Error).message).toBe(COMPLETION_INDEXING_TIMEOUT_MESSAGE);
+  });
+
+  it("shows the actionable timeout message instead of the generic completion error", async () => {
+    mockRetryUntilConditionMet.mockRejectedValue(new RetryConditionNotMetError());
+
+    const { result } = renderHook(() => useMilestone());
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone, completionForm as any).catch(() => {});
+    });
+
+    expect(mockShowError).toHaveBeenCalledWith(COMPLETION_INDEXING_TIMEOUT_MESSAGE);
+    expect(mockShowError).not.toHaveBeenCalledWith("There was an error completing the milestone");
+  });
+
+  it("marks the timeout surfaced so outer catches do not stack a second toast", async () => {
+    mockRetryUntilConditionMet.mockRejectedValue(new RetryConditionNotMetError());
+
+    const { result } = renderHook(() => useMilestone());
+
+    let caught: unknown;
+    await act(async () => {
+      await result.current
+        .completeMilestone(milestone, completionForm as any)
+        .catch((error: unknown) => {
+          caught = error;
+        });
+    });
+
+    expect(isSurfacedError(caught)).toBe(true);
+    expect(mockShowError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the timeout to telemetry exactly once", async () => {
+    mockRetryUntilConditionMet.mockRejectedValue(new RetryConditionNotMetError());
+
+    const { result } = renderHook(() => useMilestone());
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone, completionForm as any).catch(() => {});
+    });
+
+    expect(mockErrorManager).toHaveBeenCalledTimes(1);
+  });
+
+  it("still completes and celebrates when the indexer confirms", async () => {
+    mockRetryUntilConditionMet.mockImplementation(
+      async (_condition: unknown, onSuccess: () => Promise<void>) => {
+        await onSuccess();
+      }
+    );
+
+    const { result } = renderHook(() => useMilestone());
+
+    await act(async () => {
+      await result.current.completeMilestone(milestone, completionForm as any);
+    });
+
+    expect(mockShowSuccess).toHaveBeenCalled();
+    expect(mockOpenShareDialog).toHaveBeenCalled();
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useMilestone.helpers.ts
+++ b/hooks/useMilestone.helpers.ts
@@ -1,5 +1,9 @@
 import type { MilestoneCompletedFormData } from "@/components/Forms/GrantMilestoneCompletion";
-import { INDEXING_TIMEOUT_MESSAGE, IndexingTimeoutError } from "@/utilities/errors";
+import {
+  COMPLETION_INDEXING_TIMEOUT_MESSAGE,
+  INDEXING_TIMEOUT_MESSAGE,
+  IndexingTimeoutError,
+} from "@/utilities/errors";
 import { sendMilestoneImpactAnswers } from "@/utilities/impact/milestoneImpactAnswers";
 import { isRetryConditionNotMetError } from "@/utilities/retries";
 
@@ -12,6 +16,19 @@ import { isRetryConditionNotMetError } from "@/utilities/retries";
  */
 export const mapPollExhaustion = (error: unknown): unknown =>
   isRetryConditionNotMetError(error) ? new IndexingTimeoutError(INDEXING_TIMEOUT_MESSAGE) : error;
+
+/**
+ * Completion counterpart of {@link mapPollExhaustion}. Budget exhaustion after
+ * a completion attestation means the indexer never recorded it — either lag or
+ * a silent authorization rejection — so it becomes an `IndexingTimeoutError`
+ * carrying {@link COMPLETION_INDEXING_TIMEOUT_MESSAGE} instead of the generic
+ * "there was an error completing the milestone", which told the user nothing
+ * after they had already signed and paid gas.
+ */
+export const mapCompletionPollExhaustion = (error: unknown): unknown =>
+  isRetryConditionNotMetError(error)
+    ? new IndexingTimeoutError(COMPLETION_INDEXING_TIMEOUT_MESSAGE)
+    : error;
 
 // Helper function to send outputs and deliverables data
 export const sendOutputsAndDeliverables = async (

--- a/hooks/useMilestone.ts
+++ b/hooks/useMilestone.ts
@@ -19,7 +19,11 @@ import { INTERACTIVE_INDEXING_POLL, retryUntilConditionMet } from "@/utilities/r
 import { sanitizeInput, sanitizeObject } from "@/utilities/sanitize";
 import { getProjectById } from "@/utilities/sdk";
 import { SHARE_TEXTS } from "@/utilities/share/text";
-import { mapPollExhaustion, sendOutputsAndDeliverables } from "./useMilestone.helpers";
+import {
+  mapCompletionPollExhaustion,
+  mapPollExhaustion,
+  sendOutputsAndDeliverables,
+} from "./useMilestone.helpers";
 import { useOffChainRevoke } from "./useOffChainRevoke";
 import { useSetupChainAndWallet } from "./useSetupChainAndWallet";
 import { useWallet } from "./useWallet";
@@ -589,51 +593,67 @@ export const useMilestone = () => {
             );
           }
 
-          // Wait for indexer to process
-          await retryUntilConditionMet(
-            async () => {
-              const { data: fetchedGrants } = await refetchGrants();
-              // Check if any of the milestones have been completed
-              const areMilestonesCompleted = (fetchedGrants || []).some((grant) =>
-                grant.milestones?.some(
-                  (m) =>
-                    m.uid.toLowerCase() === milestoneInstance.uid.toLowerCase() && !!m.completed
-                )
-              );
-              return areMilestonesCompleted || false;
-            },
-            async () => {
-              changeStepperStep("indexed");
-            }
-          ).then(async () => {
-            showSuccess(`Completed ${milestone.title} milestone successfully!`);
+          // Wait for indexer to process. Bounded by the INTERACTIVE budget
+          // (~60s): the user is staring at the stepper, and a completion the
+          // indexer refused to record will never satisfy this condition, so the
+          // default ~5min budget just spun with no signal.
+          try {
+            await retryUntilConditionMet(
+              async () => {
+                const { data: fetchedGrants } = await refetchGrants();
+                // Check if any of the milestones have been completed
+                const areMilestonesCompleted = (fetchedGrants || []).some((grant) =>
+                  grant.milestones?.some(
+                    (m) =>
+                      m.uid.toLowerCase() === milestoneInstance.uid.toLowerCase() && !!m.completed
+                  )
+                );
+                return areMilestonesCompleted || false;
+              },
+              async () => {
+                changeStepperStep("indexed");
+              },
+              INTERACTIVE_INDEXING_POLL.maxRetries,
+              INTERACTIVE_INDEXING_POLL.delay
+            );
+          } catch (pollError) {
+            throw mapCompletionPollExhaustion(pollError);
+          }
 
-            // Open the share dialog with confetti FIRST, before any async work
-            const grantTitle = grantInstance?.details?.title || milestone.title;
-            const slugOrUid = (project?.details?.slug || project?.uid) as string;
-            openShareDialog({
-              modalShareText:
-                "You did it! Another milestone down, more impact ahead. Your onchain trail is growing — keep stacking progress.",
-              modalShareSecondText: " ",
-              shareText: SHARE_TEXTS.MILESTONE_COMPLETED(grantTitle, slugOrUid, grantInstance.uid),
-            });
+          showSuccess(`Completed ${milestone.title} milestone successfully!`);
 
-            // Send outputs and deliverables data (fire-and-forget, swallows errors)
-            await sendOutputsAndDeliverables(milestone.uid, data);
-
-            refetch();
-
-            // Let the share dialog render before any route transition
-            setTimeout(() => {
-              router.push(PAGES.PROJECT.OVERVIEW(slugOrUid));
-            }, 250);
+          // Open the share dialog with confetti FIRST, before any async work
+          const grantTitle = grantInstance?.details?.title || milestone.title;
+          const slugOrUid = (project?.details?.slug || project?.uid) as string;
+          openShareDialog({
+            modalShareText:
+              "You did it! Another milestone down, more impact ahead. Your onchain trail is growing — keep stacking progress.",
+            modalShareSecondText: " ",
+            shareText: SHARE_TEXTS.MILESTONE_COMPLETED(grantTitle, slugOrUid, grantInstance.uid),
           });
+
+          // Send outputs and deliverables data (fire-and-forget, swallows errors)
+          await sendOutputsAndDeliverables(milestone.uid, data);
+
+          refetch();
+
+          // Let the share dialog render before any route transition
+          setTimeout(() => {
+            router.push(PAGES.PROJECT.OVERVIEW(slugOrUid));
+          }, 250);
         });
     } catch (error: any) {
       // errorManager filters "reject" / transient errors, so log raw cause first.
       console.error("[completeSingleMilestone] failed:", error);
-      if (error?.message !== "WALLET_SETUP_FAILED") {
-        showError("There was an error completing the milestone");
+      if (error?.message !== "WALLET_SETUP_FAILED" && !isSurfacedError(error)) {
+        // An indexing timeout carries its own actionable message; the generic
+        // one hid the only detail the user could act on.
+        showError(
+          error instanceof IndexingTimeoutError
+            ? error.message
+            : "There was an error completing the milestone"
+        );
+        markSurfaced(error);
         errorManager("Error completing milestone.", error, { milestoneData: milestone });
       }
       throw error;
@@ -746,30 +766,38 @@ export const useMilestone = () => {
 
             changeStepperStep("indexing");
 
-            // Wait for indexer to process
-            await retryUntilConditionMet(
-              async () => {
-                const { data: fetchedGrants } = await refetchGrants();
-                if (!fetchedGrants?.length) return false;
-                // Check if any of the milestones have been completed
-                const areMilestonesCompleted = fetchedGrants.some((grant) =>
-                  grant.milestones?.some(
-                    (m) => milestoneUIDs.includes(m.uid as `0x${string}`) && !!m.completed
-                  )
-                );
-                return areMilestonesCompleted || false;
-              },
-              async () => {
-                changeStepperStep("indexed");
-              }
-            ).then(async () => {
-              // Send outputs and deliverables for each milestone
-              for (const milestoneUID of milestonesOfChain) {
-                await sendOutputsAndDeliverables(milestoneUID, data);
-              }
+            // Wait for indexer to process. Same INTERACTIVE budget as the
+            // single-milestone path — an unindexable completion must fail fast
+            // and say why, not spin out the default ~5min budget.
+            try {
+              await retryUntilConditionMet(
+                async () => {
+                  const { data: fetchedGrants } = await refetchGrants();
+                  if (!fetchedGrants?.length) return false;
+                  // Check if any of the milestones have been completed
+                  const areMilestonesCompleted = fetchedGrants.some((grant) =>
+                    grant.milestones?.some(
+                      (m) => milestoneUIDs.includes(m.uid as `0x${string}`) && !!m.completed
+                    )
+                  );
+                  return areMilestonesCompleted || false;
+                },
+                async () => {
+                  changeStepperStep("indexed");
+                },
+                INTERACTIVE_INDEXING_POLL.maxRetries,
+                INTERACTIVE_INDEXING_POLL.delay
+              );
+            } catch (pollError) {
+              throw mapCompletionPollExhaustion(pollError);
+            }
 
-              refetch();
-            });
+            // Send outputs and deliverables for each milestone
+            for (const milestoneUID of milestonesOfChain) {
+              await sendOutputsAndDeliverables(milestoneUID, data);
+            }
+
+            refetch();
           });
       }
       // Show final success message after all chains processed
@@ -792,10 +820,20 @@ export const useMilestone = () => {
       }, 250);
     } catch (error) {
       console.error("[completeMilestone] failed:", error);
-      showError("There was an error completing the milestone");
-      errorManager("Error completing milestone", error, {
-        milestoneData: milestone,
-      });
+      // Single-grant milestones are delegated to completeSingleMilestone, which
+      // already toasted and reported; re-handling a surfaced error here would
+      // stack a second toast and a duplicate Sentry event for one failure.
+      if (!isSurfacedError(error)) {
+        showError(
+          error instanceof IndexingTimeoutError
+            ? error.message
+            : "There was an error completing the milestone"
+        );
+        markSurfaced(error);
+        errorManager("Error completing milestone", error, {
+          milestoneData: milestone,
+        });
+      }
       throw error;
     } finally {
       dismiss();

--- a/utilities/errors.ts
+++ b/utilities/errors.ts
@@ -113,6 +113,18 @@ export class OffChainRevokeError extends Error {
 export const INDEXING_TIMEOUT_MESSAGE =
   "Your revocation was submitted but is still being indexed. Please refresh in a moment.";
 
+/**
+ * Completion counterpart of {@link INDEXING_TIMEOUT_MESSAGE}. Deliberately
+ * worded differently: a completion that never lands is NOT always a lagging
+ * indexer. The indexer also drops completion attestations whose signing wallet
+ * fails its authorization check, and that rejection is invisible to the client
+ * — `POST /attestations/index-by-transaction` answers 200 either way. Promising
+ * "it will appear shortly" would be a lie in the case that actually matters, so
+ * this names the likely cause and gives the user something to act on.
+ */
+export const COMPLETION_INDEXING_TIMEOUT_MESSAGE =
+  "Your completion was signed on-chain but hasn't been indexed yet. Refresh in a moment — if the milestone is still not marked complete, the wallet you signed with may not be authorized for this project.";
+
 export class IndexingTimeoutError extends Error {
   readonly name = "IndexingTimeoutError";
   readonly code = "INDEXING_TIMEOUT" as const;


### PR DESCRIPTION
Pairs with show-karma/gap-indexer#2265, which stops the rejection at its source. This side makes the remaining failures legible instead of a hang.

## The bug

`completeSingleMilestone` / `completeMilestone` sign on-chain, POST to the attestation listener, then poll `retryUntilConditionMet` waiting for `milestone.completed` to appear — on the **default** budget: 200 × 1500 ms, *plus* a full project-query invalidation and refetch every iteration.

The indexer silently refuses completion attestations it can't authorize, and `POST /attestations/index-by-transaction` answers `200` either way, so the client gets **no rejection signal at all**. That condition can never be satisfied. The stepper spun for minutes and then showed:

> There was an error completing the milestone

…to someone who had already signed and paid gas. Four such rounds are visible on Base for one Filecoin grantee (see the paired PR).

The undo-completion flow already uses `INTERACTIVE_INDEXING_POLL` for exactly this reason — completion never got it.

## Changes

- Both completion paths bounded to `INTERACTIVE_INDEXING_POLL` (30 × 2 s ≈ 60 s).
- New `mapCompletionPollExhaustion` maps budget exhaustion to `IndexingTimeoutError` carrying `COMPLETION_INDEXING_TIMEOUT_MESSAGE`.
- The timeout is marked surfaced, so outer catches don't stack a generic toast on top.
- `completeMilestone` no longer double-toasts and double-reports to Sentry when it delegates to `completeSingleMilestone`.
- Flattened the two `.then()` chains to straight-line awaits (the `.then()` bodies were the only reason the success path was nested).

### On the message wording

Deliberately different from the revoke message. A completion that never lands is **not** always a lagging indexer — it is also how an authorization rejection looks from the client. Promising "it will appear shortly" would be a lie in exactly the case that matters, so it names the likely cause:

> Your completion was signed on-chain but hasn't been indexed yet. Refresh in a moment — if the milestone is still not marked complete, the wallet you signed with may not be authorized for this project.

## Scope note

An earlier revision of this branch added a pre-flight eligibility check that blocked the signature up front, backed by a new indexer endpoint. That direction was dropped — the flow should degrade gracefully when authorization fails rather than gate signing behind an extra round-trip. Both the client half and the endpoint (show-karma/gap-indexer#2267) are gone; what remains is the graceful handling above.

## Tests

New `__tests__/unit/hooks/useMilestoneCompletionIndexingTimeout.test.ts` (6 cases) — verified **4 fail** against unmodified source:

- polls on the interactive budget, not the multi-minute default
- exhaustion throws `IndexingTimeoutError` with the completion message
- shows the actionable message, never the generic one
- marks the error surfaced
- reports to telemetry exactly once
- success path still celebrates (`showSuccess` + share dialog)

## Verification

- `__tests__/unit/hooks` + `__tests__/utilities/errors` — 607 passed
- `pnpm run build` — exit 0
- Biome — 10 pre-existing `noExplicitAny` warnings in `useMilestone.ts`, none on changed lines

## Smoke results — RESOLVED 2026-07-23, replay superseded

**Do NOT run the replay suite against production.** The dropped-completion backlog was resolved selectively after content triage (see below), and a full replay would index attestations deliberately left out — including two whose reason text embeds a tokenized Airtable invite link.

Final disposition of the five affected milestones (verified via a read-only dry-run of the merged validator against prod Mongo + live Privy + live Base resolver):

| Milestone | Outcome |
|---|---|
| Wayne's (0x35f1c4ca…) | Complete via admin's manual completion (indexed 07-20). All 4 of Wayne's attempts verified WOULD ADMIT under the fix (privy-link arm) — deliberately NOT indexed: admin's completion suffices, and the 07-17 pair embeds a tokenized invite URL |
| 0x53a09465… | Recovered post-deploy — both relayed completions indexed (only possible via the new relay arm → fix confirmed live on prod) |
| 0x145d5c1c… | Self-resolved — both completions indexed |
| 0xcbcc6ed1… | Complete via teammate's identical-content completion; grantee's 4 retries redundant |
| 0xa419abe5… | Both attempts correctly REJECTED even under the fix: signer has no linked wallet, membership, or resolver authority — separate Privy accounts. Needs owner action (MemberOf + replay, or manual completion), not indexing |

The spec remains valid for ephemeral/preview environments seeded with the Base dataset; against production it is superseded by the resolution above.