### PR TITLE
fix(home): lead the hero marquee with Regen Coordination

### DIFF
--- a/__tests__/utilities/homepageLogos.test.ts
+++ b/__tests__/utilities/homepageLogos.test.ts
@@ -6,8 +6,9 @@ describe("homepageMarqueeLogos", () => {
   const logos = homepageMarqueeLogos();
   const titles = logos.map((logo) => logo.text);
 
-  it("opens with UNICEF, the two partners, then Filecoin", () => {
-    expect(titles.slice(0, 4)).toEqual([
+  it("leads with Regen Coordination so UNICEF is still on screen after load", () => {
+    expect(titles.slice(0, 5)).toEqual([
+      "Regen Coordination",
       "UNICEF",
       "San Francisco Foundation",
       "Trinity Center",

--- a/utilities/homepageLogos.ts
+++ b/utilities/homepageLogos.ts
@@ -44,8 +44,13 @@ type MarqueeLeadEntry = { communitySlug: string } | MarqueeLogo;
  * The opening run of the carousel, in order. Everything not named here follows
  * in `chosenCommunities` order, so the first faces a visitor sees are the ones
  * we chose rather than whichever community happens to sit at the top of the list.
+ *
+ * The marquee starts scrolling on mount, so whatever sits first has already
+ * drifted off-screen by the time the page has settled. Regen Coordination leads
+ * as that buffer, which keeps UNICEF in view during the first read.
  */
 const MARQUEE_LEAD: MarqueeLeadEntry[] = [
+  { communitySlug: "regen-coordination" },
   { communitySlug: "unicef" },
   PARTNER_LOGOS.sanFranciscoFoundation,
   PARTNER_LOGOS.trinityCenter,


### PR DESCRIPTION
## Overview

Reorders the homepage hero logo marquee so **Regen Coordination** leads and **UNICEF** sits second.

## Problem

`InfiniteMovingCards` kicks off its scroll animation the moment it mounts. Whatever logo sits first in the list has already drifted off the left edge by the time the hero has settled and a visitor actually starts reading the trust strip.

UNICEF was that first pill — so our most recognisable partner was consistently the one nobody saw.

## Solution

Prepend `regen-coordination` to `MARQUEE_LEAD` in `utilities/homepageLogos.ts`. It absorbs the initial drift, and UNICEF is still fully on screen during the first read.

New opening order: `Regen Coordination → UNICEF → San Francisco Foundation → Trinity Center → Filecoin`.

Regen Coordination was already in the marquee (it just rode further back in the `chosenCommunities` tail), so this is a reorder, not an addition — the `leadSlugs` dedupe keeps it appearing exactly once.

## Testing steps

1. `pnpm test __tests__/utilities/homepageLogos.test.ts` — the ordering assertion now covers the first five pills.
2. Load `/` and watch the trust strip next to **30+ FUNDING PROGRAMS RUNNING ON KARMA**. UNICEF should be visible when the hero finishes animating in, rather than already half-gone.

## Notes

No component or animation changes — data ordering only.