### PR TITLE
perf(build): cut Sentry build-time work to reduce build memory

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -253,11 +253,21 @@ const withSentry = withSentryConfig(
     project: "gap-frontend",
     tunnelRoute: "/monitoring",
     reactComponentAnnotation: true,
-    debug: true,
+    // `silent: true` above already suppresses plugin logging; `debug: true`
+    // contradicted it and re-enabled verbose sourcemap diagnostics on every
+    // build for output nobody reads.
+    debug: false,
   },
   {
-    // Upload a larger set of source maps for prettier stack traces (increases build time)
-    widenClientFileUpload: true,
+    // Sentry's "widen" mode uploads source maps for a larger set of client
+    // files than the ones actually referenced by the emitted bundles — its
+    // own docs note this increases build time, and it grows the sourcemap
+    // set held/processed during the build. The Next 16 Turbopack build is
+    // already at the edge of the 8 GB build container, so the marginally
+    // prettier frames are not worth the headroom. Sourcemaps for the real
+    // bundles are still generated and uploaded, so stack traces stay
+    // symbolicated.
+    widenClientFileUpload: false,
 
     // Remove transpileClientSDK as it's deprecated in Next.js 15
     // transpileClientSDK: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -292,4 +292,26 @@ const withSentry = withSentryConfig(
   }
 );
 
-export default withSentry;
+// The Sentry SDK is switched OFF at runtime on every non-production
+// deployment — sentry.server.config.ts, sentry.edge.config.ts and
+// instrumentation-client.ts all set `enabled: NEXT_PUBLIC_VERCEL_ENV ===
+// "production"`. Preview builds were still paying the full build-time cost
+// of the Sentry plugin (source map generation/processing/upload plus
+// reactComponentAnnotation, an SWC transform applied to every component in
+// the tree) to produce artifacts for an SDK that never initializes on those
+// deployments.
+//
+// That work happens inside the Turbopack compile phase, which is exactly
+// where the 8 GB preview build container is OOM-killed (exit 137), so
+// skipping it on previews removes pure waste rather than trading anything
+// away.
+//
+// Deliberately fail-safe: only an explicit "preview" opts out. If the
+// variable is missing or holds anything else — including a production build
+// or a local build — Sentry stays fully enabled, so production
+// instrumentation can never be dropped by accident.
+const isPreviewBuild =
+  process.env.VERCEL_ENV === "preview" ||
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
+
+export default isPreviewBuild ? bundleAnalyzer : withSentry;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --turbopack",
     "dev:wl": "next dev --turbopack --experimental-https --experimental-https-key ./test-wl.local+2-key.pem --experimental-https-cert ./test-wl.local+2.pem",
     "build": "npm run build:widget && next build",
+    "build:debug-memory": "next build --experimental-debug-memory-usage",
     "build:widget": "vite build --config widget/vite.config.ts",
     "start": "next start",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary

Stop preview builds paying for Sentry work they can never use, and trim two Sentry knobs that cost build memory/time for little value.

## Problem

The Next.js 16 **Turbopack** production build is OOM-killed (`exit 137`) on Vercel's **8 GB** preview build container, ~2.5 min into "Creating an optimized production build". Vercel's build-system report confirms container RAM exhaustion (SIGKILL), not a V8 heap error.

The key observation: **the Sentry SDK is already switched off at runtime on every non-production deployment.** `sentry.server.config.ts`, `sentry.edge.config.ts` and `instrumentation-client.ts` all set:

```ts
enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
```

Yet preview builds still paid the **full build-time** cost of the Sentry plugin — source map generation, processing and upload, plus `reactComponentAnnotation` (an SWC transform applied to *every component in the tree*) — producing artifacts for an SDK that never initializes on those deployments. That work runs inside the exact compile phase that OOMs.

Investigation notes, so the wrong levers don't get pulled later:

- Not a static-generation problem: the app has **zero `generateStaticParams`** and generates sitemaps at request time, so the `experimental.staticGeneration*` knobs don't apply.
- `--max-old-space-size` is not the lever: Turbopack is a native Rust NAPI addon allocating outside the V8 heap, so raising the JS heap cap doesn't bound the dominant allocation.
- The upstream fix is Turbopack memory eviction in **Next.js 16.3**, currently **canary/preview only** (`latest` is 16.2.11). Worth revisiting when stable.

## Solution

- **Skip the Sentry build plugin on preview builds.** The gate is deliberately **fail-safe**: only an explicit `"preview"` opts out. A missing or unrecognized value — including production and local builds — keeps Sentry fully enabled, so production instrumentation cannot be dropped by accident.
- **`widenClientFileUpload: false`** — "widen" mode processes/uploads source maps for a larger set of client files than the emitted bundles reference; Sentry's own docs (and the replaced comment, *"increases build time"*) acknowledge the cost. Source maps for the real bundles are still generated and uploaded, so **production stack traces stay symbolicated**.
- **`debug: false`** — `silent: true` is set directly above it, so `debug: true` contradicted it and re-enabled verbose sourcemap diagnostics on every build.
- **`build:debug-memory` script** wrapping `next build --experimental-debug-memory-usage`, so future build-memory work is measured rather than guessed at.

## Testing steps

1. CI green.
2. **Production Sentry is the one real risk** — after merge, trigger an error on production and confirm the Sentry issue still appears with a **symbolicated** stack trace.
3. Confirm preview deployments still function normally (Sentry is expected to be absent there — it was already disabled at runtime).
4. Optional: `pnpm build:debug-memory` for a baseline heap profile.

## Risk

- Low and trivially revertible; all changes are build-plugin configuration.
- Production behavior is unchanged by design — the preview gate cannot trigger for a production build, and the fallback direction is "keep Sentry".
- Tradeoff: slightly less complete source map coverage for some third-party/edge frames. Core application traces remain symbolicated.
- Preview deployments no longer carry Sentry build artifacts, which is a no-op given the SDK was already disabled there at runtime.

Preview pipeline changes are tracked separately in #1924.