### PR TITLE
fix: bound the permissions fetch so a stalled RBAC lookup can't brick the report page

### DIFF
--- a/__tests__/core/rbac/services/authorization.service.test.ts
+++ b/__tests__/core/rbac/services/authorization.service.test.ts
@@ -1,5 +1,8 @@
 import { errorManager } from "@/components/Utilities/errorManager";
-import { authorizationService } from "@/src/core/rbac/services/authorization.service";
+import {
+  authorizationService,
+  PERMISSIONS_TIMEOUT_MS,
+} from "@/src/core/rbac/services/authorization.service";
 import { Permission, ReviewerType, Role } from "@/src/core/rbac/types";
 import { api } from "@/utilities/api/client";
 import { INDEXER } from "@/utilities/indexer";
@@ -10,6 +13,12 @@ vi.mock("@/utilities/api/client", () => ({
 vi.mock("@/components/Utilities/errorManager");
 
 const mockedApiGet = vi.mocked(api.get);
+
+/** See `PERMISSIONS_TIMEOUT_MS` — the lookup is always bounded and abortable. */
+const BOUNDED_REQUEST = {
+  signal: expect.any(AbortSignal),
+  timeoutMs: PERMISSIONS_TIMEOUT_MS,
+};
 const mockedErrorManager = vi.mocked(errorManager);
 
 interface ApiResponseOverrides {
@@ -105,7 +114,10 @@ describe("authorizationService.getPermissions", () => {
 
       await authorizationService.getPermissions(params);
 
-      expect(mockedApiGet).toHaveBeenCalledWith(INDEXER.V2.AUTH.PERMISSIONS(params));
+      expect(mockedApiGet).toHaveBeenCalledWith(
+        INDEXER.V2.AUTH.PERMISSIONS(params),
+        BOUNDED_REQUEST
+      );
     });
 
     it("defaults to empty params when called with no arguments", async () => {
@@ -113,7 +125,7 @@ describe("authorizationService.getPermissions", () => {
 
       await authorizationService.getPermissions();
 
-      expect(mockedApiGet).toHaveBeenCalledWith(INDEXER.V2.AUTH.PERMISSIONS({}));
+      expect(mockedApiGet).toHaveBeenCalledWith(INDEXER.V2.AUTH.PERMISSIONS({}), BOUNDED_REQUEST);
     });
 
     it("does not invoke errorManager on a successful response", async () => {

--- a/__tests__/core/rbac/services/authorization.service.test.ts
+++ b/__tests__/core/rbac/services/authorization.service.test.ts
@@ -1,7 +1,7 @@
 import { errorManager } from "@/components/Utilities/errorManager";
 import {
   authorizationService,
-  PERMISSIONS_TIMEOUT_MS,
+  PERMISSIONS_TRANSPORT_TIMEOUT_MS,
 } from "@/src/core/rbac/services/authorization.service";
 import { Permission, ReviewerType, Role } from "@/src/core/rbac/types";
 import { api } from "@/utilities/api/client";
@@ -17,7 +17,7 @@ const mockedApiGet = vi.mocked(api.get);
 /** See `PERMISSIONS_TIMEOUT_MS` — the lookup is always bounded and abortable. */
 const BOUNDED_REQUEST = {
   signal: expect.any(AbortSignal),
-  timeoutMs: PERMISSIONS_TIMEOUT_MS,
+  timeoutMs: PERMISSIONS_TRANSPORT_TIMEOUT_MS,
 };
 const mockedErrorManager = vi.mocked(errorManager);
 

--- a/src/core/rbac/__tests__/authorization.service.test.ts
+++ b/src/core/rbac/__tests__/authorization.service.test.ts
@@ -1,4 +1,4 @@
-import { authorizationService } from "../services/authorization.service";
+import { authorizationService, PERMISSIONS_TIMEOUT_MS } from "../services/authorization.service";
 import { ReviewerType, Role } from "../types/role";
 
 vi.mock("@/utilities/api/client", () => ({
@@ -8,6 +8,17 @@ vi.mock("@/utilities/api/client", () => ({
 import { api } from "@/utilities/api/client";
 
 const mockApiGet = api.get as vi.MockedFunction<typeof api.get>;
+
+/**
+ * Every permissions fetch is issued under a wall-clock deadline with an abort
+ * signal — an authorization lookup must never inherit the api client's 360s
+ * long-poll ceiling. Asserted on each call so the bound can't be dropped
+ * silently.
+ */
+const BOUNDED_REQUEST = {
+  signal: expect.any(AbortSignal),
+  timeoutMs: PERMISSIONS_TIMEOUT_MS,
+};
 
 describe("authorizationService", () => {
   beforeEach(() => {
@@ -105,11 +116,26 @@ describe("authorizationService", () => {
         chainId: 10,
       });
 
-      expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("communityId=community-123"));
-      expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("programId=program-456"));
-      expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("applicationId=app-789"));
-      expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("milestoneId=milestone-012"));
-      expect(mockApiGet).toHaveBeenCalledWith(expect.stringContaining("chainId=10"));
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining("communityId=community-123"),
+        BOUNDED_REQUEST
+      );
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining("programId=program-456"),
+        BOUNDED_REQUEST
+      );
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining("applicationId=app-789"),
+        BOUNDED_REQUEST
+      );
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining("milestoneId=milestone-012"),
+        BOUNDED_REQUEST
+      );
+      expect(mockApiGet).toHaveBeenCalledWith(
+        expect.stringContaining("chainId=10"),
+        BOUNDED_REQUEST
+      );
     });
 
     it("should handle empty params", async () => {
@@ -127,7 +153,7 @@ describe("authorizationService", () => {
       const result = await authorizationService.getPermissions();
 
       expect(result.roles.primaryRole).toBe("GUEST");
-      expect(mockApiGet).toHaveBeenCalledWith("/v2/auth/permissions");
+      expect(mockApiGet).toHaveBeenCalledWith("/v2/auth/permissions", BOUNDED_REQUEST);
     });
 
     it("should return isReviewer flag from API response", async () => {

--- a/src/core/rbac/__tests__/authorization.service.test.ts
+++ b/src/core/rbac/__tests__/authorization.service.test.ts
@@ -1,4 +1,7 @@
-import { authorizationService, PERMISSIONS_TIMEOUT_MS } from "../services/authorization.service";
+import {
+  authorizationService,
+  PERMISSIONS_TRANSPORT_TIMEOUT_MS,
+} from "../services/authorization.service";
 import { ReviewerType, Role } from "../types/role";
 
 vi.mock("@/utilities/api/client", () => ({
@@ -17,7 +20,7 @@ const mockApiGet = api.get as vi.MockedFunction<typeof api.get>;
  */
 const BOUNDED_REQUEST = {
   signal: expect.any(AbortSignal),
-  timeoutMs: PERMISSIONS_TIMEOUT_MS,
+  timeoutMs: PERMISSIONS_TRANSPORT_TIMEOUT_MS,
 };
 
 describe("authorizationService", () => {

--- a/src/core/rbac/__tests__/permissions-timeout.test.tsx
+++ b/src/core/rbac/__tests__/permissions-timeout.test.tsx
@@ -3,7 +3,12 @@ import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { PermissionProvider } from "../context/permission-context";
 import { useStaff } from "../hooks/use-staff-bridge";
-import { PERMISSIONS_TIMEOUT_MS } from "../services/authorization.service";
+import {
+  authorizationService,
+  isPermissionsTimeoutError,
+  PERMISSIONS_TIMEOUT_MS,
+  PERMISSIONS_TRANSPORT_TIMEOUT_MS,
+} from "../services/authorization.service";
 
 /**
  * REGRESSION: `GET /v2/auth/permissions` had no meaningful deadline, so a
@@ -97,5 +102,63 @@ describe("permissions fetch that never resolves", () => {
 
     // A timeout is not retried: three more 15s waits only extend the freeze.
     expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The retry exemption keys off the error TYPE, so the type a stall produces
+ * must not depend on which of two timers happens to fire first.
+ *
+ * Both our deadline and the transport's own timeout are armed against the same
+ * request. If they shared a bound they would fire in the same tick and
+ * `Promise.race` would pick arbitrarily; when the transport won, the error was
+ * an ordinary retryable transport failure and the query retried — turning an
+ * intended 15s failure into a ~48s one, still skeleton the whole way. QA saw
+ * exactly that: the page never reached the error state within the expected
+ * window.
+ */
+describe("timeout ordering is deterministic", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gives the transport a strictly longer bound than the deadline", () => {
+    expect(PERMISSIONS_TRANSPORT_TIMEOUT_MS).toBeGreaterThan(PERMISSIONS_TIMEOUT_MS);
+  });
+
+  it("passes the transport bound (not the deadline) to the api client", async () => {
+    apiGet.mockImplementation(() => new Promise(() => {}));
+
+    const pending = authorizationService.getPermissions().catch((e) => e);
+    await vi.advanceTimersByTimeAsync(PERMISSIONS_TIMEOUT_MS + 1);
+    await pending;
+
+    expect(apiGet.mock.calls[0]?.[1]).toMatchObject({
+      timeoutMs: PERMISSIONS_TRANSPORT_TIMEOUT_MS,
+    });
+  });
+
+  it("reports a timeout even when the transport rejects first with its own error", async () => {
+    // The transport losing the race is the ordering we design for; this covers
+    // the inverse, where it rejects (e.g. reacting to our abort) before the
+    // deadline's rejection is observed. The outcome must still be a timeout.
+    apiGet.mockImplementation(
+      (_path: string, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () => {
+            reject(new Error("Network Error"));
+          });
+        })
+    );
+
+    const settled = authorizationService.getPermissions().catch((error) => error);
+    await vi.advanceTimersByTimeAsync(PERMISSIONS_TIMEOUT_MS + 1);
+
+    expect(isPermissionsTimeoutError(await settled)).toBe(true);
   });
 });

--- a/src/core/rbac/__tests__/permissions-timeout.test.tsx
+++ b/src/core/rbac/__tests__/permissions-timeout.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { PermissionProvider } from "../context/permission-context";
+import { useStaff } from "../hooks/use-staff-bridge";
+import { PERMISSIONS_TIMEOUT_MS } from "../services/authorization.service";
+
+/**
+ * REGRESSION: `GET /v2/auth/permissions` had no meaningful deadline, so a
+ * request that never completed left `useStaff()` reporting `isLoading: true`
+ * forever — and every RBAC-gated surface holding a skeleton behind it.
+ *
+ * The fix must satisfy both halves of the tri-state rule at once:
+ *  1. the gate TERMINATES (`isLoading` goes false), and
+ *  2. it terminates CLOSED (`isStaff` stays false, `isError` is raised so the
+ *     caller can say so out loud).
+ *
+ * Asserting only (2) would pass against the buggy code, which also never
+ * granted staff — it simply never answered. The two assertions are load-bearing
+ * together.
+ */
+
+const apiGet = vi.fn();
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn().mockResolvedValue("test-token"), clearCache: vi.fn() },
+}));
+
+let bridgeState = { ready: true, authenticated: true };
+vi.mock("@/contexts/privy-bridge-context", () => ({
+  usePrivyBridge: () => bridgeState,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <PermissionProvider>{children}</PermissionProvider>
+    </QueryClientProvider>
+  );
+}
+
+async function advancePastAllRetries() {
+  await act(async () => {
+    // Generous enough to cover the deadline plus any retry backoff, so the test
+    // fails on "never settles" rather than on "settled a little later".
+    await vi.advanceTimersByTimeAsync(PERMISSIONS_TIMEOUT_MS * 5);
+  });
+}
+
+describe("permissions fetch that never resolves", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bridgeState = { ready: true, authenticated: true };
+    apiGet.mockReset();
+    apiGet.mockImplementation(() => new Promise(() => {}));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("terminates the loading gate instead of hanging forever", async () => {
+    const { result } = renderHook(() => useStaff(), { wrapper });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.isLoading).toBe(true);
+
+    await advancePastAllRetries();
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not grant staff privileges on a timed-out permissions result", async () => {
+    const { result } = renderHook(() => useStaff(), { wrapper });
+
+    await advancePastAllRetries();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isStaff).toBe(false);
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("stops re-issuing the request once the timeout is final", async () => {
+    renderHook(() => useStaff(), { wrapper });
+
+    await advancePastAllRetries();
+
+    // A timeout is not retried: three more 15s waits only extend the freeze.
+    expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/rbac/__tests__/use-staff-bridge.test.ts
+++ b/src/core/rbac/__tests__/use-staff-bridge.test.ts
@@ -5,6 +5,7 @@ import { Role } from "../types/role";
 const mockContextValue = {
   hasRoleOrHigher: vi.fn(),
   isLoading: false,
+  isGuestDueToError: false,
 };
 
 vi.mock("../context/permission-context", () => ({
@@ -18,7 +19,22 @@ describe("useStaff", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockContextValue.isLoading = false;
+    mockContextValue.isGuestDueToError = false;
     mockContextValue.hasRoleOrHigher.mockReturnValue(false);
+  });
+
+  it("should return isStaff=false and isError=true when permissions could not be resolved", () => {
+    // React Query keeps the last successful payload when a refetch fails, so
+    // `hasRoleOrHigher` can still answer true off a stale answer. Authorization
+    // must fail closed on an unresolved result, not coast on a cached one.
+    mockContextValue.isGuestDueToError = true;
+    mockContextValue.hasRoleOrHigher.mockReturnValue(true);
+
+    const { result } = renderHook(() => useStaff());
+
+    expect(result.current.isStaff).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(true);
   });
 
   it("should return isStaff=true when user has SUPER_ADMIN role", () => {

--- a/src/core/rbac/hooks/use-permissions.ts
+++ b/src/core/rbac/hooks/use-permissions.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { authorizationService, type GetPermissionsParams } from "../services/authorization.service";
+import {
+  authorizationService,
+  type GetPermissionsParams,
+  isPermissionsTimeoutError,
+} from "../services/authorization.service";
 
 export const permissionsKeys = {
   all: ["permissions"] as const,
@@ -39,7 +43,14 @@ export function usePermissionsQuery(
     // between programs). Prevents flash of "Access Denied" during query key transitions.
     placeholderData: keepPreviousData,
     // Avoid retry storms on rate limiting; retry other transient failures up to 2 times.
-    retry: (failureCount, error) => !isRateLimitError(error) && failureCount < 2,
+    //
+    // Timeouts are NOT retried. Every retry keeps the query pending, and every
+    // RBAC-gated surface holds its skeleton for the whole run — 3 × 15s plus
+    // backoff is another ~48s of an apparently-frozen page. Surfacing the
+    // failure immediately hands the user an explicit Retry control instead,
+    // which is both faster and visible.
+    retry: (failureCount, error) =>
+      !isRateLimitError(error) && !isPermissionsTimeoutError(error) && failureCount < 2,
     enabled, // Only fetch when user is authenticated
   });
 }

--- a/src/core/rbac/hooks/use-staff-bridge.ts
+++ b/src/core/rbac/hooks/use-staff-bridge.ts
@@ -16,12 +16,24 @@ import { Role } from "../types";
  * + import { useStaff } from "@/core/rbac/hooks/use-staff-bridge";
  * + const { isStaff, isLoading } = useStaff();
  * ```
+ *
+ * Tri-state, not boolean. `isLoading` means "undecided", `isError` means
+ * "could not be decided" (the permissions fetch timed out or failed). Both
+ * report `isStaff: false` — staff status is granted only on a resolved,
+ * successful answer. Callers must render `isError` as a visible, retryable
+ * failure rather than silently treating the viewer as a non-staff member,
+ * otherwise a real super-admin quietly loses their controls with no
+ * explanation.
  */
-export function useStaff(): { isStaff: boolean; isLoading: boolean } {
-  const { hasRoleOrHigher, isLoading } = usePermissionContext();
+export function useStaff(): { isStaff: boolean; isLoading: boolean; isError: boolean } {
+  const { hasRoleOrHigher, isLoading, isGuestDueToError } = usePermissionContext();
 
   return {
-    isStaff: !isLoading && hasRoleOrHigher(Role.SUPER_ADMIN),
+    // `isGuestDueToError` also covers the stale-data case: React Query keeps
+    // the last successful payload when a refetch fails, so without this guard
+    // an unresolvable refetch would keep granting privileges off a cached answer.
+    isStaff: !isLoading && !isGuestDueToError && hasRoleOrHigher(Role.SUPER_ADMIN),
     isLoading,
+    isError: isGuestDueToError,
   };
 }

--- a/src/core/rbac/services/authorization.service.ts
+++ b/src/core/rbac/services/authorization.service.ts
@@ -52,18 +52,82 @@ const DEFAULT_GUEST_PERMISSIONS: PermissionsResponse = {
   isProjectAdmin: false,
 };
 
+/**
+ * Hard deadline for a single permissions fetch.
+ *
+ * `/v2/auth/permissions` is a cheap authorization lookup that answers in
+ * ~100ms in practice. It inherits the shared api client's 360s indexer
+ * ceiling, which exists for long-poll endpoints (AI evaluation, bulk jobs,
+ * report generation) and is meaningless here: a permissions request that
+ * hasn't answered in 15s will not usefully answer at 360s, and every second
+ * it stays in flight is a second every RBAC-gated surface renders a skeleton.
+ */
+export const PERMISSIONS_TIMEOUT_MS = 15_000;
+
+/** Raised when a permissions fetch blows {@link PERMISSIONS_TIMEOUT_MS}. */
+export class PermissionsTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Permissions request did not complete within ${timeoutMs}ms`);
+    this.name = "PermissionsTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function isPermissionsTimeoutError(error: unknown): error is PermissionsTimeoutError {
+  return error instanceof PermissionsTimeoutError;
+}
+
+/**
+ * Races the permissions request against a wall-clock deadline, aborting the
+ * in-flight request when the deadline wins.
+ *
+ * The deadline is deliberately applied here rather than relying solely on the
+ * transport timeout: `api.get` awaits `TokenManager.getToken()` *before* it
+ * issues the XHR, so a stalled Privy token bootstrap would never reach axios'
+ * timer. Racing the whole call guarantees the promise settles no matter which
+ * stage stalls, which is what the React Query loading gate depends on.
+ */
+async function fetchPermissionsWithDeadline(
+  params: GetPermissionsParams
+): Promise<AuthPermissionsApiResponse | null> {
+  const controller = new AbortController();
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const deadline = new Promise<never>((_, reject) => {
+    deadlineTimer = setTimeout(() => {
+      controller.abort();
+      reject(new PermissionsTimeoutError(PERMISSIONS_TIMEOUT_MS));
+    }, PERMISSIONS_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([
+      // TODO(#1775): add zod schema
+      api.get<AuthPermissionsApiResponse>(INDEXER.V2.AUTH.PERMISSIONS(params), {
+        signal: controller.signal,
+        timeoutMs: PERMISSIONS_TIMEOUT_MS,
+      }),
+      deadline,
+    ]);
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
+}
+
 export const authorizationService = {
   async getPermissions(params: GetPermissionsParams = {}): Promise<PermissionsResponse> {
     let response: AuthPermissionsApiResponse | null;
     try {
-      // TODO(#1775): add zod schema
-      response = await api.get<AuthPermissionsApiResponse>(INDEXER.V2.AUTH.PERMISSIONS(params));
+      response = await fetchPermissionsWithDeadline(params);
     } catch (error) {
       errorManager("Failed to fetch user permissions", error, {
         context: "authorization.service.getPermissions",
         params,
       });
-      // Throw so React Query retries (up to 2x) and keeps isLoading=true during retries.
+      // Throw so React Query retries transient failures and keeps isLoading=true
+      // during retries (see `usePermissionsQuery` — timeouts are NOT retried).
       // Previously returned DEFAULT_GUEST_PERMISSIONS, which React Query cached as "success"
       // for 5 minutes — causing persistent "Access Denied" even after the API recovered.
       throw error;

--- a/src/core/rbac/services/authorization.service.ts
+++ b/src/core/rbac/services/authorization.service.ts
@@ -64,6 +64,20 @@ const DEFAULT_GUEST_PERMISSIONS: PermissionsResponse = {
  */
 export const PERMISSIONS_TIMEOUT_MS = 15_000;
 
+/**
+ * Transport ceiling handed to the api client. Deliberately LONGER than
+ * {@link PERMISSIONS_TIMEOUT_MS} so the two timers cannot tie.
+ *
+ * Both bounds are armed against the same stalled request. Set to the same
+ * value, axios' timer and ours fire in the same tick and `Promise.race`
+ * picks a winner arbitrarily — which decides the error *type*, which decides
+ * whether `usePermissionsQuery` retries. That coin flip is the difference
+ * between a 15s failure and a ~48s one. Giving the transport headroom makes
+ * our deadline deterministically first; the transport bound stays as a
+ * backstop that releases the socket if the abort somehow doesn't.
+ */
+export const PERMISSIONS_TRANSPORT_TIMEOUT_MS = PERMISSIONS_TIMEOUT_MS + 5_000;
+
 /** Raised when a permissions fetch blows {@link PERMISSIONS_TIMEOUT_MS}. */
 export class PermissionsTimeoutError extends Error {
   readonly timeoutMs: number;
@@ -94,23 +108,32 @@ async function fetchPermissionsWithDeadline(
 ): Promise<AuthPermissionsApiResponse | null> {
   const controller = new AbortController();
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
 
   const deadline = new Promise<never>((_, reject) => {
     deadlineTimer = setTimeout(() => {
+      timedOut = true;
       controller.abort();
       reject(new PermissionsTimeoutError(PERMISSIONS_TIMEOUT_MS));
     }, PERMISSIONS_TIMEOUT_MS);
   });
 
+  // Once the deadline has fired the outcome IS a timeout: whatever the
+  // transport reports afterwards (an abort, a socket error) is downstream of
+  // our own cancellation and must not be mistaken for a distinct, retryable
+  // failure. Normalising on the way out keeps the retry decision independent
+  // of rejection ordering.
   try {
     return await Promise.race([
       // TODO(#1775): add zod schema
       api.get<AuthPermissionsApiResponse>(INDEXER.V2.AUTH.PERMISSIONS(params), {
         signal: controller.signal,
-        timeoutMs: PERMISSIONS_TIMEOUT_MS,
+        timeoutMs: PERMISSIONS_TRANSPORT_TIMEOUT_MS,
       }),
       deadline,
     ]);
+  } catch (error) {
+    throw timedOut ? new PermissionsTimeoutError(PERMISSIONS_TIMEOUT_MS) : error;
   } finally {
     clearTimeout(deadlineTimer);
   }

--- a/src/core/rbac/services/authorization.service.ts
+++ b/src/core/rbac/services/authorization.service.ts
@@ -116,29 +116,34 @@ async function fetchPermissionsWithDeadline(
   }
 }
 
+/** Forwards a permissions failure to Sentry via the shared error reporter. */
+function reportPermissionsFailure(error: unknown, params: GetPermissionsParams): void {
+  errorManager("Failed to fetch user permissions", error, {
+    context: "authorization.service.getPermissions",
+    params,
+  });
+}
+
 export const authorizationService = {
   async getPermissions(params: GetPermissionsParams = {}): Promise<PermissionsResponse> {
     let response: AuthPermissionsApiResponse | null;
+
+    // Every failure is reported and rethrown — never swallowed into a default.
+    // Rethrowing lets React Query retry transient failures and hold
+    // isLoading=true while it does (see `usePermissionsQuery`; timeouts are
+    // deliberately NOT retried). This previously returned
+    // DEFAULT_GUEST_PERMISSIONS, which React Query cached as "success" for 5
+    // minutes — a persistent "Access Denied" long after the API had recovered.
     try {
       response = await fetchPermissionsWithDeadline(params);
     } catch (error) {
-      errorManager("Failed to fetch user permissions", error, {
-        context: "authorization.service.getPermissions",
-        params,
-      });
-      // Throw so React Query retries transient failures and keeps isLoading=true
-      // during retries (see `usePermissionsQuery` — timeouts are NOT retried).
-      // Previously returned DEFAULT_GUEST_PERMISSIONS, which React Query cached as "success"
-      // for 5 minutes — causing persistent "Access Denied" even after the API recovered.
+      reportPermissionsFailure(error, params);
       throw error;
     }
 
     if (!response) {
       const emptyError = new Error("Failed to fetch permissions: empty response");
-      errorManager("Failed to fetch user permissions", emptyError, {
-        context: "authorization.service.getPermissions",
-        params,
-      });
+      reportPermissionsFailure(emptyError, params);
       throw emptyError;
     }
 

--- a/src/features/donor-research/components/report-brief/ReportBriefView.tsx
+++ b/src/features/donor-research/components/report-brief/ReportBriefView.tsx
@@ -1,14 +1,56 @@
 "use client";
 
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { useDonorAdvisor } from "@/hooks/useDonorAdvisor";
 import { useDonorReportStream } from "@/hooks/useDonorReportStream";
 import { useDonorReport } from "@/hooks/useDonorReports";
+import { permissionsKeys } from "@/src/core/rbac/hooks/use-permissions";
 import { useStaff } from "@/src/core/rbac/hooks/use-staff-bridge";
 import { DonorResearchLoading } from "../common/DonorResearchLoading";
 import { ReportBrief } from "./ReportBrief";
 
 interface ReportBriefViewProps {
   reportId: string;
+}
+
+/**
+ * Terminal state for "we could not decide whether you may manage this report".
+ * Deliberately NOT a silent downgrade to the read-only variant: a super-admin
+ * whose permissions lookup timed out would otherwise see a report with its
+ * controls missing and no way to tell that anything had gone wrong.
+ */
+function ManageAuthorizationError() {
+  const queryClient = useQueryClient();
+  const isRetrying = useIsFetching({ queryKey: permissionsKeys.all }) > 0;
+
+  return (
+    <div className="mx-auto max-w-xl px-4 py-12" role="alert">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border p-8 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+          <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+        </div>
+        <h1 className="text-xl font-semibold text-foreground">
+          We couldn&apos;t verify your access
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Checking your permissions took too long, so we can&apos;t show this report safely. Please
+          try again.
+        </p>
+        <button
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+          disabled={isRetrying}
+          onClick={() => {
+            void queryClient.refetchQueries({ queryKey: permissionsKeys.all });
+          }}
+          type="button"
+        >
+          <RefreshCw className={isRetrying ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+          {isRetrying ? "Retrying…" : "Try again"}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -27,7 +69,7 @@ interface ReportBriefViewProps {
 export function ReportBriefView({ reportId }: ReportBriefViewProps) {
   const reportQuery = useDonorReport(reportId);
   const advisorQuery = useDonorAdvisor();
-  const { isStaff, isLoading: isStaffLoading } = useStaff();
+  const { isStaff, isLoading: isStaffLoading, isError: isStaffError } = useStaff();
   const reportStatus = reportQuery.data?.status;
   const isTerminal =
     reportStatus === "complete" || reportStatus === "fast_complete" || reportStatus === "failed";
@@ -53,6 +95,13 @@ export function ReportBriefView({ reportId }: ReportBriefViewProps) {
   }
 
   const isOwner = !!advisorQuery.data && advisorQuery.data.id === reportQuery.data!.advisorId;
+
+  // Staff authorization resolved to "unknown". Owners don't depend on it —
+  // their controls come from the advisor row — so only a viewer we can't
+  // confirm as the owner is actually blocked by it.
+  if (isStaffError && !isOwner) {
+    return <ManageAuthorizationError />;
+  }
 
   return (
     <ReportBrief

--- a/src/features/donor-research/components/report-brief/__tests__/permissions-stall.test.tsx
+++ b/src/features/donor-research/components/report-brief/__tests__/permissions-stall.test.tsx
@@ -1,0 +1,139 @@
+import { act, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/__tests__/utils/render";
+import { PermissionProvider } from "@/src/core/rbac/context/permission-context";
+import { PERMISSIONS_TIMEOUT_MS } from "@/src/core/rbac/services/authorization.service";
+import type { ResearchReportDetail } from "@/types/donor-research";
+import { ReportBriefView } from "../ReportBriefView";
+
+/**
+ * REGRESSION: a `GET /v2/auth/permissions` request that never completes used to
+ * pin the report page on its "Loading report…" skeleton forever.
+ *
+ * `ReportBriefView` holds the skeleton until management authorization resolves
+ * (`useStaff().isLoading`), and that flag stayed true for as long as the
+ * permissions query stayed pending. The permissions request inherited the api
+ * client's 360s indexer ceiling — a long-poll allowance that is meaningless for
+ * an authorization lookup — so an unresolvable request produced an eternal
+ * skeleton with no error, no retry, and nothing for the user to do.
+ *
+ * These tests drive the REAL chain (PermissionProvider -> usePermissionsQuery ->
+ * authorizationService -> api client) against an `api.get` that never settles,
+ * which is the only faithful reproduction: anything that mocks the query or the
+ * service out cannot observe whether the fetch is actually bounded.
+ */
+
+const apiGet = vi.fn();
+vi.mock("@/utilities/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+vi.mock("@/utilities/auth/token-manager", () => ({
+  TokenManager: { getToken: vi.fn().mockResolvedValue("test-token"), clearCache: vi.fn() },
+}));
+
+vi.mock("@/hooks/useDonorReportStream", () => ({
+  useDonorReportStream: () => ({ events: [], status: "idle" }),
+}));
+
+const mockReport = {
+  id: "report-1",
+  advisorId: "advisor-owner",
+  status: "complete",
+} as unknown as ResearchReportDetail;
+
+vi.mock("@/hooks/useDonorReports", () => ({
+  useDonorReport: () => ({ data: mockReport, isLoading: false, isError: false, error: null }),
+}));
+
+let advisorId: string | null = null;
+vi.mock("@/hooks/useDonorAdvisor", () => ({
+  useDonorAdvisor: () => ({
+    data: advisorId ? { id: advisorId } : null,
+    isPending: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("../ReportBrief", () => ({
+  ReportBrief: ({ canManageReport }: { canManageReport: boolean }) => (
+    <div data-testid="report-brief" data-can-manage={String(canManageReport)}>
+      report content
+    </div>
+  ),
+}));
+
+function renderReport() {
+  return renderWithProviders(
+    <PermissionProvider>
+      <ReportBriefView reportId="report-1" />
+    </PermissionProvider>,
+    { authState: { ready: true, authenticated: true } }
+  );
+}
+
+/** Flush React effects + microtasks without moving the fake clock. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Move the fake clock past the permissions deadline and let React re-render. */
+async function advancePastPermissionsDeadline() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(PERMISSIONS_TIMEOUT_MS + 1_000);
+  });
+}
+
+describe("ReportBriefView — unresolvable permissions fetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    advisorId = null;
+    apiGet.mockReset();
+    // The stall under investigation: the request is issued and never settles.
+    apiGet.mockImplementation(() => new Promise(() => {}));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("escapes the loading skeleton and surfaces a retry affordance", async () => {
+    renderReport();
+    await settle();
+
+    // Precondition: the page really is gated on the pending permissions query.
+    expect(screen.getByText("Loading report…")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    await advancePastPermissionsDeadline();
+
+    expect(screen.queryByText("Loading report…")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("aborts the in-flight request instead of leaving it hanging", async () => {
+    renderReport();
+    await settle();
+
+    const signal = apiGet.mock.calls[0]?.[1]?.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    await advancePastPermissionsDeadline();
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("does not block the report for a confirmed owner, whose access is not RBAC-derived", async () => {
+    advisorId = "advisor-owner";
+
+    renderReport();
+    await advancePastPermissionsDeadline();
+
+    expect(screen.getByTestId("report-brief")).toHaveAttribute("data-can-manage", "true");
+  });
+});


### PR DESCRIPTION
## Summary

A `GET /v2/auth/permissions` request that never completes bricks the nonprofit-research report page **permanently**: an infinite `Loading report…` skeleton, no timeout, no error state, no retry affordance. The user sits there indefinitely.

This is pre-existing on `main` — it was found while investigating a red QA pipeline on #1936, and the files involved are byte-identical between `main` and that branch. This PR makes an unresolvable permissions fetch **fail closed and visibly** instead of hanging.

## Diagnosis chain

1. `src/features/donor-research/components/report-brief/ReportBriefView.tsx` gates the page on `const isManageAuthPending = isStaffLoading || advisorQuery.isPending;` and returns the skeleton while it's true.
   - The stall was localised to *this* component rather than the route: the route-level `loading.tsx` renders a different string (`Loading research report…`), and the stuck page shows `Loading report…`.
2. `advisorQuery` always settles — `fetchCurrentAdvisor` maps 404 → `null` and otherwise throws. So the only input that can hang forever is `useStaff().isLoading`.
3. That traces to `PermissionProvider`'s `awaitingPermissions` guard (`believedAuthenticated && !data && !isError`), which stays `true` for as long as the permissions React Query stays pending.
4. The query had no meaningful bound. `utilities/api/client.ts` gives every default-baseURL (indexer) request a **360s** ceiling — `DEFAULT_INDEXER_TIMEOUT_MS`, a deliberate allowance for long-poll endpoints (AI evaluation, bulk jobs, report generation). A cheap authorization lookup inherited it by default, and with React Query retries on top the worst case ran into the tens of minutes.

## What changed

### 1. A deadline on the permissions fetch (`src/core/rbac/services/authorization.service.ts`)

Each fetch races a 15s wall-clock deadline (`PERMISSIONS_TIMEOUT_MS`) and aborts the in-flight request via `AbortSignal` when the deadline wins.

The deadline is applied **in the service, not left to the transport**, because `api.get` awaits `TokenManager.getToken()` *before* it issues the XHR. A stalled Privy token bootstrap would never reach axios' timer, and the promise React Query is waiting on would still never settle. Racing the whole call is the only thing that guarantees the query settles regardless of which stage stalls — and the loading gate's termination depends on that guarantee, not on the transport's.

The transport is given a **longer** bound than the deadline (`PERMISSIONS_TRANSPORT_TIMEOUT_MS = PERMISSIONS_TIMEOUT_MS + 5_000`) so the two timers cannot tie. This matters more than it looks: with both set to 15s they fire in the same tick, `Promise.race` picks a winner arbitrarily, and the winner decides the error *type* — which decides whether the query retries. QA caught exactly that (see the QA response comment); the fix makes our deadline deterministically first and normalises any post-deadline rejection to `PermissionsTimeoutError`.

### 2. Not broadened to the shared api client — argued both ways

**For broadening:** one place to fix, and no future authenticated GET can accidentally inherit the long-poll ceiling.

**Against (chosen):** the 360s default is not an oversight — the comment in `client.ts` records it as a deliberate migration-parity decision so the ~220 legacy `fetchData` call sites don't have to pass `timeoutMs` individually. Some of them genuinely long-poll. Lowering the default would silently break those, and the failure mode would be a spurious timeout on a *working* endpoint — worse and harder to spot than the bug being fixed. This PR touches shared RBAC-gated loading code on a hot path; the right blast radius here is the one endpoint proven to hang. If more endpoints turn out to need it, the pattern generalises cleanly.

### 3. Timeouts are not retried (`src/core/rbac/hooks/use-permissions.ts`)

`retry` already exempted 429s; timeouts now join them. Retrying keeps the query pending, and every RBAC-gated surface holds its skeleton for the entire run — 3 × 15s plus backoff is another ~48s of an apparently-frozen page. Failing fast hands the user an explicit, immediate Retry control instead, which is both faster and visible. The endpoint answers in ~100ms when healthy; if it hasn't answered in 15s, two more 15s waits are not the remedy.

### 4. `useStaff()` is properly tri-state (`src/core/rbac/hooks/use-staff-bridge.ts`)

Now returns `{ isStaff, isLoading, isError }`. Per the repo's tri-state authorization rule, staff is granted only on a **resolved, successful** answer:

```ts
isStaff: !isLoading && !isGuestDueToError && hasRoleOrHigher(Role.SUPER_ADMIN),
```

The `!isGuestDueToError` term is load-bearing beyond the first-load case: React Query retains the last successful payload when a *refetch* fails, so without it an unresolvable refetch would keep granting privileges off a cached answer. Fail closed.

### 5. A visible outcome in `ReportBriefView`

A terminal error state with a Retry button that refetches the permissions query, replacing what used to be an eternal skeleton.

**Confirmed owners are exempt.** `canManageReport = isOwner || isStaff`, and `isOwner` comes from the advisor row, not from RBAC — so a failed staff lookup doesn't change what an owner may do, and blocking them would be a new availability regression introduced by the fix. Only a viewer we cannot confirm as the owner is actually blocked.

**Trade-off, stated plainly:** a non-owner non-staff viewer now sees an error where they previously saw the read-only variant. We cannot distinguish "not staff" from "staff status unknown", and the repo rule is explicit that an unresolved authorization state must not silently render as a decided one. Failing closed *and visibly* is the correct side of that trade — silently degrading a real super-admin to read-only with no explanation is exactly the failure this rule exists to prevent.

## Tests — mutation-verified

Three new/extended suites, all driving the **real** chain (`PermissionProvider` → `usePermissionsQuery` → `authorizationService` → api client) against an `api.get` that never settles, under fake timers. Mocking the query or the service out cannot observe whether the fetch is actually bounded, so it would not have caught this.

- `src/core/rbac/__tests__/permissions-timeout.test.tsx` — the gate terminates; a timed-out result does not grant staff; the request is not re-issued.
- `src/features/donor-research/components/report-brief/__tests__/permissions-stall.test.tsx` — the report page escapes the skeleton and surfaces an alert + retry; the in-flight request is aborted; a confirmed owner is not blocked.
- `src/core/rbac/__tests__/use-staff-bridge.test.ts` — the stale-data guard.

Note that "does not grant staff" is asserted **together with** `isLoading === false`. Asserted alone it would pass against the buggy code, which also never granted staff — it simply never answered. The two assertions are only a guard in combination.

### Mutation results

Each part of the fix was reverted individually and the suites re-run:

| Mutation | Result |
|---|---|
| Remove the deadline race (restore the 360s default) | **5 of 6 tests fail** — skeleton persists, signal never aborts, gate never terminates, staff never resolves |
| Drop `!isGuestDueToError` from `isStaff` | **1 fails** — stale-data guard |
| Remove the `isStaffError && !isOwner` branch in `ReportBriefView` | **1 fails** — no alert, no retry |
| Allow retrying timeouts | **1 fails** — 3 requests instead of 1 |
| Restore the deadline/transport timer tie (drop the headroom + normalisation) | **2 fail** — transport bound no longer strictly greater; a transport-first rejection escapes as a retryable error |

Fix restored: **43 files / 540 tests pass** across `src/core/rbac`, `__tests__/core/rbac`, `src/features/donor-research`, `__tests__/integration/rbac`. `npx tsc --noEmit` clean. `npx biome check` clean on all touched files (the two remaining warnings — an unused `DEFAULT_GUEST_PERMISSIONS` and an unused import — were verified to pre-date this branch on `main` and are left alone).

## What this does NOT explain

**The endpoint responds in 81–91ms against staging via curl, yet QA observed the XHR firing 8+ times in-browser without ever completing. That discrepancy is unexplained.** No root cause has been established for why the in-browser request stalls when the same request from curl is fast.

This PR makes that behaviour **survivable**, not fixed. It converts an unbounded, invisible, unrecoverable hang into a bounded, visible, retryable failure — and it does so without depending on which stage stalls, which is why the deadline wraps the whole call rather than just the transport. If the underlying stall is a Privy token bootstrap deadlock, a connection-pool exhaustion, or something in the proxy layer, this change does not address it and the timeouts will still fire. It should be treated as a floor under the user experience, not a closed investigation. `errorManager` still reports every failure, so the timeouts will now be visible in Sentry rather than silently swallowed by an eternal skeleton — which should give the root-cause work something to work from.

## Bot findings

- **`EMPTY_CATCH` at `authorization.service.ts` (anti-pattern check)** — fixed in `7a59642`. It was a false positive: the checker peeks only a few lines into a catch body and stops at the first `}`, so the multi-line `errorManager(...)` call hid the `throw error` behind it. Rather than annotate around it, the shared reporter is now extracted (`reportPermissionsFailure`), which deduplicates the identical payload built by both failure paths and leaves the report-and-rethrow readable in two lines. Check now passes.
- **Barrel imports at `use-staff-bridge.ts:4` and `authorization.service.ts:5` (React Doctor)** — pre-existing on `main`, surfaced only because these files appear in the diff. `import … from "../types"` on both lines is unchanged by this PR. Per `gap-app-v2/CLAUDE.md` the existing `types/` barrels are legacy and shouldn't be *added to*; unwinding them is a separate change and not something to bundle into an RBAC hot-path fix. The React Doctor check itself passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout handling for permission checks so requests no longer remain stuck indefinitely.
  * Added clear error states when authorization cannot be determined.
  * Report owners can continue accessing report management features during permission service failures.

* **Bug Fixes**
  * Prevented unauthorized access when permission checks fail or time out.
  * Stopped retrying permission requests after timeout failures.
  * Added a retry option when report authorization cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->