### PR TITLE
fix: end wallet-only sessions on disconnect; drop duplicate homepage scrollbar

### DIFF
--- a/__tests__/navbar/unit/navbar-user-menu.test.tsx
+++ b/__tests__/navbar/unit/navbar-user-menu.test.tsx
@@ -39,6 +39,7 @@ const _localRefs = vi.hoisted(() => {
         logout: _vi.fn(),
         authenticate: _vi.fn(),
         disconnect: _vi.fn(),
+        connectWallet: _vi.fn(),
         getAccessToken: _vi.fn().mockResolvedValue("mock-token"),
       },
     },
@@ -111,6 +112,7 @@ const setLocalRefsFromFixture = (fixtureName: string) => {
     logout: vi.fn(),
     authenticate: vi.fn(),
     disconnect: vi.fn(),
+    connectWallet: vi.fn(),
     getAccessToken: vi.fn().mockResolvedValue("mock-token"),
   };
 
@@ -170,6 +172,7 @@ const resetLocalRefs = () => {
     logout: vi.fn(),
     authenticate: vi.fn(),
     disconnect: vi.fn(),
+    connectWallet: vi.fn(),
     getAccessToken: vi.fn().mockResolvedValue("mock-token"),
   };
   _localRefs.modalState.current = {
@@ -674,6 +677,29 @@ describe("NavbarUserMenu", () => {
       });
 
       expect(screen.queryByRole("menubar")).toBeInTheDocument();
+    });
+
+    it("offers Connect wallet as the recovery action when no wallet is resolved", async () => {
+      const user = userEvent.setup();
+      const connectWallet = vi.fn();
+      _localRefs.navPermsState.current.isLoggedIn = true;
+      _localRefs.navPermsState.current.address = undefined;
+      _localRefs.navPermsState.current.ready = true;
+      _localRefs.navPermsState.current.walletsReady = true;
+      _localRefs.authState.current.authenticated = true;
+      _localRefs.authState.current.address = undefined;
+      _localRefs.authState.current.user = null;
+      _localRefs.authState.current.connectWallet = connectWallet;
+
+      renderWithProviders(<NavbarUserMenu />, {
+        mockUseAuth: createMockUseAuth(_localRefs.authState.current),
+      });
+
+      await user.click(screen.getByRole("menuitem"));
+      const connectItem = await screen.findByText("Connect wallet");
+      await user.click(connectItem);
+
+      expect(connectWallet).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/navbar/unit/navbar-user-menu.test.tsx
+++ b/__tests__/navbar/unit/navbar-user-menu.test.tsx
@@ -14,6 +14,7 @@ const _localRefs = vi.hoisted(() => {
         isLoggedIn: false,
         address: undefined as string | undefined,
         ready: true,
+        walletsReady: true,
         isStaff: false,
         isStaffLoading: false,
         isOwner: false,
@@ -125,6 +126,7 @@ const setLocalRefsFromFixture = (fixtureName: string) => {
     isLoggedIn,
     address: authState.address,
     ready: authState.ready ?? true,
+    walletsReady: authState.walletsReady ?? true,
     isStaff: permissions.isStaff,
     isStaffLoading: false,
     isOwner: permissions.isOwner,
@@ -145,6 +147,7 @@ const resetLocalRefs = () => {
     isLoggedIn: false,
     address: undefined,
     ready: true,
+    walletsReady: true,
     isStaff: false,
     isStaffLoading: false,
     isOwner: false,
@@ -638,6 +641,7 @@ describe("NavbarUserMenu", () => {
       _localRefs.navPermsState.current.isLoggedIn = true;
       _localRefs.navPermsState.current.address = undefined;
       _localRefs.navPermsState.current.ready = true;
+      _localRefs.navPermsState.current.walletsReady = false;
       _localRefs.authState.current.authenticated = true;
       _localRefs.authState.current.address = undefined;
       _localRefs.authState.current.user = null;
@@ -650,6 +654,26 @@ describe("NavbarUserMenu", () => {
       // The skeleton replaces the menu entirely — no menubar or avatar yet.
       expect(screen.queryByRole("menubar")).not.toBeInTheDocument();
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    });
+
+    it("renders the menu once wallets are resolved even with no identity, so the user is never trapped", () => {
+      // Disconnecting the site inside the wallet extension leaves an
+      // authenticated session with no address, forever. Gating the skeleton on
+      // "did an identity resolve?" made it permanent and took the Log out item
+      // down with it — the user could only escape by clearing site data.
+      _localRefs.navPermsState.current.isLoggedIn = true;
+      _localRefs.navPermsState.current.address = undefined;
+      _localRefs.navPermsState.current.ready = true;
+      _localRefs.navPermsState.current.walletsReady = true;
+      _localRefs.authState.current.authenticated = true;
+      _localRefs.authState.current.address = undefined;
+      _localRefs.authState.current.user = null;
+
+      renderWithProviders(<NavbarUserMenu />, {
+        mockUseAuth: createMockUseAuth(_localRefs.authState.current),
+      });
+
+      expect(screen.queryByRole("menubar")).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
+++ b/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @file Tests for useAuth's wallet-disconnect logout
+ * @description Disconnecting the site from inside the wallet extension empties
+ * Privy's wallet list but leaves the session authenticated. For a wallet-only
+ * session that is a dead end — no address to render, no Sign-in button (still
+ * "logged in"), and the Log out item lives inside a menu that can no longer
+ * render. useAuth ends such a session; these tests pin the guards that keep it
+ * from becoming a sign-out loop.
+ */
+
+import type { ConnectedWallet, User } from "@privy-io/react-auth";
+import { act, renderHook } from "@testing-library/react";
+import { useAuth } from "@/hooks/useAuth";
+
+// Undo the global mock of useAuth so we exercise the real hook
+vi.unmock("@/hooks/useAuth");
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock("@/utilities/whitelabel-context", () => ({
+  useWhitelabel: vi.fn(() => ({ isWhitelabel: false, whitelabelConfig: null })),
+}));
+
+vi.mock("@/store/modals/projectCreate", () => ({
+  useProjectCreateModalStore: {
+    getState: vi.fn(() => ({ isProjectCreateModalOpen: false })),
+  },
+}));
+
+vi.mock("@/utilities/pages", () => ({ PAGES: { DASHBOARD: "/dashboard" } }));
+
+const mockLogout = vi.fn().mockResolvedValue(undefined);
+
+const mockBridgeState = {
+  ready: true,
+  authenticated: true,
+  user: null as User | null,
+  login: vi.fn(),
+  logout: mockLogout,
+  getAccessToken: vi.fn(),
+  connectWallet: vi.fn(),
+  wallets: [] as ConnectedWallet[],
+  walletsReady: true,
+  isConnected: true,
+};
+
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => mockBridgeState,
+  PrivyBridgeContext: { Provider: ({ children }: { children: any }) => children },
+  PRIVY_BRIDGE_DEFAULTS: {},
+}));
+
+vi.mock("@wagmi/core", () => ({ watchAccount: vi.fn(() => vi.fn()) }));
+vi.mock("@/utilities/wagmi/privy-config", () => ({
+  privyConfig: {},
+  getPrivyWagmiConfig: vi.fn(() => ({})),
+}));
+vi.mock("@/utilities/query-client", () => ({
+  queryClient: { clear: vi.fn(), invalidateQueries: vi.fn() },
+}));
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: {
+    getToken: vi.fn(),
+    setPrivyInstance: vi.fn(),
+    clearTokens: vi.fn(),
+    clearCache: vi.fn(),
+  },
+}));
+
+const WALLET = {
+  address: "0x1234567890abcdef1234567890abcdef12345678",
+  walletClientType: "metamask",
+} as unknown as ConnectedWallet;
+
+const walletOnlyUser = {
+  id: "user-1",
+  linkedAccounts: [{ type: "wallet", address: WALLET.address }],
+} as unknown as User;
+
+const emailUser = {
+  id: "user-2",
+  email: { address: "a@b.com" },
+  linkedAccounts: [
+    { type: "email", address: "a@b.com" },
+    { type: "wallet", address: WALLET.address },
+  ],
+} as unknown as User;
+
+const setBridge = (overrides: Partial<typeof mockBridgeState>) =>
+  Object.assign(mockBridgeState, overrides);
+
+/**
+ * Render useAuth in the CONNECTED state first, then disconnect. This mirrors
+ * the real sequence and, because useAuth's fired-guard is module-level (shared
+ * across all mounted instances), it also re-arms that guard between tests.
+ */
+function renderConnectedThenDisconnect(
+  user: User,
+  overrides: Partial<typeof mockBridgeState> = {}
+) {
+  setBridge({ user, wallets: [WALLET], walletsReady: true, authenticated: true });
+  const view = renderHook(() => useAuth());
+  setBridge({ wallets: [], ...overrides });
+  act(() => {
+    view.rerender();
+  });
+  return view;
+}
+
+describe("useAuth — wallet-disconnect logout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLogout.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("logs out a wallet-only session after the wallet is disconnected", () => {
+    renderConnectedThenDisconnect(walletOnlyUser);
+
+    // Not immediate — a transient empty list must not sign anyone out.
+    expect(mockLogout).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an email user signed in when they disconnect a linked wallet", () => {
+    renderConnectedThenDisconnect(emailUser);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("does not log out while Privy is still hydrating wallets", () => {
+    // walletsReady=false is the legitimate "wallets are empty because we haven't
+    // loaded them yet" state — logging out here is the sign-out loop.
+    renderConnectedThenDisconnect(walletOnlyUser, { walletsReady: false });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pending logout if a wallet reconnects within the delay", () => {
+    const view = renderConnectedThenDisconnect(walletOnlyUser);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    setBridge({ wallets: [WALLET] });
+    act(() => {
+      view.rerender();
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("does not log out an unauthenticated visitor who has no wallet", () => {
+    setBridge({ user: null, wallets: [], walletsReady: true, authenticated: false });
+    renderHook(() => useAuth());
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
+++ b/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
@@ -125,6 +125,12 @@ describe("useAuth — wallet-disconnect logout", () => {
   });
 
   afterEach(() => {
+    // The shared disconnect timer is module-level and intentionally survives
+    // unmount, so drain it here or a logout scheduled by one test could fire
+    // inside the next one. mockLogout is cleared in beforeEach.
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     vi.useRealTimers();
   });
 
@@ -160,6 +166,36 @@ describe("useAuth — wallet-disconnect logout", () => {
       for (const view of views) view.rerender();
     });
 
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("still logs out when the instance that scheduled the logout unmounts", () => {
+    // The pending logout belongs to the disconnected session, not to whichever
+    // component happened to schedule it — unmounting does not reconnect the
+    // wallet. If teardown cancelled the shared timer, every other instance has
+    // already returned at the guard and would never schedule a replacement,
+    // stranding the session authenticated forever.
+    setBridge({
+      user: walletOnlyUser,
+      wallets: [WALLET],
+      walletsReady: true,
+      authenticated: true,
+    });
+    const scheduler = renderHook(() => useAuth());
+    const survivor = renderHook(() => useAuth());
+    setBridge({ wallets: [] });
+    act(() => {
+      scheduler.rerender();
+      survivor.rerender();
+    });
+
+    act(() => {
+      scheduler.unmount();
+    });
     act(() => {
       vi.advanceTimersByTime(1000);
     });

--- a/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
+++ b/__tests__/unit/hooks/useAuth.wallet-disconnect.test.tsx
@@ -10,6 +10,7 @@
 
 import type { ConnectedWallet, User } from "@privy-io/react-auth";
 import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { useAuth } from "@/hooks/useAuth";
 
 // Undo the global mock of useAuth so we exercise the real hook
@@ -56,7 +57,7 @@ const mockBridgeState = {
 
 vi.mock("@/contexts/privy-bridge-context", () => ({
   usePrivyBridge: () => mockBridgeState,
-  PrivyBridgeContext: { Provider: ({ children }: { children: any }) => children },
+  PrivyBridgeContext: { Provider: ({ children }: { children: ReactNode }) => children },
   PRIVY_BRIDGE_DEFAULTS: {},
 }));
 
@@ -100,9 +101,9 @@ const setBridge = (overrides: Partial<typeof mockBridgeState>) =>
   Object.assign(mockBridgeState, overrides);
 
 /**
- * Render useAuth in the CONNECTED state first, then disconnect. This mirrors
- * the real sequence and, because useAuth's fired-guard is module-level (shared
- * across all mounted instances), it also re-arms that guard between tests.
+ * Render useAuth in the CONNECTED state first, then disconnect — the real
+ * sequence. Starting connected also clears any logout the previous test left
+ * pending on the module-level shared timer.
  */
 function renderConnectedThenDisconnect(
   user: User,
@@ -132,6 +133,32 @@ describe("useAuth — wallet-disconnect logout", () => {
 
     // Not immediate — a transient empty list must not sign anyone out.
     expect(mockLogout).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs out exactly once when many useAuth instances are mounted", () => {
+    // useAuth has ~100+ call sites. A per-instance timer would let every
+    // mounted instance schedule and fire its own logout() for one disconnect.
+    setBridge({
+      user: walletOnlyUser,
+      wallets: [WALLET],
+      walletsReady: true,
+      authenticated: true,
+    });
+    const views = [
+      renderHook(() => useAuth()),
+      renderHook(() => useAuth()),
+      renderHook(() => useAuth()),
+    ];
+    setBridge({ wallets: [] });
+    act(() => {
+      for (const view of views) view.rerender();
+    });
 
     act(() => {
       vi.advanceTimersByTime(1000);

--- a/__tests__/unit/utilities/auth/has-non-wallet-identity.test.ts
+++ b/__tests__/unit/utilities/auth/has-non-wallet-identity.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Tests for hasNonWalletIdentity
+ * @description Decides whether a Privy session survives losing every connected
+ * wallet. Drives the wallet-disconnect logout in useAuth, so a false positive
+ * here strands a user in a session with no identity, and a false negative signs
+ * out an email/social user who merely unlinked a wallet.
+ */
+
+import type { User } from "@privy-io/react-auth";
+import { describe, expect, it } from "vitest";
+import { hasNonWalletIdentity } from "@/utilities/auth/has-non-wallet-identity";
+
+const userWith = (linkedAccounts: unknown[]): User =>
+  ({ id: "user-1", linkedAccounts }) as unknown as User;
+
+describe("hasNonWalletIdentity", () => {
+  it("returns false for a wallet-only session", () => {
+    expect(hasNonWalletIdentity(userWith([{ type: "wallet", address: "0xabc" }]))).toBe(false);
+  });
+
+  it("returns false when every linked account is a wallet flavour", () => {
+    expect(
+      hasNonWalletIdentity(
+        userWith([
+          { type: "wallet", address: "0xabc" },
+          { type: "smart_wallet", address: "0xdef" },
+          { type: "cross_app", embeddedWallets: [], smartWallets: [] },
+        ])
+      )
+    ).toBe(false);
+  });
+
+  it("returns true for an email login", () => {
+    expect(hasNonWalletIdentity(userWith([{ type: "email", address: "a@b.com" }]))).toBe(true);
+  });
+
+  it("returns true for a Google login", () => {
+    expect(hasNonWalletIdentity(userWith([{ type: "google_oauth", email: "a@b.com" }]))).toBe(true);
+  });
+
+  it("returns true for a Farcaster login", () => {
+    expect(hasNonWalletIdentity(userWith([{ type: "farcaster", username: "amaury" }]))).toBe(true);
+  });
+
+  it("returns true for a social user who also linked a wallet", () => {
+    expect(
+      hasNonWalletIdentity(
+        userWith([
+          { type: "wallet", address: "0xabc" },
+          { type: "email", address: "a@b.com" },
+        ])
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for null, undefined, or a user with no linkedAccounts", () => {
+    expect(hasNonWalletIdentity(null)).toBe(false);
+    expect(hasNonWalletIdentity(undefined)).toBe(false);
+    expect(hasNonWalletIdentity({ id: "user-1" } as unknown as User)).toBe(false);
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,8 +20,14 @@ export default function Index() {
   // (the WorkflowSection alternates row bands). No outer gap or HR — the
   // editorial rhythm carries the visual transition between hero and
   // workflow.
+  //
+  // `overflow-x-clip` rather than `overflow-x-hidden`: `hidden` on one axis
+  // forces the other axis to compute as `auto`, and the layout's `h-full`
+  // chain gives <main> a definite height — that produced a second, inner
+  // scrollbar alongside the window one. `clip` leaves overflow-y `visible`
+  // while still clipping horizontal bleed.
   return (
-    <main className="flex w-full flex-col flex-1 items-center bg-background overflow-x-hidden">
+    <main className="flex w-full flex-col flex-1 items-center bg-background overflow-x-clip">
       <div className="flex w-full max-w-[1920px] flex-1 flex-col">
         <Hero />
         <WorkflowSection />

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -19,11 +19,19 @@ import { useWhitelabel } from "@/utilities/whitelabel-context";
 // inside a useEffect), so there is no SSR request bleed.
 let authReadyBarrierAddress: Hex | undefined;
 
-// Guards the wallet-disconnect logout below. useAuth is mounted by many
-// components at once, so a per-hook ref would let every instance fire its own
-// logout() for the same disconnect. Client-only (written inside a useEffect),
-// so there is no SSR request bleed.
-let walletDisconnectLogoutFired = false;
+// The single pending wallet-disconnect logout, shared across every mounted
+// useAuth instance. It must be module-level, not a per-hook ref: useAuth has
+// ~100+ call sites, so a per-hook timer would let every mounted instance
+// schedule and fire its own logout() for the same disconnect. Client-only
+// (only ever written inside a useEffect), so there is no SSR request bleed.
+let walletDisconnectLogoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearWalletDisconnectLogout = () => {
+  if (walletDisconnectLogoutTimer !== null) {
+    clearTimeout(walletDisconnectLogoutTimer);
+    walletDisconnectLogoutTimer = null;
+  }
+};
 
 /**
  * How long the wallet list must stay empty before a wallet-only session is
@@ -159,8 +167,13 @@ export const useAuth = () => {
   const isE2EMockAuthenticated = Boolean(e2eMockAuthState?.authenticated);
   const e2eMockAddress = e2eMockAuthState?.user?.wallet?.address as Hex | undefined;
   const address = (primaryWallet?.address as Hex | undefined) || e2eMockAddress;
+  // Does the session outlive losing every wallet? Derived as a boolean so the
+  // disconnect effect below doesn't re-run on every new Privy `user` identity.
+  const hasSurvivingIdentity = useMemo(() => hasNonWalletIdentity(user), [user]);
 
   const shouldLoginAfterLogout = useRef(false);
+  // Marks the instance that scheduled the shared wallet-disconnect logout timer.
+  const ownsDisconnectLogoutRef = useRef(false);
   const prevAuthRef = useRef(authenticated);
   const prevUserIdRef = useRef<string | undefined>(user?.id);
   const authFailureCount = useRef(0);
@@ -310,20 +323,29 @@ export const useAuth = () => {
    */
   useEffect(() => {
     if (!ready || !walletsReady || !authenticated) return;
-    if (wallets.length > 0 || hasNonWalletIdentity(user)) {
-      // Recovered (or never applicable) — re-arm for a later disconnect.
-      walletDisconnectLogoutFired = false;
+    if (wallets.length > 0 || hasSurvivingIdentity) {
+      // Reconnected, or never applicable — cancel any logout still pending.
+      clearWalletDisconnectLogout();
       return;
     }
-    if (walletDisconnectLogoutFired) return;
+    // Another mounted instance already scheduled this disconnect's logout.
+    if (walletDisconnectLogoutTimer !== null) return;
 
-    const timer = setTimeout(() => {
-      walletDisconnectLogoutFired = true;
+    ownsDisconnectLogoutRef.current = true;
+    walletDisconnectLogoutTimer = setTimeout(() => {
+      walletDisconnectLogoutTimer = null;
       logout();
     }, WALLET_DISCONNECT_LOGOUT_DELAY_MS);
 
-    return () => clearTimeout(timer);
-  }, [ready, walletsReady, authenticated, wallets.length, user, logout]);
+    // Only the instance that scheduled the timer may cancel it on teardown —
+    // otherwise an unrelated instance unmounting would silently drop the logout.
+    return () => {
+      if (ownsDisconnectLogoutRef.current) {
+        ownsDisconnectLogoutRef.current = false;
+        clearWalletDisconnectLogout();
+      }
+    };
+  }, [ready, walletsReady, authenticated, wallets.length, hasSurvivingIdentity, logout]);
 
   // Auto-login after logout completes
   useEffect(() => {

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -174,8 +174,6 @@ export const useAuth = () => {
   const hasSurvivingIdentity = useMemo(() => hasNonWalletIdentity(user), [user]);
 
   const shouldLoginAfterLogout = useRef(false);
-  // Marks the instance that scheduled the shared wallet-disconnect logout timer.
-  const ownsDisconnectLogoutRef = useRef(false);
   const prevAuthRef = useRef(authenticated);
   const prevUserIdRef = useRef<string | undefined>(user?.id);
   const authFailureCount = useRef(0);
@@ -333,20 +331,17 @@ export const useAuth = () => {
     // Another mounted instance already scheduled this disconnect's logout.
     if (walletDisconnectLogoutTimer !== null) return;
 
-    ownsDisconnectLogoutRef.current = true;
     walletDisconnectLogoutTimer = setTimeout(() => {
       walletDisconnectLogoutTimer = null;
       logout();
     }, WALLET_DISCONNECT_LOGOUT_DELAY_MS);
 
-    // Only the instance that scheduled the timer may cancel it on teardown —
-    // otherwise an unrelated instance unmounting would silently drop the logout.
-    return () => {
-      if (ownsDisconnectLogoutRef.current) {
-        ownsDisconnectLogoutRef.current = false;
-        clearWalletDisconnectLogout();
-      }
-    };
+    // Deliberately no teardown cancel. The timer belongs to the disconnected
+    // *session*, not to the instance that happened to schedule it: unmounting a
+    // component does not reconnect the wallet. Cancelling here would strand the
+    // session — every other instance has already returned at the guard above and
+    // would not schedule a replacement. Cancellation happens only when the state
+    // genuinely recovers (branch above) or the session ends.
   }, [ready, walletsReady, authenticated, wallets.length, hasSurvivingIdentity, logout]);
 
   // Auto-login after logout completes

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -124,7 +124,9 @@ const clearWagmiState = () => {
       localStorage.removeItem(key);
     }
   } catch {
-    // Ignore localStorage errors (e.g., private browsing, storage full)
+    // SUPPRESSED: clearing stale wagmi keys is best-effort housekeeping.
+    // localStorage throws in private browsing and when the quota is full;
+    // neither is actionable here, and failing would block logout.
   }
 };
 
@@ -386,7 +388,9 @@ export const useAuth = () => {
         // - Privy initialization timing
         handleAuthFailure();
       } catch {
-        // Token check failed (network error, etc.) - treat as a failure
+        // SUPPRESSED: not swallowed — a failed token check (network error, etc.)
+        // is deliberately routed into the consecutive-failure counter below, so
+        // a transient hiccup can't log the user out on its own.
         handleAuthFailure();
       }
     };

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -7,6 +7,7 @@ import { usePrivyBridge } from "@/contexts/privy-bridge-context";
 import { useProjectCreateModalStore } from "@/store/modals/projectCreate";
 import { compareAllWallets } from "@/utilities/auth/compare-all-wallets";
 import { getE2EMockAuthState } from "@/utilities/auth/e2e-auth";
+import { hasNonWalletIdentity } from "@/utilities/auth/has-non-wallet-identity";
 import { selectPrimaryWallet } from "@/utilities/auth/select-primary-wallet";
 import { TokenManager } from "@/utilities/auth/token-manager";
 import { queryClient } from "@/utilities/query-client";
@@ -17,6 +18,20 @@ import { useWhitelabel } from "@/utilities/whitelabel-context";
 // must be module-level and not a per-hook ref). Client-only (only ever written
 // inside a useEffect), so there is no SSR request bleed.
 let authReadyBarrierAddress: Hex | undefined;
+
+// Guards the wallet-disconnect logout below. useAuth is mounted by many
+// components at once, so a per-hook ref would let every instance fire its own
+// logout() for the same disconnect. Client-only (written inside a useEffect),
+// so there is no SSR request bleed.
+let walletDisconnectLogoutFired = false;
+
+/**
+ * How long the wallet list must stay empty before a wallet-only session is
+ * logged out. Privy can briefly report zero wallets while re-hydrating even
+ * after `walletsReady` flips true; logging out on that transient blip is the
+ * sign-out loop this delay exists to prevent.
+ */
+const WALLET_DISCONNECT_LOGOUT_DELAY_MS = 1000;
 
 /**
  * Initial delay (in ms) before first auth status check.
@@ -122,6 +137,7 @@ export const useAuth = () => {
     getAccessToken,
     connectWallet,
     wallets,
+    walletsReady,
     isConnected,
   } = usePrivyBridge();
 
@@ -267,6 +283,47 @@ export const useAuth = () => {
       queryClient.invalidateQueries();
     }
   }, [authenticated, address]);
+
+  /**
+   * WALLET-DISCONNECT LOGOUT
+   *
+   * Disconnecting the site inside the wallet extension (MetaMask ▸ Connected
+   * sites ▸ Disconnect) empties Privy's wallet list but leaves the Privy session
+   * authenticated. For a wallet-only session that is a dead end: `address` goes
+   * undefined, so the navbar has no address, no avatar and no name to render,
+   * while `authenticated` stays true so the Sign-in button never comes back —
+   * and the Log out item lives inside the menu that can no longer render. The
+   * user is locked out until they clear site data.
+   *
+   * The session is also functionally useless: every authenticated write is keyed
+   * on the signer that just went away. So end it — this mirrors the existing
+   * wallet-*switch* logout above, which already treats a change of wallet
+   * identity as the end of the session.
+   *
+   * Three guards keep this from becoming the sign-out loop CLAUDE.md warns
+   * about:
+   *  - `walletsReady`: `wallets` is legitimately empty while Privy hydrates.
+   *  - `hasNonWalletIdentity`: an email/Google/Farcaster user who merely linked
+   *    a wallet keeps their session when they disconnect it.
+   *  - the delay + cleanup: a transient empty list cancels the pending logout
+   *    instead of signing the user out.
+   */
+  useEffect(() => {
+    if (!ready || !walletsReady || !authenticated) return;
+    if (wallets.length > 0 || hasNonWalletIdentity(user)) {
+      // Recovered (or never applicable) — re-arm for a later disconnect.
+      walletDisconnectLogoutFired = false;
+      return;
+    }
+    if (walletDisconnectLogoutFired) return;
+
+    const timer = setTimeout(() => {
+      walletDisconnectLogoutFired = true;
+      logout();
+    }, WALLET_DISCONNECT_LOGOUT_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [ready, walletsReady, authenticated, wallets.length, user, logout]);
 
   // Auto-login after logout completes
   useEffect(() => {
@@ -448,6 +505,7 @@ export const useAuth = () => {
     address,
     primaryWallet,
     wallets,
+    walletsReady,
 
     // Privy methods
     login: adaptedLogin,

--- a/src/components/navbar/navbar-permissions-context.tsx
+++ b/src/components/navbar/navbar-permissions-context.tsx
@@ -19,6 +19,8 @@ export interface NavbarPermissionsContextValue {
   isLoggedIn: boolean;
   address: Hex | undefined;
   ready: boolean;
+  /** False until Privy finishes hydrating connected wallets. */
+  walletsReady: boolean;
 
   // Staff permissions
   isStaff: boolean;
@@ -48,6 +50,7 @@ const defaultContextValue: NavbarPermissionsContextValue = {
   isLoggedIn: false,
   address: undefined,
   ready: false,
+  walletsReady: false,
   isStaff: false,
   isStaffLoading: true,
   isOwner: false,
@@ -72,7 +75,7 @@ interface NavbarPermissionsProviderProps {
  * values to all child components through context.
  */
 export function NavbarPermissionsProvider({ children }: NavbarPermissionsProviderProps) {
-  const { authenticated: isLoggedIn, address, ready } = useAuth();
+  const { authenticated: isLoggedIn, address, ready, walletsReady } = useAuth();
 
   // RBAC permissions (global context - no specific community/program)
   const { data: permissions, isLoading: isPermissionsLoading } = usePermissionsQuery(
@@ -97,6 +100,7 @@ export function NavbarPermissionsProvider({ children }: NavbarPermissionsProvide
       isLoggedIn,
       address,
       ready,
+      walletsReady,
       isStaff,
       isStaffLoading: isPermissionsLoading,
       isOwner,
@@ -107,7 +111,7 @@ export function NavbarPermissionsProvider({ children }: NavbarPermissionsProvide
       hasAdminAccess,
       isRegistryAllowed,
     };
-  }, [isLoggedIn, address, ready, permissions, isPermissionsLoading, isOwner]);
+  }, [isLoggedIn, address, ready, walletsReady, permissions, isPermissionsLoading, isOwner]);
 
   return (
     <NavbarPermissionsContext.Provider value={value}>{children}</NavbarPermissionsContext.Provider>

--- a/src/components/navbar/navbar-user-menu.tsx
+++ b/src/components/navbar/navbar-user-menu.tsx
@@ -8,6 +8,7 @@ import {
   KeyRound,
   LogOutIcon,
   Settings,
+  Wallet,
 } from "lucide-react";
 import Link from "next/link";
 import EthereumAddressToENSAvatar from "@/components/EthereumAddressToENSAvatar";
@@ -82,10 +83,10 @@ const getUserEmail = (
 
 export function NavbarUserMenu() {
   // Get permission state from context (prevents duplicate hook calls across navbar)
-  const { isLoggedIn, address, ready, isRegistryAllowed } = useNavbarPermissions();
+  const { isLoggedIn, address, ready, walletsReady, isRegistryAllowed } = useNavbarPermissions();
 
-  // useAuth only needed for logout function
-  const { logout, user } = useAuth();
+  // useAuth only needed for logout / connect-wallet actions
+  const { logout, user, connectWallet } = useAuth();
 
   const { profile } = useContributorProfile(address);
 
@@ -105,11 +106,16 @@ export function NavbarUserMenu() {
   // hydration gap `authenticated` is true while `user` and `wallets[0].address`
   // are still loading, so the trigger would render a blank avatar and the
   // dropdown would say "No wallet connected" for an actually-connected user.
-  // Show the skeleton instead — a wallet user always resolves an address and a
-  // social user always resolves a farcaster/email identity, so this only covers
-  // the transient loading window.
+  //
+  // Gate this on `walletsReady` — the signal that Privy has finished hydrating
+  // wallets — NOT on "did an identity resolve?". The latter has no upper bound:
+  // when the user disconnects the site inside their wallet extension, a
+  // wallet-only session resolves no identity for the rest of its life, so the
+  // skeleton became permanent and took the Log out item down with it. Once
+  // wallets are resolved, always render the menu: it degrades to "No wallet
+  // connected" plus Connect wallet / Log out, so there is always a way out.
   const hasResolvedIdentity = Boolean(user?.farcaster || getUserEmail(user) || address);
-  if (!hasResolvedIdentity) {
+  if (!walletsReady && !hasResolvedIdentity) {
     return <NavbarUserSkeleton />;
   }
 
@@ -179,6 +185,18 @@ export function NavbarUserMenu() {
                 )}
               </div>
             </MenubarItem>
+            {/* Recovery path for a session whose wallet was disconnected from
+                the extension side. useAuth logs wallet-only sessions out, but a
+                social user who unlinked their wallet stays signed in and needs a
+                way to reconnect one. */}
+            {!address && (
+              <MenubarItem className="w-full cursor-pointer" onClick={connectWallet}>
+                <div className="flex flex-row items-center gap-2 w-full">
+                  <Wallet className={menuStyles.itemIcon} />
+                  <span className={menuStyles.itemText}>Connect wallet</span>
+                </div>
+              </MenubarItem>
+            )}
           </div>
           <hr className="h-[1px] w-full border-border" />
           <div className="flex flex-col w-full">

--- a/utilities/auth/has-non-wallet-identity.ts
+++ b/utilities/auth/has-non-wallet-identity.ts
@@ -1,0 +1,26 @@
+import type { LinkedAccountWithMetadata, User } from "@privy-io/react-auth";
+
+/**
+ * Privy linked-account types that represent a wallet rather than a standalone
+ * identity. A session built only from these has nothing left to render — or to
+ * authenticate with — once the wallet disconnects.
+ */
+const WALLET_ACCOUNT_TYPES = new Set(["wallet", "smart_wallet", "cross_app"]);
+
+/**
+ * Does the user have an identity that survives losing every connected wallet?
+ *
+ * Email, Google, Farcaster and other social logins keep the session meaningful
+ * (the navbar still resolves a name/avatar, and the Privy token still identifies
+ * the account) after the user disconnects a wallet they had merely linked.
+ *
+ * A wallet-only session has no such fallback: disconnecting the wallet in the
+ * extension leaves an authenticated session with no address, no avatar and no
+ * name — see `useAuth`'s disconnect handling.
+ */
+export const hasNonWalletIdentity = (user: User | null | undefined): boolean => {
+  if (!user?.linkedAccounts) return false;
+  return user.linkedAccounts.some(
+    (account: LinkedAccountWithMetadata) => !WALLET_ACCOUNT_TYPES.has(account.type)
+  );
+};


### PR DESCRIPTION
## Summary

Disconnecting the site from inside MetaMask (**Connected sites ▸ Disconnect**) left the app in a state the user could not escape without clearing site data. Wallet-only sessions are now ended when their wallet goes away, and the navbar menu can no longer render an unbounded skeleton.

## Problem

Privy drops the wallet but **keeps the session authenticated**. For a session whose only identity is that wallet:

1. `wallets` empties → `useAuth().address` becomes `undefined`.
2. `authenticated` stays `true` (`useAuth.ts` — "Privy authenticated is sufficient to be logged in").
3. A wallet login has no `email`/`farcaster` fallback, so `hasResolvedIdentity` is `false`.
4. `NavbarUserMenu` returned `<NavbarUserSkeleton />` — and that condition can never become true again, so the skeleton was **permanent**.
5. `NavbarDesktopNavigation` renders `isLoggedIn ? <NavbarUserMenu/> : <NavbarAuthButtons/>`, so no Sign-in button either.

The **Log out** item lives inside the very menu that could no longer render, so there was no way out: no reconnect, no sign-in, no logout. Desktop only — the mobile menu has no identity gate.

Reproduced live against a local build: valid `privy:token` alongside `privy:connections: []`.

## Solution

**End the session** (`hooks/useAuth.ts`). This mirrors the existing wallet-*switch* logout, which already treats a change of wallet identity as the end of a session; disconnect was simply an unhandled case in that same policy (the watcher explicitly bails on `!newAddress`). The session is functionally useless anyway — every authenticated write is keyed on the signer that just went away.

Three guards keep it from becoming the sign-out loop `CLAUDE.md` warns about:

| Guard | Prevents |
|---|---|
| `walletsReady` | Signing out during hydration, when `wallets` is legitimately `[]` |
| `hasNonWalletIdentity(user)` | Signing out an email/Google/Farcaster user who disconnects a merely *linked* wallet |
| 1s delay + cleanup | A transient empty list cancelling the pending logout instead of firing it |

The timer handle is module-level: `useAuth` has ~100+ call sites, so a per-instance timer would fire one `logout()` per mounted instance. Only the scheduling instance may cancel it.

**Safety net** (`navbar-user-menu.tsx`). The skeleton now gates on `walletsReady` instead of "did an identity resolve?", so no path can produce an unbounded skeleton again. Once wallets resolve the menu always renders, degrading to "No wallet connected" + **Connect wallet** (new) + Log out. This also covers a second route to the same trap: `selectPrimaryWallet` withholds an address when only a *foreign* wallet is connected.

`walletsReady` already existed in the Privy bridge context and was covered by tests — `useAuth` simply never forwarded it, which is why the component had to infer "still loading?" from `address`.

## Testing steps

1. Sign in with MetaMask (wallet only — no email/social linked).
2. In MetaMask: **Connected sites ▸ Disconnect**.
3. Navbar returns to **Sign in** within ~1s; `privy:token` is cleared. Before this change: two grey skeleton circles, forever.
4. Sign in with email, link a wallet, then disconnect it → session **survives**, menu shows "No wallet connected" + Connect wallet.
5. Hard-refresh while signed in → no spurious sign-out during hydration.

Verified end-to-end in a real browser against a local build (auto-logout fired; `privy:token` and refresh token cleared; zero skeletons).

## Tests

- `useAuth.wallet-disconnect.test.tsx` — 6 tests: logout fires, **exactly once across 3 mounted instances**, social user preserved, no logout while hydrating, reconnect cancels, unauthenticated visitor untouched.
- `has-non-wallet-identity.test.ts` — 7 tests.
- `navbar-user-menu.test.tsx` — skeleton bounded by `walletsReady`; menu renders once wallets resolve.

Both behavioural tests were confirmed **non-vacuous** by stubbing the fix out and watching them fail (the multi-instance one failed with "called 3 times").

## Risk

Medium — touches the auth lifecycle, which has a history of sign-out loops. Mitigated by the three guards, each pinned by a test, and by the render safety net that keeps a way out even if the logout path misfires.

Scope note: `hooks/useAuth.ts` is shared, but the new effect is inert unless `authenticated && walletsReady && wallets.length === 0 && !hasNonWalletIdentity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Connect wallet” option when no wallet is connected.
  * Wallet-only sessions now automatically sign out after a wallet disconnect, with a brief recovery window for reconnection.
  * Users with email or social sign-in remain logged in when a linked wallet disconnects.

* **Bug Fixes**
  * Prevented wallet-loading skeletons from persisting after wallet data is ready.
  * Improved handling of wallet hydration and disconnected-wallet states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->