### PR TITLE
fix(control-center): use row milestone UID when deleting disbursement

### DIFF
--- a/__tests__/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.test.tsx
+++ b/__tests__/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.test.tsx
@@ -274,7 +274,43 @@ describe("PaymentStatusDropdown", () => {
 
     // Should NOT call mutate directly — delegates to onRequestRecordPayment
     expect(mockMutate).not.toHaveBeenCalled();
-    expect(mockOnRequestRecordPayment).toHaveBeenCalledWith("Milestone 1", "disbursed");
+    // Passes the row's own milestoneUID (not just the free-text label) so that
+    // duplicate labels resolve to the correct milestone downstream.
+    expect(mockOnRequestRecordPayment).toHaveBeenCalledWith(
+      "milestone-uid-789",
+      "Milestone 1",
+      "disbursed"
+    );
+  });
+
+  it("should call onRequestDeleteDisbursement with the row's milestoneUID, not the label", async () => {
+    const user = userEvent.setup();
+    const mockOnRequestDeleteDisbursement = vi.fn();
+    renderWithProviders(
+      <PaymentStatusDropdown
+        {...defaultProps}
+        currentStatus="disbursed"
+        onRequestDeleteDisbursement={mockOnRequestDeleteDisbursement}
+      />
+    );
+
+    await user.click(screen.getByTestId("dropdown-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("menuitem", { name: /Unpaid/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Mark as unpaid/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Delete disbursement/i }));
+
+    // Regression (GAP-FRONTEND-25M): must forward the row UID, never the label.
+    expect(mockOnRequestDeleteDisbursement).toHaveBeenCalledWith("milestone-uid-789");
+    expect(mockOnRequestDeleteDisbursement).not.toHaveBeenCalledWith("Milestone 1");
   });
 
   it("should show confirmation dialog for unpaid status when disbursement exists", async () => {

--- a/__tests__/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.delete-disbursement.test.tsx
+++ b/__tests__/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.delete-disbursement.test.tsx
@@ -1,0 +1,288 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type CommunityPayoutInvoiceInfo,
+  MilestoneLifecycleStatus,
+} from "@/src/features/payout-disbursement/types/payout-disbursement";
+
+// Regression for GAP-FRONTEND-25M: deleting a disbursement from Control Center
+// must target the clicked row's own milestoneUID. Previously the chain threw the
+// UID away and re-derived identity from the free-text label, so two milestones
+// sharing a label sent the FIRST row's UID and the backend 404'd.
+
+// ─── Capture the delete mutation ─────────────────────────────────────────────
+
+const { deleteMutate } = vi.hoisted(() => ({ deleteMutate: vi.fn() }));
+
+vi.mock("@/src/features/payout-disbursement/hooks/use-payout-disbursement", () => ({
+  useDeleteDisbursementByMilestone: () => ({ mutate: deleteMutate, isPending: false }),
+  useToggleAgreement: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useSaveMilestoneInvoices: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useUpdateMilestonePaymentStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// ─── Boundaries the sidebar / milestones table touch ─────────────────────────
+
+vi.mock("@/src/core/rbac/context/permission-context", () => ({ useCan: () => true }));
+vi.mock("@/hooks/useCopyToClipboard", () => ({ useCopyToClipboard: () => [null, vi.fn()] }));
+vi.mock("next/navigation", () => ({ useParams: () => ({ communityId: "test-community" }) }));
+
+vi.mock("@/components/Pages/Admin/ControlCenter/DetailsSection", () => ({
+  DetailsSection: () => <div data-testid="details-section" />,
+}));
+vi.mock("@/src/features/payout-disbursement/components/PayoutConfigurationContent", () => ({
+  PayoutConfigurationContent: () => <div data-testid="config" />,
+}));
+vi.mock("@/src/features/payout-disbursement/components/PayoutHistoryContent", () => ({
+  PayoutHistoryContent: () => <div data-testid="history" />,
+}));
+vi.mock("@/src/features/payout-disbursement/components/RecordPaymentDialog", () => ({
+  RecordPaymentDialog: () => null,
+}));
+vi.mock("@/components/EthereumAddressToProfileName", () => ({ default: () => null }));
+vi.mock("@/components/Utilities/FileUpload", () => ({ FileUpload: () => null }));
+vi.mock("@/components/Milestone/MilestoneAIEvaluationBadge", () => ({
+  MilestoneAIEvaluationBadge: () => null,
+}));
+vi.mock("@/src/features/payout-disbursement/services/payout-disbursement.service", () => ({
+  getInvoiceDownloadUrl: vi.fn(),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Radix primitives for jsdom ──────────────────────────────────────────────
+
+vi.mock("@radix-ui/react-dropdown-menu", () => {
+  const React = require("react");
+  return {
+    Root: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+    }) => {
+      const [isOpen, setIsOpen] = React.useState(open ?? false);
+      const handleOpenChange = (v: boolean) => {
+        setIsOpen(v);
+        onOpenChange?.(v);
+      };
+      return (
+        <div data-testid="dropdown-root" data-open={isOpen}>
+          {React.Children.map(children, (child: React.ReactElement) => {
+            if (!React.isValidElement(child)) return child;
+            return React.cloneElement(child, {
+              _isOpen: isOpen,
+              _setOpen: handleOpenChange,
+            } as Record<string, unknown>);
+          })}
+        </div>
+      );
+    },
+    Trigger: ({
+      children,
+      asChild,
+      _setOpen,
+      ...props
+    }: {
+      children: React.ReactNode;
+      asChild?: boolean;
+      _setOpen?: (open: boolean) => void;
+    }) => (
+      <button {...props} data-testid="dropdown-trigger" onClick={() => _setOpen?.(true)}>
+        {children}
+      </button>
+    ),
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Content: ({
+      children,
+      _isOpen,
+      ...props
+    }: {
+      children: React.ReactNode;
+      _isOpen?: boolean;
+      className?: string;
+      side?: string;
+      align?: string;
+    }) =>
+      _isOpen ? (
+        <div data-testid="dropdown-content" role="menu" {...props}>
+          {children}
+        </div>
+      ) : null,
+    Item: ({
+      children,
+      onSelect,
+      disabled,
+      ...props
+    }: {
+      children: React.ReactNode;
+      onSelect?: () => void;
+      disabled?: boolean;
+      className?: string;
+    }) => (
+      <button
+        role="menuitem"
+        onClick={() => {
+          if (!disabled) onSelect?.();
+        }}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </button>
+    ),
+    Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Sub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    RadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    CheckboxItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    RadioItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    ItemIndicator: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+    Label: ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+      <div {...props}>{children}</div>
+    ),
+    Separator: (props: { className?: string }) => <hr {...props} />,
+    ShortcutKeys: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  };
+});
+
+vi.mock("@radix-ui/react-dialog", () => {
+  const React = require("react");
+  return {
+    Root: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+      open ? <div data-testid="dialog-root">{children}</div> : null,
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Overlay: ({ children, ...props }: { children?: React.ReactNode; className?: string }) => (
+      <div {...props}>{children}</div>
+    ),
+    Content: ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+      <div role="dialog" {...props}>
+        {children}
+      </div>
+    ),
+    Title: ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+      <h2 {...props}>{children}</h2>
+    ),
+    Description: ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+      <p {...props}>{children}</p>
+    ),
+    Close: ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+      <button {...props}>{children}</button>
+    ),
+    Trigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("@radix-ui/react-tooltip", () => ({
+  Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Trigger: ({ children, asChild, ...props }: { children: React.ReactNode; asChild?: boolean }) => (
+    <span {...props}>{children}</span>
+  ),
+  Content: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    side?: string;
+    className?: string;
+  }) => <div {...props}>{children}</div>,
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import type { ProjectDetailsSidebarGrant } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar";
+import { ProjectDetailsSidebar } from "@/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar";
+
+const grant: ProjectDetailsSidebarGrant = {
+  grantUid: "grant-1",
+  projectUid: "project-1",
+  projectName: "Test Project",
+  projectSlug: "test-project",
+  grantName: "Test Grant",
+  grantProgramId: "program-1",
+  grantChainId: 10,
+  projectChainId: 10,
+  currency: "USDC",
+} as unknown as ProjectDetailsSidebarGrant;
+
+// Two milestones sharing the SAME label but with DIFFERENT UIDs. The second row
+// is the one the user clicks; a label-based lookup would collapse to the first.
+function makeInvoice(milestoneUID: string): CommunityPayoutInvoiceInfo {
+  return {
+    milestoneLabel: "Milestone 1",
+    milestoneUID,
+    milestoneStatus: MilestoneLifecycleStatus.PENDING,
+    milestoneDueDate: null,
+    milestoneStatusUpdatedAt: null,
+    invoiceStatus: "pending",
+    invoiceReceivedAt: null,
+    invoiceReceivedBy: null,
+    invoiceFileKey: null,
+    allocatedAmount: null,
+    paymentStatus: "disbursed",
+    paymentStatusDate: null,
+    completionReason: null,
+  } as unknown as CommunityPayoutInvoiceInfo;
+}
+
+function renderSidebar() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectDetailsSidebar
+        grant={grant}
+        open={true}
+        onOpenChange={vi.fn()}
+        communityUID="community-1"
+        invoiceRequired={false}
+        kycStatus={null}
+        disbursementInfo={null}
+        agreement={null}
+        milestoneInvoices={[makeInvoice("uid-first"), makeInvoice("uid-second")]}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("ProjectDetailsSidebar — delete disbursement identity (GAP-FRONTEND-25M)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes using the clicked row's own milestoneUID, not the shared label", async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    // Both rows share the label, so there are two payment-status dropdowns.
+    const triggers = screen.getAllByTestId("dropdown-trigger");
+    expect(triggers).toHaveLength(2);
+
+    // Open the SECOND row's dropdown and mark it unpaid.
+    await user.click(triggers[1]);
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+    await user.click(screen.getByRole("menuitem", { name: /Unpaid/i }));
+
+    // Confirm the deletion.
+    await waitFor(() => expect(screen.getByText(/Mark as unpaid/i)).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: /Delete disbursement/i }));
+
+    // The mutation must carry the SECOND row's UID. Before the fix it re-derived
+    // identity from the label and sent "uid-first".
+    expect(deleteMutate).toHaveBeenCalledTimes(1);
+    expect(deleteMutate).toHaveBeenCalledWith({
+      grantUID: "grant-1",
+      milestoneUID: "uid-second",
+    });
+  });
+});

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -166,6 +166,7 @@ export const MilestonesSection = memo(function MilestonesSection({
         const downloadUrl = await getInvoiceDownloadUrl(grant.grantUid, fileKey);
         window.open(downloadUrl, "_blank", "noopener,noreferrer");
       } catch {
+        // SUPPRESSED: getInvoiceDownloadUrl already reports to Sentry via errorManager
         toast.error("Failed to get download link");
       } finally {
         setLoadingFileKeys((prev) => {

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -125,10 +125,11 @@ export interface MilestonesSectionProps {
   removedFiles: Set<string>;
   onFileRemoved: (mKey: string) => void;
   onRequestRecordPayment?: (
+    milestoneUID: string | null,
     milestoneLabel: string,
     targetStatus: "awaiting_signatures" | "disbursed"
   ) => void;
-  onRequestDeleteDisbursement?: (milestoneLabel: string) => void;
+  onRequestDeleteDisbursement?: (milestoneUID: string | null) => void;
 }
 
 export const MilestonesSection = memo(function MilestonesSection({

--- a/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
+++ b/components/Pages/Admin/ControlCenter/MilestonesSection.tsx
@@ -39,6 +39,7 @@ import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { PaymentStatusDropdown } from "./PaymentStatusDropdown";
 import type { ProjectDetailsSidebarGrant } from "./ProjectDetailsSidebar";
+import type { OnRequestDeleteDisbursement, OnRequestRecordPayment } from "./paymentRequestTypes";
 
 const MilestoneAIEvaluationBadge = dynamic(
   () =>
@@ -124,12 +125,8 @@ export interface MilestonesSectionProps {
   ) => void;
   removedFiles: Set<string>;
   onFileRemoved: (mKey: string) => void;
-  onRequestRecordPayment?: (
-    milestoneUID: string | null,
-    milestoneLabel: string,
-    targetStatus: "awaiting_signatures" | "disbursed"
-  ) => void;
-  onRequestDeleteDisbursement?: (milestoneUID: string | null) => void;
+  onRequestRecordPayment?: OnRequestRecordPayment;
+  onRequestDeleteDisbursement?: OnRequestDeleteDisbursement;
 }
 
 export const MilestonesSection = memo(function MilestonesSection({

--- a/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
+++ b/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
@@ -23,6 +23,7 @@ import {
 import { useUpdateMilestonePaymentStatus } from "@/src/features/payout-disbursement/hooks/use-payout-disbursement";
 import type { MilestonePaymentStatus } from "@/src/features/payout-disbursement/types/payout-disbursement";
 import { cn } from "@/utilities/tailwind";
+import type { OnRequestDeleteDisbursement, OnRequestRecordPayment } from "./paymentRequestTypes";
 
 const STATUS_OPTIONS: {
   value: MilestonePaymentStatus;
@@ -63,12 +64,8 @@ interface PaymentStatusDropdownProps {
   grantUID: string;
   communityUID: string;
   paymentStatusDate?: string | null;
-  onRequestRecordPayment?: (
-    milestoneUID: string | null,
-    milestoneLabel: string,
-    targetStatus: "awaiting_signatures" | "disbursed"
-  ) => void;
-  onRequestDeleteDisbursement?: (milestoneUID: string | null) => void;
+  onRequestRecordPayment?: OnRequestRecordPayment;
+  onRequestDeleteDisbursement?: OnRequestDeleteDisbursement;
 }
 
 export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({

--- a/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
+++ b/components/Pages/Admin/ControlCenter/PaymentStatusDropdown.tsx
@@ -64,10 +64,11 @@ interface PaymentStatusDropdownProps {
   communityUID: string;
   paymentStatusDate?: string | null;
   onRequestRecordPayment?: (
+    milestoneUID: string | null,
     milestoneLabel: string,
     targetStatus: "awaiting_signatures" | "disbursed"
   ) => void;
-  onRequestDeleteDisbursement?: (milestoneLabel: string) => void;
+  onRequestDeleteDisbursement?: (milestoneUID: string | null) => void;
 }
 
 export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
@@ -94,7 +95,7 @@ export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
 
       // "Awaiting sigs" and "Disbursed" open the Record Payment dialog
       if (status === "awaiting_signatures" || status === "disbursed") {
-        onRequestRecordPayment?.(milestoneLabel, status);
+        onRequestRecordPayment?.(milestoneUID, milestoneLabel, status);
         return;
       }
 
@@ -130,8 +131,8 @@ export const PaymentStatusDropdown = memo(function PaymentStatusDropdown({
 
   const handleConfirmUnpaid = useCallback(() => {
     setConfirmingUnpaid(false);
-    onRequestDeleteDisbursement?.(milestoneLabel);
-  }, [milestoneLabel, onRequestDeleteDisbursement]);
+    onRequestDeleteDisbursement?.(milestoneUID);
+  }, [milestoneUID, onRequestDeleteDisbursement]);
 
   return (
     <>

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
@@ -142,6 +142,7 @@ export function ProjectDetailsSidebar({
 
   const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
   const [initialPaymentMilestone, setInitialPaymentMilestone] = useState<{
+    milestoneUID: string | null;
     milestoneLabel: string;
     status: "awaiting_signatures" | "disbursed";
     amount: string | null;
@@ -516,32 +517,37 @@ export function ProjectDetailsSidebar({
   }, []);
 
   const handleRequestRecordPayment = useCallback(
-    (milestoneLabel: string, targetStatus: "awaiting_signatures" | "disbursed") => {
-      const invoice = milestoneInvoices.find((inv) => inv.milestoneLabel === milestoneLabel);
+    (
+      milestoneUID: string | null,
+      milestoneLabel: string,
+      targetStatus: "awaiting_signatures" | "disbursed"
+    ) => {
+      const invoice = milestoneUID
+        ? milestoneInvoices.find((inv) => inv.milestoneUID === milestoneUID)
+        : undefined;
       const amount =
         invoice?.allocatedAmount ??
-        (invoice?.milestoneUID ? allocationByUID.get(invoice.milestoneUID) : undefined) ??
+        (milestoneUID ? allocationByUID.get(milestoneUID) : undefined) ??
         null;
-      setInitialPaymentMilestone({ milestoneLabel, status: targetStatus, amount });
+      setInitialPaymentMilestone({ milestoneUID, milestoneLabel, status: targetStatus, amount });
       guardAction(() => setRecordPaymentOpen(true));
     },
     [guardAction, milestoneInvoices, allocationByUID]
   );
 
   const handleRequestDeleteDisbursement = useCallback(
-    (milestoneLabel: string) => {
+    (milestoneUID: string | null) => {
       if (!grant) return;
-      const invoice = milestoneInvoices.find((inv) => inv.milestoneLabel === milestoneLabel);
-      if (!invoice?.milestoneUID) {
+      if (!milestoneUID) {
         toast.error("Cannot delete: milestone UID not found");
         return;
       }
       deleteDisbursementMutation.mutate({
         grantUID: grant.grantUid,
-        milestoneUID: invoice.milestoneUID,
+        milestoneUID,
       });
     },
-    [grant, milestoneInvoices, deleteDisbursementMutation]
+    [grant, deleteDisbursementMutation]
   );
 
   const handleRequestClose = useCallback(() => {
@@ -818,6 +824,7 @@ export function ProjectDetailsSidebar({
           milestoneInvoices={milestoneInvoices}
           todayLocal={todayLocal}
           onSuccess={onConfigSuccess}
+          initialMilestoneUID={initialPaymentMilestone?.milestoneUID}
           initialMilestoneLabel={initialPaymentMilestone?.milestoneLabel}
           initialAmount={initialPaymentMilestone?.amount}
           initialStatus={

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
@@ -468,6 +468,7 @@ export function ProjectDetailsSidebar({
       setRemovedFiles(new Set());
       toast.success(`Saved ${editCount} ${editCount === 1 ? "change" : "changes"}`);
     } catch {
+      // SUPPRESSED: saveMilestoneInvoices already reports to Sentry via errorManager
       toast.error("Failed to save changes");
     }
   }, [

--- a/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
+++ b/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.tsx
@@ -51,6 +51,11 @@ import { PAGES } from "@/utilities/pages";
 import { cn } from "@/utilities/tailwind";
 import { DetailsSection } from "./DetailsSection";
 import { MilestonesSection } from "./MilestonesSection";
+import type {
+  InitialPaymentMilestone,
+  OnRequestDeleteDisbursement,
+  OnRequestRecordPayment,
+} from "./paymentRequestTypes";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -141,12 +146,8 @@ export function ProjectDetailsSidebar({
   const [confirmingUnsign, setConfirmingUnsign] = useState(false);
 
   const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
-  const [initialPaymentMilestone, setInitialPaymentMilestone] = useState<{
-    milestoneUID: string | null;
-    milestoneLabel: string;
-    status: "awaiting_signatures" | "disbursed";
-    amount: string | null;
-  } | null>(null);
+  const [initialPaymentMilestone, setInitialPaymentMilestone] =
+    useState<InitialPaymentMilestone | null>(null);
   const configRef = useRef<PayoutConfigurationContentRef>(null);
   const [configIsDirty, setConfigIsDirty] = useState(false);
   const [configIsSaving, setConfigIsSaving] = useState(false);
@@ -516,36 +517,27 @@ export function ProjectDetailsSidebar({
     pendingActionRef.current = null;
   }, []);
 
-  const handleRequestRecordPayment = useCallback(
-    (
-      milestoneUID: string | null,
-      milestoneLabel: string,
-      targetStatus: "awaiting_signatures" | "disbursed"
-    ) => {
+  const handleRequestRecordPayment = useCallback<OnRequestRecordPayment>(
+    (milestoneUID, milestoneLabel, targetStatus) => {
       const invoice = milestoneUID
         ? milestoneInvoices.find((inv) => inv.milestoneUID === milestoneUID)
-        : undefined;
-      const amount =
-        invoice?.allocatedAmount ??
-        (milestoneUID ? allocationByUID.get(milestoneUID) : undefined) ??
-        null;
+        : milestoneInvoices.find((inv) => inv.milestoneLabel === milestoneLabel);
+      const allocated = milestoneUID ? allocationByUID.get(milestoneUID) : undefined;
+      const amount = invoice?.allocatedAmount ?? allocated ?? null;
       setInitialPaymentMilestone({ milestoneUID, milestoneLabel, status: targetStatus, amount });
       guardAction(() => setRecordPaymentOpen(true));
     },
     [guardAction, milestoneInvoices, allocationByUID]
   );
 
-  const handleRequestDeleteDisbursement = useCallback(
-    (milestoneUID: string | null) => {
+  const handleRequestDeleteDisbursement = useCallback<OnRequestDeleteDisbursement>(
+    (milestoneUID) => {
       if (!grant) return;
       if (!milestoneUID) {
         toast.error("Cannot delete: milestone UID not found");
         return;
       }
-      deleteDisbursementMutation.mutate({
-        grantUID: grant.grantUid,
-        milestoneUID,
-      });
+      deleteDisbursementMutation.mutate({ grantUID: grant.grantUid, milestoneUID });
     },
     [grant, deleteDisbursementMutation]
   );

--- a/components/Pages/Admin/ControlCenter/paymentRequestTypes.ts
+++ b/components/Pages/Admin/ControlCenter/paymentRequestTypes.ts
@@ -1,0 +1,16 @@
+export type PaymentRequestStatus = "awaiting_signatures" | "disbursed";
+
+export type OnRequestRecordPayment = (
+  milestoneUID: string | null,
+  milestoneLabel: string,
+  targetStatus: PaymentRequestStatus
+) => void;
+
+export type OnRequestDeleteDisbursement = (milestoneUID: string | null) => void;
+
+export interface InitialPaymentMilestone {
+  milestoneUID: string | null;
+  milestoneLabel: string;
+  status: PaymentRequestStatus;
+  amount: string | null;
+}

--- a/scripts/check-anti-patterns.sh
+++ b/scripts/check-anti-patterns.sh
@@ -39,7 +39,8 @@ check_file() {
 
       # useState + service call without useMutation
       if grep -q "useState" "$FILE" 2>/dev/null; then
-        if grep -qE "await.*Service\.|\.post\(|\.put\(|\.patch\(|\.delete\(" "$FILE" 2>/dev/null; then
+        # ".delete(" is receiver-qualified: bare matches false-positive on Set/Map#delete
+        if grep -qE "await.*Service\.|\.post\(|\.put\(|\.patch\(|(api|axios|[A-Za-z]*[Ss]ervice)\.delete\(" "$FILE" 2>/dev/null; then
           if ! grep -q "useMutation" "$FILE" 2>/dev/null; then
             FILE_ISSUES="${FILE_ISSUES}\n  [MUTATION] useState + service call without useMutation"
             ISSUES=$((ISSUES + 1))

--- a/src/features/payout-disbursement/components/RecordPaymentDialog.tsx
+++ b/src/features/payout-disbursement/components/RecordPaymentDialog.tsx
@@ -33,7 +33,9 @@ interface RecordPaymentDialogProps {
   milestoneInvoices?: CommunityPayoutInvoiceInfo[];
   todayLocal: string;
   onSuccess?: () => void;
-  /** Pre-select a milestone by label when opening from the status dropdown */
+  /** Pre-select a milestone by its UID when opening from the status dropdown */
+  initialMilestoneUID?: string | null;
+  /** Fallback pre-select by label when the milestone has no UID */
   initialMilestoneLabel?: string;
   /** Pre-fill the amount field with the milestone's allocation value */
   initialAmount?: string | null;
@@ -88,6 +90,7 @@ function RecordPaymentDialogInner({
   milestoneInvoices,
   todayLocal,
   onSuccess,
+  initialMilestoneUID,
   initialMilestoneLabel,
   initialAmount,
   initialStatus,
@@ -176,18 +179,26 @@ function RecordPaymentDialogInner({
       .map((cat) => ({ category: cat, ...CATEGORY_CONFIG[cat], items: groups.get(cat)! }));
   }, [milestoneOptions]);
 
-  // Pre-select milestone and pre-fill amount when opening from the status dropdown
+  // Pre-select milestone and pre-fill amount when opening from the status dropdown.
+  // Match on the row's UID first so duplicate labels resolve to the correct row.
   useEffect(() => {
-    if (!isOpen || !initialMilestoneLabel || milestoneOptions.length === 0) return;
+    if (!isOpen || milestoneOptions.length === 0) return;
+    if (!initialMilestoneUID && !initialMilestoneLabel) return;
 
-    const match = milestoneOptions.find((opt) => opt.label === initialMilestoneLabel);
+    const match =
+      (initialMilestoneUID
+        ? milestoneOptions.find((opt) => opt.milestoneUID === initialMilestoneUID)
+        : undefined) ??
+      (initialMilestoneLabel
+        ? milestoneOptions.find((opt) => opt.label === initialMilestoneLabel)
+        : undefined);
     if (match && !match.isPaid) {
       setSelectedKeys([match.key]);
     }
     if (initialAmount && !Number.isNaN(Number(initialAmount))) {
       setAmount(initialAmount);
     }
-  }, [isOpen, initialMilestoneLabel, initialAmount, milestoneOptions]);
+  }, [isOpen, initialMilestoneUID, initialMilestoneLabel, initialAmount, milestoneOptions]);
 
   const toggleSelection = useCallback((key: string) => {
     setSelectedKeys((prev) =>


### PR DESCRIPTION
## Overview

Fixes the production 404 on `DELETE /v2/payouts/grant/:grantUID/milestone` fired from `/manage/control-center` (Sentry [GAP-FRONTEND-25M](https://karma-crypto-inc.sentry.io/issues/7629768286/)). The delete-disbursement flow now sends the milestone UID of the exact row the user clicked instead of re-deriving it from the milestone's display label.

Related to GAP-FRONTEND-25M (hardening; the incident root cause is fixed in gap-indexer — see the linked PR in comments)

## Problem

Clicking "mark unpaid" (delete disbursement) on a milestone row in the control center could 404 even though the payout was visibly displayed:

- Each rendered invoice row carries its own correct `milestoneUID`, but `PaymentStatusDropdown`'s confirm handler called back with only `milestoneLabel` (free text).
- `ProjectDetailsSidebar.handleRequestDeleteDisbursement` then re-resolved the UID via `milestoneInvoices.find(inv => inv.milestoneLabel === milestoneLabel)` — first match wins.
- When two milestones on a grant share a label (or a milestone was re-attested with a rotated UID), the delete request targeted the *wrong* milestone's UID. The backend lookup (`grantUID` + `milestoneUID` in `milestoneBreakdown`) correctly found no disbursement under that key and returned the domain 404 (`PayoutDisbursementNotFoundException`).

The backend route and 404 semantics are correct; this was purely a frontend identity bug. The record-payment path (`handleRequestRecordPayment` + `RecordPaymentDialog` preselect) had the same label-based re-lookup and is fixed here too.

## Solution

- `PaymentStatusDropdown`: `onRequestDeleteDisbursement` now passes the row's own `milestoneUID` (already a prop); `onRequestRecordPayment` passes `(milestoneUID, milestoneLabel, targetStatus)`.
- `MilestonesSection`: prop signatures updated to carry the UID through unchanged.
- `ProjectDetailsSidebar`: `handleRequestDeleteDisbursement` uses the received UID directly — the label `find` re-lookup is deleted; the explicit no-UID guard (error toast) is preserved. `handleRequestRecordPayment` resolves the invoice by UID.
- `RecordPaymentDialog`: new optional `initialMilestoneUID` prop; preselect matches on UID first and falls back to label only when no UID exists.

## Why This Approach

The identity sent to the API must be the identity of the specific row the user interacted with, never a value re-derived from a non-unique display field. The same file already used this pattern for row keys (`getMilestoneKey` prefers `milestoneUID`); this PR aligns the delete and record-payment paths with it. No backend change is needed — its lookup behaves as designed and is covered by existing unit tests.

## Testing Steps

1. `pnpm test -- ControlCenter` — all suites green, including the new regression test.
2. New test `__tests__/components/Pages/Admin/ControlCenter/ProjectDetailsSidebar.delete-disbursement.test.tsx` renders the real `ProjectDetailsSidebar → MilestonesSection → PaymentStatusDropdown` chain with **two invoices sharing the label "Milestone 1"** and UIDs `uid-first` / `uid-second`, clicks delete on the second row, and asserts the mutation receives `uid-second`. Against the pre-fix code this test fails (receives `uid-first`), reproducing the production 404 exactly.
3. Manual: in the control center, on a grant with two milestones sharing a title, mark the second one's disbursement as unpaid — it should delete the correct disbursement instead of returning "Error deleting disbursement".
4. `pnpm run build` passes.

## Technical Details

```mermaid
sequenceDiagram
    participant Row as PaymentStatusDropdown (row)
    participant Sidebar as ProjectDetailsSidebar
    participant API as DELETE /v2/payouts/grant/:grantUID/milestone
    Note over Row,Sidebar: Before: label-based re-lookup
    Row->>Sidebar: onRequestDeleteDisbursement(milestoneLabel)
    Sidebar->>Sidebar: find(inv => inv.milestoneLabel === label) — first match wins
    Sidebar->>API: { milestoneUID: wrong row's UID } → 404
    Note over Row,Sidebar: After: row-scoped identity
    Row->>Sidebar: onRequestDeleteDisbursement(milestoneUID)
    Sidebar->>API: { milestoneUID: clicked row's UID } → 200
```

## Checklist

- [x] Tests added/updated (regression test verified to fail pre-fix)
- [x] No breaking changes (internal component prop contract only)
- [x] Lint/build green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment actions now target the selected milestone using its unique identifier.
  * Fixed disbursement deletion when multiple milestones share the same label.
  * Record Payment dialogs now open with the correct milestone preselected by UID (with fallback to label).

* **Tests**
  * Added regression coverage for payment status updates and for deleting disbursements from duplicate-labeled milestones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
