### PR TITLE
fix(auth): clean up disconnect timers without stranding the session

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -19,19 +19,14 @@ import { useWhitelabel } from "@/utilities/whitelabel-context";
 // inside a useEffect), so there is no SSR request bleed.
 let authReadyBarrierAddress: Hex | undefined;
 
-// The single pending wallet-disconnect logout, shared across every mounted
-// useAuth instance. It must be module-level, not a per-hook ref: useAuth has
-// ~100+ call sites, so a per-hook timer would let every mounted instance
-// schedule and fire its own logout() for the same disconnect. Client-only
-// (only ever written inside a useEffect), so there is no SSR request bleed.
-let walletDisconnectLogoutTimer: ReturnType<typeof setTimeout> | null = null;
-
-const clearWalletDisconnectLogout = () => {
-  if (walletDisconnectLogoutTimer !== null) {
-    clearTimeout(walletDisconnectLogoutTimer);
-    walletDisconnectLogoutTimer = null;
-  }
-};
+// Has the current disconnect already been acted on? useAuth has ~100+ call
+// sites, so every mounted instance schedules its own timer — they must collapse
+// to a single logout(). Deduplicating here, when the timer FIRES, rather than
+// when it is scheduled, is what lets each instance keep ownership of (and clean
+// up) its own timer while still yielding exactly one logout. Reset whenever the
+// wallet state recovers. Client-only (only ever written inside an effect or its
+// timer), so there is no SSR request bleed.
+let walletDisconnectLogoutFired = false;
 
 /**
  * How long the wallet list must stay empty before a wallet-only session is
@@ -324,24 +319,25 @@ export const useAuth = () => {
   useEffect(() => {
     if (!ready || !walletsReady || !authenticated) return;
     if (wallets.length > 0 || hasSurvivingIdentity) {
-      // Reconnected, or never applicable — cancel any logout still pending.
-      clearWalletDisconnectLogout();
+      // Reconnected, or never applicable — re-arm for a future disconnect. Any
+      // timers still pending are cleared by their own instance's cleanup when
+      // this effect re-runs.
+      walletDisconnectLogoutFired = false;
       return;
     }
-    // Another mounted instance already scheduled this disconnect's logout.
-    if (walletDisconnectLogoutTimer !== null) return;
 
-    walletDisconnectLogoutTimer = setTimeout(() => {
-      walletDisconnectLogoutTimer = null;
+    // Every mounted instance schedules its own timer and cleans up its own
+    // timer. That is deliberate: a shared timer owned by one instance would be
+    // cancelled when that instance unmounts, and no other instance would
+    // reschedule — stranding the session authenticated forever. The
+    // module-level flag collapses the resulting N timers into one logout.
+    const timer = setTimeout(() => {
+      if (walletDisconnectLogoutFired) return;
+      walletDisconnectLogoutFired = true;
       logout();
     }, WALLET_DISCONNECT_LOGOUT_DELAY_MS);
 
-    // Deliberately no teardown cancel. The timer belongs to the disconnected
-    // *session*, not to the instance that happened to schedule it: unmounting a
-    // component does not reconnect the wallet. Cancelling here would strand the
-    // session — every other instance has already returned at the guard above and
-    // would not schedule a replacement. Cancellation happens only when the state
-    // genuinely recovers (branch above) or the session ends.
+    return () => clearTimeout(timer);
   }, [ready, walletsReady, authenticated, wallets.length, hasSurvivingIdentity, logout]);
 
   // Auto-login after logout completes


### PR DESCRIPTION
Follow-up to #1901. Fixes the one check that failed there: `quality-gate`, on a React Doctor regression (**64 → 65 errors**).

## Problem

The wallet-disconnect effect scheduled a `setTimeout` with no cleanup, tripping *"Effect subscription or timer never cleaned up"*.

The missing cleanup was deliberate, not an oversight. #1901 originally cancelled the timer on teardown; CodeRabbit correctly flagged that as a stranding bug — the shared timer was owned by whichever instance scheduled it, so when that component unmounted its cleanup cancelled the logout while every *other* instance had already returned at the "someone else owns it" guard and would never reschedule. The session then stayed authenticated forever, which is the exact bug #1901 exists to fix.

That left two rules apparently in conflict:

- **CodeRabbit:** don't cancel on unmount, or the session is stranded.
- **React Doctor:** timers in effects must be cleaned up.

## Solution

They only conflict while deduplication happens at *scheduling* time. Moving it to *execution* time satisfies both:

- Every instance schedules **and cleans up its own** timer → React Doctor satisfied, no leak past unmount.
- Unmounting one instance leaves the others' timers pending → the logout still fires, session never stranded.
- A module-level flag checked **inside** the callback collapses the N timers into exactly one `logout()`.

## Verification

- React Doctor on `hooks/`: *"never cleaned up"* **×3 → ×2**, Bugs **5 → 4 errors** — baseline restored.
- 1475 tests pass across navbar / hooks / utilities / auth suites; tsc, biome and anti-pattern checks clean.
- Both behaviours stay pinned by the existing tests: one logout across three mounted instances, and a logout that still fires when the scheduling instance unmounts.

## Risk

Low. Single hook, no API change, and the two failure modes this rework navigates between are each covered by a test that was verified to fail against the wrong implementation.