### PR TITLE
feat(find-funders): surface the Claude/ChatGPT connector CTA

### DIFF
--- a/app/nonprofits/find-funders/search/[id]/page.tsx
+++ b/app/nonprofits/find-funders/search/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { ChatViewDynamic } from "@/src/features/non-profits/components/chat-view-dynamic";
-import { DeepResearchPromo } from "@/src/features/non-profits/components/deep-research-promo";
+import { SearchRail } from "@/src/features/non-profits/components/search-rail";
 import { customMetadata } from "@/utilities/meta";
 
 interface SearchPageParams {
@@ -34,7 +34,7 @@ export default async function SearchResultsPage({ params }: { params: Promise<Se
       <div className="min-w-0 flex-1">
         <ChatViewDynamic searchId={id} />
       </div>
-      <DeepResearchPromo />
+      <SearchRail />
     </main>
   );
 }

--- a/src/features/non-profits/__tests__/connect-cta.test.tsx
+++ b/src/features/non-profits/__tests__/connect-cta.test.tsx
@@ -113,7 +113,7 @@ describe("ConnectFloatingCard", () => {
     fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
 
     expect(screen.queryByRole("link", { name: /Add to Claude/i })).not.toBeInTheDocument();
-    expect(window.sessionStorage.getItem("np-connect-bar-dismissed")).toBe("1");
+    expect(window.sessionStorage.getItem("np-connect-cta-dismissed")).toBe("1");
 
     unmount();
     stubIntersectionObserver();

--- a/src/features/non-profits/__tests__/connect-cta.test.tsx
+++ b/src/features/non-profits/__tests__/connect-cta.test.tsx
@@ -1,0 +1,133 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectFloatingCard } from "../components/connect-cta";
+
+vi.mock("@/src/components/navigation/Link", () => ({
+  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+/**
+ * The global IntersectionObserver stub in __tests__/setup.ts never invokes its
+ * callback, so the card could never reach its retired state. This one captures
+ * the callback and hands it back for the test to fire.
+ */
+function stubIntersectionObserver() {
+  const callbacks: IntersectionObserverCallback[] = [];
+  const disconnect = vi.fn();
+  global.IntersectionObserver = class {
+    constructor(cb: IntersectionObserverCallback) {
+      callbacks.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect = disconnect;
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof global.IntersectionObserver;
+
+  return {
+    disconnect,
+    // The observer fires outside React's event loop, so the resulting state
+    // update has to be flushed explicitly.
+    reachTarget: () => fire(callbacks, true),
+    leaveTarget: () => fire(callbacks, false),
+  };
+}
+
+function fire(callbacks: IntersectionObserverCallback[], isIntersecting: boolean) {
+  act(() => {
+    for (const cb of callbacks) {
+      cb(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        null as unknown as IntersectionObserver
+      );
+    }
+  });
+}
+
+describe("ConnectFloatingCard", () => {
+  let connector: HTMLElement;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    connector = document.createElement("div");
+    connector.id = "connector";
+    document.body.appendChild(connector);
+  });
+
+  afterEach(() => {
+    connector.remove();
+    window.sessionStorage.clear();
+  });
+
+  it("is visible from page load, without waiting on any scroll", () => {
+    stubIntersectionObserver();
+    render(<ConnectFloatingCard />);
+
+    expect(screen.getByRole("link", { name: /Add to Claude/i })).toHaveAttribute(
+      "href",
+      "/nonprofits/find-funders/connect/claude"
+    );
+    expect(screen.getByRole("link", { name: /Add to ChatGPT/i })).toHaveAttribute(
+      "href",
+      "/nonprofits/find-funders/connect/chatgpt"
+    );
+  });
+
+  it("hides while the connector section is on screen", () => {
+    const { reachTarget } = stubIntersectionObserver();
+    render(<ConnectFloatingCard />);
+
+    reachTarget();
+
+    // Section 05 makes the same offer full-size — floating a duplicate over it
+    // would just cover it.
+    expect(screen.queryByRole("link", { name: /Add to Claude/i })).not.toBeInTheDocument();
+  });
+
+  it("comes back after scrolling away from the connector section", () => {
+    const { reachTarget, leaveTarget } = stubIntersectionObserver();
+    render(<ConnectFloatingCard />);
+
+    reachTarget();
+    leaveTarget();
+
+    expect(screen.getByRole("link", { name: /Add to Claude/i })).toBeInTheDocument();
+  });
+
+  it("stays dismissed for the rest of the session once closed", () => {
+    stubIntersectionObserver();
+    const { unmount } = render(<ConnectFloatingCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
+
+    expect(screen.queryByRole("link", { name: /Add to Claude/i })).not.toBeInTheDocument();
+    expect(window.sessionStorage.getItem("np-connect-bar-dismissed")).toBe("1");
+
+    unmount();
+    stubIntersectionObserver();
+    render(<ConnectFloatingCard />);
+
+    expect(screen.queryByRole("link", { name: /Add to Claude/i })).not.toBeInTheDocument();
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { disconnect } = stubIntersectionObserver();
+    const { unmount } = render(<ConnectFloatingCard />);
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/features/non-profits/__tests__/connect-cta.test.tsx
+++ b/src/features/non-profits/__tests__/connect-cta.test.tsx
@@ -16,6 +16,11 @@ vi.mock("next/image", () => ({
   default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
 }));
 
+// Restored in afterEach — stubIntersectionObserver replaces the global stub
+// from __tests__/setup.ts, and leaving it in place would leak a
+// callback-capturing observer into every later test in the run.
+const realIntersectionObserver = global.IntersectionObserver;
+
 /**
  * The global IntersectionObserver stub in __tests__/setup.ts never invokes its
  * callback, so the card could never reach its retired state. This one captures
@@ -69,6 +74,7 @@ describe("ConnectFloatingCard", () => {
   afterEach(() => {
     connector.remove();
     window.sessionStorage.clear();
+    global.IntersectionObserver = realIntersectionObserver;
   });
 
   it("is visible from page load, without waiting on any scroll", () => {

--- a/src/features/non-profits/__tests__/connect-cta.test.tsx
+++ b/src/features/non-profits/__tests__/connect-cta.test.tsx
@@ -1,16 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectFloatingCard } from "../components/connect-cta";
-
-vi.mock("@/src/components/navigation/Link", () => ({
-  Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
-}));
 
 vi.mock("next/image", () => ({
   default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
@@ -75,6 +66,19 @@ describe("ConnectFloatingCard", () => {
     connector.remove();
     window.sessionStorage.clear();
     global.IntersectionObserver = realIntersectionObserver;
+  });
+
+  it("opens both setup guides in a new tab", () => {
+    // Matches the rail and inline CTAs. A same-tab navigation would drop the
+    // reader out of the landing page they were part-way through.
+    stubIntersectionObserver();
+    render(<ConnectFloatingCard />);
+
+    for (const name of [/Add to Claude/i, /Add to ChatGPT/i]) {
+      const link = screen.getByRole("link", { name });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    }
   });
 
   it("is visible from page load, without waiting on any scroll", () => {

--- a/src/features/non-profits/__tests__/search-rail.test.tsx
+++ b/src/features/non-profits/__tests__/search-rail.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchRail } from "../components/search-rail";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+describe("SearchRail", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("puts the connector CTA above the deep-research promo", () => {
+    render(<SearchRail />);
+
+    const links = screen.getAllByRole("link").map((link) => link.getAttribute("href"));
+
+    expect(links).toEqual([
+      "/nonprofits/find-funders/connect/claude",
+      "/nonprofits/find-funders/connect/chatgpt",
+      "/nonprofits/find-funders-deep-research",
+    ]);
+  });
+
+  it("keeps the rail connector visible even after the inline banner was dismissed", () => {
+    // The inline banner is a per-session dismissal; the rail is the permanent
+    // home for the CTA and must not inherit it.
+    window.sessionStorage.setItem("np-connector-nudge-dismissed", "1");
+
+    render(<SearchRail />);
+
+    expect(screen.getByText(/Do this in Claude or ChatGPT/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it("opens both connector guides in a new tab", () => {
+    render(<SearchRail />);
+
+    for (const name of [/Add to Claude/i, /Add to ChatGPT/i]) {
+      const link = screen.getByRole("link", { name });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    }
+  });
+});

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -484,8 +484,11 @@ export function ChatView({ searchId }: { searchId?: string }) {
                   </div>
                 )
               )}
+              {/* The connector CTA lives in the right rail (SearchRail), which
+                  only renders at `xl`. Below that the rail is hidden, so the
+                  inline banner is the fallback rather than a duplicate. */}
               {showNudge && (
-                <div className="mx-auto w-full max-w-2xl">
+                <div className="mx-auto w-full max-w-2xl xl:hidden">
                   <ConnectorNudge />
                 </div>
               )}

--- a/src/features/non-profits/components/chat-view-client.tsx
+++ b/src/features/non-profits/components/chat-view-client.tsx
@@ -365,10 +365,11 @@ export function ChatView({ searchId }: { searchId?: string }) {
 
   const showEmpty = messages.length === 0 && !isSearching;
   const lastTurn = messages[messages.length - 1];
-  const showNudge = useMemo(
-    () => messages.some((m) => m.status === "done" && m.entities.length > 0),
-    [messages]
-  );
+  // Any completed turn is enough — a search that returned nothing still means
+  // the user has seen the agent work, and gating on `entities.length > 0` left
+  // narrow viewports with no connector CTA at all on a zero-result search while
+  // the (unconditional) rail kept showing one above `xl`.
+  const showNudge = useMemo(() => messages.some((m) => m.status === "done"), [messages]);
 
   // Not-found state: the conversation URL is private to another account,
   // deleted, or never existed (server 404 with no local query to re-run).

--- a/src/features/non-profits/components/connect-cta.tsx
+++ b/src/features/non-profits/components/connect-cta.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+/**
+ * Landing-page connector CTAs.
+ *
+ * /find-funders gets steady search traffic but very few Claude/ChatGPT
+ * connections, so the "use it in your own AI tool" path needs to be visible
+ * above the fold rather than only in section 05:
+ *
+ * - `ConnectFloatingCard` — a dismissable bottom-right card, present from page
+ *   load and hidden only while the connector section is on screen.
+ * - `ConnectLogos` — the bare brand marks, for the hero eyebrow.
+ *
+ * Both use the lp-* design system in styles/non-profits-landing.css. Plain
+ * Tailwind colour utilities lose to the `.landing button/a` resets, which is
+ * why these are CSS classes rather than utility strings.
+ */
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { Link } from "@/src/components/navigation/Link";
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+const DISMISS_KEY = "np-connect-bar-dismissed";
+
+// The brand marks are single-path black SVGs — `dark:invert` is what keeps them
+// legible on the dark theme (same treatment as the /mcp connect page).
+const CONNECT_TARGETS = [
+  {
+    label: "Claude",
+    href: NON_PROFITS_PAGES.CONNECT_CLAUDE,
+    logo: "/images/mcp/claude.svg",
+  },
+  {
+    label: "ChatGPT",
+    href: NON_PROFITS_PAGES.CONNECT_CHATGPT,
+    logo: "/images/mcp/openai.svg",
+  },
+] as const;
+
+function ConnectButton({
+  href,
+  logo,
+  label,
+  className = "lp-connect-btn",
+}: {
+  href: string;
+  logo: string;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Link href={href} className={className}>
+      <Image
+        src={logo}
+        alt=""
+        width={16}
+        height={16}
+        aria-hidden="true"
+        className="lp-connect-btn-logo dark:invert"
+      />
+      <span>Add to {label}</span>
+    </Link>
+  );
+}
+
+/**
+ * The two brand marks on their own — an at-a-glance "this runs in your AI
+ * tool" signal for the hero eyebrow, which is the very first thing on the
+ * page.
+ */
+export function ConnectLogos() {
+  return (
+    <span className="lp-eyebrow-brands">
+      {CONNECT_TARGETS.map((target) => (
+        <Image
+          key={target.href}
+          src={target.logo}
+          alt=""
+          width={13}
+          height={13}
+          aria-hidden="true"
+          className="lp-eyebrow-brand-logo dark:invert"
+        />
+      ))}
+    </span>
+  );
+}
+
+function isDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function persistDismiss(): void {
+  try {
+    window.sessionStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // sessionStorage unavailable — ignore
+  }
+}
+
+/**
+ * Bottom-right floating connector card.
+ *
+ * Present from the moment the page loads — the whole problem with putting this
+ * in the hero was that the CTA lived below the fold on a tall hero; a corner
+ * card is on the first screen without spending any hero real estate.
+ *
+ * It hides only while the connector section (05 — ADD THE AGENT) is on screen,
+ * since that section makes the same offer at full size and a floating
+ * duplicate would sit on top of it. Scrolling away from that section brings
+ * the card back — it tracks the section's current visibility rather than
+ * latching on first sight.
+ */
+export function ConnectFloatingCard({ hideAtId = "connector" }: { hideAtId?: string }) {
+  const [dismissed, setDismissed] = useState(true);
+  const [atSection, setAtSection] = useState(false);
+
+  // Start hidden and flip after mount: the landing page is client-only, but
+  // reading sessionStorage during render would still make the first paint
+  // depend on browser state.
+  useEffect(() => {
+    if (!isDismissed()) setDismissed(false);
+  }, []);
+
+  useEffect(() => {
+    const target = document.getElementById(hideAtId);
+    if (!target) return;
+    const observer = new IntersectionObserver(([entry]) => setAtSection(entry.isIntersecting), {
+      threshold: 0,
+    });
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hideAtId]);
+
+  if (dismissed || atSection) return null;
+
+  const handleDismiss = () => {
+    persistDismiss();
+    setDismissed(true);
+  };
+
+  return (
+    <aside className="lp-connect-float" aria-label="Add the agent to your AI tool">
+      <div className="lp-connect-float-head">
+        <span className="lp-connect-float-title">
+          <ConnectLogos />
+          Do it in your own AI tool
+        </span>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="lp-connect-float-close"
+        >
+          &times;
+        </button>
+      </div>
+      <div className="lp-connect-float-actions">
+        {CONNECT_TARGETS.map((target) => (
+          <ConnectButton
+            key={target.href}
+            href={target.href}
+            logo={target.logo}
+            label={target.label}
+            className="lp-connect-btn lp-connect-btn-sm"
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/features/non-profits/components/connect-cta.tsx
+++ b/src/features/non-profits/components/connect-cta.tsx
@@ -18,11 +18,15 @@
 
 import Image from "next/image";
 import { memo, useEffect, useState } from "react";
-import { Link } from "@/src/components/navigation/Link";
 import { CONNECT_TARGETS } from "../lib/connect-targets";
 
 const DISMISS_KEY = "np-connect-cta-dismissed";
 
+/**
+ * Opens in a new tab, matching the rail and inline CTAs: the setup guide is a
+ * detour, and the reader should come back to where they were rather than lose
+ * the page they were reading.
+ */
 const ConnectButton = memo(function ConnectButton({
   href,
   logo,
@@ -35,7 +39,7 @@ const ConnectButton = memo(function ConnectButton({
   className: string;
 }) {
   return (
-    <Link href={href} className={className}>
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
       <Image
         src={logo}
         alt=""
@@ -45,7 +49,7 @@ const ConnectButton = memo(function ConnectButton({
         className="lp-connect-btn-logo dark:invert"
       />
       <span>Add to {name}</span>
-    </Link>
+    </a>
   );
 });
 
@@ -85,7 +89,9 @@ function persistDismiss(): void {
   try {
     window.sessionStorage.setItem(DISMISS_KEY, "1");
   } catch {
-    // sessionStorage unavailable — ignore
+    // SUPPRESSED: sessionStorage throws in private mode / when storage is
+    // disabled. Dismissal is best-effort cosmetic state — the CTA simply
+    // reappears next load, which is not worth reporting.
   }
 }
 

--- a/src/features/non-profits/components/connect-cta.tsx
+++ b/src/features/non-profits/components/connect-cta.tsx
@@ -17,37 +17,22 @@
  */
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { Link } from "@/src/components/navigation/Link";
-import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { CONNECT_TARGETS } from "../lib/connect-targets";
 
-const DISMISS_KEY = "np-connect-bar-dismissed";
+const DISMISS_KEY = "np-connect-cta-dismissed";
 
-// The brand marks are single-path black SVGs — `dark:invert` is what keeps them
-// legible on the dark theme (same treatment as the /mcp connect page).
-const CONNECT_TARGETS = [
-  {
-    label: "Claude",
-    href: NON_PROFITS_PAGES.CONNECT_CLAUDE,
-    logo: "/images/mcp/claude.svg",
-  },
-  {
-    label: "ChatGPT",
-    href: NON_PROFITS_PAGES.CONNECT_CHATGPT,
-    logo: "/images/mcp/openai.svg",
-  },
-] as const;
-
-function ConnectButton({
+const ConnectButton = memo(function ConnectButton({
   href,
   logo,
-  label,
-  className = "lp-connect-btn",
+  name,
+  className,
 }: {
   href: string;
   logo: string;
-  label: string;
-  className?: string;
+  name: string;
+  className: string;
 }) {
   return (
     <Link href={href} className={className}>
@@ -59,10 +44,10 @@ function ConnectButton({
         aria-hidden="true"
         className="lp-connect-btn-logo dark:invert"
       />
-      <span>Add to {label}</span>
+      <span>Add to {name}</span>
     </Link>
   );
-}
+});
 
 /**
  * The two brand marks on their own — an at-a-glance "this runs in your AI
@@ -71,7 +56,7 @@ function ConnectButton({
  */
 export function ConnectLogos() {
   return (
-    <span className="lp-eyebrow-brands">
+    <span className="lp-brand-marks">
       {CONNECT_TARGETS.map((target) => (
         <Image
           key={target.href}
@@ -80,7 +65,7 @@ export function ConnectLogos() {
           width={13}
           height={13}
           aria-hidden="true"
-          className="lp-eyebrow-brand-logo dark:invert"
+          className="lp-brand-mark-logo dark:invert"
         />
       ))}
     </span>
@@ -167,7 +152,7 @@ export function ConnectFloatingCard({ hideAtId = "connector" }: { hideAtId?: str
             key={target.href}
             href={target.href}
             logo={target.logo}
-            label={target.label}
+            name={target.name}
             className="lp-connect-btn lp-connect-btn-sm"
           />
         ))}

--- a/src/features/non-profits/components/connector-nudge.tsx
+++ b/src/features/non-profits/components/connector-nudge.tsx
@@ -4,15 +4,43 @@
  * ConnectorNudge — ported from grant-atlas
  * features/grant-atlas/components/research-workbench/connector-nudge.tsx.
  *
- * Dismissable CTA banner prompting users to connect the agent to Claude/ChatGPT.
- * Uses CSS transitions only (no motion). Dismissal is persisted to sessionStorage.
+ * CTA prompting users to connect the agent to Claude/ChatGPT. Two variants:
+ *
+ * - `inline` (default): the original dismissable banner in the conversation
+ *   flow. Dismissal is persisted to sessionStorage. The workbench only renders
+ *   it below `xl`, where the right rail is hidden.
+ * - `rail`: a compact card for the search workbench's right rail. Deliberately
+ *   not dismissable — keeping the connector permanently in view is the whole
+ *   point of moving it out of the conversation, and in the rail it never
+ *   competes with the answer for vertical space.
+ *
+ * Uses CSS transitions only (no motion).
  */
 
 import { ArrowUpRight, Sparkles, X } from "lucide-react";
+import Image from "next/image";
 import { useEffect, useState } from "react";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 
 const DISMISS_KEY = "np-connector-nudge-dismissed";
+
+// The brand marks are single-path black SVGs, so `dark:invert` is what makes
+// them legible on a dark card (same treatment as the /mcp connect page).
+const CONNECT_TARGETS = [
+  {
+    label: "Add to Claude",
+    href: NON_PROFITS_PAGES.CONNECT_CLAUDE,
+    logo: "/images/mcp/claude.svg",
+  },
+  {
+    label: "Add to ChatGPT",
+    href: NON_PROFITS_PAGES.CONNECT_CHATGPT,
+    logo: "/images/mcp/openai.svg",
+  },
+] as const;
+
+const LINK_BASE =
+  "inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800";
 
 function isDismissed(): boolean {
   if (typeof window === "undefined") return false;
@@ -31,15 +59,75 @@ function persistDismiss(): void {
   }
 }
 
-export function ConnectorNudge() {
+/**
+ * Setup guides always open in a new tab so the user never loses the
+ * conversation they're in the middle of.
+ */
+function ConnectLink({
+  href,
+  logo,
+  label,
+  className,
+}: {
+  href: string;
+  logo: string;
+  label: string;
+  className: string;
+}) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      <Image
+        src={logo}
+        alt=""
+        width={14}
+        height={14}
+        aria-hidden="true"
+        className="size-3.5 shrink-0 dark:invert"
+      />
+      {label}
+      <ArrowUpRight className="size-3" />
+    </a>
+  );
+}
+
+export function ConnectorNudge({ variant = "inline" }: { variant?: "inline" | "rail" }) {
   const [hidden, setHidden] = useState(true);
 
   // Avoid SSR/hydration mismatch — only show after mount, only if not dismissed.
+  // The rail variant carries no dismiss affordance, so it always shows.
   useEffect(() => {
-    if (!isDismissed()) setHidden(false);
-  }, []);
+    if (variant === "rail" || !isDismissed()) setHidden(false);
+  }, [variant]);
 
   if (hidden) return null;
+
+  if (variant === "rail") {
+    return (
+      <div className="overflow-hidden rounded-xl border border-zinc-200 bg-gradient-to-br from-amber-50 via-white to-blue-50 p-4 dark:border-zinc-800 dark:from-amber-900/10 dark:via-zinc-900 dark:to-blue-900/10">
+        <div className="flex size-9 items-center justify-center rounded-lg bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900">
+          <Sparkles className="size-4" />
+        </div>
+        <p className="mt-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Do this in Claude or ChatGPT
+        </p>
+        <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+          Run the same prospecting agent inside the AI tool you already use. About 60 seconds to
+          connect — no new login.
+        </p>
+        <div className="mt-3 flex flex-col gap-2">
+          {CONNECT_TARGETS.map((target) => (
+            <ConnectLink
+              key={target.href}
+              href={target.href}
+              logo={target.logo}
+              label={target.label}
+              className={`${LINK_BASE} justify-center`}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   const handleDismiss = () => {
     persistDismiss();
@@ -72,27 +160,16 @@ export function ConnectorNudge() {
               <X className="size-4" />
             </button>
           </div>
-          {/* Open the setup guides in a new tab so the user never loses the
-              conversation they're in the middle of. */}
           <div className="mt-3 flex flex-wrap items-center gap-2">
-            <a
-              href={NON_PROFITS_PAGES.CONNECT_CLAUDE}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
-            >
-              Add to Claude
-              <ArrowUpRight className="size-3" />
-            </a>
-            <a
-              href={NON_PROFITS_PAGES.CONNECT_CHATGPT}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
-            >
-              Add to ChatGPT
-              <ArrowUpRight className="size-3" />
-            </a>
+            {CONNECT_TARGETS.map((target) => (
+              <ConnectLink
+                key={target.href}
+                href={target.href}
+                logo={target.logo}
+                label={target.label}
+                className={LINK_BASE}
+              />
+            ))}
             <span className="text-xs text-zinc-400 dark:text-zinc-500">Opens in a new tab</span>
           </div>
         </div>

--- a/src/features/non-profits/components/connector-nudge.tsx
+++ b/src/features/non-profits/components/connector-nudge.tsx
@@ -40,7 +40,9 @@ function persistDismiss(): void {
   try {
     window.sessionStorage.setItem(DISMISS_KEY, "1");
   } catch {
-    // sessionStorage unavailable — ignore
+    // SUPPRESSED: sessionStorage throws in private mode / when storage is
+    // disabled. Dismissal is best-effort cosmetic state — the banner simply
+    // reappears next load, which is not worth reporting.
   }
 }
 

--- a/src/features/non-profits/components/connector-nudge.tsx
+++ b/src/features/non-profits/components/connector-nudge.tsx
@@ -76,12 +76,16 @@ const ConnectLink = memo(function ConnectLink({
 });
 
 export function ConnectorNudge({ variant = "inline" }: { variant?: "inline" | "rail" }) {
-  const [hidden, setHidden] = useState(true);
+  // The inline variant starts hidden and reveals after mount, because whether
+  // it renders depends on sessionStorage — reading that during render would
+  // desync the server output from the first client paint. The rail variant has
+  // no dismissal to consult, so it renders immediately: SearchRail is
+  // server-rendered, and deferring it to an effect would flash an empty rail.
+  const [hidden, setHidden] = useState(variant !== "rail");
 
-  // Avoid SSR/hydration mismatch — only show after mount, only if not dismissed.
-  // The rail variant carries no dismiss affordance, so it always shows.
   useEffect(() => {
-    if (variant === "rail" || !isDismissed()) setHidden(false);
+    if (variant === "rail") return;
+    if (!isDismissed()) setHidden(false);
   }, [variant]);
 
   if (hidden) return null;

--- a/src/features/non-profits/components/connector-nudge.tsx
+++ b/src/features/non-profits/components/connector-nudge.tsx
@@ -19,25 +19,10 @@
 
 import { ArrowUpRight, Sparkles, X } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import { NON_PROFITS_PAGES } from "@/utilities/pages";
+import { memo, useEffect, useState } from "react";
+import { CONNECT_TARGETS } from "../lib/connect-targets";
 
 const DISMISS_KEY = "np-connector-nudge-dismissed";
-
-// The brand marks are single-path black SVGs, so `dark:invert` is what makes
-// them legible on a dark card (same treatment as the /mcp connect page).
-const CONNECT_TARGETS = [
-  {
-    label: "Add to Claude",
-    href: NON_PROFITS_PAGES.CONNECT_CLAUDE,
-    logo: "/images/mcp/claude.svg",
-  },
-  {
-    label: "Add to ChatGPT",
-    href: NON_PROFITS_PAGES.CONNECT_CHATGPT,
-    logo: "/images/mcp/openai.svg",
-  },
-] as const;
 
 const LINK_BASE =
   "inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800";
@@ -63,15 +48,15 @@ function persistDismiss(): void {
  * Setup guides always open in a new tab so the user never loses the
  * conversation they're in the middle of.
  */
-function ConnectLink({
+const ConnectLink = memo(function ConnectLink({
   href,
   logo,
-  label,
+  name,
   className,
 }: {
   href: string;
   logo: string;
-  label: string;
+  name: string;
   className: string;
 }) {
   return (
@@ -84,11 +69,11 @@ function ConnectLink({
         aria-hidden="true"
         className="size-3.5 shrink-0 dark:invert"
       />
-      {label}
+      Add to {name}
       <ArrowUpRight className="size-3" />
     </a>
   );
-}
+});
 
 export function ConnectorNudge({ variant = "inline" }: { variant?: "inline" | "rail" }) {
   const [hidden, setHidden] = useState(true);
@@ -120,7 +105,7 @@ export function ConnectorNudge({ variant = "inline" }: { variant?: "inline" | "r
               key={target.href}
               href={target.href}
               logo={target.logo}
-              label={target.label}
+              name={target.name}
               className={`${LINK_BASE} justify-center`}
             />
           ))}
@@ -166,7 +151,7 @@ export function ConnectorNudge({ variant = "inline" }: { variant?: "inline" | "r
                 key={target.href}
                 href={target.href}
                 logo={target.logo}
-                label={target.label}
+                name={target.name}
                 className={LINK_BASE}
               />
             ))}

--- a/src/features/non-profits/components/deep-research-promo.tsx
+++ b/src/features/non-profits/components/deep-research-promo.tsx
@@ -1,38 +1,39 @@
 "use client";
 
 /**
- * DeepResearchPromo — right-rail advertisement shown on the search workbench
- * pointing users to the hand-curated deep research intake page. Opens the
- * deep-research page in a new tab so the active search is preserved.
+ * DeepResearchPromoCard — right-rail card pointing users to the hand-curated
+ * deep research intake page. Opens the deep-research page in a new tab so the
+ * active search is preserved.
+ *
+ * The surrounding `<aside>` lives in `search-rail.tsx`, which stacks this card
+ * below the connector CTA.
  */
 
 import { ArrowUpRight, Telescope } from "lucide-react";
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 
-export function DeepResearchPromo() {
+export function DeepResearchPromoCard() {
   return (
-    <aside className="hidden w-72 shrink-0 border-l border-zinc-200 p-4 xl:block dark:border-zinc-800">
-      <div className="sticky top-4 overflow-hidden rounded-xl border border-zinc-200 bg-gradient-to-br from-brand-faint via-white to-blue-50 p-4 dark:border-zinc-800 dark:from-brand/10 dark:via-zinc-900 dark:to-blue-900/10">
-        <div className="flex size-9 items-center justify-center rounded-lg bg-brand text-white">
-          <Telescope className="size-4" />
-        </div>
-        <p className="mt-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          Want better results?
-        </p>
-        <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-          Our AI agents can perform deep research, scour the internet, and find you exactly what you
-          need.
-        </p>
-        <a
-          href={NON_PROFITS_PAGES.DEEP_RESEARCH}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
-        >
-          Try deep research
-          <ArrowUpRight className="size-3" />
-        </a>
+    <div className="overflow-hidden rounded-xl border border-zinc-200 bg-gradient-to-br from-brand-faint via-white to-blue-50 p-4 dark:border-zinc-800 dark:from-brand/10 dark:via-zinc-900 dark:to-blue-900/10">
+      <div className="flex size-9 items-center justify-center rounded-lg bg-brand text-white">
+        <Telescope className="size-4" />
       </div>
-    </aside>
+      <p className="mt-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Want better results?
+      </p>
+      <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+        Our AI agents can perform deep research, scour the internet, and find you exactly what you
+        need.
+      </p>
+      <a
+        href={NON_PROFITS_PAGES.DEEP_RESEARCH}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs font-medium text-zinc-800 transition-colors hover:border-zinc-400 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+      >
+        Try deep research
+        <ArrowUpRight className="size-3" />
+      </a>
+    </div>
   );
 }

--- a/src/features/non-profits/components/landing-page-client.tsx
+++ b/src/features/non-profits/components/landing-page-client.tsx
@@ -25,6 +25,7 @@ import { NON_PROFITS_PAGES } from "@/utilities/pages";
 import { INSTALL_CONFIGS, type InstallTab } from "../lib/install-configs";
 import { FILINGS_STATS } from "../lib/stats";
 import { useSearchSessionStore } from "../store/search-session";
+import { ConnectFloatingCard, ConnectLogos } from "./connect-cta";
 
 // ————————————————————————— Icons —————————————————————————
 
@@ -209,7 +210,9 @@ function Hero({ onSearch }: { onSearch: (query: string) => void }) {
       <div className="lp-container lp-hero-inner lp-fade-in">
         <div className="lp-eyebrow">
           <span className="lp-eyebrow-dot" />
-          <span>AI Agents for Funder Research &middot; Works in Claude &amp; ChatGPT</span>
+          <span>AI Agents for Funder Research &middot; Works in</span>
+          <ConnectLogos />
+          <span>Claude &amp; ChatGPT</span>
         </div>
         <h1 className="lp-hero-title">
           Stop hunting for funders.
@@ -287,16 +290,6 @@ function Hero({ onSearch }: { onSearch: (query: string) => void }) {
                 </button>
               ))}
             </div>
-          </div>
-
-          <div className="lp-hero-foot">
-            <span>Prefer to stay in your AI tool?</span>
-            <Link href={NON_PROFITS_PAGES.CONNECT_CLAUDE} className="lp-hero-foot-link">
-              Add to Claude <Icon.arrow />
-            </Link>
-            <Link href={NON_PROFITS_PAGES.CONNECT_CHATGPT} className="lp-hero-foot-link">
-              Add to ChatGPT <Icon.arrow />
-            </Link>
           </div>
         </div>
       </div>
@@ -1054,6 +1047,7 @@ export function LandingPageClient() {
       <TheData />
       <Audience />
       <FinalCTA onSearchFocus={scrollToHero} />
+      <ConnectFloatingCard />
     </div>
   );
 }

--- a/src/features/non-profits/components/search-rail.tsx
+++ b/src/features/non-profits/components/search-rail.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * SearchRail — the right rail on the search workbench.
+ *
+ * The connector CTA sits at the top: /find-funders sees steady search usage but
+ * very few Claude/ChatGPT connections, and the CTA previously lived inline in
+ * the conversation, below the answer and its entity list — i.e. only after a
+ * long scroll, and dismissable in one click. In the rail it stays in view for
+ * the whole session without pushing the conversation around.
+ *
+ * The rail is `xl`-only; below that the workbench falls back to the inline
+ * ConnectorNudge banner so the CTA is never lost on narrow screens.
+ */
+
+import { ConnectorNudge } from "./connector-nudge";
+import { DeepResearchPromoCard } from "./deep-research-promo";
+
+export function SearchRail() {
+  return (
+    <aside
+      aria-label="Get more from the agent"
+      className="hidden w-72 shrink-0 border-l border-zinc-200 p-4 xl:block dark:border-zinc-800"
+    >
+      <div className="sticky top-4 flex flex-col gap-4">
+        <ConnectorNudge variant="rail" />
+        <DeepResearchPromoCard />
+      </div>
+    </aside>
+  );
+}

--- a/src/features/non-profits/lib/connect-targets.ts
+++ b/src/features/non-profits/lib/connect-targets.ts
@@ -1,0 +1,32 @@
+/**
+ * The AI tools the Karma Find Funders agent can be connected to.
+ *
+ * Single source of truth for the connector CTAs, which appear in three places
+ * with different chrome but the same destinations: the landing page floating
+ * card, the search workbench right rail, and the inline conversation banner.
+ *
+ * The brand marks are single-path black SVGs, so every consumer pairs them
+ * with `dark:invert` to stay legible on the dark theme (same treatment as the
+ * /mcp connect page).
+ */
+import { NON_PROFITS_PAGES } from "@/utilities/pages";
+
+export interface ConnectTarget {
+  /** Product name — callers format their own label, e.g. `Add to ${name}`. */
+  name: string;
+  href: string;
+  logo: string;
+}
+
+export const CONNECT_TARGETS: readonly ConnectTarget[] = [
+  {
+    name: "Claude",
+    href: NON_PROFITS_PAGES.CONNECT_CLAUDE,
+    logo: "/images/mcp/claude.svg",
+  },
+  {
+    name: "ChatGPT",
+    href: NON_PROFITS_PAGES.CONNECT_CHATGPT,
+    logo: "/images/mcp/openai.svg",
+  },
+] as const;

--- a/src/features/non-profits/lib/connect-targets.ts
+++ b/src/features/non-profits/lib/connect-targets.ts
@@ -11,7 +11,9 @@
  */
 import { NON_PROFITS_PAGES } from "@/utilities/pages";
 
-export interface ConnectTarget {
+// Deliberately not exported: consumers read the array, never the element type,
+// and an unused exported type trips the knip check in the quality gate.
+interface ConnectTarget {
   /** Product name — callers format their own label, e.g. `Add to ${name}`. */
   name: string;
   href: string;

--- a/styles/non-profits-landing.css
+++ b/styles/non-profits-landing.css
@@ -1183,14 +1183,14 @@
 }
 .lp-hero-foot-link:hover { color: var(--lp-primary); border-color: var(--lp-primary); }
 
-/* Brand marks inline in the hero eyebrow — the first "runs in your AI tool"
+/* Brand marks — hero eyebrow and the floating connect card — the first "runs in your AI tool"
    signal on the page, above the title. */
-.lp-eyebrow-brands {
+.lp-brand-marks {
   display: inline-flex;
   align-items: center;
   gap: 5px;
 }
-.lp-eyebrow-brand-logo { width: 13px; height: 13px; }
+.lp-brand-mark-logo { width: 13px; height: 13px; }
 
 /* Scoped under `.landing` so these beat the `.landing a`/`.landing button`
    resets at the top of this file, which would otherwise force `color: inherit`

--- a/styles/non-profits-landing.css
+++ b/styles/non-profits-landing.css
@@ -1167,19 +1167,10 @@
 }
 
 /* ———————— Responsive ———————— */
-/* ———————— Hero foot (nudge to connector) ———————— */
-.lp-hero-foot {
-  margin-top: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--lp-ink-3);
-}
+/* ———————— Hero foot (nudge to connector) ————————
+   `.lp-hero-foot` itself is gone — the hero's connector row was replaced by the
+   floating card. The link style below is still used by the install widget's
+   footer in section 05. */
 .lp-hero-foot-link {
   display: inline-flex;
   align-items: center;
@@ -1191,6 +1182,114 @@
   transition: color 0.15s, border-color 0.15s;
 }
 .lp-hero-foot-link:hover { color: var(--lp-primary); border-color: var(--lp-primary); }
+
+/* Brand marks inline in the hero eyebrow — the first "runs in your AI tool"
+   signal on the page, above the title. */
+.lp-eyebrow-brands {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.lp-eyebrow-brand-logo { width: 13px; height: 13px; }
+
+/* Scoped under `.landing` so these beat the `.landing a`/`.landing button`
+   resets at the top of this file, which would otherwise force `color: inherit`
+   and strip the border. */
+.landing .lp-connect-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-elev);
+  color: var(--lp-ink);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+.landing .lp-connect-btn:hover {
+  border-color: var(--lp-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px -6px color-mix(in oklch, var(--lp-ink) 40%, transparent);
+}
+.lp-connect-btn-logo { width: 16px; height: 16px; flex-shrink: 0; }
+.landing .lp-connect-btn-sm { padding: 7px 12px; font-size: 12px; border-radius: 8px; }
+.lp-connect-btn-sm .lp-connect-btn-logo { width: 14px; height: 14px; }
+
+/* ———————— Floating connect card ————————
+   Bottom-right from page load; retires at the connector section, which makes
+   the same offer at full size. */
+.lp-connect-float {
+  position: fixed;
+  right: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  z-index: 40;
+  width: 290px;
+  max-width: calc(100vw - 32px);
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--bg-elev);
+  box-shadow: 0 12px 32px -12px color-mix(in oklch, var(--lp-ink) 45%, transparent),
+              0 2px 6px -2px color-mix(in oklch, var(--lp-ink) 20%, transparent);
+  animation: lp-float-in 0.3s ease both;
+}
+
+@keyframes lp-float-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lp-connect-float { animation: none; }
+  .lp-connect-btn:hover { transform: none; }
+}
+
+.lp-connect-float-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.lp-connect-float-title {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--lp-ink);
+}
+
+.lp-connect-float-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+/* Fill the card width evenly rather than leaving a ragged right edge. */
+.lp-connect-float-actions .lp-connect-btn {
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+.landing .lp-connect-float-close {
+  flex-shrink: 0;
+  padding: 0 6px;
+  border-radius: 6px;
+  font-size: 20px;
+  line-height: 1.1;
+  color: var(--lp-ink-3);
+  transition: background 0.15s, color 0.15s;
+}
+.landing .lp-connect-float-close:hover { background: var(--bg-sunken); color: var(--lp-ink); }
+
+@media (max-width: 640px) {
+  .lp-connect-float { right: 12px; left: 12px; width: auto; bottom: calc(12px + env(safe-area-inset-bottom)); }
+}
 
 /* ———————— Nav ———————— */
 .lp-nav {


### PR DESCRIPTION
## Overview

Raises the visibility of the "use this agent inside Claude / ChatGPT" path on `/nonprofits/find-funders`, in two places: the search workbench gets a persistent right-rail card, and the landing page gets a floating corner CTA.

No behaviour changes to search, streaming, or feedback — this is placement and presentation only.

## Problem

`/find-funders` gets a steady stream of search traffic, but almost nobody connects the agent to their own Claude or ChatGPT. Looking at where the CTA actually lived explains why:

- **In the search workbench**, `ConnectorNudge` rendered inline in the conversation, *after* the answer narrative and the full entity list. On a real result that's several screens of funder cards before the CTA appears — and a single click on its `×` dismissed it for the rest of the session.
- **On the landing page**, the only connector affordance above the fold was a pair of dashed text links in the hero foot ("Prefer to stay in your AI tool?"), with the real pitch sitting far down in section 05.

Both placements meant the offer was easy to miss and easy to permanently dismiss.

## Solution

**1. Search workbench — right rail (`SearchRail`)**

The connector card moves into the existing right rail, above the deep-research promo, inside one sticky container:

```mermaid
graph LR
    A["/find-funders/search/[id]"] --> B[ChatViewDynamic]
    A --> C[SearchRail  aside, xl only]
    C --> D["ConnectorNudge variant=rail<br/>(not dismissable)"]
    C --> E[DeepResearchPromoCard]
    B --> F["ConnectorNudge inline<br/>(xl:hidden fallback)"]
```

- The rail card is **not dismissable** — keeping the connector in view is the point of moving it there, and in the rail it costs no vertical space in the conversation.
- The rail is `xl`-only, which the deep-research promo already was. Below `xl` the inline banner still renders (now `xl:hidden`), so narrow screens keep the CTA rather than losing it — and no width shows both.
- `DeepResearchPromo` → `DeepResearchPromoCard`: the `<aside>` wrapper moved up into `SearchRail` so both cards share one sticky container.

**2. Landing page — floating card (`ConnectFloatingCard`)**

A dismissable bottom-right card with both brand marks and Add-to-Claude / Add-to-ChatGPT buttons:

- Present from page load, so it's on the first screen without spending any hero real estate.
- Hides while the connector section (`#connector`, "05 — ADD THE AGENT") is on screen, since that section makes the same offer full-size and a floating duplicate would sit on top of it. It **tracks** that section's visibility rather than latching, so scrolling back up brings it back.
- Dismissal persists for the session via `sessionStorage`.
- Under 640px it becomes a full-width bar with side margins instead of a corner card.

The hero eyebrow also picks up the two brand marks ("Works in ⬥ ◎ Claude & ChatGPT") as a first-glance signal above the headline.

## Why This Approach

Two alternatives were built and rejected during review:

1. **A prominent CTA block inside the hero** (branded buttons under the search box). Rejected: the hero already carries a rotating-placeholder search box plus a six-chip example grid, so the block landed below the fold on normal viewports. Moving it *above* the chips fixed the fold problem but crowded the primary search action. A corner card gets first-screen presence without competing with the search box at all.
2. **A full-width sticky bottom bar.** Rejected in favour of the corner card, which is less intrusive on long marketing pages and easier to dismiss deliberately.

Styling goes through the `lp-*` design system in `styles/non-profits-landing.css` rather than Tailwind utilities, because `.landing a` / `.landing button` resets strip `background`/`color`/`border` from utility-styled controls inside that scope. New rules are scoped under `.landing` so they win against those resets without `!important`.

## Technical Details

- `ConnectorNudge` gains a `variant` prop (`"inline" | "rail"`), defaulting to `inline` — existing call sites are unaffected.
- Brand marks are the existing `/images/mcp/claude.svg` and `/images/mcp/openai.svg`, single-path black SVGs, so they carry `dark:invert` (same treatment as the `/mcp` connect page).
- `ConnectFloatingCard` uses an `IntersectionObserver` on `#connector` and disconnects on unmount.
- Dead CSS removed: `.lp-hero-foot` (its markup is gone). `.lp-hero-foot-link` is kept — still used by the install widget footer in section 05.

## Testing Steps

**Search rail**

1. Go to `/nonprofits/find-funders`, run any search.
2. **Widen the window past 1280px (`xl`).** The right rail shows the connector card ("Do this in Claude or ChatGPT") *above* "Want better results?", sticky while scrolling.
3. Confirm the inline connector banner no longer appears in the conversation at this width.
4. Narrow below 1280px: the rail disappears and the inline banner appears in the conversation. Confirm both are never visible at once.
5. Dismiss the inline banner, then widen again — the rail card must still be there (the two dismissals are independent).
6. Both buttons open `/connect/claude` and `/connect/chatgpt` in a new tab.

**Landing floating card**

1. Load `/nonprofits/find-funders`. The card is bottom-right immediately, no scrolling needed.
2. Scroll to section "05 — ADD THE AGENT" — the card hides.
3. Scroll back up — the card returns (it must not stay hidden).
4. Dismiss with `×`, reload the page — it stays hidden for the session; open a new tab and it returns.
5. Resize under 640px — it becomes a full-width bar with side margins, not a cramped corner card.

**Automated**

```bash
cd gap-app-v2 && pnpm vitest run src/features/non-profits/__tests__/
```

240 passing, including 8 new across `connect-cta.test.tsx` and `search-rail.test.tsx` (rail ordering, rail-vs-inline dismissal independence, floating card visible-on-load, hide-at-section, return-after-section, session dismissal, observer cleanup).

## Screenshots

_To add — this is a visual change and screenshots should be attached before merge._

## Checklist

- [x] Tests added/updated (8 new; 240 pass in the feature suite)
- [x] Biome lint/format clean
- [x] No `any` casts, no hardcoded URLs (uses `NON_PROFITS_PAGES`), no hardcoded colors (uses `lp-*` tokens)
- [x] List-rendered components memoized where applicable; constants at module level
- [x] Dark mode handled on every new surface
- [ ] Screenshots attached


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added connection prompts for Claude and ChatGPT across nonprofit search pages, including secure links that open in new tabs.
  - Introduced a desktop right-rail panel with connection options and a deep research promotion.
  - Added a dismissible floating connection card with session-based persistence, plus updated hero connection branding.

- **Bug Fixes**
  - Fixed the inline connection prompt so it also appears for zero-result searches.
  - Prevented duplicate/undesired prompt visibility across screen sizes and scrolling states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->