### PR TITLE
fix(sanity): never let a malformed projectId fail the whole build

### DIFF
--- a/__tests__/unit/sanity/env.test.ts
+++ b/__tests__/unit/sanity/env.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @file `sanity/env.ts` project-id normalization.
+ *
+ * A malformed `NEXT_PUBLIC_SANITY_PROJECT_ID` must never reach
+ * `createClient` — it validates synchronously and throws during Next's
+ * page-data collection, which fails the entire production build (every
+ * route, not just /blog). These pin the degrade-to-unconfigured contract.
+ *
+ * `envVars` is mocked per-case rather than via `process.env`: the global
+ * suite setup (`__tests__/setup-mocks.ts`) already replaces that module, so
+ * setting `process.env` here would never reach `sanity/env`.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Re-imports `sanity/env` with `envVars.NEXT_PUBLIC_SANITY_PROJECT_ID` set
+ * to the raw value under test. */
+async function loadProjectId(raw: string | undefined): Promise<string> {
+  vi.resetModules();
+  vi.doMock("@/utilities/enviromentVars", () => ({
+    envVars: {
+      NEXT_PUBLIC_SANITY_PROJECT_ID: raw ?? "",
+      NEXT_PUBLIC_SANITY_DATASET: "production",
+      NEXT_PUBLIC_SANITY_API_VERSION: "2024-01-01",
+    },
+  }));
+  const mod = await import("@/sanity/env");
+  return mod.projectId;
+}
+
+afterEach(() => {
+  vi.doUnmock("@/utilities/enviromentVars");
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("sanity env projectId", () => {
+  it("passes through a well-formed id unchanged", async () => {
+    await expect(loadProjectId("tc4p00d9")).resolves.toBe("tc4p00d9");
+  });
+
+  it("accepts dashes", async () => {
+    await expect(loadProjectId("my-blog-1")).resolves.toBe("my-blog-1");
+  });
+
+  it("trims surrounding whitespace and newlines pasted into a dashboard", async () => {
+    await expect(loadProjectId("  tc4p00d9\n")).resolves.toBe("tc4p00d9");
+  });
+
+  it("is empty when the variable is unset", async () => {
+    await expect(loadProjectId(undefined)).resolves.toBe("");
+  });
+
+  it("is empty when the variable is only whitespace", async () => {
+    await expect(loadProjectId("   ")).resolves.toBe("");
+  });
+
+  it.each([
+    ["surrounding quotes", '"tc4p00d9"'],
+    ["uppercase letters", "TC4P00D9"],
+    ["an inner space", "tc4p 00d9"],
+    ["a full URL", "https://tc4p00d9.sanity.io"],
+    ["an underscore", "tc4p_00d9"],
+  ])("degrades to unconfigured for %s", async (_label, raw) => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(loadProjectId(raw)).resolves.toBe("");
+  });
+
+  it("reports the offending characters and length without echoing the whole value", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await loadProjectId('"tc4p00d9"');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("NEXT_PUBLIC_SANITY_PROJECT_ID");
+    expect(message).toContain("length 10");
+    expect(message).toContain('"\\""');
+    expect(message).not.toContain('"tc4p00d9"');
+  });
+
+  it("does not warn for a well-formed id", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await loadProjectId("tc4p00d9");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/sanity/env.ts
+++ b/sanity/env.ts
@@ -8,6 +8,36 @@ import { envVars } from "@/utilities/enviromentVars";
  * content gateway is responsible for treating that as "no CMS" and
  * returning empty results instead of throwing).
  */
-export const projectId = envVars.NEXT_PUBLIC_SANITY_PROJECT_ID;
+/**
+ * Sanity project ids are restricted to lowercase letters, digits and dashes.
+ * `createClient` validates this synchronously at construction time, so a
+ * malformed value does not degrade gracefully — it throws while Next collects
+ * page data and takes down the *entire* production build (every route, not
+ * just /blog). A CMS misconfiguration must never be able to block the whole
+ * site from deploying, so normalize here and fall back to "not configured".
+ */
+const PROJECT_ID_PATTERN = /^[a-z0-9-]+$/;
+
+function resolveProjectId(raw: string): string {
+  // Values pasted into a hosting dashboard routinely pick up surrounding
+  // whitespace or a trailing newline — a valid id, just dirty.
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (PROJECT_ID_PATTERN.test(trimmed)) return trimmed;
+
+  // Non-empty but malformed: report enough to identify the problem (length and
+  // the offending characters) without echoing the whole configured value, then
+  // fall back to the already-supported "unconfigured" state.
+  const offending = Array.from(new Set(trimmed.replace(/[a-z0-9-]/g, ""))).join("");
+  console.warn(
+    `[Sanity] Ignoring malformed NEXT_PUBLIC_SANITY_PROJECT_ID: length ${trimmed.length}, ` +
+      `disallowed character(s) ${JSON.stringify(offending)}. ` +
+      'Expected only lowercase letters, digits and dashes (e.g. "abc12xyz"). ' +
+      "Treating Sanity as unconfigured — blog content stays empty until this is fixed."
+  );
+  return "";
+}
+
+export const projectId = resolveProjectId(envVars.NEXT_PUBLIC_SANITY_PROJECT_ID);
 export const dataset = envVars.NEXT_PUBLIC_SANITY_DATASET;
 export const apiVersion = envVars.NEXT_PUBLIC_SANITY_API_VERSION;


### PR DESCRIPTION
## Problem

The production deploy of `v1.8.10` failed three times with:

```
Error: `projectId` can only contain only a-z, 0-9 and dashes
Error: Failed to collect page data for /sitemaps/static/sitemap.xml
```

`createClient` validates `projectId` synchronously against `/^[a-z0-9-]+$/`. The Sanity client is constructed at module scope, so a malformed value throws while Next collects page data and fails the **entire** production build — every route, not just `/blog`. An empty value was already handled (falls back to a placeholder); a non-empty malformed one was not.

The Production environment currently has a malformed `NEXT_PUBLIC_SANITY_PROJECT_ID`, but the deeper issue is that a CMS misconfiguration can block the whole site from deploying.

## Solution

Normalize in `sanity/env.ts` — the single source `client.ts`, `gateway.ts`, `sanity.config.ts` and the Studio route all read:

- **Trim** the value, so a stray space or trailing newline picked up when pasting into a hosting dashboard resolves to the valid id it was meant to be.
- If still malformed, fall back to `""` — the already-supported "not configured" state every consumer handles — and **warn** with the value's length and the specific disallowed characters, without echoing the configured value.

This is fail-soft by design: a bad id degrades the blog to empty instead of taking the site down, and the log names the exact problem.

## Testing

`__tests__/unit/sanity/env.test.ts` (14 assertions) covers pass-through, dashes, trimming, unset/whitespace, and rejection of quotes / uppercase / inner spaces / URLs / underscores, plus the warning contents.

Verified with a **full production build** using a quoted id (`"tc4p00d9"`):

- **Before:** died at `Failed to collect page data for /sitemaps/static/sitemap.xml`.
- **After:** `✓ Compiled successfully`, page data collected, **exit 0**, and the log reads:
  ```
  [Sanity] Ignoring malformed NEXT_PUBLIC_SANITY_PROJECT_ID: length 10,
    disallowed character(s) "\"". ... Treating Sanity as unconfigured
  ```

## Note / correction

An earlier commit on `main` (`2b02c5ecf`) was described as switching the production build to webpack. That was inaccurate — **Next.js 16 uses Turbopack by default for `next build`**, so dropping the flag was a no-op. The Vercel preview OOM was actually resolved by the `NODE_OPTIONS` heap cap added to `vercel.json` in that same commit. No behavior change is needed here; recording it so the history isn't misleading.

## Risk

Low. Only narrows an invalid value to the existing "unconfigured" path; a well-formed id is passed through byte-identical (asserted in tests).