### PR TITLE
feat(donor-research): drop share-link expiry label

### DIFF
--- a/src/features/donor-research/components/report-brief/Masthead.tsx
+++ b/src/features/donor-research/components/report-brief/Masthead.tsx
@@ -73,7 +73,6 @@ export function Masthead({
             hasShareToken={report.hasShareToken}
             reportId={report.id}
             shareToken={report.shareToken}
-            shareTokenExpiresAt={report.shareTokenExpiresAt}
           />
         </div>
       ) : null}

--- a/src/features/donor-research/components/report-viewer/ShareTokenControls.tsx
+++ b/src/features/donor-research/components/report-viewer/ShareTokenControls.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Share2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import toast from "react-hot-toast";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import {
@@ -19,7 +19,6 @@ interface ShareTokenControlsProps {
   reportId: string;
   hasShareToken: boolean;
   shareToken: string | null;
-  shareTokenExpiresAt: string | null;
 }
 
 const DEFAULT_TTL_DAYS = 30;
@@ -43,7 +42,6 @@ export function ShareTokenControls({
   reportId,
   hasShareToken,
   shareToken,
-  shareTokenExpiresAt,
 }: ShareTokenControlsProps) {
   const [, copyFn] = useCopyToClipboard();
   const copy = async (text: string) => {
@@ -62,14 +60,6 @@ export function ShareTokenControls({
   const [regenerateOpen, setRegenerateOpen] = useState(false);
 
   const effectiveToken = generatedToken ?? shareToken;
-  // Locale/timezone formatting must run after mount: `toLocaleString()` renders
-  // with the server's locale during SSR and the browser's on hydration, so
-  // formatting it in render would produce a hydration mismatch. Compute the
-  // label in an effect and render nothing until it resolves client-side.
-  const [expiresLabel, setExpiresLabel] = useState<string | null>(null);
-  useEffect(() => {
-    setExpiresLabel(shareTokenExpiresAt ? new Date(shareTokenExpiresAt).toLocaleString() : null);
-  }, [shareTokenExpiresAt]);
 
   const rotateShareToken = async () => {
     const result = await generate.mutateAsync({
@@ -161,7 +151,6 @@ export function ShareTokenControls({
           Revoke
         </button>
       </div>
-      {expiresLabel ? <p className="text-xs text-sf-muted">Link expires {expiresLabel}</p> : null}
 
       <DeleteDialog
         title={

--- a/src/features/donor-research/components/report-viewer/__tests__/ShareTokenControls.test.tsx
+++ b/src/features/donor-research/components/report-viewer/__tests__/ShareTokenControls.test.tsx
@@ -33,14 +33,7 @@ describe("ShareTokenControls", () => {
   });
 
   it("enables Copy share link when an existing shareToken prop is present (no prior generate)", async () => {
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken
-        shareToken="existing-token"
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken shareToken="existing-token" />);
 
     const copyButton = screen.getByRole("button", { name: "Copy share link" });
     expect(copyButton).not.toBeDisabled();
@@ -56,27 +49,13 @@ describe("ShareTokenControls", () => {
   });
 
   it("disables Copy share link when there is no token at all", () => {
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken
-        shareToken={null}
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken shareToken={null} />);
 
     expect(screen.getByRole("button", { name: "Copy share link" })).toBeDisabled();
   });
 
   it("opens a confirmation dialog on Regenerate instead of rotating immediately", () => {
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken
-        shareToken="existing-token"
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken shareToken="existing-token" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
 
@@ -86,14 +65,7 @@ describe("ShareTokenControls", () => {
   });
 
   it("rotates the token only after confirming the Regenerate dialog", () => {
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken
-        shareToken="existing-token"
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken shareToken="existing-token" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
@@ -107,14 +79,7 @@ describe("ShareTokenControls", () => {
   it("keeps the confirm dialog open when Regenerate fails, instead of presenting failure as success", async () => {
     mockGenerateMutateAsync.mockRejectedValueOnce(new Error("Rotate failed"));
 
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken
-        shareToken="existing-token"
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken shareToken="existing-token" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
@@ -128,14 +93,7 @@ describe("ShareTokenControls", () => {
   it("shows a toast instead of failing silently when 'Share with donor' fails", async () => {
     mockGenerateMutateAsync.mockRejectedValueOnce(new Error("Network down"));
 
-    render(
-      <ShareTokenControls
-        reportId="report-1"
-        hasShareToken={false}
-        shareToken={null}
-        shareTokenExpiresAt={null}
-      />
-    );
+    render(<ShareTokenControls reportId="report-1" hasShareToken={false} shareToken={null} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Share with donor" }));
 


### PR DESCRIPTION
## Overview

Removes the "Link expires {date}" label from the donor-research share controls.

## Problem

The indexer no longer enforces the share-link TTL (see the companion gap-indexer PR on this branch name), so the expiry date shown under the share buttons would tell advisors their link stops working on a date when it actually keeps working.

## Solution

- Dropped the expiry label, its SSR-safe formatting effect, and the `shareTokenExpiresAt` prop from `ShareTokenControls`.
- Updated the `Masthead` callsite and the component tests accordingly.

Generation still sends `ttlSeconds` so the backend keeps stamping `share_token_expires_at`; only the display is removed, which keeps re-enabling expiry later a backend-only change.

## Testing Steps

1. `pnpm vitest run src/features/donor-research/components/report-viewer/__tests__/ShareTokenControls.test.tsx` — 6 tests pass.
2. Open a completed research report as an advisor with an active share link — Copy/Regenerate/Revoke render with no expiry line beneath.

## Related

Backend counterpart: show-karma/gap-indexer PR with the same branch name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the share-link expiration message from report sharing controls.
  * Simplified share-link management while preserving copy, regenerate, confirmation, and error-handling behaviors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->