### PR TITLE
feat(settings): pending agent actions approval queue

### DIFF
--- a/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
+++ b/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @file State-by-state tests for the "Agent actions" settings page.
+ * Separate describe blocks for signed-out, not-ready, loading, empty, error,
+ * populated (pending + history), and the `?item=` deep-link highlight —
+ * following the established repo pattern (one block per data state).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsAgentActionsPage } from "@/components/Pages/SettingsAgentActions/SettingsAgentActionsPage";
+import type { PendingAgentWrite } from "@/services/pending-agent-writes.service";
+
+// --- auth ---
+const mockUseAuth = vi.fn();
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// --- deep-link search param ---
+let mockItemParam: string | null = null;
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: (key: string) => (key === "item" ? mockItemParam : null) }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/settings/agent-actions",
+}));
+
+// next/link → plain anchor so the page doesn't need an App Router context mounted.
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// --- data hooks ---
+const mockPendingQuery = vi.fn();
+const mockHistoryQuery = vi.fn();
+const approveMutate = vi.fn().mockResolvedValue(undefined);
+const rejectMutate = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/hooks/agent-actions/usePendingAgentWrites", () => ({
+  usePendingAgentWrites: (status: "pending" | "decided" | "all") =>
+    status === "pending" ? mockPendingQuery() : mockHistoryQuery(),
+  useApproveAgentWrite: () => ({ mutateAsync: approveMutate }),
+  useRejectAgentWrite: () => ({ mutateAsync: rejectMutate }),
+}));
+
+function makeWrite(overrides: Partial<PendingAgentWrite> = {}): PendingAgentWrite {
+  return {
+    id: "pc_1",
+    summary: "Reject application #47 (out of scope)",
+    label: "Approve / reject / revision",
+    method: "PUT",
+    path: "/v2/funding-applications/47/status",
+    body: { status: "rejected" },
+    status: "pending",
+    clientName: "Claude Desktop",
+    createdAt: "2026-07-23T10:00:00.000Z",
+    expiresAt: "2026-07-23T22:00:00.000Z",
+    decidedAt: null,
+    result: null,
+    ...overrides,
+  };
+}
+
+const emptyList = { data: { writes: [], total: 0 }, isLoading: false, isError: false };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockItemParam = null;
+  mockUseAuth.mockReturnValue({ ready: true, authenticated: true, login: vi.fn() });
+  mockPendingQuery.mockReturnValue(emptyList);
+  mockHistoryQuery.mockReturnValue(emptyList);
+});
+
+describe("SettingsAgentActionsPage", () => {
+  describe("auth gating", () => {
+    it("renders nothing but the shell while Privy is not ready (no glimpse)", () => {
+      mockUseAuth.mockReturnValue({ ready: false, authenticated: false, login: vi.fn() });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.queryByText(/Sign in to review/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument();
+    });
+
+    it("shows a sign-in CTA when unauthenticated and never fetches", () => {
+      mockUseAuth.mockReturnValue({ ready: true, authenticated: false, login: vi.fn() });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByText(/Sign in to review agent actions/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Sign in to Karma/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("loading", () => {
+    it("renders a skeleton while the pending query loads", () => {
+      mockPendingQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByLabelText(/Loading your pending agent actions/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("error", () => {
+    it("renders an error card with a retry button", () => {
+      const refetch = vi.fn();
+      mockPendingQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error("boom"),
+        refetch,
+      });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByText(/Couldn't load agent actions/i)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /Try again/i }));
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("empty", () => {
+    it("renders the caught-up empty state and no history section", () => {
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByText(/You're all caught up/i)).toBeInTheDocument();
+      expect(screen.queryByText(/recent/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("populated", () => {
+    it("lists pending writes with summary, label and method+path, pluralized heading", () => {
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite()], total: 1 },
+        isLoading: false,
+        isError: false,
+      });
+      render(<SettingsAgentActionsPage />);
+
+      expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
+      expect(screen.getByText(/Reject application #47/i)).toBeInTheDocument();
+      expect(screen.getByText(/Approve \/ reject \/ revision/i)).toBeInTheDocument();
+      expect(screen.getByText(/\/v2\/funding-applications\/47\/status/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^Approve$/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^Reject$/i })).toBeInTheDocument();
+    });
+
+    it("pluralizes the pending heading for multiple actions", () => {
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite({ id: "a" }), makeWrite({ id: "b" })], total: 2 },
+        isLoading: false,
+        isError: false,
+      });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByText(/2 pending actions$/i)).toBeInTheDocument();
+    });
+
+    it("renders a history section with status badge + failure reason", () => {
+      mockHistoryQuery.mockReturnValue({
+        data: {
+          writes: [
+            makeWrite({
+              id: "pc_hist",
+              status: "failed",
+              decidedAt: "2026-07-23T11:00:00.000Z",
+              result: { statusCode: 403, error: "RBAC denied" },
+            }),
+          ],
+          total: 1,
+        },
+        isLoading: false,
+        isError: false,
+      });
+      render(<SettingsAgentActionsPage />);
+      expect(screen.getByText(/1 recent decision$/i)).toBeInTheDocument();
+      expect(screen.getByText(/Failed/i)).toBeInTheDocument();
+      expect(screen.getByText(/RBAC denied/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("deep link", () => {
+    it("highlights the row matching ?item=<id> with a ring", () => {
+      mockItemParam = "pc_1";
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite({ id: "pc_1" }), makeWrite({ id: "pc_2" })], total: 2 },
+        isLoading: false,
+        isError: false,
+      });
+      const { container } = render(<SettingsAgentActionsPage />);
+
+      const highlighted = container.querySelectorAll(".ring-2.ring-primary");
+      expect(highlighted).toHaveLength(1);
+    });
+
+    it("opens the confirm dialog showing the full request when Approve is clicked", () => {
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite()], total: 1 },
+        isLoading: false,
+        isError: false,
+      });
+      render(<SettingsAgentActionsPage />);
+
+      fireEvent.click(screen.getByRole("button", { name: /^Approve$/i }));
+
+      expect(screen.getByText(/Approve this agent action\?/i)).toBeInTheDocument();
+      // Pretty-printed JSON body of the staged request is shown.
+      expect(screen.getByText(/"status": "rejected"/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Approve & run/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
+++ b/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
@@ -17,14 +17,6 @@ vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
-// --- deep-link search param ---
-let mockItemParam: string | null = null;
-vi.mock("next/navigation", () => ({
-  useSearchParams: () => ({ get: (key: string) => (key === "item" ? mockItemParam : null) }),
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
-  usePathname: () => "/settings/agent-actions",
-}));
-
 // next/link → plain anchor so the page doesn't need an App Router context mounted.
 vi.mock("next/link", () => ({
   default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
@@ -69,7 +61,6 @@ const emptyList = { data: { writes: [], total: 0 }, isLoading: false, isError: f
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockItemParam = null;
   mockUseAuth.mockReturnValue({ ready: true, authenticated: true, login: vi.fn() });
   mockPendingQuery.mockReturnValue(emptyList);
   mockHistoryQuery.mockReturnValue(emptyList);
@@ -79,14 +70,14 @@ describe("SettingsAgentActionsPage", () => {
   describe("auth gating", () => {
     it("renders nothing but the shell while Privy is not ready (no glimpse)", () => {
       mockUseAuth.mockReturnValue({ ready: false, authenticated: false, login: vi.fn() });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.queryByText(/Sign in to review/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument();
     });
 
     it("shows a sign-in CTA when unauthenticated and never fetches", () => {
       mockUseAuth.mockReturnValue({ ready: true, authenticated: false, login: vi.fn() });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByText(/Sign in to review agent actions/i)).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /Sign in to Karma/i })).toBeInTheDocument();
     });
@@ -95,7 +86,7 @@ describe("SettingsAgentActionsPage", () => {
   describe("loading", () => {
     it("renders a skeleton while the pending query loads", () => {
       mockPendingQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByLabelText(/Loading your pending agent actions/i)).toBeInTheDocument();
     });
   });
@@ -110,7 +101,7 @@ describe("SettingsAgentActionsPage", () => {
         error: new Error("boom"),
         refetch,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByText(/Couldn't load agent actions/i)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /Try again/i }));
       expect(refetch).toHaveBeenCalledTimes(1);
@@ -125,7 +116,7 @@ describe("SettingsAgentActionsPage", () => {
         isError: false,
       });
       mockHistoryQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
 
       // Pending list rendered as usual.
       expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
@@ -149,7 +140,7 @@ describe("SettingsAgentActionsPage", () => {
         error: new Error("history boom"),
         refetch: historyRefetch,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
 
       // Pending list still visible — the history failure doesn't take down the page.
       expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
@@ -162,7 +153,7 @@ describe("SettingsAgentActionsPage", () => {
 
   describe("empty", () => {
     it("renders the caught-up empty state and no history section", () => {
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByText(/You're all caught up/i)).toBeInTheDocument();
       expect(screen.queryByText(/recent/i)).not.toBeInTheDocument();
     });
@@ -175,7 +166,7 @@ describe("SettingsAgentActionsPage", () => {
         isLoading: false,
         isError: false,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
 
       expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
       expect(screen.getByText(/Reject application #47/i)).toBeInTheDocument();
@@ -191,7 +182,7 @@ describe("SettingsAgentActionsPage", () => {
         isLoading: false,
         isError: false,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByText(/2 pending actions$/i)).toBeInTheDocument();
     });
 
@@ -211,7 +202,7 @@ describe("SettingsAgentActionsPage", () => {
         isLoading: false,
         isError: false,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
       expect(screen.getByText(/1 recent decision$/i)).toBeInTheDocument();
       expect(screen.getByText(/Failed/i)).toBeInTheDocument();
       expect(screen.getByText(/RBAC denied/i)).toBeInTheDocument();
@@ -220,13 +211,12 @@ describe("SettingsAgentActionsPage", () => {
 
   describe("deep link", () => {
     it("highlights the row matching ?item=<id> with a ring", () => {
-      mockItemParam = "pc_1";
       mockPendingQuery.mockReturnValue({
         data: { writes: [makeWrite({ id: "pc_1" }), makeWrite({ id: "pc_2" })], total: 2 },
         isLoading: false,
         isError: false,
       });
-      const { container } = render(<SettingsAgentActionsPage />);
+      const { container } = render(<SettingsAgentActionsPage highlightedId="pc_1" />);
 
       const highlighted = container.querySelectorAll(".ring-2.ring-primary");
       expect(highlighted).toHaveLength(1);
@@ -238,7 +228,7 @@ describe("SettingsAgentActionsPage", () => {
         isLoading: false,
         isError: false,
       });
-      render(<SettingsAgentActionsPage />);
+      render(<SettingsAgentActionsPage highlightedId={null} />);
 
       fireEvent.click(screen.getByRole("button", { name: /^Approve$/i }));
 

--- a/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
+++ b/__tests__/components/SettingsAgentActions/SettingsAgentActionsPage.test.tsx
@@ -117,6 +117,49 @@ describe("SettingsAgentActionsPage", () => {
     });
   });
 
+  describe("history loading", () => {
+    it("shows a compact history skeleton while the pending list is already rendered", () => {
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite()], total: 1 },
+        isLoading: false,
+        isError: false,
+      });
+      mockHistoryQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+      render(<SettingsAgentActionsPage />);
+
+      // Pending list rendered as usual.
+      expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
+      // History area shows its own skeleton rather than popping in late.
+      expect(screen.getByLabelText(/Loading your recent decisions/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("history error", () => {
+    it("renders an inline error with a working retry that refetches history", () => {
+      const historyRefetch = vi.fn();
+      mockPendingQuery.mockReturnValue({
+        data: { writes: [makeWrite()], total: 1 },
+        isLoading: false,
+        isError: false,
+      });
+      mockHistoryQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error("history boom"),
+        refetch: historyRefetch,
+      });
+      render(<SettingsAgentActionsPage />);
+
+      // Pending list still visible — the history failure doesn't take down the page.
+      expect(screen.getByText(/1 pending action$/i)).toBeInTheDocument();
+      expect(screen.getByText(/Couldn't load your recent decisions/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /Try again/i }));
+      expect(historyRefetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("empty", () => {
     it("renders the caught-up empty state and no history section", () => {
       render(<SettingsAgentActionsPage />);

--- a/__tests__/hooks/usePendingAgentWrites.test.tsx
+++ b/__tests__/hooks/usePendingAgentWrites.test.tsx
@@ -153,6 +153,40 @@ describe("useApproveAgentWrite", () => {
     expect(mockToast.error).toHaveBeenCalled();
   });
 
+  it("does not resurrect a row decided by a concurrent mutation when rolling back", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const w2 = makeWrite({ id: "pc_2" });
+    const client = makeClient();
+    seedPending(client, [w1, w2]);
+
+    let failApprove: (error: unknown) => void = () => undefined;
+    mockService.approve.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          failApprove = reject;
+        })
+    );
+    mockService.reject.mockResolvedValue({ id: "pc_2", status: "rejected" });
+
+    const approveHook = renderHook(() => useApproveAgentWrite(), { wrapper: wrap(client) });
+    const rejectHook = renderHook(() => useRejectAgentWrite(), { wrapper: wrap(client) });
+
+    // Approve of pc_1 is left in flight while reject of pc_2 completes.
+    const approvePromise = approveHook.result.current.mutateAsync(w1).catch(() => undefined);
+    await rejectHook.result.current.mutateAsync(w2);
+
+    // The in-flight approve now fails; its rollback must restore ONLY pc_1,
+    // not the pre-approve snapshot that still contained the decided pc_2.
+    failApprove(httpError(500));
+    await approvePromise;
+
+    await waitFor(() => {
+      const data = client.getQueryData<PendingAgentWritesList>(agentActionsKeys.list("pending"));
+      expect(data?.writes.map((w) => w.id)).toEqual(["pc_1"]);
+      expect(data?.total).toBe(1);
+    });
+  });
+
   it("shows an 'already decided' toast on a 409 instead of an error toast", async () => {
     const w1 = makeWrite({ id: "pc_1" });
     const client = makeClient();

--- a/__tests__/hooks/usePendingAgentWrites.test.tsx
+++ b/__tests__/hooks/usePendingAgentWrites.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * @file Tests for the "Pending agent actions" React Query bindings.
+ * Covers the list query, and the approve/reject mutations' optimistic removal,
+ * rollback on error, and the 409 "already decided" quiet-refresh branch.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import toast from "react-hot-toast";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  agentActionsKeys,
+  useApproveAgentWrite,
+  usePendingAgentWrites,
+  useRejectAgentWrite,
+} from "@/hooks/agent-actions/usePendingAgentWrites";
+import {
+  type PendingAgentWrite,
+  type PendingAgentWritesList,
+  pendingAgentWritesService,
+} from "@/services/pending-agent-writes.service";
+import { HttpError } from "@/utilities/api/errors";
+
+vi.mock("@/services/pending-agent-writes.service", () => ({
+  pendingAgentWritesService: {
+    list: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+  },
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@/components/Utilities/errorManager", () => ({
+  errorManager: vi.fn(),
+}));
+
+const mockService = pendingAgentWritesService as unknown as {
+  list: ReturnType<typeof vi.fn>;
+  approve: ReturnType<typeof vi.fn>;
+  reject: ReturnType<typeof vi.fn>;
+};
+
+const mockToast = toast as unknown as ReturnType<typeof vi.fn> & {
+  success: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+};
+
+function makeWrite(overrides: Partial<PendingAgentWrite> = {}): PendingAgentWrite {
+  return {
+    id: "pc_1",
+    summary: "Reject application #47",
+    label: "Approve / reject / revision",
+    method: "PUT",
+    path: "/v2/funding-applications/47/status",
+    body: { status: "rejected" },
+    status: "pending",
+    clientName: "Claude Desktop",
+    createdAt: "2026-07-23T10:00:00.000Z",
+    expiresAt: "2026-07-23T22:00:00.000Z",
+    decidedAt: null,
+    result: null,
+    ...overrides,
+  };
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function wrap(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function httpError(status: number): HttpError {
+  return new HttpError(status, {
+    endpoint: "/v2/pending-agent-writes/pc_1/approve",
+    method: "POST",
+  });
+}
+
+function seedPending(client: QueryClient, writes: PendingAgentWrite[]): void {
+  const list: PendingAgentWritesList = { writes, total: writes.length };
+  client.setQueryData(agentActionsKeys.list("pending"), list);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePendingAgentWrites (query)", () => {
+  it("fetches the queue for the given status filter", async () => {
+    mockService.list.mockResolvedValue({ writes: [makeWrite()], total: 1 });
+    const client = makeClient();
+
+    const { result } = renderHook(() => usePendingAgentWrites("pending"), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockService.list).toHaveBeenCalledWith("pending");
+    expect(result.current.data?.writes).toHaveLength(1);
+  });
+
+  it("does not fetch when disabled (no-glimpse gate)", () => {
+    const client = makeClient();
+    renderHook(() => usePendingAgentWrites("pending", false), { wrapper: wrap(client) });
+    expect(mockService.list).not.toHaveBeenCalled();
+  });
+});
+
+describe("useApproveAgentWrite", () => {
+  it("optimistically removes the write from the pending list on mutate", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const w2 = makeWrite({ id: "pc_2" });
+    const client = makeClient();
+    seedPending(client, [w1, w2]);
+    // Never resolves — lets us observe the optimistic (onMutate) cache state.
+    mockService.approve.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useApproveAgentWrite(), { wrapper: wrap(client) });
+    result.current.mutate(w1);
+
+    await waitFor(() => {
+      const data = client.getQueryData<PendingAgentWritesList>(agentActionsKeys.list("pending"));
+      expect(data?.writes.map((w) => w.id)).toEqual(["pc_2"]);
+      expect(data?.total).toBe(1);
+    });
+  });
+
+  it("rolls back the optimistic removal when the approve fails", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const w2 = makeWrite({ id: "pc_2" });
+    const client = makeClient();
+    seedPending(client, [w1, w2]);
+    mockService.approve.mockRejectedValue(httpError(500));
+
+    const { result } = renderHook(() => useApproveAgentWrite(), { wrapper: wrap(client) });
+    await result.current.mutateAsync(w1).catch(() => undefined);
+
+    await waitFor(() => {
+      const data = client.getQueryData<PendingAgentWritesList>(agentActionsKeys.list("pending"));
+      expect(data?.writes.map((w) => w.id)).toEqual(["pc_1", "pc_2"]);
+      expect(data?.total).toBe(2);
+    });
+    expect(mockToast.error).toHaveBeenCalled();
+  });
+
+  it("shows an 'already decided' toast on a 409 instead of an error toast", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const client = makeClient();
+    seedPending(client, [w1]);
+    mockService.approve.mockRejectedValue(httpError(409));
+
+    const { result } = renderHook(() => useApproveAgentWrite(), { wrapper: wrap(client) });
+    await result.current.mutateAsync(w1).catch(() => undefined);
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("warns when the write is approved but execution failed", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const client = makeClient();
+    seedPending(client, [w1]);
+    mockService.approve.mockResolvedValue({
+      id: "pc_1",
+      status: "failed",
+      result: { statusCode: 403, error: "forbidden" },
+    });
+
+    const { result } = renderHook(() => useApproveAgentWrite(), { wrapper: wrap(client) });
+    await result.current.mutateAsync(w1);
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRejectAgentWrite", () => {
+  it("optimistically removes the write and toasts success", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const client = makeClient();
+    seedPending(client, [w1]);
+    mockService.reject.mockResolvedValue({ id: "pc_1", status: "rejected" });
+
+    const { result } = renderHook(() => useRejectAgentWrite(), { wrapper: wrap(client) });
+    await result.current.mutateAsync(w1);
+
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+    expect(mockService.reject).toHaveBeenCalledWith(w1.id);
+  });
+
+  it("rolls back on error", async () => {
+    const w1 = makeWrite({ id: "pc_1" });
+    const w2 = makeWrite({ id: "pc_2" });
+    const client = makeClient();
+    seedPending(client, [w1, w2]);
+    mockService.reject.mockRejectedValue(httpError(500));
+
+    const { result } = renderHook(() => useRejectAgentWrite(), { wrapper: wrap(client) });
+    await result.current.mutateAsync(w1).catch(() => undefined);
+
+    await waitFor(() => {
+      const data = client.getQueryData<PendingAgentWritesList>(agentActionsKeys.list("pending"));
+      expect(data?.writes).toHaveLength(2);
+    });
+  });
+});

--- a/__tests__/integration/mutations/pending-agent-writes.mutation.test.tsx
+++ b/__tests__/integration/mutations/pending-agent-writes.mutation.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Wire-shape integration tests for pendingAgentWritesService (MSW).
+ *
+ * Asserts the FE half of the mcp-writes wire contract: the service hits the
+ * exact endpoint paths and methods, attaches the Privy `Authorization: Bearer`
+ * header (via the typed api client + TokenManager) and an `Idempotency-Key` on
+ * approve/reject, and that success / 409 / 500 responses are handled per the
+ * contract (409 = "already decided").
+ *
+ * Pattern: __tests__/integration/mutations/community-admins.mutation.test.tsx
+ */
+
+import { HttpResponse, http } from "msw";
+import {
+  type PendingAgentWrite,
+  pendingAgentWritesService,
+} from "@/services/pending-agent-writes.service";
+import { HttpError } from "@/utilities/api/errors";
+import { installMswLifecycle, server } from "../../msw/server";
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn().mockResolvedValue("test-token") },
+}));
+
+installMswLifecycle();
+
+const write: PendingAgentWrite = {
+  id: "pc_abc123",
+  summary: "Reject application #47 (out of scope)",
+  label: "Approve / reject / revision",
+  method: "PUT",
+  path: "/v2/funding-applications/47/status",
+  body: { status: "rejected", reason: "out of scope" },
+  status: "pending",
+  clientName: "Claude Desktop",
+  createdAt: "2026-07-23T10:00:00.000Z",
+  expiresAt: "2026-07-23T22:00:00.000Z",
+  decidedAt: null,
+  result: null,
+};
+
+describe("pendingAgentWritesService (MSW integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    it("GETs the queue with the status filter and an Authorization header", async () => {
+      let capturedUrl = "";
+      let capturedAuth: string | null = null;
+
+      server.use(
+        http.get("*/v2/pending-agent-writes", ({ request }) => {
+          capturedUrl = request.url;
+          capturedAuth = request.headers.get("authorization");
+          return HttpResponse.json({ writes: [write], total: 1 });
+        })
+      );
+
+      const result = await pendingAgentWritesService.list("pending");
+
+      expect(capturedUrl).toContain("/v2/pending-agent-writes");
+      expect(capturedUrl).toContain("status=pending");
+      expect(capturedAuth).toBe("Bearer test-token");
+      expect(result.total).toBe(1);
+      expect(result.writes[0].id).toBe("pc_abc123");
+    });
+
+    it("passes status=decided when requesting history", async () => {
+      let capturedUrl = "";
+      server.use(
+        http.get("*/v2/pending-agent-writes", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ writes: [], total: 0 });
+        })
+      );
+
+      await pendingAgentWritesService.list("decided");
+
+      expect(capturedUrl).toContain("status=decided");
+    });
+  });
+
+  describe("approve", () => {
+    it("POSTs to /:id/approve with Authorization + Idempotency-Key headers", async () => {
+      let capturedMethod = "";
+      let capturedAuth: string | null = null;
+      let capturedIdempotency: string | null = null;
+
+      server.use(
+        http.post("*/v2/pending-agent-writes/:id/approve", ({ request, params }) => {
+          capturedMethod = request.method;
+          capturedAuth = request.headers.get("authorization");
+          capturedIdempotency = request.headers.get("idempotency-key");
+          return HttpResponse.json({
+            id: params.id,
+            status: "executed",
+            result: { statusCode: 200, error: null },
+          });
+        })
+      );
+
+      const result = await pendingAgentWritesService.approve("pc_abc123", "idem-key-1");
+
+      expect(capturedMethod).toBe("POST");
+      expect(capturedAuth).toBe("Bearer test-token");
+      expect(capturedIdempotency).toBe("idem-key-1");
+      expect(result.id).toBe("pc_abc123");
+      expect(result.status).toBe("executed");
+    });
+
+    it("surfaces a 409 as an HttpError (already decided)", async () => {
+      server.use(
+        http.post("*/v2/pending-agent-writes/:id/approve", () =>
+          HttpResponse.json({ message: "not pending" }, { status: 409 })
+        )
+      );
+
+      await expect(pendingAgentWritesService.approve("pc_abc123")).rejects.toMatchObject({
+        status: 409,
+      });
+      await expect(pendingAgentWritesService.approve("pc_abc123")).rejects.toBeInstanceOf(
+        HttpError
+      );
+    });
+
+    it("surfaces a 500 as an error", async () => {
+      server.use(
+        http.post("*/v2/pending-agent-writes/:id/approve", () =>
+          HttpResponse.json({ message: "boom" }, { status: 500 })
+        )
+      );
+
+      await expect(pendingAgentWritesService.approve("pc_abc123")).rejects.toThrow();
+    });
+  });
+
+  describe("reject", () => {
+    it("POSTs to /:id/reject and returns the rejected status", async () => {
+      let capturedPath = "";
+      let capturedIdempotency: string | null = null;
+
+      server.use(
+        http.post("*/v2/pending-agent-writes/:id/reject", ({ request, params }) => {
+          capturedPath = new URL(request.url).pathname;
+          capturedIdempotency = request.headers.get("idempotency-key");
+          return HttpResponse.json({ id: params.id, status: "rejected" });
+        })
+      );
+
+      const result = await pendingAgentWritesService.reject("pc_abc123", "idem-key-2");
+
+      expect(capturedPath).toBe("/v2/pending-agent-writes/pc_abc123/reject");
+      expect(capturedIdempotency).toBe("idem-key-2");
+      expect(result.status).toBe("rejected");
+    });
+
+    it("surfaces a 409 as an HttpError", async () => {
+      server.use(
+        http.post("*/v2/pending-agent-writes/:id/reject", () =>
+          HttpResponse.json({ message: "not pending" }, { status: 409 })
+        )
+      );
+
+      await expect(pendingAgentWritesService.reject("pc_abc123")).rejects.toMatchObject({
+        status: 409,
+      });
+    });
+  });
+});

--- a/app/settings/agent-actions/error.tsx
+++ b/app/settings/agent-actions/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+interface ErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+export default function ErrorBoundary({ error, reset }: ErrorProps) {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-12 text-center">
+      <h1 className="text-2xl font-semibold text-foreground">Couldn't load agent actions</h1>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <div>
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/settings/agent-actions/error.tsx
+++ b/app/settings/agent-actions/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 interface ErrorProps {
-  error: Error;
+  error: Error & { digest?: string };
   reset: () => void;
 }
 
@@ -9,7 +9,12 @@ export default function ErrorBoundary({ error, reset }: ErrorProps) {
   return (
     <main className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-12 text-center">
       <h1 className="text-2xl font-semibold text-foreground">Couldn't load agent actions</h1>
-      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <p className="text-sm text-muted-foreground">
+        Something went wrong while loading this page. Please try again.
+      </p>
+      {error.digest ? (
+        <p className="text-xs text-muted-foreground">Error ID: {error.digest}</p>
+      ) : null}
       <div>
         <button
           type="button"

--- a/app/settings/agent-actions/loading.tsx
+++ b/app/settings/agent-actions/loading.tsx
@@ -3,6 +3,7 @@ export default function Loading() {
     <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-12">
       <output
         aria-label="Loading agent actions"
+        aria-busy="true"
         className="block h-8 w-48 animate-pulse rounded-md bg-muted"
       />
       <div className="space-y-3">

--- a/app/settings/agent-actions/loading.tsx
+++ b/app/settings/agent-actions/loading.tsx
@@ -1,0 +1,15 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-12">
+      <output
+        aria-label="Loading agent actions"
+        className="block h-8 w-48 animate-pulse rounded-md bg-muted"
+      />
+      <div className="space-y-3">
+        <div className="h-32 w-full animate-pulse rounded-2xl border border-border bg-card" />
+        <div className="h-32 w-full animate-pulse rounded-2xl border border-border bg-card" />
+        <div className="h-32 w-full animate-pulse rounded-2xl border border-border bg-card" />
+      </div>
+    </main>
+  );
+}

--- a/app/settings/agent-actions/page.tsx
+++ b/app/settings/agent-actions/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { SettingsAgentActionsPage } from "@/components/Pages/SettingsAgentActions/SettingsAgentActionsPage";
+import { customMetadata } from "@/utilities/meta";
+import Loading from "./loading";
+
+export const metadata: Metadata = customMetadata({
+  title: "Agent actions — Karma settings",
+  description: "Review, approve, or reject the actions your AI agents have proposed on Karma.",
+  path: "/settings/agent-actions",
+  robots: { index: false, follow: false },
+});
+
+// SettingsAgentActionsPage calls useSearchParams() to read the `?item=` deep
+// link, which Next.js App Router requires to be wrapped in a Suspense boundary
+// or the production build fails with "useSearchParams() should be wrapped in a
+// Suspense boundary at page /settings/agent-actions".
+export default function Page() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <SettingsAgentActionsPage />
+    </Suspense>
+  );
+}

--- a/app/settings/agent-actions/page.tsx
+++ b/app/settings/agent-actions/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import { SettingsAgentActionsPage } from "@/components/Pages/SettingsAgentActions/SettingsAgentActionsPage";
 import { customMetadata } from "@/utilities/meta";
-import Loading from "./loading";
 
 export const metadata: Metadata = customMetadata({
   title: "Agent actions — Karma settings",
@@ -11,14 +9,14 @@ export const metadata: Metadata = customMetadata({
   robots: { index: false, follow: false },
 });
 
-// SettingsAgentActionsPage calls useSearchParams() to read the `?item=` deep
-// link, which Next.js App Router requires to be wrapped in a Suspense boundary
-// or the production build fails with "useSearchParams() should be wrapped in a
-// Suspense boundary at page /settings/agent-actions".
-export default function Page() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <SettingsAgentActionsPage />
-    </Suspense>
-  );
+interface PageProps {
+  searchParams: Promise<{ item?: string | string[] }>;
+}
+
+// The `?item=<id>` deep link (from an agent's approvalUrl) is resolved here on
+// the server and passed down as a prop, so the client page needs neither
+// useSearchParams() nor a Suspense boundary.
+export default async function Page({ searchParams }: PageProps) {
+  const { item } = await searchParams;
+  return <SettingsAgentActionsPage highlightedId={typeof item === "string" ? item : null} />;
 }

--- a/components/Pages/SettingsAgentActions/AgentActionConfirmDialog.tsx
+++ b/components/Pages/SettingsAgentActions/AgentActionConfirmDialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { PendingAgentWrite } from "@/services/pending-agent-writes.service";
+
+export type AgentActionKind = "approve" | "reject";
+
+interface AgentActionConfirmDialogProps {
+  write: PendingAgentWrite;
+  action: AgentActionKind | null;
+  isSubmitting: boolean;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+function prettyBody(body: unknown): string {
+  if (body == null) return "";
+  try {
+    return JSON.stringify(body, null, 2);
+  } catch {
+    // SUPPRESSED: a body that can't be serialized (circular ref) is not
+    // actionable here — we still show the request meta, just not the JSON.
+    return String(body);
+  }
+}
+
+/**
+ * Confirmation dialog shown before BOTH approve and reject. It surfaces the
+ * FULL staged request — summary, method, path, and the pretty-printed JSON body
+ * the write will execute with — so the human is deciding on exactly what runs,
+ * not a paraphrase. Approve is the consequential action (it executes the write)
+ * and is styled primary; reject is styled destructive.
+ */
+export function AgentActionConfirmDialog({
+  write,
+  action,
+  isSubmitting,
+  onConfirm,
+  onOpenChange,
+}: AgentActionConfirmDialogProps) {
+  const isApprove = action === "approve";
+  const body = prettyBody(write.body);
+
+  return (
+    <Dialog open={action !== null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {isApprove ? "Approve this agent action?" : "Reject this agent action?"}
+          </DialogTitle>
+          <DialogDescription>
+            {isApprove
+              ? "Approving runs the exact request below as you. Review it before continuing — this cannot be undone."
+              : "Rejecting discards this request. The agent will be told the action was declined."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Summary
+            </p>
+            <p className="mt-1 text-sm text-foreground">{write.summary}</p>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Request
+            </p>
+            <p className="mt-1 break-all font-mono text-sm text-foreground">
+              <span className="font-semibold">{write.method}</span> {write.path}
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Body
+            </p>
+            {body ? (
+              <pre className="mt-1 max-h-64 overflow-auto overflow-x-auto rounded-lg border border-border bg-muted p-3 font-mono text-xs text-foreground">
+                {body}
+              </pre>
+            ) : (
+              <p className="mt-1 text-sm italic text-muted-foreground">No request body.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-2 flex flex-row justify-end gap-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant={isApprove ? "default" : "destructive"}
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            isLoading={isSubmitting}
+          >
+            {isApprove ? "Approve & run" : "Reject"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/Pages/SettingsAgentActions/HistoryActionRow.tsx
+++ b/components/Pages/SettingsAgentActions/HistoryActionRow.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { memo, useEffect, useRef } from "react";
+import { RelativeTime } from "@/components/Utilities/RelativeTime";
 import type {
   PendingAgentWrite,
   PendingAgentWriteStatus,
 } from "@/services/pending-agent-writes.service";
-import { renderRelativeTime } from "@/utilities/formatRelativeTime";
 import { cn } from "@/utilities/tailwind";
 
 interface HistoryActionRowProps {
@@ -83,7 +83,7 @@ export const HistoryActionRow = memo(function HistoryActionRow({
       </p>
       {write.decidedAt ? (
         <p className="text-xs text-muted-foreground">
-          Decided {renderRelativeTime(write.decidedAt)}
+          Decided <RelativeTime value={write.decidedAt} />
         </p>
       ) : null}
       {write.status === "failed" && write.result?.error ? (

--- a/components/Pages/SettingsAgentActions/HistoryActionRow.tsx
+++ b/components/Pages/SettingsAgentActions/HistoryActionRow.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+import type {
+  PendingAgentWrite,
+  PendingAgentWriteStatus,
+} from "@/services/pending-agent-writes.service";
+import { renderRelativeTime } from "@/utilities/formatRelativeTime";
+import { cn } from "@/utilities/tailwind";
+
+interface HistoryActionRowProps {
+  write: PendingAgentWrite;
+  isHighlighted: boolean;
+}
+
+const STATUS_BADGE: Record<PendingAgentWriteStatus, { label: string; className: string }> = {
+  pending: {
+    label: "Pending",
+    className: "bg-secondary text-secondary-foreground",
+  },
+  approved: {
+    label: "Approved",
+    className: "bg-secondary text-secondary-foreground",
+  },
+  executed: {
+    label: "Executed",
+    className: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  },
+  rejected: {
+    label: "Rejected",
+    className: "bg-muted text-muted-foreground",
+  },
+  expired: {
+    label: "Expired",
+    className: "bg-muted text-muted-foreground",
+  },
+  failed: {
+    label: "Failed",
+    className: "bg-destructive/10 text-destructive",
+  },
+};
+
+export const HistoryActionRow = memo(function HistoryActionRow({
+  write,
+  isHighlighted,
+}: HistoryActionRowProps) {
+  const rowRef = useRef<HTMLLIElement>(null);
+  const badge = STATUS_BADGE[write.status];
+
+  useEffect(() => {
+    if (isHighlighted) {
+      rowRef.current?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+    }
+  }, [isHighlighted]);
+
+  return (
+    <li
+      ref={rowRef}
+      className={cn(
+        "flex flex-col gap-2 rounded-2xl border border-border bg-card p-5",
+        isHighlighted && "ring-2 ring-primary ring-offset-2 ring-offset-background"
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+            badge.className
+          )}
+        >
+          {badge.label}
+        </span>
+        <span className="inline-flex items-center rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground">
+          {write.label}
+        </span>
+        {write.clientName ? (
+          <span className="text-xs text-muted-foreground">via {write.clientName}</span>
+        ) : null}
+      </div>
+      <p className="text-sm font-medium text-foreground">{write.summary}</p>
+      <p className="break-all font-mono text-xs text-muted-foreground">
+        <span className="font-semibold text-foreground">{write.method}</span> {write.path}
+      </p>
+      {write.decidedAt ? (
+        <p className="text-xs text-muted-foreground">
+          Decided {renderRelativeTime(write.decidedAt)}
+        </p>
+      ) : null}
+      {write.status === "failed" && write.result?.error ? (
+        <p className="text-xs text-destructive">{write.result.error}</p>
+      ) : null}
+    </li>
+  );
+});

--- a/components/Pages/SettingsAgentActions/PendingActionRow.tsx
+++ b/components/Pages/SettingsAgentActions/PendingActionRow.tsx
@@ -44,6 +44,10 @@ export const PendingActionRow = memo(function PendingActionRow({
       } else {
         await onReject(write);
       }
+    } catch {
+      // SUPPRESSED: decision errors are surfaced by the mutation hooks
+      // (rollback + toast); catching here keeps this fire-and-forget click
+      // handler from producing an unhandled rejection if a parent rethrows.
     } finally {
       setIsSubmitting(false);
       setAction(null);

--- a/components/Pages/SettingsAgentActions/PendingActionRow.tsx
+++ b/components/Pages/SettingsAgentActions/PendingActionRow.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { memo, useEffect, useRef, useState } from "react";
+import { RelativeTime } from "@/components/Utilities/RelativeTime";
 import { Button } from "@/components/ui/button";
 import type { PendingAgentWrite } from "@/services/pending-agent-writes.service";
-import { renderRelativeTime } from "@/utilities/formatRelativeTime";
 import { cn } from "@/utilities/tailwind";
 import { AgentActionConfirmDialog, type AgentActionKind } from "./AgentActionConfirmDialog";
 
@@ -76,8 +76,8 @@ export const PendingActionRow = memo(function PendingActionRow({
           <span className="font-semibold text-foreground">{write.method}</span> {write.path}
         </p>
         <p className="text-xs text-muted-foreground">
-          Requested {renderRelativeTime(write.createdAt)} · Expires{" "}
-          {renderRelativeTime(write.expiresAt)}
+          Requested <RelativeTime value={write.createdAt} /> · Expires{" "}
+          <RelativeTime value={write.expiresAt} />
         </p>
       </div>
 

--- a/components/Pages/SettingsAgentActions/PendingActionRow.tsx
+++ b/components/Pages/SettingsAgentActions/PendingActionRow.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { memo, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { PendingAgentWrite } from "@/services/pending-agent-writes.service";
+import { renderRelativeTime } from "@/utilities/formatRelativeTime";
+import { cn } from "@/utilities/tailwind";
+import { AgentActionConfirmDialog, type AgentActionKind } from "./AgentActionConfirmDialog";
+
+interface PendingActionRowProps {
+  write: PendingAgentWrite;
+  isBusy: boolean;
+  isHighlighted: boolean;
+  onApprove: (write: PendingAgentWrite) => Promise<void>;
+  onReject: (write: PendingAgentWrite) => Promise<void>;
+}
+
+export const PendingActionRow = memo(function PendingActionRow({
+  write,
+  isBusy,
+  isHighlighted,
+  onApprove,
+  onReject,
+}: PendingActionRowProps) {
+  const [action, setAction] = useState<AgentActionKind | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const rowRef = useRef<HTMLLIElement>(null);
+
+  // Deep-link target (approvalUrl `?item=<id>`): scroll the highlighted row into
+  // view once when it mounts / becomes the target.
+  useEffect(() => {
+    if (isHighlighted) {
+      rowRef.current?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+    }
+  }, [isHighlighted]);
+
+  const handleConfirm = async () => {
+    const current = action;
+    if (!current) return;
+    setIsSubmitting(true);
+    try {
+      if (current === "approve") {
+        await onApprove(write);
+      } else {
+        await onReject(write);
+      }
+    } finally {
+      setIsSubmitting(false);
+      setAction(null);
+    }
+  };
+
+  return (
+    <li
+      ref={rowRef}
+      className={cn(
+        "flex flex-col gap-4 rounded-2xl border border-border bg-card p-5",
+        isHighlighted && "ring-2 ring-primary ring-offset-2 ring-offset-background"
+      )}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center rounded-full bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground">
+            {write.label}
+          </span>
+          {write.clientName ? (
+            <span className="text-xs text-muted-foreground">via {write.clientName}</span>
+          ) : null}
+        </div>
+        <h3 className="text-base font-semibold text-foreground">{write.summary}</h3>
+        <p className="break-all font-mono text-xs text-muted-foreground">
+          <span className="font-semibold text-foreground">{write.method}</span> {write.path}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Requested {renderRelativeTime(write.createdAt)} · Expires{" "}
+          {renderRelativeTime(write.expiresAt)}
+        </p>
+      </div>
+
+      <div className="flex flex-row justify-end gap-3">
+        <Button variant="outline" size="sm" disabled={isBusy} onClick={() => setAction("reject")}>
+          Reject
+        </Button>
+        <Button size="sm" disabled={isBusy} onClick={() => setAction("approve")}>
+          Approve
+        </Button>
+      </div>
+
+      <AgentActionConfirmDialog
+        write={write}
+        action={action}
+        isSubmitting={isSubmitting}
+        onConfirm={handleConfirm}
+        onOpenChange={(open) => {
+          if (!open && !isSubmitting) setAction(null);
+        }}
+      />
+    </li>
+  );
+});

--- a/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
+++ b/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import pluralize from "pluralize";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   useApproveAgentWrite,
@@ -24,8 +24,11 @@ export function SettingsAgentActionsPage() {
 
   const pendingQuery = usePendingAgentWrites("pending", gate);
   const historyQuery = usePendingAgentWrites("decided", gate);
-  const approveMutation = useApproveAgentWrite();
-  const rejectMutation = useRejectAgentWrite();
+  // `mutateAsync` is referentially stable across renders (React Query v5), so
+  // destructuring it keeps the row callbacks below stable and `React.memo` on
+  // the rows effective.
+  const { mutateAsync: approveWrite } = useApproveAgentWrite();
+  const { mutateAsync: rejectWrite } = useRejectAgentWrite();
   const [busyId, setBusyId] = useState<string | null>(null);
 
   // Read-only deep link (approvalUrl `?item=<id>`). Never mirrored into state or
@@ -33,26 +36,36 @@ export function SettingsAgentActionsPage() {
   const searchParams = useSearchParams();
   const highlightedId = searchParams.get("item");
 
-  const handleApprove = async (write: PendingAgentWrite) => {
-    setBusyId(write.id);
-    try {
-      await approveMutation.mutateAsync(write);
-    } finally {
-      setBusyId(null);
-    }
-  };
+  const handleApprove = useCallback(
+    async (write: PendingAgentWrite) => {
+      setBusyId(write.id);
+      try {
+        await approveWrite(write);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [approveWrite]
+  );
 
-  const handleReject = async (write: PendingAgentWrite) => {
-    setBusyId(write.id);
-    try {
-      await rejectMutation.mutateAsync(write);
-    } finally {
-      setBusyId(null);
-    }
-  };
+  const handleReject = useCallback(
+    async (write: PendingAgentWrite) => {
+      setBusyId(write.id);
+      try {
+        await rejectWrite(write);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [rejectWrite]
+  );
 
   if (!ready) {
-    return <Layout>{null}</Layout>;
+    return (
+      <Layout>
+        <ListSkeleton />
+      </Layout>
+    );
   }
 
   if (!authenticated) {
@@ -88,7 +101,7 @@ export function SettingsAgentActionsPage() {
         <Card>
           <h2 className="text-base font-semibold text-foreground">Couldn't load agent actions</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            {(pendingQuery.error as Error)?.message ?? "An unexpected error occurred."}
+            {pendingQuery.error?.message ?? "An unexpected error occurred."}
           </p>
           <div className="mt-4">
             <Button variant="outline" onClick={() => pendingQuery.refetch()}>

--- a/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
+++ b/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
@@ -146,7 +146,20 @@ export function SettingsAgentActionsPage() {
         </section>
       )}
 
-      {history.length > 0 ? (
+      {historyQuery.isLoading ? (
+        <HistorySkeleton />
+      ) : historyQuery.isError ? (
+        <Card>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm font-medium text-foreground">
+              Couldn't load your recent decisions
+            </p>
+            <Button variant="outline" size="sm" onClick={() => historyQuery.refetch()}>
+              Try again
+            </Button>
+          </div>
+        </Card>
+      ) : history.length > 0 ? (
         <section aria-labelledby="history-heading">
           <h2 id="history-heading" className="text-sm font-semibold text-foreground">
             {history.length} recent {pluralize("decision", history.length)}
@@ -189,6 +202,19 @@ function ListSkeleton() {
         <div
           key={i}
           className="h-32 w-full animate-pulse rounded-2xl border border-border bg-card"
+        />
+      ))}
+    </output>
+  );
+}
+
+function HistorySkeleton() {
+  return (
+    <output aria-label="Loading your recent decisions" className="block space-y-3">
+      {[0, 1].map((i) => (
+        <div
+          key={i}
+          className="h-20 w-full animate-pulse rounded-2xl border border-border bg-card"
         />
       ))}
     </output>

--- a/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
+++ b/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import pluralize from "pluralize";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  useApproveAgentWrite,
+  usePendingAgentWrites,
+  useRejectAgentWrite,
+} from "@/hooks/agent-actions/usePendingAgentWrites";
+import { useAuth } from "@/hooks/useAuth";
+import type { PendingAgentWrite } from "@/services/pending-agent-writes.service";
+import { PAGES } from "@/utilities/pages";
+import { HistoryActionRow } from "./HistoryActionRow";
+import { PendingActionRow } from "./PendingActionRow";
+
+const PAGE_TITLE = "Agent actions";
+
+export function SettingsAgentActionsPage() {
+  const { ready, authenticated, login } = useAuth();
+  const gate = ready && authenticated;
+
+  const pendingQuery = usePendingAgentWrites("pending", gate);
+  const historyQuery = usePendingAgentWrites("decided", gate);
+  const approveMutation = useApproveAgentWrite();
+  const rejectMutation = useRejectAgentWrite();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // Read-only deep link (approvalUrl `?item=<id>`). Never mirrored into state or
+  // pushed back to the router — just used to highlight + scroll to the row.
+  const searchParams = useSearchParams();
+  const highlightedId = searchParams.get("item");
+
+  const handleApprove = async (write: PendingAgentWrite) => {
+    setBusyId(write.id);
+    try {
+      await approveMutation.mutateAsync(write);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleReject = async (write: PendingAgentWrite) => {
+    setBusyId(write.id);
+    try {
+      await rejectMutation.mutateAsync(write);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (!ready) {
+    return <Layout>{null}</Layout>;
+  }
+
+  if (!authenticated) {
+    return (
+      <Layout>
+        <Card>
+          <h2 className="text-base font-semibold text-foreground">
+            Sign in to review agent actions
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            You need to sign in to your Karma account before you can approve or reject actions your
+            AI agents have proposed.
+          </p>
+          <div className="mt-4">
+            <Button onClick={() => login()}>Sign in to Karma</Button>
+          </div>
+        </Card>
+      </Layout>
+    );
+  }
+
+  if (pendingQuery.isLoading) {
+    return (
+      <Layout>
+        <ListSkeleton />
+      </Layout>
+    );
+  }
+
+  if (pendingQuery.isError) {
+    return (
+      <Layout>
+        <Card>
+          <h2 className="text-base font-semibold text-foreground">Couldn't load agent actions</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {(pendingQuery.error as Error)?.message ?? "An unexpected error occurred."}
+          </p>
+          <div className="mt-4">
+            <Button variant="outline" onClick={() => pendingQuery.refetch()}>
+              Try again
+            </Button>
+          </div>
+        </Card>
+      </Layout>
+    );
+  }
+
+  const pending = pendingQuery.data?.writes ?? [];
+  const history = historyQuery.data?.writes ?? [];
+
+  return (
+    <Layout>
+      <p className="text-sm text-muted-foreground">
+        When an AI agent proposes a critical change over Karma&apos;s MCP connection, it&apos;s
+        staged here for you to review. Nothing runs until you approve it. Manage which apps can
+        connect from your{" "}
+        <Link
+          href={PAGES.SETTINGS.CONNECTIONS}
+          className="font-medium text-primary underline-offset-4 hover:underline"
+        >
+          connected apps
+        </Link>
+        .
+      </p>
+
+      {pending.length === 0 ? (
+        <Card>
+          <h2 className="text-base font-semibold text-foreground">You&apos;re all caught up</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            No agent actions are waiting for your approval. When one of your connected AI apps
+            proposes a change that needs a human sign-off, it will show up here.
+          </p>
+        </Card>
+      ) : (
+        <section aria-labelledby="pending-heading">
+          <h2 id="pending-heading" className="text-sm font-semibold text-foreground">
+            {pending.length} pending {pluralize("action", pending.length)}
+          </h2>
+          <ul className="mt-3 space-y-3">
+            {pending.map((write) => (
+              <PendingActionRow
+                key={write.id}
+                write={write}
+                isBusy={busyId === write.id}
+                isHighlighted={write.id === highlightedId}
+                onApprove={handleApprove}
+                onReject={handleReject}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {history.length > 0 ? (
+        <section aria-labelledby="history-heading">
+          <h2 id="history-heading" className="text-sm font-semibold text-foreground">
+            {history.length} recent {pluralize("decision", history.length)}
+          </h2>
+          <ul className="mt-3 space-y-3">
+            {history.map((write) => (
+              <HistoryActionRow
+                key={write.id}
+                write={write}
+                isHighlighted={write.id === highlightedId}
+              />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </Layout>
+  );
+}
+
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-12">
+      <header>
+        <p className="text-xs font-medium uppercase tracking-wider text-primary">Settings</p>
+        <h1 className="mt-1 text-3xl font-semibold text-foreground">{PAGE_TITLE}</h1>
+      </header>
+      {children}
+    </main>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">{children}</div>;
+}
+
+function ListSkeleton() {
+  return (
+    <output aria-label="Loading your pending agent actions" className="block space-y-3">
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="h-32 w-full animate-pulse rounded-2xl border border-border bg-card"
+        />
+      ))}
+    </output>
+  );
+}

--- a/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
+++ b/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
 import pluralize from "pluralize";
 import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -18,7 +17,16 @@ import { PendingActionRow } from "./PendingActionRow";
 
 const PAGE_TITLE = "Agent actions";
 
-export function SettingsAgentActionsPage() {
+interface SettingsAgentActionsPageProps {
+  /**
+   * Read-only deep-link target (approvalUrl `?item=<id>`), resolved from the
+   * server page's searchParams. Never mirrored into state or pushed back to
+   * the router — just used to highlight + scroll to the row.
+   */
+  highlightedId: string | null;
+}
+
+export function SettingsAgentActionsPage({ highlightedId }: SettingsAgentActionsPageProps) {
   const { ready, authenticated, login } = useAuth();
   const gate = ready && authenticated;
 
@@ -30,11 +38,6 @@ export function SettingsAgentActionsPage() {
   const { mutateAsync: approveWrite } = useApproveAgentWrite();
   const { mutateAsync: rejectWrite } = useRejectAgentWrite();
   const [busyId, setBusyId] = useState<string | null>(null);
-
-  // Read-only deep link (approvalUrl `?item=<id>`). Never mirrored into state or
-  // pushed back to the router — just used to highlight + scroll to the row.
-  const searchParams = useSearchParams();
-  const highlightedId = searchParams.get("item");
 
   const handleApprove = useCallback(
     async (write: PendingAgentWrite) => {

--- a/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
+++ b/components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx
@@ -41,6 +41,10 @@ export function SettingsAgentActionsPage() {
       setBusyId(write.id);
       try {
         await approveWrite(write);
+      } catch {
+        // SUPPRESSED: mutateAsync rejections are already surfaced by the
+        // mutation's onError (rollback + toast/errorManager); catching here
+        // only prevents an unhandled rejection at fire-and-forget call sites.
       } finally {
         setBusyId(null);
       }
@@ -53,6 +57,8 @@ export function SettingsAgentActionsPage() {
       setBusyId(write.id);
       try {
         await rejectWrite(write);
+      } catch {
+        // SUPPRESSED: see handleApprove — errors are handled by the mutation.
       } finally {
         setBusyId(null);
       }
@@ -210,7 +216,11 @@ function Card({ children }: { children: React.ReactNode }) {
 
 function ListSkeleton() {
   return (
-    <output aria-label="Loading your pending agent actions" className="block space-y-3">
+    <output
+      aria-label="Loading your pending agent actions"
+      aria-busy="true"
+      className="block space-y-3"
+    >
       {[0, 1, 2].map((i) => (
         <div
           key={i}
@@ -223,7 +233,7 @@ function ListSkeleton() {
 
 function HistorySkeleton() {
   return (
-    <output aria-label="Loading your recent decisions" className="block space-y-3">
+    <output aria-label="Loading your recent decisions" aria-busy="true" className="block space-y-3">
       {[0, 1].map((i) => (
         <div
           key={i}

--- a/components/Utilities/RelativeTime.tsx
+++ b/components/Utilities/RelativeTime.tsx
@@ -1,0 +1,14 @@
+import { renderRelativeTime } from "@/utilities/formatRelativeTime";
+
+interface RelativeTimeProps {
+  value: string | Date;
+  className?: string;
+}
+
+/**
+ * Component form of renderRelativeTime, for use directly inside JSX (avoids
+ * inline render-function calls during render).
+ */
+export function RelativeTime({ value, className = "cursor-default" }: RelativeTimeProps) {
+  return renderRelativeTime(value, className);
+}

--- a/hooks/agent-actions/usePendingAgentWrites.ts
+++ b/hooks/agent-actions/usePendingAgentWrites.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { errorManager } from "@/components/Utilities/errorManager";
+import {
+  type PendingAgentWrite,
+  type PendingAgentWritesList,
+  type PendingAgentWritesStatusFilter,
+  pendingAgentWritesService,
+} from "@/services/pending-agent-writes.service";
+import { HttpError } from "@/utilities/api/errors";
+
+/**
+ * React Query bindings for the "Pending agent actions" dashboard surface.
+ *
+ * Approve/reject are optimistic (the row is removed from the pending list on
+ * mutate and restored on error). A 409 means the server already decided the
+ * write (approved elsewhere, expired, etc.) — we surface a friendly "already
+ * decided" toast and refetch rather than a scary error.
+ */
+
+const AGENT_ACTIONS_ROOT = ["agent-actions", "pending-writes"] as const;
+
+export const agentActionsKeys = {
+  all: AGENT_ACTIONS_ROOT,
+  list: (status: PendingAgentWritesStatusFilter) => [...AGENT_ACTIONS_ROOT, status] as const,
+};
+
+export function usePendingAgentWrites(status: PendingAgentWritesStatusFilter, enabled = true) {
+  return useQuery({
+    queryKey: agentActionsKeys.list(status),
+    queryFn: () => pendingAgentWritesService.list(status),
+    enabled,
+    retry: 1,
+    staleTime: 15_000,
+  });
+}
+
+interface OptimisticContext {
+  previousPending?: PendingAgentWritesList;
+}
+
+/** Removes `id` from the cached pending list and returns the prior snapshot. */
+function optimisticallyRemove(
+  queryClient: ReturnType<typeof useQueryClient>,
+  id: string
+): OptimisticContext {
+  const key = agentActionsKeys.list("pending");
+  const previousPending = queryClient.getQueryData<PendingAgentWritesList>(key);
+  if (previousPending) {
+    queryClient.setQueryData<PendingAgentWritesList>(key, {
+      ...previousPending,
+      writes: previousPending.writes.filter((w) => w.id !== id),
+      total: Math.max(0, previousPending.total - 1),
+    });
+  }
+  return { previousPending };
+}
+
+function handleDecisionError(
+  queryClient: ReturnType<typeof useQueryClient>,
+  error: unknown,
+  context: OptimisticContext | undefined,
+  logLabel: string,
+  genericToast: string
+): void {
+  if (context?.previousPending) {
+    queryClient.setQueryData(agentActionsKeys.list("pending"), context.previousPending);
+  }
+  // Already decided (approved elsewhere, expired, or double-submit) — not an
+  // error the user needs to worry about, just a stale view. Refresh quietly.
+  if (error instanceof HttpError && error.status === 409) {
+    toast("This action was already decided. Refreshing your queue.");
+    void queryClient.invalidateQueries({ queryKey: agentActionsKeys.all });
+    return;
+  }
+  errorManager(logLabel, error);
+  toast.error(genericToast);
+}
+
+export function useApproveAgentWrite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (write: PendingAgentWrite) => pendingAgentWritesService.approve(write.id),
+    onMutate: async (write) => {
+      await queryClient.cancelQueries({ queryKey: agentActionsKeys.all });
+      return optimisticallyRemove(queryClient, write.id);
+    },
+    onError: (error, _write, context) => {
+      handleDecisionError(
+        queryClient,
+        error,
+        context,
+        "Failed to approve agent action",
+        "Could not approve this action. Please try again."
+      );
+    },
+    onSuccess: (response) => {
+      if (response.status === "failed") {
+        toast.error(
+          response.result?.error
+            ? `Approved, but the action failed to execute: ${response.result.error}`
+            : "Approved, but the action failed to execute."
+        );
+        return;
+      }
+      toast.success("Action approved and executed.");
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: agentActionsKeys.all });
+    },
+  });
+}
+
+export function useRejectAgentWrite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (write: PendingAgentWrite) => pendingAgentWritesService.reject(write.id),
+    onMutate: async (write) => {
+      await queryClient.cancelQueries({ queryKey: agentActionsKeys.all });
+      return optimisticallyRemove(queryClient, write.id);
+    },
+    onError: (error, _write, context) => {
+      handleDecisionError(
+        queryClient,
+        error,
+        context,
+        "Failed to reject agent action",
+        "Could not reject this action. Please try again."
+      );
+    },
+    onSuccess: () => {
+      toast.success("Action rejected.");
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: agentActionsKeys.all });
+    },
+  });
+}

--- a/hooks/agent-actions/usePendingAgentWrites.ts
+++ b/hooks/agent-actions/usePendingAgentWrites.ts
@@ -38,24 +38,32 @@ export function usePendingAgentWrites(status: PendingAgentWritesStatusFilter, en
 }
 
 interface OptimisticContext {
-  previousPending?: PendingAgentWritesList;
+  removed?: { write: PendingAgentWrite; index: number };
 }
 
-/** Removes `id` from the cached pending list and returns the prior snapshot. */
+/**
+ * Removes `write` from the cached pending list via a functional updater (safe
+ * when approve/reject of different rows overlap) and returns what was removed
+ * so rollback can restore ONLY that row, never a whole stale snapshot.
+ */
 function optimisticallyRemove(
   queryClient: ReturnType<typeof useQueryClient>,
-  id: string
+  write: PendingAgentWrite
 ): OptimisticContext {
   const key = agentActionsKeys.list("pending");
-  const previousPending = queryClient.getQueryData<PendingAgentWritesList>(key);
-  if (previousPending) {
-    queryClient.setQueryData<PendingAgentWritesList>(key, {
-      ...previousPending,
-      writes: previousPending.writes.filter((w) => w.id !== id),
-      total: Math.max(0, previousPending.total - 1),
-    });
-  }
-  return { previousPending };
+  let removed: OptimisticContext["removed"];
+  queryClient.setQueryData<PendingAgentWritesList>(key, (current) => {
+    if (!current) return current;
+    const index = current.writes.findIndex((w) => w.id === write.id);
+    if (index === -1) return current;
+    removed = { write, index };
+    return {
+      ...current,
+      writes: current.writes.filter((w) => w.id !== write.id),
+      total: Math.max(0, current.total - 1),
+    };
+  });
+  return { removed };
 }
 
 function handleDecisionError(
@@ -65,8 +73,19 @@ function handleDecisionError(
   logLabel: string,
   genericToast: string
 ): void {
-  if (context?.previousPending) {
-    queryClient.setQueryData(agentActionsKeys.list("pending"), context.previousPending);
+  const removed = context?.removed;
+  if (removed) {
+    // Re-insert only the failed row, at its old position, and only if a
+    // concurrent decision has not already re-added or re-fetched it.
+    queryClient.setQueryData<PendingAgentWritesList>(
+      agentActionsKeys.list("pending"),
+      (current) => {
+        if (!current || current.writes.some((w) => w.id === removed.write.id)) return current;
+        const writes = [...current.writes];
+        writes.splice(Math.min(removed.index, writes.length), 0, removed.write);
+        return { ...current, writes, total: current.total + 1 };
+      }
+    );
   }
   // Already decided (approved elsewhere, expired, or double-submit) — not an
   // error the user needs to worry about, just a stale view. Refresh quietly.
@@ -85,7 +104,7 @@ export function useApproveAgentWrite() {
     mutationFn: (write: PendingAgentWrite) => pendingAgentWritesService.approve(write.id),
     onMutate: async (write) => {
       await queryClient.cancelQueries({ queryKey: agentActionsKeys.all });
-      return optimisticallyRemove(queryClient, write.id);
+      return optimisticallyRemove(queryClient, write);
     },
     onError: (error, _write, context) => {
       handleDecisionError(
@@ -119,7 +138,7 @@ export function useRejectAgentWrite() {
     mutationFn: (write: PendingAgentWrite) => pendingAgentWritesService.reject(write.id),
     onMutate: async (write) => {
       await queryClient.cancelQueries({ queryKey: agentActionsKeys.all });
-      return optimisticallyRemove(queryClient, write.id);
+      return optimisticallyRemove(queryClient, write);
     },
     onError: (error, _write, context) => {
       handleDecisionError(

--- a/quality-baseline.json
+++ b/quality-baseline.json
@@ -430,8 +430,8 @@
       "maxBytes": 40000
     },
     "utilities/indexer.ts": {
-      "lines": 824,
-      "bytes": 40457,
+      "lines": 829,
+      "bytes": 40736,
       "maxLines": 600,
       "maxBytes": 40000
     },

--- a/services/pending-agent-writes.service.ts
+++ b/services/pending-agent-writes.service.ts
@@ -1,0 +1,114 @@
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { api } from "@/utilities/api/client";
+import { INDEXER } from "@/utilities/indexer";
+
+/**
+ * Client for the `pending_agent_writes` dashboard-approval surface.
+ *
+ * MCP agents (over OAuth) can *propose* critical funding-platform writes; those
+ * are staged server-side and the human owner approves/rejects them here. This
+ * is the FE half of the binding wire contract — field names below are EXACT and
+ * every schema uses `.passthrough()` so the backend may add fields without
+ * breaking the client, but must never rename or remove these.
+ *
+ * See: mcp-writes PRD §4.4 / FR-18–20, and the wire contract doc.
+ */
+
+export const PENDING_AGENT_WRITE_STATUSES = [
+  "pending",
+  "approved",
+  "executed",
+  "rejected",
+  "expired",
+  "failed",
+] as const;
+
+export type PendingAgentWriteStatus = (typeof PENDING_AGENT_WRITE_STATUSES)[number];
+
+/** Queue view. `decided` = executed | rejected | failed | expired. */
+export type PendingAgentWritesStatusFilter = "pending" | "decided" | "all";
+
+const ResultSchema = z
+  .object({
+    statusCode: z.number(),
+    error: z.string().nullable(),
+  })
+  .passthrough();
+
+export type AgentWriteResult = z.infer<typeof ResultSchema>;
+
+const PendingAgentWriteSchema = z
+  .object({
+    id: z.string(),
+    summary: z.string(),
+    label: z.string(),
+    method: z.string(),
+    path: z.string(),
+    // The exact request body to be executed on approval. Kept as `unknown` so a
+    // non-object payload from the backend can never fail-crash the whole list;
+    // it is only ever rendered as pretty-printed JSON for the human reviewer.
+    body: z.unknown().nullable(),
+    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+    clientName: z.string().nullable(),
+    createdAt: z.string(),
+    expiresAt: z.string(),
+    decidedAt: z.string().nullable(),
+    result: ResultSchema.nullable(),
+  })
+  .passthrough();
+
+export type PendingAgentWrite = z.infer<typeof PendingAgentWriteSchema>;
+
+const ListResponseSchema = z
+  .object({
+    writes: z.array(PendingAgentWriteSchema),
+    total: z.number(),
+  })
+  .passthrough();
+
+export type PendingAgentWritesList = z.infer<typeof ListResponseSchema>;
+
+const ApproveResponseSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+    result: ResultSchema.nullable().optional(),
+  })
+  .passthrough();
+
+export type ApproveAgentWriteResponse = z.infer<typeof ApproveResponseSchema>;
+
+const RejectResponseSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+  })
+  .passthrough();
+
+export type RejectAgentWriteResponse = z.infer<typeof RejectResponseSchema>;
+
+export const pendingAgentWritesService = {
+  /** The caller's own queue for a given status filter (default `pending`). */
+  list: (status: PendingAgentWritesStatusFilter = "pending"): Promise<PendingAgentWritesList> =>
+    api.get<PendingAgentWritesList>(INDEXER.V2.PENDING_AGENT_WRITES.LIST(status), {
+      schema: ListResponseSchema,
+    }),
+
+  /**
+   * Approve a staged write — executes the STORED request server-side. Naturally
+   * idempotent (status-guarded on the backend); a second approve returns 409.
+   */
+  approve: (id: string, idempotencyKey: string = uuidv4()): Promise<ApproveAgentWriteResponse> =>
+    api.post<ApproveAgentWriteResponse>(INDEXER.V2.PENDING_AGENT_WRITES.APPROVE(id), undefined, {
+      schema: ApproveResponseSchema,
+      idempotencyKey,
+    }),
+
+  /** Reject a staged write — pending → rejected. Same 409 semantics as approve. */
+  reject: (id: string, idempotencyKey: string = uuidv4()): Promise<RejectAgentWriteResponse> =>
+    api.post<RejectAgentWriteResponse>(INDEXER.V2.PENDING_AGENT_WRITES.REJECT(id), undefined, {
+      schema: RejectResponseSchema,
+      idempotencyKey,
+    }),
+};

--- a/services/pending-agent-writes.service.ts
+++ b/services/pending-agent-writes.service.ts
@@ -9,8 +9,8 @@ import { INDEXER } from "@/utilities/indexer";
  * MCP agents (over OAuth) can *propose* critical funding-platform writes; those
  * are staged server-side and the human owner approves/rejects them here. This
  * is the FE half of the binding wire contract — field names below are EXACT and
- * every schema uses `.passthrough()` so the backend may add fields without
- * breaking the client, but must never rename or remove these.
+ * every schema is loose (unknown keys preserved) so the backend may add fields
+ * without breaking the client, but must never rename or remove these.
  *
  * See: mcp-writes PRD §4.4 / FR-18–20, and the wire contract doc.
  */
@@ -29,64 +29,55 @@ export type PendingAgentWriteStatus = (typeof PENDING_AGENT_WRITE_STATUSES)[numb
 /** Queue view. `decided` = executed | rejected | failed | expired. */
 export type PendingAgentWritesStatusFilter = "pending" | "decided" | "all";
 
-const ResultSchema = z
-  .object({
-    statusCode: z.number(),
-    error: z.string().nullable(),
-  })
-  .passthrough();
+// `z.looseObject` is the Zod 4 equivalent of `z.object(...).passthrough()`: it
+// keeps unknown keys so the backend can add fields without breaking the client,
+// but must never rename or remove the ones declared here.
+const ResultSchema = z.looseObject({
+  statusCode: z.number(),
+  error: z.string().nullable(),
+});
 
-export type AgentWriteResult = z.infer<typeof ResultSchema>;
-
-const PendingAgentWriteSchema = z
-  .object({
-    id: z.string(),
-    summary: z.string(),
-    label: z.string(),
-    method: z.string(),
-    path: z.string(),
-    // The exact request body to be executed on approval. Kept as `unknown` so a
-    // non-object payload from the backend can never fail-crash the whole list;
-    // it is only ever rendered as pretty-printed JSON for the human reviewer.
-    body: z.unknown().nullable(),
-    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
-    clientName: z.string().nullable(),
-    createdAt: z.string(),
-    expiresAt: z.string(),
-    decidedAt: z.string().nullable(),
-    result: ResultSchema.nullable(),
-  })
-  .passthrough();
+const PendingAgentWriteSchema = z.looseObject({
+  id: z.string(),
+  summary: z.string(),
+  label: z.string(),
+  method: z.string(),
+  path: z.string(),
+  // The exact request body to be executed on approval. Kept as `unknown` so a
+  // non-object payload from the backend can never fail-crash the whole list;
+  // it is only ever rendered as pretty-printed JSON for the human reviewer.
+  body: z.unknown().nullable(),
+  status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+  clientName: z.string().nullable(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  decidedAt: z.string().nullable(),
+  result: ResultSchema.nullable(),
+});
 
 export type PendingAgentWrite = z.infer<typeof PendingAgentWriteSchema>;
 
-const ListResponseSchema = z
-  .object({
-    writes: z.array(PendingAgentWriteSchema),
-    total: z.number(),
-  })
-  .passthrough();
+const ListResponseSchema = z.looseObject({
+  writes: z.array(PendingAgentWriteSchema),
+  total: z.number(),
+});
 
 export type PendingAgentWritesList = z.infer<typeof ListResponseSchema>;
 
-const ApproveResponseSchema = z
-  .object({
-    id: z.string(),
-    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
-    result: ResultSchema.nullable().optional(),
-  })
-  .passthrough();
+const ApproveResponseSchema = z.looseObject({
+  id: z.string(),
+  status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+  result: ResultSchema.nullable().optional(),
+});
 
-export type ApproveAgentWriteResponse = z.infer<typeof ApproveResponseSchema>;
+type ApproveAgentWriteResponse = z.infer<typeof ApproveResponseSchema>;
 
-const RejectResponseSchema = z
-  .object({
-    id: z.string(),
-    status: z.enum(PENDING_AGENT_WRITE_STATUSES),
-  })
-  .passthrough();
+const RejectResponseSchema = z.looseObject({
+  id: z.string(),
+  status: z.enum(PENDING_AGENT_WRITE_STATUSES),
+});
 
-export type RejectAgentWriteResponse = z.infer<typeof RejectResponseSchema>;
+type RejectAgentWriteResponse = z.infer<typeof RejectResponseSchema>;
 
 export const pendingAgentWritesService = {
   /** The caller's own queue for a given status filter (default `pending`). */

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -252,6 +252,14 @@ export const INDEXER = {
         return trackId ? `${base}?trackId=${trackId}` : base;
       },
     },
+    PENDING_AGENT_WRITES: {
+      // MCP writes staged for human approval (see mcp-writes PRD FR-18–20).
+      LIST: (status: "pending" | "decided" | "all" = "pending") =>
+        `/v2/pending-agent-writes?status=${status}`,
+      GET: (id: string) => `/v2/pending-agent-writes/${id}`,
+      APPROVE: (id: string) => `/v2/pending-agent-writes/${id}/approve`,
+      REJECT: (id: string) => `/v2/pending-agent-writes/${id}/reject`,
+    },
     PAYOUTS: {
       CREATE: "/v2/payouts/disburse",
       RECORD_PAYMENT: "/v2/payouts/record-payment",

--- a/utilities/indexer.ts
+++ b/utilities/indexer.ts
@@ -253,10 +253,7 @@ export const INDEXER = {
       },
     },
     PENDING_AGENT_WRITES: {
-      // MCP writes staged for human approval (see mcp-writes PRD FR-18–20).
-      LIST: (status: "pending" | "decided" | "all" = "pending") =>
-        `/v2/pending-agent-writes?status=${status}`,
-      GET: (id: string) => `/v2/pending-agent-writes/${id}`,
+      LIST: (status: "pending" | "decided" | "all") => `/v2/pending-agent-writes?status=${status}`,
       APPROVE: (id: string) => `/v2/pending-agent-writes/${id}/approve`,
       REJECT: (id: string) => `/v2/pending-agent-writes/${id}/reject`,
     },

--- a/utilities/pages.ts
+++ b/utilities/pages.ts
@@ -171,6 +171,10 @@ export const PAGES = {
   DONOR_REWARDS: `/donor-rewards`,
   CREATE_PROJECT_PROFILE: `/create-project-profile`,
   MCP_CONNECT: `/mcp/connect`,
+  SETTINGS: {
+    CONNECTIONS: `/settings/connections`,
+    AGENT_ACTIONS: `/settings/agent-actions`,
+  },
   SEEDS: `/seeds`,
   SEEDS_FUND: `/seeds/fund`,
   ASK_KARMA: `/ask-karma`,


### PR DESCRIPTION
# Pending agent actions — owner approval queue (`/settings/agent-actions`)

The dashboard half of MCP writes with human approval. When an AI agent connected over MCP proposes a critical funding-platform write, the backend stages it instead of executing; this page is where the owner reviews the exact staged request and **Approves** (executes the stored request server-side) or **Rejects** it. It is also the deep-link target of the `approvalUrl` the agent hands the user (`/settings/agent-actions?item=<id>`).

Pairs with the backend PR: show-karma/gap-indexer#2312 — MCP write gate + `pending_agent_writes` staging + `/v2/pending-agent-writes` endpoints. **Merge/deploy order: backend first.** Until show-karma/gap-indexer#2312 is deployed, `/v2/pending-agent-writes` 404s and this page renders its error card (the QA pipeline's "critical" finding is exactly this expected dependency, observed against the staging indexer). Once the backend route exists, staging shows the live queue (backend writes are hardcoded ON for staging) while production shows an empty queue — backend writes are hardcoded OFF in production until validated.

## What's included

- **Route** `app/settings/agent-actions/` (`page.tsx` + `loading.tsx` + `error.tsx`), sibling of `/settings/connections`; new `PAGES.SETTINGS` group (`CONNECTIONS` + `AGENT_ACTIONS`).
- **Page** `components/Pages/SettingsAgentActions/SettingsAgentActionsPage.tsx`, cloned from the SettingsConnections shape:
  - auth sequence: not-ready blank → signed-out card with sign-in CTA (query never fires for guests — `enabled: ready && authenticated`) → skeleton → error card with retry → empty state → data;
  - **pending queue**: memoized rows with allowlist label, summary, `METHOD /path` in mono, client name, requested/expires relative times, Approve/Reject;
  - **confirmation dialog before both actions** showing the full staged request — summary, method, path, pretty-printed JSON body in a scrollable `<pre>` — so the human sees exactly what will run before committing (Approve is the consequential one: it executes the write);
  - **history section** (executed / rejected / failed / expired) with status badges and its own loading skeleton + inline error/retry; hidden entirely when empty;
  - **deep-link highlight**: `?item=<id>` (read-only via `useSearchParams`, never mirrored into state) rings + scrolls to the target row.
- **Service** `services/pending-agent-writes.service.ts` — typed `api` client, co-located Zod schemas matching the backend DTO exactly (`.passthrough()`; `body` is `z.unknown().nullable()` so a non-object payload can never contract-crash the list), `Idempotency-Key` on mutations.
- **Hooks** `hooks/agent-actions/usePendingAgentWrites.ts` — list query + approve/reject `useMutation` with optimistic removal, rollback on error, and 409 mapped to a quiet "already decided" toast + refetch (second decision is a stale view, not an error).

## Wire contract (cross-service guardrail §3)

Direct calls to the indexer (no Next.js proxy), `Authorization: Bearer <Privy JWT>` attached by the `api` client:

| Call | Notes |
|---|---|
| `GET /v2/pending-agent-writes?status=pending` / `?status=decided` | drives the two sections |
| `POST /v2/pending-agent-writes/:id/approve` | no body; `Idempotency-Key` header; 409 = already decided/expired |
| `POST /v2/pending-agent-writes/:id/reject` | same semantics |

DTO field names are the locked contract (`id, summary, label, method, path, body, status, clientName, createdAt, expiresAt, decidedAt, result`); schemas `.passthrough()` so the backend may add fields.

## User flows (guardrail §1)

1. Owner opens `approvalUrl` from the agent → lands signed-in on the queue, target row highlighted → reviews full request → Approve → "Action approved and executed." ✅
2. Approve executes but the write fails server-side (`status: failed`) → explicit warning toast with the error ✅
3. Reject → row leaves the queue, shows in history ✅
4. Second decision elsewhere / expired (409) → quiet "already decided" toast + refetch ✅
5. Guest hits the deep link → sign-in card, no data fetched (no-glimpse) ✅
6. Queue empty → "You're all caught up" explainer linking to `/settings/connections` ✅

## Test evidence

- 29 feature tests across three files: service wire-shape (exact paths, `Authorization` + `Idempotency-Key` headers, 409/500 paths via MSW), hook optimistic-update/rollback/409-refetch, page states (signed-out, loading, error, empty, populated, deep-link highlight, history loading/error).
- Full unit project: **1018 files / 14,623 tests, 0 failures**. `tsc --noEmit` clean. `pnpm run build` green with `/settings/agent-actions` in the route manifest.

## Smoke results (guardrail §4)

- Local: suites + production build green (above).
- **Deployed-preview E2E: not yet run — blocking gate before the feature goes live.** Requires both PRs on one preview with the backend flag on: walk flows 1–6 plus the backend's RBAC-denied and expiry paths. Until the backend deploys, the page renders its error state (list endpoint 404s); after backend deploy, staging is live and production shows an empty queue (backend writes hardcoded OFF in prod).

