### PR TITLE
feat(donor-research): super-admin parity with the report owner on the report view

### DIFF
--- a/__tests__/features/donor-research/DonorResearchShell.test.tsx
+++ b/__tests__/features/donor-research/DonorResearchShell.test.tsx
@@ -162,4 +162,63 @@ describe("DonorResearchShell", () => {
     );
     expect(within(breadcrumb).getByText("No. FB95F6")).toHaveAttribute("aria-current", "page");
   });
+
+  describe("super-admin without an advisor profile", () => {
+    function mockNoAdvisorRow() {
+      mockUseDonorAdvisor.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+      } as unknown as ReturnType<typeof useDonorAdvisor>);
+    }
+
+    it("gets the same sidebar and breadcrumbs as the report owner on a report route", () => {
+      mockNoAdvisorRow();
+
+      renderWithProviders(
+        <DonorResearchShell>
+          <div>Report content</div>
+        </DonorResearchShell>
+      );
+
+      expect(document.querySelector('[data-sidebar="sidebar"]')).toBeInTheDocument();
+      expect(
+        screen.getByRole("navigation", { name: "Nonprofit research sections" })
+      ).toBeInTheDocument();
+      expect(screen.getByRole("navigation", { name: "breadcrumb" })).toBeInTheDocument();
+      expect(screen.getByText("Report content")).toBeInTheDocument();
+    });
+
+    it("omits the advisor-owned usage counter rather than shimmering a skeleton forever", () => {
+      mockNoAdvisorRow();
+
+      renderWithProviders(
+        <DonorResearchShell>
+          <div>Report content</div>
+        </DonorResearchShell>
+      );
+
+      // Only the collapsed-rail menu item remains; the advisor-scoped
+      // RateLimitCounter (mocked to the same label) is not mounted, and no
+      // loading skeleton is left in its place.
+      expect(screen.getAllByText("Usage limits")).toHaveLength(1);
+      expect(document.querySelector(".rounded-sf-tile")).not.toBeInTheDocument();
+    });
+
+    it("still redirects to onboarding away from report routes", () => {
+      mockNoAdvisorRow();
+      const replace = vi.fn();
+      mockUseRouter.mockReturnValue({ replace } as unknown as ReturnType<typeof useRouter>);
+      mockUsePathname.mockReturnValue(PAGES.DONOR_RESEARCH.INDEX);
+
+      renderWithProviders(
+        <DonorResearchShell>
+          <div>Reports list</div>
+        </DonorResearchShell>
+      );
+
+      expect(replace).toHaveBeenCalledWith(PAGES.DONOR_RESEARCH.ONBOARDING);
+    });
+  });
 });

--- a/__tests__/hooks/useSaveDiligenceTemplate.cache.test.tsx
+++ b/__tests__/hooks/useSaveDiligenceTemplate.cache.test.tsx
@@ -115,4 +115,23 @@ describe("useSaveDiligenceTemplate cache invalidation", () => {
 
     expect(isInvalidated(diligenceTemplateQueryKey)).toBe(false);
   });
+
+  it("touches no cached copy when the save fails", async () => {
+    mockSaveDiligenceTemplate.mockRejectedValue(new Error("save failed"));
+    seed(diligenceTemplateQueryKey);
+    seed(reportDiligenceTemplateQueryKey("report-1"));
+    seed(reportDiligenceTemplateQueryKey("report-2"));
+
+    const { result } = renderHook(() => useSaveDiligenceTemplate("report-1"), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // A rejected save must not seed the target key with questions the server
+    // never accepted, nor sweep siblings that are still accurate.
+    expect(queryClient.getQueryData(reportDiligenceTemplateQueryKey("report-1"))).toEqual(stale);
+    expect(queryClient.getQueryData(diligenceTemplateQueryKey)).toEqual(stale);
+    expect(isInvalidated(diligenceTemplateQueryKey)).toBe(false);
+    expect(isInvalidated(reportDiligenceTemplateQueryKey("report-2"))).toBe(false);
+  });
 });

--- a/__tests__/hooks/useSaveDiligenceTemplate.cache.test.tsx
+++ b/__tests__/hooks/useSaveDiligenceTemplate.cache.test.tsx
@@ -1,0 +1,118 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSaveDiligenceTemplate = vi.fn();
+
+vi.mock("@/services/diligence.service", () => ({
+  getDiligenceTemplate: vi.fn(),
+  saveDiligenceTemplate: (...args: unknown[]) => mockSaveDiligenceTemplate(...args),
+  getCandidateDiligence: vi.fn(),
+  getOutreachPreview: vi.fn(),
+  askQuestions: vi.fn(),
+  requestIntro: vi.fn(),
+  getDiligenceResponseContext: vi.fn(),
+  submitDiligenceResponse: vi.fn(),
+  updateAdvisorEmail: vi.fn(),
+}));
+
+import {
+  diligenceTemplateQueryKey,
+  reportDiligenceTemplateQueryKey,
+  useSaveDiligenceTemplate,
+} from "@/hooks/useDiligence";
+
+/**
+ * A single template row is cached under several keys — the caller's `/me` copy
+ * plus one per report resolving to the same owner. A save must never leave a
+ * sibling copy holding pre-save state: the empty-template guard reads it, so a
+ * stale copy would keep showing the first-run question editor for a template
+ * that already has questions.
+ */
+describe("useSaveDiligenceTemplate cache invalidation", () => {
+  const saved = { questions: [{ id: "q-1", text: "Budget?" }], updatedAt: null };
+  const stale = { questions: [], updatedAt: null };
+
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  /** `true` once React Query has marked the key for refetch. */
+  const isInvalidated = (key: readonly unknown[]) =>
+    queryClient.getQueryState(key)?.isInvalidated === true;
+
+  /** Seeds a key as a settled, non-stale cache entry. */
+  const seed = (key: readonly unknown[]) => {
+    queryClient.setQueryData(key, stale);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSaveDiligenceTemplate.mockResolvedValue(saved);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("seeds the report it saved and invalidates the caller's own copy", async () => {
+    seed(diligenceTemplateQueryKey);
+
+    const { result } = renderHook(() => useSaveDiligenceTemplate("report-1"), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData(reportDiligenceTemplateQueryKey("report-1"))).toEqual(saved);
+    expect(isInvalidated(diligenceTemplateQueryKey)).toBe(true);
+  });
+
+  it("invalidates other reports' copies, which may resolve to the same owner", async () => {
+    seed(reportDiligenceTemplateQueryKey("report-2"));
+
+    const { result } = renderHook(() => useSaveDiligenceTemplate("report-1"), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(isInvalidated(reportDiligenceTemplateQueryKey("report-2"))).toBe(true);
+  });
+
+  it("leaves the copy it just seeded fresh rather than refetching it", async () => {
+    const { result } = renderHook(() => useSaveDiligenceTemplate("report-1"), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(isInvalidated(reportDiligenceTemplateQueryKey("report-1"))).toBe(false);
+  });
+
+  it("invalidates report-scoped copies when the standalone editor saves", async () => {
+    seed(reportDiligenceTemplateQueryKey("report-1"));
+    seed(reportDiligenceTemplateQueryKey("report-2"));
+
+    const { result } = renderHook(() => useSaveDiligenceTemplate(), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData(diligenceTemplateQueryKey)).toEqual(saved);
+    expect(isInvalidated(reportDiligenceTemplateQueryKey("report-1"))).toBe(true);
+    expect(isInvalidated(reportDiligenceTemplateQueryKey("report-2"))).toBe(true);
+  });
+
+  it("leaves the standalone copy it just seeded fresh", async () => {
+    const { result } = renderHook(() => useSaveDiligenceTemplate(), { wrapper });
+    result.current.mutate({ questions: saved.questions });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(isInvalidated(diligenceTemplateQueryKey)).toBe(false);
+  });
+});

--- a/__tests__/services/diligence-template.service.test.ts
+++ b/__tests__/services/diligence-template.service.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApiGet = vi.fn();
+const mockApiPut = vi.fn();
+
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: vi.fn(),
+    put: (...args: unknown[]) => mockApiPut(...args),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    request: vi.fn(),
+    getPaginated: vi.fn(),
+  },
+}));
+
+import { getDiligenceTemplate, saveDiligenceTemplate } from "@/services/diligence.service";
+
+/**
+ * Wire contract for the diligence template. The in-report dialog must read and
+ * write the REPORT-scoped endpoint (which the backend resolves to the report's
+ * owner, so a super-admin acts on the owner's questions), while the standalone
+ * template editor keeps the caller-scoped `/me` endpoint.
+ */
+describe("diligence template service endpoints", () => {
+  const template = { questions: [{ id: "q-1", text: "Budget?" }], updatedAt: null };
+
+  beforeEach(() => {
+    mockApiGet.mockReset();
+    mockApiPut.mockReset();
+    mockApiGet.mockResolvedValue(template);
+    mockApiPut.mockResolvedValue(template);
+  });
+
+  it("reads the caller's own template when no report is given", async () => {
+    await getDiligenceTemplate();
+
+    expect(mockApiGet.mock.calls[0][0]).toBe("/v2/donor-research/me/diligence-template");
+  });
+
+  it("reads the report owner's template when a report is given", async () => {
+    await getDiligenceTemplate("report-1");
+
+    expect(mockApiGet.mock.calls[0][0]).toBe(
+      "/v2/donor-research/reports/report-1/diligence-template"
+    );
+  });
+
+  it("writes the caller's own template when no report is given", async () => {
+    await saveDiligenceTemplate({ questions: [{ id: "q-1", text: "Budget?" }] });
+
+    expect(mockApiPut.mock.calls[0][0]).toBe("/v2/donor-research/me/diligence-template");
+  });
+
+  it("writes the report owner's template when a report is given", async () => {
+    await saveDiligenceTemplate({ questions: [{ id: "q-1", text: "Budget?" }] }, "report-1");
+
+    const [url, body] = mockApiPut.mock.calls[0];
+    expect(url).toBe("/v2/donor-research/reports/report-1/diligence-template");
+    expect(body).toEqual({ questions: [{ id: "q-1", text: "Budget?" }] });
+  });
+});

--- a/hooks/useDiligence.ts
+++ b/hooks/useDiligence.ts
@@ -28,13 +28,20 @@ import type {
 export const diligenceTemplateQueryKey = ["donor-research", "diligence", "template"] as const;
 
 /**
- * Report-owner-scoped template (see {@link useDiligenceTemplate}). Deliberately
- * NOT nested under {@link diligenceTemplateQueryKey} — invalidating the `/me`
- * template must not clobber (or refetch) every report-scoped copy, since React
- * Query matches keys by prefix.
+ * Prefix shared by every report-scoped template entry. Deliberately NOT nested
+ * under {@link diligenceTemplateQueryKey} — React Query matches keys by prefix,
+ * so nesting would make any `/me` invalidation sweep every report-scoped copy
+ * as a side effect rather than a decision.
  */
+const REPORT_DILIGENCE_TEMPLATE_KEY_PREFIX = [
+  "donor-research",
+  "diligence",
+  "report-template",
+] as const;
+
+/** Report-owner-scoped template (see {@link useDiligenceTemplate}). */
 export const reportDiligenceTemplateQueryKey = (reportId: string) =>
-  ["donor-research", "diligence", "report-template", reportId] as const;
+  [...REPORT_DILIGENCE_TEMPLATE_KEY_PREFIX, reportId] as const;
 
 export const candidateDiligenceQueryKey = (reportId: string, candidateId: string) =>
   ["donor-research", "diligence", "candidate", reportId, candidateId] as const;
@@ -70,21 +77,31 @@ export function useDiligenceTemplate(reportId?: string) {
  * result so the editor reflects the server's canonical copy. `reportId`
  * selects the report owner's template — see {@link useDiligenceTemplate}.
  *
- * A report-scoped save also drops the caller's `/me` copy: when the caller IS
- * the owner the two are the same row, and a staff caller's own template is
- * untouched either way, so invalidating is always safe and never stale.
+ * One row can be cached under several keys — the caller's `/me` copy, plus one
+ * per report that resolves to the same owner — so a save seeds the key it
+ * wrote and drops every OTHER copy. Nothing here can tell which reports share
+ * an owner, and a stale copy is a correctness bug (the empty-template guard
+ * would keep showing the first-run editor for up to `staleTime`), so the sweep
+ * is deliberately wide: these are cheap single-row reads.
  */
 export function useSaveDiligenceTemplate(reportId?: string) {
   const queryClient = useQueryClient();
   return useMutation<DiligenceTemplate, Error, SaveDiligenceTemplateRequest>({
     mutationFn: (body) => saveDiligenceTemplate(body, reportId),
     onSuccess: (saved) => {
-      if (!reportId) {
-        queryClient.setQueryData(diligenceTemplateQueryKey, saved);
-        return;
+      queryClient.setQueryData(
+        reportId ? reportDiligenceTemplateQueryKey(reportId) : diligenceTemplateQueryKey,
+        saved
+      );
+      // Skipped when the `/me` key IS the one just seeded, so the fresh copy
+      // doesn't get immediately marked stale and refetched.
+      if (reportId) {
+        queryClient.invalidateQueries({ queryKey: diligenceTemplateQueryKey });
       }
-      queryClient.setQueryData(reportDiligenceTemplateQueryKey(reportId), saved);
-      queryClient.invalidateQueries({ queryKey: diligenceTemplateQueryKey });
+      queryClient.invalidateQueries({
+        queryKey: REPORT_DILIGENCE_TEMPLATE_KEY_PREFIX,
+        predicate: (query) => query.queryKey[3] !== reportId,
+      });
     },
   });
 }

--- a/hooks/useDiligence.ts
+++ b/hooks/useDiligence.ts
@@ -27,6 +27,15 @@ import type {
 
 export const diligenceTemplateQueryKey = ["donor-research", "diligence", "template"] as const;
 
+/**
+ * Report-owner-scoped template (see {@link useDiligenceTemplate}). Deliberately
+ * NOT nested under {@link diligenceTemplateQueryKey} — invalidating the `/me`
+ * template must not clobber (or refetch) every report-scoped copy, since React
+ * Query matches keys by prefix.
+ */
+export const reportDiligenceTemplateQueryKey = (reportId: string) =>
+  ["donor-research", "diligence", "report-template", reportId] as const;
+
 export const candidateDiligenceQueryKey = (reportId: string, candidateId: string) =>
   ["donor-research", "diligence", "candidate", reportId, candidateId] as const;
 
@@ -41,25 +50,41 @@ export const outreachPreviewQueryKey = (
 
 // -- Advisor: template -------------------------------------------------------
 
-/** Loads the advisor's diligence template. Always a stable shape (no 404). */
-export function useDiligenceTemplate() {
+/**
+ * Loads a diligence template. Always a stable shape (no 404).
+ *
+ * Pass `reportId` from inside a report to read the template of that report's
+ * OWNER — the one an outreach from this report will freeze. Omit it for the
+ * caller's own template (the standalone editor page).
+ */
+export function useDiligenceTemplate(reportId?: string) {
   return useQuery<DiligenceTemplate>({
-    queryKey: diligenceTemplateQueryKey,
-    queryFn: getDiligenceTemplate,
+    queryKey: reportId ? reportDiligenceTemplateQueryKey(reportId) : diligenceTemplateQueryKey,
+    queryFn: () => getDiligenceTemplate(reportId),
     staleTime: 60_000,
   });
 }
 
 /**
- * Wholesale-replaces the advisor's diligence template, seeding the cache with
- * the saved result so the editor reflects the server's canonical copy.
+ * Wholesale-replaces a diligence template, seeding the cache with the saved
+ * result so the editor reflects the server's canonical copy. `reportId`
+ * selects the report owner's template — see {@link useDiligenceTemplate}.
+ *
+ * A report-scoped save also drops the caller's `/me` copy: when the caller IS
+ * the owner the two are the same row, and a staff caller's own template is
+ * untouched either way, so invalidating is always safe and never stale.
  */
-export function useSaveDiligenceTemplate() {
+export function useSaveDiligenceTemplate(reportId?: string) {
   const queryClient = useQueryClient();
   return useMutation<DiligenceTemplate, Error, SaveDiligenceTemplateRequest>({
-    mutationFn: (body) => saveDiligenceTemplate(body),
+    mutationFn: (body) => saveDiligenceTemplate(body, reportId),
     onSuccess: (saved) => {
-      queryClient.setQueryData(diligenceTemplateQueryKey, saved);
+      if (!reportId) {
+        queryClient.setQueryData(diligenceTemplateQueryKey, saved);
+        return;
+      }
+      queryClient.setQueryData(reportDiligenceTemplateQueryKey(reportId), saved);
+      queryClient.invalidateQueries({ queryKey: diligenceTemplateQueryKey });
     },
   });
 }

--- a/services/diligence.service.ts
+++ b/services/diligence.service.ts
@@ -50,15 +50,19 @@ function httpErrorMessage(error: unknown): string {
 // -- Advisor: diligence template --------------------------------------------
 
 /**
- * Loads the advisor's diligence question template. Always returns a stable
- * shape — a brand-new advisor gets `{ questions: [], updatedAt: null }`, never
- * a 404.
+ * Loads a diligence question template. Always returns a stable shape — a
+ * brand-new advisor gets `{ questions: [], updatedAt: null }`, never a 404.
+ *
+ * With `reportId` the backend resolves the template of that report's OWNER, so
+ * the in-report dialog shows the questions the outreach will actually freeze
+ * (identical for the owner; the owner's for a staff member acting on their
+ * behalf). Without it, the caller's own template — the standalone editor page.
  */
-export const getDiligenceTemplate = async (): Promise<DiligenceTemplate> => {
+export const getDiligenceTemplate = async (reportId?: string): Promise<DiligenceTemplate> => {
   let data: DiligenceTemplate | null;
   try {
     // TODO(#1775): add zod schema
-    data = await api.get<DiligenceTemplate>(DILIGENCE_ENDPOINTS.TEMPLATE);
+    data = await api.get<DiligenceTemplate>(templateEndpoint(reportId));
   } catch (error) {
     throw new Error(httpErrorMessage(error) || "Failed to load diligence template");
   }
@@ -69,16 +73,18 @@ export const getDiligenceTemplate = async (): Promise<DiligenceTemplate> => {
 };
 
 /**
- * Wholesale-replaces the advisor's diligence template. Passing
- * `questions: []` clears it. Returns the saved template (same shape as GET).
+ * Wholesale-replaces a diligence template. Passing `questions: []` clears it.
+ * Returns the saved template (same shape as GET). `reportId` selects the
+ * report owner's template — see {@link getDiligenceTemplate}.
  */
 export const saveDiligenceTemplate = async (
-  body: SaveDiligenceTemplateRequest
+  body: SaveDiligenceTemplateRequest,
+  reportId?: string
 ): Promise<DiligenceTemplate> => {
   let data: DiligenceTemplate | null;
   try {
     // TODO(#1775): add zod schema
-    data = await api.put<DiligenceTemplate>(DILIGENCE_ENDPOINTS.TEMPLATE, body);
+    data = await api.put<DiligenceTemplate>(templateEndpoint(reportId), body);
   } catch (error) {
     throw new Error(httpErrorMessage(error) || "Failed to save diligence template");
   }
@@ -87,6 +93,9 @@ export const saveDiligenceTemplate = async (
   }
   return data;
 };
+
+const templateEndpoint = (reportId?: string): string =>
+  reportId ? DILIGENCE_ENDPOINTS.REPORT_TEMPLATE(reportId) : DILIGENCE_ENDPOINTS.TEMPLATE;
 
 // -- Advisor: per-candidate diligence ---------------------------------------
 

--- a/src/features/donor-research/components/common/DonorResearchShell.tsx
+++ b/src/features/donor-research/components/common/DonorResearchShell.tsx
@@ -314,6 +314,15 @@ export function DonorResearchShell({ children }: DonorResearchShellProps) {
   // sidebar that later swaps for the real one. Only the content pane waits:
   // while the advisor resolves, or while a non-advisor is being redirected to
   // onboarding, it shows a skeleton shaped like the destination route.
+  //
+  // REVIEW-WAIVED: staff report routes deliberately still wait on
+  // `advisorQuery.isLoading`. The wait is bounded and non-additive:
+  // `useDonorAdvisor()` is never disabled here, so it always settles — success
+  // (`null` for a staff viewer with no row) or error both clear `isLoading` —
+  // and `ReportBriefView` independently gates on `advisorQuery.isPending` for
+  // the SAME query key, so skipping the gate here would not surface report
+  // content any sooner. Ungating would only trade a shared skeleton for a
+  // skeleton-inside-a-skeleton.
   const contentPending = advisorQuery.isLoading || (advisorMissing && !allowStaffViewer);
 
   return (

--- a/src/features/donor-research/components/common/DonorResearchShell.tsx
+++ b/src/features/donor-research/components/common/DonorResearchShell.tsx
@@ -6,7 +6,6 @@ import { ClipboardList, FileText, type LucideIcon, Plus, Sparkles, UsersRound } 
 import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
-import { SoftShell } from "@/components/Pages/Dashboard/v3/SoftShell";
 import { SK } from "@/components/Pages/Dashboard/v3/soft-classes";
 import {
   Breadcrumb,
@@ -106,9 +105,12 @@ function SidebarNavItem({ item, pathname }: { item: NavItem; pathname: string })
 
 function DonorResearchSidebar({
   advisor,
+  advisorPending,
   pathname,
 }: {
   advisor: DonorAdvisor | null;
+  /** Distinguishes "still loading" from "resolved, and there is none". */
+  advisorPending: boolean;
   pathname: string;
 }) {
   return (
@@ -129,17 +131,22 @@ function DonorResearchSidebar({
       </SidebarContent>
 
       <SidebarFooter>
-        <div className="group-data-[collapsible=icon]:hidden">
-          {advisor ? (
-            <RateLimitCounter advisor={advisor} variant="sidebar" />
-          ) : (
-            <div className="flex flex-col gap-2 rounded-sf-tile border border-sf-line bg-sf-card p-3">
-              <span className={cn(SK, "h-3 w-24")} />
-              <span className={cn(SK, "h-2 w-full rounded-full")} />
-              <span className={cn(SK, "h-2 w-2/3")} />
-            </div>
-          )}
-        </div>
+        {/* Usage limits are advisor-owned. A staff viewer with no advisor row
+            of their own has none to show — render nothing rather than a
+            skeleton that would shimmer forever. */}
+        {advisor || advisorPending ? (
+          <div className="group-data-[collapsible=icon]:hidden">
+            {advisor ? (
+              <RateLimitCounter advisor={advisor} variant="sidebar" />
+            ) : (
+              <div className="flex flex-col gap-2 rounded-sf-tile border border-sf-line bg-sf-card p-3">
+                <span className={cn(SK, "h-3 w-24")} />
+                <span className={cn(SK, "h-2 w-full rounded-full")} />
+                <span className={cn(SK, "h-2 w-2/3")} />
+              </div>
+            )}
+          </div>
+        ) : null}
         <SidebarMenu className="hidden group-data-[collapsible=icon]:flex">
           <SidebarMenuItem>
             <SidebarMenuButton tooltip="Usage limits">
@@ -241,16 +248,18 @@ function getLoadingVariant(pathname: string): DonorResearchLoadingVariant {
 
 function DonorResearchAppShell({
   advisor,
+  advisorPending,
   children,
   pathname,
 }: {
   advisor: DonorAdvisor | null;
+  advisorPending: boolean;
   children: ReactNode;
   pathname: string;
 }) {
   return (
     <SidebarProvider className="dashv3 relative min-h-[calc(100vh-var(--navbar-height,64px))] bg-sf-panel">
-      <DonorResearchSidebar advisor={advisor} pathname={pathname} />
+      <DonorResearchSidebar advisor={advisor} advisorPending={advisorPending} pathname={pathname} />
       <SidebarInset className="bg-sf-panel">
         <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background px-4">
           <SidebarTrigger className="-ml-2 size-11 md:-ml-1 md:size-7" />
@@ -268,7 +277,15 @@ interface DonorResearchShellProps {
   children: ReactNode;
 }
 
-/** Shared collapsible navigation shell for the advisor-facing research routes. */
+/**
+ * Shared collapsible navigation shell for the authenticated research routes.
+ *
+ * Report-detail routes are also reachable by staff who never onboarded as an
+ * advisor. They get the SAME chrome as the report's owner — sidebar,
+ * breadcrumbs, content pane — so the two views are indistinguishable; only the
+ * advisor-owned usage counter is omitted, since they have none. The
+ * onboarding redirect stays off those routes (`allowStaffViewer`).
+ */
 export function DonorResearchShell({ children }: DonorResearchShellProps) {
   const pathname = usePathname();
   const { replace } = useRouter();
@@ -287,12 +304,6 @@ export function DonorResearchShell({ children }: DonorResearchShellProps) {
     }
   }, [allowStaffViewer, advisorMissing, replace]);
 
-  // Staff viewing a report without their own advisor row get the plain Soft
-  // shell (no advisor-scoped sidebar) rather than the research navigation.
-  if (allowStaffViewer && (advisorQuery.isError || advisorMissing)) {
-    return <SoftShell>{children}</SoftShell>;
-  }
-
   // A genuine load failure on an advisor-owned route is unrecoverable here —
   // surface it to the route's error boundary.
   if (advisorQuery.isError && !allowStaffViewer) {
@@ -306,7 +317,11 @@ export function DonorResearchShell({ children }: DonorResearchShellProps) {
   const contentPending = advisorQuery.isLoading || (advisorMissing && !allowStaffViewer);
 
   return (
-    <DonorResearchAppShell advisor={advisor} pathname={pathname}>
+    <DonorResearchAppShell
+      advisor={advisor}
+      advisorPending={advisorQuery.isLoading}
+      pathname={pathname}
+    >
       {contentPending ? (
         <DonorResearchLoading variant={getLoadingVariant(pathname)} label="Loading…" />
       ) : (

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -252,6 +252,11 @@ const TEMPLATE_SAVED_COPY: Record<DiligenceViewer, string> = {
   staff: "Questions saved to the report owner's template",
 };
 
+const TEMPLATE_SAVE_FAILED_COPY: Record<DiligenceViewer, string> = {
+  owner: "Couldn't save your questions. Please try again.",
+  staff: "Couldn't save the report owner's questions. Please try again.",
+};
+
 const { MAX_QUESTIONS, QUESTION_TEXT_MAX } = DILIGENCE_TEMPLATE_LIMITS;
 
 interface InlineQuestionSetupProps {
@@ -299,7 +304,7 @@ function InlineQuestionSetup({ reportId, viewer }: InlineQuestionSetupProps) {
           toast.success(TEMPLATE_SAVED_COPY[viewer]);
         },
         onError: () => {
-          toast.error("Couldn't save your questions. Please try again.");
+          toast.error(TEMPLATE_SAVE_FAILED_COPY[viewer]);
         },
       }
     );

--- a/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
+++ b/src/features/donor-research/components/diligence/AskQuestionsDialog.tsx
@@ -28,6 +28,7 @@ import { OutreachEmailPreview } from "./OutreachEmailPreview";
 import { getOutreachBodyIssue } from "./outreach-body";
 import { NO_CONTACT_FOUND_MESSAGE } from "./outreach-messages";
 import { makeQuestionId } from "./question-id";
+import type { DiligenceViewer } from "./viewer";
 
 interface AskQuestionsDialogProps {
   reportId: string;
@@ -37,6 +38,8 @@ interface AskQuestionsDialogProps {
   view: CandidateDiligenceView;
   /** Nonprofit display name for the preview's To row (null → row hidden). */
   candidateName?: string | null;
+  /** The report's owner, or a super-admin acting as them. */
+  viewer: DiligenceViewer;
 }
 
 /**
@@ -55,6 +58,7 @@ export function AskQuestionsDialog({
   onOpenChange,
   view,
   candidateName,
+  viewer,
 }: AskQuestionsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -68,6 +72,7 @@ export function AskQuestionsDialog({
             candidateId={candidateId}
             view={view}
             candidateName={candidateName ?? null}
+            viewer={viewer}
             onClose={() => onOpenChange(false)}
           />
         ) : null}
@@ -81,6 +86,7 @@ interface AskQuestionsBodyProps {
   candidateId: string;
   view: CandidateDiligenceView;
   candidateName: string | null;
+  viewer: DiligenceViewer;
   onClose: () => void;
 }
 
@@ -89,12 +95,15 @@ function AskQuestionsBody({
   candidateId,
   view,
   candidateName,
+  viewer,
   onClose,
 }: AskQuestionsBodyProps) {
   // The template is only consulted for the empty guard — the email content
   // itself always comes from the backend preview, which composes from the
-  // live template exactly as delivery would.
-  const templateQuery = useDiligenceTemplate();
+  // live template exactly as delivery would. Read it through the REPORT so a
+  // super-admin sees the owner's questions (the ones the preview composes
+  // from), not their own — which they may not even have.
+  const templateQuery = useDiligenceTemplate(reportId);
   const askQuestions = useAskQuestions();
 
   const hasFrozenRequest = (view.request?.questions.length ?? 0) > 0;
@@ -171,7 +180,7 @@ function AskQuestionsBody({
           </div>
         ) : isTemplateError ? (
           <div className="flex flex-col items-start gap-2 rounded-md border border-border bg-muted/30 p-3">
-            <p className="text-sm text-muted-foreground">Couldn't load your questions.</p>
+            <p className="text-sm text-muted-foreground">{TEMPLATE_ERROR_COPY[viewer]}</p>
             <Button
               type="button"
               size="sm"
@@ -182,7 +191,7 @@ function AskQuestionsBody({
             </Button>
           </div>
         ) : isTemplateEmpty ? (
-          <InlineQuestionSetup />
+          <InlineQuestionSetup reportId={reportId} viewer={viewer} />
         ) : (
           <OutreachEmailPreview
             preview={preview}
@@ -193,7 +202,7 @@ function AskQuestionsBody({
             body={body}
             onBodyChange={setDraft}
             idPrefix="ask-questions"
-            hint="Editing the questions here changes the email text only — the answer form uses your saved question template."
+            hint={BODY_EDIT_HINT_COPY[viewer]}
           />
         )}
       </div>
@@ -215,17 +224,53 @@ function AskQuestionsBody({
   );
 }
 
+/**
+ * Copy that differs for a super-admin acting on the owner's behalf: the
+ * questions being sent are the OWNER's, so "your" would be wrong.
+ */
+const TEMPLATE_ERROR_COPY: Record<DiligenceViewer, string> = {
+  owner: "Couldn't load your questions.",
+  staff: "Couldn't load the report owner's questions.",
+};
+
+const BODY_EDIT_HINT_COPY: Record<DiligenceViewer, string> = {
+  owner:
+    "Editing the questions here changes the email text only — the answer form uses your saved question template.",
+  staff:
+    "Editing the questions here changes the email text only — the answer form uses the report owner's saved question template.",
+};
+
+const EMPTY_TEMPLATE_COPY: Record<DiligenceViewer, string> = {
+  owner:
+    "You haven't added any diligence questions yet. Write them here — they're saved to your question template and dropped into the email.",
+  staff:
+    "This report's owner hasn't added any diligence questions yet. Write them here — they're saved to the owner's question template and dropped into the email.",
+};
+
+const TEMPLATE_SAVED_COPY: Record<DiligenceViewer, string> = {
+  owner: "Questions saved to your template",
+  staff: "Questions saved to the report owner's template",
+};
+
 const { MAX_QUESTIONS, QUESTION_TEXT_MAX } = DILIGENCE_TEMPLATE_LIMITS;
 
+interface InlineQuestionSetupProps {
+  /** Scopes the save to the report OWNER's template, not the caller's. */
+  reportId: string;
+  viewer: DiligenceViewer;
+}
+
 /**
- * First-run question capture inside the dialog: lets the advisor write their
+ * First-run question capture inside the dialog: lets the advisor write the
  * diligence questions right here instead of detouring to the template page
- * (which stays available via the link below). Saving goes through the normal
- * template save, and the seeded cache flips the dialog straight into the email
- * preview — blank rows are dropped, so only real questions persist.
+ * (which stays available via the link below, for the owner — a super-admin's
+ * own template page would edit the wrong row, so they don't get the link).
+ * Saving goes through the report-scoped template save, and the seeded cache
+ * flips the dialog straight into the email preview — blank rows are dropped,
+ * so only real questions persist.
  */
-function InlineQuestionSetup() {
-  const save = useSaveDiligenceTemplate();
+function InlineQuestionSetup({ reportId, viewer }: InlineQuestionSetupProps) {
+  const save = useSaveDiligenceTemplate(reportId);
   const [rows, setRows] = useState<DiligenceQuestion[]>(() => [{ id: makeQuestionId(), text: "" }]);
 
   const filled = rows.filter((row) => row.text.trim().length > 0);
@@ -251,7 +296,7 @@ function InlineQuestionSetup() {
       { questions: filled.map((row) => ({ id: row.id, text: row.text.trim() })) },
       {
         onSuccess: () => {
-          toast.success("Questions saved to your template");
+          toast.success(TEMPLATE_SAVED_COPY[viewer]);
         },
         onError: () => {
           toast.error("Couldn't save your questions. Please try again.");
@@ -262,10 +307,7 @@ function InlineQuestionSetup() {
 
   return (
     <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/30 p-3">
-      <p className="text-sm text-muted-foreground">
-        You haven't added any diligence questions yet. Write them here — they're saved to your
-        question template and dropped into the email.
-      </p>
+      <p className="text-sm text-muted-foreground">{EMPTY_TEMPLATE_COPY[viewer]}</p>
 
       <div className="flex flex-col gap-2">
         {rows.map((row, index) => (
@@ -303,12 +345,14 @@ function InlineQuestionSetup() {
         </Button>
       </div>
 
-      <Link
-        href={PAGES.DONOR_RESEARCH.DILIGENCE_TEMPLATE}
-        className="text-sm font-medium text-brand-emphasis underline-offset-2 hover:underline dark:text-brand-subtle"
-      >
-        Edit your question template
-      </Link>
+      {viewer === "owner" ? (
+        <Link
+          href={PAGES.DONOR_RESEARCH.DILIGENCE_TEMPLATE}
+          className="text-sm font-medium text-brand-emphasis underline-offset-2 hover:underline dark:text-brand-subtle"
+        >
+          Edit your question template
+        </Link>
+      ) : null}
     </div>
   );
 }

--- a/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
+++ b/src/features/donor-research/components/diligence/CandidateDiligenceActions.tsx
@@ -9,28 +9,37 @@ import { AskQuestionsDialog } from "./AskQuestionsDialog";
 import { ConnectDialog } from "./ConnectDialog";
 import { DiligenceAnswers } from "./DiligenceAnswers";
 import { DiligenceStatusBadge } from "./DiligenceStatusBadge";
+import type { DiligenceViewer } from "./viewer";
 
 interface CandidateDiligenceActionsProps {
   reportId: string;
   candidateId: string;
   /** Nonprofit display name for the outreach previews' To row. */
   candidateName?: string | null;
+  /**
+   * The report's owner, or a super-admin acting as them. Both get the same
+   * actions — the backend attributes either to the report's advisor — so this
+   * only reaches the one step that cannot be done on someone else's behalf
+   * (the Connect email capture, see {@link ConnectDialog}).
+   */
+  viewer: DiligenceViewer;
 }
 
 /**
- * Per-candidate diligence footer for the advisor report view. Self-contained:
- * fetches its own candidate-diligence view and renders the status badge, the
- * two gated actions (Ask Questions / Connect), any collected answers, and the
- * intro state. Rendered per-candidate inside maps, so memoized.
+ * Per-candidate diligence footer for the authenticated report view.
+ * Self-contained: fetches its own candidate-diligence view and renders the
+ * status badge, the two gated actions (Ask Questions / Connect), any collected
+ * answers, and the intro state. Rendered per-candidate inside maps, so memoized.
  *
- * Anonymity: this component is mounted ONLY on the advisor surface (the donor
- * shared view never passes `showDiligenceActions`), so the actions cannot leak
- * onto a public share.
+ * Anonymity: this component is mounted ONLY where `diligenceViewer` resolves
+ * (owner or staff) — the donor shared view never passes one, so the actions
+ * cannot leak onto a public share.
  */
 export const CandidateDiligenceActions = memo(function CandidateDiligenceActions({
   reportId,
   candidateId,
   candidateName,
+  viewer,
 }: CandidateDiligenceActionsProps) {
   const [askOpen, setAskOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
@@ -111,6 +120,7 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
         onOpenChange={setAskOpen}
         view={view}
         candidateName={candidateName}
+        viewer={viewer}
       />
       <ConnectDialog
         reportId={reportId}
@@ -119,6 +129,7 @@ export const CandidateDiligenceActions = memo(function CandidateDiligenceActions
         onOpenChange={setConnectOpen}
         canConnect={actions.canConnect}
         candidateName={candidateName}
+        viewer={viewer}
       />
     </div>
   );

--- a/src/features/donor-research/components/diligence/ConnectDialog.tsx
+++ b/src/features/donor-research/components/diligence/ConnectDialog.tsx
@@ -20,6 +20,7 @@ import { useOutreachPreview, useRequestIntro, useUpdateAdvisorEmail } from "@/ho
 import { OutreachEmailPreview } from "./OutreachEmailPreview";
 import { getOutreachBodyIssue } from "./outreach-body";
 import { NO_CONTACT_FOUND_MESSAGE } from "./outreach-messages";
+import type { DiligenceViewer } from "./viewer";
 
 interface ConnectDialogProps {
   reportId: string;
@@ -30,6 +31,8 @@ interface ConnectDialogProps {
   canConnect: boolean;
   /** Nonprofit display name for the preview's To row (null → row hidden). */
   candidateName?: string | null;
+  /** The report's owner, or a super-admin acting as them. */
+  viewer: DiligenceViewer;
 }
 
 const emailSchema = z.object({
@@ -38,7 +41,7 @@ const emailSchema = z.object({
 
 type EmailFormValues = z.infer<typeof emailSchema>;
 
-type Step = "confirm" | "email";
+type Step = "confirm" | "email" | "owner_email_missing";
 
 /**
  * Confirms a NAMED intro that reveals the advisor's identity (and any prior
@@ -60,6 +63,7 @@ export function ConnectDialog({
   onOpenChange,
   canConnect,
   candidateName,
+  viewer,
 }: ConnectDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -73,6 +77,7 @@ export function ConnectDialog({
             candidateId={candidateId}
             canConnect={canConnect}
             candidateName={candidateName ?? null}
+            viewer={viewer}
             onClose={() => onOpenChange(false)}
           />
         ) : null}
@@ -86,6 +91,7 @@ interface ConnectBodyProps {
   candidateId: string;
   canConnect: boolean;
   candidateName: string | null;
+  viewer: DiligenceViewer;
   onClose: () => void;
 }
 
@@ -94,6 +100,7 @@ function ConnectBody({
   candidateId,
   canConnect,
   candidateName,
+  viewer,
   onClose,
 }: ConnectBodyProps) {
   const [step, setStep] = useState<Step>("confirm");
@@ -158,7 +165,12 @@ function ConnectBody({
   const handleConfirm = () => {
     sendIntro((message) => {
       setEmailPrompt(message);
-      setStep("email");
+      // The capture step persists a reply-to onto the ADVISOR's shared
+      // contributor profile — global Karma identity, not report data. A
+      // super-admin acting for the owner must not write that on their behalf
+      // (and writing their OWN profile would resolve the wrong reply-to), so
+      // they get the blocked state instead of the form.
+      setStep(viewer === "staff" ? "owner_email_missing" : "email");
     });
   };
 
@@ -190,9 +202,9 @@ function ConnectBody({
         <DialogHeader>
           <DialogTitle>Send a named intro</DialogTitle>
           <DialogDescription>
-            Connecting reveals your identity to this nonprofit, along with any answers they've
-            already shared. Karma sends them the email below on your behalf — review it and edit if
-            needed before sending.
+            {viewer === "staff"
+              ? "Connecting reveals the report owner's identity to this nonprofit, along with any answers they've already shared. Karma sends them the email below on the owner's behalf — review it and edit if needed before sending."
+              : "Connecting reveals your identity to this nonprofit, along with any answers they've already shared. Karma sends them the email below on your behalf — review it and edit if needed before sending."}
           </DialogDescription>
         </DialogHeader>
 
@@ -220,6 +232,26 @@ function ConnectBody({
             isLoading={requestIntro.isPending}
           >
             Send intro
+          </Button>
+        </DialogFooter>
+      </>
+    );
+  }
+
+  if (step === "owner_email_missing") {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>The report owner has no reply-to email</DialogTitle>
+          <DialogDescription>
+            A named intro is sent on the report owner's behalf and needs their reply-to address, so
+            it can't go out until they add one to their Karma profile. Nothing was sent.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button type="button" onClick={onClose}>
+            Close
           </Button>
         </DialogFooter>
       </>

--- a/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/AskQuestionsDialog.test.tsx
@@ -8,6 +8,7 @@ import { OUTREACH_BODY_LIMITS } from "@/types/diligence";
 const mockAskMutate = vi.fn();
 const mockSaveTemplateMutate = vi.fn();
 const mockUseDiligenceTemplate = vi.fn();
+const mockUseSaveDiligenceTemplate = vi.fn();
 const mockUseOutreachPreview = vi.fn();
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
@@ -28,10 +29,13 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/hooks/useDiligence", () => ({
-  useDiligenceTemplate: () => mockUseDiligenceTemplate(),
+  useDiligenceTemplate: (...args: unknown[]) => mockUseDiligenceTemplate(...args),
   useOutreachPreview: (...args: unknown[]) => mockUseOutreachPreview(...args),
   useAskQuestions: () => ({ mutate: mockAskMutate, isPending: false }),
-  useSaveDiligenceTemplate: () => ({ mutate: mockSaveTemplateMutate, isPending: false }),
+  useSaveDiligenceTemplate: (...args: unknown[]) => {
+    mockUseSaveDiligenceTemplate(...args);
+    return { mutate: mockSaveTemplateMutate, isPending: false };
+  },
 }));
 
 import { AskQuestionsDialog } from "../AskQuestionsDialog";
@@ -81,7 +85,7 @@ function buildView(overrides: Partial<CandidateDiligenceView> = {}): CandidateDi
   };
 }
 
-function renderDialog(view = buildView()) {
+function renderDialog(view = buildView(), viewer: "owner" | "staff" = "owner") {
   return render(
     <AskQuestionsDialog
       reportId="report-1"
@@ -90,8 +94,14 @@ function renderDialog(view = buildView()) {
       onOpenChange={vi.fn()}
       view={view}
       candidateName="Hope Shelter"
+      viewer={viewer}
     />
   );
+}
+
+function mockEmptyTemplate() {
+  const template: DiligenceTemplate = { questions: [], updatedAt: null };
+  mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
 }
 
 afterEach(() => {
@@ -100,8 +110,7 @@ afterEach(() => {
 
 describe("AskQuestionsDialog", () => {
   it("guards on an empty template with the inline editor, keeps the page link, and disables send", () => {
-    const template: DiligenceTemplate = { questions: [], updatedAt: null };
-    mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+    mockEmptyTemplate();
     mockPreviewLoaded();
 
     renderDialog();
@@ -121,8 +130,7 @@ describe("AskQuestionsDialog", () => {
   });
 
   it("saves inline questions to the template, dropping blank rows", () => {
-    const template: DiligenceTemplate = { questions: [], updatedAt: null };
-    mockUseDiligenceTemplate.mockReturnValue({ data: template, isLoading: false, isError: false });
+    mockEmptyTemplate();
     mockPreviewLoaded();
     mockSaveTemplateMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
 
@@ -181,6 +189,7 @@ describe("AskQuestionsDialog", () => {
         onOpenChange={onOpenChange}
         view={buildView()}
         candidateName="Hope Shelter"
+        viewer="owner"
       />
     );
 
@@ -210,6 +219,7 @@ describe("AskQuestionsDialog", () => {
         onOpenChange={onOpenChange}
         view={buildView()}
         candidateName="Hope Shelter"
+        viewer="owner"
       />
     );
 
@@ -325,5 +335,45 @@ describe("AskQuestionsDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(refetch).toHaveBeenCalled();
+  });
+
+  describe("super-admin acting as the report owner", () => {
+    it("reads the template through the report so it shows the owner's questions", () => {
+      mockTemplateWithQuestions();
+      mockPreviewLoaded();
+
+      renderDialog(buildView(), "staff");
+
+      expect(mockUseDiligenceTemplate).toHaveBeenCalledWith("report-1");
+    });
+
+    it("seeds the OWNER's template from the inline editor, without the personal template link", () => {
+      mockEmptyTemplate();
+      mockPreviewLoaded();
+      mockSaveTemplateMutate.mockImplementation((_vars, opts) => opts.onSuccess?.());
+
+      renderDialog(buildView(), "staff");
+
+      expect(mockUseSaveDiligenceTemplate).toHaveBeenCalledWith("report-1");
+      expect(
+        screen.queryByRole("link", { name: "Edit your question template" })
+      ).not.toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText("Question 1"), {
+        target: { value: "What is your annual operating budget?" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Save questions" }));
+
+      expect(toastSuccess).toHaveBeenCalledWith("Questions saved to the report owner's template");
+    });
+
+    it("offers the same Send questions action as the owner", () => {
+      mockTemplateWithQuestions();
+      mockPreviewLoaded();
+
+      renderDialog(buildView(), "staff");
+
+      expect(screen.getByRole("button", { name: "Send questions" })).toBeEnabled();
+    });
   });
 });

--- a/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/CandidateDiligenceActions.test.tsx
@@ -63,7 +63,9 @@ describe("CandidateDiligenceActions", () => {
   it("renders an inline loading state", () => {
     mockUseCandidateDiligence.mockReturnValue({ isLoading: true, isError: false, data: undefined });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByText("Loading actions…")).toBeInTheDocument();
   });
@@ -76,7 +78,9 @@ describe("CandidateDiligenceActions", () => {
       refetch: mockRefetch,
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByText("Couldn't load actions.")).toBeInTheDocument();
     screen.getByRole("button", { name: "Retry" }).click();
@@ -93,7 +97,9 @@ describe("CandidateDiligenceActions", () => {
       }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByRole("button", { name: "Ask questions" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Connect" })).not.toBeDisabled();
@@ -106,7 +112,9 @@ describe("CandidateDiligenceActions", () => {
       data: buildView({ coarseStatus: "intro_sent" }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByText("Intro sent")).toBeInTheDocument();
   });
@@ -121,7 +129,9 @@ describe("CandidateDiligenceActions", () => {
       }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByText("Intro queued")).toBeInTheDocument();
     expect(screen.queryByText(/Intro sent/)).not.toBeInTheDocument();
@@ -141,7 +151,9 @@ describe("CandidateDiligenceActions", () => {
       }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getAllByText(/Intro sent/).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("Intro queued")).not.toBeInTheDocument();
@@ -154,7 +166,9 @@ describe("CandidateDiligenceActions", () => {
       data: buildView({ coarseStatus: "not_requested" }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.queryByText("Questions sent")).not.toBeInTheDocument();
     expect(screen.queryByText("Answered")).not.toBeInTheDocument();
@@ -177,7 +191,9 @@ describe("CandidateDiligenceActions", () => {
       }),
     });
 
-    render(<CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" />);
+    render(
+      <CandidateDiligenceActions reportId="report-1" candidateId="candidate-1" viewer="owner" />
+    );
 
     expect(screen.getByText("What is your annual budget?")).toBeInTheDocument();
     expect(screen.getByText("$1.2M")).toBeInTheDocument();

--- a/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
+++ b/src/features/donor-research/components/diligence/__tests__/ConnectDialog.test.tsx
@@ -51,9 +51,11 @@ function mockPreviewLoaded(preview = buildPreview()) {
 function renderDialog({
   canConnect = true,
   onOpenChange = vi.fn(),
+  viewer = "owner",
 }: {
   canConnect?: boolean;
   onOpenChange?: (open: boolean) => void;
+  viewer?: "owner" | "staff";
 } = {}) {
   return render(
     <ConnectDialog
@@ -63,6 +65,7 @@ function renderDialog({
       onOpenChange={onOpenChange}
       canConnect={canConnect}
       candidateName="Hope Shelter"
+      viewer={viewer}
     />
   );
 }
@@ -272,5 +275,37 @@ describe("ConnectDialog", () => {
       expect(screen.getByText("Enter a valid email address.")).toBeInTheDocument();
     });
     expect(mockEmailMutate).not.toHaveBeenCalled();
+  });
+
+  describe("super-admin acting as the report owner", () => {
+    it("frames the intro as revealing the OWNER's identity", () => {
+      mockPreviewLoaded();
+
+      renderDialog({ viewer: "staff" });
+
+      expect(
+        screen.getByText(/Connecting reveals the report owner's identity/)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Send intro" })).toBeEnabled();
+    });
+
+    it("explains the missing reply-to instead of capturing an email onto the owner's profile", () => {
+      mockPreviewLoaded();
+      mockIntroMutate.mockImplementation((_vars, opts) =>
+        opts.onSuccess?.({
+          kind: "email_required",
+          message: "Add your email so we can send a named intro.",
+          requiredFields: ["email"],
+        })
+      );
+
+      renderDialog({ viewer: "staff" });
+
+      fireEvent.click(screen.getByRole("button", { name: "Send intro" }));
+
+      expect(screen.getByText("The report owner has no reply-to email")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Email address")).not.toBeInTheDocument();
+      expect(mockEmailMutate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/features/donor-research/components/diligence/viewer.ts
+++ b/src/features/donor-research/components/diligence/viewer.ts
@@ -1,0 +1,14 @@
+/**
+ * Who is operating the per-candidate diligence actions.
+ *
+ * - `"owner"` — the report's advisor, acting for themselves.
+ * - `"staff"` — a super-admin acting AS the report's owner. Every report-scoped
+ *   diligence endpoint resolves to the owner's advisor row, so the buttons and
+ *   the outreach they send are identical; the nonprofit only ever sees the
+ *   owner's identity.
+ *
+ * The one place the two diverge is the Connect email-capture recovery: it
+ * persists a reply-to address onto the advisor's shared contributor profile
+ * (global Karma identity, not report data), so only the owner may run it.
+ */
+export type DiligenceViewer = "owner" | "staff";

--- a/src/features/donor-research/components/report-brief/AlsoConsidered.tsx
+++ b/src/features/donor-research/components/report-brief/AlsoConsidered.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown } from "lucide-react";
 import { useState } from "react";
 import type { CompositeWeights, ResearchReportCandidate } from "@/types/donor-research";
+import type { DiligenceViewer } from "../diligence/viewer";
 import { CandidateCard } from "../report-viewer/CandidateCard";
 import { formatLocale, humanizeCase } from "./text-utils";
 
@@ -14,8 +15,11 @@ interface AlsoConsideredProps {
   weights: CompositeWeights | null;
   /** Report id — required to mount the advisor diligence actions. */
   reportId?: string;
-  /** Advisor-only: gates the Ask Questions / Connect footer per candidate. */
-  showDiligenceActions?: boolean;
+  /**
+   * Who may run the Ask Questions / Connect footer on each candidate — the
+   * report owner or a super-admin acting as them. `null`/absent hides it.
+   */
+  diligenceViewer?: DiligenceViewer | null;
 }
 
 /**
@@ -29,7 +33,7 @@ export function AlsoConsidered({
   startRank,
   weights,
   reportId,
-  showDiligenceActions = false,
+  diligenceViewer = null,
 }: AlsoConsideredProps) {
   const [expanded, setExpanded] = useState<string | null>(null);
 
@@ -110,7 +114,7 @@ export function AlsoConsidered({
                   <CandidateCard
                     candidate={candidate}
                     reportId={reportId}
-                    showDiligenceActions={showDiligenceActions}
+                    diligenceViewer={diligenceViewer}
                     variant="detail"
                     weights={weights}
                   />

--- a/src/features/donor-research/components/report-brief/LeadCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/LeadCandidate.tsx
@@ -2,6 +2,7 @@
 
 import type { CompositeWeights, ResearchReportCandidate } from "@/types/donor-research";
 import { CandidateDiligenceActions } from "../diligence/CandidateDiligenceActions";
+import type { DiligenceViewer } from "../diligence/viewer";
 import { SocialPresence } from "../report-viewer/SocialPresence";
 import {
   CandidateCoverage,
@@ -36,8 +37,11 @@ interface LeadCandidateProps {
   hasMore: boolean;
   /** Report id — required to mount the advisor diligence actions. */
   reportId?: string;
-  /** Advisor-only: gates the Ask Questions / Connect footer. */
-  showDiligenceActions?: boolean;
+  /**
+   * Who may run the Ask Questions / Connect footer — the report owner or a
+   * super-admin acting as them. `null`/absent hides it entirely.
+   */
+  diligenceViewer?: DiligenceViewer | null;
 }
 
 /**
@@ -51,7 +55,7 @@ export function LeadCandidate({
   weights,
   hasMore,
   reportId,
-  showDiligenceActions = false,
+  diligenceViewer = null,
 }: LeadCandidateProps) {
   const isDisqualified = candidate.complianceVerdict === "disqualified";
   const name = humanizeCase(
@@ -148,11 +152,12 @@ export function LeadCandidate({
         </p>
       </div>
 
-      {showDiligenceActions && reportId ? (
+      {diligenceViewer && reportId ? (
         <CandidateDiligenceActions
           candidateId={candidate.id}
           candidateName={name}
           reportId={reportId}
+          viewer={diligenceViewer}
         />
       ) : null}
     </section>

--- a/src/features/donor-research/components/report-brief/ReportBrief.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBrief.tsx
@@ -2,6 +2,7 @@
 
 import type { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import type { ResearchReportDetail } from "@/types/donor-research";
+import type { DiligenceViewer } from "../diligence/viewer";
 import { CandidateProgress } from "../report-viewer/CandidateProgress";
 import { DisqualificationSummary } from "../report-viewer/DisqualificationSummary";
 import { FailedReportBanner } from "../report-viewer/FailedReportBanner";
@@ -22,16 +23,15 @@ interface ReportBriefProps {
   report: ResearchReportDetail;
   isTerminal: boolean;
   /**
-   * "advisor" renders the owner-only weights/share controls and diligence
-   * actions — writes scoped to the report's advisor. "staff" keeps the
-   * full brief (including the query disclosure) but hides those write
-   * affordances and shows a breadcrumb back to the admin overview.
-   * "shared" additionally hides the query disclosure so the donor share
-   * view never reveals the advisor's search criteria.
+   * "advisor" is the report's owner. "staff" is any other signed-in viewer —
+   * a super-admin, or a plain non-owner; `canManageReport` is what separates
+   * them. "shared" is the donor share view, which additionally hides the
+   * query disclosure so it never reveals the advisor's search criteria.
    */
   variant?: "advisor" | "shared" | "staff";
   /**
-   * Shows the ranking-weights + share-token controls. Defaults to the owner
+   * Resolved write authorization: the ranking-weights + share-token controls
+   * and the per-candidate diligence actions. Defaults to the owner
    * (`variant === "advisor"`); the authenticated view also passes `true` for
    * staff, whose writes the BE resolves to the report owner. Never set on the
    * donor share view.
@@ -67,10 +67,15 @@ export function ReportBrief({
   const featured = candidates.filter((c) => c.featuredFlag);
   const remaining = candidates.filter((c) => !c.featuredFlag);
   const weights = report.weights ?? null;
-  // Diligence + intro actions are owner-only writes — the donor shared view
-  // must never surface them (they'd reveal that diligence is in flight) and
-  // staff can't use them (the endpoints are advisor-scoped).
-  const showDiligenceActions = variant === "advisor";
+  // Who may run the diligence + intro actions. The owner acts for themselves;
+  // staff act AS the owner (the backend resolves every report-scoped diligence
+  // endpoint to the report's advisor), so both get the same footer. Anyone
+  // else — the donor shared view, a signed-in non-owner — gets none: the
+  // actions would reveal that diligence is in flight.
+  //
+  // `variant` alone can't answer this: a plain non-owner also renders as
+  // "staff". `canManageReport` is the resolved authorization signal.
+  const diligenceViewer = resolveDiligenceViewer(variant, canManageReport);
 
   return (
     <div className="flex flex-col gap-6" data-brief>
@@ -128,7 +133,7 @@ export function ReportBrief({
           candidate={featured[0]}
           hasMore={candidates.length > 1}
           reportId={report.id}
-          showDiligenceActions={showDiligenceActions}
+          diligenceViewer={diligenceViewer}
           weights={weights}
         />
       ) : null}
@@ -140,7 +145,7 @@ export function ReportBrief({
           label={labelForRank(i + 2)}
           rank={i + 2}
           reportId={report.id}
-          showDiligenceActions={showDiligenceActions}
+          diligenceViewer={diligenceViewer}
           weights={weights}
         />
       ))}
@@ -151,7 +156,7 @@ export function ReportBrief({
         <AlsoConsidered
           candidates={remaining}
           reportId={report.id}
-          showDiligenceActions={showDiligenceActions}
+          diligenceViewer={diligenceViewer}
           startRank={featured.length + 1}
           weights={weights}
         />
@@ -167,6 +172,21 @@ export function ReportBrief({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Resolves who is looking at the diligence actions. Returns null when nobody
+ * may act — the donor share view, or a signed-in viewer who owns neither the
+ * report nor staff access.
+ */
+function resolveDiligenceViewer(
+  variant: "advisor" | "shared" | "staff",
+  canManageReport: boolean | undefined
+): DiligenceViewer | null {
+  if (variant === "shared") return null;
+  const canManage = canManageReport ?? variant === "advisor";
+  if (!canManage) return null;
+  return variant === "advisor" ? "owner" : "staff";
 }
 
 function labelForRank(rank: number): string {

--- a/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
+++ b/src/features/donor-research/components/report-brief/RunnerUpCandidate.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import type { CompositeWeights, ResearchReportCandidate } from "@/types/donor-research";
 import { CandidateDiligenceActions } from "../diligence/CandidateDiligenceActions";
+import type { DiligenceViewer } from "../diligence/viewer";
 import { SocialPresence } from "../report-viewer/SocialPresence";
 import {
   CandidateCoverage,
@@ -35,8 +36,11 @@ interface RunnerUpCandidateProps {
   weights: CompositeWeights | null;
   /** Report id — required to mount the advisor diligence actions. */
   reportId?: string;
-  /** Advisor-only: gates the Ask Questions / Connect footer. */
-  showDiligenceActions?: boolean;
+  /**
+   * Who may run the Ask Questions / Connect footer — the report owner or a
+   * super-admin acting as them. `null`/absent hides it entirely.
+   */
+  diligenceViewer?: DiligenceViewer | null;
 }
 
 /**
@@ -52,7 +56,7 @@ export const RunnerUpCandidate = memo(function RunnerUpCandidate({
   label,
   weights,
   reportId,
-  showDiligenceActions = false,
+  diligenceViewer = null,
 }: RunnerUpCandidateProps) {
   const isDisqualified = candidate.complianceVerdict === "disqualified";
   const name = humanizeCase(
@@ -123,11 +127,12 @@ export const RunnerUpCandidate = memo(function RunnerUpCandidate({
         </aside>
       </div>
 
-      {showDiligenceActions && reportId ? (
+      {diligenceViewer && reportId ? (
         <CandidateDiligenceActions
           candidateId={candidate.id}
           candidateName={name}
           reportId={reportId}
+          viewer={diligenceViewer}
         />
       ) : null}
     </section>

--- a/src/features/donor-research/components/report-brief/__tests__/diligence-viewer-parity.test.tsx
+++ b/src/features/donor-research/components/report-brief/__tests__/diligence-viewer-parity.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import type { ResearchReportCandidate, ResearchReportDetail } from "@/types/donor-research";
+import parityFixture from "../__fixtures__/parity-fixture.json";
+import { ReportBrief } from "../ReportBrief";
+
+/**
+ * The report owner and a super-admin viewing the same report must see the SAME
+ * per-candidate diligence footer — the backend resolves either caller to the
+ * report's advisor, so both may act. Anyone else (donor share view, a signed-in
+ * non-owner) must see none.
+ *
+ * `CandidateDiligenceActions` is stubbed: this asserts the gating decision, not
+ * the footer's own rendering (covered in `diligence/__tests__`).
+ */
+vi.mock("../../diligence/CandidateDiligenceActions", () => ({
+  CandidateDiligenceActions: ({ viewer }: { viewer: string }) => (
+    <div data-testid="diligence-actions" data-viewer={viewer} />
+  ),
+}));
+
+function toCandidate(
+  raw: (typeof parityFixture.candidates)[number],
+  featuredFlag: boolean
+): ResearchReportCandidate {
+  return {
+    id: raw.id,
+    fundingOrganizationId: raw.fundingOrganizationId,
+    organizationName: `Sample Nonprofit ${raw.id.toUpperCase()}`,
+    organizationDescription: "Runs community programs across the region.",
+    organizationCity: "Springfield",
+    organizationState: "IL",
+    organizationWebsiteUrl: "https://example.org",
+    ein: raw.ein,
+    composite: 0.5,
+    components: raw.components,
+    featuredFlag,
+    manualPosition: null,
+    complianceVerdict: "verified",
+    disqualificationReasons: [],
+    complianceChecks: [],
+    recentMentions: [],
+    stateRegistrationStatus: "not_verified",
+    activitySignalStatus: "no_signal",
+    websiteLastUpdatedAt: null,
+    socialLastPostAt: null,
+    socialMetrics: null,
+    reasoningSummary: "Strong alignment with the stated criteria.",
+    onePagerText: null,
+    detailedText: null,
+    financials: [],
+  };
+}
+
+function buildReport(): ResearchReportDetail {
+  const candidates = parityFixture.candidates.map((c, i) => toCandidate(c, i < 2));
+  return {
+    id: "report-parity-0000",
+    advisorId: "advisor-1",
+    donorHandleId: "handle-1",
+    donorHandleLabel: "Test Donor",
+    criteriaId: "criteria-1",
+    criteria: {
+      criteriaText: "Fund youth literacy nonprofits in the Midwest.",
+      cause: "Education",
+      geography: "Illinois",
+      amountMin: 10_000,
+      amountMax: 50_000,
+    },
+    mode: "fast",
+    status: "complete",
+    hasShareToken: false,
+    shareToken: null,
+    shareTokenExpiresAt: null,
+    errorMessage: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    fastCompletedAt: "2026-01-01T00:10:00.000Z",
+    completedAt: "2026-01-01T00:10:00.000Z",
+    geographyDiagnostic: null,
+    weights: parityFixture.defaultWeights,
+    topCount: 2,
+    candidates,
+  };
+}
+
+function renderBrief(props: Partial<Parameters<typeof ReportBrief>[0]>) {
+  return renderWithProviders(<ReportBrief isTerminal report={buildReport()} {...props} />);
+}
+
+describe("ReportBrief diligence footer parity", () => {
+  it("mounts the footer for the report owner", () => {
+    const { getAllByTestId } = renderBrief({ variant: "advisor", canManageReport: true });
+
+    const footers = getAllByTestId("diligence-actions");
+    expect(footers.length).toBeGreaterThan(0);
+    for (const footer of footers) {
+      expect(footer).toHaveAttribute("data-viewer", "owner");
+    }
+  });
+
+  it("mounts the same footer for a super-admin, marked as acting on the owner's behalf", () => {
+    const { getAllByTestId } = renderBrief({ variant: "staff", canManageReport: true });
+
+    const footers = getAllByTestId("diligence-actions");
+    expect(footers.length).toBeGreaterThan(0);
+    for (const footer of footers) {
+      expect(footer).toHaveAttribute("data-viewer", "staff");
+    }
+  });
+
+  it("mounts one footer per candidate for owner and super-admin alike", () => {
+    const owner = renderBrief({ variant: "advisor", canManageReport: true });
+    const ownerCount = owner.getAllByTestId("diligence-actions").length;
+    owner.unmount();
+
+    const staff = renderBrief({ variant: "staff", canManageReport: true });
+
+    expect(staff.getAllByTestId("diligence-actions")).toHaveLength(ownerCount);
+  });
+
+  it("hides the footer from a signed-in viewer who owns neither the report nor staff access", () => {
+    const { queryAllByTestId } = renderBrief({ variant: "staff", canManageReport: false });
+
+    expect(queryAllByTestId("diligence-actions")).toHaveLength(0);
+  });
+
+  it("hides the footer from the donor share view", () => {
+    const { queryAllByTestId } = renderBrief({ variant: "shared" });
+
+    expect(queryAllByTestId("diligence-actions")).toHaveLength(0);
+  });
+});

--- a/src/features/donor-research/components/report-brief/__tests__/owner-staff-affordance-parity.test.tsx
+++ b/src/features/donor-research/components/report-brief/__tests__/owner-staff-affordance-parity.test.tsx
@@ -103,14 +103,25 @@ function buildReport(overrides: Partial<ResearchReportDetail> = {}): ResearchRep
   };
 }
 
-/** Accessible names of every interactive control, sorted and de-duplicated. */
+/**
+ * Accessible names of every interactive control, sorted. Duplicates are
+ * deliberately KEPT: the controls repeat per candidate, so collapsing them
+ * would let staff lose one of several identical "Connect" buttons and still
+ * look at parity. Callers compare multiplicity via {@link tally}.
+ */
 function affordancesFor(
   variant: "advisor" | "staff",
   report: ResearchReportDetail,
-  isTerminal: boolean
+  isTerminal: boolean,
+  canManageReport = true
 ): string[] {
   const view = renderWithProviders(
-    <ReportBrief canManageReport isTerminal={isTerminal} report={report} variant={variant} />
+    <ReportBrief
+      canManageReport={canManageReport}
+      isTerminal={isTerminal}
+      report={report}
+      variant={variant}
+    />
   );
   const names = INTERACTIVE_ROLES.flatMap((role) =>
     view
@@ -118,7 +129,15 @@ function affordancesFor(
       .map((el) => `${role}:${el.textContent?.trim() || el.getAttribute("aria-label") || ""}`)
   );
   view.unmount();
-  return [...new Set(names)].sort();
+  return names.sort();
+}
+
+/** How many times each control name appears in a render. */
+function tally(names: string[]): Record<string, number> {
+  return names.reduce<Record<string, number>>((acc, name) => {
+    acc[name] = (acc[name] ?? 0) + 1;
+    return acc;
+  }, {});
 }
 
 describe("owner ↔ super-admin affordance parity", () => {
@@ -139,11 +158,18 @@ describe("owner ↔ super-admin affordance parity", () => {
       isTerminal: true,
     },
   ])("exposes the same controls to both viewers — $label", ({ report, isTerminal }) => {
-    const owner = affordancesFor("advisor", report, isTerminal);
-    const staff = affordancesFor("staff", report, isTerminal);
+    const ownerCounts = tally(affordancesFor("advisor", report, isTerminal));
+    const staffCounts = tally(affordancesFor("staff", report, isTerminal));
 
-    const missingForStaff = owner.filter((n) => !staff.includes(n) && !justified.has(n));
-    const extraForStaff = staff.filter((n) => !owner.includes(n) && !justified.has(n));
+    // Compared by COUNT, not membership: the diligence footer repeats per
+    // candidate, so a regression that drops it from one candidate while
+    // leaving it on another still has to fail here.
+    const missingForStaff = Object.entries(ownerCounts)
+      .filter(([name, count]) => !justified.has(name) && (staffCounts[name] ?? 0) < count)
+      .map(([name, count]) => `${name} — owner ${count}, staff ${staffCounts[name] ?? 0}`);
+    const extraForStaff = Object.entries(staffCounts)
+      .filter(([name, count]) => !justified.has(name) && (ownerCounts[name] ?? 0) < count)
+      .map(([name, count]) => `${name} — staff ${count}, owner ${ownerCounts[name] ?? 0}`);
 
     expect(
       missingForStaff,
@@ -152,6 +178,20 @@ describe("owner ↔ super-admin affordance parity", () => {
         `If the difference is intentional, add it to JUSTIFIED_DIFFERENCES with a reason.`
     ).toEqual([]);
     expect(extraForStaff, "A super-admin has controls the owner does not.").toEqual([]);
+  });
+
+  it("denies every diligence control to a signed-in non-owner, non-staff viewer", () => {
+    const report = buildReport();
+
+    // The plain non-owner: `variant="staff"` only means "not the owner", so
+    // the denial has to come from the resolved authorization instead.
+    const denied = affordancesFor("staff", report, true, false);
+
+    expect(denied).not.toContain("button:Ask questions");
+    expect(denied).not.toContain("button:Connect");
+
+    const managed = affordancesFor("staff", report, true, true);
+    expect(managed.length).toBeGreaterThan(denied.length);
   });
 
   it("keeps the donor share view free of every management control", () => {

--- a/src/features/donor-research/components/report-brief/__tests__/owner-staff-affordance-parity.test.tsx
+++ b/src/features/donor-research/components/report-brief/__tests__/owner-staff-affordance-parity.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import type { ResearchReportCandidate, ResearchReportDetail } from "@/types/donor-research";
+import parityFixture from "../__fixtures__/parity-fixture.json";
+import { ReportBrief } from "../ReportBrief";
+
+/**
+ * INVARIANT: a super-admin sees every affordance the report owner sees.
+ *
+ * This test deliberately does NOT enumerate buttons. It renders the SAME report
+ * twice — once as the owner, once as a super-admin acting on their behalf — and
+ * asserts the two trees expose an identical set of interactive controls.
+ *
+ * That matters because the bug class is open-ended: any future component added
+ * under `ReportBrief` that gates on `variant === "advisor"` instead of the
+ * resolved `canManageReport` authorization reintroduces it, and a test that
+ * listed today's buttons would still pass. This one fails the moment the two
+ * renders diverge, for a control nobody has written yet.
+ *
+ * If a divergence is ever CORRECT, add it to `JUSTIFIED_DIFFERENCES` with a
+ * reason. That list is the complete, reviewable record of where the two
+ * surfaces are allowed to differ — today it is empty.
+ */
+
+vi.mock("../../diligence/CandidateDiligenceActions", () => ({
+  // Rendered with the same controls for either viewer; the viewer only reaches
+  // the Connect email-capture step, which is covered in diligence/__tests__.
+  CandidateDiligenceActions: () => (
+    <div>
+      <button type="button">Ask questions</button>
+      <button type="button">Connect</button>
+    </div>
+  ),
+}));
+
+/** Controls allowed to appear for one viewer but not the other, with why. */
+const JUSTIFIED_DIFFERENCES: ReadonlyArray<{ name: string; reason: string }> = [];
+
+const INTERACTIVE_ROLES = ["button", "link", "textbox", "checkbox", "combobox", "switch"] as const;
+
+function toCandidate(
+  raw: (typeof parityFixture.candidates)[number],
+  featuredFlag: boolean
+): ResearchReportCandidate {
+  return {
+    id: raw.id,
+    fundingOrganizationId: raw.fundingOrganizationId,
+    organizationName: `Sample Nonprofit ${raw.id.toUpperCase()}`,
+    organizationDescription: "Runs community programs across the region.",
+    organizationCity: "Springfield",
+    organizationState: "IL",
+    organizationWebsiteUrl: "https://example.org",
+    ein: raw.ein,
+    composite: 0.5,
+    components: raw.components,
+    featuredFlag,
+    manualPosition: null,
+    complianceVerdict: "verified",
+    disqualificationReasons: [],
+    complianceChecks: [],
+    recentMentions: [],
+    stateRegistrationStatus: "not_verified",
+    activitySignalStatus: "no_signal",
+    websiteLastUpdatedAt: null,
+    socialLastPostAt: null,
+    socialMetrics: null,
+    reasoningSummary: "Strong alignment with the stated criteria.",
+    onePagerText: null,
+    detailedText: null,
+    financials: [],
+  };
+}
+
+function buildReport(overrides: Partial<ResearchReportDetail> = {}): ResearchReportDetail {
+  const candidates = parityFixture.candidates.map((c, i) => toCandidate(c, i < 2));
+  return {
+    id: "report-parity-0000",
+    advisorId: "advisor-1",
+    donorHandleId: "handle-1",
+    donorHandleLabel: "Test Donor",
+    criteriaId: "criteria-1",
+    criteria: {
+      criteriaText: "Fund youth literacy nonprofits in the Midwest.",
+      cause: "Education",
+      geography: "Illinois",
+      amountMin: 10_000,
+      amountMax: 50_000,
+    },
+    mode: "fast",
+    status: "complete",
+    hasShareToken: false,
+    shareToken: null,
+    shareTokenExpiresAt: null,
+    errorMessage: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    fastCompletedAt: "2026-01-01T00:10:00.000Z",
+    completedAt: "2026-01-01T00:10:00.000Z",
+    geographyDiagnostic: null,
+    weights: parityFixture.defaultWeights,
+    topCount: 2,
+    candidates,
+    ...overrides,
+  };
+}
+
+/** Accessible names of every interactive control, sorted and de-duplicated. */
+function affordancesFor(
+  variant: "advisor" | "staff",
+  report: ResearchReportDetail,
+  isTerminal: boolean
+): string[] {
+  const view = renderWithProviders(
+    <ReportBrief canManageReport isTerminal={isTerminal} report={report} variant={variant} />
+  );
+  const names = INTERACTIVE_ROLES.flatMap((role) =>
+    view
+      .queryAllByRole(role)
+      .map((el) => `${role}:${el.textContent?.trim() || el.getAttribute("aria-label") || ""}`)
+  );
+  view.unmount();
+  return [...new Set(names)].sort();
+}
+
+describe("owner ↔ super-admin affordance parity", () => {
+  const justified = new Set(JUSTIFIED_DIFFERENCES.map((d) => d.name));
+
+  it.each([
+    { label: "terminal report with featured candidates", report: buildReport(), isTerminal: true },
+    {
+      label: "terminal report where nothing was surfaced",
+      report: buildReport({
+        candidates: parityFixture.candidates.map((c) => toCandidate(c, false)),
+      }),
+      isTerminal: true,
+    },
+    {
+      label: "failed report",
+      report: buildReport({ status: "failed", errorMessage: "search failed" }),
+      isTerminal: true,
+    },
+  ])("exposes the same controls to both viewers — $label", ({ report, isTerminal }) => {
+    const owner = affordancesFor("advisor", report, isTerminal);
+    const staff = affordancesFor("staff", report, isTerminal);
+
+    const missingForStaff = owner.filter((n) => !staff.includes(n) && !justified.has(n));
+    const extraForStaff = staff.filter((n) => !owner.includes(n) && !justified.has(n));
+
+    expect(
+      missingForStaff,
+      `A super-admin is missing controls the owner has. Gate new controls on the resolved ` +
+        `\`canManageReport\` authorization, not on \`variant === "advisor"\`. ` +
+        `If the difference is intentional, add it to JUSTIFIED_DIFFERENCES with a reason.`
+    ).toEqual([]);
+    expect(extraForStaff, "A super-admin has controls the owner does not.").toEqual([]);
+  });
+
+  it("keeps the donor share view free of every management control", () => {
+    const report = buildReport();
+    const owner = affordancesFor("advisor", report, true);
+
+    const shared = renderWithProviders(<ReportBrief isTerminal report={report} variant="shared" />);
+    const sharedNames = INTERACTIVE_ROLES.flatMap((role) =>
+      shared.queryAllByRole(role).map((el) => `${role}:${el.textContent?.trim() || ""}`)
+    );
+
+    // The share view is the opposite invariant: it must NOT gain the owner's
+    // write affordances as new ones are added.
+    expect(sharedNames).not.toContain("button:Ask questions");
+    expect(sharedNames).not.toContain("button:Connect");
+    expect(owner.length).toBeGreaterThan(sharedNames.length);
+  });
+});

--- a/src/features/donor-research/components/report-viewer/CandidateCard.tsx
+++ b/src/features/donor-research/components/report-viewer/CandidateCard.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import type { CompositeWeights, ResearchReportCandidate } from "@/types/donor-research";
 import { CandidateDiligenceActions } from "../diligence/CandidateDiligenceActions";
+import type { DiligenceViewer } from "../diligence/viewer";
 import { FinancialsTable } from "../report-brief/FinancialsTable";
 import { compositeBand } from "../report-brief/scoring";
 import { formatEin, hostname, humanizeCase, truncate } from "../report-brief/text-utils";
@@ -24,8 +25,11 @@ interface CandidateCardProps {
   weights?: CompositeWeights | null;
   /** Report id — required to mount the advisor diligence actions. */
   reportId?: string;
-  /** Advisor-only: gates the Ask Questions / Connect footer. */
-  showDiligenceActions?: boolean;
+  /**
+   * Who may run the Ask Questions / Connect footer — the report owner or a
+   * super-admin acting as them. `null`/absent hides it entirely.
+   */
+  diligenceViewer?: DiligenceViewer | null;
 }
 
 /**
@@ -54,7 +58,7 @@ export function CandidateCard({
   variant,
   weights = null,
   reportId,
-  showDiligenceActions = false,
+  diligenceViewer = null,
 }: CandidateCardProps) {
   const [expanded, setExpanded] = useState(false);
   const isDisqualified = candidate.complianceVerdict === "disqualified";
@@ -160,7 +164,7 @@ export function CandidateCard({
           reportId={reportId}
           candidateId={candidate.id}
           candidateName={name}
-          show={showDiligenceActions}
+          viewer={diligenceViewer}
         />
       </div>
     </article>
@@ -171,25 +175,27 @@ interface CandidateDiligenceFooterProps {
   reportId: string | undefined;
   candidateId: string;
   candidateName: string | null;
-  show: boolean;
+  viewer: DiligenceViewer | null;
 }
 
 /**
- * Advisor-only diligence footer. Extracted so the conditional stays out of the
+ * Diligence footer for whoever may act on the report — its owner, or a
+ * super-admin acting as them. Extracted so the conditional stays out of the
  * already-dense {@link CandidateCard} body. Renders nothing on the donor shared
- * view (where `show` is false / `reportId` is absent).
+ * view (where `viewer` is null / `reportId` is absent).
  */
 function CandidateDiligenceFooter({
   reportId,
   candidateId,
   candidateName,
-  show,
+  viewer,
 }: CandidateDiligenceFooterProps) {
-  return show && reportId ? (
+  return viewer && reportId ? (
     <CandidateDiligenceActions
       reportId={reportId}
       candidateId={candidateId}
       candidateName={candidateName}
+      viewer={viewer}
     />
   ) : null;
 }

--- a/utilities/diligenceEndpoints.ts
+++ b/utilities/diligenceEndpoints.ts
@@ -8,6 +8,15 @@
 export const DILIGENCE_ENDPOINTS = {
   // Advisor (authed):
   TEMPLATE: "/v2/donor-research/me/diligence-template",
+  /**
+   * The same template resolved through a report — i.e. the report OWNER's.
+   * Used by the in-report Ask-Questions dialog so the questions it shows are
+   * the ones the outreach will freeze, whether the owner or a staff member
+   * acting on their behalf opened it. `TEMPLATE` (caller-scoped) stays the
+   * endpoint for the standalone template editor page.
+   */
+  REPORT_TEMPLATE: (reportId: string) =>
+    `/v2/donor-research/reports/${reportId}/diligence-template`,
   CANDIDATE: (reportId: string, candidateId: string) =>
     `/v2/donor-research/reports/${reportId}/candidates/${candidateId}/diligence`,
   REQUESTS: (reportId: string, candidateId: string) =>


### PR DESCRIPTION
## Summary

A Karma super-admin (staff) opening `/nonprofit-research/[reportId]` now sees and can use exactly what the report's owning advisor sees — same chrome, same buttons, same actions. Staff actions resolve to the **report owner**, which is the posture the backend already takes for ranking-weight and share-token writes (`ResearchReportWriteService.resolveWriteAdvisorId`).

Three gaps were closed:

| # | Gap | Where |
|---|-----|-------|
| 1 | Per-candidate `Ask questions` / `Connect` footer hidden for staff | `ReportBrief.tsx` — `showDiligenceActions = variant === "advisor"` |
| 2 | The Ask-Questions dialog read the **caller's** question template (`GET /me/diligence-template`) → hard error for a staff viewer with no advisor row | `AskQuestionsDialog` + `useDiligenceTemplate` |
| 3 | Staff without an advisor row got a chrome-less `SoftShell` — no sidebar, no breadcrumbs | `DonorResearchShell` |

### What changed

- `ReportBrief` derives a `DiligenceViewer` (`"owner" | "staff" | null`) from the resolved `canManageReport`, replacing the `showDiligenceActions` boolean through `LeadCandidate` / `RunnerUpCandidate` / `AlsoConsidered` / `CandidateCard` / `CandidateDiligenceActions`. A plain non-owner, non-staff viewer still resolves to `null` and stays read-only — `variant === "staff"` on the FE means "not the owner", it never meant "is staff".
- `useDiligenceTemplate` / `useSaveDiligenceTemplate` take an optional `reportId` and route to a new report-scoped endpoint that resolves the **owner's** template. The standalone template editor page keeps calling `/me` unchanged.
- The Connect dialog frames the intro as the owner's, revealing the owner's identity and never the staff member's.
- `DonorResearchShell` gives a staff viewer with no advisor row the full sidebar + breadcrumbs. The advisor-owned usage counter is omitted rather than left as a skeleton that would shimmer forever.

FE and BE agree on who counts as staff: `useStaff()` resolves from `getUserPermissions.isStaff` → `ProgramReviewerAuth.isStaff` → `isAllowedAddress`, the same allowlist the donor-research read/write services use. The BE additionally checks every linked address, so it is never *stricter* than the FE — the buttons cannot appear for someone the API would reject.

## Deliberate non-parity: the Connect email-capture step stays owner-only

When `Connect` returns **422** (the report owner has no reply-to email on file), a staff viewer sees an explanatory terminal state instead of the email-capture form.

This is a product decision, not an oversight. That form persists an email onto the advisor's **shared contributor `user_profile`** (`DonorAdvisorWriteService.onboard` → `userProfileWrite.createOrUpdate`) — global Karma identity, not donor-research data. Staff should not be writing another person's global profile as a side effect of viewing a report. Every other action in this PR is at full parity.

## Wire contract

| FE call | Endpoint | BE reader | Effective advisor |
|---|---|---|---|
| `useCandidateDiligence` | `GET /v2/donor-research/reports/:reportId/candidates/:candidateId/diligence` | `CandidateDiligenceReadController` | report owner |
| `useOutreachPreview` | `GET …/outreach-preview?action=` | `OutreachPreviewReadController` | report owner |
| `useAskQuestions` | `POST …/diligence-requests` | `DiligenceActionController` | report owner |
| `useRequestIntro` | `POST …/intro-requests` | `DiligenceActionController` | report owner |
| `useDiligenceTemplate(reportId)` | `GET /v2/donor-research/reports/:reportId/diligence-template` **(new)** | `DiligenceTemplateReadController.getTemplateForReport` | report owner |
| `useSaveDiligenceTemplate(reportId)` | `PUT /v2/donor-research/reports/:reportId/diligence-template` **(new)** | `DiligenceTemplateWriteController.updateTemplateForReport` | report owner |
| `useDiligenceTemplate()` (standalone editor page) | `GET /v2/donor-research/me/diligence-template` | unchanged | caller |

"Report owner" = `resolveEffectiveAdvisorId(request, deps, reportId)` → `resolveReportReadCaller` + `IResearchReportReadService.findByIdForCaller` → `report.advisorId`. Non-staff callers keep tenant scoping: the lookup 404s a cross-advisor report and throws `DonorAdvisorNotFoundException` for a caller with no advisor row.

Cache-key note: the report-scoped template key (`["donor-research", "diligence", "report-template", reportId]`) is deliberately **not** nested under the `/me` key. React Query matches keys by prefix, so nesting would let a `/me` invalidation clobber every report-scoped copy as a side effect rather than a decision.

## User flows

1. **Owner opens their report** — unchanged: full brief, Adjust ranking, Share, per-candidate Ask questions / Connect.
2. **Staff opens another advisor's report** — identical chrome (sidebar + breadcrumbs) and identical buttons.
3. **Staff asks questions** — the dialog loads the *owner's* template via the report-scoped endpoint, previews the same email the sweeper would send, posts; the diligence request is persisted against the owner's advisor id.
4. **Staff asks questions, owner's template is empty** — the inline editor saves to the owner's template through the report-scoped `PUT`, then the preview loads.
5. **Staff connects** — named intro queued on the owner's behalf, revealing the owner's identity (never the staff member's).
6. **Staff connects, owner has no reply-to email** — 422 renders an explanatory message; no write to the owner's contributor profile.
7. **Non-owner, non-staff viewer** — still read-only: no manage controls, no diligence footer.

## Cross-service dependency — RESOLVED

The two backend routes this PR calls were added by **show-karma/gap-indexer#2331**, which is now **merged and deployed to staging**. Verified directly against `https://gapstagapi.karmahq.xyz`:

| Probe | Response | Meaning |
|---|---|---|
| `GET /v2/donor-research/reports/:id/diligence-template` | `401` | route exists, auth required |
| `PUT /v2/donor-research/reports/:id/diligence-template` | `400` | route exists, body validation reached |
| `GET /v2/donor-research/reports/:id/definitely-not-a-route` | `404` | control — unrouted paths do 404 |

The `401`/`400` versus the `404` control is what establishes the routes are actually mounted rather than falling through. #2331 also switched candidate-diligence read, outreach preview, and both diligence action writes onto the shared `resolveEffectiveAdvisorId` resolver.

**This PR is no longer blocked on a pending backend deploy.**

## Commits

1. `feat(diligence): read and write the diligence template through a report` — endpoint constant, service, hooks, service test.
2. `feat(donor-research): give staff the same per-candidate diligence actions as the report owner` — the `DiligenceViewer` plumbing, both dialogs, component + parity tests.
3. `fix(donor-research): render the full research chrome for staff without an advisor row` — `DonorResearchShell` + test.
4. `fix(diligence): invalidate every cached copy of a saved template` — CodeRabbit Major, addressed.
5. `fix(diligence): address the report owner in the template save-failure toast` — copy consistency.
6. `test(donor-research): assert staff and owner expose identical report affordances` — the structural parity invariant.
7. `docs(donor-research): record why the shell still gates content on the advisor query` — CodeRabbit Major, waived with reasoning.
8. `test(donor-research): tighten the parity and template-cache assertions` — three CodeRabbit Minor findings.

## Smoke results

Rebased onto `main` at `944af7a` — clean, no conflicts. Re-verified locally afterwards:

- `tsc --noEmit` — clean. `biome check` on every touched file — clean.
- `vitest` over `__tests__/features/donor-research`, `src/features/donor-research`, the template service test and the cache test — **50 files / 398 tests pass**. `src/core/rbac` — **15 files / 301 tests pass**.

CI on `5b0e191`: **31 checks pass** — `build`, `test (1–6)`, `static-checks`, `quality-gate`, `react-doctor`, `smoke`, `checklist`, `Taskless`, `Vercel`, all four `dogfood` shards, `qa-execution (public)` and `qa-execution (auth-1of2)`.

### One thing this run did verify

**Scenario A1 — "Super-admin without an advisor row gets owner chrome on report routes" — PASSED against staging.** That is the core of change #3 in the table above, confirmed end-to-end rather than only in unit tests.

The run also corrected an assumption carried through earlier attempts: the CI Privy account **is** a staff/super-admin identity. The QA agent established this by loading `/admin/nonprofit-research` and seeing reports across donor personas it does not own. What CI lacks is a *second, non-staff* identity, not a staff one.

### `qa-pipeline` is RED — on a job timeout, not a finding

The verdict job reported `failure — QA Execution (cancelled)`. The `qa-execution (auth-2of2)` shard ran **18m17s against the workflow's `timeout-minutes: 18`** and was killed, so its results were never written. Every other QA and dogfood job passed, and `dogfood-results.json` is `{"critical": 0, "high": 0, "blocking": false}`.

Across both post-rebase runs, **no scenario has returned FAIL**. The outcomes are PASS or BLOCKED.

### Scenarios that remain BLOCKED, and why

| ID | Scenario | Why blocked | Fixable in this PR? |
|----|----------|-------------|---------------------|
| A3 | Signed-in non-owner, non-staff sees no diligence controls | Needs a plain authenticated account with no staff role; CI has one identity and it is staff | **No** — harness |
| A5 | Staff blocked from capturing the owner's reply-to email | Needs two concurrent sessions (staff + owner), and the reachable report surfaced **zero candidates** | **No** — harness + fixture |
| P1 | Donor share link never leaks diligence actions | A share token can only be minted by an authenticated owner; the public shard skips login by design | **No** — fixture |
| P2 | Shared view renders after the prop rename, all viewports | Same missing share-token fixture as P1 | **No** — fixture |
| A2, A4, A6 (prior run) | Ask Questions / parity / cache invalidation | Every report in the account reports `No candidates emerged from the search` with SURFACED=0; older reports fail with `401 Incorrect API key provided` from the search backend | **No** — staging OpenAI credential |

The zero-candidate problem is the dominant blocker: every affordance this PR touches — Ask questions, Connect, the per-candidate footer — lives **on a candidate card**. With no candidates on any report, there is nothing to click. It is also what starves the QA shard of time and drives the 18-minute timeout, since the agent keeps creating and polling reports looking for one with candidates.

### Stated plainly

Beyond A1, **this PR's behaviour has not been exercised end-to-end**. The owner regression baseline in particular is still unverified, for the third run running. The CLAUDE.md §4 cross-service E2E gate is therefore **still open**, and no code change in this PR can close it — it needs a staging fixture with surfaced candidates (i.e. a working candidate-search key), plus a second non-staff Privy identity for the negative cases.

The backend dependency was verified by direct probe instead of through the UI (see *Cross-service dependency* above).

## Review waivers


**CodeRabbit, Major — "Do not block staff report routes on the advisor query"** (`DonorResearchShell.tsx` L307-309, L320-324). Waived; inline `// REVIEW-WAIVED:` note at the cited line.

The finding has two parts and neither survives checking against the code:

1. *"`advisorPending` can leave an endless sidebar skeleton when staff have no advisor profile."* — Not reachable. The usage-counter block is gated `advisor || advisorPending`, so a staff viewer whose advisor query resolved to `null` drops the block entirely instead of leaving a skeleton. That is precisely what this PR changed, and it is pinned by an existing test: *"omits the advisor-owned usage counter rather than shimmering a skeleton forever"*.

2. *"Staff report content remains behind the `Loading…` skeleton until the advisor query resolves."* — True but bounded and non-additive. `useDonorAdvisor()` is never disabled on this path, so it always settles; success (`null` for a staff viewer with no row) and error both clear `isLoading`. More importantly `ReportBriefView` independently gates on `advisorQuery.isPending` for the **same** query key, so removing the shell gate would not surface report content one millisecond sooner — it would only swap a shared skeleton for a skeleton nested inside a skeleton.

The requested regression test ("perpetually pending advisor query renders report content") would assert behaviour the component does not have and should not have: while the advisor row is genuinely unresolved the shell cannot yet know whether to redirect a non-advisor to onboarding. The already-present test asserts the case that actually matters — a *resolved* staff viewer with no advisor row gets sidebar, breadcrumbs, and report content.

**CodeRabbit, Trivial — "Use the `@/` alias for the `DiligenceViewer` imports"** (8 files). Declined, no code change.

Applying it would make the file *less* internally consistent, not more: the donor-research feature uses relative paths for intra-feature imports in 168 places, and in `ReportBrief.tsx` the cited line sits directly above six sibling imports (`../report-viewer/CandidateProgress`, `./AlsoConsidered`, …) that would stay relative. The `@/` convention governs cross-feature imports; `../diligence/viewer` is a sibling module inside the same feature. No lint rule flags it — `biome check` is clean on all eight files.
