### PR TITLE
fix(forms): stop ContributorProfile validation escaping as an unhandled ZodError

### DIFF
--- a/components/Dialogs/ContributorProfileDialog.tsx
+++ b/components/Dialogs/ContributorProfileDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 /* eslint-disable @next/next/no-img-element */
 import { Dialog, Transition } from "@headlessui/react";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { ContributorProfile } from "@show-karma/karma-gap-sdk";
 import { X } from "lucide-react";
 import { useSearchParams } from "next/navigation";
@@ -27,6 +26,7 @@ import { INDEXER } from "@/utilities/indexer";
 import { gapSupportedNetworks, getChainIdByName } from "@/utilities/network";
 import { urlRegex } from "@/utilities/regexs/urlRegex";
 import { cn } from "@/utilities/tailwind";
+import { safeZodResolver } from "@/utilities/validation/safe-zod-resolver";
 import { requiredString } from "@/utilities/validation/zod-primitives";
 
 const profileSchema = z.object({
@@ -108,7 +108,7 @@ export const ContributorProfileDialog: FC = () => {
     reset,
     formState: { errors, isValid },
   } = useForm<SchemaType>({
-    resolver: zodResolver(profileSchema),
+    resolver: safeZodResolver(profileSchema),
     reValidateMode: "onChange",
     mode: "onChange",
     defaultValues: {

--- a/utilities/validation/__tests__/safe-zod-resolver.test.ts
+++ b/utilities/validation/__tests__/safe-zod-resolver.test.ts
@@ -1,0 +1,61 @@
+import type { ResolverOptions } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { safeZodResolver } from "../safe-zod-resolver";
+import { requiredString } from "../zod-primitives";
+
+const schema = z.object({
+  name: requiredString("Name", {
+    min: 3,
+    messages: { min: "This name is too short" },
+  }),
+  bio: z.string().optional(),
+  nested: z.object({ handle: requiredString("Handle") }).optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const options: ResolverOptions<FormValues> = {
+  fields: {},
+  shouldUseNativeValidation: false,
+};
+
+describe("safeZodResolver", () => {
+  it("returns parsed values and no errors for valid input", async () => {
+    const resolver = safeZodResolver(schema);
+
+    const result = await resolver({ name: "Alice", bio: "hi" }, undefined, options);
+
+    expect(result.errors).toEqual({});
+    expect(result.values).toEqual({ name: "Alice", bio: "hi" });
+  });
+
+  it("resolves with a field error instead of throwing when required input is empty (GAP-FRONTEND-21N)", async () => {
+    const resolver = safeZodResolver(schema);
+
+    // Previously the stock resolver let this ZodError escape as an unhandled
+    // rejection; it must now RESOLVE with the field error.
+    const result = await resolver({ name: "", bio: "" }, undefined, options);
+
+    expect(result.values).toEqual({});
+    expect(result.errors.name).toMatchObject({ message: "Name is required" });
+  });
+
+  it("reports the length message when the value is too short", async () => {
+    const resolver = safeZodResolver(schema);
+
+    const result = await resolver({ name: "ab", bio: "" }, undefined, options);
+
+    expect(result.errors.name).toMatchObject({ message: "This name is too short" });
+  });
+
+  it("nests errors under their field path", async () => {
+    const resolver = safeZodResolver(schema);
+
+    const result = await resolver({ name: "Alice", nested: { handle: "" } }, undefined, options);
+
+    expect(result.errors.nested?.handle).toMatchObject({
+      message: "Handle is required",
+    });
+  });
+});

--- a/utilities/validation/safe-zod-resolver.ts
+++ b/utilities/validation/safe-zod-resolver.ts
@@ -1,0 +1,55 @@
+import type { FieldError, FieldErrors, FieldValues, Resolver } from "react-hook-form";
+import type { z } from "zod";
+
+/**
+ * A react-hook-form resolver built on Zod's `safeParse`.
+ *
+ * The stock `@hookform/resolvers/zod` resolver recovers validation errors with
+ * `error instanceof $ZodError`. When the bundle ships more than one physical
+ * copy of `zod/v4/core` (turbopack does here — there are three zod copies in
+ * the tree), the thrown `$ZodError` is not an instance of the copy the resolver
+ * imported, so it re-throws: the ZodError escapes as an unhandled promise
+ * rejection (GAP-FRONTEND-21N) AND the field errors never reach the form.
+ *
+ * `safeParse` never throws — it returns `{ success, error }` — and we map
+ * `error.issues` structurally (no `instanceof`), so this is immune to the
+ * duplicate-copy problem regardless of how the bundler dedupes zod. First error
+ * per field wins, matching react-hook-form's default `criteriaMode: "firstError"`.
+ */
+export function safeZodResolver<TInput extends FieldValues>(
+  schema: z.ZodType<TInput>
+): Resolver<TInput> {
+  return async (values) => {
+    const result = schema.safeParse(values);
+
+    if (result.success) {
+      return { values: result.data, errors: {} };
+    }
+
+    const errors: FieldErrors<TInput> = {};
+
+    for (const issue of result.error.issues) {
+      if (issue.path.length === 0) continue;
+
+      let node = errors as Record<string, unknown>;
+      for (let i = 0; i < issue.path.length - 1; i += 1) {
+        const key = String(issue.path[i]);
+        if (typeof node[key] !== "object" || node[key] === null) {
+          node[key] = {};
+        }
+        node = node[key] as Record<string, unknown>;
+      }
+
+      const leaf = String(issue.path[issue.path.length - 1]);
+      if (node[leaf] === undefined) {
+        const fieldError: FieldError = {
+          type: String(issue.code),
+          message: issue.message,
+        };
+        node[leaf] = fieldError;
+      }
+    }
+
+    return { values: {}, errors };
+  };
+}

--- a/utilities/validation/safe-zod-resolver.ts
+++ b/utilities/validation/safe-zod-resolver.ts
@@ -29,18 +29,20 @@ export function safeZodResolver<TInput extends FieldValues>(
     const errors: FieldErrors<TInput> = {};
 
     for (const issue of result.error.issues) {
-      if (issue.path.length === 0) continue;
+      const { path } = issue;
+      const depth = path.length;
+      if (depth === 0) continue;
 
       let node = errors as Record<string, unknown>;
-      for (let i = 0; i < issue.path.length - 1; i += 1) {
-        const key = String(issue.path[i]);
+      for (let i = 0; i < depth - 1; i += 1) {
+        const key = String(path[i]);
         if (typeof node[key] !== "object" || node[key] === null) {
           node[key] = {};
         }
         node = node[key] as Record<string, unknown>;
       }
 
-      const leaf = String(issue.path[issue.path.length - 1]);
+      const leaf = String(path[depth - 1]);
       if (node[leaf] === undefined) {
         const fieldError: FieldError = {
           type: String(issue.code),


### PR DESCRIPTION
## Root cause

`ContributorProfileDialog` is mounted globally (via `DeferredLayoutComponents`), uses `zodResolver(profileSchema)` with `mode: "onChange"`, and its `name` field is `requiredString("Name", { min: 3 })`. When `name` is empty, Zod produces a `$ZodError`.

The installed `@hookform/resolvers@5.4.0` resolver recovers Zod-4 errors like this:

```js
import * as o from "zod/v4/core";
… catch (r) { if (r instanceof o.$ZodError) return { errors }; throw r }  // ← re-throws otherwise
```

The bundle ships **duplicate copies of `zod/v4/core`** (this is turbopack — the Sentry event is tagged `turbopack: true`, and there are three zod copies in the tree: `3.22.4`, `3.25.76`, `4.1.13`). The thrown `$ZodError` is therefore **not an instance of the copy the resolver imported**, so `instanceof o.$ZodError` is false and the resolver **re-throws**. Result:

1. the ZodError escapes as an **unhandled promise rejection** → **GAP-FRONTEND-21N: 1,538 events / 700 users** on `/`, and
2. the field errors **never reach react-hook-form**, so the form shows no validation feedback.

(In a correctly-deduped Node context the `instanceof` holds — I reproduced `= true` — confirming this is a bundle-level duplication, not a package-version bug.)

## Fix

Add `safeZodResolver` (`utilities/validation/safe-zod-resolver.ts`) — a resolver built on Zod's **`safeParse`**, which never throws and returns `{ success, error }`. It maps `error.issues` **structurally** (by path/code/message, no `instanceof`), so it is immune to duplicate-copy problems regardless of how the bundler dedupes zod. Swap it into `ContributorProfileDialog`.

This is the targeted, self-contained fix (option A). The deeper root — deduping `zod/v4/core` at the bundler level so `instanceof` holds app-wide — is left as a separate consideration; `safeZodResolver` is now available as a drop-in for any other form that hits the same symptom.

## Test plan

- New unit test (`utilities/validation/__tests__/safe-zod-resolver.test.ts`): valid input → values; **empty required input resolves with a field error instead of throwing** (the 21N regression); too-short → length message; nested paths nest correctly. 4/4 pass.
- `pnpm run build` ✓ (compiled successfully); `tsc --noEmit` clean of the changed files; biome clean on the new files. Only pre-existing (unchanged) `onSubmit` complexity / `walletSigner as any` warnings remain in the dialog.

Fixes GAP-FRONTEND-21N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contributor profile form validation to display field-level errors instead of failing unexpectedly.
  - Preserved custom validation messages, including minimum-length requirements.
  - Improved error handling for nested profile fields, ensuring messages appear beside the correct input.

- **Tests**
  - Added coverage for successful validation, required fields, custom messages, and nested field errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->