### PR TITLE
test(e2e): mock the program reviewers endpoint in smoke runs

### DIFF
--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -52,6 +52,14 @@ function defaultHandlers(): Record<string, RouteHandler> {
     // My reviewer programs
     "**/v2/funding-program-configs/my-reviewer-programs**": (route) => jsonResponse(route, []),
 
+    // Program reviewers. Left unmocked this reaches the live indexer for a
+    // program id that only exists in these fixtures, and SetupWizard blocks on
+    // it (`useProgramSetupProgress` = config + reviewers), so the setup page
+    // renders nothing but its spinner until the request resolves — T-MGMT-04
+    // then passes or fails on staging latency alone.
+    "**/v2/funding-program-configs/*/reviewers**": (route) =>
+      jsonResponse(route, { reviewers: [] }),
+
     // KYC config - default disabled
     "**/v2/communities/*/kyc-config**": (route) => jsonResponse(route, { enabled: false }),
 


### PR DESCRIPTION
## Problem

`smoke` → `T-MGMT-04: program setup page loads` has been failing on `main` and on unrelated PR branches (e.g. run [30285365031](https://github.com/show-karma/gap-app-v2/actions/runs/30285365031) on `perf/reduce-build-memory`, and every recent run on #1928). It failed all 3 retries, so it is not ordinary flake.

The failure is **not** the `assertNoJsErrors` line it appears to be near — the trace contains zero `pageerror` events. It is the assertion one line earlier, `manage-pages.smoke.spec.ts:147`:

```
Error: expect(received).toBeTruthy()   // wasRedirected || hasText || hasSetup
  preceded by:
TimeoutError: locator.waitFor: getByText('Manage Test Program')      (spec:136)
TimeoutError: locator.waitFor: getByText(/setup|configuration/i)     (spec:142)
```

## Root cause

`manageMocks()` mocks the program config (`/v2/funding-program-configs/program-manage-001`) but nothing mocks `GET /v2/funding-program-configs/:id/reviewers`, and `defaultHandlers()` has no pattern for it either. That request therefore escapes the fixture layer and hits the real staging indexer, asking for a program id that only exists in these fixtures.

`SetupWizard` blocks on it:

- `hooks/useProgramSetupProgress.ts` → `isLoading = isLoadingConfig || isLoadingReviewers`
- `components/FundingPlatform/SetupWizard/SetupWizard.tsx:56-61` → renders only a spinner while `progress.isLoading`

The trace confirms it: the request is recorded with status `-1` (still pending when the context closed) and the DOM contains nothing but `<div class="flex items-center justify-center min-h-[400px]"><spinner/></div>`. Neither "Manage Test Program" nor `/setup|configuration/` ever renders.

**Why it ever passed:** when that unmocked request fails *fast*, the wizard reaches its error branch and prints "Failed to load program **setup** data" — which incidentally matches `/setup|configuration/i`. So a green result meant "staging answered quickly", not "the setup page works". The check was decided by live latency either way.

## Fix

Mock the endpoint in `defaultHandlers()` with the shape `programReviewersService.getReviewers` expects (`{ reviewers: [...] }`, see `services/program-reviewers.service.ts:99-104`):

```ts
"**/v2/funding-program-configs/*/reviewers**": (route) => jsonResponse(route, { reviewers: [] }),
```

The wizard now resolves and the assertion tests what it claims to. Deliberately not loosening the assertion — the point is for it to mean something.

## Verification

I could not run this suite locally: it needs `QA_TEST_EMAIL` / `QA_TEST_OTP`, which are repo secrets. **The `smoke` check on this PR is the verification** — the job takes `e2e/**` from the PR checkout, so this run exercises the new mock against staging.

## Note for reviewers

`.github/workflows/smoke-tests.yml:70` pins `BASE_URL` to `https://staging.karmahq.xyz`, so `smoke` only ever tests deployed staging — a PR's own frontend changes are never exercised by it. Worth deciding separately whether it should keep reporting as a per-PR check, since a red mark there says nothing about the PR it is attached to.
