### PR TITLE
ci(vercel): skip preview builds for docs, test and CI-only changes

### DIFF
--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -3,6 +3,13 @@
 # Vercel Ignored Build Step
 # This script determines whether Vercel should proceed with a build
 # Exit 0 = Skip build, Exit 1 = Proceed with build
+#
+# Two skip conditions:
+#   1. Pushes to main (deployed via GitHub Actions)
+#   2. Pushes that only touch files which cannot affect the built output
+#
+# Everything else builds. Any error while inspecting the diff fails OPEN
+# (exit 1 / build), so we never miss a preview because of a git hiccup.
 
 echo "Branch: $VERCEL_GIT_COMMIT_REF"
 
@@ -12,6 +19,70 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then
   exit 0
 fi
 
-# Proceed with build for all other branches (PR previews)
-echo "Proceeding with preview build"
-exit 1
+# --- Path-based skip -------------------------------------------------------
+#
+# Paths that are inert with respect to the Next.js build. Anything not matched
+# here is treated as build-affecting.
+#
+#   docs/                      documentation only
+#   .github/                   CI workflows and templates
+#   .claude/ .agents/          agent tooling
+#   __tests__/ e2e/            test suites
+#   *.test.* *.spec.*          co-located tests anywhere
+#   *.md                       markdown anywhere EXCEPT public/, which is
+#                              served verbatim (public/pricing.md, agents.md)
+is_inert_path() {
+  case "$1" in
+    public/*) return 1 ;;
+    docs/* | .github/* | .claude/* | .agents/* | __tests__/* | e2e/*) return 0 ;;
+    *.md) return 0 ;;
+    *.test.* | *.spec.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+PREVIOUS_SHA="$VERCEL_GIT_PREVIOUS_SHA"
+CURRENT_SHA="$VERCEL_GIT_COMMIT_SHA"
+
+if [ -z "$PREVIOUS_SHA" ] || [ -z "$CURRENT_SHA" ]; then
+  echo "No previous/current commit SHA available - proceeding with build"
+  exit 1
+fi
+
+if ! git cat-file -e "${PREVIOUS_SHA}^{commit}" 2>/dev/null; then
+  echo "Previous SHA $PREVIOUS_SHA is not reachable (shallow clone?) - proceeding with build"
+  exit 1
+fi
+
+if ! git cat-file -e "${CURRENT_SHA}^{commit}" 2>/dev/null; then
+  echo "Current SHA $CURRENT_SHA is not reachable - proceeding with build"
+  exit 1
+fi
+
+if ! CHANGED_FILES=$(git diff --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" 2>&1); then
+  echo "Could not compute diff - proceeding with build"
+  echo "$CHANGED_FILES"
+  exit 1
+fi
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No changed files detected between $PREVIOUS_SHA and $CURRENT_SHA - proceeding with build"
+  exit 1
+fi
+
+echo "Changed files between $PREVIOUS_SHA and $CURRENT_SHA:"
+echo "$CHANGED_FILES"
+
+while IFS= read -r changed_file; do
+  [ -z "$changed_file" ] && continue
+  if ! is_inert_path "$changed_file"; then
+    echo "Build-affecting change detected: $changed_file"
+    echo "Proceeding with preview build"
+    exit 1
+  fi
+done <<EOF
+$CHANGED_FILES
+EOF
+
+echo "All changed files are inert (docs/tests/CI/agent tooling) - skipping build"
+exit 0


### PR DESCRIPTION
## Why

Vercel spend for the Karma Devs team roughly doubled (~$137/mo → ~$268/mo). The dominant driver is Build CPU Minutes for `gap-app-v2`, which went from **$10.57/mo to $124.70/mo**.

Cause: `vercel-ignore.sh` (wired up as the Ignored Build Step via `ignoreCommand` in `vercel.json`) only skips builds on `main`. Every other commit on every branch triggers a full preview build — roughly **6.5 min wall / ~52 CPU-min / ~$0.18 each**, and a hung build that hits the timeout costs **~$0.85**. We have a real 30-minute `BUILD_UTILS_SPAWN_124` timeout triggered by a commit whose message was literally `docs: record QA remediation outcomes in run report`.

Documentation, test and CI commits are paying full price for output they cannot change.

## What changed

`vercel-ignore.sh` now additionally diffs `VERCEL_GIT_PREVIOUS_SHA..VERCEL_GIT_COMMIT_SHA` and skips the build when **every** changed path is inert with respect to the Next.js build.

Skipped path patterns:

| Pattern | Rationale |
| --- | --- |
| `docs/**` | documentation only |
| `.github/**` | CI workflows, templates, actions |
| `.claude/**`, `.agents/**` | agent tooling, not bundled |
| `__tests__/**`, `e2e/**` | test suites |
| `*.test.*`, `*.spec.*` (anywhere) | co-located tests |
| `*.md` (anywhere) | markdown |

Deliberate exclusion: **anything under `public/` always builds**, including `public/*.md`. `public/pricing.md` and `public/agents.md` are served verbatim as static assets, so a blanket markdown rule would have been a false skip.

`main`-branch skip behaviour is unchanged.

## Fail open

Every error path exits **1 (build)**. The script never skips because something went wrong:

- `VERCEL_GIT_PREVIOUS_SHA` or `VERCEL_GIT_COMMIT_SHA` empty (first build on a branch) → build
- either SHA unreachable, e.g. Vercel's shallow clone → build
- `git diff` returns non-zero → build
- diff is empty (redeploy of the same SHA) → build
- any path not in the allowlist → build

A missed preview is worse than an unnecessary build, so the allowlist is intentionally narrow. Adding more patterns later is cheap; a false skip is not.

## Verification

`bash -n vercel-ignore.sh` passes. Exercised locally against real commits in this repo by setting the env vars by hand:

| Case | Range / env | Exit |
| --- | --- | --- |
| CI-only change (`.github/workflows/qa-pipeline.yml`) | `69ae18f7^..69ae18f7` | **0** (skip) |
| Source change (`sanity/env.ts` + its test) | `10f7665b^..10f7665b` | **1** (build) |
| Empty `VERCEL_GIT_PREVIOUS_SHA` | — | **1** (build) |
| Garbage/unreachable `VERCEL_GIT_PREVIOUS_SHA` | `deadbeef…` | **1** (build) |
| `VERCEL_GIT_COMMIT_REF=main` | — | **0** (skip, unchanged) |
| Empty diff (same SHA both sides) | — | **1** (build) |

The path classifier was also unit-checked in isolation: `docs/a.md`, `README.md`, `components/x.test.tsx`, `e2e/a.spec.ts`, `.claude/skills/s.md`, `.agents/x` → inert; `app/page.tsx`, `public/pricing.md`, `public/img.png`, `package.json`, `scripts/build.ts` → build.

A sweep of the last 300 commits on `main` shows this rule would have skipped a meaningful tail of `test(…)`, `ci(…)`, `docs(…)` and `style(…)` commits.

## Notes

Opened as a **draft** on purpose — this repo runs an expensive AI CI stack on ready-for-review PRs and the whole point of the change is to cut CI/build cost. Bash only, no new dependencies.
