### PR TITLE
chore(quality): sync useMilestone baseline entry after #1894

### DIFF
--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -346,8 +346,8 @@
       "maxBytes": 40000
     },
     "hooks/useMilestone.ts": {
-      "lines": 1138,
-      "bytes": 41352,
+      "lines": 1176,
+      "bytes": 42936,
       "maxLines": 600,
       "maxBytes": 40000
     },


### PR DESCRIPTION
## Why

PR #1894 merged at 16:03 UTC with a red `quality-gate`: it grew `hooks/useMilestone.ts` from 1138 to 1176 lines (already over the 600-line limit) without bumping `quality-baseline.json`. Since then **every open PR fails `quality-gate`** on a regression its own diff does not contain — e.g. #1891's gate went red at 16:49 purely from the merge ref pulling in main.

## What

Targeted sync of the single stale entry to the file's actual size on `main` @ `24a5b6619`: `lines` 1138 → 1176, `bytes` 41352 → 42936 (measured via `git show origin/main:hooks/useMilestone.ts | wc -lc`). Not a full regeneration: every other delta in the failing gate reports is 0, so only this entry drifted.

Carries the `quality-baseline` label per the `baseline-guard` policy.

## After merge

Re-run `quality-gate` on open PRs (their merge refs pick up the synced baseline). The underlying debt — `useMilestone.ts` being ~2× the line limit — is untouched; shrinking it is a separate refactor.