### PR TITLE
feat(milestones): polish cancelled milestone banner on review page

### DIFF
--- a/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
+++ b/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
@@ -322,6 +322,21 @@ describe("MilestoneCard (admin review) — cancellation banner", () => {
     expect(screen.getByText(/Scope moved to next quarter/i)).toBeInTheDocument();
   });
 
+  it("should_render_cancelled_banner_for_a_status_only_cancellation_without_overlay", () => {
+    render(
+      <MilestoneCard
+        {...DEFAULT_PROPS}
+        milestone={createMilestone({ status: "cancelled", cancellation: null })}
+      />
+    );
+
+    // Terminal cancelled state still surfaces the banner (header badge + banner
+    // label) even when the on-chain overlay is absent.
+    expect(screen.getAllByText("Cancelled").length).toBeGreaterThanOrEqual(2);
+    // No canceller metadata is rendered when the overlay is missing.
+    expect(screen.queryByText(CANCELLER)).not.toBeInTheDocument();
+  });
+
   it("should_not_render_cancellation_banner_for_a_non_cancelled_milestone", () => {
     render(<MilestoneCard {...DEFAULT_PROPS} milestone={createMilestone()} />);
 

--- a/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
+++ b/__tests__/components/Pages/Admin/MilestonesReview/MilestoneCard.test.tsx
@@ -272,3 +272,60 @@ describe("MilestoneCard (admin review) — complete on behalf of grantee", () =>
     expect(onSubmitCompletion).toHaveBeenCalledWith(milestone);
   });
 });
+
+describe("MilestoneCard (admin review) — cancellation banner", () => {
+  const CANCELLER = "0x7177000000000000000000000000000000e1e141";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should_render_cancelled_state_with_canceller_profile_name", () => {
+    render(
+      <MilestoneCard
+        {...DEFAULT_PROPS}
+        milestone={createMilestone({
+          status: "cancelled",
+          cancellation: {
+            uid: "0xcancel-uid",
+            cancelledBy: CANCELLER,
+            cancelledAt: "2026-07-24T12:00:00Z",
+            reason: null,
+          },
+        })}
+      />
+    );
+
+    // "Cancelled" appears twice: the header status badge and the banner label.
+    expect(screen.getAllByText("Cancelled").length).toBeGreaterThanOrEqual(2);
+    // The canceller address is handed to EthereumAddressToProfileName (which
+    // resolves it to a name/ENS/email), not printed raw as a label.
+    expect(screen.getByText(CANCELLER)).toBeInTheDocument();
+  });
+
+  it("should_render_cancellation_reason_when_present", () => {
+    render(
+      <MilestoneCard
+        {...DEFAULT_PROPS}
+        milestone={createMilestone({
+          status: "cancelled",
+          cancellation: {
+            uid: "0xcancel-uid",
+            cancelledBy: CANCELLER,
+            cancelledAt: "2026-07-24T12:00:00Z",
+            reason: "Scope moved to next quarter",
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Scope moved to next quarter/i)).toBeInTheDocument();
+  });
+
+  it("should_not_render_cancellation_banner_for_a_non_cancelled_milestone", () => {
+    render(<MilestoneCard {...DEFAULT_PROPS} milestone={createMilestone()} />);
+
+    expect(screen.queryByText("Cancelled")).not.toBeInTheDocument();
+    expect(screen.queryByText(CANCELLER)).not.toBeInTheDocument();
+  });
+});

--- a/components/Pages/Admin/MilestonesReview/CancelledMilestoneBanner.tsx
+++ b/components/Pages/Admin/MilestonesReview/CancelledMilestoneBanner.tsx
@@ -1,0 +1,52 @@
+import { NoSymbolIcon } from "@heroicons/react/24/outline";
+import { memo } from "react";
+
+import EthereumAddressToProfileName from "@/components/EthereumAddressToProfileName";
+import type { MilestoneCancellation } from "@/services/milestones";
+import { formatDate } from "@/utilities/formatDate";
+
+interface CancelledMilestoneBannerProps {
+  cancellation: MilestoneCancellation;
+}
+
+/**
+ * Quiet terminal state for a cancelled milestone (DEV-523). Styled to match the
+ * neutral "Cancelled" badge rather than the colored completion/verification
+ * boxes, and surfaces the canceller as a human-readable profile name.
+ */
+function CancelledMilestoneBannerComponent({ cancellation }: CancelledMilestoneBannerProps) {
+  return (
+    <div className="mb-3 flex items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/60">
+      <span className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500 dark:bg-zinc-700 dark:text-gray-400">
+        <NoSymbolIcon className="h-4 w-4" aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm leading-tight">
+          <span className="font-semibold text-gray-800 dark:text-gray-200">Cancelled</span>
+          {cancellation.cancelledBy ? (
+            <span className="text-gray-500 dark:text-gray-400">
+              by{" "}
+              <EthereumAddressToProfileName
+                address={cancellation.cancelledBy}
+                className="font-medium text-gray-700 dark:text-gray-300"
+              />
+            </span>
+          ) : null}
+          {cancellation.cancelledAt ? (
+            <span className="text-gray-400 dark:text-gray-500">
+              <span aria-hidden="true">·</span> {formatDate(cancellation.cancelledAt)}
+            </span>
+          ) : null}
+        </div>
+        {cancellation.reason ? (
+          <p className="mt-1.5 text-sm text-gray-600 dark:text-gray-400">
+            <span className="font-medium text-gray-700 dark:text-gray-300">Reason:</span>{" "}
+            {cancellation.reason}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export const CancelledMilestoneBanner = memo(CancelledMilestoneBannerComponent);

--- a/components/Pages/Admin/MilestonesReview/CancelledMilestoneBanner.tsx
+++ b/components/Pages/Admin/MilestonesReview/CancelledMilestoneBanner.tsx
@@ -6,7 +6,12 @@ import type { MilestoneCancellation } from "@/services/milestones";
 import { formatDate } from "@/utilities/formatDate";
 
 interface CancelledMilestoneBannerProps {
-  cancellation: MilestoneCancellation;
+  /**
+   * On-chain cancellation overlay. May be absent for a status-only cancellation
+   * (`status === "cancelled"` with no overlay), in which case the banner still
+   * renders the terminal "Cancelled" state without the metadata.
+   */
+  cancellation: MilestoneCancellation | null;
 }
 
 /**
@@ -23,7 +28,7 @@ function CancelledMilestoneBannerComponent({ cancellation }: CancelledMilestoneB
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm leading-tight">
           <span className="font-semibold text-gray-800 dark:text-gray-200">Cancelled</span>
-          {cancellation.cancelledBy ? (
+          {cancellation?.cancelledBy ? (
             <span className="text-gray-500 dark:text-gray-400">
               by{" "}
               <EthereumAddressToProfileName
@@ -32,13 +37,13 @@ function CancelledMilestoneBannerComponent({ cancellation }: CancelledMilestoneB
               />
             </span>
           ) : null}
-          {cancellation.cancelledAt ? (
+          {cancellation?.cancelledAt ? (
             <span className="text-gray-400 dark:text-gray-500">
               <span aria-hidden="true">·</span> {formatDate(cancellation.cancelledAt)}
             </span>
           ) : null}
         </div>
-        {cancellation.reason ? (
+        {cancellation?.reason ? (
           <p className="mt-1.5 text-sm text-gray-600 dark:text-gray-400">
             <span className="font-medium text-gray-700 dark:text-gray-300">Reason:</span>{" "}
             {cancellation.reason}

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -614,9 +614,7 @@ export function MilestoneCard({
         ) : null}
       </div>
 
-      {isCancelled && milestone.cancellation && (
-        <CancelledMilestoneBanner cancellation={milestone.cancellation} />
-      )}
+      {isCancelled && <CancelledMilestoneBanner cancellation={milestone.cancellation ?? null} />}
 
       {/* Collapsible description */}
       <div className="mb-3">

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -613,21 +613,39 @@ export function MilestoneCard({
         ) : null}
       </div>
 
-      {/* Cancellation banner (DEV-523) */}
+      {/* Cancellation banner (DEV-523) — quiet terminal state, styled to match
+          the neutral "Cancelled" badge rather than the colored completion/
+          verification boxes. */}
       {isCancelled && milestone.cancellation && (
-        <div className="mb-3 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm dark:border-zinc-700 dark:bg-zinc-800/50">
-          <p className="text-gray-700 dark:text-gray-300">
-            <span className="font-medium">Cancelled</span>
-            {milestone.cancellation.cancelledBy ? (
-              <>
-                {" by "}
-                <EthereumAddressToProfileName address={milestone.cancellation.cancelledBy} />
-              </>
+        <div className="mb-3 flex items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/60">
+          <span className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500 dark:bg-zinc-700 dark:text-gray-400">
+            <NoSymbolIcon className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm leading-tight">
+              <span className="font-semibold text-gray-800 dark:text-gray-200">Cancelled</span>
+              {milestone.cancellation.cancelledBy ? (
+                <span className="text-gray-500 dark:text-gray-400">
+                  by{" "}
+                  <EthereumAddressToProfileName
+                    address={milestone.cancellation.cancelledBy}
+                    className="font-medium text-gray-700 dark:text-gray-300"
+                  />
+                </span>
+              ) : null}
+              {milestone.cancellation.cancelledAt ? (
+                <span className="text-gray-400 dark:text-gray-500">
+                  <span aria-hidden="true">·</span> {formatDate(milestone.cancellation.cancelledAt)}
+                </span>
+              ) : null}
+            </div>
+            {milestone.cancellation.reason ? (
+              <p className="mt-1.5 text-sm text-gray-600 dark:text-gray-400">
+                <span className="font-medium text-gray-700 dark:text-gray-300">Reason:</span>{" "}
+                {milestone.cancellation.reason}
+              </p>
             ) : null}
-          </p>
-          {milestone.cancellation.reason ? (
-            <p className="mt-1 text-gray-600 dark:text-gray-400">{milestone.cancellation.reason}</p>
-          ) : null}
+          </div>
         </div>
       )}
 

--- a/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
+++ b/components/Pages/Admin/MilestonesReview/MilestoneCard.tsx
@@ -27,6 +27,7 @@ import { useAgentChatStore } from "@/store/agentChat";
 import { formatDate } from "@/utilities/formatDate";
 import { toEditableUnifiedMilestone } from "@/utilities/milestoneTransforms";
 import { cn } from "@/utilities/tailwind";
+import { CancelledMilestoneBanner } from "./CancelledMilestoneBanner";
 import { getMilestoneStatus, MILESTONE_STATUS_CONFIG } from "./utils/milestone-review-status";
 
 // useLayoutEffect mirrors useEffect on the server to avoid Next.js SSR warnings.
@@ -613,40 +614,8 @@ export function MilestoneCard({
         ) : null}
       </div>
 
-      {/* Cancellation banner (DEV-523) — quiet terminal state, styled to match
-          the neutral "Cancelled" badge rather than the colored completion/
-          verification boxes. */}
       {isCancelled && milestone.cancellation && (
-        <div className="mb-3 flex items-start gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/60">
-          <span className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gray-200 text-gray-500 dark:bg-zinc-700 dark:text-gray-400">
-            <NoSymbolIcon className="h-4 w-4" aria-hidden="true" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm leading-tight">
-              <span className="font-semibold text-gray-800 dark:text-gray-200">Cancelled</span>
-              {milestone.cancellation.cancelledBy ? (
-                <span className="text-gray-500 dark:text-gray-400">
-                  by{" "}
-                  <EthereumAddressToProfileName
-                    address={milestone.cancellation.cancelledBy}
-                    className="font-medium text-gray-700 dark:text-gray-300"
-                  />
-                </span>
-              ) : null}
-              {milestone.cancellation.cancelledAt ? (
-                <span className="text-gray-400 dark:text-gray-500">
-                  <span aria-hidden="true">·</span> {formatDate(milestone.cancellation.cancelledAt)}
-                </span>
-              ) : null}
-            </div>
-            {milestone.cancellation.reason ? (
-              <p className="mt-1.5 text-sm text-gray-600 dark:text-gray-400">
-                <span className="font-medium text-gray-700 dark:text-gray-300">Reason:</span>{" "}
-                {milestone.cancellation.reason}
-              </p>
-            ) : null}
-          </div>
-        </div>
+        <CancelledMilestoneBanner cancellation={milestone.cancellation} />
       )}
 
       {/* Collapsible description */}


### PR DESCRIPTION
## Overview

On the milestone review page (`/community/[communityId]/manage/funding-platform/[programId]/milestones/[projectId]`), a cancelled milestone (DEV-523) rendered as a plain gray box with a bare truncated wallet address. This restyles that banner into a restrained, on-brand status banner and surfaces the canceller's human-readable identity.

## What changed

- **Canceller identity** — the canceller is resolved through `EthereumAddressToProfileName` (contributor name → Privy name → ENS → self identity → truncated address), instead of a raw `0x7177…e1e141`. The component was already wired here; this keeps it and styles its output.
- **Timestamp** — shows *when* the milestone was cancelled (`cancellation.cancelledAt`) when a timestamp exists, via the shared `formatDate`.
- **Visual treatment** — a muted circular `NoSymbolIcon` chip, a clear bold **Cancelled** label, a wrapping meta line (`Cancelled · by <name> · <date>`), and a labelled **Reason** block. Neutral gray/zinc tokens matching the terminal "Cancelled" badge (not the colored completion/verification boxes). Full dark-mode support. No hardcoded colors or routes.

## Before / After

**Before:** `┌ Cancelled by 0x7177…e1e141 ┐` — a flat gray box, raw truncated address, no icon, no date.

**After:** a status banner with a muted icon chip, a bold **Cancelled** label, the canceller's resolved name/ENS/email, the cancellation date when present, and a labelled reason — consistent with the review-workspace design language, light and dark.

## Tests

- New unit tests in `MilestoneCard.test.tsx`: renders the cancelled state, hands the canceller address to the profile-name component, renders the reason, and does **not** render the banner for a non-cancelled milestone.
- `pnpm test` for the file: 13/13 pass.
- `tsc --noEmit`: clean across the whole project.

Scope: two files — `components/Pages/Admin/MilestonesReview/MilestoneCard.tsx` and its test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the cancellation banner for milestones under admin review.
  * Displays a clear “Cancelled” label, cancellation details, timestamp, and optional reason.
  * Shows the canceller’s profile name when available.

* **Bug Fixes**
  * Ensured cancellation information is hidden for milestones that are not cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->