### PR TITLE
fix(sitemap): add hourly ISR backstop to the static sitemap

### DIFF
--- a/__tests__/app/sitemaps/static/sitemap.test.ts
+++ b/__tests__/app/sitemaps/static/sitemap.test.ts
@@ -108,6 +108,15 @@ describe("app/sitemaps/static/sitemap.ts", () => {
     expect(urls).toHaveLength(new Set(urls).size); // no duplicates injected
   });
 
+  it("revalidates hourly as a backstop for missed blog webhooks", async () => {
+    // Without this export the route is fully static and only picks up new
+    // posts on deploy — a missed/unconfigured webhook, a scheduled post
+    // crossing its publish date, or a Sanity blip that cached an empty post
+    // list would all silently keep posts out of the sitemap.
+    const sitemapModule = await import("@/app/sitemaps/static/sitemap");
+    expect(sitemapModule.revalidate).toBe(3600);
+  });
+
   it("falls back to just the static pages when the gateway errors", async () => {
     getPublishedSlugsMock.mockRejectedValue(new Error("Sanity unavailable"));
 

--- a/app/sitemaps/static/sitemap.ts
+++ b/app/sitemaps/static/sitemap.ts
@@ -56,6 +56,22 @@ const staticPages = [
 
 const lowPriorityPages = ["/privacy-policy", "/terms-and-conditions"];
 
+// Self-healing ISR, mirroring the `revalidate = 60` ceiling on /blog and
+// /blog/[slug]. The Sanity webhook (app/api/blog/revalidate) stays the fast
+// path; without a ceiling here this route is fully static and only rebuilds on
+// deploy, so three failure modes leave published posts out of the sitemap with
+// no visible symptom:
+//   1. Webhook never fires — unset SANITY_WEBHOOK_SECRET (route 401s) or no
+//      webhook configured in Sanity. Post pages self-heal in 60s; this doesn't.
+//   2. Scheduled posts — the slug query filters `publishedAt <= now()`, so a
+//      future-dated post fires the webhook while still excluded and nothing
+//      fires again once its date arrives.
+//   3. Sanity blip — getPublishedSlugs resolves to `[]` on error, so a
+//      revalidation during an outage caches a post-less sitemap indefinitely.
+// An hour is well inside search engines' recrawl cadence and costs one extra
+// CMS query per hour.
+export const revalidate = 3600;
+
 // `lastModified` is intentionally omitted for the static pages below — we
 // have no accurate per-page modified date, and a fabricated "now" makes
 // Google distrust the signal (see utilities/sitemap.ts buildUrlsetXml).


### PR DESCRIPTION
## Overview

Adds `export const revalidate = 3600` to `app/sitemaps/static/sitemap.ts` so published Sanity posts can't silently stay out of the sitemap. The Sanity webhook remains the fast path; this is a self-healing backstop.

## Problem

`app/sitemaps/static/sitemap.ts` is async and appends published Sanity posts (`getPublishedSlugs()`) to `/sitemaps/static/sitemap.xml`, which is a child of the sitemap index that `robots.txt` advertises. But unlike `app/blog/page.tsx` and `app/blog/[slug]/page.tsx` — both `export const revalidate = 60` — the sitemap route exports **no** `revalidate`, so it is fully static and only rebuilds on deploy.

**Prod evidence:**

```
$ curl -sI https://www.karmahq.xyz/sitemaps/static/sitemap.xml
x-vercel-cache: HIT
age: 229581        # ~2.7 days — i.e. the last deploy
```

Its only non-deploy refresh path is the Sanity webhook: `app/api/blog/revalidate/route.ts` → `mapPayloadToPaths` (`src/domain/blog/revalidate.ts`) → `revalidatePath('/sitemaps/static/sitemap.xml')`. The `warm-sitemaps` cron (every 6h) only warms the CDN/Data Cache — it does not rebuild a fully-static route, so it does not pick up new posts.

## Three failure modes this closes

1. **Webhook never fires.** If `SANITY_WEBHOOK_SECRET` is unset in Vercel prod the route returns `401 Webhook not configured`; same outcome if the webhook was never configured in Sanity. Post pages self-heal within 60s, so `/blog/my-post` works and looks fine — but the sitemap never updates until a redeploy. No visible symptom.
2. **Scheduled posts.** `SLUGS_QUERY` filters `publishedAt <= now()`. A future-dated post fires the webhook at publish time *while still excluded from the query*, and nothing fires again when the date actually arrives. The post goes live and stays out of the sitemap indefinitely.
3. **Sanity blip.** `getPublishedSlugs` returns `[]` on any Sanity error (Sentry-captured). A revalidation that lands during a blip regenerates the sitemap with every post dropped, and that empty result stays cached until the next revalidation — which, without this change, means until the next deploy.

## Solution

One hour ceiling, mirroring the `revalidate = 60` already on `/blog` and `/blog/[slug]`. Cost is one extra CMS query per hour; an hour is well inside search engines' recrawl cadence. Failure mode 3 in particular goes from "cached until redeploy" to "at most an hour."

## Testing

Extended the existing suite (`__tests__/app/sitemaps/static/sitemap.test.ts`) rather than rewriting it — it already covers post entries, the `/blog` index, drafts, and the gateway-error fallback. New case asserts the `revalidate` export exists and is an hour.

```
pnpm test __tests__/app/sitemaps/static/sitemap.test.ts
✓ 10 passed (10)
```

`pnpm lint:fix` clean on the touched files. (It also reformats three unrelated files that carry pre-existing formatting debt on `main` — those were reverted and are not part of this PR.)

## Follow-up

**No blog post has ever been published** — live `/blog` renders "No posts", so the webhook path has never been exercised end-to-end. On the first real publish, verify that (a) the webhook actually fires and returns 200 (i.e. `SANITY_WEBHOOK_SECRET` is set in Vercel prod and the webhook is configured in Sanity), and (b) the post appears in `/sitemaps/static/sitemap.xml`. This PR makes the sitemap correct within an hour either way, but the fast path should still be confirmed working rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sitemap freshness with hourly automatic revalidation.
  * Helps ensure newly published blog posts appear in the sitemap even when update notifications are missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->