### PR TITLE
feat(nonprofit-research): show ranking and share controls to staff

### DIFF
--- a/__tests__/features/donor-research/report-brief/Masthead.test.tsx
+++ b/__tests__/features/donor-research/report-brief/Masthead.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import type { ResearchReportDetail } from "@/types/donor-research";
+
+vi.mock("@/src/features/donor-research/components/report-viewer/WeightsPanel", () => ({
+  WeightsPanel: vi.fn(() => <div>Adjust ranking</div>),
+}));
+vi.mock("@/src/features/donor-research/components/report-viewer/ShareTokenControls", () => ({
+  ShareTokenControls: vi.fn(() => <div>Share</div>),
+}));
+
+import { Masthead } from "@/src/features/donor-research/components/report-brief/Masthead";
+
+function createReport(overrides: Partial<ResearchReportDetail> = {}): ResearchReportDetail {
+  return {
+    id: "report-1",
+    status: "fast_complete",
+    mode: "fast",
+    hasShareToken: false,
+    shareToken: null,
+    shareTokenExpiresAt: null,
+    weights: { mission: 2500, activity: 2500, compliance: 2500, recency: 2500 },
+    candidates: [{ id: "cand-1" }],
+    ...overrides,
+  } as unknown as ResearchReportDetail;
+}
+
+function renderMasthead(props: Partial<React.ComponentProps<typeof Masthead>> = {}) {
+  return render(
+    <Masthead
+      candidatesCount={5}
+      isTerminal={true}
+      report={createReport()}
+      surfacedCount={3}
+      variant="advisor"
+      {...props}
+    />
+  );
+}
+
+describe("Masthead manage controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows ranking and share controls for staff (canManageReport)", () => {
+    renderMasthead({ variant: "staff", canManageReport: true });
+
+    expect(screen.getByText("Adjust ranking")).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+  });
+
+  it("shows controls for the owner by default when canManageReport is unset", () => {
+    renderMasthead({ variant: "advisor", canManageReport: undefined });
+
+    expect(screen.getByText("Adjust ranking")).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+  });
+
+  it("hides controls on the shared read-only document", () => {
+    renderMasthead({ variant: "shared", canManageReport: undefined });
+
+    expect(screen.queryByText("Adjust ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Share")).not.toBeInTheDocument();
+  });
+
+  it("hides controls for a non-owner non-staff viewer even on the staff variant", () => {
+    renderMasthead({ variant: "staff", canManageReport: false });
+
+    expect(screen.queryByText("Adjust ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Share")).not.toBeInTheDocument();
+  });
+
+  it("hides controls until the report reaches a terminal status", () => {
+    renderMasthead({ variant: "staff", canManageReport: true, isTerminal: false });
+
+    expect(screen.queryByText("Adjust ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Share")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
+++ b/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
@@ -2,22 +2,29 @@ import { screen } from "@testing-library/react";
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import { useDonorReport } from "@/hooks/useDonorReports";
+import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
+import { ReportBrief } from "@/src/features/donor-research/components/report-brief/ReportBrief";
 import { ReportBriefView } from "@/src/features/donor-research/components/report-brief/ReportBriefView";
 import { renderWithProviders } from "../../../utils/render";
 
 vi.mock("@/hooks/useDonorAdvisor", () => ({ useDonorAdvisor: vi.fn() }));
 vi.mock("@/hooks/useDonorReportStream", () => ({ useDonorReportStream: vi.fn() }));
 vi.mock("@/hooks/useDonorReports", () => ({ useDonorReport: vi.fn() }));
+vi.mock("@/src/core/rbac/hooks/use-staff-bridge", () => ({ useStaff: vi.fn() }));
+
 vi.mock("@/src/features/donor-research/components/report-brief/ReportBrief", () => ({
-  ReportBrief: () => <div>Report brief content</div>,
+  ReportBrief: vi.fn(() => <div>Report brief content</div>),
 }));
 
 const mockUseDonorAdvisor = vi.mocked(useDonorAdvisor);
 const mockUseDonorReport = vi.mocked(useDonorReport);
 const mockUseDonorReportStream = vi.mocked(useDonorReportStream);
+const mockUseStaff = vi.mocked(useStaff);
+const mockReportBrief = vi.mocked(ReportBrief);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUseStaff.mockReturnValue({ isStaff: false, isLoading: false });
   mockUseDonorAdvisor.mockReturnValue({
     data: { id: "advisor-1" },
   } as unknown as ReturnType<typeof useDonorAdvisor>);
@@ -35,5 +42,41 @@ describe("ReportBriefView", () => {
 
     expect(screen.getByText("Report brief content")).toBeInTheDocument();
     expect(screen.queryByRole("navigation", { name: "breadcrumb" })).not.toBeInTheDocument();
+  });
+
+  it("lets the owner manage the report on the advisor variant", () => {
+    renderWithProviders(<ReportBriefView reportId="fb95f6f5-1630-4f72-a8b9-d052030d9c3d" />);
+
+    expect(mockReportBrief.mock.lastCall?.[0]).toMatchObject({
+      variant: "advisor",
+      canManageReport: true,
+    });
+  });
+
+  it("lets staff manage another advisor's report on the staff variant", () => {
+    mockUseDonorAdvisor.mockReturnValue({
+      data: { id: "advisor-2" },
+    } as unknown as ReturnType<typeof useDonorAdvisor>);
+    mockUseStaff.mockReturnValue({ isStaff: true, isLoading: false });
+
+    renderWithProviders(<ReportBriefView reportId="fb95f6f5-1630-4f72-a8b9-d052030d9c3d" />);
+
+    expect(mockReportBrief.mock.lastCall?.[0]).toMatchObject({
+      variant: "staff",
+      canManageReport: true,
+    });
+  });
+
+  it("keeps non-owner non-staff viewers read-only", () => {
+    mockUseDonorAdvisor.mockReturnValue({
+      data: { id: "advisor-2" },
+    } as unknown as ReturnType<typeof useDonorAdvisor>);
+
+    renderWithProviders(<ReportBriefView reportId="fb95f6f5-1630-4f72-a8b9-d052030d9c3d" />);
+
+    expect(mockReportBrief.mock.lastCall?.[0]).toMatchObject({
+      variant: "staff",
+      canManageReport: false,
+    });
   });
 });

--- a/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
+++ b/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
@@ -79,4 +79,25 @@ describe("ReportBriefView", () => {
       canManageReport: false,
     });
   });
+
+  it("holds the skeleton while staff authorization is resolving", () => {
+    mockUseStaff.mockReturnValue({ isStaff: false, isLoading: true });
+
+    renderWithProviders(<ReportBriefView reportId="fb95f6f5-1630-4f72-a8b9-d052030d9c3d" />);
+
+    expect(screen.getByText("Loading report…")).toBeInTheDocument();
+    expect(mockReportBrief).not.toHaveBeenCalled();
+  });
+
+  it("holds the skeleton while the advisor row is resolving", () => {
+    mockUseDonorAdvisor.mockReturnValue({
+      data: undefined,
+      isPending: true,
+    } as unknown as ReturnType<typeof useDonorAdvisor>);
+
+    renderWithProviders(<ReportBriefView reportId="fb95f6f5-1630-4f72-a8b9-d052030d9c3d" />);
+
+    expect(screen.getByText("Loading report…")).toBeInTheDocument();
+    expect(mockReportBrief).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
+++ b/__tests__/features/donor-research/report-brief/ReportBriefView.test.tsx
@@ -1,11 +1,11 @@
 import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/__tests__/utils/render";
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import { useDonorReport } from "@/hooks/useDonorReports";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { ReportBrief } from "@/src/features/donor-research/components/report-brief/ReportBrief";
 import { ReportBriefView } from "@/src/features/donor-research/components/report-brief/ReportBriefView";
-import { renderWithProviders } from "../../../utils/render";
 
 vi.mock("@/hooks/useDonorAdvisor", () => ({ useDonorAdvisor: vi.fn() }));
 vi.mock("@/hooks/useDonorReportStream", () => ({ useDonorReportStream: vi.fn() }));

--- a/src/features/donor-research/components/report-brief/Masthead.tsx
+++ b/src/features/donor-research/components/report-brief/Masthead.tsx
@@ -18,13 +18,19 @@ interface MastheadProps {
    * the shared document gets none.
    */
   variant?: "advisor" | "shared" | "staff";
+  /**
+   * Shows the weights/share-token controls. Defaults to owner-only
+   * (`variant === "advisor"`); the authenticated view passes `true` for
+   * staff as well.
+   */
+  canManageReport?: boolean;
 }
 
 /**
  * Report header (redesign spec 2.3): the dynamic headline/byline (kept
  * verbatim from the editorial brief — `headline()` / `byline()` below) and
- * the owner-only Adjust ranking + Share actions. Report number, status, mode,
- * and issue date live in the summary immediately below.
+ * the Adjust ranking + Share actions (owner and staff). Report number,
+ * status, mode, and issue date live in the summary immediately below.
  */
 export function Masthead({
   report,
@@ -32,8 +38,9 @@ export function Masthead({
   surfacedCount,
   isTerminal,
   variant = "advisor",
+  canManageReport,
 }: MastheadProps) {
-  const isOwner = variant === "advisor";
+  const showManageControls = canManageReport ?? variant === "advisor";
   return (
     <header
       className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-8"
@@ -59,7 +66,7 @@ export function Masthead({
         </p>
       </div>
 
-      {isTerminal && isOwner ? (
+      {isTerminal && showManageControls ? (
         <div className="flex flex-none flex-wrap items-start gap-2">
           {report.weights && report.candidates.length > 0 ? <WeightsPanel report={report} /> : null}
           <ShareTokenControls

--- a/src/features/donor-research/components/report-brief/ReportBrief.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBrief.tsx
@@ -31,6 +31,13 @@ interface ReportBriefProps {
    */
   variant?: "advisor" | "shared" | "staff";
   /**
+   * Shows the ranking-weights + share-token controls. Defaults to the owner
+   * (`variant === "advisor"`); the authenticated view also passes `true` for
+   * staff, whose writes the BE resolves to the report owner. Never set on the
+   * donor share view.
+   */
+  canManageReport?: boolean;
+  /**
    * Live SSE stream — advisor view only. Omitted on the unauthenticated share
    * view (which refreshes via polling instead), so the running panel is hidden.
    */
@@ -53,6 +60,7 @@ export function ReportBrief({
   report,
   isTerminal,
   variant = "advisor",
+  canManageReport,
   stream = null,
 }: ReportBriefProps) {
   const candidates = report.candidates ?? [];
@@ -68,6 +76,7 @@ export function ReportBrief({
     <div className="flex flex-col gap-6" data-brief>
       <Masthead
         candidatesCount={candidates.length}
+        canManageReport={canManageReport}
         isTerminal={isTerminal}
         report={report}
         surfacedCount={featured.length}

--- a/src/features/donor-research/components/report-brief/ReportBriefView.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBriefView.tsx
@@ -27,11 +27,18 @@ interface ReportBriefViewProps {
 export function ReportBriefView({ reportId }: ReportBriefViewProps) {
   const reportQuery = useDonorReport(reportId);
   const advisorQuery = useDonorAdvisor();
-  const { isStaff } = useStaff();
+  const { isStaff, isLoading: isStaffLoading } = useStaff();
   const reportStatus = reportQuery.data?.status;
   const isTerminal =
     reportStatus === "complete" || reportStatus === "fast_complete" || reportStatus === "failed";
   const stream = useDonorReportStream(isTerminal ? null : reportId);
+
+  // Management authorization (owner OR staff) must fully resolve before we pick
+  // a variant or expose write controls. While RBAC or the advisor row is still
+  // pending both `isStaff` and `isOwner` read `false`, so rendering here would
+  // flash the read-only staff variant and then pop the controls in once it
+  // settles — hold the skeleton until authorization is decided instead.
+  const isManageAuthPending = isStaffLoading || advisorQuery.isPending;
 
   if (reportQuery.isLoading) {
     return <DonorResearchLoading label="Loading report…" variant="report" />;
@@ -39,6 +46,10 @@ export function ReportBriefView({ reportId }: ReportBriefViewProps) {
 
   if (reportQuery.isError) {
     throw reportQuery.error;
+  }
+
+  if (isManageAuthPending) {
+    return <DonorResearchLoading label="Loading report…" variant="report" />;
   }
 
   const isOwner = !!advisorQuery.data && advisorQuery.data.id === reportQuery.data!.advisorId;

--- a/src/features/donor-research/components/report-brief/ReportBriefView.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBriefView.tsx
@@ -3,6 +3,7 @@
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import { useDonorReport } from "@/hooks/useDonorReports";
+import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { DonorResearchLoading } from "../common/DonorResearchLoading";
 import { ReportBrief } from "./ReportBrief";
 
@@ -16,14 +17,17 @@ interface ReportBriefViewProps {
  * all rendering to {@link ReportBrief}, the same presentational component the
  * donor share view uses — so the surfaces stay visually identical.
  *
- * Owner-only write controls (share, weights, diligence actions) render only
- * once the viewer is CONFIRMED as the report's advisor — a resolving or
- * absent advisor row gets the read-only staff variant, never a flash of
- * controls that would only error for a non-owner.
+ * Write controls render only once the viewer is CONFIRMED as either the
+ * report's advisor or staff — a resolving or absent advisor row gets the
+ * read-only staff variant, never a flash of controls that would only error
+ * for a non-owner. Staff get the ranking + share controls (the BE write
+ * routes resolve staff to the report owner), but not the advisor-scoped
+ * diligence actions.
  */
 export function ReportBriefView({ reportId }: ReportBriefViewProps) {
   const reportQuery = useDonorReport(reportId);
   const advisorQuery = useDonorAdvisor();
+  const { isStaff } = useStaff();
   const reportStatus = reportQuery.data?.status;
   const isTerminal =
     reportStatus === "complete" || reportStatus === "fast_complete" || reportStatus === "failed";
@@ -41,6 +45,7 @@ export function ReportBriefView({ reportId }: ReportBriefViewProps) {
 
   return (
     <ReportBrief
+      canManageReport={isOwner || isStaff}
       isTerminal={isTerminal}
       report={reportQuery.data!}
       stream={stream}


### PR DESCRIPTION
## Overview

Staff (super-admins) opening another advisor's nonprofit-research report got a read-only staff variant — no **Adjust ranking** (weights panel) and no **Share** controls. Now that the backend write endpoints resolve staff to the report owner, this surfaces those controls to staff in the report brief.

Pairs with gap-indexer #2285 (staff bypass on the ranking-config + share-token write endpoints). **Merge order:** BE first, or deploy both to the same preview together — the FE controls call endpoints that only accept staff writes once #2285 lands.

## Background

gap-app-v2 #1818 intentionally gave staff a read-only variant *"since those endpoints are advisor-scoped."* That's still true for **diligence** actions (kept advisor-only here), but ranking + share are now staff-capable on the backend, so the UI should expose them.

## Solution

- `ReportBriefView` combines the existing owner check (`advisor.id === report.advisorId`) with `useStaff()` (RBAC `SUPER_ADMIN`, already available via the section's `PermissionProvider`) into a `canManageReport` flag, passed down through `ReportBrief` → `Masthead`.
- `Masthead` gates the `WeightsPanel` + `ShareTokenControls` on `canManageReport` (defaulting to owner-only when the prop is absent, so the donor share view and other callers are unchanged).
- The report **variant** is untouched (`advisor` for the owner, `staff` otherwise) — only the manage-controls gate changed. Diligence/intro actions remain `variant === "advisor"` only.

## Wire contract

| FE field → | proxy → | BE reader |
|---|---|---|
| `useStaff()` (RBAC role) gates UI only | — | authorization re-checked server-side via the Privy session → `resolveWriteAdvisorId` (gap-indexer #2285) |

Staff status is **not** trusted from the client for the actual write — the FE gate is purely presentational; the backend independently authorizes every write from the session.

## Testing

- `pnpm vitest run __tests__/features/donor-research src/features/donor-research` — **44 files / 362 tests pass**, incl. 3 new `ReportBriefView` tests: owner→`canManageReport: true`, staff-on-another-report→`true`, non-owner-non-staff→`false`.
- Biome clean (pre-commit hook).

## Smoke results

Manual cross-service E2E against a shared preview is pending (umbrella CLAUDE.md §4), to be run with gap-indexer #2285 deployed to the same preview: staff opens another advisor's report → **Adjust ranking** recomputes weights, **Share** generates/revokes a link; a non-staff non-owner sees neither control and the endpoints deny them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff members can now manage eligible donor research reports.
  * Report header controls now honor a manage permission flag and render only when management is allowed.

* **Bug Fixes**
  * Management controls are now correctly shown or hidden based on whether the viewer is the advisor owner or an authorized staff member.
  * Improved loading behavior by ensuring the page shows “Loading report…” while authorization or advisor data is still resolving.

* **Tests**
  * Expanded coverage for owner, staff, non-authorized, and pending/loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->