### PR TITLE
test(e2e): fix T-DON-04 smoke failure from staging hydration latency

### DIFF
--- a/e2e/tests/smoke/donation-pages.smoke.spec.ts
+++ b/e2e/tests/smoke/donation-pages.smoke.spec.ts
@@ -12,6 +12,12 @@ import { GOTO_OPTIONS, waitForPageReady } from "../../helpers/navigation";
 // measured at ~5.5 s from `goto`, which overruns Playwright's 5 s default
 // `expect` timeout. Matches the allowance T-DON-05 already uses for the same
 // page's post-hydration redirect.
+//
+// Only the *first* assertion after a navigation needs this — it absorbs the
+// hydration wait, and anything rendered in the same commit is already in the
+// DOM by the time it resolves. Follow-up assertions keep the 5 s default so a
+// copy regression still fails fast, and so a hung page can't chain 20 s waits
+// past Playwright's 30 s per-test budget and mask the real assertion error.
 const HYDRATED_QUERY_TIMEOUT = 20000;
 
 test.describe("Smoke Tests — Donation Pages", () => {
@@ -133,9 +139,7 @@ test.describe("Smoke Tests — Donation Pages", () => {
       await expect(page.getByRole("heading", { name: /no programs available/i })).toBeVisible({
         timeout: HYDRATED_QUERY_TIMEOUT,
       });
-      await expect(page.getByText(/no programs available for donations/i)).toBeVisible({
-        timeout: HYDRATED_QUERY_TIMEOUT,
-      });
+      await expect(page.getByText(/no programs available for donations/i)).toBeVisible();
     });
 
     test("T-DON-05: donation page auto-redirects when only one program exists", async ({

--- a/e2e/tests/smoke/donation-pages.smoke.spec.ts
+++ b/e2e/tests/smoke/donation-pages.smoke.spec.ts
@@ -4,6 +4,16 @@ import { expect, mockJson, test } from "../../fixtures";
 import { assertNoJsErrors, collectJsErrors } from "../../helpers/assertions";
 import { GOTO_OPTIONS, waitForPageReady } from "../../helpers/navigation";
 
+// The donate page is a client component: `waitForPageReady` only waits for
+// `domcontentloaded` + a visible body, so it returns long before React has
+// hydrated and fired the `useCommunityPrograms` / community-details queries.
+// Until those resolve the page renders its "Loading programs..." spinner, so
+// any assertion on post-fetch UI is really a race against staging hydration —
+// measured at ~5.5 s from `goto`, which overruns Playwright's 5 s default
+// `expect` timeout. Matches the allowance T-DON-05 already uses for the same
+// page's post-hydration redirect.
+const HYDRATED_QUERY_TIMEOUT = 20000;
+
 test.describe("Smoke Tests — Donation Pages", () => {
   const community = MOCK_COMMUNITIES.optimism;
   const programA = createMockProgram({
@@ -120,8 +130,12 @@ test.describe("Smoke Tests — Donation Pages", () => {
       await page.goto("/community/optimism/donate", GOTO_OPTIONS);
       await waitForPageReady(page);
 
-      await expect(page.getByRole("heading", { name: /no programs available/i })).toBeVisible();
-      await expect(page.getByText(/no programs available for donations/i)).toBeVisible();
+      await expect(page.getByRole("heading", { name: /no programs available/i })).toBeVisible({
+        timeout: HYDRATED_QUERY_TIMEOUT,
+      });
+      await expect(page.getByText(/no programs available for donations/i)).toBeVisible({
+        timeout: HYDRATED_QUERY_TIMEOUT,
+      });
     });
 
     test("T-DON-05: donation page auto-redirects when only one program exists", async ({


### PR DESCRIPTION
## Problem

`T-DON-04: donation page shows empty state when no programs exist` fails on `main`.

```
Locator: getByRole('heading', { name: /no programs available/i })
Expected: visible
Timeout: 5000ms
Error: element(s) not found
```

This is **not** branch-specific — the smoke suite dispatched against `main` with no changes reproduces it: [run 30292054757](https://github.com/show-karma/gap-app-v2/actions/runs/30292054757).

## Root cause

Not a missing mock and not a copy change. The mocks match and the page renders the right thing — the assertion just runs out of time.

`/community/[communityId]/donate` is a client component. `waitForPageReady` only waits for `domcontentloaded` + a visible `body`, which is satisfied long before React hydrates and fires `useCommunityPrograms` and the community-details query. Until both resolve, the page is gated on `programsLoading || communityLoading` and renders its `Loading programs...` spinner. So every assertion on post-fetch UI in this test is really a race against staging hydration, run on Playwright's **5 s default** `expect` timeout.

Timeline reconstructed from the failing run's trace (`test.trace` + `0-trace.network`, retry 1):

| t (ms) | event |
|---|---|
| 58652 | `page.goto("/community/optimism/donate")` |
| 59216 | navigation resolved (`domcontentloaded`) |
| 59884 | `expect(...).toBeVisible()` starts — deadline **64884** |
| 64154 | client `GET /v2/communities/optimism/programs` finally fires |
| 64175 | route fulfilled by the test's own mock with `[]` |
| 64232 | `/v2/communities/optimism` fulfilled |
| ~64.4–64.9 s | screencast frames flip from `Loading programs...` to the empty state |
| 64884 | expect deadline expires |

The mocked request landed **4.3 s into a 5 s budget**, and the empty state painted right as it expired. The DOM snapshot captured at failure already contains `<h2>No Programs Available</h2>` inside `<main>` with no `aria-hidden` ancestor, and the failure screenshot shows the empty state fully rendered — the page was correct, the assertion was just too early.

Confirmation that the glob was never the issue: the network trace shows `https://gapstagapi.karmahq.xyz/v2/communities/optimism/programs` intercepted and fulfilled with `[]` by the test's `**/communities/optimism/programs**` override. Nothing escaped to the live indexer.

## Fix

Give both assertions an explicit post-hydration timeout, and name it so the reason survives:

```ts
const HYDRATED_QUERY_TIMEOUT = 20000;
```

20 s is the allowance sibling **T-DON-05** already uses for the same page's post-hydration redirect. T-DON-04 was the only test in this file still relying on the 5 s default; every other test in the suite passes an explicit 8–10 s (or 20 s) wait for exactly this reason.

## Verification

Reproduced and fixed locally against staging before pushing:

- **Without** the change: `1 failed` — same `element(s) not found` at line 123.
- **With** the change: `1 passed (24.5s)`.

Then dispatched the smoke suite against this branch:

- ✅ **[run 30295313045](https://github.com/show-karma/gap-app-v2/actions/runs/30295313045)** — `85 passed (2.3m)`, at commit `6221876`.
- ❌ [run 30292054757](https://github.com/show-karma/gap-app-v2/actions/runs/30292054757) — same suite on `main`, T-DON-04 fails.

> **Note on what the green run proves.** `.github/workflows/smoke-tests.yml` pins `BASE_URL: https://staging.karmahq.xyz`, so only `e2e/**` comes from this checkout — the app under test is deployed staging, not this PR. The green run therefore validates **the test-side fix**, not any application behaviour. That is the correct scope here: the app was already rendering the empty state correctly.

## Scope

One file, test-only. No application code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved donation-page smoke test reliability by allowing additional time for client-side content to load.
  * Updated “no programs available” checks to wait for hydrated page results before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->