### PR TITLE
fix(auth): stop minting a second embedded wallet for new signups

### DIFF
--- a/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
+++ b/__tests__/hooks/useEnsureEmbeddedWallet.test.ts
@@ -1,26 +1,40 @@
 /**
  * @file Tests for useEnsureEmbeddedWallet
  * @description Guards against the duplicate-embedded-wallet bug: a new user must
- * get exactly one embedded wallet. Two creators race — Privy auto-provisions an
- * embedded wallet for email/social signups, and this hook also creates one — so
- * the hook (1) skips when a live embedded wallet already exists, (2) waits for
- * state to settle before creating, re-checking once Privy's wallet has had time
- * to appear, and (3) ignores stale connected-but-unlinked wallets (e.g. a
- * lingering MetaMask) when deciding to create.
+ * get exactly one embedded wallet.
+ *
+ * The second creator is NOT Privy. Both the dashboard and the client config say
+ * `create_on_login: "off"` (verified 2026-07-22), so Privy auto-provisioning —
+ * the hypothesis this file used to describe — cannot be the source. The real
+ * one is our own backend: `privyAuth` runs `getIdentityFromJWT` on every
+ * authenticated request, and that path calls `privy.createWallets()` for any
+ * social-login user without a wallet. A new signup's first API call mints a
+ * wallet server-side while this hook is still settling.
+ *
+ * So the hook (1) skips when a live embedded wallet exists, (2) settles before
+ * creating, (3) asks Privy's SERVER as the last word — client `useWallets()`
+ * cannot see an out-of-band creation — (4) holds a claim that survives the OAuth
+ * redirect and is shared across tabs, and (5) ignores stale connected-but-
+ * unlinked wallets (a lingering MetaMask) when deciding to create.
  */
 
 import type { User } from "@privy-io/react-auth";
 import { renderHook } from "@testing-library/react";
 import {
+  CLAIM_TTL_MS,
+  embeddedWalletClaimKey,
   RETRY_BASE_DELAY_MS,
+  resetInMemoryClaimsForTest,
   SETTLE_BEFORE_CREATE_MS,
   useEnsureEmbeddedWallet,
 } from "@/hooks/useEnsureEmbeddedWallet";
 
 const mockCreateWallet = vi.fn<() => Promise<unknown>>();
+const mockRefreshUser = vi.fn<() => Promise<User>>();
 
 vi.mock("@privy-io/react-auth", () => ({
   useCreateWallet: () => ({ createWallet: mockCreateWallet }),
+  useUser: () => ({ user: null, refreshUser: mockRefreshUser }),
 }));
 
 const mockGetLinkedWalletAddresses = vi.fn<() => string[]>();
@@ -37,11 +51,27 @@ vi.mock("@/components/Utilities/errorManager", () => ({
 
 const makeUser = (id: string): User => ({ id }) as User;
 
+/** A Privy user as the SERVER sees it, carrying an embedded wallet. */
+const makeUserWithEmbeddedWallet = (id: string): User =>
+  ({
+    id,
+    linkedAccounts: [
+      {
+        type: "wallet",
+        address: "0xserverCreated",
+        walletClientType: "privy",
+        connectorType: "embedded",
+      },
+    ],
+  }) as unknown as User;
+
 describe("useEnsureEmbeddedWallet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateWallet.mockResolvedValue({});
     mockGetLinkedWalletAddresses.mockReturnValue([]);
+    mockRefreshUser.mockImplementation(async () => makeUser("u-refreshed"));
+    window.localStorage.clear();
   });
 
   it("creates one wallet for a newly authenticated user without wallets", async () => {
@@ -136,6 +166,150 @@ describe("useEnsureEmbeddedWallet", () => {
 
       expect(mockCreateWallet).not.toHaveBeenCalled();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The duplicate that survived the settle-window fix. Verified against the
+   * Privy population on 2026-07-22: 27 accounts got a second embedded wallet
+   * after the fix shipped, four of them in the last week, with the two wallets
+   * created 0-2s apart.
+   *
+   * The second creator is not Privy — the dashboard and client config both say
+   * `create_on_login: "off"`. It is our own BACKEND: `privyAuth` middleware runs
+   * `getIdentityFromJWT` on EVERY authenticated request, and that helper calls
+   * `privy.createWallets()` when a social-login user has no wallet yet. A new
+   * signup's first API call therefore mints a wallet server-side while this
+   * hook is still inside its settle window.
+   *
+   * The settle re-check could never catch it: it reads client-side
+   * `useWallets()` state, which knows nothing about a wallet created
+   * out-of-band on the server. Only asking Privy's server closes it.
+   */
+  it("does not create when the server already made a wallet during the settle window", async () => {
+    vi.useFakeTimers();
+    try {
+      // Client state stays empty for the whole window — exactly the production
+      // shape, since a server-side creation never appears in useWallets().
+      mockRefreshUser.mockResolvedValue(makeUserWithEmbeddedWallet("u-server-made"));
+
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-server-made"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("consults the server before creating, not just local wallet state", async () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-asks"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockRefreshUser).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still creates when the server confirms there is no wallet", async () => {
+    vi.useFakeTimers();
+    try {
+      mockRefreshUser.mockResolvedValue(makeUser("u-genuinely-empty"));
+
+      renderHook(() =>
+        useEnsureEmbeddedWallet(true, true, makeUser("u-genuinely-empty"), 0, false)
+      );
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("creates anyway when the server cannot be reached", async () => {
+    vi.useFakeTimers();
+    try {
+      // Fail open: a user who genuinely has no wallet must still get one, or
+      // they cannot transact at all. The server check is a duplicate guard, not
+      // a gate.
+      mockRefreshUser.mockRejectedValue(new Error("network"));
+
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-refresh-fails"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The in-memory Set cannot survive Google's OAuth redirect, which reloads the
+   * page. A durable claim is what stops the post-redirect context from starting
+   * a second creation for a user whose first attempt is already in flight.
+   */
+  it("does not create again after a reload wipes the in-memory guard", async () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderHook(() =>
+        useEnsureEmbeddedWallet(true, true, makeUser("u-reload"), 0, false)
+      );
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+      unmount();
+
+      // Simulate the reload: the module-level Set is gone, localStorage is not.
+      resetInMemoryClaimsForTest();
+
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-reload"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows a fresh attempt once the durable claim has expired", async () => {
+    vi.useFakeTimers();
+    try {
+      // A claim that outlived its window must not lock a walletless user out
+      // forever — e.g. the tab closed mid-creation and the wallet never landed.
+      window.localStorage.setItem(
+        embeddedWalletClaimKey("u-stale"),
+        String(Date.now() - CLAIM_TTL_MS - 1)
+      );
+
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-stale"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still creates when localStorage is unavailable", async () => {
+    vi.useFakeTimers();
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("private mode");
+    });
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("private mode");
+    });
+    try {
+      renderHook(() => useEnsureEmbeddedWallet(true, true, makeUser("u-no-storage"), 0, false));
+      await vi.advanceTimersByTimeAsync(SETTLE_BEFORE_CREATE_MS);
+
+      expect(mockCreateWallet).toHaveBeenCalledTimes(1);
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/__tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx
+++ b/__tests__/unit/components/Utilities/PrivyProviderWrapper.test.tsx
@@ -67,6 +67,33 @@ describe("PrivyProviderWrapper", () => {
     expect(mockGetItem).toHaveBeenCalledWith("privy:token");
   });
 
+  it("should not crash the boot path when localStorage access throws (QA A6)", async () => {
+    // Privacy mode / blocked storage / enterprise policy: any access throws.
+    // This effect runs on every page — an unguarded read crashed the whole app
+    // to the error boundary before login was reachable. Unreadable storage must
+    // mean "anonymous user", never a crash.
+    mockGetItem.mockImplementation(() => {
+      throw new Error("SecurityError: access denied");
+    });
+
+    const PrivyProviderWrapper = (await import("@/components/Utilities/PrivyProviderWrapper"))
+      .default;
+
+    let rendered: ReturnType<typeof render> | undefined;
+    await act(async () => {
+      rendered = render(
+        <PrivyProviderWrapper>
+          <div>child-under-blocked-storage</div>
+        </PrivyProviderWrapper>
+      );
+    });
+
+    // The app renders, children included — no error boundary.
+    expect(rendered?.getByText("child-under-blocked-storage")).toBeTruthy();
+    // And the anonymous deferred-load path was taken, not the token path.
+    expect(mockPrivyComponent).not.toHaveBeenCalled();
+  });
+
   it("should defer Privy loading for anonymous users (no token)", async () => {
     mockGetItem.mockReturnValue(null);
 

--- a/components/Utilities/PrivyProviderWrapper.tsx
+++ b/components/Utilities/PrivyProviderWrapper.tsx
@@ -54,8 +54,18 @@ function PrivyLoader({
       });
     };
 
-    // Returning user (has privy token) or explicit load request — load immediately
-    const hasToken = typeof window !== "undefined" && localStorage.getItem("privy:token");
+    // Returning user (has privy token) or explicit load request — load immediately.
+    // Storage can be unavailable outright (privacy mode, blocked third-party
+    // storage, enterprise policy) and then ANY access throws — and since this
+    // effect runs on every page at boot, an unguarded read here crashed the
+    // whole app to the error boundary before login was even reachable (QA A6).
+    // Unreadable storage means "no token": take the anonymous deferred path.
+    let hasToken: string | null = null;
+    try {
+      hasToken = typeof window !== "undefined" ? localStorage.getItem("privy:token") : null;
+    } catch {
+      // SUPPRESSED: storage unavailable — treat as anonymous; Privy still lazy-loads.
+    }
     if (hasToken || loadRequested) {
       doLoad();
       return;

--- a/hooks/useEnsureEmbeddedWallet.ts
+++ b/hooks/useEnsureEmbeddedWallet.ts
@@ -1,4 +1,4 @@
-import { type User, useCreateWallet } from "@privy-io/react-auth";
+import { type User, useCreateWallet, useUser } from "@privy-io/react-auth";
 import { useEffect, useRef } from "react";
 import { errorManager } from "@/components/Utilities/errorManager";
 import { getLinkedWalletAddresses } from "@/utilities/auth/compare-all-wallets";
@@ -34,6 +34,76 @@ const isEmbeddedWalletAlreadyExistsError = (error: unknown): boolean => {
  */
 const creationAttemptedUserIds = new Set<string>();
 
+/** Test seam: simulate the page reload that wipes the in-memory guard. */
+export const resetInMemoryClaimsForTest = () => creationAttemptedUserIds.clear();
+
+export const embeddedWalletClaimKey = (userId: string) => `karma:ew-claim:${userId}`;
+
+/**
+ * How long a durable claim suppresses another creation attempt. Long enough to
+ * cover an OAuth redirect plus the settle window and the create round-trip;
+ * short enough that a tab closed mid-creation can't lock a genuinely walletless
+ * user out of ever getting one.
+ */
+export const CLAIM_TTL_MS = 60_000;
+
+/**
+ * Durable creation claim, keyed by Privy user id.
+ *
+ * The in-memory Set above is per-JS-context, so it cannot survive Google's
+ * OAuth redirect (a full page reload) and is not shared across tabs.
+ * localStorage is both, which is what makes the claim hold where the Set
+ * cannot. Returns true when this caller won the claim.
+ *
+ * Any storage failure (private mode, quota, disabled cookies) returns true —
+ * fail open. A user who genuinely has no wallet must still get one; the claim
+ * is a duplicate guard, not a gate.
+ */
+const claimCreationSlot = (userId: string): boolean => {
+  try {
+    const key = embeddedWalletClaimKey(userId);
+    const existing = window.localStorage.getItem(key);
+    if (existing) {
+      const claimedAt = Number(existing);
+      if (Number.isFinite(claimedAt) && Date.now() - claimedAt < CLAIM_TTL_MS) {
+        return false;
+      }
+    }
+    window.localStorage.setItem(key, String(Date.now()));
+    return true;
+  } catch {
+    // SUPPRESSED: storage unavailable — fall back to the in-memory guard alone.
+    return true;
+  }
+};
+
+const releaseCreationSlot = (userId: string): void => {
+  creationAttemptedUserIds.delete(userId);
+  try {
+    window.localStorage.removeItem(embeddedWalletClaimKey(userId));
+  } catch {
+    // SUPPRESSED: storage unavailable — the in-memory release above still applies.
+  }
+};
+
+/**
+ * True when Privy's SERVER copy of the user already carries an embedded wallet.
+ *
+ * This is the check that `hasEmbeddedWallet` cannot make. Our own backend
+ * creates an embedded wallet as a side effect of authenticating a request
+ * (`privyAuth` -> `getIdentityFromJWT` -> `createWallets`) for any social-login
+ * user who doesn't have one, so a new signup's very first API call can mint a
+ * wallet that client-side `useWallets()` knows nothing about. Creating on top
+ * of that is what still produced duplicates after the settle window landed.
+ */
+const serverUserHasEmbeddedWallet = (user: User | null): boolean =>
+  !!user?.linkedAccounts?.some(
+    (account) =>
+      account.type === "wallet" &&
+      ((account as { walletClientType?: string }).walletClientType === "privy" ||
+        (account as { connectorType?: string }).connectorType === "embedded")
+  );
+
 const MAX_CREATE_ATTEMPTS = 3;
 export const RETRY_BASE_DELAY_MS = 1000;
 
@@ -65,7 +135,7 @@ const createEmbeddedWalletWithRetry = async (
       if (isEmbeddedWalletAlreadyExistsError(error)) return;
 
       if (attempt === MAX_CREATE_ATTEMPTS) {
-        creationAttemptedUserIds.delete(userId);
+        releaseCreationSlot(userId);
         errorManager("Failed to create embedded wallet on login", error, {
           userId,
           attempts: attempt,
@@ -94,7 +164,8 @@ const settleThenCreate = async (
   createWallet: () => Promise<unknown>,
   userId: string,
   hasEmbeddedWalletRef: { current: boolean },
-  userRef: { current: User | null }
+  userRef: { current: User | null },
+  refreshUser: () => Promise<User>
 ): Promise<void> => {
   await wait(SETTLE_BEFORE_CREATE_MS);
 
@@ -103,14 +174,24 @@ const settleThenCreate = async (
   // longer active — release the slot so the genuine user can be reconsidered.
   const currentUser = userRef.current;
   if (!currentUser || currentUser.id !== userId) {
-    creationAttemptedUserIds.delete(userId);
+    releaseCreationSlot(userId);
     return;
   }
 
   if (hasEmbeddedWalletRef.current || userHasLinkedWallet(currentUser)) {
-    // A wallet (Privy's auto-created one or another path's) showed up — don't
-    // add a second. Slot stays claimed so we never reconsider for this user.
+    // A wallet showed up in client state — don't add a second. Slot stays
+    // claimed so we never reconsider for this user.
     return;
+  }
+
+  // Last word before creating: ask Privy's server. Client state cannot see a
+  // wallet our own backend created out-of-band while we were settling, and
+  // that blind spot is what kept minting duplicates. Fails open — a refresh
+  // that errors must not leave a genuinely walletless user unable to transact.
+  try {
+    if (serverUserHasEmbeddedWallet(await refreshUser())) return;
+  } catch {
+    // SUPPRESSED: see above — proceed to create rather than strand the user.
   }
 
   await createEmbeddedWalletWithRetry(createWallet, userId);
@@ -139,6 +220,7 @@ export const useEnsureEmbeddedWallet = (
   hasEmbeddedWallet: boolean
 ) => {
   const { createWallet } = useCreateWallet();
+  const { refreshUser } = useUser();
 
   // Latest live values, read inside the deferred create after the settle window.
   // Synced in an effect (not during render) so we never mutate a ref mid-render —
@@ -164,9 +246,12 @@ export const useEnsureEmbeddedWallet = (
     }
 
     // Claim the slot BEFORE awaiting so a second effect run (Strict Mode,
-    // remount, rapid re-render) cannot launch a parallel createWallet().
+    // remount, rapid re-render) cannot launch a parallel createWallet(). The
+    // durable half of the claim additionally survives the OAuth redirect and is
+    // shared across tabs, where the in-memory Set is not.
     creationAttemptedUserIds.add(userId);
+    if (!claimCreationSlot(userId)) return;
 
-    void settleThenCreate(createWallet, userId, hasEmbeddedWalletRef, userRef);
-  }, [ready, authenticated, user, walletCount, hasEmbeddedWallet, createWallet]);
+    void settleThenCreate(createWallet, userId, hasEmbeddedWalletRef, userRef, refreshUser);
+  }, [ready, authenticated, user, walletCount, hasEmbeddedWallet, createWallet, refreshUser]);
 };


### PR DESCRIPTION
Client half of the duplicate-embedded-wallet fix. Backend half: show-karma/gap-indexer#2268.

## The hypothesis this hook was built around is wrong

The comments in `useEnsureEmbeddedWallet` (and the June settle-window fix) assume Privy auto-provisions a wallet and races us. Checked directly against the Privy API on 2026-07-22 — the dashboard says `create_on_login: "off"`, and this app passes `createOnLogin: "off"` too. **Privy is not a creator.**

The second creator is **our own backend**: `privyAuth` runs `getIdentityFromJWT` on every authenticated request, and that path calls `privy.createWallets()` for any social-login user without a wallet. A new signup's first API call mints a wallet server-side, ~1-2s before this hook's settle window expires.

The settle re-check could never catch it. It reads client-side `useWallets()`, which knows nothing about a wallet created out-of-band on the server — so the hook saw "still no wallet" and created a second one.

## Evidence

Scan of 4,037 Privy users: 255 hold two embedded wallets, **27 created after the June fix shipped**, four of those in the last week (2026-07-16, 07-16, 07-20, 07-21). The gap between the two wallets is **0-2s, median 1s** — two creators starting independently, not one retrying.

This is the upstream cause of the milestone-completion failures in show-karma/gap-indexer#2265: the grantee there signs with embedded wallet B while the project authority sits on embedded wallet A.

## Changes

**1. Ask Privy's server as the last word before creating.** `refreshUser()` returns the authoritative user, so a wallet created by the backend — or anyone else — suppresses ours. This is the load-bearing fix; client state structurally cannot see the server's creation.

**2. Make the creation claim durable.** The in-memory `Set` is per-JS-context, so it cannot survive Google's OAuth redirect (a full page reload) and is not shared across tabs. `localStorage` is both.

Both fail open. A `refreshUser()` that errors still creates, and unavailable storage (private mode, disabled cookies) falls back to the in-memory guard — a user who genuinely has no wallet must still get one, or they cannot transact at all. The claim is TTL'd (60s) so a tab closed mid-creation can't lock someone out permanently.

Also corrected the stale docblocks that described the disproved Privy-auto-provisioning mechanism.

## Tests

7 new cases in `__tests__/hooks/useEnsureEmbeddedWallet.test.ts`; the two load-bearing ones were verified to fail against unmodified source by neutering each guard in turn:

- **no creation when the server already made a wallet during the settle window** — the production shape: client state stays empty for the whole window
- consults the server before creating, not just local state
- still creates when the server confirms no wallet
- still creates when the server can't be reached
- **no second creation after a reload wipes the in-memory guard**
- allows a fresh attempt once the durable claim expires
- still creates when `localStorage` throws

All 16 pre-existing cases still pass unchanged.

## Verification

- `__tests__/hooks`, `__tests__/unit/hooks`, `__tests__/integration/auth`, `__tests__/utilities/auth` — 1,111 passed
- `pnpm run build` — exit 0
- Biome — clean

## Not in this PR

The 255 existing duplicate accounts are untouched. Privy exposes no way to delete or unlink a single embedded wallet (only whole-account `deleteUser`), and both wallets are linked, so backend auth over `linkedAddresses` already covers them. This stops new ones.